### PR TITLE
Fix Oracle TimeSpan mapping.

### DIFF
--- a/Source/DataProvider/Oracle/OracleDataProvider.cs
+++ b/Source/DataProvider/Oracle/OracleDataProvider.cs
@@ -335,7 +335,13 @@ namespace LinqToDB.DataProvider.Oracle
 				case DataType.Guid       :
 					if (value is Guid) value = ((Guid)value).ToByteArray();
 					break;
-			}
+                case DataType.Time:
+                    // According to http://docs.oracle.com/cd/E16655_01/win.121/e17732/featOraCommand.htm#ODPNT258
+                    // Inference of DbType and OracleDbType from Value: TimeSpan - Object - IntervalDS
+                    if (value is TimeSpan)
+                        dataType = DataType.Undefined;
+                    break;
+            }
 
 			base.SetParameter(parameter, name, dataType, value);
 		}


### PR DESCRIPTION
Исправлен баг с маппингом TimeSpan в Oracle отсюда: http://rsdn.ru/forum/prj.rfd/5374816.1

В соответствии с официальной документацией (http://docs.oracle.com/cd/E16655_01/win.121/e17732/featOraCommand.htm#ODPNT258) типу TimeSpan соответствует тип IntervalDS который задается посредством типа DbType.Object, который можно задать в linq2db с помощью DataType.Undefined.
