### PR TITLE
fix for GetDefaultMappingFromEnumType

### DIFF
--- a/Source/Common/ConvertBuilder.cs
+++ b/Source/Common/ConvertBuilder.cs
@@ -599,8 +599,8 @@ namespace LinqToDB.Common
 			if (defaultType == null)
 				defaultType = Enum.GetUnderlyingType(type);
 
-			if (type.IsNullable() && !defaultType.IsClassEx() && !defaultType.IsNullable())
-				defaultType = typeof(Nullable<>).MakeGenericType(defaultType);
+            if (enumType.IsNullable() && !defaultType.IsClassEx() && !defaultType.IsNullable())
+                defaultType = typeof(Nullable<>).MakeGenericType(defaultType);
 
 			return defaultType;
 		}

--- a/Tests/Linq/Mapping/MappingSchemaTest.cs
+++ b/Tests/Linq/Mapping/MappingSchemaTest.cs
@@ -299,5 +299,17 @@ namespace Tests.Mapping
 			var conv = new MappingSchema("1").GetConverter<int,Enum1>();
 			Assert.That(conv(2), Is.EqualTo(Enum1.Value2));
 		}
+
+        [Test]
+        public void ConvertNullableEnum()
+        {
+            var schema = new MappingSchema("2");
+            Assert.That(schema.GetDefaultValue(typeof(Enum1?)), Is.Null);
+            var mapType = ConvertBuilder.GetDefaultMappingFromEnumType(schema, typeof(Enum1?));
+            Assert.That(mapType, Is.EqualTo(typeof(int?)));
+            var convertedValue = Converter.ChangeType(null, mapType, schema);
+            Assert.IsNull(convertedValue);
+        }
+
 	}
 }


### PR DESCRIPTION
changed type.IsNullable() to enumType.IsNullable(). The issue I got was trying to update nullable int table field from the class having nullable Enum property. It appears that ConvertBuilder.GetDefaultMappingFromEnumType do not respect original enum type when trying to decide if the type mapping to should also be be made nullable. Please review and let me know if it makes sense for you.

Thanks!
