### PR TITLE
Firebird Provider natively supports Guid, so Linq2Db should not do hard cast guid to string.

### DIFF
--- a/Source/DataProvider/Firebird/FirebirdDataProvider.cs
+++ b/Source/DataProvider/Firebird/FirebirdDataProvider.cs
@@ -78,12 +78,7 @@ namespace LinqToDB.DataProvider.Firebird
 				value = (bool)value ? "1" : "0";
 				dataType = DataType.Char;
 			}
-			else if (value is Guid)
-			{
-				value = value.ToString();
-				dataType = DataType.Char;
-			}
-
+            
 			base.SetParameter(parameter, name, dataType, value);
 		}
 


### PR DESCRIPTION
Firebird Provider natively supports Guid, so Linq2Db should not do hard cast guid to string.
