### PR TITLE
PostgreSQL: quote database and schema names

### DIFF
--- a/Source/DataProvider/PostgreSQL/PostgreSQLSqlBuilder.cs
+++ b/Source/DataProvider/PostgreSQL/PostgreSQLSqlBuilder.cs
@@ -103,6 +103,8 @@ namespace LinqToDB.DataProvider.PostgreSQL
 				case ConvertType.NameToQueryFieldAlias:
 				case ConvertType.NameToQueryTable:
 				case ConvertType.NameToQueryTableAlias:
+				case ConvertType.NameToDatabase:
+				case ConvertType.NameToOwner:
 					if (value != null && IdentifierQuoteMode != PostgreSQLIdentifierQuoteMode.None)
 					{
 						var name = value.ToString();


### PR DESCRIPTION
Hello!
I've encountered a bug when using CamelCase schema name in PostgreSQL. While linq2db quotes table names if they contain upper case letters, but linq2db didn't quote database and schema names.
I provide a simple change for that problem and it helped in my case.
