### PR TITLE
Prepare db command before executing

### DIFF
--- a/Source/Data/CommandInfo.cs
+++ b/Source/Data/CommandInfo.cs
@@ -11,7 +11,8 @@ using System.Threading.Tasks;
 
 namespace LinqToDB.Data
 {
-	using Common;
+
+    using Common;
 	using Expressions;
 	using Extensions;
 
@@ -64,11 +65,8 @@ namespace LinqToDB.Data
 
 		public IEnumerable<T> Query<T>(Func<IDataReader,T> objectReader)
 		{
-			DataConnection.InitCommand(CommandText);
-			DataConnection.Command.CommandType = CommandType;
-
-			if (Parameters != null && Parameters.Length > 0)
-				SetParameters(DataConnection, Parameters);
+			DataConnection.InitCommand();
+		    DataConnection.SetCommand(this);
 
 			using (var rd = DataConnection.ExecuteReader(CommandBehavior))
 				while (rd.Read())
@@ -106,11 +104,8 @@ namespace LinqToDB.Data
 
 		public async Task QueryForEachAsync<T>(Func<IDataReader,T> objectReader, Action<T> action, CancellationToken cancellationToken)
 		{
-			await DataConnection.InitCommandAsync(CommandText, cancellationToken);
-			DataConnection.Command.CommandType = CommandType;
-
-			if (Parameters != null && Parameters.Length > 0)
-				SetParameters(DataConnection, Parameters);
+			await DataConnection.InitCommandAsync(cancellationToken);
+            DataConnection.SetCommand(this);
 
 			using (var rd = await DataConnection.ExecuteReaderAsync(CommandBehavior, cancellationToken))
 				while (await rd.ReadAsync(cancellationToken))
@@ -129,11 +124,8 @@ namespace LinqToDB.Data
 
 		public IEnumerable<T> Query<T>()
 		{
-			DataConnection.InitCommand(CommandText);
-			DataConnection.Command.CommandType = CommandType;
-
-			if (Parameters != null && Parameters.Length > 0)
-				SetParameters(DataConnection, Parameters);
+			DataConnection.InitCommand();
+		    DataConnection.SetCommand(this);
 
 			using (var rd = DataConnection.ExecuteReader(CommandBehavior))
 			{
@@ -198,11 +190,8 @@ namespace LinqToDB.Data
 
 		public async Task QueryForEachAsync<T>(Action<T> action, CancellationToken cancellationToken)
 		{
-			await DataConnection.InitCommandAsync(CommandText, cancellationToken);
-			DataConnection.Command.CommandType = CommandType;
-
-			if (Parameters != null && Parameters.Length > 0)
-				SetParameters(DataConnection, Parameters);
+			await DataConnection.InitCommandAsync(cancellationToken);
+            DataConnection.SetCommand(this);
 
 			using (var rd = await DataConnection.ExecuteReaderAsync(CommandBehavior, cancellationToken))
 			{
@@ -262,11 +251,8 @@ namespace LinqToDB.Data
 
 		public int Execute()
 		{
-			DataConnection.InitCommand(CommandText);
-			DataConnection.Command.CommandType = CommandType;
-
-			if (Parameters != null && Parameters.Length > 0)
-				SetParameters(DataConnection, Parameters);
+            DataConnection.InitCommand();
+            DataConnection.SetCommand(this);
 
 			return DataConnection.ExecuteNonQuery();
 		}
@@ -290,11 +276,8 @@ namespace LinqToDB.Data
 
 		public async Task<int> ExecuteAsync(CancellationToken cancellationToken)
 		{
-			await DataConnection.InitCommandAsync(CommandText, cancellationToken);
-			DataConnection.Command.CommandType = CommandType;
-
-			if (Parameters != null && Parameters.Length > 0)
-				SetParameters(DataConnection, Parameters);
+			await DataConnection.InitCommandAsync(cancellationToken);
+            DataConnection.SetCommand(this);
 
 			return await DataConnection.ExecuteNonQueryAsync(cancellationToken);
 		}
@@ -311,11 +294,8 @@ namespace LinqToDB.Data
 
 		public T Execute<T>()
 		{
-			DataConnection.InitCommand(CommandText);
-			DataConnection.Command.CommandType = CommandType;
-
-			if (Parameters != null && Parameters.Length > 0)
-				SetParameters(DataConnection, Parameters);
+            DataConnection.InitCommand();
+            DataConnection.SetCommand(this);
 
 			using (var rd = DataConnection.ExecuteReader(CommandBehavior))
 			{
@@ -349,12 +329,8 @@ namespace LinqToDB.Data
 
 		public async Task<T> ExecuteAsync<T>(CancellationToken cancellationToken)
 		{
-			await DataConnection.InitCommandAsync(CommandText, cancellationToken);
-
-			DataConnection.Command.CommandType = CommandType;
-
-			if (Parameters != null && Parameters.Length > 0)
-				SetParameters(DataConnection, Parameters);
+			await DataConnection.InitCommandAsync(cancellationToken);
+            DataConnection.SetCommand(this);
 
 			using (var rd = await DataConnection.ExecuteReaderAsync(CommandBehavior, cancellationToken))
 			{
@@ -386,11 +362,8 @@ namespace LinqToDB.Data
 
 		public DataReader ExecuteReader()
 		{
-			DataConnection.InitCommand(CommandText);
-			DataConnection.Command.CommandType = CommandType;
-
-			if (Parameters != null && Parameters.Length > 0)
-				SetParameters(DataConnection, Parameters);
+            DataConnection.InitCommand();
+            DataConnection.SetCommand(this);
 
 			return new DataReader { CommandInfo = this, Reader = DataConnection.ExecuteReader(CommandBehavior) };
 		}
@@ -454,11 +427,8 @@ namespace LinqToDB.Data
 
 		public async Task<DataReaderAsync> ExecuteReaderAsync(CancellationToken cancellationToken)
 		{
-			await DataConnection.InitCommandAsync(CommandText, cancellationToken);
-			DataConnection.Command.CommandType = CommandType;
-
-			if (Parameters != null && Parameters.Length > 0)
-				SetParameters(DataConnection, Parameters);
+			await DataConnection.InitCommandAsync(cancellationToken);
+            DataConnection.SetCommand(this);
 
 			return new DataReaderAsync { CommandInfo = this, Reader = await DataConnection.ExecuteReaderAsync(CommandBehavior, cancellationToken) };
 		}
@@ -515,7 +485,7 @@ namespace LinqToDB.Data
 
 		#region SetParameters
 
-		static void SetParameters(DataConnection dataConnection, DataParameter[] parameters)
+		internal static void SetParameters(DataConnection dataConnection, DataParameter[] parameters)
 		{
 			if (parameters == null)
 				return;
@@ -539,14 +509,14 @@ namespace LinqToDB.Data
 
 		struct ParamKey : IEquatable<ParamKey>
 		{
-			public ParamKey(Type type, int configID)
+			public ParamKey(Type type, int configId)
 			{
 				_type     = type;
-				_configID = configID;
+				_configId = configId;
 
 				unchecked
 				{
-					_hashCode = -1521134295 * (-1521134295 * 639348056 + _type.GetHashCode()) + _configID.GetHashCode();
+					_hashCode = -1521134295 * (-1521134295 * 639348056 + _type.GetHashCode()) + _configId.GetHashCode();
 				}
 			}
 
@@ -557,7 +527,7 @@ namespace LinqToDB.Data
 
 			readonly int    _hashCode;
 			readonly Type   _type;
-			readonly int    _configID;
+			readonly int    _configId;
 
 			public override int GetHashCode()
 			{
@@ -568,7 +538,7 @@ namespace LinqToDB.Data
 			{
 				return
 					_type     == other._type &&
-					_configID == other._configID
+					_configId == other._configId
 					;
 			}
 		}
@@ -585,11 +555,13 @@ namespace LinqToDB.Data
 			if (parameters == null)
 				return null;
 
-			if (parameters is DataParameter[])
-				return (DataParameter[])parameters;
+		    var dataParameters = parameters as DataParameter[];
+		    if (dataParameters != null)
+				return dataParameters;
 
-			if (parameters is DataParameter)
-				return new[] { (DataParameter)parameters };
+		    var parameter = parameters as DataParameter;
+		    if (parameter != null)
+				return new[] { parameter };
 
 			Func<object,DataParameter[]> func;
 			var type = parameters.GetType();
@@ -697,15 +669,15 @@ namespace LinqToDB.Data
 
 		struct QueryKey : IEquatable<QueryKey>
 		{
-			public QueryKey(Type type, int configID, string sql)
+			public QueryKey(Type type, int configId, string sql)
 			{
 				_type     = type;
-				_configID = configID;
+				_configId = configId;
 				_sql      = sql;
 
 				unchecked
 				{
-					_hashCode = -1521134295 * (-1521134295 * (-1521134295 * 639348056 + _type.GetHashCode()) + _configID.GetHashCode()) + _sql.GetHashCode();
+					_hashCode = -1521134295 * (-1521134295 * (-1521134295 * 639348056 + _type.GetHashCode()) + _configId.GetHashCode()) + _sql.GetHashCode();
 				}
 			}
 
@@ -716,7 +688,7 @@ namespace LinqToDB.Data
 
 			readonly int    _hashCode;
 			readonly Type   _type;
-			readonly int    _configID;
+			readonly int    _configId;
 			readonly string _sql;
 
 			public override int GetHashCode()
@@ -729,7 +701,7 @@ namespace LinqToDB.Data
 				return
 					_type     == other._type &&
 					_sql      == other._sql  &&
-					_configID == other._configID
+					_configId == other._configId
 					;
 			}
 		}

--- a/Source/Data/DataConnection.Async.cs
+++ b/Source/Data/DataConnection.Async.cs
@@ -9,7 +9,7 @@ namespace LinqToDB.Data
 {
 	public partial class DataConnection
 	{
-		internal async Task InitCommandAsync(string sql, CancellationToken cancellationToken)
+		internal async Task InitCommandAsync(CancellationToken cancellationToken)
 		{
 			if (_connection == null)
 				_connection = DataProvider.CreateConnection(ConnectionString);
@@ -20,7 +20,7 @@ namespace LinqToDB.Data
 				_closeConnection = true;
 			}
 
-			InitCommand(sql);
+			InitCommand();
 		}
 
 		internal async Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)

--- a/Source/Data/DataConnection.cs
+++ b/Source/Data/DataConnection.cs
@@ -492,13 +492,34 @@ namespace LinqToDB.Data
 
 		public string LastQuery;
 
-		internal void InitCommand(string sql)
+		internal void InitCommand()
 		{
 			DataProvider.InitCommand(this);
-			Command.CommandText = LastQuery = sql;
 		}
 
-		private int? _commandTimeout;
+	    internal void SetCommand(CommandInfo commandInfo)
+	    {
+            DataProvider.PrepareCommandInfo(commandInfo);
+
+            Command.CommandText = LastQuery = commandInfo.CommandText;
+            Command.CommandType = commandInfo.CommandType;
+
+            if (commandInfo.Parameters != null && commandInfo.Parameters.Length > 0)
+                CommandInfo.SetParameters(this, commandInfo.Parameters);	        
+	    }
+
+	    internal void SetCommand(PreparedQuery preparedQuery, int commandIndex)
+	    {
+	        var sql = preparedQuery.Commands[commandIndex];
+            Command.CommandText = LastQuery = sql;
+            Command.CommandType = CommandType.Text;
+
+	        if (preparedQuery.Parameters == null || commandIndex > 0) return;
+	        foreach (var p in preparedQuery.Parameters)
+	            Command.Parameters.Add(p);
+	    }
+
+	    private int? _commandTimeout;
 		public  int   CommandTimeout
 		{
 			get { return _commandTimeout ?? 0; }

--- a/Source/DataProvider/DataProviderBase.cs
+++ b/Source/DataProvider/DataProviderBase.cs
@@ -85,11 +85,14 @@ namespace LinqToDB.DataProvider
 
 		public virtual void InitCommand(DataConnection dataConnection)
 		{
-			dataConnection.Command.CommandType = CommandType.Text;
-
 			if (dataConnection.Command.Parameters.Count != 0)
 				dataConnection.Command.Parameters.Clear();
 		}
+
+        public virtual void PrepareCommandInfo(CommandInfo commandInfo)
+        {
+        }
+
 
 		public virtual object GetConnectionInfo(DataConnection dataConnection, string parameterName)
 		{

--- a/Source/DataProvider/IDataProvider.cs
+++ b/Source/DataProvider/IDataProvider.cs
@@ -22,6 +22,7 @@ namespace LinqToDB.DataProvider
 		ISqlBuilder        CreateSqlBuilder      ();
 		ISqlOptimizer      GetSqlOptimizer       ();
 		void               InitCommand           (DataConnection dataConnection);
+	    void               PrepareCommandInfo    (CommandInfo commandInfo);
 		object             GetConnectionInfo     (DataConnection dataConnection, string parameterName);
 		Expression         GetReaderExpression   (MappingSchema mappingSchema, IDataReader reader, int idx, Expression readerExpression, Type toType);
 		bool?              IsDBNullAllowed       (IDataReader reader, int idx);

--- a/Source/DataProvider/SapHana/SapHanaMappingSchema.cs
+++ b/Source/DataProvider/SapHana/SapHanaMappingSchema.cs
@@ -7,7 +7,7 @@ namespace LinqToDB.DataProvider.SapHana
 
 	public class SapHanaMappingSchema : MappingSchema
 	{
-		public SapHanaMappingSchema() : base(ProviderName.SapHana)
+		public SapHanaMappingSchema() : this(ProviderName.SapHana)
 		{
 		}
 

--- a/Source/DataProvider/SapHana/SapHanaOdbcDataProvider.cs
+++ b/Source/DataProvider/SapHana/SapHanaOdbcDataProvider.cs
@@ -4,7 +4,10 @@ using System.Data.Odbc;
 
 namespace LinqToDB.DataProvider.SapHana
 {
-	using Extensions;
+    using System.Linq;
+    using Data;
+
+    using Extensions;
 	using Mapping;
 	using SqlProvider;
 
@@ -57,7 +60,19 @@ namespace LinqToDB.DataProvider.SapHana
 			return new SapHanaOdbcSchemaProvider();
 		}
 
-		public override ISqlBuilder CreateSqlBuilder()
+	    public override void PrepareCommandInfo(CommandInfo commandInfo)
+	    {
+	        if (commandInfo.CommandType == CommandType.StoredProcedure)
+	        {
+	            commandInfo.CommandText = String.Format("{{ CALL {0} ({1}) }}",
+	                commandInfo.CommandText,
+	                String.Join(",", commandInfo.Parameters.Select(x => "?")));
+	            commandInfo.CommandType = CommandType.Text;
+	        }
+            base.PrepareCommandInfo(commandInfo);
+	    }
+
+	    public override ISqlBuilder CreateSqlBuilder()
 		{
 			return new SapHanaOdbcSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, MappingSchema.ValueToSqlConverter);            
 		}

--- a/Source/DataProvider/SapHana/SapHanaSqlBuilder.cs
+++ b/Source/DataProvider/SapHana/SapHanaSqlBuilder.cs
@@ -77,42 +77,45 @@ namespace LinqToDB.DataProvider.SapHana
 				case DataType.Int32         :
 				case DataType.UInt16        :
 					StringBuilder.Append("Integer");
-					break;
+                    return;
 				case DataType.Double:
 					StringBuilder.Append("Double");
-					break;
-				case DataType.Money         : 
-					StringBuilder.Append("Decimal(19,4)");
-					break;
-				case DataType.SmallMoney    : 
-					StringBuilder.Append("Decimal(10,4)");
-					break;			        
+                    return;
 #if !MONO
 				case DataType.DateTime2     :
 #endif
 				case DataType.DateTime      :
 				case DataType.Time:
 					StringBuilder.Append("Timestamp");
-					break;                
+                    return;                
 				case DataType.SmallDateTime : 
 					StringBuilder.Append("SecondDate");
-					break;
+                    return;
 				case DataType.Boolean       : 
 					StringBuilder.Append("TinyInt");
-					break;
+                    return;
 				case DataType.Image:
 					StringBuilder.Append("Blob");
-					break;
+                    return;
 				case DataType.Xml:
 					StringBuilder.Append("Clob");
-					break;
+					return;
 				case DataType.Guid:
 					StringBuilder.Append("Char (36)");
-					break;
-				default:
-					base.BuildDataType(type, createDbType); 
-					break;
+			        return;
+                case DataType.NVarChar:
+                case DataType.VarChar:
+                case DataType.VarBinary:
+                    if (type.Length == int.MaxValue || type.Length < 0)
+                    {
+                        StringBuilder
+                            .Append(type.DataType)
+                            .Append("(Max)");
+                        return;
+                    }
+			        break;
 			}
+            base.BuildDataType(type, createDbType); 
 		}
 
 		protected override void BuildFromClause()

--- a/Tests/Linq/DataProvider/ExpressionTest.cs
+++ b/Tests/Linq/DataProvider/ExpressionTest.cs
@@ -21,7 +21,8 @@ namespace Tests.DataProvider
 
 			using (var conn = new DataConnection(SqlServerTools.GetDataProvider(), connectionString))
 			{
-				conn.InitCommand("SELECT 1");
+				conn.InitCommand();
+			    conn.SetCommand(new CommandInfo(conn, "SELECT 1"));
 
 				var rd = conn.Command.ExecuteReader();
 

--- a/Tests/Linq/Linq/SelectScalar.cs
+++ b/Tests/Linq/Linq/SelectScalar.cs
@@ -222,7 +222,7 @@ namespace Tests.Linq
 					db.Child.Select(c => string.Format("{0},{1}", c.ChildID, text)).FirstOrDefault());
 		}
 
-		[Test, DataContextSource(ProviderName.Access, ProviderName.Informix, ProviderName.SqlCe, ProviderName.Sybase)]
+		[Test, DataContextSource(ProviderName.Access, ProviderName.Informix, ProviderName.SqlCe, ProviderName.Sybase, ProviderName.SapHana)]
 		public void SubQueryTest(string context)
 		{
 			using (var db = GetDataContext(context))

--- a/Tests/Linq/Linq/TableFunctionTest.cs
+++ b/Tests/Linq/Linq/TableFunctionTest.cs
@@ -40,7 +40,7 @@ namespace Tests.Linq
 			}
 		}
 
-		[Test, IncludeDataContextSource(ProviderName.SqlServer2008, ProviderName.SapHana)]
+		[Test, IncludeDataContextSource(ProviderName.SqlServer2008)]
 		public void Func3(string context)
 		{
 			using (var db = GetDataContext(context))

--- a/Tests/Linq/Update/MergeTest.cs
+++ b/Tests/Linq/Update/MergeTest.cs
@@ -14,7 +14,7 @@ namespace Tests.Update
 	public class MergeTest : TestBase
 	{
 		[Test, DataContextSource(false,
-			ProviderName.Access, ProviderName.Informix, ProviderName.MySql, ProviderName.PostgreSQL, ProviderName.SQLite,
+            ProviderName.Access, ProviderName.Informix, ProviderName.MySql, ProviderName.PostgreSQL, ProviderName.SQLite, ProviderName.SapHana,
 			ProviderName.SqlCe, ProviderName.SqlServer2000, ProviderName.SqlServer2005, ProviderName.Sybase)]
 		public void Merge(string context)
 		{
@@ -25,7 +25,7 @@ namespace Tests.Update
 		}
 
 		[Test, DataContextSource(false,
-			ProviderName.Access, ProviderName.DB2, ProviderName.Firebird, ProviderName.Informix, ProviderName.Oracle, ProviderName.MySql,
+			ProviderName.Access, ProviderName.DB2, ProviderName.Firebird, ProviderName.Informix, ProviderName.Oracle, ProviderName.MySql, ProviderName.SapHana,
 			ProviderName.PostgreSQL, ProviderName.SQLite, ProviderName.SqlCe, ProviderName.SqlServer2000, ProviderName.SqlServer2005, ProviderName.Sybase)]
 		public void MergeWithDelete(string context)
 		{
@@ -36,7 +36,7 @@ namespace Tests.Update
 		}
 
 		[Test, DataContextSource(false,
-			ProviderName.Access, ProviderName.DB2, ProviderName.Firebird, ProviderName.Informix, ProviderName.Oracle, ProviderName.MySql,
+            ProviderName.Access, ProviderName.DB2, ProviderName.Firebird, ProviderName.Informix, ProviderName.Oracle, ProviderName.MySql, ProviderName.SapHana,
 			ProviderName.PostgreSQL, ProviderName.SQLite, ProviderName.SqlCe, ProviderName.SqlServer2000, ProviderName.SqlServer2005, ProviderName.Sybase)]
 		public void MergeWithDeletePredicate1(string context)
 		{
@@ -47,7 +47,7 @@ namespace Tests.Update
 		}
 
 		[Test, DataContextSource(false,
-			ProviderName.Access, ProviderName.DB2, ProviderName.Firebird, ProviderName.Informix, ProviderName.Oracle, ProviderName.MySql,
+            ProviderName.Access, ProviderName.DB2, ProviderName.Firebird, ProviderName.Informix, ProviderName.Oracle, ProviderName.MySql, ProviderName.SapHana,
 			ProviderName.PostgreSQL, ProviderName.SQLite, ProviderName.SqlCe, ProviderName.SqlServer2000, ProviderName.SqlServer2005, ProviderName.Sybase)]
 		public void MergeWithDeletePredicate2(string context)
 		{


### PR DESCRIPTION
Hi,

I use SapHanaOdbcDataProvider, because at current state ADO.NET drivers have poor performance.
I need ability to call stored procedures, and ODBC drivers use [different approach] (http://support.microsoft.com/kb/310130) than ADO.NET drivers.
Before CommandInfo class was added, i was able to write my own DataConnection extension method and change this behavior outside of linq2db library, but this approach was ugly, so now i fixed it :)

I added PrepareCommandInfo method for IDataProvider, so that DataProvider could change command state, if it needs, before execution.
