### PR TITLE
Fix BulkCopy for objects with custom type properties

### DIFF
--- a/Source/DataProvider/MultipleRowsHelper.cs
+++ b/Source/DataProvider/MultipleRowsHelper.cs
@@ -63,6 +63,11 @@ namespace LinqToDB.DataProvider
 					var name = ParameterName == "?" ? ParameterName : ParameterName + ++ParameterIndex;
 
 					StringBuilder.Append(name);
+					if (value is DataParameter)
+					{
+						value = ((DataParameter)value).Value;
+					}
+
 					Parameters.Add(new DataParameter(ParameterName == "?" ? ParameterName : "p" + ParameterIndex, value,
 						column.DataType));
 				}


### PR DESCRIPTION
This change need to properly insert bulk of items like this:

```
	[Table("CableCurve")]
	public partial class CableCurve
	{
		[Column(                  DataType=DataType.Int32,  Precision=10), PrimaryKey, Identity] public int          CableCurveID { get; set; } // Long
		[Column(                  DataType=DataType.Int32,  Precision=10), NotNull             ] public int          CableID      { get; set; } // Long
		[Column(                  DataType=DataType.Double, Precision=15), NotNull             ] public double       Load         { get; set; } // Double
		[Column("T_UTemperature", DataType=DataType.Double, Precision=15), NotNull             ] public UTemperature T            { get; set; } // Double
	}
```

ConvertExpression also set:
```
MappingSchema.Default.SetConvertExpression<Double, UTemperature>(n => new UTemperature(n, _unitsTypeProvider));
MappingSchema.Default.SetConvertExpression<UTemperature, DataParameter>(n => new DataParameter { Value = n.Celsius, DataType = DataType.Double });
MappingSchema.Default.SetConvertExpression<UTemperature, Double>(n => n.Celsius);
```