### PR TITLE
Added parent property comparison to Column.Equals

### DIFF
--- a/Source/SqlQuery/SelectQuery.cs
+++ b/Source/SqlQuery/SelectQuery.cs
@@ -187,7 +187,8 @@ namespace LinqToDB.SqlQuery
 
 			public bool Equals(Column other)
 			{
-				return Expression.Equals(other.Expression);
+				return Expression.Equals(other.Expression)
+					&& ((Parent == null && other.Parent == null) || (Parent != null && Parent.Equals(other.Parent)));
 			}
 
 #if OVERRIDETOSTRING


### PR DESCRIPTION
fix #223 

The same SqlValue (with value 1) shoul be considered as different if they belong different contexts.