### PR TITLE
Fix wrong descriptions for columns.

### DIFF
--- a/Source/DataProvider/SqlServer/SqlServerSchemaProvider.cs
+++ b/Source/DataProvider/SqlServer/SqlServerSchemaProvider.cs
@@ -136,7 +136,7 @@ namespace LinqToDB.DataProvider.SqlServer
 						sys.extended_properties x
 					ON
 						OBJECT_ID('[' + TABLE_CATALOG + '].[' + TABLE_SCHEMA + '].[' + TABLE_NAME + ']') = x.major_id AND
-						ORDINAL_POSITION = x.minor_id AND
+						COLUMNPROPERTY(object_id('[' + TABLE_SCHEMA + '].[' + TABLE_NAME + ']'), COLUMN_NAME, 'ColumnID') = x.minor_id AND
 						x.name = 'MS_Description'")
 				.Select(c =>
 				{


### PR DESCRIPTION
In sys.extended_properties minor_id is columnId and in INFORMATION_SCHEMA.COLUMNS ORDINAL_POSITION is not columnId.
See remarks in https://msdn.microsoft.com/en-us/library/ms188348(v=sql.110).aspx.