### PR TITLE
Fix OracleCommand that hang when using "RETURNING" statement

### DIFF
--- a/Source/DataProvider/Oracle/OracleSqlBuilder.cs
+++ b/Source/DataProvider/Oracle/OracleSqlBuilder.cs
@@ -34,7 +34,7 @@ namespace LinqToDB.DataProvider.Oracle
 			if (identityField == null)
 				throw new SqlException("Identity field must be defined for '{0}'.", SelectQuery.Insert.Into.Name);
 
-			AppendIndent().AppendLine("RETURNING");
+			AppendIndent().AppendLine("RETURNING ");
 			AppendIndent().Append("\t");
 			BuildExpression(identityField, false, true);
 			StringBuilder.AppendLine(" INTO :IDENTITY_PARAMETER");


### PR DESCRIPTION
Weird bug on OracleCommand. If a line break occurs right after a "RETURNING" statement, the command would hang forever. 