### PR TITLE
Npgsql 3.0+ hstore and linq2db

### DIFF
--- a/Source/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
+++ b/Source/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
@@ -62,7 +62,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			NpgsqlMacAddressType  = connectionType.Assembly.GetType("NpgsqlTypes.NpgsqlMacAddress",  false);
 			NpgsqlCircleType      = connectionType.Assembly.GetType("NpgsqlTypes.NpgsqlCircle",      true);
 			NpgsqlPolygonType     = connectionType.Assembly.GetType("NpgsqlTypes.NpgsqlPolygon",     true);
-
+            
 			if (BitStringType        != null) SetProviderField(BitStringType,        BitStringType,        "GetBitString");
 			if (NpgsqlIntervalType   != null) SetProviderField(NpgsqlIntervalType,   NpgsqlIntervalType,   "GetInterval");
 			if (NpgsqlTimeType       != null) SetProviderField(NpgsqlTimeType,       NpgsqlTimeType,       "GetTime");
@@ -94,6 +94,8 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			_setBoolean   = GetSetParameter(connectionType, "NpgsqlParameter", "NpgsqlDbType", "NpgsqlTypes.NpgsqlDbType", "Boolean");
 			_setXml       = GetSetParameter(connectionType, "NpgsqlParameter", "NpgsqlDbType", "NpgsqlTypes.NpgsqlDbType", "Xml");
 			_setText      = GetSetParameter(connectionType, "NpgsqlParameter", "NpgsqlDbType", "NpgsqlTypes.NpgsqlDbType", "Text");
+            _setHstore    = GetSetParameter(connectionType, "NpgsqlParameter", "NpgsqlDbType", "NpgsqlTypes.NpgsqlDbType", "Hstore");
+
 
 			if (BitStringType        != null) MappingSchema.AddScalarType(BitStringType);
 			if (NpgsqlIntervalType   != null) MappingSchema.AddScalarType(NpgsqlIntervalType);
@@ -111,6 +113,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			MappingSchema.AddScalarType(NpgsqlCircleType);
 			MappingSchema.AddScalarType(_npgsqlDate);
 			MappingSchema.AddScalarType(NpgsqlPolygonType);
+            
 
 			if (_npgsqlTimeStampTZ != null) 
 			{
@@ -160,6 +163,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 		static Action<IDbDataParameter> _setBoolean;
 		static Action<IDbDataParameter> _setXml;
 		static Action<IDbDataParameter> _setText;
+        static Action<IDbDataParameter> _setHstore;
 
 		public override void SetParameter(IDbDataParameter parameter, string name, DataType dataType, object value)
 		{
@@ -190,6 +194,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 				case DataType.Xml        : _setXml      (parameter);                   break;
 				case DataType.Text       :
 				case DataType.NText      : _setText     (parameter);                   break;
+                case DataType.Dictionary : _setHstore(parameter);                      break;
 				default                  : base.SetParameterType(parameter, dataType); break;
 			}
 		}

--- a/Source/DataProvider/PostgreSQL/PostgreSQLSchemaProvider.cs
+++ b/Source/DataProvider/PostgreSQL/PostgreSQLSchemaProvider.cs
@@ -32,6 +32,8 @@ namespace LinqToDB.DataProvider.PostgreSQL
 				new DataTypeInfo { TypeName = "bytea",                       DataType = typeof(byte[]).        FullName },
 				new DataTypeInfo { TypeName = "uuid",                        DataType = typeof(Guid).          FullName },
 
+                new DataTypeInfo { TypeName = "hstore",                      DataType = typeof(Dictionary<string, string>).FullName},
+
 				new DataTypeInfo { TypeName = "character varying",           DataType = typeof(string).        FullName, CreateFormat = "character varying({0})",            CreateParameters = "length" },
 				new DataTypeInfo { TypeName = "character",                   DataType = typeof(string).        FullName, CreateFormat = "character({0})",                    CreateParameters = "length" },
 				new DataTypeInfo { TypeName = "numeric",                     DataType = typeof(decimal).       FullName, CreateFormat = "numeric({0},{1})",                  CreateParameters = "precision,scale" },

--- a/Source/DataType.cs
+++ b/Source/DataType.cs
@@ -202,6 +202,11 @@ namespace LinqToDB
 		/// </summary>
 		Udt,
 
+        /// <summary>
+        /// Dictionary type for key-value pairs
+        /// </summary>
+        Dictionary
+
 		/*
 		Structured	A special data type for specifying structured data contained in table-valued parameters.
 		*/


### PR DESCRIPTION
Hi,

Npgsql added hstore support as of 3.0 previous hack of using string as parameter type for hstore doesn't work anymore. Added new DataType Dictionary - maybe other DB-s will also have keyvalue extensions in the future. Currently requires Column attribute to have DataType = DataType.Dictionary set to work.