### PR TITLE
Fixed problem with generic filter predicates

### DIFF
--- a/Source/Linq/Builder/SelectContext.cs
+++ b/Source/Linq/Builder/SelectContext.cs
@@ -1078,6 +1078,30 @@ namespace LinqToDB.Linq.Builder
 									GetMemberExpression(binding.Expression.Unwrap(), expression, level + 1);
 						}
 
+						if (me.Member.DeclaringType != null && me.Member.DeclaringType.IsInterface && me.Member.DeclaringType.IsAssignableFrom(expr.Type))
+						{
+							var interfaceProperty = me.Member as PropertyInfo;
+							if (interfaceProperty != null)
+							{
+								var interfaceAccessors = interfaceProperty.GetAccessors();
+								var typemap = expr.Type.GetInterfaceMap(me.Member.DeclaringType);
+								var typeAccessors = typemap.InterfaceMethods
+									.Zip(typemap.TargetMethods, (interfaceMethod, typeMethod) => new {interfaceMethod, typeMethod})
+									.Where(x => interfaceAccessors.Contains(x.interfaceMethod))
+									.Select(x => x.typeMethod)
+									.ToArray();
+
+								foreach (var binding in expr.Bindings.Cast<MemberAssignment>())
+								{
+									var typeProperty = binding.Member as PropertyInfo;
+									if (typeProperty != null && typeProperty.GetAccessors().Intersect(typeAccessors).Any())
+										return ReferenceEquals(levelExpresion, expression)
+											? binding.Expression.Unwrap()
+											: GetMemberExpression(binding.Expression.Unwrap(), expression, level + 1);
+								}
+							}
+						}
+
 						throw new LinqException("Invalid expression {0}", expression);
 					}
 			}

--- a/Tests/Linq/Tests.csproj
+++ b/Tests/Linq/Tests.csproj
@@ -332,6 +332,7 @@
     <Compile Include="Linq\WhereTest.cs" />
     <Compile Include="UserTests\CompareNullableChars.cs" />
     <Compile Include="UserTests\FirstOrDefaultNullReferenceExceptionTest.cs" />
+    <Compile Include="UserTests\GenericsFilterTest.cs" />
     <Compile Include="UserTests\GroupBySubqueryTest.cs" />
     <Compile Include="UserTests\LetTest.cs" />
     <Compile Include="UserTests\MultiPartIdentifierTest.cs" />

--- a/Tests/Linq/UserTests/GenericsFilterTest.cs
+++ b/Tests/Linq/UserTests/GenericsFilterTest.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Linq;
+
+using LinqToDB;
+using LinqToDB.Data;
+
+using NUnit.Framework;
+
+namespace Tests.UserTests
+{
+	[TestFixture]
+	internal class GenericsFilterTest
+	{
+		[Test]
+		public void WhenPredicateFactoryIsGeneric()
+		{
+			var predicate = ById<Firm>(0);
+			Assert.DoesNotThrow(() => CheckPredicate(predicate));
+		}
+
+		[Test]
+		public void WhenPredicateFactoryIsNotGeneric()
+		{
+			var predicate = ById(0);
+			Assert.DoesNotThrow(() => CheckPredicate(predicate));
+		}
+
+		private Expression<Func<T, bool>> ById<T>(int foobar)
+			where T : class, IIdentifiable
+		{
+			return identifiable => identifiable.Id == foobar;
+		}
+
+		private Expression<Func<Firm, bool>> ById(int foobar)
+		{
+			return identifiable => identifiable.Id == foobar;
+		}
+
+		private void CheckPredicate(Expression<Func<Firm, bool>> predicate)
+		{
+			using (var db = new DataConnection(ProviderName.SQLite, "Data Source=:memory:;Version=3;New=True;"))
+			{
+				db.CreateTable<TypeA>();
+				db.CreateTable<TypeB>();
+
+				var query = db.GetTable<TypeA>()
+					.Select(a => new Firm {Id = a.Id, Value = db.GetTable<TypeB>().Select(b => b.Id).FirstOrDefault()});
+
+				query.Where(predicate).GetEnumerator();
+			}
+		}
+
+		private interface IIdentifiable
+		{
+			int Id { get; set; }
+		}
+
+		private class Firm : IIdentifiable
+		{
+			public int Id { get; set; }
+			public int Value { get; set; }
+		}
+
+		private class TypeA
+		{
+			public int Id { get; set; }
+		}
+
+		private class TypeB
+		{
+			public int Id { get; set; }
+		}
+	}
+}


### PR DESCRIPTION
Hi! We have a problem with some complex queries. I think that the cause in line 
```
if (me.Member == binding.Member)
```

When compared "me.Member" and "binding.Member" the first one can be interface preperty that is implemented by type with the second one. In this case comparision gives us "false" and then exception raised, but I think that it is possible to proceed.

Simplest solution is to replace "me.Member == binding.Member" with "me.Member.Name == binding.Member.Name", but it is not good idea, so I used InterfaceMapping to determine if property is interface implementation.

Without this fix test "WhenPredicateFactoryIsNotGeneric" passes, but "WhenPredicateFactoryIsGeneric" fails. With it both tests pass.