### PR TITLE
Npgsql 3.0 datetime and hstore support

### DIFF
--- a/Source/Data/DataParameter.cs
+++ b/Source/Data/DataParameter.cs
@@ -3,6 +3,8 @@ using System.Data;
 using System.Data.Linq;
 using System.Xml;
 using System.Xml.Linq;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace LinqToDB.Data
 {
@@ -151,6 +153,8 @@ namespace LinqToDB.Data
 		public static DataParameter Variant       (string name, object         value) { return new DataParameter { DataType = DataType.Variant,        Name = name, Value = value, }; }
 		public static DataParameter VarNumeric    (string name, decimal        value) { return new DataParameter { DataType = DataType.VarNumeric,     Name = name, Value = value, }; }
 		public static DataParameter Udt           (string name, object         value) { return new DataParameter { DataType = DataType.Udt,            Name = name, Value = value, }; }
+
+        public static DataParameter Dictionary    (string name, IDictionary    value) { return new DataParameter { DataType = DataType.Dictionary,     Name = name, Value = value, }; }
 
 		public static DataParameter Create        (string name, char           value) { return new DataParameter { DataType = DataType.NChar,          Name = name, Value = value, }; }
 		public static DataParameter Create        (string name, string         value) { return new DataParameter { DataType = DataType.NVarChar,       Name = name, Value = value, }; }

--- a/Source/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
+++ b/Source/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
@@ -62,7 +62,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			NpgsqlMacAddressType  = connectionType.Assembly.GetType("NpgsqlTypes.NpgsqlMacAddress",  false);
 			NpgsqlCircleType      = connectionType.Assembly.GetType("NpgsqlTypes.NpgsqlCircle",      true);
 			NpgsqlPolygonType     = connectionType.Assembly.GetType("NpgsqlTypes.NpgsqlPolygon",     true);
-
+            
 			if (BitStringType        != null) SetProviderField(BitStringType,        BitStringType,        "GetBitString");
 			if (NpgsqlIntervalType   != null) SetProviderField(NpgsqlIntervalType,   NpgsqlIntervalType,   "GetInterval");
 			if (NpgsqlTimeType       != null) SetProviderField(NpgsqlTimeType,       NpgsqlTimeType,       "GetTime");
@@ -94,6 +94,8 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			_setBoolean   = GetSetParameter(connectionType, "NpgsqlParameter", "NpgsqlDbType", "NpgsqlTypes.NpgsqlDbType", "Boolean");
 			_setXml       = GetSetParameter(connectionType, "NpgsqlParameter", "NpgsqlDbType", "NpgsqlTypes.NpgsqlDbType", "Xml");
 			_setText      = GetSetParameter(connectionType, "NpgsqlParameter", "NpgsqlDbType", "NpgsqlTypes.NpgsqlDbType", "Text");
+            _setHstore    = GetSetParameter(connectionType, "NpgsqlParameter", "NpgsqlDbType", "NpgsqlTypes.NpgsqlDbType", "Hstore");
+
 
 			if (BitStringType        != null) MappingSchema.AddScalarType(BitStringType);
 			if (NpgsqlIntervalType   != null) MappingSchema.AddScalarType(NpgsqlIntervalType);
@@ -111,6 +113,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			MappingSchema.AddScalarType(NpgsqlCircleType);
 			MappingSchema.AddScalarType(_npgsqlDate);
 			MappingSchema.AddScalarType(NpgsqlPolygonType);
+            
 
 			if (_npgsqlTimeStampTZ != null) 
 			{
@@ -160,6 +163,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 		static Action<IDbDataParameter> _setBoolean;
 		static Action<IDbDataParameter> _setXml;
 		static Action<IDbDataParameter> _setText;
+        static Action<IDbDataParameter> _setHstore;
 
 		public override void SetParameter(IDbDataParameter parameter, string name, DataType dataType, object value)
 		{
@@ -190,6 +194,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 				case DataType.Xml        : _setXml      (parameter);                   break;
 				case DataType.Text       :
 				case DataType.NText      : _setText     (parameter);                   break;
+                case DataType.Dictionary : _setHstore(parameter);                      break;
 				default                  : base.SetParameterType(parameter, dataType); break;
 			}
 		}

--- a/Source/DataProvider/PostgreSQL/PostgreSQLSchemaProvider.cs
+++ b/Source/DataProvider/PostgreSQL/PostgreSQLSchemaProvider.cs
@@ -32,6 +32,8 @@ namespace LinqToDB.DataProvider.PostgreSQL
 				new DataTypeInfo { TypeName = "bytea",                       DataType = typeof(byte[]).        FullName },
 				new DataTypeInfo { TypeName = "uuid",                        DataType = typeof(Guid).          FullName },
 
+                new DataTypeInfo { TypeName = "hstore",                      DataType = typeof(Dictionary<string, string>).FullName},
+
 				new DataTypeInfo { TypeName = "character varying",           DataType = typeof(string).        FullName, CreateFormat = "character varying({0})",            CreateParameters = "length" },
 				new DataTypeInfo { TypeName = "character",                   DataType = typeof(string).        FullName, CreateFormat = "character({0})",                    CreateParameters = "length" },
 				new DataTypeInfo { TypeName = "numeric",                     DataType = typeof(decimal).       FullName, CreateFormat = "numeric({0},{1})",                  CreateParameters = "precision,scale" },

--- a/Source/DataProvider/PostgreSQL/PostgreSQLTools.cs
+++ b/Source/DataProvider/PostgreSQL/PostgreSQLTools.cs
@@ -44,6 +44,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 		public static Type GetNpgsqlCircleType    () { return _postgreSQLDataProvider.NpgsqlCircleType;     }
 		public static Type GetNpgsqlMacAddressType() { return _postgreSQLDataProvider.NpgsqlMacAddressType; }
 
+
 		#region CreateDataConnection
 
 		public static DataConnection CreateDataConnection(string connectionString)

--- a/Source/DataType.cs
+++ b/Source/DataType.cs
@@ -202,6 +202,11 @@ namespace LinqToDB
 		/// </summary>
 		Udt,
 
+        /// <summary>
+        /// Dictionary type for key-value pairs
+        /// </summary>
+        Dictionary
+
 		/*
 		Structured	A special data type for specifying structured data contained in table-valued parameters.
 		*/

--- a/Source/DataType.cs
+++ b/Source/DataType.cs
@@ -206,7 +206,7 @@ namespace LinqToDB
         /// Dictionary type for key-value pairs
         /// </summary>
         Dictionary
-
+		
 		/*
 		Structured	A special data type for specifying structured data contained in table-valued parameters.
 		*/


### PR DESCRIPTION
Added support to npsql 3.x datetime and new datatype Dictionary for hstore key-value pairs that are now supported by npgsql driver.