### PR TITLE
Retrieving identity value by using the OUTPUT clause. MSSQL Server since 2005 version. #268

### DIFF
--- a/Source/DataProvider/SqlServer/SqlServer2000SqlBuilder.cs
+++ b/Source/DataProvider/SqlServer/SqlServer2000SqlBuilder.cs
@@ -19,19 +19,19 @@ namespace LinqToDB.DataProvider.SqlServer
 			return new SqlServer2000SqlBuilder(SqlOptimizer, SqlProviderFlags, ValueToSqlConverter);
 		}
 
-        protected override void BuildOutputSubclause()
-        {
-            // OUTPUT clause is only supported by the MS SQL Server starts with 2005 version.
-        }
+		protected override void BuildOutputSubclause()
+		{
+			// OUTPUT clause is only supported by the MS SQL Server starts with 2005 version.
+		}
 
-        protected override void BuildGetIdentity()
-        {
-            StringBuilder
-                .AppendLine()
-                .AppendLine("SELECT SCOPE_IDENTITY()");
-        }
+		protected override void BuildGetIdentity()
+		{
+			StringBuilder
+				.AppendLine()
+				.AppendLine("SELECT SCOPE_IDENTITY()");
+		}
 
-        protected override void BuildDataType(SqlDataType type, bool createDbType = false)
+		protected override void BuildDataType(SqlDataType type, bool createDbType = false)
 		{
 			switch (type.DataType)
 			{

--- a/Source/DataProvider/SqlServer/SqlServer2000SqlBuilder.cs
+++ b/Source/DataProvider/SqlServer/SqlServer2000SqlBuilder.cs
@@ -19,7 +19,19 @@ namespace LinqToDB.DataProvider.SqlServer
 			return new SqlServer2000SqlBuilder(SqlOptimizer, SqlProviderFlags, ValueToSqlConverter);
 		}
 
-		protected override void BuildDataType(SqlDataType type, bool createDbType = false)
+        protected override void BuildOutputSubclause()
+        {
+            // OUTPUT clause is only supported by the MS SQL Server starts with 2005 version.
+        }
+
+        protected override void BuildGetIdentity()
+        {
+            StringBuilder
+                .AppendLine()
+                .AppendLine("SELECT SCOPE_IDENTITY()");
+        }
+
+        protected override void BuildDataType(SqlDataType type, bool createDbType = false)
 		{
 			switch (type.DataType)
 			{

--- a/Source/DataProvider/SqlServer/SqlServerSqlBuilder.cs
+++ b/Source/DataProvider/SqlServer/SqlServerSqlBuilder.cs
@@ -36,10 +36,12 @@ namespace LinqToDB.DataProvider.SqlServer
 			{
 				var identityField = SelectQuery.Insert.Into.GetIdentityField();
 
-				if (identityField != null && identityField.DataType == DataType.Guid)
+				if (identityField != null)
 				{
 					StringBuilder
-						.AppendFormat("OUTPUT [INSERTED].[{0}]", identityField.Name)
+						.Append("OUTPUT [INSERTED].[")
+                        .Append(identityField.Name)
+                        .Append("]")
 						.AppendLine();
 				}
 			}
@@ -47,17 +49,11 @@ namespace LinqToDB.DataProvider.SqlServer
 
 		protected override void BuildGetIdentity()
 		{
-			var identityField = SelectQuery.Insert.Into.GetIdentityField();
+            // The better way of retrieving identity value is to use the OUTPUT clause
+            // (since MS SQL Server 2005).
+        }
 
-			if (identityField == null || identityField.DataType != DataType.Guid)
-			{
-				StringBuilder
-					.AppendLine()
-					.AppendLine("SELECT SCOPE_IDENTITY()");
-			}
-		}
-
-		protected override void BuildOrderByClause()
+        protected override void BuildOrderByClause()
 		{
 			if (!BuildAlternativeSql || !NeedSkip)
 				base.BuildOrderByClause();

--- a/Source/DataProvider/SqlServer/SqlServerSqlBuilder.cs
+++ b/Source/DataProvider/SqlServer/SqlServerSqlBuilder.cs
@@ -40,8 +40,8 @@ namespace LinqToDB.DataProvider.SqlServer
 				{
 					StringBuilder
 						.Append("OUTPUT [INSERTED].[")
-                        .Append(identityField.Name)
-                        .Append("]")
+						.Append(identityField.Name)
+						.Append("]")
 						.AppendLine();
 				}
 			}
@@ -49,11 +49,11 @@ namespace LinqToDB.DataProvider.SqlServer
 
 		protected override void BuildGetIdentity()
 		{
-            // The better way of retrieving identity value is to use the OUTPUT clause
-            // (since MS SQL Server 2005).
-        }
+			// The better way of retrieving identity value is to use the OUTPUT clause
+			// (since MS SQL Server 2005).
+		}
 
-        protected override void BuildOrderByClause()
+		protected override void BuildOrderByClause()
 		{
 			if (!BuildAlternativeSql || !NeedSkip)
 				base.BuildOrderByClause();


### PR DESCRIPTION
Replace SCOPE_IDENTITY() with OUTPUT for all types, not only for GUIDs,
SCOPE_IDENTITY also does not working with SEQUENCEs (MS SQL 2012).

http://www.sqlbadpractices.com/how-not-to-retrieve-identity-value/