### PR TITLE
Fixed column's Precision and Scale when creating table

### DIFF
--- a/Source/SqlQuery/SqlTable.cs
+++ b/Source/SqlQuery/SqlTable.cs
@@ -110,6 +110,12 @@ namespace LinqToDB.SqlQuery
 
 					if (field.Length == null)
 						field.Length = dataType.Length;
+
+					if (field.Precision == null)
+						field.Precision = dataType.Precision;
+
+					if (field.Scale == null)
+						field.Scale = dataType.Scale;
 				}
 			}
 

--- a/Tests/Linq/Tests.csproj
+++ b/Tests/Linq/Tests.csproj
@@ -331,6 +331,7 @@
     <Compile Include="TestBase.cs" />
     <Compile Include="Linq\WhereTest.cs" />
     <Compile Include="UserTests\CompareNullableChars.cs" />
+    <Compile Include="UserTests\CreateDecimalTableColumn.cs" />
     <Compile Include="UserTests\FirstOrDefaultNullReferenceExceptionTest.cs" />
     <Compile Include="UserTests\GenericsFilterTest.cs" />
     <Compile Include="UserTests\GroupBySubqueryTest.cs" />

--- a/Tests/Linq/UserTests/CreateDecimalTableColumn.cs
+++ b/Tests/Linq/UserTests/CreateDecimalTableColumn.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Linq;
+
+using LinqToDB;
+using LinqToDB.Mapping;
+using LinqToDB.SqlQuery;
+
+using NUnit.Framework;
+
+namespace Tests.UserTests
+{
+	[TestFixture]
+	public sealed class CreateDecimalTableColumn
+	{
+		[Test]
+		public void Test()
+		{
+			var schema = new MappingSchema();
+			schema.SetDataType(typeof (decimal), new SqlDataType(DataType.Decimal, 19, 4));
+
+			var table = new SqlTable<Foo>(schema);
+
+			Assert.That(table.Fields.Single().Value.Precision, Is.EqualTo(19));
+			Assert.That(table.Fields.Single().Value.Scale, Is.EqualTo(4));
+		}
+
+		class Foo
+		{
+			public decimal Field { get; set; }
+		}
+	}
+}


### PR DESCRIPTION
Hi!

I've noticed that 'Precision' and 'Scale' of SqlDataType are ignored when creating table. 
Here is posible fix and test.