### PR TITLE
Fixed MySql CAST operation

### DIFF
--- a/Source/DataProvider/MySql/MySqlSqlBuilder.cs
+++ b/Source/DataProvider/MySql/MySqlSqlBuilder.cs
@@ -57,39 +57,42 @@ namespace LinqToDB.DataProvider.MySql
 			}
 		}
 
-		protected override void BuildDataType(SqlDataType type, bool createDbType = false)
-		{
-			switch (type.DataType)
-			{
-				case DataType.Int32         :
-				case DataType.UInt16        :
-				case DataType.Int16         :
-					if (createDbType) goto default;
-					StringBuilder.Append("Signed");
-					break;
-				case DataType.SByte         :
-				case DataType.Byte          :
-					if (createDbType) goto default;
-					StringBuilder.Append("Unsigned");
-					break;
-				case DataType.Money         : StringBuilder.Append("Decimal(19,4)");   break;
-				case DataType.SmallMoney    : StringBuilder.Append("Decimal(10,4)");   break;
-				case DataType.DateTime2     :
-				case DataType.SmallDateTime : StringBuilder.Append("DateTime");        break;
-				case DataType.Boolean       : StringBuilder.Append("Boolean");         break;
-				case DataType.Double        :
-				case DataType.Single        : base.BuildDataType(SqlDataType.Decimal); break;
-				case DataType.VarChar       :
-				case DataType.NVarChar      :
-					StringBuilder.Append("Char");
-					if (type.Length > 0)
-						StringBuilder.Append('(').Append(type.Length).Append(')');
-					break;
-				default                     : base.BuildDataType(type); break;
-			}
-		}
+        protected override void BuildDataType(SqlDataType type, bool createDbType = false)
+        {
+            switch (type.DataType)
+            {
+                case DataType.Int16:
+                case DataType.Int32:
+                case DataType.Int64:
+                    if (createDbType) goto default;
+                    StringBuilder.Append("Signed");
+                    break;
+                case DataType.SByte:
+                case DataType.Byte:
+                case DataType.UInt16:
+                case DataType.UInt32:
+                case DataType.UInt64:
+                    if (createDbType) goto default;
+                    StringBuilder.Append("Unsigned");
+                    break;
+                case DataType.Money: StringBuilder.Append("Decimal(19,4)"); break;
+                case DataType.SmallMoney: StringBuilder.Append("Decimal(10,4)"); break;
+                case DataType.DateTime2:
+                case DataType.SmallDateTime: StringBuilder.Append("DateTime"); break;
+                case DataType.Boolean: StringBuilder.Append("Boolean"); break;
+                case DataType.Double:
+                case DataType.Single: base.BuildDataType(SqlDataType.Decimal); break;
+                case DataType.VarChar:
+                case DataType.NVarChar:
+                    StringBuilder.Append("Char");
+                    if (type.Length > 0)
+                        StringBuilder.Append('(').Append(type.Length).Append(')');
+                    break;
+                default: base.BuildDataType(type); break;
+            }
+        }
 
-		protected override void BuildDeleteClause()
+        protected override void BuildDeleteClause()
 		{
 			var table = SelectQuery.Delete.Table != null ?
 				(SelectQuery.From.FindTableSource(SelectQuery.Delete.Table) ?? SelectQuery.Delete.Table) :


### PR DESCRIPTION
 http://dev.mysql.com/doc/refman/5.7/en/cast-functions.html#function_cast

Previous behaviour: DataType.Int64 were built to default BIGINT which leads to error on sql side:
'You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'BIGINT) ='

Fixed: DataType.Int32, Int64, Int32 -> 'Signed', UInt16, UInt32, UInt64 -> 'Unsigned'