### PR TITLE
Rebind command return parameters

### DIFF
--- a/Source/Data/CommandInfo.cs
+++ b/Source/Data/CommandInfo.cs
@@ -582,7 +582,9 @@ namespace LinqToDB.Data
 				var dataParameter = parameters[i];
 
 				if (dataParameter.Direction.HasValue &&
-					(dataParameter.Direction == ParameterDirection.Output || dataParameter.Direction == ParameterDirection.InputOutput))
+					(dataParameter.Direction == ParameterDirection.Output ||
+					 dataParameter.Direction == ParameterDirection.InputOutput ||
+					 dataParameter.Direction == ParameterDirection.ReturnValue))
 				{
 					var dbParameter = (IDbDataParameter)dbParameters[i];
 


### PR DESCRIPTION
If a command requires a parameter with `ParameterDirection.ReturnValue`,
its value must also be rebound after execution.

Otherwise e.g. calling an Oracle PL/SQL stored procedure that returns a value can be called, but the result cannot be obtained.
