### PR TITLE
Add missing extension method ExecuteProc<T>

### DIFF
--- a/Source/Data/DataConnectionExtensions.cs
+++ b/Source/Data/DataConnectionExtensions.cs
@@ -140,6 +140,11 @@ namespace LinqToDB.Data
 			return new CommandInfo(connection, sql, parameters).Execute<T>();
 		}
 
+		public static T ExecuteProc<T>(this DataConnection connection, string sql, params DataParameter[] parameters)
+		{
+			return new CommandInfo(connection, sql, parameters).ExecuteProc<T>();
+		}
+
 		public static T Execute<T>(this DataConnection connection, string sql, DataParameter parameter)
 		{
 			return new CommandInfo(connection, sql, parameter).Execute<T>();


### PR DESCRIPTION
`CommandInfo` provides the method `ExecuteProc<T>` to execute scalar
commands. This pull request adds the missing extension method to call it
directly via a `DataConnection` object.
