### PR TITLE
T4 Oracle Template does not generate XML code comments for columns.

### DIFF
--- a/Source/DataProvider/Oracle/OracleSchemaProvider.cs
+++ b/Source/DataProvider/Oracle/OracleSchemaProvider.cs
@@ -93,20 +93,20 @@ namespace LinqToDB.DataProvider.Oracle
 		{
 			return dataConnection.Query<ColumnInfo>(@"
 				SELECT 
-					c.OWNER || '.' || c.TABLE_NAME as TableID,
-					c.COLUMN_NAME as Name,
-					c.DATA_TYPE as DataType,
-					CASE c.NULLABLE WHEN 'Y' THEN 1 ELSE 0 END as IsNullable,
-					c.COLUMN_ID as Ordinal,
-					c.DATA_LENGTH as Length,
-					c.DATA_PRECISION as Precision,
-					c.DATA_SCALE as Scale,
-					0 as IsIdentity,
-					cc.COMMENTS as Description
+					c.OWNER || '.' || c.TABLE_NAME				as TableID,
+					c.COLUMN_NAME								as Name,
+					c.DATA_TYPE									as DataType,
+					CASE c.NULLABLE WHEN 'Y' THEN 1 ELSE 0 END	as IsNullable,
+					c.COLUMN_ID									as Ordinal,
+					c.DATA_LENGTH								as Length,
+					c.DATA_PRECISION							as Precision,
+					c.DATA_SCALE								as Scale,
+					0											as IsIdentity,
+					cc.COMMENTS									as Description
 				FROM ALL_TAB_COLUMNS c
-					JOIN USER_COL_COMMENTS cc
-						ON c.TABLE_NAME = cc.TABLE_NAME
-						AND c.COLUMN_NAME = cc.COLUMN_NAME
+					JOIN USER_COL_COMMENTS cc ON
+						c.TABLE_NAME = cc.TABLE_NAME AND
+						c.COLUMN_NAME = cc.COLUMN_NAME
 				ORDER BY TableID, Ordinal
 				")
 			.ToList();

--- a/Source/DataProvider/Oracle/OracleSchemaProvider.cs
+++ b/Source/DataProvider/Oracle/OracleSchemaProvider.cs
@@ -93,16 +93,16 @@ namespace LinqToDB.DataProvider.Oracle
 		{
 			return dataConnection.Query<ColumnInfo>(@"
 				SELECT 
-					c.OWNER || '.' || c.TABLE_NAME				as TableID,
-					c.COLUMN_NAME								as Name,
-					c.DATA_TYPE									as DataType,
-					CASE c.NULLABLE WHEN 'Y' THEN 1 ELSE 0 END	as IsNullable,
-					c.COLUMN_ID									as Ordinal,
-					c.DATA_LENGTH								as Length,
-					c.DATA_PRECISION							as Precision,
-					c.DATA_SCALE								as Scale,
-					0											as IsIdentity,
-					cc.COMMENTS									as Description
+					c.OWNER || '.' || c.TABLE_NAME             as TableID,
+					c.COLUMN_NAME                              as Name,
+					c.DATA_TYPE                                as DataType,
+					CASE c.NULLABLE WHEN 'Y' THEN 1 ELSE 0 END as IsNullable,
+					c.COLUMN_ID                                as Ordinal,
+					c.DATA_LENGTH                              as Length,
+					c.DATA_PRECISION                           as Precision,
+					c.DATA_SCALE                               as Scale,
+					0                                          as IsIdentity,
+					cc.COMMENTS                                as Description
 				FROM ALL_TAB_COLUMNS c
 					JOIN USER_COL_COMMENTS cc ON
 						c.TABLE_NAME = cc.TABLE_NAME AND

--- a/Source/DataProvider/Oracle/OracleSchemaProvider.cs
+++ b/Source/DataProvider/Oracle/OracleSchemaProvider.cs
@@ -91,25 +91,53 @@ namespace LinqToDB.DataProvider.Oracle
 
 		protected override List<ColumnInfo> GetColumns(DataConnection dataConnection)
 		{
-			return dataConnection.Query<ColumnInfo>(@"
-				SELECT 
-					c.OWNER || '.' || c.TABLE_NAME             as TableID,
-					c.COLUMN_NAME                              as Name,
-					c.DATA_TYPE                                as DataType,
-					CASE c.NULLABLE WHEN 'Y' THEN 1 ELSE 0 END as IsNullable,
-					c.COLUMN_ID                                as Ordinal,
-					c.DATA_LENGTH                              as Length,
-					c.DATA_PRECISION                           as Precision,
-					c.DATA_SCALE                               as Scale,
-					0                                          as IsIdentity,
-					cc.COMMENTS                                as Description
-				FROM ALL_TAB_COLUMNS c
-					JOIN USER_COL_COMMENTS cc ON
-						c.TABLE_NAME = cc.TABLE_NAME AND
-						c.COLUMN_NAME = cc.COLUMN_NAME
-				ORDER BY TableID, Ordinal
-				")
-			.ToList();
+			if (IncludedSchemas.Length != 0 || ExcludedSchemas.Length != 0)
+			{
+				// This is very slow
+				return dataConnection.Query<ColumnInfo>(@"
+					SELECT
+						c.OWNER || '.' || c.TABLE_NAME             as TableID,
+						c.COLUMN_NAME                              as Name,
+						c.DATA_TYPE                                as DataType,
+						CASE c.NULLABLE WHEN 'Y' THEN 1 ELSE 0 END as IsNullable,
+						c.COLUMN_ID                                as Ordinal,
+						c.DATA_LENGTH                              as Length,
+						c.DATA_PRECISION                           as Precision,
+						c.DATA_SCALE                               as Scale,
+						0                                          as IsIdentity,
+						cc.COMMENTS                                as Description
+					FROM ALL_TAB_COLUMNS c
+						JOIN ALL_COL_COMMENTS cc ON
+							c.OWNER       = cc.OWNER      AND
+							c.TABLE_NAME  = cc.TABLE_NAME AND
+							c.COLUMN_NAME = cc.COLUMN_NAME
+					ORDER BY TableID, Ordinal
+					")
+				.ToList();
+			}
+			else
+			{
+				// This is significally faster
+				return dataConnection.Query<ColumnInfo>(@"
+					SELECT 
+						(SELECT USER FROM DUAL) || '.' || c.TABLE_NAME as TableID,
+						c.COLUMN_NAME                                  as Name,
+						c.DATA_TYPE                                    as DataType,
+						CASE c.NULLABLE WHEN 'Y' THEN 1 ELSE 0 END     as IsNullable,
+						c.COLUMN_ID                                    as Ordinal,
+						c.DATA_LENGTH                                  as Length,
+						c.DATA_PRECISION                               as Precision,
+						c.DATA_SCALE                                   as Scale,
+						0                                              as IsIdentity,
+						cc.COMMENTS                                    as Description
+				    FROM USER_TAB_COLUMNS c
+						JOIN USER_COL_COMMENTS cc ON
+							c.TABLE_NAME  = cc.TABLE_NAME AND
+							c.COLUMN_NAME = cc.COLUMN_NAME
+					ORDER BY TableID, Ordinal
+					")
+				.ToList();
+			}
 		}
 
 		protected override List<ForeingKeyInfo> GetForeignKeys(DataConnection dataConnection)

--- a/Source/DataProvider/Oracle/OracleSchemaProvider.cs
+++ b/Source/DataProvider/Oracle/OracleSchemaProvider.cs
@@ -130,7 +130,7 @@ namespace LinqToDB.DataProvider.Oracle
 						c.DATA_SCALE                                   as Scale,
 						0                                              as IsIdentity,
 						cc.COMMENTS                                    as Description
-				    FROM USER_TAB_COLUMNS c
+					FROM USER_TAB_COLUMNS c
 						JOIN USER_COL_COMMENTS cc ON
 							c.TABLE_NAME  = cc.TABLE_NAME AND
 							c.COLUMN_NAME = cc.COLUMN_NAME


### PR DESCRIPTION
I have comments on columns in DB. But Oracle T4 Template does not fill Description properties on ColumnInfo's. Therefore there no XML comments on the generated code.
#452 