### PR TITLE
Disable Clear of oderbys

### DIFF
--- a/Source/Common/Configuration.cs
+++ b/Source/Common/Configuration.cs
@@ -13,6 +13,7 @@ namespace LinqToDB.Common
 			public static bool IgnoreEmptyUpdate;
 			public static bool AllowMultipleQuery;
 			public static bool GenerateExpressionTest;
+			public static bool DoNotClearOrderBys;
 		}
 
 		public static class LinqService

--- a/Source/Linq/Builder/OrderByBuilder.cs
+++ b/Source/Linq/Builder/OrderByBuilder.cs
@@ -50,8 +50,8 @@ namespace LinqToDB.Linq.Builder
 
 			builder.ReplaceParent(order, sparent);
 
-			if (!methodCall.Method.Name.StartsWith("Then"))
-				sequence.SelectQuery.OrderBy.Items.Clear();
+			//if (!methodCall.Method.Name.StartsWith("Then"))
+			//	sequence.SelectQuery.OrderBy.Items.Clear();
 
 			foreach (var expr in sql)
 			{

--- a/Source/Linq/Builder/OrderByBuilder.cs
+++ b/Source/Linq/Builder/OrderByBuilder.cs
@@ -50,8 +50,8 @@ namespace LinqToDB.Linq.Builder
 
 			builder.ReplaceParent(order, sparent);
 
-			//if (!methodCall.Method.Name.StartsWith("Then"))
-			//	sequence.SelectQuery.OrderBy.Items.Clear();
+			if (!methodCall.Method.Name.StartsWith("Then") && !Configuration.Linq.DoNotClearOrderBys)
+				sequence.SelectQuery.OrderBy.Items.Clear();
 
 			foreach (var expr in sql)
 			{

--- a/Tests/Linq/Linq/OrderByTests.cs
+++ b/Tests/Linq/Linq/OrderByTests.cs
@@ -159,6 +159,30 @@ namespace Tests.Linq
 		}
 
 		[Test, DataContextSource]
+		public void OrderBy7(string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				LinqToDB.Common.Configuration.Linq.DoNotClearOrderBys = true;
+
+				var expected =
+					from ch in Child
+					orderby ch.ChildID % 2, ch.ChildID
+					select new { ch };
+
+				var result =
+					from ch in db.Child
+					orderby ch.ChildID % 2
+					select new { ch };
+
+				result = result.OrderBy(x => x.ch.ChildID);
+
+
+				Assert.IsTrue(result.ToList().SequenceEqual(expected));
+			}
+		}
+
+		[Test, DataContextSource]
 		public void OrderBySelf1(string context)
 		{
 			using (var db = GetDataContext(context))


### PR DESCRIPTION
If you hav nested Queryables, your object may become a Iqueryable again so you cannot use ThenBy. So don't clear orderbys