### PR TITLE
Add appropriate oracle type for datetimeoffset to SQL builder

### DIFF
--- a/Source/DataProvider/Oracle/OracleSqlBuilder.cs
+++ b/Source/DataProvider/Oracle/OracleSqlBuilder.cs
@@ -196,8 +196,9 @@ namespace LinqToDB.DataProvider.Oracle
 		{
 			switch (type.DataType)
 			{
-				case DataType.DateTime   : StringBuilder.Append("timestamp");    break;
-				case DataType.DateTime2  : StringBuilder.Append("timestamp");    break;
+				case DataType.DateTime       : StringBuilder.Append("timestamp");    break;
+				case DataType.DateTime2      : StringBuilder.Append("timestamp");    break;
+                case DataType.DateTimeOffset : StringBuilder.Append("timestamp with time zone");  break;
 				case DataType.UInt32     :
 				case DataType.Int64      : StringBuilder.Append("Number(19)");   break;
 				case DataType.SByte      :


### PR DESCRIPTION
Added DateTimeOffset to oracle create test, and verified I could write a date in and read it back out the same. Ultimately didn't leave it in the test project.