### PR TITLE
Proposal for adding fluent mapping api for associations

### DIFF
--- a/Source/Mapping/EntityMappingBuilder.cs
+++ b/Source/Mapping/EntityMappingBuilder.cs
@@ -115,7 +115,20 @@ namespace LinqToDB.Mapping
 			return new PropertyMappingBuilder<T>(this, func);
 		}
 
-		public EntityMappingBuilder<T> HasPrimaryKey(Expression<Func<T,object>> func, int order = -1)
+        public PropertyMappingBuilder<T> Association<S, ID1, ID2>(
+            Expression<Func<T, S>> prop,
+            Expression<Func<T, ID1>> thisKey,
+            Expression<Func<S, ID2>> otherKey )
+        {
+            var thisKeyName = ((MemberExpression)thisKey.Body).Member.Name;
+            var otherKeyName = ((MemberExpression)otherKey.Body).Member.Name;
+
+            var objProp = Expression.Lambda<Func<T, object>>( prop.Body, prop.Parameters );
+
+            return Property( objProp ).IsNotColumn().HasAttribute( new AssociationAttribute { ThisKey = thisKeyName, OtherKey = otherKeyName } );
+        }
+
+        public EntityMappingBuilder<T> HasPrimaryKey(Expression<Func<T,object>> func, int order = -1)
 		{
 			var n = 0;
 

--- a/Source/Mapping/PropertyMappingBuilder.cs
+++ b/Source/Mapping/PropertyMappingBuilder.cs
@@ -46,7 +46,15 @@ namespace LinqToDB.Mapping
 			return _entity.Property(func);
 		}
 
-		public PropertyMappingBuilder<T> IsPrimaryKey(int order = -1)
+        public PropertyMappingBuilder<T> Association<S, ID1, ID2>(
+            Expression<Func<T, S>> prop,
+            Expression<Func<T, ID1>> thisKey,
+            Expression<Func<S, ID2>> otherKey )
+        {
+            return _entity.Association( prop, thisKey, otherKey );
+        }
+
+        public PropertyMappingBuilder<T> IsPrimaryKey(int order = -1)
 		{
 			_entity.HasPrimaryKey(_memberGetter, order);
 			return this;

--- a/Tests/Linq/Mapping/FluentMappingTests.cs
+++ b/Tests/Linq/Mapping/FluentMappingTests.cs
@@ -178,5 +178,19 @@ namespace Tests.Mapping
 
 			Assert.That(ed["Class3"], Is.Not.Null);
 		}
-	}
+
+        [Test]
+        public void FluentAssociation()
+        {
+            var ms = new MappingSchema();
+            var mb = ms.GetFluentMappingBuilder();
+
+            mb.Entity<MyClass>()
+                .Association( e => e.Parent, e => e.ID, o => o.ID1 );
+
+            var ed = ms.GetEntityDescriptor(typeof(MyClass));
+
+            Assert.That( ed.Associations, Is.Not.EqualTo( 0 ) );
+        }
+    }
 }


### PR DESCRIPTION
Hi.

I like to keep my models free of mapping attributes, and my mapping free of stringy property names, which is easily done by using the fluent mapping api. Except for associations, which doesn't seem to enjoy any fluent support. To fix that I've been using the below extension method. It works great, but I thought I'd try and submit it as a proper addition to the fluent mapping, so here you go.

```cs
using System;
using System.Linq.Expressions;

using LinqToDB.Mapping;

namespace Actimizer.LRM.Linq2DB.Mappers
{
    public static class MapperExtensions
    {
        //private static GetMemberName( Expression expr )
        //{
        //    ExpressionVisitor

        //}

        public static PropertyMappingBuilder<T> Association<T,S,ID1,ID2>( 
            this PropertyMappingBuilder<T> pmb, 
            Expression<Func<T, S>> prop, 
            Expression<Func<T, ID1>> thisKey, 
            Expression<Func<S, ID2>> otherKey )
        {
            var thisKeyName = ((MemberExpression)thisKey.Body).Member.Name;
            var otherKeyName = ((MemberExpression)otherKey.Body).Member.Name;

            var objProp = Expression.Lambda<Func<T, object>>( prop.Body, prop.Parameters );

            return pmb.Property( objProp ).IsNotColumn().HasAttribute( new AssociationAttribute { ThisKey = thisKeyName, OtherKey = otherKeyName } );
        }

        public static PropertyMappingBuilder<T> IsNotNullable<T>(
            this PropertyMappingBuilder<T> pmb )
        {
            return pmb.IsNullable( false );
        }
    }
}
```