### PR TITLE
Adding support for fsharp climutable attribute

### DIFF
--- a/Tests/FSharp/Models.fs
+++ b/Tests/FSharp/Models.fs
@@ -3,28 +3,28 @@
 open LinqToDB
 open LinqToDB.Mapping
 
-type Gender = 
+type Gender =
     | [<MapValue("M")>] Male = 0
     | [<MapValue("F")>] Female = 1
-    | [<MapValue("U")>] Unknown = 2 
+    | [<MapValue("U")>] Unknown = 2
     | [<MapValue("O")>] Other = 3
 type PersonID = int
 
-type Person = 
+type Person =
     { [<SequenceName(ProviderName.Firebird, "PersonID")>]
       [<Column("PersonID"); Identity; PrimaryKey>]
-      ID : int 
-      [<NotNull>] 
+      ID : int
+      [<NotNull>]
       FirstName : string
       [<NotNull>]
       LastName : string
       [<Nullable>]
-      MiddleName : string 
+      MiddleName : string
       Gender : Gender }
 //      [<Association(ThisKey = "ID", OtherKey = "PersonID", CanBeNull=true)>]
 //      Patient : Patient }
 
-type Child = 
+type Child =
     { [<PrimaryKey>] ParentID : int
       [<PrimaryKey>] ChildID : int }
 
@@ -37,7 +37,7 @@ type NestedFullName = { FirstName : string; MiddleName: string; LastName: LastNa
 [<Column("FirstName",  "Name.FirstName")>]
 [<Column("MiddleName", "Name.MiddleName")>]
 [<Column("LastName",   "Name.LastName")>]
-type ComplexPerson = 
+type ComplexPerson =
     { [<Identity>]
       [<SequenceName(ProviderName.Firebird, "PersonID")>]
       [<Column("PersonID", IsPrimaryKey=true)>]
@@ -49,7 +49,7 @@ type ComplexPerson =
 [<Column("FirstName",  "Name.FirstName")>]
 [<Column("MiddleName", "Name.MiddleName")>]
 [<Column("LastName",   "Name.LastName.Value")>]
-type DeeplyComplexPerson = 
+type DeeplyComplexPerson =
     { [<Identity>]
       [<SequenceName(ProviderName.Firebird, "PersonID")>]
       [<Column("PersonID", IsPrimaryKey=true)>]
@@ -70,14 +70,38 @@ type DeeplyComplexPerson =
 // .AddScalarType(typeof<string option>,          None, LinqToDB.DataType.NVarChar)
 // .SetConvertExpression<Option<_>,_>( fun x -> if x.IsSome then x.Value else None )
 [<Table("Person", IsColumnAttributeRequired=false)>]
-type PersonWithOptions = 
+type PersonWithOptions =
     { [<SequenceName(ProviderName.Firebird, "PersonID")>]
       [<Column("PersonID"); Identity; PrimaryKey>]
-      ID : int 
-      [<NotNull>] 
+      ID : int
+      [<NotNull>]
       FirstName : string
       [<Nullable>]
       LastName : string option
       [<Nullable>]
       MiddleName : string option
       Gender : Gender }
+
+
+
+type [<CLIMutable; Table("Person", IsColumnAttributeRequired=false)>]
+    PersonCLIMutable =
+    { [<SequenceName(ProviderName.Firebird, "PersonID")>]
+      [<Column("PersonID"); Identity; PrimaryKey>]
+      ID : int
+      [<NotNull>]
+      FirstName : string
+      [<NotNull>]
+      LastName : string
+      [<Nullable>]
+      MiddleName : string
+      Gender : Gender
+      [<Association(ThisKey = "ID", OtherKey = "PersonID", CanBeNull=true)>]
+      Patient : PatientCLIMutable }
+and [<CLIMutable; Table("Patient", IsColumnAttributeRequired=false)>]
+    PatientCLIMutable =
+    { [<PrimaryKey>]
+      PersonID : PersonID
+      Diagnosis : string
+      [<Association(ThisKey = "PersonID", OtherKey = "ID", CanBeNull = false)>]
+      Person : PersonCLIMutable }

--- a/Tests/FSharp/WhereTest.fs
+++ b/Tests/FSharp/WhereTest.fs
@@ -1,12 +1,14 @@
 ﻿module Tests.FSharp.WhereTest
 
+open System
+
 open Tests.FSharp.Models
 
 open LinqToDB
 open LinqToDB.Mapping
 open NUnit.Framework
 
-let private TestOnePerson id firstName persons = 
+let private TestOnePerson id firstName persons =
     let list = persons :> Person System.Linq.IQueryable |> Seq.toList
     Assert.AreEqual(1, list |> List.length )
 
@@ -17,10 +19,10 @@ let private TestOnePerson id firstName persons =
 
 let TestOneJohn = TestOnePerson 1 "John"
 
-let TestMethod() = 
+let TestMethod() =
     1
 
-let LoadSingle (db : IDataContext) = 
+let LoadSingle (db : IDataContext) =
     let persons = db.GetTable<Person>()
     TestOneJohn(query {
         for p in persons do
@@ -28,7 +30,7 @@ let LoadSingle (db : IDataContext) =
         select p
     })
 
-let LoadSingleComplexPerson (db : IDataContext) = 
+let LoadSingleComplexPerson (db : IDataContext) =
     let persons = db.GetTable<ComplexPerson>()
     let john = query {
         for p in persons do
@@ -41,7 +43,7 @@ let LoadSingleComplexPerson (db : IDataContext) =
           Gender="M" }
         , john)
 
-let LoadSingleDeeplyComplexPerson (db : IDataContext) = 
+let LoadSingleDeeplyComplexPerson (db : IDataContext) =
     let persons = db.GetTable<DeeplyComplexPerson>()
     let john = query {
         for p in persons do
@@ -54,7 +56,7 @@ let LoadSingleDeeplyComplexPerson (db : IDataContext) =
           Gender="M" }
         , john)
 
-let LoadColumnOfDeeplyComplexPerson (db : IDataContext) = 
+let LoadColumnOfDeeplyComplexPerson (db : IDataContext) =
     let persons = db.GetTable<DeeplyComplexPerson>()
     let lastName = query {
         for p in persons do
@@ -64,7 +66,7 @@ let LoadColumnOfDeeplyComplexPerson (db : IDataContext) =
     }
     Assert.AreEqual("Pupkin", lastName)
 
-let LoadSingleWithOptions (db : IDataContext) = 
+let LoadSingleWithOptions (db : IDataContext) =
     let persons = db.GetTable<PersonWithOptions>()
     let john = query {
         for p in persons do
@@ -83,3 +85,15 @@ let LoadSingleWithOptions (db : IDataContext) =
     Assert.IsTrue( match john.MiddleName with |None -> true;  |Some _ -> false );
     Assert.IsTrue( match john.LastName   with |None -> false; |Some _ -> true );
 
+
+
+let LoadSingleCLIMutable (db : IDataContext) =
+    let persons = db.GetTable<PersonCLIMutable>().LoadWith( fun x -> x.Patient :> Object )
+    let john = query {
+        for p in persons do
+        where (p.ID = TestMethod())
+        exactlyOne
+    }
+
+    Assert.IsNotNull( john.Patient )
+    Assert.AreEqual( john.Patient.PersonID, 1 )

--- a/Tests/FSharp/WhereTest.fs
+++ b/Tests/FSharp/WhereTest.fs
@@ -87,13 +87,25 @@ let LoadSingleWithOptions (db : IDataContext) =
 
 
 
-let LoadSingleCLIMutable (db : IDataContext) =
+let LoadSingleCLIMutable (db : IDataContext)  (nullPatient : PatientCLIMutable)  =
     let persons = db.GetTable<PersonCLIMutable>().LoadWith( fun x -> x.Patient :> Object )
     let john = query {
         for p in persons do
-        where (p.ID = TestMethod())
+        where (p.ID = 1)
         exactlyOne
     }
 
-    Assert.IsNotNull( john.Patient )
-    Assert.AreEqual( john.Patient.PersonID, 1 )
+    Assert.IsNotNull( john )
+    Assert.AreEqual( john.ID, 1 )
+    Assert.IsNull( john.Patient )
+
+    let tester = query {
+        for p in persons do
+        where (p.ID = 2)
+        exactlyOne
+    }
+
+    Assert.IsNotNull( tester )
+    Assert.AreEqual( tester.ID, 2 )
+    Assert.IsNotNull( tester.Patient )
+    Assert.AreEqual( tester.Patient.PersonID, 2 )

--- a/Tests/Linq/Linq/FSharpTests.cs
+++ b/Tests/Linq/Linq/FSharpTests.cs
@@ -25,7 +25,14 @@ namespace Tests.Linq
 				FSharp.WhereTest.LoadSingleWithOptions(db);
 		}
 
-		[Test, DataContextSource]
+        [Test, DataContextSource]
+        public void LoadSingleCLIMutable(string context)
+        {
+            using (var db = GetDataContext(context))
+                FSharp.WhereTest.LoadSingleCLIMutable(db);
+        }
+
+        [Test, DataContextSource]
 		public void LoadSingleComplexPerson(string context)
 		{
 			using (var db = GetDataContext(context))

--- a/Tests/Linq/Linq/FSharpTests.cs
+++ b/Tests/Linq/Linq/FSharpTests.cs
@@ -29,7 +29,7 @@ namespace Tests.Linq
         public void LoadSingleCLIMutable(string context)
         {
             using (var db = GetDataContext(context))
-                FSharp.WhereTest.LoadSingleCLIMutable(db);
+                FSharp.WhereTest.LoadSingleCLIMutable(db, null);
         }
 
         [Test, DataContextSource]


### PR DESCRIPTION
Hi.

To make Entity Framework work with F# records, you have to mark the records with the CLIMutableAttribute. This makes the porperties settable from other CLR languages, but still read-only from F#. It works pretty well.

I have a bunch of EF models that I'm trying to migrate to linq2db, but ironically linq2dbs support for records made this problematic for two reasons:

1. Linq2db exprect that records have only 1 constructor, but the CLIMutable attribute causes the record class to also have a default constructor.
2. Linq2db doesn't support relational properties for true records.

This pull request deals with 1.

I didn't plan on keeping the CLIMutable attribute, but reason number 2 made it the easier option to begin with. I have one more PR coming which implements relational properties for true records, but it's a bit more invasive, so to avoid getting delayed by a long feedback cycle, I'm starting with this simpler option.

All I've done is to extend how a record is recognized. If a CLIMutable attribute is present it's treated as a normal class.

I'm sorry about the space formatting btw. F# power tools is very insistent. I'll try to limit that in the future.
