### PR TITLE
Adding F# sharp record support for relational properties

### DIFF
--- a/Source/Linq/Builder/TableBuilder.cs
+++ b/Source/Linq/Builder/TableBuilder.cs
@@ -361,8 +361,8 @@ namespace LinqToDB.Linq.Builder
 						Builder.MappingSchema.GetAttributes<Attribute>(m.MemberInfo).Any(IsRecordAttribute)) :
 					typeAccessor.Members;
 
-                var loadWith = GetLoadWith();
-                var loadWithItems = loadWith == null ? new List<LoadWithItem>() : GetLoadWith(loadWith);
+				var loadWith = GetLoadWith();
+				var loadWithItems = loadWith == null ? new List<LoadWithItem>() : GetLoadWith(loadWith);
 				foreach (var member in members)
 				{
 					var column = columns.FirstOrDefault(c => !c.IsComplex && c.Name == member.Name);
@@ -370,77 +370,77 @@ namespace LinqToDB.Linq.Builder
 					if (column != null)
 					{
 						yield return column.Expression;
-                    }
-                    else
-                    {
-                        var assocAttr = Builder.MappingSchema.GetAttributes<AssociationAttribute>(member.MemberInfo).FirstOrDefault();
-                        bool isAssociation = assocAttr != null;
-                        if (isAssociation)
-                        {
-                            var loadWithItem = loadWithItems.FirstOrDefault(_ => _.MemberInfo == member.MemberInfo);
-                            if (loadWithItem != null)
-                            {
-                                var ma = Expression.MakeMemberAccess(Expression.Constant(null, typeAccessor.Type), member.MemberInfo);
-                                if (loadWithItem.NextLoadWith.Count > 0)
-                                {
-                                    var table = FindTable(ma, 1, false, true);
-                                    table.Table.LoadWith = loadWithItem.NextLoadWith;
-                                }
-                                yield return BuildExpression(ma, 1);
-                            }
 					}
 					else
 					{
-						var name = member.Name + '.';
-						var cols = columns.Where(c => c.IsComplex && c.Name.StartsWith(name)).ToList();
-
-						if (cols.Count == 0)
+						var assocAttr = Builder.MappingSchema.GetAttributes<AssociationAttribute>(member.MemberInfo).FirstOrDefault();
+						bool isAssociation = assocAttr != null;
+						if (isAssociation)
 						{
-							yield return null;
+							var loadWithItem = loadWithItems.FirstOrDefault(_ => _.MemberInfo == member.MemberInfo);
+							if (loadWithItem != null)
+							{
+								var ma = Expression.MakeMemberAccess(Expression.Constant(null, typeAccessor.Type), member.MemberInfo);
+								if (loadWithItem.NextLoadWith.Count > 0)
+								{
+									var table = FindTable(ma, 1, false, true);
+									table.Table.LoadWith = loadWithItem.NextLoadWith;
+								}
+								yield return BuildExpression(ma, 1);
+							}
 						}
 						else
 						{
-							foreach (var col in cols)
+							var name = member.Name + '.';
+							var cols = columns.Where(c => c.IsComplex && c.Name.StartsWith(name)).ToList();
+
+							if (cols.Count == 0)
 							{
-								col.Name      = col.Name.Substring(name.Length);
-								col.IsComplex = col.Name.Contains(".");
-							}
-
-							var typeAcc = TypeAccessor.GetAccessor(member.Type);
-							var isRec   = Builder.MappingSchema.GetAttributes<Attribute>(member.Type).Any(IsRecordAttribute);
-
-							var exprs = GetExpressions(typeAcc, isRec, cols).ToList();
-
-							if (isRec)
-							{
-								var ctor      = member.Type.GetConstructorsEx().Single();
-								var ctorParms = ctor.GetParameters();
-
-								var parms =
-								(
-									from p in ctorParms.Select((p,i) => new { p, i })
-									join e in exprs.Select((e,i) => new { e, i }) on p.i equals e.i into j
-									from e in j.DefaultIfEmpty()
-									select
-										e.e ?? Expression.Constant(p.p.DefaultValue ?? Builder.MappingSchema.GetDefaultValue(p.p.ParameterType), p.p.ParameterType)
-								).ToList();
-
-								yield return Expression.New(ctor, parms);
+								yield return null;
 							}
 							else
 							{
-								var expr = Expression.MemberInit(
-									Expression.New(member.Type),
-									from m in typeAcc.Members.Zip(exprs, (m,e) => new { m, e })
-									where m.e != null
-									select (MemberBinding)Expression.Bind(m.m.MemberInfo, m.e));
+								foreach (var col in cols)
+								{
+									col.Name      = col.Name.Substring(name.Length);
+									col.IsComplex = col.Name.Contains(".");
+								}
 
-								yield return expr;
+								var typeAcc = TypeAccessor.GetAccessor(member.Type);
+								var isRec   = Builder.MappingSchema.GetAttributes<Attribute>(member.Type).Any(IsRecordAttribute);
+
+								var exprs = GetExpressions(typeAcc, isRec, cols).ToList();
+
+								if (isRec)
+								{
+									var ctor      = member.Type.GetConstructorsEx().Single();
+									var ctorParms = ctor.GetParameters();
+
+									var parms =
+									(
+										from p in ctorParms.Select((p,i) => new { p, i })
+										join e in exprs.Select((e,i) => new { e, i }) on p.i equals e.i into j
+										from e in j.DefaultIfEmpty()
+										select
+											e.e ?? Expression.Constant(p.p.DefaultValue ?? Builder.MappingSchema.GetDefaultValue(p.p.ParameterType), p.p.ParameterType)
+									).ToList();
+
+									yield return Expression.New(ctor, parms);
+								}
+								else
+								{
+									var expr = Expression.MemberInit(
+										Expression.New(member.Type),
+										from m in typeAcc.Members.Zip(exprs, (m,e) => new { m, e })
+										where m.e != null
+										select (MemberBinding)Expression.Bind(m.m.MemberInfo, m.e));
+
+									yield return expr;
+								}
 							}
 						}
 					}
 				}
-			}
 			}
 
 			Expression BuildRecordConstructor(EntityDescriptor entityDescriptor, Type objectType, int[] index)

--- a/Tests/FSharp/Models.fs
+++ b/Tests/FSharp/Models.fs
@@ -20,9 +20,16 @@ type Person =
       LastName : string
       [<Nullable>]
       MiddleName : string 
-      Gender : Gender }
-//      [<Association(ThisKey = "ID", OtherKey = "PersonID", CanBeNull=true)>]
-//      Patient : Patient }
+      Gender : Gender
+      [<Association(ThisKey = "ID", OtherKey = "PersonID", CanBeNull=true)>]
+      Patient : Patient }
+and Patient =
+    { [<PrimaryKey>]
+      PersonID : PersonID
+      [<Nullable>]
+      Diagnosis : string
+      [<Association(ThisKey = "PersonID", OtherKey = "ID", CanBeNull = false)>]
+      Person : Person }
 
 type Child = 
     { [<PrimaryKey>] ParentID : int

--- a/Tests/FSharp/WhereTest.fs
+++ b/Tests/FSharp/WhereTest.fs
@@ -1,5 +1,7 @@
 ﻿module Tests.FSharp.WhereTest
 
+open System
+
 open Tests.FSharp.Models
 
 open LinqToDB
@@ -27,6 +29,33 @@ let LoadSingle (db : IDataContext) =
         where (p.ID = TestMethod())
         select p
     })
+
+
+let LoadSinglesWithPatient (db : IDataContext) = 
+    let persons = db.GetTable<Person>().LoadWith( fun x -> x.Patient :> Object )
+    let johnId = 1
+    let john = query {
+        for p in persons do
+        where (p.ID = johnId)
+        exactlyOne
+    }
+
+    Assert.AreEqual(johnId, john.ID)
+    Assert.AreEqual("John", john.FirstName)
+    Assert.IsNull( john.Patient)
+
+    let testerId = 2
+    let tester = query {
+        for p in persons do
+        where (p.ID = testerId)
+        exactlyOne
+    }
+
+    Assert.AreEqual(testerId, tester.ID)
+    Assert.AreEqual("Tester", tester.FirstName)
+    Assert.IsNotNull( tester.Patient)
+    Assert.AreEqual( tester.Patient.PersonID, testerId )
+
 
 let LoadSingleComplexPerson (db : IDataContext) = 
     let persons = db.GetTable<ComplexPerson>()

--- a/Tests/Linq/Linq/FSharpTests.cs
+++ b/Tests/Linq/Linq/FSharpTests.cs
@@ -16,6 +16,13 @@ namespace Tests.Linq
 		}
 
 		[Test, DataContextSource]
+		public void LoadSinglesWithPatient( string context)
+		{
+			using (var db = GetDataContext(context))
+				FSharp.WhereTest.LoadSinglesWithPatient( db);
+		}
+
+		[Test, DataContextSource]
 		public void LoadSingleWithOptions(string context)
 		{
 


### PR DESCRIPTION
Hi again

So this is my first attempt at proper support for relational properties in F# records.

Initially I played with copying the LoadWith logic from BuildDefaultConstructor and setting the association property mutable. That worked, but was obviously undesireable.

What was really needed was a way to pass the associated instance object to the record constructor. This PR is the result of that change. 

I decided to put the association check before the complex check, since I see that as the more likely scenario.

I haven't tested relational nesting deeper that one level yet, but I'll get to that.

Initially I had hoped to add support for option type relations, to make it truly F# ideomatic. Unfortunately that turned out to be complicated, so I'll start a separate issue about that.

Things to note:
* I hope I'm using GetLoadWith correctly here. It's cut'n'paste code.
* The loadWithItem.NextLoadWith.Count > 0 if is also pure cut'n'paste. I have no idea whether it's needed or indeed correct.
* I've had to change how the constructor parameter default value logic worked, since it, for some strange reason, thought that DBNull was and appropriate default value for the relational property.

That's it.

~John
