### PR TITLE
implement ConcreteType property for associations

### DIFF
--- a/Source/Linq/Builder/TableBuilder.cs
+++ b/Source/Linq/Builder/TableBuilder.cs
@@ -1276,7 +1276,7 @@ namespace LinqToDB.Linq.Builder
 			public AssociatedTableContext(ExpressionBuilder builder, TableContext parent, AssociationDescriptor association)
 				: base(builder, parent.SelectQuery)
 			{
-				var type = association.MemberInfo.GetMemberType();
+				var type = association.ConcreteType;
 				var left = association.CanBeNull;
 
 				if (typeof(IEnumerable).IsSameOrParentOf(type))

--- a/Source/Linq/Builder/TableBuilder.cs
+++ b/Source/Linq/Builder/TableBuilder.cs
@@ -1276,7 +1276,7 @@ namespace LinqToDB.Linq.Builder
 			public AssociatedTableContext(ExpressionBuilder builder, TableContext parent, AssociationDescriptor association)
 				: base(builder, parent.SelectQuery)
 			{
-				var type = association.ConcreteType;
+				var type = association.OtherType;
 				var left = association.CanBeNull;
 
 				if (typeof(IEnumerable).IsSameOrParentOf(type))

--- a/Source/Mapping/AssociationAttribute.cs
+++ b/Source/Mapping/AssociationAttribute.cs
@@ -22,6 +22,7 @@ namespace LinqToDB.Mapping
 		public string       BackReferenceName { get; set; }
 		public bool         IsBackReference   { get; set; }
 		public Relationship Relationship      { get; set; }
+		public Type         ConcreteType      { get; set; }
 
 		public string[] GetThisKeys () { return AssociationDescriptor.ParseKeys(ThisKey);  }
 		public string[] GetOtherKeys() { return AssociationDescriptor.ParseKeys(OtherKey); }

--- a/Source/Mapping/AssociationAttribute.cs
+++ b/Source/Mapping/AssociationAttribute.cs
@@ -22,7 +22,7 @@ namespace LinqToDB.Mapping
 		public string       BackReferenceName { get; set; }
 		public bool         IsBackReference   { get; set; }
 		public Relationship Relationship      { get; set; }
-		public Type         ConcreteType      { get; set; }
+		public Type         OtherType         { get; set; }
 
 		public string[] GetThisKeys () { return AssociationDescriptor.ParseKeys(ThisKey);  }
 		public string[] GetOtherKeys() { return AssociationDescriptor.ParseKeys(OtherKey); }

--- a/Source/Mapping/AssociationDescriptor.cs
+++ b/Source/Mapping/AssociationDescriptor.cs
@@ -6,6 +6,7 @@ using JNotNull = JetBrains.Annotations.NotNullAttribute;
 namespace LinqToDB.Mapping
 {
 	using Common;
+	using Extensions;
 
 	public class AssociationDescriptor
 	{
@@ -15,7 +16,8 @@ namespace LinqToDB.Mapping
 			[JNotNull] string[]   thisKey,
 			[JNotNull] string[]   otherKey,
 			           string     storage,
-			           bool       canBeNull)
+			           bool       canBeNull,
+			           Type       concreteType)
 		{
 			if (memberInfo == null) throw new ArgumentNullException("memberInfo");
 			if (thisKey    == null) throw new ArgumentNullException("thisKey");
@@ -37,6 +39,7 @@ namespace LinqToDB.Mapping
 			OtherKey   = otherKey;
 			Storage    = storage;
 			CanBeNull  = canBeNull;
+			ConcreteType = concreteType ?? memberInfo.GetMemberType();
 		}
 
 		public MemberInfo MemberInfo { get; set; }
@@ -44,6 +47,7 @@ namespace LinqToDB.Mapping
 		public string[]   OtherKey   { get; set; }
 		public string     Storage    { get; set; }
 		public bool       CanBeNull  { get; set; }
+		public Type       ConcreteType { get; set; }
 
 		public static string[] ParseKeys(string keys)
 		{

--- a/Source/Mapping/AssociationDescriptor.cs
+++ b/Source/Mapping/AssociationDescriptor.cs
@@ -34,19 +34,19 @@ namespace LinqToDB.Mapping
 						"Association '{0}.{1}' has different number of keys for parent and child objects.",
 						type.Name, memberInfo.Name));
 
-			MemberInfo = memberInfo;
-			ThisKey    = thisKey;
-			OtherKey   = otherKey;
-			Storage    = storage;
-			CanBeNull  = canBeNull;
+			MemberInfo   = memberInfo;
+			ThisKey      = thisKey;
+			OtherKey     = otherKey;
+			Storage      = storage;
+			CanBeNull    = canBeNull;
 			ConcreteType = concreteType ?? memberInfo.GetMemberType();
 		}
 
-		public MemberInfo MemberInfo { get; set; }
-		public string[]   ThisKey    { get; set; }
-		public string[]   OtherKey   { get; set; }
-		public string     Storage    { get; set; }
-		public bool       CanBeNull  { get; set; }
+		public MemberInfo MemberInfo   { get; set; }
+		public string[]   ThisKey      { get; set; }
+		public string[]   OtherKey     { get; set; }
+		public string     Storage      { get; set; }
+		public bool       CanBeNull    { get; set; }
 		public Type       ConcreteType { get; set; }
 
 		public static string[] ParseKeys(string keys)

--- a/Source/Mapping/AssociationDescriptor.cs
+++ b/Source/Mapping/AssociationDescriptor.cs
@@ -17,7 +17,7 @@ namespace LinqToDB.Mapping
 			[JNotNull] string[]   otherKey,
 			           string     storage,
 			           bool       canBeNull,
-			           Type       concreteType)
+			           Type       otherType)
 		{
 			if (memberInfo == null) throw new ArgumentNullException("memberInfo");
 			if (thisKey    == null) throw new ArgumentNullException("thisKey");
@@ -34,20 +34,20 @@ namespace LinqToDB.Mapping
 						"Association '{0}.{1}' has different number of keys for parent and child objects.",
 						type.Name, memberInfo.Name));
 
-			MemberInfo   = memberInfo;
-			ThisKey      = thisKey;
-			OtherKey     = otherKey;
-			Storage      = storage;
-			CanBeNull    = canBeNull;
-			ConcreteType = concreteType ?? memberInfo.GetMemberType();
+			MemberInfo = memberInfo;
+			ThisKey    = thisKey;
+			OtherKey   = otherKey;
+			Storage    = storage;
+			CanBeNull  = canBeNull;
+			OtherType  = otherType ?? memberInfo.GetMemberType();
 		}
 
-		public MemberInfo MemberInfo   { get; set; }
-		public string[]   ThisKey      { get; set; }
-		public string[]   OtherKey     { get; set; }
-		public string     Storage      { get; set; }
-		public bool       CanBeNull    { get; set; }
-		public Type       ConcreteType { get; set; }
+		public MemberInfo MemberInfo { get; set; }
+		public string[]   ThisKey    { get; set; }
+		public string[]   OtherKey   { get; set; }
+		public string     Storage    { get; set; }
+		public bool       CanBeNull  { get; set; }
+		public Type       OtherType  { get; set; }
 
 		public static string[] ParseKeys(string keys)
 		{

--- a/Source/Mapping/EntityDescriptor.cs
+++ b/Source/Mapping/EntityDescriptor.cs
@@ -83,7 +83,7 @@ namespace LinqToDB.Mapping
 				if (aa != null)
 				{
 					Associations.Add(new AssociationDescriptor(
-						TypeAccessor.Type, member.MemberInfo, aa.GetThisKeys(), aa.GetOtherKeys(), aa.Storage, aa.CanBeNull));
+						TypeAccessor.Type, member.MemberInfo, aa.GetThisKeys(), aa.GetOtherKeys(), aa.Storage, aa.CanBeNull, aa.ConcreteType));
 					continue;
 				}
 

--- a/Source/Mapping/EntityDescriptor.cs
+++ b/Source/Mapping/EntityDescriptor.cs
@@ -83,7 +83,7 @@ namespace LinqToDB.Mapping
 				if (aa != null)
 				{
 					Associations.Add(new AssociationDescriptor(
-						TypeAccessor.Type, member.MemberInfo, aa.GetThisKeys(), aa.GetOtherKeys(), aa.Storage, aa.CanBeNull, aa.ConcreteType));
+						TypeAccessor.Type, member.MemberInfo, aa.GetThisKeys(), aa.GetOtherKeys(), aa.Storage, aa.CanBeNull, aa.OtherType));
 					continue;
 				}
 


### PR DESCRIPTION
🚧 work in progress 🚧 

By specifying ConcreteType in the AssociationAttribute, subtypes of the declared types are instantiated.

First attempt at implementing #529. I still get an exception:
```
fail: Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware[0]
      An unhandled exception has occurred:  Argument type 'System.Collections.Generic.List`1[Lingvo.Common.Entities.Page]' does not match the corresponding member type 'System.Collections.Generic.List`1[Lingvo.Common.Entities.IPage]'
      Parameter name: arguments[4]
System.ArgumentException:  Argument type 'System.Collections.Generic.List`1[Lingvo.Common.Entities.Page]' does not match the corresponding member type 'System.Collections.Generic.List`1[Lingvo.Common.Entities.IPage]'
Parameter name: arguments[4]
   at System.Linq.Expressions.Expression.ValidateNewArgs(ConstructorInfo constructor, ReadOnlyCollection`1& arguments, ReadOnlyCollection`1& members)
   at System.Linq.Expressions.Expression.New(ConstructorInfo constructor, IEnumerable`1 arguments, IEnumerable`1 members)
   at LinqToDB.Expressions.Extensions.Transform(Expression expr, Func`2 func)
   at LinqToDB.Linq.Builder.ExpressionBuilder.BuildExpression(IBuildContext context, Expression expression)
   at LinqToDB.Linq.Builder.SelectContext.BuildExpression(Expression expression, Int32 level)
   at LinqToDB.Linq.Builder.SelectContext.BuildQuery[T](Query`1 query, ParameterExpression queryParameter)
   at LinqToDB.Linq.Builder.ExpressionBuilder.Build[T]()
   at LinqToDB.Linq.Query`1.GetQuery(IDataContextInfo dataContextInfo, Expression expr)
   at LinqToDB.Linq.ExpressionQuery`1.GetQuery(Expression expression, Boolean cache)
   at LinqToDB.Linq.ExpressionQuery`1.get_SqlText()
   at LinqToDB.Linq.ExpressionQueryImpl`1.ToString()
```