### PR TITLE
Possible fix for #498

### DIFF
--- a/Source/Linq/Builder/GroupByBuilder.cs
+++ b/Source/Linq/Builder/GroupByBuilder.cs
@@ -80,16 +80,6 @@ namespace LinqToDB.Linq.Builder
 			foreach (var sql in groupSql)
 				sequence.SelectQuery.GroupBy.Expr(sql.Sql);
 
-			new QueryVisitor().Visit(sequence.SelectQuery.From, e =>
-			{
-				if (e.ElementType == QueryElementType.JoinedTable)
-				{
-					var jt = (SelectQuery.JoinedTable)e;
-					if (jt.JoinType == SelectQuery.JoinType.Inner)
-						jt.IsWeak = false;
-				}
-			});
-
 			var element = new SelectContext (buildInfo.Parent, elementSelector, sequence/*, key*/);
 			var groupBy = new GroupByContext(buildInfo.Parent, sequenceExpr, groupingType, sequence, key, element);
 

--- a/Tests/Linq/Linq/IssueTests.cs
+++ b/Tests/Linq/Linq/IssueTests.cs
@@ -107,5 +107,34 @@ namespace Tests.Linq
 					select t);
 			}
 		}
+
+		// https://github.com/linq2db/linq2db/issues/498
+		//
+		[Test, DataContextSource()]
+		public void Issue498Test(string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var q = from x in db.Child
+					from y in x.GrandChildren1
+					select x.ParentID;
+
+				var r = from x in q
+					group x by x
+					into g
+					select new { g.Key, Cghildren = g.Count() };
+
+				var qq = from x in Child
+					from y in x.GrandChildren
+					select x.ParentID;
+
+				var rr = from x in qq
+					group x by x
+					into g
+					select new { g.Key, Cghildren = g.Count() };
+
+				AreEqual(rr, r);
+			}
+		}
 	}
 }


### PR DESCRIPTION
@igor-tkachev, another fix that needs your support.
I have not found any source history, even in BLToolkit, why this part of code was introduced,

In #498 introduced Association with CanBeNull = false. After grouping join become not weak and duplicate is not removed later.