### PR TITLE
Possible fix for #75

### DIFF
--- a/Source/Linq/Builder/AggregationBuilder.cs
+++ b/Source/Linq/Builder/AggregationBuilder.cs
@@ -102,7 +102,10 @@ namespace LinqToDB.Linq.Builder
 
 			public override Expression BuildExpression(Expression expression, int level)
 			{
-				return BuildExpression(ConvertToIndex(expression, level, ConvertFlags.Field)[0].Index);
+				var index = ConvertToIndex(expression, level, ConvertFlags.Field)[0].Index;
+				if (Parent != null)
+					ConvertToParentIndex(index, Parent);
+				return BuildExpression(index);
 			}
 
 			Expression BuildExpression(int fieldIndex)

--- a/Source/Linq/Builder/AllAnyBuilder.cs
+++ b/Source/Linq/Builder/AllAnyBuilder.cs
@@ -88,8 +88,10 @@ namespace LinqToDB.Linq.Builder
 
 			public override Expression BuildExpression(Expression expression, int level)
 			{
-				var idx = ConvertToIndex(expression, level, ConvertFlags.Field);
-				return Builder.BuildSql(typeof(bool), idx[0].Index);
+				var index = ConvertToIndex(expression, level, ConvertFlags.Field)[0].Index;
+				if (Parent != null)
+					ConvertToParentIndex(index, Parent);
+				return Builder.BuildSql(typeof(bool), index);
 			}
 
 			public override SqlInfo[] ConvertToSql(Expression expression, int level, ConvertFlags flags)

--- a/Source/Linq/Builder/CountBuilder.cs
+++ b/Source/Linq/Builder/CountBuilder.cs
@@ -111,7 +111,10 @@ namespace LinqToDB.Linq.Builder
 
 			public override Expression BuildExpression(Expression expression, int level)
 			{
-				return Builder.BuildSql(_returnType, ConvertToIndex(expression, level, ConvertFlags.Field)[0].Index);
+				var index = ConvertToIndex(expression, level, ConvertFlags.Field)[0].Index;
+				if (Parent != null)
+					ConvertToParentIndex(index, Parent);
+				return Builder.BuildSql(_returnType, index);
 			}
 
 			public override SqlInfo[] ConvertToSql(Expression expression, int level, ConvertFlags flags)

--- a/Source/Linq/Builder/ExpressionBuilder.QueryBuilder.cs
+++ b/Source/Linq/Builder/ExpressionBuilder.QueryBuilder.cs
@@ -285,8 +285,6 @@ namespace LinqToDB.Linq.Builder
 		public Expression GetSubQueryExpression(IBuildContext context, MethodCallExpression expr)
 		{
 			var info = GetSubQueryContext(context, expr);
-			var index = info.Context.ConvertToIndex(null, 0, ConvertFlags.Field)[0].Index;
-			context.ConvertToParentIndex(index, context);
 			return info.Expression ?? (info.Expression = info.Context.BuildExpression(null, 0));
 		}
 

--- a/Source/Linq/Builder/ExpressionBuilder.QueryBuilder.cs
+++ b/Source/Linq/Builder/ExpressionBuilder.QueryBuilder.cs
@@ -285,6 +285,8 @@ namespace LinqToDB.Linq.Builder
 		public Expression GetSubQueryExpression(IBuildContext context, MethodCallExpression expr)
 		{
 			var info = GetSubQueryContext(context, expr);
+			var index = info.Context.ConvertToIndex(null, 0, ConvertFlags.Field)[0].Index;
+			context.ConvertToParentIndex(index, context);
 			return info.Expression ?? (info.Expression = info.Context.BuildExpression(null, 0));
 		}
 

--- a/Tests/Linq/Linq/IssueTests.cs
+++ b/Tests/Linq/Linq/IssueTests.cs
@@ -122,6 +122,7 @@ namespace Tests.Linq
 					HasChildren = db.Child.Any(c2 => c2.ParentID == c.ParentID),
 					HasChildren2 = db.Child.Where(c2 => c2.ParentID == c.ParentID).Any(),
 					AllChildren = db.Child.All(c2 => c2.ParentID == c.ParentID),
+					AllChildrenMin = db.Child.Where(c2 => c2.ParentID == c.ParentID).Min(c2 => c2.ChildID)
  				});
 
  				childs =
@@ -139,6 +140,7 @@ namespace Tests.Linq
 					HasChildren = Child.Any(c2 => c2.ParentID == c.ParentID),
 					HasChildren2 = Child.Where(c2 => c2.ParentID == c.ParentID).Any(),
 					AllChildren = Child.All(c2 => c2.ParentID == c.ParentID),
+					AllChildrenMin = Child.Where(c2 => c2.ParentID == c.ParentID).Min(c2 => c2.ChildID)
  				});
 
  				childs_list =

--- a/Tests/Linq/Linq/IssueTests.cs
+++ b/Tests/Linq/Linq/IssueTests.cs
@@ -108,6 +108,33 @@ namespace Tests.Linq
 			}
 		}
 
+		[Test, DataContextSource()]
+ 		public void Test(string context)
+ 		{
+ 			using (var db = GetDataContext(context))
+ 			{
+ 				var childs = db.Child.Select(c => new
+				{
+					HasChildren = db.Child.Any(c2 => c2.ParentID == c.ChildID),
+ 					c.ChildID,
+					c.ParentID,
+ 				});
+
+//				 var s = childs.ToString();
+ 				childs =
+ 					from child in childs
+ 					join parent in db.Parent on child.ParentID equals parent.ParentID
+ 					where parent.Value1 == 1
+ 					select child;
+
+//				 var list = childs.ToList();
+ 
+ 				var sql = childs.ToString();
+ 				Assert.That(sql, Contains.Substring("HasChildren"));
+ 				Assert.That(childs.ToList().Count, Is.GreaterThan(0));
+ 			}
+		}
+
 		[Test, DataContextSource]
 		public void Issue424Test1(string context)
 		{

--- a/Tests/Linq/Linq/IssueTests.cs
+++ b/Tests/Linq/Linq/IssueTests.cs
@@ -109,29 +109,45 @@ namespace Tests.Linq
 		}
 
 		[Test, DataContextSource()]
- 		public void Test(string context)
+ 		public void Issue75Test(string context)
  		{
  			using (var db = GetDataContext(context))
  			{
  				var childs = db.Child.Select(c => new
 				{
-					HasChildren = db.Child.Any(c2 => c2.ParentID == c.ChildID),
  					c.ChildID,
 					c.ParentID,
+					CountChildren = db.Child.Count(c2 => c2.ParentID == c.ParentID),
+					CountChildren2 = db.Child.Where(c2 => c2.ParentID == c.ParentID).Count(),
+					HasChildren = db.Child.Any(c2 => c2.ParentID == c.ParentID),
+					HasChildren2 = db.Child.Where(c2 => c2.ParentID == c.ParentID).Any(),
+					AllChildren = db.Child.All(c2 => c2.ParentID == c.ParentID),
  				});
 
-//				 var s = childs.ToString();
  				childs =
  					from child in childs
  					join parent in db.Parent on child.ParentID equals parent.ParentID
- 					where parent.Value1 == 1
+ 					where parent.Value1 < 7
  					select child;
 
-//				 var list = childs.ToList();
- 
- 				var sql = childs.ToString();
- 				Assert.That(sql, Contains.Substring("HasChildren"));
- 				Assert.That(childs.ToList().Count, Is.GreaterThan(0));
+ 				var childs_list = Child.Select(c => new
+				{
+ 					c.ChildID,
+					c.ParentID,
+					CountChildren = Child.Count(c2 => c2.ParentID == c.ParentID),
+					CountChildren2 = Child.Where(c2 => c2.ParentID == c.ParentID).Count(),
+					HasChildren = Child.Any(c2 => c2.ParentID == c.ParentID),
+					HasChildren2 = Child.Where(c2 => c2.ParentID == c.ParentID).Any(),
+					AllChildren = Child.All(c2 => c2.ParentID == c.ParentID),
+ 				});
+
+ 				childs_list =
+ 					from child in childs_list
+ 					join parent in Parent on child.ParentID equals parent.ParentID
+ 					where parent.Value1 < 7
+ 					select child;
+
+				AreEqual(childs_list, childs);
  			}
 		}
 


### PR DESCRIPTION
Fix for issue #75

I've found that for sub-queries is not called function ConvertToParentIndex which registers such kind of columns in parent query.
@igor-tkachev, please review this pull request.