### PR TITLE
Possible fix for #115

### DIFF
--- a/Tests/Linq/Linq/IssueTests.cs
+++ b/Tests/Linq/Linq/IssueTests.cs
@@ -109,6 +109,38 @@ namespace Tests.Linq
 		}
 
 		[Test, DataContextSource]
+		public void Issue115Test(string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var qs = (from c in db.Child
+						join r in db.Parent on c.ParentID equals r.ParentID
+						where r.ParentID > 4
+						select c
+					)
+					.Union(from c in db.Child
+						join r in db.Parent on c.ParentID equals r.ParentID
+						where r.ParentID <= 4
+						select c
+					);
+
+				var ql = (from c in Child
+						join r in Parent on c.ParentID equals r.ParentID
+						where r.ParentID > 4
+						select c
+					)
+					.Union(from c in Child
+						join r in Parent on c.ParentID equals r.ParentID
+						where r.ParentID <= 4
+						select c
+					);
+
+				AreEqual(ql, qs);
+			}
+		}
+
+
+		[Test, DataContextSource]
 		public void Issue424Test1(string context)
 		{
 			using (var db = GetDataContext(context))

--- a/linq2db.sln.DotSettings
+++ b/linq2db.sln.DotSettings
@@ -4,7 +4,9 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ANONYMOUS_METHOD_DECLARATION_BRACES/@EntryValue">NEXT_LINE</s:String>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/BLANK_LINES_BETWEEN_USING_GROUPS/@EntryValue">1</s:Int64>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/BLANK_LINES_INSIDE_REGION/@EntryValue">0</s:Int64>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/CASE_BLOCK_BRACES/@EntryValue">NEXT_LINE_SHIFTED_2</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INITIALIZER_BRACES/@EntryValue">NEXT_LINE</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_COLON_IN_CASE/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/AddImportsToDeepestScope/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CSharpUsing/KeepImports/=System/@EntryIndexedValue">System</s:String>
 	<s:String x:Key="/Default/CodeStyle/CSharpUsing/MandatoryImports/=System/@EntryIndexedValue">System</s:String>


### PR DESCRIPTION
Fix for #115 

Problem that columns for MemberExpression correctly expanded in TableBuilder in ConvertToSql method bu not in SelectContext. I hope that i found appropriate place and correctly fixed this issue.

@igor-tkachev, please review it's not obvious for me.