### PR TITLE
Fix for #271

### DIFF
--- a/Source/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -1544,6 +1544,15 @@ namespace LinqToDB.Linq.Builder
 			var l = ConvertToSql(context, left);
 			var r = ConvertToSql(context, right, true);
 
+			var lValue = l as SqlValue;
+			var rValue = r as SqlValue;
+
+			if (lValue != null)
+				lValue.DataType = GetDataType(r);
+
+			if (rValue != null)
+				rValue.DataType = GetDataType(l);
+
 			switch (nodeType)
 			{
 				case ExpressionType.Equal   :
@@ -1909,6 +1918,37 @@ namespace LinqToDB.Linq.Builder
 				dataType = dta.DataType.Value;
 
 			return dataType;
+		}
+
+		static DataType? GetDataType(ISqlExpression expr)
+		{
+			DataType? result = null;
+
+			new QueryVisitor().Find(expr, e =>
+			{
+				switch (e.ElementType)
+				{
+					case QueryElementType.SqlField:
+						result = ((SqlField)e).DataType;
+						return true;
+					case QueryElementType.SqlParameter:
+						result = ((SqlParameter)e).DataType;
+						return true;
+					case QueryElementType.SqlDataType:
+						result = ((SqlDataType)e).DataType;
+						return true;
+					case QueryElementType.SqlValue:
+						result = ((SqlValue)e).DataType;
+						return true;
+					default:
+						return false;
+				}
+			});
+
+			if (result == DataType.Undefined)
+				result = null;
+
+			return result;
 		}
 
 		internal static ParameterAccessor CreateParameterAccessor(

--- a/Source/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/SqlProvider/BasicSqlBuilder.cs
@@ -1880,6 +1880,14 @@ namespace LinqToDB.SqlProvider
 				case QueryElementType.SqlValue:
 					var sqlval = (SqlValue)expr;
 					var dt = sqlval.SystemType == null ? null : new SqlDataType(sqlval.SystemType);
+
+					if (sqlval.DataType != null)
+					{
+						dt = sqlval.SystemType == null
+							? new SqlDataType(sqlval.DataType.Value)
+							: new SqlDataType(sqlval.DataType.Value, sqlval.SystemType);
+					}
+
 					BuildValue(dt, sqlval.Value);
 					break;
 

--- a/Source/SqlQuery/SqlDataType.cs
+++ b/Source/SqlQuery/SqlDataType.cs
@@ -331,6 +331,10 @@ namespace LinqToDB.SqlQuery
 				case DataType.Time             : return DbTime;
 				case DataType.DateTime2        : return DbDateTime2;
 				case DataType.DateTimeOffset   : return DbDateTimeOffset;
+				case DataType.UInt16           : return DbUInt16;
+				case DataType.UInt32           : return DbUInt32;
+				case DataType.UInt64           : return DbUInt64;
+
 			}
 
 			throw new InvalidOperationException();
@@ -375,6 +379,9 @@ namespace LinqToDB.SqlQuery
 		public static readonly SqlDataType DbInt64          = new SqlDataType(DataType.Int64,          typeof(Int64),                  0, 0,                0);
 		public static readonly SqlDataType DbInt32          = new SqlDataType(DataType.Int32,          typeof(Int32),                  0, 0,                0);
 		public static readonly SqlDataType DbInt16          = new SqlDataType(DataType.Int16,          typeof(Int16),                  0, 0,                0);
+		public static readonly SqlDataType DbUInt64         = new SqlDataType(DataType.UInt64,         typeof(UInt64),                 0, 0,                0);
+		public static readonly SqlDataType DbUInt32         = new SqlDataType(DataType.UInt32,         typeof(UInt32),                 0, 0,                0);
+		public static readonly SqlDataType DbUInt16         = new SqlDataType(DataType.UInt16,         typeof(UInt16),                 0, 0,                0);
 		public static readonly SqlDataType DbSByte          = new SqlDataType(DataType.SByte,          typeof(SByte),                  0, 0,                0);
 		public static readonly SqlDataType DbByte           = new SqlDataType(DataType.Byte,           typeof(Byte),                   0, 0,                0);
 		public static readonly SqlDataType DbBoolean        = new SqlDataType(DataType.Boolean,        typeof(Boolean),                0, 0,                0);

--- a/Source/SqlQuery/SqlValue.cs
+++ b/Source/SqlQuery/SqlValue.cs
@@ -20,8 +20,9 @@ namespace LinqToDB.SqlQuery
 				SystemType = value.GetType();
 		}
 
-		public object Value      { get; internal set; }
-		public Type   SystemType { get; private set; }
+		public   object    Value      { get; internal set; }
+		public   Type      SystemType { get; private set; }
+		internal DataType? DataType   { get; set; }
 
 		#region Overrides
 

--- a/Source/SqlQuery/SqlValue.cs
+++ b/Source/SqlQuery/SqlValue.cs
@@ -22,6 +22,12 @@ namespace LinqToDB.SqlQuery
 
 		public   object    Value      { get; internal set; }
 		public   Type      SystemType { get; private set; }
+
+		// TODO refactor this to make DataType required parameter for SqlValue
+		/// <summary>
+		/// This implementation is hack to fix https://github.com/linq2db/linq2db/issues/271
+		/// https://github.com/linq2db/linq2db/pull/608
+		/// </summary>
 		internal DataType? DataType   { get; set; }
 
 		#region Overrides

--- a/Tests/Linq/Tests.csproj
+++ b/Tests/Linq/Tests.csproj
@@ -363,6 +363,7 @@
     <Compile Include="UserTests\GenericsFilterTests.cs" />
     <Compile Include="UserTests\GroupBySubqueryTests.cs" />
     <Compile Include="UserTests\Issue175Tests.cs" />
+    <Compile Include="UserTests\Issue271Tests.cs" />
     <Compile Include="UserTests\Issue358Tests.cs" />
     <Compile Include="UserTests\Issue356Tests.cs" />
     <Compile Include="UserTests\Issue395Tests.cs" />

--- a/Tests/Linq/UserTests/Issue271Tests.cs
+++ b/Tests/Linq/UserTests/Issue271Tests.cs
@@ -1,0 +1,83 @@
+﻿using LinqToDB;
+using LinqToDB.Mapping;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Tests.UserTests
+{
+	[TestFixture]
+	public class Issue271Tests : TestBase
+	{
+		public class Entity
+		{
+			[Column(DataType = LinqToDB.DataType.Char)]
+			public string CharValue;
+			[Column(DataType = LinqToDB.DataType.VarChar)]
+			public string VarCharValue;
+			[Column(DataType = LinqToDB.DataType.NChar)]
+			public string NCharValue;
+			[Column(DataType = LinqToDB.DataType.NVarChar)]
+			public string NVarCharValue;
+		}
+
+		[Test, IncludeDataContextSource(ProviderName.SqlCe, ProviderName.SqlServer2014, ProviderName.SqlServer2012, ProviderName.SqlServer2008, ProviderName.SqlServer2005)]
+		public void Test1(string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var q = from e in db.GetTable<Entity>()
+						where
+						e.CharValue     == "CharValue"     &&
+						e.VarCharValue  == "VarCharValue"  &&
+						e.NCharValue    == "NCharValue"    &&
+						e.NVarCharValue == "NVarCharValue"
+						select e;
+
+				var str = q.ToString();
+
+				Console.WriteLine(str);
+
+				Assert.False(str.Contains("N'CharValue'"));
+				Assert.False(str.Contains("N'VarCharValue'"));
+
+				Assert.True(str.Contains("N'NCharValue'"));
+				Assert.True(str.Contains("N'NVarCharValue'"));
+			}
+
+		}
+
+		[Test, IncludeDataContextSource(ProviderName.SqlCe, ProviderName.SqlServer2014, ProviderName.SqlServer2012, ProviderName.SqlServer2008, ProviderName.SqlServer2005)]
+		public void Test2(string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var @char     = new[] { "CharValue"     };
+				var @varChar  = new[] { "VarCharValue"  };
+				var @nChar    = new[] { "NCharValue"    };
+				var @nVarChar = new[] { "NVarCharValue" };
+
+				var q = from e in db.GetTable<Entity>()
+						where
+						@char    .Contains(e.CharValue    ) &&
+						@varChar .Contains(e.VarCharValue ) &&
+						@nChar   .Contains(e.NCharValue   ) &&
+						@nVarChar.Contains(e.NVarCharValue)
+						select e;
+
+				var str = q.ToString();
+
+				Console.WriteLine(str);
+
+				Assert.False(str.Contains("N'CharValue'"));
+				Assert.False(str.Contains("N'VarCharValue'"));
+
+				Assert.True(str.Contains("N'NCharValue'"));
+				Assert.True(str.Contains("N'NVarCharValue'"));
+			}
+		}
+	}
+}


### PR DESCRIPTION
In general this implementation is hack.
It would be better to make `DataType`  required parameter for `SqlValue` but it would break tons of code. And only for char\nchar in predicate. I think is does not worth.

If we would face with same situation in another query part or with other type we'll make total refactoring.