### PR TITLE
Bugfix for issue #612

### DIFF
--- a/Tests/Linq/DataProvider/OracleTests.cs
+++ b/Tests/Linq/DataProvider/OracleTests.cs
@@ -1650,9 +1650,9 @@ namespace Tests.DataProvider
 		}
 
 		[Test, OracleDataContext]
-		public void Issue612Test()
+		public void Issue612Test(string context)
 		{
-			using (var db = GetDataContext("Oracle.Managed"))
+			using (var db = GetDataContext(context))
 			{
 				try
 				{

--- a/Tests/Linq/DataProvider/OracleTests.cs
+++ b/Tests/Linq/DataProvider/OracleTests.cs
@@ -1649,6 +1649,32 @@ namespace Tests.DataProvider
 
 		}
 
+		[Test, OracleDataContext]
+		public void Issue612Test()
+		{
+			using (var db = GetDataContext("Oracle.Managed"))
+			{
+				try
+				{
+                    // initialize with ticks with default oracle timestamp presicion (6 fractional seconds)
+                    var expected = new DateTimeOffset(636264847785126550, TimeSpan.FromHours(3));
+
+                    db.CreateTable<DateTimeOffsetTable>();
+
+                    db.Insert(new DateTimeOffsetTable { DateTimeOffsetValue = expected });
+
+				    var actual = db.GetTable<DateTimeOffsetTable>().Select(x => x.DateTimeOffsetValue).Single();
+
+				    Assert.That(actual, Is.EqualTo(expected)); 
+				}
+				finally
+				{
+                    db.DropTable<DateTimeOffsetTable>();
+                }
+			}
+
+		}
+
 		public static IEnumerable<Person> PersonSelectByKey(DataConnection dataConnection, int id)
 		{
 			return dataConnection.QueryProc<Person>("Person_SelectByKey",


### PR DESCRIPTION
Bugfix for DateTimeOffset in Orace: nanoseconds was
improperly initialized from milliseconds; added full DateTimeOffset
precision (100 ns) instead of millisecond, like native DateTime.