### PR TITLE
Do not use mapping attributes from "parent" object

### DIFF
--- a/Source/Mapping/ColumnDescriptor.cs
+++ b/Source/Mapping/ColumnDescriptor.cs
@@ -76,7 +76,7 @@ namespace LinqToDB.Mapping
 
 			if (columnAttribute.HasIsIdentity())
 				IsIdentity = columnAttribute.IsIdentity;
-			else
+			else if (MemberName.IndexOf(".") < 0)
 			{
 				var a = mappingSchema.GetAttribute<IdentityAttribute>(MemberAccessor.TypeAccessor.Type, MemberInfo, attr => attr.Configuration);
 				if (a != null)
@@ -91,7 +91,7 @@ namespace LinqToDB.Mapping
 
 			if (columnAttribute.HasIsPrimaryKey())
 				IsPrimaryKey = columnAttribute.IsPrimaryKey;
-			else
+			else if (MemberName.IndexOf(".") < 0)
 			{
 				var a = mappingSchema.GetAttribute<PrimaryKeyAttribute>(MemberAccessor.TypeAccessor.Type, MemberInfo, attr => attr.Configuration);
 

--- a/Tests/Linq/Mapping/MappingSchemaTests.cs
+++ b/Tests/Linq/Mapping/MappingSchemaTests.cs
@@ -2,7 +2,9 @@
 using System.Globalization;
 using System.IO;
 using System.Text;
+using System.Linq;
 
+using LinqToDB;
 using LinqToDB.Common;
 using LinqToDB.Expressions;
 using LinqToDB.Mapping;
@@ -393,6 +395,34 @@ namespace Tests.Mapping
 			Assert.That(mapType, Is.EqualTo(typeof(int?)));
 			var convertedValue = Converter.ChangeType(null, mapType, schema);
 			Assert.IsNull(convertedValue);
+		}
+
+		public class PkTable
+		{
+			[PrimaryKey, Identity]
+			[DataType(DataType.DateTime)]
+			public int Id;
+		}
+
+		[Column("ParentId", "Parent.Id")]
+		public class FkTable
+		{
+			[PrimaryKey]
+			public int Id;
+
+			public PkTable Parent;
+		}
+
+		[Test]
+		public void DoNotUseComplexAttributes()
+		{
+			var ed = MappingSchema.Default.GetEntityDescriptor(typeof(FkTable));
+			var c  = ed.Columns.Single(_ => _.ColumnName == "ParentId");
+
+			Assert.False(c.IsPrimaryKey);
+			Assert.False(c.IsIdentity);
+			Assert.AreEqual(DataType.DateTime, c.DataType);
+
 		}
 	}
 }


### PR DESCRIPTION
We should not use PrimartKey & Identity attributes from complex members (foreign keys for example)