### PR TITLE
Fix #681, #682, #683

### DIFF
--- a/Source/DataProvider/DB2/DB2SqlBuilderBase.cs
+++ b/Source/DataProvider/DB2/DB2SqlBuilderBase.cs
@@ -210,6 +210,15 @@ namespace LinqToDB.DataProvider.DB2
 			StringBuilder.Append("GENERATED ALWAYS AS IDENTITY");
 		}
 
+		public override StringBuilder BuildTableName(StringBuilder sb, string database, string owner, string table)
+		{
+			// "db..table" syntax not supported
+			if (database != null && owner == null)
+				throw new LinqToDBException("DB2 requires schema name if database name provided.");
+
+			return base.BuildTableName(sb, database, owner, table);
+		}
+
 #if !SILVERLIGHT && !NETFX_CORE
 
 		protected override string GetProviderTypeName(IDbDataParameter parameter)

--- a/Source/DataProvider/Firebird/FirebirdSqlBuilder.cs
+++ b/Source/DataProvider/Firebird/FirebirdSqlBuilder.cs
@@ -12,6 +12,7 @@ namespace LinqToDB.DataProvider.Firebird
 	using Common;
 	using SqlQuery;
 	using SqlProvider;
+	using System.Text;
 
 	public class FirebirdSqlBuilder : BasicSqlBuilder
 	{
@@ -294,6 +295,11 @@ namespace LinqToDB.DataProvider.Firebird
 						.AppendLine  ("END");
 				}
 			}
+		}
+
+		public override StringBuilder BuildTableName(StringBuilder sb, string database, string owner, string table)
+		{
+			return sb.Append(table);
 		}
 
 #if !SILVERLIGHT

--- a/Source/DataProvider/Informix/InformixSqlBuilder.cs
+++ b/Source/DataProvider/Informix/InformixSqlBuilder.cs
@@ -161,6 +161,20 @@ namespace LinqToDB.DataProvider.Informix
 			StringBuilder.Append(")");
 		}
 
+		public override StringBuilder BuildTableName(StringBuilder sb, string database, string owner, string table)
+		{
+			// TODO: FQN could also contain server name, but we don't have such API for now
+			// https://www.ibm.com/support/knowledgecenter/en/SSGU8G_12.1.0/com.ibm.sqls.doc/ids_sqs_1652.htm
+			if (database != null)
+				sb.Append(database).Append(":");
+
+			if (owner != null)
+				sb.Append(owner).Append(".");
+
+			return sb.Append(table);
+		}
+
+
 #if !SILVERLIGHT
 
 		protected override string GetProviderTypeName(IDbDataParameter parameter)

--- a/Source/DataProvider/MySql/MySqlSqlBuilder.cs
+++ b/Source/DataProvider/MySql/MySqlSqlBuilder.cs
@@ -286,6 +286,14 @@ namespace LinqToDB.DataProvider.MySql
 			StringBuilder.Append(")");
 		}
 
+		public override StringBuilder BuildTableName(StringBuilder sb, string database, string owner, string table)
+		{
+			if (database != null)
+				sb.Append(database).Append(".");
+
+			return sb.Append(table);
+		}
+
 #if !SILVERLIGHT
 
 		protected override string GetProviderTypeName(IDbDataParameter parameter)

--- a/Source/DataProvider/Oracle/OracleSqlBuilder.cs
+++ b/Source/DataProvider/Oracle/OracleSqlBuilder.cs
@@ -6,6 +6,7 @@ namespace LinqToDB.DataProvider.Oracle
 	using Common;
 	using SqlQuery;
 	using SqlProvider;
+	using System.Text;
 
 	class OracleSqlBuilder : BasicSqlBuilder
 	{
@@ -368,6 +369,13 @@ namespace LinqToDB.DataProvider.Oracle
 			}
 		}
 
+		public override StringBuilder BuildTableName(StringBuilder sb, string database, string owner, string table)
+		{
+			if (owner != null)
+				sb.Append(owner).Append(".");
+
+			return sb.Append(table);
+		}
 
 #if !SILVERLIGHT
 

--- a/Source/DataProvider/PostgreSQL/PostgreSQLSqlBuilder.cs
+++ b/Source/DataProvider/PostgreSQL/PostgreSQLSqlBuilder.cs
@@ -198,6 +198,16 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			return base.BuildJoinType(join);
 		}
 
+		public override StringBuilder BuildTableName(StringBuilder sb, string database, string owner, string table)
+		{
+			// "db..table" syntax not supported and postgresql doesn't support database name, if it is not current database
+			// so we can clear database name to avoid error from server
+			if (database != null && owner == null)
+				database = null;
+
+			return base.BuildTableName(sb, database, owner, table);
+		}
+
 #if !SILVERLIGHT
 
 		protected override string GetProviderTypeName(IDbDataParameter parameter)

--- a/Source/DataProvider/SapHana/SapHanaSqlBuilder.cs
+++ b/Source/DataProvider/SapHana/SapHanaSqlBuilder.cs
@@ -257,5 +257,15 @@ namespace LinqToDB.DataProvider.SapHana
 				parameters[start + 1],
 				ConvertCase(systemType, parameters, start + 2));
 		}
+
+		public override StringBuilder BuildTableName(StringBuilder sb, string database, string owner, string table)
+		{
+			// "db..table" syntax not supported:
+			// <table_name> ::= [[<database_name>.]<schema.name>.]<identifier>
+			if (database != null && owner == null)
+				throw new LinqToDBException("SAP HANA requires schema name if database name provided.");
+
+			return base.BuildTableName(sb, database, owner, table);
+		}
 	}
 }

--- a/Tests/Linq/Tests.csproj
+++ b/Tests/Linq/Tests.csproj
@@ -43,7 +43,7 @@
     <DefineConstants>TRACE;DEBUG;FW4;MOBILE1</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>3</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <NoWarn>649 429</NoWarn>
     <Prefer32Bit>false</Prefer32Bit>
@@ -382,6 +382,7 @@
     <Compile Include="UserTests\Issue358Tests.cs" />
     <Compile Include="UserTests\Issue356Tests.cs" />
     <Compile Include="UserTests\Issue082Tests.cs" />
+    <Compile Include="UserTests\Issue681Tests.cs" />
     <Compile Include="UserTests\Issue737Tests.cs" />
     <Compile Include="UserTests\Issue395Tests.cs" />
     <Compile Include="UserTests\Issue273Tests.cs" />

--- a/Tests/Linq/UserTests/Issue681Tests.cs
+++ b/Tests/Linq/UserTests/Issue681Tests.cs
@@ -56,9 +56,11 @@ namespace Tests.UserTests
 				if (   context == ProviderName.SapHana
 					|| context == ProviderName.DB2)
 					Assert.Throws<LinqToDBException>(() => db.GetTable<TestTable>().DatabaseName(dbName).ToList());
+#if !NETFX_CORE
 				else if (context == ProviderName.SapHana + ".LinqService"
 					||   context == ProviderName.DB2     + ".LinqService")
 					Assert.Throws<FaultException<ExceptionDetail>>(() => db.GetTable<TestTable>().DatabaseName(dbName).ToList());
+#endif
 				else
 					db.GetTable<TestTable>().DatabaseName(dbName).ToList();
 			}

--- a/Tests/Linq/UserTests/Issue681Tests.cs
+++ b/Tests/Linq/UserTests/Issue681Tests.cs
@@ -125,6 +125,7 @@ namespace Tests.UserTests
 			switch (context)
 			{
 				case ProviderName.SQLite:
+				case TestProvName.SQLiteMs:
 					return "main";
 				case ProviderName.Access:
 					return "Database\\TestData";

--- a/Tests/Linq/UserTests/Issue681Tests.cs
+++ b/Tests/Linq/UserTests/Issue681Tests.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 using System;
 using System.Linq;
 using Tests.Model;
-#if !NETFX_CORE
+#if !MONO
 using System.ServiceModel;
 #endif
 
@@ -58,7 +58,7 @@ namespace Tests.UserTests
 				if (   context == ProviderName.SapHana
 					|| context == ProviderName.DB2)
 					Assert.Throws<LinqToDBException>(() => db.GetTable<TestTable>().DatabaseName(dbName).ToList());
-#if !NETFX_CORE
+#if !MONO
 				else if (context == ProviderName.SapHana + ".LinqService"
 					||   context == ProviderName.DB2     + ".LinqService")
 					Assert.Throws<FaultException<ExceptionDetail>>(() => db.GetTable<TestTable>().DatabaseName(dbName).ToList());

--- a/Tests/Linq/UserTests/Issue681Tests.cs
+++ b/Tests/Linq/UserTests/Issue681Tests.cs
@@ -5,9 +5,6 @@ using NUnit.Framework;
 using System;
 using System.Linq;
 using Tests.Model;
-#if !MONO
-using System.ServiceModel;
-#endif
 
 namespace Tests.UserTests
 {
@@ -58,11 +55,9 @@ namespace Tests.UserTests
 				if (   context == ProviderName.SapHana
 					|| context == ProviderName.DB2)
 					Assert.Throws<LinqToDBException>(() => db.GetTable<TestTable>().DatabaseName(dbName).ToList());
-#if !MONO
 				else if (context == ProviderName.SapHana + ".LinqService"
 					||   context == ProviderName.DB2     + ".LinqService")
-					Assert.Throws<FaultException<ExceptionDetail>>(() => db.GetTable<TestTable>().DatabaseName(dbName).ToList());
-#endif
+					Assert.Throws<Exception>(() => db.GetTable<TestTable>().DatabaseName(dbName).ToList());
 				else
 					db.GetTable<TestTable>().DatabaseName(dbName).ToList();
 			}

--- a/Tests/Linq/UserTests/Issue681Tests.cs
+++ b/Tests/Linq/UserTests/Issue681Tests.cs
@@ -6,6 +6,10 @@ using System;
 using System.Linq;
 using Tests.Model;
 
+#if !NETFX_CORE
+using System.ServiceModel;
+#endif
+
 namespace Tests.UserTests
 {
 	[TestFixture]
@@ -55,9 +59,11 @@ namespace Tests.UserTests
 				if (   context == ProviderName.SapHana
 					|| context == ProviderName.DB2)
 					Assert.Throws<LinqToDBException>(() => db.GetTable<TestTable>().DatabaseName(dbName).ToList());
+#if !NETFX_CORE
 				else if (context == ProviderName.SapHana + ".LinqService"
 					||   context == ProviderName.DB2     + ".LinqService")
-					Assert.Throws<Exception>(() => db.GetTable<TestTable>().DatabaseName(dbName).ToList());
+					Assert.Throws<FaultException<ExceptionDetail>>(() => db.GetTable<TestTable>().DatabaseName(dbName).ToList());
+#endif
 				else
 					db.GetTable<TestTable>().DatabaseName(dbName).ToList();
 			}

--- a/Tests/Linq/UserTests/Issue681Tests.cs
+++ b/Tests/Linq/UserTests/Issue681Tests.cs
@@ -6,7 +6,7 @@ using System;
 using System.Linq;
 using Tests.Model;
 
-#if !NETFX_CORE
+#if !NETFX_CORE && !NETSTANDARD
 using System.ServiceModel;
 #endif
 
@@ -59,7 +59,7 @@ namespace Tests.UserTests
 				if (   context == ProviderName.SapHana
 					|| context == ProviderName.DB2)
 					Assert.Throws<LinqToDBException>(() => db.GetTable<TestTable>().DatabaseName(dbName).ToList());
-#if !NETFX_CORE
+#if !NETFX_CORE && !NETSTANDARD
 				else if (context == ProviderName.SapHana + ".LinqService"
 					||   context == ProviderName.DB2     + ".LinqService")
 					Assert.Throws<FaultException<ExceptionDetail>>(() => db.GetTable<TestTable>().DatabaseName(dbName).ToList());

--- a/Tests/Linq/UserTests/Issue681Tests.cs
+++ b/Tests/Linq/UserTests/Issue681Tests.cs
@@ -4,8 +4,10 @@ using LinqToDB.Mapping;
 using NUnit.Framework;
 using System;
 using System.Linq;
-using System.ServiceModel;
 using Tests.Model;
+#if !NETFX_CORE
+using System.ServiceModel;
+#endif
 
 namespace Tests.UserTests
 {

--- a/Tests/Linq/UserTests/Issue681Tests.cs
+++ b/Tests/Linq/UserTests/Issue681Tests.cs
@@ -1,0 +1,183 @@
+﻿using LinqToDB;
+using LinqToDB.Data;
+using LinqToDB.Mapping;
+using NUnit.Framework;
+using System;
+using System.Linq;
+using System.ServiceModel;
+using Tests.Model;
+
+namespace Tests.UserTests
+{
+	[TestFixture]
+	public class Issue681Tests : TestBase
+	{
+		[DataContextSource]
+		public void TestTableName(string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				db.GetTable<TestTable>().ToList();
+			}
+		}
+
+		[DataContextSource]
+		public void TestTableNameWithSchema(string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var ctx = context;
+				if (ctx.EndsWith(".LinqService"))
+					ctx = ctx.Substring(0, ctx.Length - ".LinqService".Length);
+
+				string schemaName;
+
+				using (new DisableLogging())
+					schemaName = GetSchemaName(ctx, db);
+
+				db.GetTable<TestTable>().SchemaName(schemaName).ToList();
+			}
+		}
+
+		[DataContextSource]
+		public void TestTableNameWithDatabase(string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var ctx = context;
+				if (ctx.EndsWith(".LinqService"))
+					ctx = ctx.Substring(0, ctx.Length - ".LinqService".Length);
+
+				string dbName;
+
+				using (new DisableLogging())
+					dbName = GetDatabaseName(ctx, db);
+
+				if (   context == ProviderName.SapHana
+					|| context == ProviderName.DB2)
+					Assert.Throws<LinqToDBException>(() => db.GetTable<TestTable>().DatabaseName(dbName).ToList());
+				else if (context == ProviderName.SapHana + ".LinqService"
+					||   context == ProviderName.DB2     + ".LinqService")
+					Assert.Throws<FaultException<ExceptionDetail>>(() => db.GetTable<TestTable>().DatabaseName(dbName).ToList());
+				else
+					db.GetTable<TestTable>().DatabaseName(dbName).ToList();
+			}
+		}
+
+		// SAP HANA should be configured for such queries (I failed)
+		// Maybe this will help:
+		// https://www.linkedin.com/pulse/cross-database-queries-thing-past-how-use-sap-hana-your-nandan
+		// https://blogs.sap.com/2017/04/12/introduction-to-the-sap-hana-smart-data-access-linked-database-feature/
+		// https://blogs.sap.com/2014/12/19/step-by-step-tutorial-cross-database-queries-in-sap-hana-sps09/
+		[DataContextSource(ProviderName.SapHana)]
+		public void TestTableNameWithDatabaseAndSchema(string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var ctx = context;
+				if (ctx.EndsWith(".LinqService"))
+					ctx = ctx.Substring(0, ctx.Length - ".LinqService".Length);
+
+				string schemaName;
+				string dbName;
+
+				using (new DisableLogging())
+				{
+					schemaName = GetSchemaName(ctx, db);
+					dbName = GetDatabaseName(ctx, db);
+				}
+
+				db.GetTable<TestTable>().SchemaName(schemaName).DatabaseName(dbName).ToList();
+			}
+		}
+
+		private static string GetSchemaName(string context, ITestDataContext db)
+		{
+			switch (context)
+			{
+				case ProviderName.SapHana:
+				case ProviderName.Informix:
+				case ProviderName.Oracle:
+				case ProviderName.OracleNative:
+				case ProviderName.OracleManaged:
+				case ProviderName.PostgreSQL:
+				case ProviderName.DB2:
+				case ProviderName.Sybase:
+				case ProviderName.SqlServer2000:
+				case ProviderName.SqlServer2005:
+				case ProviderName.SqlServer2008:
+				case ProviderName.SqlServer2012:
+				case ProviderName.SqlServer2014:
+				case TestProvName.SqlAzure:
+					return db.Types.Select(_ => SchemaName()).First();
+			}
+
+			return "UNUSED_SCHEMA";
+		}
+
+		private static string GetDatabaseName(string context, ITestDataContext db)
+		{
+			switch (context)
+			{
+				case ProviderName.SQLite:
+					return "main";
+				case ProviderName.Access:
+					return "Database\\TestData";
+				case ProviderName.SapHana:
+				case ProviderName.MySql:
+				case TestProvName.MariaDB:
+				case TestProvName.MySql57:
+				case ProviderName.PostgreSQL:
+				case ProviderName.DB2:
+				case ProviderName.Sybase:
+				case ProviderName.SqlServer2000:
+				case ProviderName.SqlServer2005:
+				case ProviderName.SqlServer2008:
+				case ProviderName.SqlServer2012:
+				case ProviderName.SqlServer2014:
+				case TestProvName.SqlAzure:
+					return db.Types.Select(_ => DbName()).First();
+				case ProviderName.Informix:
+					return db.Types.Select(_ => DbInfo("dbname")).First();
+			}
+
+			return "UNUSED_DB";
+		}
+
+		[Sql.Function("DBINFO", ServerSideOnly = true)]
+		static string DbInfo(string property)
+		{
+			throw new InvalidOperationException();
+		}
+
+		[Sql.Expression("current_schema", ServerSideOnly = true, Configuration = ProviderName.SapHana   )]
+		[Sql.Expression("current server", ServerSideOnly = true, Configuration = ProviderName.DB2       )]
+		[Sql.Function("current_database", ServerSideOnly = true, Configuration = ProviderName.PostgreSQL)]
+		[Sql.Function("DATABASE"        , ServerSideOnly = true, Configuration = ProviderName.MySql     )]
+		[Sql.Function("DB_NAME"         , ServerSideOnly = true                                         )]
+		static string DbName()
+		{
+			throw new InvalidOperationException();
+		}
+
+		[Sql.Expression("user"          , ServerSideOnly = true, Configuration = ProviderName.Informix     )]
+		[Sql.Expression("user"          , ServerSideOnly = true, Configuration = ProviderName.OracleNative )]
+		[Sql.Expression("user"          , ServerSideOnly = true, Configuration = ProviderName.OracleManaged)]
+		[Sql.Expression("current_user"  , ServerSideOnly = true, Configuration = ProviderName.SapHana      )]
+		[Sql.Expression("current schema", ServerSideOnly = true, Configuration = ProviderName.DB2          )]
+		[Sql.Function("current_schema"  , ServerSideOnly = true, Configuration = ProviderName.PostgreSQL   )]
+		[Sql.Function("USER_NAME"       , ServerSideOnly = true, Configuration = ProviderName.Sybase       )]
+		[Sql.Function("SCHEMA_NAME"     , ServerSideOnly = true                                            )]
+		static string SchemaName()
+		{
+			throw new InvalidOperationException();
+		}
+
+		[Table("LinqDataTypes")]
+		class TestTable
+		{
+			[Column("ID")]
+			public int ID { get; set; }
+		}
+	}
+}


### PR DESCRIPTION
Fixes fully-qualified table name generation for:
 - Firebird
 - Oracle
 - MySql
 - Informix (without server name support, create feature request if you need it)
 - SAP HANA
 - DB2