### PR TITLE
Add CanCombineParameters support in merge-based InsertOrUpdate

### DIFF
--- a/Tests/Linq/UserTests/Issue513Tests.cs
+++ b/Tests/Linq/UserTests/Issue513Tests.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 
 namespace Tests.UserTests
 {
+	using LinqToDB;
 	using Model;
 
 	[TestFixture]
@@ -25,7 +26,9 @@ namespace Tests.UserTests
 			}
 		}
 
-		[Test, DataContextSource(TestProvName.SQLiteMs), Category("WindowsOnly")]
+		// Informix disabled due to issue, described here (but it reproduced with client 4.1):
+		// https://www-01.ibm.com/support/docview.wss?uid=swg1IC66046
+		[Test, DataContextSource(TestProvName.SQLiteMs, ProviderName.Informix), Category("WindowsOnly")]
 		public void Test(string context)
 		{
 			using (var semaphore = new Semaphore(0, 10))


### PR DESCRIPTION
Post-mortem for review.
Looks like CanCombineParameters flag was never supported for merge-based InsertOrUpdate query and we didn't spotted it before due to:
- only Sybase use this flag in default distribution
- Sybase doesn't use merge-based query for InsertOrUpdate
- for iSeries it wasn't spotted before due to a bug with duplicate parameters, which I fixed here https://github.com/linq2db/linq2db/pull/686#pullrequestreview-40652778
