### PR TITLE
move take\skip\distinct to subquery in join

### DIFF
--- a/Source/Linq/Builder/SelectManyBuilder.cs
+++ b/Source/Linq/Builder/SelectManyBuilder.cs
@@ -25,7 +25,10 @@ namespace LinqToDB.Linq.Builder
 			var collectionSelector = (LambdaExpression)methodCall.Arguments[1].Unwrap();
 			var resultSelector     = (LambdaExpression)methodCall.Arguments[2].Unwrap();
 
-			if (!sequence.SelectQuery.GroupBy.IsEmpty)
+			if (!sequence.SelectQuery.GroupBy.IsEmpty         ||
+				sequence.SelectQuery.Select.TakeValue != null ||
+				sequence.SelectQuery.Select.SkipValue != null ||
+				sequence.SelectQuery.Select .IsDistinct)
 			{
 				sequence = new SubQueryContext(sequence);
 			}

--- a/Tests/Linq/Linq/DistinctTests.cs
+++ b/Tests/Linq/Linq/DistinctTests.cs
@@ -129,5 +129,25 @@ namespace Tests.Linq
 					   Child.Select(ch => ch.ParentID).Distinct().OrderBy(ch => ch),
 					db.Child.Select(ch => ch.ParentID).Distinct().OrderBy(ch => ch));
 		}
+
+		[Test, DataContextSource]
+		public void DistinctJoin(string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var q1 = Types;
+				var q2 = db.Types.Select(_ => new LinqDataTypes() {ID = _.ID, SmallIntValue = _.SmallIntValue }).Distinct();
+
+				AreEqual(
+					from e in q1
+					from p in q1.Where(_ => _.ID == e.ID).DefaultIfEmpty()
+					select new { e.ID, p.SmallIntValue },
+					from e in q2
+					from p in q2.Where(_ => _.ID == e.ID).DefaultIfEmpty()
+					select new { e.ID, p.SmallIntValue }
+					);
+			}
+		}
+
 	}
 }

--- a/Tests/Linq/Linq/TakeSkipTests.cs
+++ b/Tests/Linq/Linq/TakeSkipTests.cs
@@ -449,5 +449,24 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 				Assert.Throws<LinqException>(() => db.Parent.Take(10, TakeHints.Percent).ToList());
 		}
+
+		[Test, DataContextSource(/*ProviderName.Access*/)]
+		public void TakeSkipJoin(string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var q1 =    Types.Concat(   Types).Take(15);
+				var q2 = db.Types.Concat(db.Types).Take(15);
+
+				AreEqual(
+					from e in q1
+					from p in q1.Where(_ => _.ID == e.ID).DefaultIfEmpty()
+					select new {e.ID, p.SmallIntValue},
+					from e in q2
+					from p in q2.Where(_ => _.ID == e.ID).DefaultIfEmpty()
+					select new { e.ID, p.SmallIntValue }
+					);
+			}
+		}
 	}
 }


### PR DESCRIPTION
In queries like:

```cs
from a in db.Some.Skip(0).Take(10).Distinct()
from b in db.Other.Where(...).DefaultIfEmpty()
select {}
```

take, skip & distinct used to be applied to result query, now `db.Some.Skip(0).Take(10).Distinct()` closure is moved to subquery

