### PR TITLE
fixed extension associations

### DIFF
--- a/Source/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -1061,7 +1061,7 @@ namespace LinqToDB.Linq.Builder
 							if (CountBuilder.MethodNames.Contains(e.Method.Name) || e.IsAggregate(MappingSchema))
 								result = IsQueryMember(e.Arguments[0]);
 						}
-						else if (e.IsAggregate(MappingSchema))
+						else if (e.IsAggregate(MappingSchema) || e.IsAssociation(MappingSchema))
 						{
 							result = true;
 						}

--- a/Source/Linq/Builder/TableBuilder.cs
+++ b/Source/Linq/Builder/TableBuilder.cs
@@ -1264,9 +1264,9 @@ namespace LinqToDB.Linq.Builder
 				AssociatedTableContext tableAssociation = null;
 						var isNew = false;
 
-				if (expression.NodeType == ExpressionType.Call)
+				if (levelExpression.NodeType == ExpressionType.Call)
 				{
-					var mc = (MethodCallExpression) expression;
+					var mc = (MethodCallExpression) levelExpression;
 					var aa = Builder.MappingSchema.GetAttribute<AssociationAttribute>(mc.Method.DeclaringType, mc.Method, a => a.Configuration);
 
 					if (aa != null)

--- a/Source/Linq/Builder/TableBuilder.cs
+++ b/Source/Linq/Builder/TableBuilder.cs
@@ -971,7 +971,10 @@ namespace LinqToDB.Linq.Builder
 							{
 								var ma     = expression.NodeType == ExpressionType.MemberAccess 
 												? ((MemberExpression)buildInfo.Expression).Expression 
+												: expression.NodeType == ExpressionType.Call 
+												? ((MethodCallExpression)buildInfo.Expression).Arguments[0]
 												: buildInfo.Expression.GetRootObject(Builder.MappingSchema);
+
 								var atype  = typeof(AssociationHelper<>).MakeGenericType(association.ObjectType);
 								var helper = (IAssociationHelper)Activator.CreateInstance(atype);
 								var expr   = helper.GetExpression(ma, association);

--- a/Tests/Linq/Linq/AssociationTests.cs
+++ b/Tests/Linq/Linq/AssociationTests.cs
@@ -702,6 +702,18 @@ namespace Tests.Linq
 		}
 
 		[Test, DataContextSource]
+		public void ExtensionTest3(string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				AreEqual(
+				   Child.Select(_ => new { p = _.Parent   }).Select(_ => _.p.ParentID),
+				db.Child.Select(_ => new { p = _.Parent() }).Select(_ => _.p.ParentID));
+
+			}
+		}
+
+		[Test, DataContextSource]
 		public void QuerableExtensionTest1(string context)
 		{
 			using (var db = GetDataContext(context))

--- a/Tests/Linq/Linq/AssociationTests.cs
+++ b/Tests/Linq/Linq/AssociationTests.cs
@@ -714,6 +714,18 @@ namespace Tests.Linq
 		}
 
 		[Test, DataContextSource]
+		public void ExtensionTest4(string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				AreEqual(
+				   Child.Select(_ => new { c = _,  p = _.Parent   }).Select(_ => _.c.Parent),
+				db.Child.Select(_ => new { c = _,  p = _.Parent() }).Select(_ => _.c.Parent()));
+
+			}
+		}
+
+		[Test, DataContextSource]
 		public void QuerableExtensionTest1(string context)
 		{
 			using (var db = GetDataContext(context))


### PR DESCRIPTION
Fixed
```cs
public void ExtensionTest3(string context) 
{ 
	using (var db = GetDataContext(context)) 
	{ 
		AreEqual( 
		   Child.Select(_ => new { p = _.Parent   }).Select(_ => _.p.ParentID), 
		db.Child.Select(_ => new { p = _.Parent() }).Select(_ => _.p.ParentID)); 
	} 
} 
``


