### PR TITLE
Support for custom expression postprocessing

### DIFF
--- a/Source/Linq/Query.cs
+++ b/Source/Linq/Query.cs
@@ -21,6 +21,11 @@ namespace LinqToDB.Linq
 	using SqlQuery;
 	using SqlProvider;
 
+	public interface IExpressionPostprocessor
+	{
+		Expression PostprocessExpression(Expression expression);
+	}
+
 	abstract class Query
 	{
 		public Func<IDataContextEx,Expression,object[],object> GetElement;
@@ -196,6 +201,9 @@ namespace LinqToDB.Linq
 
 		public static Query<T> GetQuery(IDataContext dataContext, ref Expression expr)
 		{
+			if (dataContext is IExpressionPostprocessor)
+				expr = ((IExpressionPostprocessor)dataContext).PostprocessExpression(expr);
+
 			if (Configuration.Linq.UseBinaryAggregateExpression)
 				expr = ExpressionBuilder.AggregateExpression(expr);
 

--- a/Source/LinqToDB.csproj
+++ b/Source/LinqToDB.csproj
@@ -22,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
This small change adds support for a custom expression postprocessor. (Postprocessor is not configured statically but by particular DataContext.)