### PR TITLE
Added Sql.NoConvert function.

### DIFF
--- a/Source/DataProvider/SqlServer/SqlServerSqlBuilder.cs
+++ b/Source/DataProvider/SqlServer/SqlServerSqlBuilder.cs
@@ -96,7 +96,7 @@ namespace LinqToDB.DataProvider.SqlServer
 				AppendOutputTableVariable(SelectQuery.Insert.Into)
 					.AppendLine();
 			}
-			else 
+			else
 			{
 				StringBuilder
 					.AppendLine()

--- a/Source/Sql/Sql.ExtensionAttribute.cs
+++ b/Source/Sql/Sql.ExtensionAttribute.cs
@@ -146,13 +146,16 @@ namespace LinqToDB
 			SqlExtension   Extension        { get; }
 			ISqlExpression ResultExpression { get; set; }
 			string         Expression       { get; set; }
+			Expression[]   Arguments        { get; }
 
 			T GetValue<T>(int index);
 			T GetValue<T>(string argName);
+
 			ISqlExpression GetExpression(int index);
 			ISqlExpression GetExpression(string argName);
 			ISqlExpression ConvertToSqlExpression();
 			ISqlExpression ConvertToSqlExpression(int precedence);
+			ISqlExpression ConvertExpressionToSql(Expression expression);
 
 			SqlExtensionParam AddParameter(string name, ISqlExpression expr);
 		}
@@ -286,8 +289,6 @@ namespace LinqToDB
 					return _convert.Convert(expr);
 				}
 
-				public Expression[]   Arguments        { get; private set; }
-
 				#region ISqExtensionBuilder Members
 
 				public string         Configuration    { get; private set; }
@@ -296,6 +297,7 @@ namespace LinqToDB
 				public MemberInfo     Member           { get; private set; }
 				public SqlExtension   Extension        { get; private set; }
 				public ISqlExpression ResultExpression { get;         set; }
+				public Expression[]   Arguments        { get; private set; }
 
 				public string Expression
 				{
@@ -356,6 +358,11 @@ namespace LinqToDB
 				public ISqlExpression ConvertToSqlExpression(int precedence)
 				{
 					return BuildSqlExpression(Extension, Extension.SystemType, precedence, Extension.IsAggregate);
+				}
+
+				public ISqlExpression ConvertExpressionToSql(Expression expression)
+				{
+					return ConvertExpression(expression);
 				}
 
 				public SqlExtensionParam AddParameter(string name, ISqlExpression expr)

--- a/Source/Sql/Sql.ExtensionAttribute.cs
+++ b/Source/Sql/Sql.ExtensionAttribute.cs
@@ -428,15 +428,11 @@ namespace LinqToDB
 
 								break;
 							}
-						case ExpressionType.Constant:
-						case ExpressionType.Parameter:
-							{
-								current = null;
-								continue;
-							}
 						default:
-							throw new InvalidOperationException(string.Format("Invalid method chain for Extension ({0}) -> {1}", expr, current));
-
+						{
+							current = null;
+							continue;
+						}
 					}
 
 					var attributes = mapping.GetAttributes<ExtensionAttribute>(memberInfo.ReflectedTypeEx(), memberInfo,

--- a/Source/Sql/Sql.cs
+++ b/Source/Sql/Sql.cs
@@ -132,14 +132,14 @@ namespace LinqToDB
 		#region NoConvert
 
 		[Sql.Function("$Convert_Remover$", ServerSideOnly = true)]
-		public static TR ConvertRemover<T, TR>(T input)
+		static TR ConvertRemover<T, TR>(T input)
 		{
 			throw new NotImplementedException();
 		}
 
 		class NoConvertBuilder : Sql.IExtensionCallBuilder
 		{
-			private MethodInfo _method = MethodHelper.GetMethodInfo(Sql.ConvertRemover<int, int>, 0).GetGenericMethodDefinition();
+			private static readonly MethodInfo _method = MethodHelper.GetMethodInfo(Sql.ConvertRemover<int, int>, 0).GetGenericMethodDefinition();
 
 			public void Build(Sql.ISqExtensionBuilder builder)
 			{

--- a/Source/Sql/Sql.cs
+++ b/Source/Sql/Sql.cs
@@ -127,6 +127,35 @@ namespace LinqToDB
 
 		#endregion
 
+		#region NoConvert
+
+		class NoConvertBuilder : Sql.IExtensionCallBuilder
+		{
+			public void Build(Sql.ISqExtensionBuilder builder)
+			{
+				var expr = builder.GetExpression("expr");
+				expr = new QueryVisitor().Convert(expr, e =>
+				{
+					var func = e as SqlFunction;
+					if (func != null && func.Name == "Convert" && func.Parameters.Length > 0)
+					{
+						return func.Parameters[func.Parameters.Length - 1];
+					}
+					return e;
+				});
+
+				builder.ResultExpression = expr;
+			}
+		}
+
+		[Sql.Extension("", BuilderType = typeof(NoConvertBuilder))]
+		public static T NoConvert<T>([ExprParameter] T expr)
+		{
+			return expr;
+		}
+
+		#endregion
+
 		#region Guid Functions
 
 		[Sql.Function  (PN.Oracle,   "Sys_Guid", ServerSideOnly=true)]

--- a/Tests/Linq/Linq/ConvertTests.cs
+++ b/Tests/Linq/Linq/ConvertTests.cs
@@ -651,5 +651,28 @@ namespace Tests.Linq
 				}
 			}
 		}
+
+		[Test, NorthwindDataContext]
+		public void ConvertDataToDecimalNoConvert(string context)
+		{
+			using (var db = new NorthwindDB(context))
+			{
+				var actual = (from od in db.OrderDetail
+					select
+						Sql.NoConvert(Sql.AsSql(od.UnitPrice * od.Quantity * (decimal)(1 - od.Discount)))).ToArray();
+
+				var expected = (from od in db.OrderDetail
+					select
+						od.UnitPrice * od.Quantity * (decimal)(1 - od.Discount)).ToArray();
+
+				Assert.AreEqual(actual.Length, expected.Length);
+
+				for (var i = 0; i < actual.Length; i++)
+				{
+					Assert.GreaterOrEqual(0.01m, Math.Abs(actual[i] - expected[i]));
+				}
+			}
+		}
+
 	}
 }

--- a/Tests/Linq/Linq/ConvertTests.cs
+++ b/Tests/Linq/Linq/ConvertTests.cs
@@ -657,13 +657,24 @@ namespace Tests.Linq
 		{
 			using (var db = new NorthwindDB(context))
 			{
-				var actual = (from od in db.OrderDetail
+				var qActual =
+					from od in db.OrderDetail
 					select
-						Sql.NoConvert(Sql.AsSql(od.UnitPrice * od.Quantity * (decimal)(1 - od.Discount)))).ToArray();
+						Sql.NoConvert(Sql.AsSql(od.UnitPrice * od.Quantity * (decimal)(1 - od.Discount)));
 
-				var expected = (from od in db.OrderDetail
+				var qExpected =
+					from od in db.OrderDetail
 					select
-						od.UnitPrice * od.Quantity * (decimal)(1 - od.Discount)).ToArray();
+						Sql.AsSql(od.UnitPrice * od.Quantity * (decimal)(1 - od.Discount));
+
+				var sqlActual   = qActual.  ToString();
+				var sqlExpected = qExpected.ToString();
+
+				Assert.That(sqlActual,   Is.Not.Contains("Convert"));
+				Assert.That(sqlExpected, Contains.Substring("Convert"));
+
+				var actual   = qActual.  ToArray();
+				var expected = qExpected.ToArray();
 
 				Assert.AreEqual(actual.Length, expected.Length);
 
@@ -673,6 +684,5 @@ namespace Tests.Linq
 				}
 			}
 		}
-
 	}
 }

--- a/Tests/Linq/Linq/ConvertTests.cs
+++ b/Tests/Linq/Linq/ConvertTests.cs
@@ -660,7 +660,7 @@ namespace Tests.Linq
 				var qActual =
 					from od in db.OrderDetail
 					select
-						Sql.NoConvert(Sql.AsSql(od.UnitPrice * od.Quantity * (decimal)(1 - od.Discount)));
+						Sql.NoConvert(od.UnitPrice * od.Quantity * (decimal)(1 - od.Discount));
 
 				var qExpected =
 					from od in db.OrderDetail
@@ -670,8 +670,8 @@ namespace Tests.Linq
 				var sqlActual   = qActual.  ToString();
 				var sqlExpected = qExpected.ToString();
 
-				Assert.That(sqlActual,   Is.Not.Contains("Convert"));
-				Assert.That(sqlExpected, Contains.Substring("Convert"));
+				Assert.That(sqlActual,   Is.Not.Contains   ("Convert").Or.Contains("Cast"));
+				Assert.That(sqlExpected, Contains.Substring("Convert").Or.Contains("Cast"));
 
 				var actual   = qActual.  ToArray();
 				var expected = qExpected.ToArray();


### PR DESCRIPTION
Added Sql.NoConvert function. Sample usage:

```cs
from od in db.OrderDetail
select Sql.NoConvert(od.UnitPrice * od.Quantity * (decimal)(1 - od.Discount))
```
Before:
```sql
SELECT
    ([t1].[UnitPrice] * Convert(Decimal(29,10), [t1].[Quantity])) * Convert(Decimal(29,10), 1 - [t1].[Discount]) as [c1]
FROM
    [Order Details] [t1]
```
After:
```sql
SELECT
    ([t1].[UnitPrice] * [t1].[Quantity]) * (1 - [t1].[Discount]) as [c1]
FROM
    [Order Details] [t1]
```