### PR TITLE
Allow PostgreSQLBulkCopy to keep identities

### DIFF
--- a/Source/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
+++ b/Source/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
@@ -10,7 +10,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 		protected override BulkCopyRowsCopied MultipleRowsCopy<T>(
 			DataConnection dataConnection, BulkCopyOptions options, IEnumerable<T> source)
 		{
-			return MultipleRowsCopy1(dataConnection, options, false, source);
+			return MultipleRowsCopy1(dataConnection, options, true, source);
 		}
 	}
 }


### PR DESCRIPTION
No special mode is required in Postgres (https://www.postgresql.org/docs/9.6/static/datatype-numeric.html#DATATYPE-SERIAL), so BulkCopy can just insert data as is.