### PR TITLE
Provider-specific BulkCopy for PostgreSQL

### DIFF
--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using LinqToDB.Extensions;
+using LinqToDB.SqlProvider;
 
 namespace LinqToDB.DataProvider.PostgreSQL
 {
@@ -7,10 +10,89 @@ namespace LinqToDB.DataProvider.PostgreSQL
 
 	class PostgreSQLBulkCopy : BasicBulkCopy
 	{
+		private readonly PostgreSQLDataProvider _dataProvider;
+		private readonly Type _connectionType;
+
+		public PostgreSQLBulkCopy(PostgreSQLDataProvider dataProvider, Type connectionType)
+		{
+			_dataProvider = dataProvider;
+			_connectionType = connectionType;
+		}
+
 		protected override BulkCopyRowsCopied MultipleRowsCopy<T>(
 			DataConnection dataConnection, BulkCopyOptions options, IEnumerable<T> source)
 		{
 			return MultipleRowsCopy1(dataConnection, options, false, source);
+		}
+
+		protected override BulkCopyRowsCopied ProviderSpecificCopy<T>(DataConnection dataConnection, BulkCopyOptions options, IEnumerable<T> source)
+		{
+			if (dataConnection == null) throw new ArgumentNullException("dataConnection");
+
+			var connection = dataConnection.Connection;
+
+			if (connection == null)
+				return MultipleRowsCopy(dataConnection, options, source);
+
+			if (!(connection.GetType() == _connectionType || connection.GetType().IsSubclassOfEx(_connectionType)))
+				return MultipleRowsCopy(dataConnection, options, source);
+
+			var sqlBuilder = _dataProvider.CreateSqlBuilder();
+			var ed = dataConnection.MappingSchema.GetEntityDescriptor(typeof(T));
+			var tableName = GetTableName(sqlBuilder, options, ed);
+			var columns = ed.Columns.Where(c => !c.SkipOnInsert || options.KeepIdentity == true && c.IsIdentity).ToList();
+
+			var fields = string.Join(", ", columns.Select(column => sqlBuilder.Convert(column.ColumnName, ConvertType.NameToQueryField)));
+			var copyCommand = $"COPY {tableName} ({fields}) FROM STDIN (FORMAT BINARY)";
+
+			var rowsCopied = new BulkCopyRowsCopied();
+			var batchSize = Math.Max(10, options.MaxBatchSize ?? 10000);
+			var currentCount = 0;
+
+			var dc = (dynamic)connection;
+			var writer = dc.BeginBinaryImport(copyCommand);
+
+			foreach (var item in source)
+			{
+				writer.StartRow();
+
+				for (var i = 0; i < columns.Count; i++)
+				{
+					var column = columns[i];
+					var value = column.GetValue(dataConnection.MappingSchema, item);
+
+					if (value == null)
+					{
+						writer.WriteNull();
+					}
+					else
+					{
+						writer.Write(value);
+					}
+				}
+
+				currentCount++;
+				rowsCopied.RowsCopied++;
+
+				if (currentCount >= batchSize)
+				{
+					writer.Dispose();
+
+					if (options.RowsCopiedCallback != null)
+					{
+						options.RowsCopiedCallback(rowsCopied);
+
+						if (rowsCopied.Abort) break;
+					}
+
+					writer = dc.BeginBinaryImport(copyCommand);
+					currentCount = 0;
+				}
+			}
+
+			writer.Dispose();
+
+			return rowsCopied;
 		}
 	}
 }

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using LinqToDB.Extensions;
@@ -11,23 +11,22 @@ namespace LinqToDB.DataProvider.PostgreSQL
 	class PostgreSQLBulkCopy : BasicBulkCopy
 	{
 		private readonly PostgreSQLDataProvider _dataProvider;
-		private readonly Type _connectionType;
+		private readonly Type                   _connectionType;
 
 		public PostgreSQLBulkCopy(PostgreSQLDataProvider dataProvider, Type connectionType)
 		{
-			_dataProvider = dataProvider;
+			_dataProvider   = dataProvider;
 			_connectionType = connectionType;
 		}
 
-		protected override BulkCopyRowsCopied MultipleRowsCopy<T>(
-			DataConnection dataConnection, BulkCopyOptions options, IEnumerable<T> source)
+		protected override BulkCopyRowsCopied MultipleRowsCopy<T>(DataConnection dataConnection, BulkCopyOptions options, IEnumerable<T> source)
 		{
 			return MultipleRowsCopy1(dataConnection, options, false, source);
 		}
 
 		protected override BulkCopyRowsCopied ProviderSpecificCopy<T>(DataConnection dataConnection, BulkCopyOptions options, IEnumerable<T> source)
 		{
-			if (dataConnection == null) throw new ArgumentNullException("dataConnection");
+			if (dataConnection == null) throw new ArgumentNullException(nameof(dataConnection));
 
 			var connection = dataConnection.Connection;
 
@@ -37,38 +36,34 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			if (!(connection.GetType() == _connectionType || connection.GetType().IsSubclassOfEx(_connectionType)))
 				return MultipleRowsCopy(dataConnection, options, source);
 
-			var sqlBuilder = _dataProvider.CreateSqlBuilder();
-			var ed = dataConnection.MappingSchema.GetEntityDescriptor(typeof(T));
-			var tableName = GetTableName(sqlBuilder, options, ed);
-			var columns = ed.Columns.Where(c => !c.SkipOnInsert || options.KeepIdentity == true && c.IsIdentity).ToList();
+			var sqlBuilder   = _dataProvider.CreateSqlBuilder();
+			var ed           = dataConnection.MappingSchema.GetEntityDescriptor(typeof(T));
+			var tableName    = GetTableName(sqlBuilder, options, ed);
+			var columns      = ed.Columns.Where(c => !c.SkipOnInsert || options.KeepIdentity == true && c.IsIdentity).ToArray();
 
-			var fields = string.Join(", ", columns.Select(column => sqlBuilder.Convert(column.ColumnName, ConvertType.NameToQueryField)));
-			var copyCommand = $"COPY {tableName} ({fields}) FROM STDIN (FORMAT BINARY)";
+			var fields       = string.Join(", ", columns.Select(column => sqlBuilder.Convert(column.ColumnName, ConvertType.NameToQueryField)));
+			var copyCommand  = $"COPY {tableName} ({fields}) FROM STDIN (FORMAT BINARY)";
 
-			var rowsCopied = new BulkCopyRowsCopied();
-			var batchSize = Math.Max(10, options.MaxBatchSize ?? 10000);
+			var rowsCopied   = new BulkCopyRowsCopied();
+			var batchSize    = Math.Max(10, options.MaxBatchSize ?? 10000);
 			var currentCount = 0;
 
-			var dc = (dynamic)connection;
-			var writer = dc.BeginBinaryImport(copyCommand);
+			var dc           = (dynamic)connection;
+			var writer       = dc.BeginBinaryImport(copyCommand);
 
 			foreach (var item in source)
 			{
 				writer.StartRow();
 
-				for (var i = 0; i < columns.Count; i++)
+				for (var i = 0; i < columns.Length; i++)
 				{
 					var column = columns[i];
-					var value = column.GetValue(dataConnection.MappingSchema, item);
+					var value  = column.GetValue(dataConnection.MappingSchema, item);
 
 					if (value == null)
-					{
 						writer.WriteNull();
-					}
 					else
-					{
 						writer.Write(value);
-					}
 				}
 
 				currentCount++;

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
@@ -279,13 +279,13 @@ namespace LinqToDB.DataProvider.PostgreSQL
 		public override BulkCopyRowsCopied BulkCopy<T>(
 			[JetBrains.Annotations.NotNull] DataConnection dataConnection, BulkCopyOptions options, IEnumerable<T> source)
 		{
-			return new PostgreSQLBulkCopy().BulkCopy(
+			return new PostgreSQLBulkCopy(this, GetConnectionType()).BulkCopy(
 				options.BulkCopyType == BulkCopyType.Default ? PostgreSQLTools.DefaultBulkCopyType : options.BulkCopyType,
 				dataConnection,
 				options,
 				source);
 		}
 
-#endregion
+		#endregion
 	}
 }


### PR DESCRIPTION
References:
PostgreSQL COPY documentation - https://www.postgresql.org/docs/current/static/sql-copy.html
COPY support in Npgsql - http://www.npgsql.org/doc/copy.html

It would be better to explicitly specify field type (second parameter in writer method), but I didn't figure out how to get NpgsqlDbType from field description.