### PR TITLE
PostgreSQL 9.5 UPSERT support

### DIFF
--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
@@ -16,7 +16,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 	{
 		public PostgreSQLDataProvider(PostgreSQLVersion version = PostgreSQLVersion.v92)
 			: this(
-				version == PostgreSQLVersion.v92 ? ProviderName.PostgreSQL92 : ProviderName.PostgreSQL93,
+				GetProviderName(version),
 				new PostgreSQLMappingSchema(),
 				version)
 		{
@@ -32,10 +32,8 @@ namespace LinqToDB.DataProvider.PostgreSQL
 		{
 			Version = version;
 
-			if (version == PostgreSQLVersion.v93)
-				SqlProviderFlags.IsApplyJoinSupported = true;
-
-			SqlProviderFlags.IsInsertOrUpdateSupported      = false;
+			SqlProviderFlags.IsApplyJoinSupported           = version != PostgreSQLVersion.v92;
+			SqlProviderFlags.IsInsertOrUpdateSupported      = version == PostgreSQLVersion.v95;
 			SqlProviderFlags.IsUpdateSetTableAliasSupported = false;
 
 			SetCharFieldToType<char>("bpchar", (r, i) => DataTools.GetChar(r, i));
@@ -66,6 +64,19 @@ namespace LinqToDB.DataProvider.PostgreSQL
 		Type _npgsqlDateTime;
 
 		CommandBehavior _commandBehavior = CommandBehavior.Default;
+
+		private static string GetProviderName(PostgreSQLVersion version)
+		{
+			switch (version)
+			{
+				case PostgreSQLVersion.v92:
+					return ProviderName.PostgreSQL92;
+				case PostgreSQLVersion.v93:
+					return ProviderName.PostgreSQL93;
+				default:
+					return ProviderName.PostgreSQL95;
+			}
+		}
 
 		protected override void OnConnectionTypeCreated(Type connectionType)
 		{

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLTools.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLTools.cs
@@ -16,6 +16,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 		static readonly PostgreSQLDataProvider _postgreSQLDataProvider   = new PostgreSQLDataProvider();
 		static readonly PostgreSQLDataProvider _postgreSQLDataProvider92 = new PostgreSQLDataProvider(ProviderName.PostgreSQL92, PostgreSQLVersion.v92);
 		static readonly PostgreSQLDataProvider _postgreSQLDataProvider93 = new PostgreSQLDataProvider(ProviderName.PostgreSQL93, PostgreSQLVersion.v93);
+		static readonly PostgreSQLDataProvider _postgreSQLDataProvider95 = new PostgreSQLDataProvider(ProviderName.PostgreSQL95, PostgreSQLVersion.v95);
 
 		public static bool AutoDetectProvider { get; set; }
 
@@ -26,6 +27,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			DataConnection.AddDataProvider(_postgreSQLDataProvider);
 			DataConnection.AddDataProvider(_postgreSQLDataProvider92);
 			DataConnection.AddDataProvider(_postgreSQLDataProvider93);
+			DataConnection.AddDataProvider(_postgreSQLDataProvider95);
 
 			DataConnection.AddProviderDetector(ProviderDetector);
 		}
@@ -51,8 +53,11 @@ namespace LinqToDB.DataProvider.PostgreSQL
 
 				case "PostgreSQL93"   : case "PostgreSQL.93"  : case "PostgreSQL.9.3" :
 				case "PostgreSQL94"   : case "PostgreSQL.94"  : case "PostgreSQL.9.4" :
-				case "PostgreSQL95"   : case "PostgreSQL.95"  : case "PostgreSQL.9.5" :
 					return _postgreSQLDataProvider93;
+
+				case "PostgreSQL95"   : case "PostgreSQL.95"  : case "PostgreSQL.9.5" :
+				case "PostgreSQL96"   : case "PostgreSQL.96"  : case "PostgreSQL.9.6" :
+					return _postgreSQLDataProvider95;
 
 				case "PostgreSQL"     :
 				case "Npgsql"         :
@@ -61,9 +66,12 @@ namespace LinqToDB.DataProvider.PostgreSQL
 						return _postgreSQLDataProvider;
 
 					if (css.Name.Contains("93") || css.Name.Contains("9.3") ||
-						css.Name.Contains("94") || css.Name.Contains("9.4") ||
-						css.Name.Contains("95") || css.Name.Contains("9.5"))
+						css.Name.Contains("94") || css.Name.Contains("9.4"))
 						return _postgreSQLDataProvider93;
+
+					if (css.Name.Contains("95") || css.Name.Contains("9.5") ||
+						css.Name.Contains("96") || css.Name.Contains("9.6"))
+						return _postgreSQLDataProvider95;
 
 					if (AutoDetectProvider)
 					{
@@ -79,8 +87,17 @@ namespace LinqToDB.DataProvider.PostgreSQL
 
 								var postgreSqlVersion = ((dynamic)conn).PostgreSqlVersion;
 
-								return postgreSqlVersion.Major > 9 || postgreSqlVersion.Major == 9 && postgreSqlVersion.Minor > 2
-									? _postgreSQLDataProvider93 : _postgreSQLDataProvider;
+								if (postgreSqlVersion.Major > 9 || postgreSqlVersion.Major == 9 && postgreSqlVersion.Minor > 4)
+								{
+									return _postgreSQLDataProvider95;
+								}
+
+								if (postgreSqlVersion.Major == 9 && postgreSqlVersion.Minor > 2)
+								{
+									return _postgreSQLDataProvider93;
+								}
+
+								return _postgreSQLDataProvider;
 							}
 						}
 						catch (Exception)
@@ -97,7 +114,17 @@ namespace LinqToDB.DataProvider.PostgreSQL
 
 		public static IDataProvider GetDataProvider(PostgreSQLVersion version = PostgreSQLVersion.v92)
 		{
-			return version == PostgreSQLVersion.v92 ? _postgreSQLDataProvider : _postgreSQLDataProvider93;
+			switch (version)
+			{
+				case PostgreSQLVersion.v95:
+					return _postgreSQLDataProvider95;
+				case PostgreSQLVersion.v93:
+					return _postgreSQLDataProvider93;
+				case PostgreSQLVersion.v92:
+					return _postgreSQLDataProvider92;
+				default:
+					return _postgreSQLDataProvider;
+			}
 		}
 
 		public static void ResolvePostgreSQL(string path)

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLVersion.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLVersion.cs
@@ -6,5 +6,6 @@ namespace LinqToDB.DataProvider.PostgreSQL
 	{
 		v92,
 		v93,
+		v95,
 	}
 }

--- a/Source/LinqToDB/ProviderName.cs
+++ b/Source/LinqToDB/ProviderName.cs
@@ -101,6 +101,10 @@ namespace LinqToDB
 		/// </summary>
 		public const string PostgreSQL93  = "PostgreSQL.9.3";
 		/// <summary>
+		/// PostgreSQL 9.5+ data provider.
+		/// </summary>
+		public const string PostgreSQL95  = "PostgreSQL.9.5";
+		/// <summary>
 		/// Microsoft SQL Server Compact Edition provider.
 		/// Used as configuration name for SQL CE mapping schema <see cref="DataProvider.SqlCe.SqlCeMappingSchema"/>.
 		/// </summary>

--- a/Source/LinqToDB/SqlQuery/ReservedWords.cs
+++ b/Source/LinqToDB/SqlQuery/ReservedWords.cs
@@ -16,6 +16,7 @@ namespace LinqToDB.SqlQuery
 			_reservedWords[ProviderName.PostgreSQL]    = _reservedWordsPostgres;
 			_reservedWords[ProviderName.PostgreSQL92]  = _reservedWordsPostgres;
 			_reservedWords[ProviderName.PostgreSQL93]  = _reservedWordsPostgres;
+			_reservedWords[ProviderName.PostgreSQL95]  = _reservedWordsPostgres;
 			_reservedWords[ProviderName.Oracle]        = _reservedWordsOracle;
 			_reservedWords[ProviderName.OracleManaged] = _reservedWordsOracle;
 			_reservedWords[ProviderName.OracleNative]  = _reservedWordsOracle;

--- a/Tests/Linq/Update/MergeTests.cs
+++ b/Tests/Linq/Update/MergeTests.cs
@@ -44,6 +44,7 @@ namespace Tests.xUpdate
 				ProviderName.PostgreSQL,
 				ProviderName.PostgreSQL92,
 				ProviderName.PostgreSQL93,
+				ProviderName.PostgreSQL95,
 				ProviderName.MySql,
 				TestProvName.MySql57,
 				TestProvName.MariaDB


### PR DESCRIPTION
INSERT ... ON CONFLICT clause (UPSERT) support for InsertOrUpdate, see https://www.postgresql.org/docs/9.5/static/sql-insert.html#SQL-ON-CONFLICT

It contains questionable code which overrides and restores table alias. But there is no existing facility to create an alias in INSERT clause and I wanted to make as little changes to the core as possible.