### PR TITLE
[WIP] Dynamic columns

### DIFF
--- a/Source/LinqToDB/Expressions/InternalExtensions.cs
+++ b/Source/LinqToDB/Expressions/InternalExtensions.cs
@@ -810,7 +810,7 @@ namespace LinqToDB.Expressions
 						if (e.Object != null)
 							return GetRootObject(e.Object, mapping);
 
-						if (e.Arguments != null && e.Arguments.Count > 0 && (e.IsQueryable() || e.IsAggregate(mapping) || e.IsAssociation(mapping)))
+						if (e.Arguments != null && e.Arguments.Count > 0 && (e.IsQueryable() || e.IsAggregate(mapping) || e.IsAssociation(mapping) || e.Method.IsSqlPropertyMethodEx()))
 							return GetRootObject(e.Arguments[0], mapping);
 
 						break;
@@ -922,7 +922,7 @@ namespace LinqToDB.Expressions
 						var call = (MethodCallExpression)expression;
 						var expr = call.Object;
 
-						if (expr == null && (call.IsQueryable() || call.IsAggregate(mapping) || call.IsAssociation(mapping)) && call.Arguments.Count > 0)
+						if (expr == null && (call.IsQueryable() || call.IsAggregate(mapping) || call.IsAssociation(mapping) || call.Method.IsSqlPropertyMethodEx()) && call.Arguments.Count > 0)
 							expr = call.Arguments[0];
 
 						if (expr != null)

--- a/Source/LinqToDB/Expressions/MemberHelper.cs
+++ b/Source/LinqToDB/Expressions/MemberHelper.cs
@@ -11,8 +11,6 @@ namespace LinqToDB.Expressions
 
 	public static class MemberHelper
 	{
-		private static readonly MemberInfo SQLPropertyMethod = MethodOf(() => Sql.Property<string>(null, null)).GetGenericMethodDefinition();
-
 		/// <summary>
 		/// Gets the member information from given lambda expression. <seealso cref="GetMemberInfo(System.Linq.Expressions.Expression)"/>
 		/// </summary>
@@ -47,8 +45,7 @@ namespace LinqToDB.Expressions
 			if (expr.NodeType == ExpressionType.New)
 				return ((NewExpression)expr).Constructor;
 
-			if (expr is MethodCallExpression methodCall && methodCall.Method.IsGenericMethod &&
-			    methodCall.Method.GetGenericMethodDefinition() == SQLPropertyMethod)
+			if (expr is MethodCallExpression methodCall && methodCall.Method.IsSqlPropertyMethodEx())
 			{
 				// validate expression and get member name
 				var arg1 = methodCall.Arguments[0].NodeType == ExpressionType.Convert

--- a/Source/LinqToDB/Expressions/MemberHelper.cs
+++ b/Source/LinqToDB/Expressions/MemberHelper.cs
@@ -12,11 +12,11 @@ namespace LinqToDB.Expressions
 	public static class MemberHelper
 	{
 		/// <summary>
-		/// Gets the member information from given lambda expression. <seealso cref="GetMemberInfo(System.Linq.Expressions.Expression)"/>
+		/// Gets the member information from given lambda expression. <seealso cref="GetMemberInfo(Expression)" />
 		/// </summary>
 		/// <param name="func">The lambda expression.</param>
 		/// <returns></returns>
-		/// <exception cref="ArgumentException">Only simple, non-navigational, member names are supported in this context (e.g.: x => Sql.Property(x, \"SomeProperty\")).</exception>
+		/// <exception cref="ArgumentException">Only simple, non-navigational, member names are supported in this context (e.g.: x =&gt; Sql.Property(x, \"SomeProperty\")).</exception>
 		public static MemberInfo GetMemberInfo(LambdaExpression func)
 		{
 			return GetMemberInfo(func.Body);
@@ -28,15 +28,15 @@ namespace LinqToDB.Expressions
 		/// <remarks>
 		/// Returns member information for given expressions, e.g.:
 		/// <list type="bullet">
-		/// <item><description>For: x => x.SomeProperty, returns MemberInfo of SomeProperty.</description></item>
-		/// <item><description>For: x => x.SomeMethod(), returns MethodInfo of SomeMethod.</description></item>
-		/// <item><description>For: x => new { X = x.Name }, return ConstructorInfo of anonymous type.</description></item>
-		/// <item><description>For: x => Sql.Property&lt;int&gt;(x, "SomeProperty"), returns MemberInfo of "SomeProperty" if exists on type, otherwise returns DynamicColumnInfo for SomeProperty on given type.</description></item>
+		/// <item><description>For: x =&gt; x.SomeProperty, returns MemberInfo of SomeProperty.</description></item>
+		/// <item><description>For: x =&gt; x.SomeMethod(), returns MethodInfo of SomeMethod.</description></item>
+		/// <item><description>For: x =&gt; new { X = x.Name }, return ConstructorInfo of anonymous type.</description></item>
+		/// <item><description>For: x =&gt; Sql.Property&lt;int&gt;(x, "SomeProperty"), returns MemberInfo of "SomeProperty" if exists on type, otherwise returns DynamicColumnInfo for SomeProperty on given type.</description></item>
 		/// </list>
 		/// </remarks>
 		/// <param name="expr">The expression.</param>
 		/// <returns></returns>
-		/// <exception cref="ArgumentException">Only simple, non-navigational, member names are supported in this context (e.g.: x => Sql.Property(x, \"SomeProperty\")).</exception>
+		/// <exception cref="ArgumentException">Only simple, non-navigational, member names are supported in this context (e.g.: x =&gt; Sql.Property(x, \"SomeProperty\")).</exception>
 		public static MemberInfo GetMemberInfo(Expression expr)
 		{
 			while (expr.NodeType == ExpressionType.Convert)

--- a/Source/LinqToDB/Expressions/MemberHelper.cs
+++ b/Source/LinqToDB/Expressions/MemberHelper.cs
@@ -39,7 +39,7 @@ namespace LinqToDB.Expressions
 		/// <exception cref="ArgumentException">Only simple, non-navigational, member names are supported in this context (e.g.: x =&gt; Sql.Property(x, \"SomeProperty\")).</exception>
 		public static MemberInfo GetMemberInfo(Expression expr)
 		{
-			while (expr.NodeType == ExpressionType.Convert)
+			while (expr.NodeType == ExpressionType.Convert || expr.NodeType == ExpressionType.ConvertChecked)
 				expr = ((UnaryExpression)expr).Operand;
 
 			if (expr.NodeType == ExpressionType.New)

--- a/Source/LinqToDB/Extensions/ReflectionExtensions.cs
+++ b/Source/LinqToDB/Extensions/ReflectionExtensions.cs
@@ -274,16 +274,32 @@ namespace LinqToDB.Extensions
 		private static readonly MemberInfo SQLPropertyMethod = MemberHelper.MethodOf(() => Sql.Property<string>(null, null)).GetGenericMethodDefinition();
 
 		/// <summary>
-		/// Determines whether given member info represent a Sql.Property method.
+		/// Determines whether member info represent a Sql.Property method.
 		/// </summary>
 		/// <param name="memberInfo">The member information.</param>
 		/// <returns>
-		///   <c>true</c> if given member info is Sql.Property method; otherwise, <c>false</c>.
+		///   <c>true</c> if member info is Sql.Property method; otherwise, <c>false</c>.
 		/// </returns>
 		public static bool IsSqlPropertyMethodEx(this MemberInfo memberInfo)
 		{
 			return memberInfo is MethodInfo methodCall && methodCall.IsGenericMethod &&
 			       methodCall.GetGenericMethodDefinition() == SQLPropertyMethod;
+		}
+
+		/// <summary>
+		/// Determines whether member info is dynamic column property.
+		/// </summary>
+		/// <param name="memberInfo">The member information.</param>
+		/// <returns>
+		///   <c>true</c> if member info is dynamic column property; otherwise, <c>false</c>.
+		/// </returns>
+		public static bool IsDynamicColumnPropertyEx(this MemberInfo memberInfo)
+		{
+#if !NETSTANDARD1_6
+			return memberInfo.MemberType == MemberTypes.Property && memberInfo is Mapping.DynamicColumnInfo;
+#else
+			return false;
+#endif
 		}
 
 		public static object[] GetCustomAttributesEx(this MemberInfo memberInfo, Type attributeType, bool inherit)
@@ -404,7 +420,7 @@ namespace LinqToDB.Extensions
 			public static readonly ConcurrentDictionary<Type,T[]> TypeAttributes = new ConcurrentDictionary<Type,T[]>();
 		}
 
-		#region Attributes cache
+#region Attributes cache
 
 		static readonly ConcurrentDictionary<Type, object[]> _typeAttributesTopInternal = new ConcurrentDictionary<Type, object[]>();
 
@@ -470,7 +486,7 @@ namespace LinqToDB.Extensions
 				GetAttributesTreeInternal(list, type.BaseTypeEx());
 		}
 
-		#endregion
+#endregion
 
 		/// <summary>
 		/// Returns an array of custom attributes applied to a type.
@@ -909,9 +925,9 @@ namespace LinqToDB.Extensions
 			return type.GetEvent(eventName);
 		}
 		
-		#endregion
+#endregion
 
-		#region MethodInfo extensions
+#region MethodInfo extensions
 
 		public static PropertyInfo GetPropertyInfo(this MethodInfo method)
 		{
@@ -932,9 +948,9 @@ namespace LinqToDB.Extensions
 			return null;
 		}
 
-		#endregion
+#endregion
 
-		#region MemberInfo extensions
+#region MemberInfo extensions
 
 		public static Type GetMemberType(this MemberInfo memberInfo)
 		{
@@ -1074,7 +1090,7 @@ namespace LinqToDB.Extensions
 			return false;
 		}
 
-		#endregion
+#endregion
 
 	}
 }

--- a/Source/LinqToDB/Extensions/ReflectionExtensions.cs
+++ b/Source/LinqToDB/Extensions/ReflectionExtensions.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.Xml;
 
 using JetBrains.Annotations;
+using LinqToDB.Expressions;
 
 namespace LinqToDB.Extensions
 {
@@ -268,6 +269,21 @@ namespace LinqToDB.Extensions
 		public static bool IsMethodEx(this MemberInfo memberInfo)
 		{
 			return memberInfo.MemberType == MemberTypes.Method;
+		}
+
+		private static readonly MemberInfo SQLPropertyMethod = MemberHelper.MethodOf(() => Sql.Property<string>(null, null)).GetGenericMethodDefinition();
+
+		/// <summary>
+		/// Determines whether given member info represent a Sql.Property method.
+		/// </summary>
+		/// <param name="memberInfo">The member information.</param>
+		/// <returns>
+		///   <c>true</c> if given member info is Sql.Property method; otherwise, <c>false</c>.
+		/// </returns>
+		public static bool IsSqlPropertyMethodEx(this MemberInfo memberInfo)
+		{
+			return memberInfo is MethodInfo methodCall && methodCall.IsGenericMethod &&
+			       methodCall.GetGenericMethodDefinition() == SQLPropertyMethod;
 		}
 
 		public static object[] GetCustomAttributesEx(this MemberInfo memberInfo, Type attributeType, bool inherit)

--- a/Source/LinqToDB/Extensions/ReflectionExtensions.cs
+++ b/Source/LinqToDB/Extensions/ReflectionExtensions.cs
@@ -420,7 +420,7 @@ namespace LinqToDB.Extensions
 			public static readonly ConcurrentDictionary<Type,T[]> TypeAttributes = new ConcurrentDictionary<Type,T[]>();
 		}
 
-#region Attributes cache
+		#region Attributes cache
 
 		static readonly ConcurrentDictionary<Type, object[]> _typeAttributesTopInternal = new ConcurrentDictionary<Type, object[]>();
 
@@ -486,7 +486,7 @@ namespace LinqToDB.Extensions
 				GetAttributesTreeInternal(list, type.BaseTypeEx());
 		}
 
-#endregion
+		#endregion
 
 		/// <summary>
 		/// Returns an array of custom attributes applied to a type.
@@ -925,9 +925,9 @@ namespace LinqToDB.Extensions
 			return type.GetEvent(eventName);
 		}
 		
-#endregion
+		#endregion
 
-#region MethodInfo extensions
+		#region MethodInfo extensions
 
 		public static PropertyInfo GetPropertyInfo(this MethodInfo method)
 		{
@@ -948,9 +948,9 @@ namespace LinqToDB.Extensions
 			return null;
 		}
 
-#endregion
+		#endregion
 
-#region MemberInfo extensions
+		#region MemberInfo extensions
 
 		public static Type GetMemberType(this MemberInfo memberInfo)
 		{
@@ -1090,7 +1090,7 @@ namespace LinqToDB.Extensions
 			return false;
 		}
 
-#endregion
+		#endregion
 
 	}
 }

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.QueryBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.QueryBuilder.cs
@@ -235,6 +235,9 @@ namespace LinqToDB.Linq.Builder
 
 						if (IsServerSideOnly(expr) || PreferServerSide(expr, enforceServerSide))
 							return new TransformInfo(BuildSql(context, expr));
+
+						if (ce.Method.IsSqlPropertyMethodEx())
+							return new TransformInfo(BuildSql(context, expr));
 					}
 
 					break;

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.QueryBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.QueryBuilder.cs
@@ -233,10 +233,7 @@ namespace LinqToDB.Linq.Builder
 							return new TransformInfo(GetSubQueryExpression(context, ce, enforceServerSide));
 						}
 
-						if (IsServerSideOnly(expr) || PreferServerSide(expr, enforceServerSide))
-							return new TransformInfo(BuildSql(context, expr));
-
-						if (ce.Method.IsSqlPropertyMethodEx())
+						if (IsServerSideOnly(expr) || PreferServerSide(expr, enforceServerSide) || ce.Method.IsSqlPropertyMethodEx())
 							return new TransformInfo(BuildSql(context, expr));
 					}
 

--- a/Source/LinqToDB/Linq/Builder/LoadWithBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/LoadWithBuilder.cs
@@ -47,10 +47,20 @@ namespace LinqToDB.Linq.Builder
 
 					case ExpressionType.Call      :
 						{
+							var cexpr = (MethodCallExpression)expression;
+
+							if (cexpr.Method.IsSqlPropertyMethodEx())
+							{
+								foreach (var assoc in GetAssociations(builder, builder.ConvertExpression(expression)))
+									yield return assoc;
+
+								yield break;
+							}
+
+
 							if (lastMember == null)
 								goto default;
-
-							var cexpr = (MethodCallExpression)expression;
+							
 							var expr  = cexpr.Object;
 
 							if (expr == null)

--- a/Source/LinqToDB/Linq/Builder/UpdateBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/UpdateBuilder.cs
@@ -267,16 +267,13 @@ namespace LinqToDB.Linq.Builder
 			SqlTable                        table,
 			List<SqlSetExpression> items)
 		{
-			var ext = extract.Body;
+			var member = MemberHelper.GetMemberInfo(extract.Body);
+			var rootObject = extract.Body.GetRootObject(builder.MappingSchema);
 
-			while (ext.NodeType == ExpressionType.Convert || ext.NodeType == ExpressionType.ConvertChecked)
-				ext = ((UnaryExpression)ext).Operand;
-
-			if (ext.NodeType != ExpressionType.MemberAccess || ext.GetRootObject(builder.MappingSchema) != extract.Parameters[0])
+			if (!member.IsPropertyEx() && !member.IsFieldEx() || rootObject != extract.Parameters[0])
 				throw new LinqException("Member expression expected for the 'Set' statement.");
 
-			var body   = (MemberExpression)ext;
-			var member = body.Member;
+			var body = Expression.MakeMemberAccess(rootObject, member);
 
 			if (member is MethodInfo)
 				member = ((MethodInfo)member).GetPropertyInfo();

--- a/Source/LinqToDB/Mapping/ColumnDescriptor.cs
+++ b/Source/LinqToDB/Mapping/ColumnDescriptor.cs
@@ -27,7 +27,7 @@ namespace LinqToDB.Mapping
 		{
 			MemberAccessor = memberAccessor;
 			MemberInfo     = memberAccessor.MemberInfo;
-
+			
 			if (MemberInfo.IsFieldEx())
 			{
 				var fieldInfo = (FieldInfo)MemberInfo;
@@ -38,12 +38,6 @@ namespace LinqToDB.Mapping
 				var propertyInfo = (PropertyInfo)MemberInfo;
 				MemberType = propertyInfo.PropertyType;
 			}
-#if !NETSTANDARD1_6
-			else if (MemberInfo is DynamicColumnInfo dynamicColumnInfo)
-			{
-				MemberType = dynamicColumnInfo.ColumnType;
-			}
-#endif
 
 			MemberName      = columnAttribute.MemberName ?? MemberInfo.Name;
 			ColumnName      = columnAttribute.Name       ?? MemberInfo.Name;

--- a/Source/LinqToDB/Mapping/ColumnDescriptor.cs
+++ b/Source/LinqToDB/Mapping/ColumnDescriptor.cs
@@ -38,6 +38,12 @@ namespace LinqToDB.Mapping
 				var propertyInfo = (PropertyInfo)MemberInfo;
 				MemberType = propertyInfo.PropertyType;
 			}
+#if !NETSTANDARD1_6
+			else if (MemberInfo is DynamicColumnInfo dynamicColumnInfo)
+			{
+				MemberType = dynamicColumnInfo.ColumnType;
+			}
+#endif
 
 			MemberName      = columnAttribute.MemberName ?? MemberInfo.Name;
 			ColumnName      = columnAttribute.Name       ?? MemberInfo.Name;

--- a/Source/LinqToDB/Mapping/ColumnDescriptor.cs
+++ b/Source/LinqToDB/Mapping/ColumnDescriptor.cs
@@ -27,7 +27,7 @@ namespace LinqToDB.Mapping
 		{
 			MemberAccessor = memberAccessor;
 			MemberInfo     = memberAccessor.MemberInfo;
-			
+
 			if (MemberInfo.IsFieldEx())
 			{
 				var fieldInfo = (FieldInfo)MemberInfo;

--- a/Source/LinqToDB/Mapping/DynamicColumnInfo.cs
+++ b/Source/LinqToDB/Mapping/DynamicColumnInfo.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Reflection;
+
+namespace LinqToDB.Mapping
+{
+#if !NETSTANDARD1_6
+
+	/// <summary>
+	/// Represents a dynamic column, which doesn't have a backing field in it's declaring type.
+	/// </summary>
+	/// <seealso cref="System.Reflection.MemberInfo" />
+	public class DynamicColumnInfo : MemberInfo, IEquatable<DynamicColumnInfo>
+	{
+		/// <inheritdoc cref="MemberInfo.MemberType"/>
+		public override MemberTypes MemberType => MemberTypes.Custom;
+		
+		/// <inheritdoc cref="MemberInfo.Name"/>
+		public override string Name { get; }
+
+		/// <inheritdoc cref="MemberInfo.DeclaringType"/>
+		public override Type DeclaringType { get; }
+
+		/// <inheritdoc cref="MemberInfo.ReflectedType"/>
+		public override Type ReflectedType => DeclaringType;
+
+		/// <inheritdoc cref="MemberInfo.GetCustomAttributes(bool)"/>
+		public override object[] GetCustomAttributes(bool inherit)
+			=> new object[0];
+
+		/// <inheritdoc cref="MemberInfo.GetCustomAttributes(Type, bool)"/>
+		public override object[] GetCustomAttributes(Type attributeType, bool inherit)
+			=> new object[0];
+
+		/// <inheritdoc cref="MemberInfo.IsDefined"/>
+		public override bool IsDefined(Type attributeType, bool inherit)
+			=> false;
+
+		/// <summary>
+		/// Gets the type of the column.
+		/// </summary>
+		/// <value>
+		/// The type of the column.
+		/// </value>
+		public Type ColumnType { get; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DynamicColumnInfo" /> class.
+		/// </summary>
+		/// <param name="declaringType">Type of the declaring.</param>
+		/// <param name="columnType">Type of the column.</param>
+		/// <param name="memberName">Name of the member.</param>
+		public DynamicColumnInfo(Type declaringType, Type columnType, string memberName)
+		{
+			DeclaringType = declaringType ?? throw new ArgumentNullException(nameof(declaringType));
+			ColumnType = columnType ?? throw new ArgumentNullException(nameof(columnType));
+			Name = !string.IsNullOrEmpty(memberName) ? memberName : throw new ArgumentNullException(nameof(memberName));
+		}
+
+		/// <inheritdoc cref="IEquatable{T}.Equals(T)"/>
+		public bool Equals(DynamicColumnInfo other)
+		{
+			if (other == null)
+				return false;
+
+			return ReferenceEquals(this, other) || Name.Equals(other.Name, StringComparison.Ordinal) && other.DeclaringType == DeclaringType;
+		}
+
+		/// <inheritdoc cref="object.Equals(object)"/>
+		public override bool Equals(object obj)
+		{
+			if (obj is DynamicColumnInfo dynamicColumnInfo)
+				return Equals(dynamicColumnInfo);
+
+			return false;
+		}
+
+		/// <inheritdoc cref="object.GetHashCode"/>
+		public override int GetHashCode()
+			=> unchecked ((Name.GetHashCode() * 397) ^ DeclaringType.GetHashCode());
+
+		/// <summary>
+		/// Implements the operator ==.
+		/// </summary>
+		/// <param name="a">a.</param>
+		/// <param name="b">The b.</param>
+		/// <returns>
+		/// The result of the operator.
+		/// </returns>
+		public static bool operator ==(DynamicColumnInfo a, DynamicColumnInfo b)
+			=> a?.Equals(b) ?? ReferenceEquals(b, null);
+
+		/// <summary>
+		/// Implements the operator !=.
+		/// </summary>
+		/// <param name="a">a.</param>
+		/// <param name="b">The b.</param>
+		/// <returns>
+		/// The result of the operator.
+		/// </returns>
+		public static bool operator !=(DynamicColumnInfo a, DynamicColumnInfo b)
+			=> !a?.Equals(b) ?? !ReferenceEquals(b, null);
+	}
+	
+#endif
+}

--- a/Source/LinqToDB/Mapping/DynamicColumnsStoreAttribute.cs
+++ b/Source/LinqToDB/Mapping/DynamicColumnsStoreAttribute.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace LinqToDB.Mapping
+{
+	/// <summary>
+	/// Marks target member as dynamic columns store.
+	/// </summary>
+	/// <seealso cref="System.Attribute" />
+	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public class DynamicColumnsStoreAttribute : Attribute
+    {
+	    /// <summary>
+	    /// Gets or sets mapping schema configuration name, for which this attribute should be taken into account.
+	    /// <see cref="ProviderName"/> for standard names.
+	    /// Attributes with <c>null</c> or empty string <see cref="Configuration"/> value applied to all configurations (if no attribute found for current configuration).
+	    /// </summary>
+	    public string Configuration { get; set; }
+	}
+}

--- a/Source/LinqToDB/Mapping/EntityMappingBuilder.cs
+++ b/Source/LinqToDB/Mapping/EntityMappingBuilder.cs
@@ -205,7 +205,7 @@ namespace LinqToDB.Mapping
 		{
 			return (new PropertyMappingBuilder<T>(this, func)).IsColumn();
 		}
-		
+
 		/// <summary>
 		/// Adds association mapping to current entity.
 		/// </summary>
@@ -329,7 +329,7 @@ namespace LinqToDB.Mapping
 		{
 			return SetTable(a => a.Database = databaseName);
 		}
-		
+
 		/// <summary>
 		/// Adds inheritance mapping for specified discriminator value.
 		/// </summary>

--- a/Source/LinqToDB/Mapping/EntityMappingBuilder.cs
+++ b/Source/LinqToDB/Mapping/EntityMappingBuilder.cs
@@ -329,22 +329,7 @@ namespace LinqToDB.Mapping
 		{
 			return SetTable(a => a.Database = databaseName);
 		}
-
-		/// <summary>
-		/// Sets dynamic columns store for current entity.
-		/// </summary>
-		/// <param name="func">Dynamic columns store getter.</param>
-		/// <returns>Returns current fluent entity mapping builder.</returns>
-		public EntityMappingBuilder<T> HasDynamicColumnsStore(Expression<Func<T, object>> func)
-		{
-			return SetAttribute(
-				func,
-				false,
-				_ => new DynamicColumnsStoreAttribute(),
-				(_, a) => { },
-				a => a.Configuration);
-		}
-
+		
 		/// <summary>
 		/// Adds inheritance mapping for specified discriminator value.
 		/// </summary>

--- a/Source/LinqToDB/Mapping/EntityMappingBuilder.cs
+++ b/Source/LinqToDB/Mapping/EntityMappingBuilder.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-
+using LinqToDB.Expressions;
 using LinqToDB.Extensions;
 
 namespace LinqToDB.Mapping
@@ -205,7 +205,7 @@ namespace LinqToDB.Mapping
 		{
 			return (new PropertyMappingBuilder<T>(this, func)).IsColumn();
 		}
-
+		
 		/// <summary>
 		/// Adds association mapping to current entity.
 		/// </summary>
@@ -221,8 +221,8 @@ namespace LinqToDB.Mapping
 			Expression<Func<T, ID1>> thisKey,
 			Expression<Func<S, ID2>> otherKey )
 		{
-			var thisKeyName = ((MemberExpression)thisKey.Body).Member.Name;
-			var otherKeyName = ((MemberExpression)otherKey.Body).Member.Name;
+			var thisKeyName = MemberHelper.GetMemberInfo(thisKey).Name;
+			var otherKeyName = MemberHelper.GetMemberInfo(otherKey).Name;
 
 			var objProp = Expression.Lambda<Func<T, object>>(Expression.Convert(prop.Body, typeof(object)), prop.Parameters );
 
@@ -331,6 +331,21 @@ namespace LinqToDB.Mapping
 		}
 
 		/// <summary>
+		/// Sets dynamic columns store for current entity.
+		/// </summary>
+		/// <param name="func">Dynamic columns store getter.</param>
+		/// <returns>Returns current fluent entity mapping builder.</returns>
+		public EntityMappingBuilder<T> HasDynamicColumnsStore(Expression<Func<T, object>> func)
+		{
+			return SetAttribute(
+				func,
+				false,
+				_ => new DynamicColumnsStoreAttribute(),
+				(_, a) => { },
+				a => a.Configuration);
+		}
+
+		/// <summary>
 		/// Adds inheritance mapping for specified discriminator value.
 		/// </summary>
 		/// <typeparam name="S">Discriminator value type.</typeparam>
@@ -421,10 +436,8 @@ namespace LinqToDB.Mapping
 
 			Action<Expression,bool> setAttr = (e,m) =>
 			{
-				var memberInfo =
-					e is MemberExpression     ? ((MemberExpression)    e).Member :
-					e is MethodCallExpression ? ((MethodCallExpression)e).Method : null;
-
+				var memberInfo = MemberHelper.GetMemberInfo(e);
+					
 				if (e is MemberExpression && memberInfo.ReflectedTypeEx() != typeof(T))
 					memberInfo = typeof(T).GetMemberEx(memberInfo);
 

--- a/Source/LinqToDB/Mapping/MappingSchema.cs
+++ b/Source/LinqToDB/Mapping/MappingSchema.cs
@@ -923,6 +923,14 @@ namespace LinqToDB.Mapping
 		}
 
 		/// <summary>
+		/// Gets the dynamic columns defined on given type.
+		/// </summary>
+		/// <param name="type">The type.</param>
+		/// <returns>All dynamic columns defined on given type.</returns>
+		public MemberInfo[] GetDynamicColumns(Type type)
+			=> MetadataReaders.SelectMany(mr => mr.GetDynamicColumns(type)).ToArray();
+
+		/// <summary>
 		/// Gets fluent mapping builder for current schema.
 		/// </summary>
 		/// <returns>Fluent mapping builder.</returns>

--- a/Source/LinqToDB/Metadata/AttributeReader.cs
+++ b/Source/LinqToDB/Metadata/AttributeReader.cs
@@ -34,5 +34,9 @@ namespace LinqToDB.Metadata
 
 			return arr;
 		}
+
+		/// <inheritdoc cref="IMetadataReader.GetDynamicColumns"/>
+		public MemberInfo[] GetDynamicColumns(Type type)
+			=> new MemberInfo[0];
 	}
 }

--- a/Source/LinqToDB/Metadata/FluentMetadataReader.cs
+++ b/Source/LinqToDB/Metadata/FluentMetadataReader.cs
@@ -26,7 +26,7 @@ namespace LinqToDB.Metadata
 		{
 			_types.GetOrAdd(type, t => new List<Attribute>()).Add(attribute);
 		}
-		
+
 		readonly ConcurrentDictionary<MemberInfo,List<Attribute>> _members = new ConcurrentDictionary<MemberInfo,List<Attribute>>();
 
 		public T[] GetAttributes<T>(Type type, MemberInfo memberInfo, bool inherit = true)
@@ -52,7 +52,7 @@ namespace LinqToDB.Metadata
 
 			return GetAttributes<T>(parent, mi, inherit);
 		}
-		
+
 		public void AddAttribute(MemberInfo memberInfo, Attribute attribute)
 		{
 			if (memberInfo.IsDynamicColumnPropertyEx())

--- a/Source/LinqToDB/Metadata/FluentMetadataReader.cs
+++ b/Source/LinqToDB/Metadata/FluentMetadataReader.cs
@@ -55,10 +55,8 @@ namespace LinqToDB.Metadata
 		
 		public void AddAttribute(MemberInfo memberInfo, Attribute attribute)
 		{
-#if !NETSTANDARD1_6
-			if (memberInfo is DynamicColumnInfo)
+			if (memberInfo.IsDynamicColumnPropertyEx())
 				_dynamicColumns.GetOrAdd(memberInfo.DeclaringType, new ConcurrentDictionary<MemberInfo, byte>()).TryAdd(memberInfo, 0);
-#endif
 
 			_members.GetOrAdd(memberInfo, t => new List<Attribute>()).Add(attribute);
 		}

--- a/Source/LinqToDB/Metadata/IMetadataReader.cs
+++ b/Source/LinqToDB/Metadata/IMetadataReader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using JetBrains.Annotations;
 
 namespace LinqToDB.Metadata
 {
@@ -7,5 +8,14 @@ namespace LinqToDB.Metadata
 	{
 		T[] GetAttributes<T>(Type type,                        bool inherit = true) where T : Attribute;
 		T[] GetAttributes<T>(Type type, MemberInfo memberInfo, bool inherit = true) where T : Attribute;
+
+		/// <summary>
+		/// Gets the dynamic columns defined on given type.
+		/// </summary>
+		/// <param name="type">The type.</param>
+		/// <returns>All dynamic columns defined on given type.</returns>
+		[NotNull]
+		[ItemNotNull]
+		MemberInfo[] GetDynamicColumns(Type type);
 	}
 }

--- a/Source/LinqToDB/Metadata/MetadataReader.cs
+++ b/Source/LinqToDB/Metadata/MetadataReader.cs
@@ -36,5 +36,9 @@ namespace LinqToDB.Metadata
 		{
 			return _readers.SelectMany(r => r.GetAttributes<T>(type, memberInfo, inherit)).ToArray();
 		}
+
+		/// <inheritdoc cref="IMetadataReader.GetDynamicColumns"/>
+		public MemberInfo[] GetDynamicColumns(Type type)
+			=> _readers.SelectMany(r => r.GetDynamicColumns(type)).ToArray();
 	}
 }

--- a/Source/LinqToDB/Metadata/SystemComponentModelDataAnnotationsSchemaAttributeReader.cs
+++ b/Source/LinqToDB/Metadata/SystemComponentModelDataAnnotationsSchemaAttributeReader.cs
@@ -74,5 +74,8 @@ namespace LinqToDB.Metadata
 
 			return Array<T>.Empty;
 		}
+
+		public MemberInfo[] GetDynamicColumns(Type type)
+			=> new MemberInfo[0];
 	}
 }

--- a/Source/LinqToDB/Metadata/SystemComponentModelDataAnnotationsSchemaAttributeReader.cs
+++ b/Source/LinqToDB/Metadata/SystemComponentModelDataAnnotationsSchemaAttributeReader.cs
@@ -75,6 +75,7 @@ namespace LinqToDB.Metadata
 			return Array<T>.Empty;
 		}
 
+		/// <inheritdoc cref="IMetadataReader.GetDynamicColumns"/>
 		public MemberInfo[] GetDynamicColumns(Type type)
 			=> new MemberInfo[0];
 	}

--- a/Source/LinqToDB/Metadata/SystemDataLinqAttributeReader.cs
+++ b/Source/LinqToDB/Metadata/SystemDataLinqAttributeReader.cs
@@ -97,5 +97,9 @@ namespace LinqToDB.Metadata
 
 			return Array<T>.Empty;
 		}
+
+		/// <inheritdoc cref="IMetadataReader.GetDynamicColumns"/>
+		public MemberInfo[] GetDynamicColumns(Type type)
+			=> _reader.GetDynamicColumns(type);
 	}
 }

--- a/Source/LinqToDB/Metadata/SystemDataSqlServerAttributeReader.cs
+++ b/Source/LinqToDB/Metadata/SystemDataSqlServerAttributeReader.cs
@@ -112,5 +112,9 @@ namespace LinqToDB.Metadata
 
 			return Array<T>.Empty;
 		}
+
+		/// <inheritdoc cref="IMetadataReader.GetDynamicColumns"/>
+		public MemberInfo[] GetDynamicColumns(Type type)
+			=> _reader.GetDynamicColumns(type);
 	}
 }

--- a/Source/LinqToDB/Metadata/XmlAttributeReader.cs
+++ b/Source/LinqToDB/Metadata/XmlAttributeReader.cs
@@ -168,5 +168,8 @@ namespace LinqToDB.Metadata
 
 			return Array<T>.Empty;
 		}
+
+		public MemberInfo[] GetDynamicColumns(Type type)
+			=> new MemberInfo[0];
 	}
 }

--- a/Source/LinqToDB/Metadata/XmlAttributeReader.cs
+++ b/Source/LinqToDB/Metadata/XmlAttributeReader.cs
@@ -169,6 +169,7 @@ namespace LinqToDB.Metadata
 			return Array<T>.Empty;
 		}
 
+		/// <inheritdoc cref="IMetadataReader.GetDynamicColumns"/>
 		public MemberInfo[] GetDynamicColumns(Type type)
 			=> new MemberInfo[0];
 	}

--- a/Source/LinqToDB/Reflection/MemberAccessor.cs
+++ b/Source/LinqToDB/Reflection/MemberAccessor.cs
@@ -188,7 +188,7 @@ namespace LinqToDB.Reflection
 		void SetSimple(MemberInfo memberInfo)
 		{
 			MemberInfo = memberInfo;
-			Type = MemberInfo is PropertyInfo ? ((PropertyInfo)MemberInfo).PropertyType : ((FieldInfo)MemberInfo).FieldType;
+			Type       = MemberInfo is PropertyInfo ? ((PropertyInfo)MemberInfo).PropertyType : ((FieldInfo)MemberInfo).FieldType;
 
 			if (memberInfo is PropertyInfo)
 			{
@@ -370,4 +370,3 @@ namespace LinqToDB.Reflection
 		#endregion
 	}
 }
-

--- a/Source/LinqToDB/Reflection/MemberAccessor.cs
+++ b/Source/LinqToDB/Reflection/MemberAccessor.cs
@@ -188,25 +188,23 @@ namespace LinqToDB.Reflection
 		void SetSimple(MemberInfo memberInfo)
 		{
 			MemberInfo = memberInfo;
+			Type = MemberInfo is PropertyInfo ? ((PropertyInfo)MemberInfo).PropertyType : ((FieldInfo)MemberInfo).FieldType;
 
-			if (memberInfo is PropertyInfo)
-			{
-				Type = ((PropertyInfo)memberInfo).PropertyType;
-				HasGetter = ((PropertyInfo)memberInfo).GetGetMethodEx(true) != null;
-				HasSetter = ((PropertyInfo)memberInfo).GetSetMethodEx(true) != null;
-			}
 #if !NETSTANDARD1_6
-			else if (memberInfo is DynamicColumnInfo dynamicColumnInfo)
+			if (memberInfo is DynamicColumnInfo)
 			{
-				Type = dynamicColumnInfo.ColumnType;
-				// TODO: create dictionary getters and setters (if DynamicColumnStore is defined)
 				HasGetter = false;
 				HasSetter = false;
 			}
+			else
 #endif
+			if (memberInfo is PropertyInfo)
+			{
+				HasGetter = ((PropertyInfo)memberInfo).GetGetMethodEx(true) != null;
+				HasSetter = ((PropertyInfo)memberInfo).GetSetMethodEx(true) != null;
+			}
 			else
 			{
-				Type = ((FieldInfo)memberInfo).FieldType;
 				HasGetter = true;
 				HasSetter = !((FieldInfo)memberInfo).IsInitOnly;
 			}

--- a/Source/LinqToDB/Reflection/MemberAccessor.cs
+++ b/Source/LinqToDB/Reflection/MemberAccessor.cs
@@ -188,15 +188,25 @@ namespace LinqToDB.Reflection
 		void SetSimple(MemberInfo memberInfo)
 		{
 			MemberInfo = memberInfo;
-			Type       = MemberInfo is PropertyInfo ? ((PropertyInfo)MemberInfo).PropertyType : ((FieldInfo)MemberInfo).FieldType;
 
 			if (memberInfo is PropertyInfo)
 			{
+				Type = ((PropertyInfo)memberInfo).PropertyType;
 				HasGetter = ((PropertyInfo)memberInfo).GetGetMethodEx(true) != null;
 				HasSetter = ((PropertyInfo)memberInfo).GetSetMethodEx(true) != null;
 			}
+#if !NETSTANDARD1_6
+			else if (memberInfo is DynamicColumnInfo dynamicColumnInfo)
+			{
+				Type = dynamicColumnInfo.ColumnType;
+				// TODO: create dictionary getters and setters (if DynamicColumnStore is defined)
+				HasGetter = false;
+				HasSetter = false;
+			}
+#endif
 			else
 			{
+				Type = ((FieldInfo)memberInfo).FieldType;
 				HasGetter = true;
 				HasSetter = !((FieldInfo)memberInfo).IsInitOnly;
 			}

--- a/Source/LinqToDB/Reflection/TypeAccessor.cs
+++ b/Source/LinqToDB/Reflection/TypeAccessor.cs
@@ -40,8 +40,13 @@ namespace LinqToDB.Reflection
 
 		#region Public Members
 
-		public IObjectFactory ObjectFactory { get; set; }
-		public abstract Type  Type          { get; }
+		public IObjectFactory          ObjectFactory               { get; set; }
+		public abstract Type           Type                        { get; }
+
+		/// <summary>
+		/// Gets the dynamic columns store accessor.
+		/// </summary>
+		public abstract MemberAccessor DynamicColumnsStoreAccessor { get; }
 
 		#endregion
 

--- a/Source/LinqToDB/Reflection/TypeAccessorT.cs
+++ b/Source/LinqToDB/Reflection/TypeAccessorT.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using LinqToDB.Mapping;
 
 namespace LinqToDB.Reflection
 {
@@ -94,6 +95,13 @@ namespace LinqToDB.Reflection
 
 		internal TypeAccessor()
 		{
+			// set DynamicColumnStoreAccessor
+			var columnStoreProperty = typeof(T).GetMembers().FirstOrDefault(m => m.GetCustomAttributes<DynamicColumnsStoreAttribute>().Any());
+
+			if (columnStoreProperty != null)
+				DynamicColumnsStoreAccessor = new MemberAccessor(this, columnStoreProperty);
+
+			// init members
 			foreach (var member in _members)
 				AddMember(new MemberAccessor(this, member));
 
@@ -112,5 +120,8 @@ namespace LinqToDB.Reflection
 		}
 
 		public override Type Type { get { return typeof(T); } }
+
+		/// <inheritdoc cref="TypeAccessor.DynamicColumnsStoreAccessor"/>
+		public override MemberAccessor DynamicColumnsStoreAccessor { get; }
 	}
 }

--- a/Source/LinqToDB/Sql/Sql.cs
+++ b/Source/LinqToDB/Sql/Sql.cs
@@ -127,6 +127,14 @@ namespace LinqToDB
 			return value != null && (value.Value.CompareTo(low) < 0 || value.Value.CompareTo(high) > 0);
 		}
 
+		/// <summary>
+		/// Allows access to entity property via name. Property can be dynamic or non-dynamic.
+		/// </summary>
+		/// <typeparam name="T">Property type.</typeparam>
+		/// <param name="entity">The entity.</param>
+		/// <param name="propertyName">Name of the property.</param>
+		/// <returns></returns>
+		/// <exception cref="LinqException">'Property' is only server-side method.</exception>
 		public static T Property<T>(object entity, string propertyName)
 		{
 			throw new LinqException("'Property' is only server-side method.");

--- a/Source/LinqToDB/Sql/Sql.cs
+++ b/Source/LinqToDB/Sql/Sql.cs
@@ -127,6 +127,11 @@ namespace LinqToDB
 			return value != null && (value.Value.CompareTo(low) < 0 || value.Value.CompareTo(high) > 0);
 		}
 
+		public static T Property<T>(object entity, string propertyName)
+		{
+			throw new LinqException("'Property' is only server-side method.");
+		}
+
 		#endregion
 
 		#region NoConvert

--- a/Tests/Base/TestBase.cs
+++ b/Tests/Base/TestBase.cs
@@ -322,7 +322,7 @@ namespace Tests
 			return res;
 		}
 
-		protected void TestOnePerson(int id, string firstName, IQueryable<IPerson> persons)
+		protected void TestOnePerson(int id, string firstName, IQueryable<Person> persons)
 		{
 			var list = persons.ToList();
 
@@ -339,7 +339,7 @@ namespace Tests
 			TestOnePerson(1, "John", persons);
 		}
 
-		protected void TestPerson(int id, string firstName, IQueryable<IPerson> persons)
+		protected void TestPerson(int id, string firstName, IQueryable<Person> persons)
 		{
 			var person = persons.ToList().First(p => p.ID == id);
 

--- a/Tests/Base/TestBase.cs
+++ b/Tests/Base/TestBase.cs
@@ -334,12 +334,12 @@ namespace Tests
 			Assert.AreEqual(firstName, person.FirstName);
 		}
 
-		protected void TestOneJohn(IQueryable<IPerson> persons)
+		protected void TestOneJohn(IQueryable<Person> persons)
 		{
 			TestOnePerson(1, "John", persons);
 		}
 
-		protected void TestPerson(int id, string firstName, IQueryable<Person> persons)
+		protected void TestPerson(int id, string firstName, IQueryable<IPerson> persons)
 		{
 			var person = persons.ToList().First(p => p.ID == id);
 

--- a/Tests/Base/TestBase.cs
+++ b/Tests/Base/TestBase.cs
@@ -322,7 +322,7 @@ namespace Tests
 			return res;
 		}
 
-		protected void TestOnePerson(int id, string firstName, IQueryable<Person> persons)
+		protected void TestOnePerson(int id, string firstName, IQueryable<IPerson> persons)
 		{
 			var list = persons.ToList();
 
@@ -334,7 +334,7 @@ namespace Tests
 			Assert.AreEqual(firstName, person.FirstName);
 		}
 
-		protected void TestOneJohn(IQueryable<Person> persons)
+		protected void TestOneJohn(IQueryable<IPerson> persons)
 		{
 			TestOnePerson(1, "John", persons);
 		}

--- a/Tests/Linq/Linq/DynamicColumnsTests.cs
+++ b/Tests/Linq/Linq/DynamicColumnsTests.cs
@@ -294,7 +294,7 @@ namespace Tests.Linq
 			    var result = db.GetTable<MyClass>()
 				    .LoadWith(x => Sql.Property<Patient>(x, "Patient"))
 				    .ToList()
-				    .Select(p => ((Patient)p.ExtendedProperties["Patient"]).Diagnosis)
+				    .Select(p => ((Patient)p.ExtendedProperties["Patient"])?.Diagnosis)
 				    .ToList();
 
 				Assert.IsTrue(result.SequenceEqual(expected));
@@ -306,7 +306,7 @@ namespace Tests.Linq
 		    var ms = new MappingSchema();
 
 		    ms.GetFluentMappingBuilder()
-			    .Entity<MyClass>().HasTableName("Person").HasDynamicColumnsStore(x => x.ExtendedProperties)
+			    .Entity<MyClass>().HasTableName("Person")
 			    .HasPrimaryKey(x => Sql.Property<int>(x, "ID"))
 			    .Property(x => Sql.Property<string>(x, "FirstName")).IsNullable(false)
 			    .Property(x => Sql.Property<string>(x, "LastName")).IsNullable(false)
@@ -316,40 +316,13 @@ namespace Tests.Linq
 		    return ms;
 	    }
 
-		public class MyClass : IPerson
+		public class MyClass
 	    {
 		    [Column("PersonID"), Identity]
 		    public int ID { get; set; }
 
+			[DynamicColumnsStore]
 		    public IDictionary<string, object> ExtendedProperties { get; set; }
-
-		    [NotColumn]
-		    Gender IPerson.Gender
-		    {
-			    get => (Gender)ExtendedProperties["Gender"];
-			    set => ExtendedProperties["Gender"] = value;
-		    }
-
-		    [NotColumn]
-		    string IPerson.FirstName
-		    {
-			    get => (string)ExtendedProperties["FirstName"];
-			    set => ExtendedProperties["FirstName"] = value;
-		    }
-
-		    [NotColumn]
-		    string IPerson.MiddleName
-		    {
-			    get => (string)ExtendedProperties["MiddleName"];
-			    set => ExtendedProperties["MiddleName"] = value;
-		    }
-
-		    [NotColumn]
-		    string IPerson.LastName
-		    {
-			    get => (string)ExtendedProperties["LastName"];
-			    set => ExtendedProperties["LastName"] = value;
-		    }
 	    }
 	}
 }

--- a/Tests/Linq/Linq/DynamicColumnsTests.cs
+++ b/Tests/Linq/Linq/DynamicColumnsTests.cs
@@ -1,0 +1,355 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using LinqToDB;
+using LinqToDB.Mapping;
+using NUnit.Framework;
+using Tests.Model;
+
+namespace Tests.Linq
+{
+	[TestFixture]
+    public class DynamicColumnsTests : TestBase
+    {
+	    [Test, DataContextSource]
+		public void SqlPropertyWithNonDynamicColumn(string context)
+	    {
+		    using (var db = GetDataContext(context))
+		    {
+			    var result = db.GetTable<Person>()
+				    .Where(x => Sql.Property<int>(x, "ID") == 1)
+				    .ToList();
+
+				Assert.AreEqual(1, result.Count);
+				Assert.AreEqual("John", result.Single().FirstName);
+		    }
+		}
+
+	    [Test, DataContextSource]
+		public void SqlPropertyWithNavigationalNonDynamicColumn(string context)
+	    {
+		    using (var db = GetDataContext(context))
+		    {
+			    var result = db.GetTable<Person>()
+				    .Where(x => Sql.Property<string>(x.Patient, "Diagnosis") ==
+				                "Hallucination with Paranoid Bugs\' Delirium of Persecution")
+				    .ToList();
+
+			    Assert.AreEqual(1, result.Count);
+			    Assert.AreEqual("Tester", result.Single().FirstName);
+			}
+	    }
+
+	    [Test, DataContextSource]
+	    public void SqlPropertyWithNonDynamicAssociation(string context)
+	    {
+		    using (var db = GetDataContext(context))
+		    {
+				var result = db.GetTable<Person>()
+					.Where(x => Sql.Property<string>(Sql.Property<Patient>(x, "Patient"), "Diagnosis") ==
+					            "Hallucination with Paranoid Bugs\' Delirium of Persecution")
+					.ToList();
+
+			    Assert.AreEqual(1, result.Count);
+			    Assert.AreEqual("Tester", result.Single().FirstName);
+			}
+	    }
+
+	    [Test, DataContextSource]
+	    public void SqlPropertyWithNonDynamicAssociationViaObject1(string context)
+	    {
+		    using (var db = GetDataContext(context))
+		    {
+			    var result = db.GetTable<Person>()
+				    .Where(x => (string)Sql.Property<object>(Sql.Property<object>(x, "Patient"), "Diagnosis") ==
+				                "Hallucination with Paranoid Bugs\' Delirium of Persecution")
+				    .ToList();
+
+			    Assert.AreEqual(1, result.Count);
+			    Assert.AreEqual("Tester", result.Single().FirstName);
+		    }
+	    }
+
+	    [Test, DataContextSource]
+	    public void SqlPropertyWithNonDynamicAssociationViaObject2(string context)
+	    {
+		    using (var db = GetDataContext(context))
+		    {
+			    var expected = Person.Select(p => p.Patient?.Diagnosis).ToList();
+				var result = db.GetTable<Person>()
+				    .Select(x => Sql.Property<object>(Sql.Property<object>(x, "Patient"), "Diagnosis"))
+				    .ToList();
+
+				Assert.IsTrue(result.SequenceEqual(expected));
+			}
+	    }
+
+		[Test, DataContextSource]
+	    public void SqlPropertyWithDynamicColumn(string context)
+	    {
+		    using (var db = GetDataContext(context, ConfigureDynamicMyClass()))
+		    {
+			    var result = db.GetTable<MyClass>()
+				    .Where(x => Sql.Property<string>(x, "FirstName") == "John")
+				    .ToList();
+
+			    Assert.AreEqual(1, result.Count);
+			    Assert.AreEqual(1, result.Single().ID);
+		    }
+	    }
+		
+	    [Test, DataContextSource]
+	    public void SqlPropertyWithDynamicAssociation(string context)
+	    {
+		    using (var db = GetDataContext(context, ConfigureDynamicMyClass()))
+		    {
+			    var result = db.GetTable<MyClass>()
+				    .Where(x => Sql.Property<string>(Sql.Property<Patient>(x, "Patient"), "Diagnosis") ==
+				                "Hallucination with Paranoid Bugs\' Delirium of Persecution")
+				    .ToList();
+
+			    Assert.AreEqual(1, result.Count);
+			    Assert.AreEqual(2, result.Single().ID);
+		    }
+	    }
+
+		[Test, DataContextSource]
+	    public void SqlPropertySelectAll(string context)
+	    {
+		    using (var db = GetDataContext(context, ConfigureDynamicMyClass()))
+		    {
+			    var expected = Person.Select(p => p.FirstName).ToList();
+				var result = db.GetTable<MyClass>().ToList().Select(p => p.ExtendedProperties["FirstName"]).ToList();
+
+				Assert.IsTrue(result.SequenceEqual(expected));
+			}
+	    }
+
+		[Test, DataContextSource]
+		public void SqlPropertySelectOne(string context)
+	    {
+		    using (var db = GetDataContext(context, ConfigureDynamicMyClass()))
+		    {
+			    var expected = Person.Select(p => p.FirstName).ToList();
+			    var result = db.GetTable<MyClass>()
+				    .Select(x => Sql.Property<string>(x, "FirstName"))
+				    .ToList();
+
+				Assert.IsTrue(result.SequenceEqual(expected));
+		    }
+	    }
+
+	    [Test, DataContextSource]
+	    public void SqlPropertySelectProject(string context)
+	    {
+		    using (var db = GetDataContext(context, ConfigureDynamicMyClass()))
+		    {
+			    var expected = Person.Select(p => new
+			    {
+				    PersonId = p.ID,
+				    Name = p.FirstName
+			    }).ToList();
+
+			    var result = db.GetTable<MyClass>()
+				    .Select(x => new
+				    {
+					    PersonId = x.ID,
+					    Name = Sql.Property<string>(x, "FirstName")
+				    })
+				    .ToList();
+
+			    Assert.IsTrue(result.SequenceEqual(expected));
+		    }
+	    }
+
+	    [Test, DataContextSource]
+		public void SqlPropertySelectAssociated(string context)
+	    {
+		    using (var db = GetDataContext(context, ConfigureDynamicMyClass()))
+		    {
+			    var expected = Person.Select(p => p.Patient?.Diagnosis).ToList();
+
+			    var result = db.GetTable<MyClass>()
+				    .Select(x => Sql.Property<string>(Sql.Property<Patient>(x, "Patient"), "Diagnosis"))
+				    .ToList();
+
+			    Assert.IsTrue(result.SequenceEqual(expected));
+		    }
+	    }
+
+	    [Test, DataContextSource]
+		public void SqlPropertyWhere(string context)
+	    {
+		    using (var db = GetDataContext(context, ConfigureDynamicMyClass()))
+		    {
+			    var expected = Person.Where(p => p.FirstName == "John").Select(p => p.ID).ToList();
+			    var result = db.GetTable<MyClass>()
+				    .Where(x => Sql.Property<string>(x, "FirstName") == "John")
+				    .Select(x => x.ID)
+				    .ToList();
+
+				Assert.IsTrue(result.SequenceEqual(expected));
+		    }
+	    }
+
+	    [Test, DataContextSource]
+		public void SqlPropertyWhereAssociated(string context)
+	    {
+		    using (var db = GetDataContext(context, ConfigureDynamicMyClass()))
+		    {
+			    var expected = Person.Where(p => p.Patient?.Diagnosis != null).Select(p => p.ID).ToList();
+			    var result = db.GetTable<MyClass>()
+				    .Where(x => Sql.Property<string>(Sql.Property<Patient>(x, "Patient"), "Diagnosis") != null)
+				    .Select(x => x.ID)
+				    .ToList();
+
+				Assert.IsTrue(result.SequenceEqual(expected));
+		    }
+	    }
+
+	    [Test, DataContextSource]
+		public void SqlPropertyOrderBy(string context)
+	    {
+		    using (var db = GetDataContext(context, ConfigureDynamicMyClass()))
+		    {
+			    var expected = Person.OrderByDescending(p => p.FirstName).Select(p => p.ID).ToList();
+			    var result = db.GetTable<MyClass>()
+				    .OrderByDescending(x => Sql.Property<string>(x, "FirstName"))
+				    .Select(x => x.ID)
+				    .ToList();
+
+				Assert.IsTrue(result.SequenceEqual(expected));
+		    }
+	    }
+
+	    [Test, DataContextSource]
+		public void SqlPropertyOrderByAssociated(string context)
+	    {
+		    using (var db = GetDataContext(context, ConfigureDynamicMyClass()))
+		    {
+			    var expected = Person.OrderBy(p => p.Patient?.Diagnosis).Select(p => p.ID).ToList();
+			    var result = db.GetTable<MyClass>()
+				    .OrderBy(x => Sql.Property<string>(Sql.Property<Patient>(x, "Patient"), "Diagnosis"))
+				    .Select(x => x.ID)
+				    .ToList();
+
+			    Assert.IsTrue(result.SequenceEqual(expected));
+		    }
+		}
+
+	    [Test, DataContextSource]
+		public void SqlPropertyGroupBy(string context)
+	    {
+		    using (var db = GetDataContext(context, ConfigureDynamicMyClass()))
+		    {
+			    var expected = Person.GroupBy(p => p.FirstName).Select(p => new {p.Key, Count = p.Count()}).ToList();
+			    var result = db.GetTable<MyClass>()
+				    .GroupBy(x => Sql.Property<string>(x, "FirstName"))
+				    .Select(p => new {p.Key, Count = p.Count()})
+				    .ToList();
+
+				Assert.IsTrue(result.SequenceEqual(expected));
+		    }
+		}
+
+	    [Test, DataContextSource]
+		public void SqlPropertyGroupByAssociated(string context)
+	    {
+		    using (var db = GetDataContext(context, ConfigureDynamicMyClass()))
+		    {
+			    var expected = Person.GroupBy(p => p.Patient?.Diagnosis).Select(p => new {p.Key, Count = p.Count()}).ToList();
+			    var result = db.GetTable<MyClass>()
+				    .GroupBy(x => Sql.Property<string>(Sql.Property<Patient>(x, "Patient"), "Diagnosis"))
+				    .Select(p => new {p.Key, Count = p.Count()})
+				    .ToList();
+
+				Assert.IsTrue(result.SequenceEqual(expected));
+		    }
+	    }
+
+		[Test, DataContextSource]
+	    public void SqlPropertyJoin(string context)
+	    {
+		    using (var db = GetDataContext(context, ConfigureDynamicMyClass()))
+		    {
+			    var expected = 
+				    from p in Person
+				    join pa in Patient on p.FirstName equals pa.Diagnosis
+				    select p;
+
+			    var result =
+				    from p in db.Person
+				    join pa in db.Patient on Sql.Property<string>(p, "FirstName") equals Sql.Property<string>(pa, "Diagnosis")
+					select p;
+
+				Assert.IsTrue(result.ToList().SequenceEqual(expected.ToList()));
+			}
+	    }
+
+		[Test, DataContextSource]
+		public void SqlPropertyLoadWith(string context)
+	    {
+		    using (var db = GetDataContext(context, ConfigureDynamicMyClass()))
+		    {
+			    var expected = Person.Select(p => p.Patient?.Diagnosis).ToList();
+			    var result = db.GetTable<MyClass>()
+				    .LoadWith(x => Sql.Property<Patient>(x, "Patient"))
+				    .ToList()
+				    .Select(p => ((Patient)p.ExtendedProperties["Patient"]).Diagnosis)
+				    .ToList();
+
+				Assert.IsTrue(result.SequenceEqual(expected));
+		    }
+	    }
+		
+	    private MappingSchema ConfigureDynamicMyClass()
+	    {
+		    var ms = new MappingSchema();
+
+		    ms.GetFluentMappingBuilder()
+			    .Entity<MyClass>().HasTableName("Person").HasDynamicColumnsStore(x => x.ExtendedProperties)
+			    .HasPrimaryKey(x => Sql.Property<int>(x, "ID"))
+			    .Property(x => Sql.Property<string>(x, "FirstName")).IsNullable(false)
+			    .Property(x => Sql.Property<string>(x, "LastName")).IsNullable(false)
+			    .Property(x => Sql.Property<string>(x, "MiddleName"))
+			    .Association(x => Sql.Property<Patient>(x, "Patient"), x => Sql.Property<int>(x, "ID"), x => x.PersonID);
+
+		    return ms;
+	    }
+
+		public class MyClass : IPerson
+	    {
+		    [Column("PersonID"), Identity]
+		    public int ID { get; set; }
+
+		    public IDictionary<string, object> ExtendedProperties { get; set; }
+
+		    [NotColumn]
+		    Gender IPerson.Gender
+		    {
+			    get => (Gender)ExtendedProperties["Gender"];
+			    set => ExtendedProperties["Gender"] = value;
+		    }
+
+		    [NotColumn]
+		    string IPerson.FirstName
+		    {
+			    get => (string)ExtendedProperties["FirstName"];
+			    set => ExtendedProperties["FirstName"] = value;
+		    }
+
+		    [NotColumn]
+		    string IPerson.MiddleName
+		    {
+			    get => (string)ExtendedProperties["MiddleName"];
+			    set => ExtendedProperties["MiddleName"] = value;
+		    }
+
+		    [NotColumn]
+		    string IPerson.LastName
+		    {
+			    get => (string)ExtendedProperties["LastName"];
+			    set => ExtendedProperties["LastName"] = value;
+		    }
+	    }
+	}
+}

--- a/Tests/Linq/Mapping/FluentDynamicMappingTests.cs
+++ b/Tests/Linq/Mapping/FluentDynamicMappingTests.cs
@@ -21,19 +21,13 @@ namespace Tests.Mapping
 
 			public byte RowType { get; set; }
 
+		    [DynamicColumnsStore]
 			public IDictionary<string, object> ExtendedColumns { get; set; }
 	    }
 
 		[Table]
 		public class MyClass2 : MyClass { }
-
-		[Table]
-	    public class MyClass3
-	    {
-			[DynamicColumnsStore]
-		    public IDictionary<string, object> ExtendedColumns { get; set; }
-		}
-
+		
 	    [Test]
 		public void HasAttribute1()
 	    {
@@ -217,55 +211,18 @@ namespace Tests.Mapping
 
 		    Assert.IsNull(ed["ID"]);
 	    }
-
+		
 	    [Test]
-		public void HasDynamicColumnStore1()
-	    {
-		    var ms = new MappingSchema();
-		    var mb = ms.GetFluentMappingBuilder();
-
-		    mb.Entity<MyClass>()
-			    .HasDynamicColumnsStore(x => x.ExtendedColumns);
-
-		    var ed = ms.GetEntityDescriptor(typeof(MyClass));
-
-		    Assert.AreEqual(ed.DynamicColumnsStore.MemberName, "ExtendedColumns");
-	    }
-
-	    [Test]
-		public void HasDynamicColumnStore2()
-	    {
-		    var ms = new MappingSchema();
-		    var mb = ms.GetFluentMappingBuilder();
-
-		    mb.Entity<MyClass>()
-			    .HasDynamicColumnsStore(x => Sql.Property<IDictionary<string, object>>(x, "ExtendedColumns"));
-
-		    var ed = ms.GetEntityDescriptor(typeof(MyClass));
-
-		    Assert.AreEqual(ed.DynamicColumnsStore.MemberName, "ExtendedColumns");
-	    }
-
-	    [Test]
-	    public void HasDynamicColumnStore3()
+	    public void HasDynamicColumnStore1()
 	    {
 		    var ms = new MappingSchema();
 		    
-		    var ed = ms.GetEntityDescriptor(typeof(MyClass3));
+		    var ed = ms.GetEntityDescriptor(typeof(MyClass));
 
 		    Assert.AreEqual(ed.DynamicColumnsStore.MemberName, "ExtendedColumns");
-	    }
-
-	    [Test]
-	    public void HasDynamicColumnStore4()
-	    {
-		    var ms = new MappingSchema();
-
-		    var ed = ms.GetEntityDescriptor(typeof(MyClass3));
-
 		    Assert.IsFalse(ed.Columns.Any(c => c.MemberName == "ExtendedColumns"));
-	    }
-
+		}
+		
 		[Test]
 		public void Inheritance1()
 	    {

--- a/Tests/Linq/Mapping/FluentDynamicMappingTests.cs
+++ b/Tests/Linq/Mapping/FluentDynamicMappingTests.cs
@@ -1,0 +1,297 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using LinqToDB;
+using LinqToDB.Mapping;
+using NUnit.Framework;
+
+namespace Tests.Mapping
+{
+	[TestFixture]
+    public class FluentDynamicMappingTests : TestBase
+    {
+		[Table]
+	    public class MyClass
+	    {
+		    public int ID;
+
+			public int ID1 { get; set; }
+
+			[NotColumn]
+		    public MyClass Parent;
+
+			public byte RowType { get; set; }
+
+			public IDictionary<string, object> ExtendedColumns { get; set; }
+	    }
+
+		[Table]
+		public class MyClass2 : MyClass { }
+
+		[Table]
+	    public class MyClass3
+	    {
+			[DynamicColumnsStore]
+		    public IDictionary<string, object> ExtendedColumns { get; set; }
+		}
+
+	    [Test]
+		public void HasAttribute1()
+	    {
+		    var ms = new MappingSchema();
+		    var mb = ms.GetFluentMappingBuilder();
+
+		    mb.HasAttribute<MyClass>(x => Sql.Property<int>(x, "ID"), new PrimaryKeyAttribute());
+
+		    var ed = ms.GetEntityDescriptor(typeof(MyClass));
+
+			Assert.IsTrue(ed["ID"].IsPrimaryKey);
+	    }
+
+	    [Test]
+		public void HasAttribute2()
+	    {
+		    var ms = new MappingSchema();
+		    var mb = ms.GetFluentMappingBuilder();
+
+		    mb.HasAttribute<MyClass>(x => Sql.Property<int>(x, "ID2"), new PrimaryKeyAttribute());
+
+		    var ed = ms.GetEntityDescriptor(typeof(MyClass));
+
+			Assert.IsTrue(ed["ID2"].IsPrimaryKey);
+	    }
+
+	    [Test]
+		public void Property1()
+	    {
+		    var ms = new MappingSchema();
+		    var mb = ms.GetFluentMappingBuilder();
+
+		    mb.Entity<MyClass>()
+			    .Property(x => Sql.Property<int>(x, "ID")).IsPrimaryKey();
+
+		    var ed = ms.GetEntityDescriptor(typeof(MyClass));
+
+		    Assert.IsTrue(ed["ID"].IsPrimaryKey);
+		}
+
+	    [Test]
+		public void Property2()
+	    {
+		    var ms = new MappingSchema();
+		    var mb = ms.GetFluentMappingBuilder();
+
+		    mb.Entity<MyClass>()
+			    .Property(x => Sql.Property<int>(x, "ID2")).IsPrimaryKey();
+
+		    var ed = ms.GetEntityDescriptor(typeof(MyClass));
+
+		    Assert.IsTrue(ed["ID2"].IsPrimaryKey);
+	    }
+
+	    [Test]
+		public void Association1()
+	    {
+			var ms = new MappingSchema();
+		    var mb = ms.GetFluentMappingBuilder();
+
+		    mb.Entity<MyClass>()
+			    .Association(x => Sql.Property<MyClass>(x, "Parent"), x => Sql.Property<int>(x, "ID1"), x => Sql.Property<int>(x, "ID"));
+
+		    var ed = ms.GetEntityDescriptor(typeof(MyClass));
+
+		    Assert.AreEqual(ed.Associations.Single().MemberInfo.Name, "Parent");
+		    Assert.AreEqual(ed.Associations.Single().ThisKey.Single(), "ID1");
+		    Assert.AreEqual(ed.Associations.Single().OtherKey.Single(), "ID");
+		}
+
+	    [Test]
+		public void Association2()
+	    {
+		    var ms = new MappingSchema();
+		    var mb = ms.GetFluentMappingBuilder();
+
+		    mb.Entity<MyClass>()
+			    .Association(x => Sql.Property<MyClass>(x, "Parent2"), x => Sql.Property<int>(x, "ID2"), x => Sql.Property<int>(x, "ID3"));
+
+		    var ed = ms.GetEntityDescriptor(typeof(MyClass));
+
+		    Assert.AreEqual(ed.Associations.Single().MemberInfo.Name, "Parent2");
+		    Assert.AreEqual(ed.Associations.Single().ThisKey.Single(), "ID2");
+		    Assert.AreEqual(ed.Associations.Single().OtherKey.Single(), "ID3");
+	    }
+
+	    [Test]
+		public void HasPrimaryKey1()
+	    {
+		    var ms = new MappingSchema();
+		    var mb = ms.GetFluentMappingBuilder();
+
+		    mb.Entity<MyClass>()
+			    .HasPrimaryKey(x => Sql.Property<int>(x, "ID"));
+
+		    var ed = ms.GetEntityDescriptor(typeof(MyClass));
+
+		    Assert.IsTrue(ed["ID"].IsPrimaryKey);
+	    }
+
+	    [Test]
+		public void HasPrimaryKey2()
+	    {
+		    var ms = new MappingSchema();
+		    var mb = ms.GetFluentMappingBuilder();
+
+		    mb.Entity<MyClass>()
+			    .HasPrimaryKey(x => Sql.Property<int>(x, "ID2"));
+
+		    var ed = ms.GetEntityDescriptor(typeof(MyClass));
+
+		    Assert.IsTrue(ed["ID2"].IsPrimaryKey);
+	    }
+
+	    [Test]
+		public void HasIdentity1()
+	    {
+		    var ms = new MappingSchema();
+		    var mb = ms.GetFluentMappingBuilder();
+
+		    mb.Entity<MyClass>()
+			    .HasIdentity(x => Sql.Property<int>(x, "ID"));
+
+		    var ed = ms.GetEntityDescriptor(typeof(MyClass));
+
+		    Assert.IsTrue(ed["ID"].IsIdentity);
+	    }
+
+	    [Test]
+		public void HasIdentity2()
+	    {
+		    var ms = new MappingSchema();
+		    var mb = ms.GetFluentMappingBuilder();
+
+		    mb.Entity<MyClass>()
+			    .HasIdentity(x => Sql.Property<int>(x, "ID2"));
+
+		    var ed = ms.GetEntityDescriptor(typeof(MyClass));
+
+		    Assert.IsTrue(ed["ID2"].IsIdentity);
+	    }
+
+	    [Test]
+		public void HasColumn1()
+	    {
+		    var ms = new MappingSchema();
+		    var mb = ms.GetFluentMappingBuilder();
+
+		    mb.Entity<MyClass>()
+			    .HasColumn(x => Sql.Property<int>(x, "ID"));
+
+		    var ed = ms.GetEntityDescriptor(typeof(MyClass));
+
+		    Assert.NotNull(ed["ID"]);
+	    }
+
+	    [Test]
+		public void HasColumn2()
+	    {
+		    var ms = new MappingSchema();
+		    var mb = ms.GetFluentMappingBuilder();
+
+		    mb.Entity<MyClass>()
+			    .HasColumn(x => Sql.Property<int>(x, "ID2"));
+
+		    var ed = ms.GetEntityDescriptor(typeof(MyClass));
+
+			Assert.NotNull(ed["ID2"]);
+		}
+
+	    [Test]
+		public void Ignore()
+	    {
+		    var ms = new MappingSchema();
+		    var mb = ms.GetFluentMappingBuilder();
+
+		    mb.Entity<MyClass>()
+			    .Ignore(x => Sql.Property<int>(x, "ID"));
+
+		    var ed = ms.GetEntityDescriptor(typeof(MyClass));
+
+		    Assert.IsNull(ed["ID"]);
+	    }
+
+	    [Test]
+		public void HasDynamicColumnStore1()
+	    {
+		    var ms = new MappingSchema();
+		    var mb = ms.GetFluentMappingBuilder();
+
+		    mb.Entity<MyClass>()
+			    .HasDynamicColumnsStore(x => x.ExtendedColumns);
+
+		    var ed = ms.GetEntityDescriptor(typeof(MyClass));
+
+		    Assert.AreEqual(ed.DynamicColumnsStore.MemberName, "ExtendedColumns");
+	    }
+
+	    [Test]
+		public void HasDynamicColumnStore2()
+	    {
+		    var ms = new MappingSchema();
+		    var mb = ms.GetFluentMappingBuilder();
+
+		    mb.Entity<MyClass>()
+			    .HasDynamicColumnsStore(x => Sql.Property<IDictionary<string, object>>(x, "ExtendedColumns"));
+
+		    var ed = ms.GetEntityDescriptor(typeof(MyClass));
+
+		    Assert.AreEqual(ed.DynamicColumnsStore.MemberName, "ExtendedColumns");
+	    }
+
+	    [Test]
+	    public void HasDynamicColumnStore3()
+	    {
+		    var ms = new MappingSchema();
+		    
+		    var ed = ms.GetEntityDescriptor(typeof(MyClass3));
+
+		    Assert.AreEqual(ed.DynamicColumnsStore.MemberName, "ExtendedColumns");
+	    }
+
+	    [Test]
+	    public void HasDynamicColumnStore4()
+	    {
+		    var ms = new MappingSchema();
+
+		    var ed = ms.GetEntityDescriptor(typeof(MyClass3));
+
+		    Assert.IsFalse(ed.Columns.Any(c => c.MemberName == "ExtendedColumns"));
+	    }
+
+		[Test]
+		public void Inheritance1()
+	    {
+		    var ms = new MappingSchema();
+		    var mb = ms.GetFluentMappingBuilder();
+
+		    mb.Entity<MyClass>()
+			    .Inheritance(x => Sql.Property<byte>(x, "RowType"), 1, typeof(MyClass2));
+
+		    var ed = ms.GetEntityDescriptor(typeof(MyClass));
+
+		    Assert.AreEqual(ed.InheritanceMapping.Single().DiscriminatorName, "RowType");
+	    }
+
+	    [Test]
+		public void Inheritance2()
+	    {
+		    var ms = new MappingSchema();
+		    var mb = ms.GetFluentMappingBuilder();
+
+		    mb.Entity<MyClass>()
+			    .Inheritance(x => Sql.Property<byte>(x, "RowType2"), 1, typeof(MyClass2));
+
+		    var ed = ms.GetEntityDescriptor(typeof(MyClass));
+
+		    Assert.AreEqual(ed.InheritanceMapping.Single().DiscriminatorName, "RowType2");
+	    }
+	}
+}

--- a/Tests/Linq/Update/DynamicColumnsTests.cs
+++ b/Tests/Linq/Update/DynamicColumnsTests.cs
@@ -1,0 +1,155 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using LinqToDB;
+using LinqToDB.Mapping;
+using NUnit.Framework;
+using Tests.Model;
+
+namespace Tests.Update
+{
+	[TestFixture]
+    public class DynamicColumnsTests : TestBase
+    {
+	    [Test, DataContextSource]
+	    public void InsertViaSqlProperty(string context)
+	    {
+		    using (var db = GetDataContext(context))
+		    {
+				try
+				{
+					var id = 1001;
+
+					db.Child.Delete(c => Sql.Property<int>(c, "ChildID") > 1000);
+
+					Assert.AreEqual(1,
+						db
+							.Into(db.Child)
+							.Value(c => Sql.Property<int>(c, "ParentID"), () => 1)
+							.Value(c => Sql.Property<int>(c, "ChildID"), () => id)
+							.Insert());
+					Assert.AreEqual(1, db.Child.Count(c => Sql.Property<int>(c, "ChildID") == id));
+				}
+				finally
+				{
+					db.Child.Delete(c => Sql.Property<int>(c, "ChildID") > 1000);
+				}
+			}
+	    }
+
+	    [Test, DataContextSource(ProviderName.Informix)]
+	    public void UpdateViaSqlProperty(string context)
+	    {
+		    using (var db = GetDataContext(context))
+		    {
+			    try
+			    {
+				    var id = 1001;
+
+				    db.Child.Delete(c => Sql.Property<int>(c, "ChildID") > 1000);
+				    db.Child.Insert(() => new Child { ParentID = 1, ChildID = id });
+
+				    Assert.AreEqual(1, db.Child.Count(c => Sql.Property<int>(c, "ChildID") == id));
+				    Assert.AreEqual(1,
+					    db.Child
+						    .Where(c => Sql.Property<int>(c, "ChildID") == id && Sql.Property<int?>(Sql.Property<Parent>(c, "Parent"), "Value1") == 1)
+						    .Set(c => Sql.Property<int>(c, "ChildID"), c => Sql.Property<int>(c, "ChildID") + 1)
+						    .Update());
+				    Assert.AreEqual(1, db.Child.Count(c => Sql.Property<int>(c, "ChildID") == id + 1));
+			    }
+			    finally
+			    {
+				    db.Child.Delete(c => Sql.Property<int>(c, "ChildID") > 1000);
+			    }
+		    }
+	    }
+
+	    [Test, DataContextSource]
+	    public void InsertDynamicColumns(string context)
+	    {
+		    using (var db = GetDataContext(context, ConfigureDynamicMyClass()))
+		    {
+			    try
+			    {
+				    var id = 1001;
+
+				    db.GetTable<MyClass>().Delete(c => Sql.Property<int>(c, "ID") > 1000);
+
+				    Assert.AreEqual(1,
+					    db
+						    .GetTable<MyClass>()
+							.Value(c => Sql.Property<int>(c, "ID"), () => id)
+						    .Value(c => Sql.Property<string>(c, "FirstName"), () => "John1")
+						    .Value(c => Sql.Property<string>(c, "LastName"), () => "Test1")
+						    .Value(c => Sql.Property<Gender>(c, "Gender"), () => Gender.Male)
+							.Insert());
+				    Assert.AreEqual(1,
+					    db.GetTable<MyClass>().Count(c =>
+						    Sql.Property<int>(c, "ID") == id && 
+						    Sql.Property<string>(c, "FirstName") == "John1" &&
+						    Sql.Property<string>(c, "LastName") == "Test1"));
+			    }
+			    finally
+			    {
+				    db.GetTable<MyClass>().Delete(c => Sql.Property<int>(c, "ID") > 1000);
+			    }
+		    }
+	    }
+
+	    [Test, DataContextSource(ProviderName.Informix)]
+	    public void UpdateDynamicColumn(string context)
+	    {
+		    using (var db = GetDataContext(context, ConfigureDynamicMyClass()))
+		    {
+			    try
+			    {
+				    var id = 1001;
+
+				    db.GetTable<MyClass>().Delete(c => Sql.Property<int>(c, "ID") > 1000);
+				    db.GetTable<MyClass>()
+					    .Value(c => Sql.Property<int>(c, "ID"), () => id)
+					    .Value(c => Sql.Property<string>(c, "FirstName"), () => "John1")
+					    .Value(c => Sql.Property<string>(c, "LastName"), () => "Test1")
+					    .Value(c => Sql.Property<Gender>(c, "Gender"), () => Gender.Male)
+						.Insert();
+
+				    Assert.AreEqual(1, db.GetTable<MyClass>().Count(c => Sql.Property<int>(c, "ID") == id));
+				    Assert.AreEqual(1,
+					    db.GetTable<MyClass>()
+							.Where(c => Sql.Property<int>(c, "ID") == id)
+						    .Set(c => Sql.Property<string>(c, "FirstName"), () => "Johnny1")
+						    .Update());
+				    Assert.AreEqual(1, db.GetTable<MyClass>().Count(c => Sql.Property<int>(c, "ID") == id && Sql.Property<string>(c, "FirstName") == "Johnny1"));
+			    }
+			    finally
+			    {
+				    db.GetTable<MyClass>().Delete(c => Sql.Property<int>(c, "ID") > 1000);
+			    }
+		    }
+	    }
+
+	    private MappingSchema ConfigureDynamicMyClass()
+	    {
+		    var ms = new MappingSchema();
+
+		    ms.GetFluentMappingBuilder()
+			    .Entity<MyClass>().HasTableName("Person")
+			    .HasPrimaryKey(x => Sql.Property<int>(x, "ID"))
+			    .Property(x => Sql.Property<string>(x, "FirstName")).IsNullable(false)
+			    .Property(x => Sql.Property<string>(x, "LastName")).IsNullable(false)
+			    .Property(x => Sql.Property<string>(x, "MiddleName"))
+			    .Property(x => Sql.Property<Gender>(x, "Gender")).IsNullable(false)
+				.Association(x => Sql.Property<Patient>(x, "Patient"), x => Sql.Property<int>(x, "ID"), x => x.PersonID);
+
+		    return ms;
+	    }
+
+	    public class MyClass
+	    {
+		    [Column("PersonID"), Identity]
+		    public int ID { get; set; }
+
+		    [DynamicColumnsStore]
+		    public IDictionary<string, object> ExtendedProperties { get; set; }
+	    }
+	}
+}


### PR DESCRIPTION
## Background

Our project has multitenant model in which customers can add columns to existing entities, or create completly new entities. These can then be used through the application in the same way as built-in entities/columns. Also, most of the core functionalities are trully generic/dynamic (like listings, forms, etc.). We have implemented custom LINQ provider very similar in design to linq2db, which supports our core scenarios, but is very limited in terms of extensibility and query translation. We're now looking to replace our custom provider with something more mature.

We tried (and are using to some extent) linq2db in combination with runtime emiting of new types for dynamic entities and columns. But that approach has some rough corners in scenarios where we want to use strongly typed models in code, which can be extended with dynamic columns. Thus, we propose to include support for dynamic columns to linq2db (as already requested in #744 and #507).

## Proposal

We propose to add a new method Sql.Property which allows to access arbitrary column/association on given entity (whether the column/association is dynamic or non-dynamic):
```C#
public static Property<T>(object entity, string propertyName)
```

### Use in queries

Accessing column "FirstName" on Person:
```C#
db.GetTable<Person>()
    .Where(x => Sql.Property<string>(x, "FirstName") == "John")
    .ToList()
```

Accessing column "Diagnosis" on associated member Person.Patient:
```C#
db.GetTable<Person>()
    .Where(x => Sql.Property<string>(x.Patient, "Diagnosis") != null)
    .ToList()
```

Combining the above examples
```C#
db.GetTable<Person>()
    .Where(x => Sql.Property<string>(Sql.Property<Patient>(x, "Patient"), "Diagnosis") != null)
    .ToList()
```

The type in Sql.Property is somewhat optional, it helps with writing typesafe code, but we could also write the above query as:
```C#
db.GetTable<Person>()
    .Where(x => Sql.Property<object>(Sql.Property<object>(x, "Patient"), "Diagnosis") != null != null)
    .ToList()
```
Which gives a great amount of flexibility in writing dynamic queries. Think about dynamic order-by, or filter:
```C#
var filteringColumn = "FirstName";
var sortingColumn = "LastName";
var filter = "John";

db.GetTable<Person>()
    .Where(p => Sql.Property<object>(p, filteringColumn) == filter)
    .OrderBy(p => Sql.Property<object>(p, sortingColumn))
    .ToList();
```

Obviously, the Sql.Property can be used in any of the query methods:
```C#
(from p in db.Person
    join pa in db.Patient on Sql.Property<string>(p, "FirstName") equals Sql.Property<string>(pa, "Diagnosis")
    select p)
    .LoadWith(x => Sql.Property<Patient>(x, "Patient"))
    .GroupBy(x => Sql.Property<string>(Sql.Property<Patient>(x, "Patient"), "Diagnosis"))
    .Select(p => new {p.Key, Count = p.Count()})
    .ToList();
```

### Use in insert/update

Sql.Property can also be used in set operators:
```C#
db
    .GetTable<Person>()
    .Value(c => Sql.Property<int>(c, "ID"), () => id)
    .Value(c => Sql.Property<string>(c, "FirstName"), () => "John1")
    .Value(c => Sql.Property<string>(c, "LastName"), () => "Test1")
    .Value(c => Sql.Property<Gender>(c, "Gender"), () => Gender.Male)
    .Insert();

db.GetTable<Person>()
    .Where(c => Sql.Property<int>(c, "ID") == id)
    .Set(c => Sql.Property<string>(c, "FirstName"), () => "Johnny1")
    .Update();
```

### Use in metadata configuration

```C#
var ms = new MappingSchema();

ms.GetFluentMappingBuilder()
    .Entity<Person>().HasTableName("Person")
    .HasPrimaryKey(x => Sql.Property<int>(x, "ID"))
    .Property(x => Sql.Property<string>(x, "FirstName")).IsNullable(false)
    .Property(x => Sql.Property<string>(x, "LastName")).IsNullable(false)
    .Property(x => Sql.Property<string>(x, "MiddleName"))
    .Association(x => Sql.Property<Patient>(x, "Patient"), x => Sql.Property<int>(x, "ID"), x => x.PersonID);
```

When the member used in Sql.Property is not defined on class, then it's added to entity definition as dynamic column (only in fluent mapping builder scenario).

### Storing dynamic columns/associations data

The class CAN HAVE a "DynamicColumnsStore" property, which has to be assignable from Dictionary type. For example:
```C#
[DynamicColumnsStore]
public IDictionary<string, object> ExtendedProperties { get; set; }
```

This property is required only when we want to have dynamic columns/associations accessible in materialized entity. "Sql.Property" can be used in queries with or without the dynamic columns store property defined. 

## Implementation

The proposed approach has minimal impact on public API of linq2db (only one additional public API method - Sql.Property). 

Dynamic properties are represented as new type "DynamicColumnInfo" inheriting from "PropertyInfo". This enables implementation of dynamic columns with minimal changes to linq2db code. Note that this approach does not work in NETSTANDARD1_6, since it doesn't have required APIs.

Included are unit tests covering querying, updating, and metadata configuration scenarios. I will also prepare documentation chapter if this proposal gets approved.