### PR TITLE
Setting string parameters to max size for SQL Server.

### DIFF
--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
@@ -225,6 +225,7 @@ namespace LinqToDB.DataProvider.SqlServer
 					case SqlDbType.VarChar:
 					case SqlDbType.NVarChar:
 						{
+							// Setting for NVarchar and Varchar (max) size. It reduces count of cached plans.
 							param.Size = -1;
 							break;
 						}

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
@@ -217,16 +217,27 @@ namespace LinqToDB.DataProvider.SqlServer
 
 			base.SetParameter(parameter, name, dataType, value);
 
-			var param = parameter as SqlParameter;
-			if (param != null)
+			if (parameter is SqlParameter param)
 			{
+				// Setting for NVarChar and VarChar constant size. It reduces count of cached plans.
 				switch (param.SqlDbType)
 				{
 					case SqlDbType.VarChar:
+						{
+							if (value is string strValue && strValue.Length > 8000)
+								param.Size = -1;
+							else
+								param.Size = 8000;
+
+							break;
+						}
 					case SqlDbType.NVarChar:
 						{
-							// Setting for NVarchar and Varchar (max) size. It reduces count of cached plans.
-							param.Size = -1;
+							if (value is string strValue && strValue.Length > 4000)
+								param.Size = -1;
+							else
+								param.Size = 4000;
+
 							break;
 						}
 				}

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
@@ -216,6 +216,20 @@ namespace LinqToDB.DataProvider.SqlServer
 			}
 
 			base.SetParameter(parameter, name, dataType, value);
+
+			var param = parameter as SqlParameter;
+			if (param != null)
+			{
+				switch (param.SqlDbType)
+				{
+					case SqlDbType.VarChar:
+					case SqlDbType.NVarChar:
+						{
+							param.Size = -1;
+							break;
+						}
+				}
+			}
 		}
 
 		protected override void SetParameterType(IDbDataParameter parameter, DataType dataType)

--- a/Tests/Linq/Linq/ParameterTests.cs
+++ b/Tests/Linq/Linq/ParameterTests.cs
@@ -108,6 +108,22 @@ namespace Tests.Linq
 		}
 
 		[Test, DataContextSource(false)]
+		public void SqlStringParameter(string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var p = "John";
+				var person1 = db.GetTable<Person>().Where(t => t.FirstName == p).Single();
+
+				p = "Tester";
+				var person2 = db.GetTable<Person>().Where(t => t.FirstName == p).Single();
+
+				Assert.That(person1.FirstName, Is.EqualTo("John"));
+				Assert.That(person2.FirstName, Is.EqualTo("Tester"));
+			}
+		}
+
+		[Test, DataContextSource(false)]
 		public void ExposeSqlStringParameter(string context)
 		{
 			using (var db = new DataConnection(context))

--- a/Tests/Linq/Linq/ParameterTests.cs
+++ b/Tests/Linq/Linq/ParameterTests.cs
@@ -133,7 +133,7 @@ namespace Tests.Linq
 
 				Console.WriteLine(sql);
 
-				Assert.That(sql, Contains.Substring("(3)"));
+				Assert.That(sql, Contains.Substring("(3)").Or.Contains("(4000)"));
 			}
 		}
 


### PR DESCRIPTION
Setting string parameters to max size for SQL Server. 
It minimizes number of cached plans.

Fixes #989