### PR TITLE
Test for #994 #996 und #1006

### DIFF
--- a/Source/LinqToDB/Common/Configuration.cs
+++ b/Source/LinqToDB/Common/Configuration.cs
@@ -21,6 +21,12 @@ namespace LinqToDB.Common
 		public static bool IsStructIsScalarType = true;
 
 		/// <summary>
+		/// If <c>true</c> - Enum Values are stored as by calling ToString().
+		/// Default value: <c>true</c>.
+		/// </summary>
+		public static bool UseEnumValueNameForStringColumns = true;
+
+		/// <summary>
 		/// If <c>true</c> - data providers will try to use standard ADO.NET interfaces instead of provider-specific functionality when possible. This option could be usefull if you need to intercept
 		/// database calls using tools such as <a href="https://github.com/MiniProfiler/dotnet">MiniProfiler</a>.
 		/// Default value: <c>false</c>.

--- a/Source/LinqToDB/Expressions/ConvertFromDataReaderExpression.cs
+++ b/Source/LinqToDB/Expressions/ConvertFromDataReaderExpression.cs
@@ -151,7 +151,22 @@ namespace LinqToDB.Expressions
 					_columnConverters[fromType] = func = lex.Compile();
 				}
 
-				return func(dataReader);
+				try
+				{
+					return func(dataReader);
+				}
+				catch (FormatException ex)
+				{
+					throw new FormatException("FormatException on Column: " + dataReader.GetName(_columnIndex), ex);
+				}
+				catch (InvalidCastException ex)
+				{
+					throw new InvalidCastException("InvalidCastException on Column: " + dataReader.GetName(_columnIndex), ex);
+				}
+				catch (Exception ex)
+				{
+					throw new Exception("Exception on Column: " + dataReader.GetName(_columnIndex), ex);
+				}
 
 				/*
 				var value = dataReader.GetValue(_columnIndex);

--- a/Source/LinqToDB/Extensions/MappingExtensions.cs
+++ b/Source/LinqToDB/Extensions/MappingExtensions.cs
@@ -27,7 +27,7 @@ namespace LinqToDB.Extensions
 				{
 
 					var type = Converter.GetDefaultMappingFromEnumType(mappingSchema, systemType);
-					if (type == typeof(string))
+					if (Configuration.UseEnumValueNameForStringColumns && type == typeof(string))
 						return new SqlValue(type, value.ToString());
 
 					return new SqlValue(type, Converter.ChangeType(value, type, mappingSchema));

--- a/Source/LinqToDB/Extensions/MappingExtensions.cs
+++ b/Source/LinqToDB/Extensions/MappingExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using LinqToDB.Data;
 
 namespace LinqToDB.Extensions
 {
@@ -24,7 +25,10 @@ namespace LinqToDB.Extensions
 			{
 				if (value != null || systemType == underlyingType)
 				{
+
 					var type = Converter.GetDefaultMappingFromEnumType(mappingSchema, systemType);
+					if (type == typeof(string))
+						return new SqlValue(type, value.ToString());
 
 					return new SqlValue(type, Converter.ChangeType(value, type, mappingSchema));
 				}

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -1676,6 +1676,10 @@ namespace LinqToDB.Linq.Builder
 						var ce = MappingSchema.GetConverter(type, typeof(DataParameter), false);
 						if (ce != null)
 						{
+							var p = Expression.Parameter(typeof(object));
+							var a = Expression.Lambda<Func<object, DataParameter>>(Expression.Invoke(ce.Lambda, Expression.Convert(p, type)), p);
+							var tr = a.Compile();
+							var tt = tr(origValue);
 							mapValue = ((DataParameter) ce.Lambda.Compile().DynamicInvoke(origValue)).Value;
 							sqlvalue = new SqlValue(mapValue);
 						}

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -2345,7 +2345,7 @@ namespace LinqToDB.Linq.Builder
 			if (typeOperand == table.ObjectType && table.InheritanceMapping.All(m => m.Type != typeOperand))
 				return Convert(table, new SqlPredicate.Expr(new SqlValue(true)));
 
-			var mapping = table.InheritanceMapping.Select((m,i) => new { m, i }).Where(m => m.m.Type == typeOperand && !m.m.IsDefault).ToList();
+			var mapping = table.InheritanceMapping.Select((m,i) => new { m, i }).Where(m => typeOperand.IsAssignableFrom(m.m.Type) && !m.m.IsDefault).ToList();
 			var isEqual = true;
 
 			if (mapping.Count == 0)
@@ -2377,7 +2377,7 @@ namespace LinqToDB.Linq.Builder
 
 				var e = isEqual ? Expression.Equal(left, right) : Expression.NotEqual(left, right);
 
-				expr = expr != null ? Expression.AndAlso(expr, e) : e;
+				expr = expr != null ? Expression.OrElse(expr, e) : e;
 			}
 
 			return ConvertPredicate(context, expr);

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -2381,6 +2381,7 @@ namespace LinqToDB.Linq.Builder
 
 				var e = isEqual ? Expression.Equal(left, right) : Expression.NotEqual(left, right);
 
+				//expr = expr != null ? Expression.AndAlso(expr, e) : e;
 				expr = expr != null ? Expression.OrElse(expr, e) : e;
 			}
 

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -2381,8 +2381,10 @@ namespace LinqToDB.Linq.Builder
 
 				var e = isEqual ? Expression.Equal(left, right) : Expression.NotEqual(left, right);
 
-				//expr = expr != null ? Expression.AndAlso(expr, e) : e;
-				expr = expr != null ? Expression.OrElse(expr, e) : e;
+				if (!isEqual)
+					expr = expr != null ? Expression.AndAlso(expr, e) : e;
+				else
+					expr = expr != null ? Expression.OrElse(expr, e) : e;
 			}
 
 			return ConvertPredicate(context, expr);

--- a/Source/LinqToDB/Linq/Builder/LoadWithBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/LoadWithBuilder.cs
@@ -100,24 +100,19 @@ namespace LinqToDB.Linq.Builder
 
 					case ExpressionType.Extension    :
 						{
-							if (expression is GetItemExpression)
+							if (expression is GetItemExpression getItemExpression)
 							{
-								expression = ((GetItemExpression)expression).Expression;
+								expression = getItemExpression.Expression;
 								break;
 							}
 
 							goto default;
 						}
 
-					case ExpressionType.Convert:
+					case ExpressionType.Convert      :
 						{
-							if (expression is UnaryExpression)
-							{
-								expression = ((UnaryExpression)expression).Operand;
-								break;
-							}
-
-							goto default;
+							expression = ((UnaryExpression)expression).Operand;
+							break;
 						}
 
 					default :

--- a/Source/LinqToDB/Linq/Builder/LoadWithBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/LoadWithBuilder.cs
@@ -14,7 +14,7 @@ namespace LinqToDB.Linq.Builder
 	{
 		protected override bool CanBuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo)
 		{
-			return methodCall.IsQueryable("LoadWith");
+			return methodCall.IsQueryable("LoadWith") || methodCall.IsQueryable("LoadWithDerived");
 		}
 
 		protected override IBuildContext BuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo)

--- a/Source/LinqToDB/Linq/Builder/LoadWithBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/LoadWithBuilder.cs
@@ -109,6 +109,17 @@ namespace LinqToDB.Linq.Builder
 							goto default;
 						}
 
+					case ExpressionType.Convert:
+						{
+							if (expression is UnaryExpression)
+							{
+								expression = ((UnaryExpression)expression).Operand;
+								break;
+							}
+
+							goto default;
+						}
+
 					default :
 						{
 							throw new LinqToDBException(

--- a/Source/LinqToDB/Linq/Builder/LoadWithBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/LoadWithBuilder.cs
@@ -14,7 +14,7 @@ namespace LinqToDB.Linq.Builder
 	{
 		protected override bool CanBuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo)
 		{
-			return methodCall.IsQueryable("LoadWith") || methodCall.IsQueryable("LoadWithDerived");
+			return methodCall.IsQueryable("LoadWith");
 		}
 
 		protected override IBuildContext BuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo)

--- a/Source/LinqToDB/Linq/Builder/TableBuilder.TableContext.cs
+++ b/Source/LinqToDB/Linq/Builder/TableBuilder.TableContext.cs
@@ -468,6 +468,8 @@ namespace LinqToDB.Linq.Builder
 								Expression.Constant(dindex)),
 							Expression.Constant(ObjectType)),
 						ObjectType);
+
+					//expr = Expression.Constant(null, ObjectType);
 				}
 
 				foreach (var mapping in InheritanceMapping.Select((m,i) => new { m, i }).Where(m => m.m != defaultMapping))

--- a/Source/LinqToDB/Linq/Builder/TableBuilder.TableContext.cs
+++ b/Source/LinqToDB/Linq/Builder/TableBuilder.TableContext.cs
@@ -473,7 +473,7 @@ namespace LinqToDB.Linq.Builder
 							Expression.Constant(ObjectType)),
 						ObjectType);
 
-					//expr = Expression.Constant(null, ObjectType);
+					expr = Expression.Constant(null, ObjectType);
 				}
 
 				foreach (var mapping in InheritanceMapping.Select((m,i) => new { m, i }).Where(m => m.m != defaultMapping))

--- a/Source/LinqToDB/Linq/Builder/TableBuilder.TableContext.cs
+++ b/Source/LinqToDB/Linq/Builder/TableBuilder.TableContext.cs
@@ -456,24 +456,29 @@ namespace LinqToDB.Linq.Builder
 				}
 				else
 				{
-					var exceptionMethod = MemberHelper.MethodOf(() => DefaultInheritanceMappingException(null, null));
-					var dindex          =
+					if (tableContext is AssociatedTableContext)
+					{
+						expr = Expression.Constant(null, ObjectType);
+					}
+					else
+					{
+						var exceptionMethod = MemberHelper.MethodOf(() => DefaultInheritanceMappingException(null, null));
+						var dindex =
 						(
 							from f in SqlTable.Fields.Values
 							where f.Name == InheritanceMapping[0].DiscriminatorName
 							select ConvertToParentIndex(_indexes[f].Index, null)
 						).First();
 
-					expr = Expression.Convert(
-						Expression.Call(null, exceptionMethod,
-							Expression.Call(
-								ExpressionBuilder.DataReaderParam,
-								ReflectionHelper.DataReader.GetValue,
-								Expression.Constant(dindex)),
-							Expression.Constant(ObjectType)),
-						ObjectType);
-
-					expr = Expression.Constant(null, ObjectType);
+						expr = Expression.Convert(
+							Expression.Call(null, exceptionMethod,
+								Expression.Call(
+									ExpressionBuilder.DataReaderParam,
+									ReflectionHelper.DataReader.GetValue,
+									Expression.Constant(dindex)),
+								Expression.Constant(ObjectType)),
+							ObjectType);
+					}
 				}
 
 				foreach (var mapping in InheritanceMapping.Select((m,i) => new { m, i }).Where(m => m.m != defaultMapping))

--- a/Source/LinqToDB/Linq/QueryRunner.Delete.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.Delete.cs
@@ -17,7 +17,7 @@ namespace LinqToDB.Linq
 
 			static Query<int> CreateQuery(IDataContext dataContext, string tableName, string databaseName, string schemaName, Type type)
 			{
-				var sqlTable = new SqlTable<T>(dataContext.MappingSchema);
+				var sqlTable = new SqlTable(dataContext.MappingSchema, type);
 
 				if (tableName    != null) sqlTable.PhysicalName = tableName;
 				if (databaseName != null) sqlTable.Database     = databaseName;

--- a/Source/LinqToDB/Linq/QueryRunner.Insert.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.Insert.cs
@@ -16,7 +16,7 @@ namespace LinqToDB.Linq
 
 			static Query<int> CreateQuery(IDataContext dataContext, string tableName, string databaseName, string schemaName, Type type)
 			{
-				var sqlTable = new SqlTable<T>(dataContext.MappingSchema);
+				var sqlTable = new SqlTable(dataContext.MappingSchema, type);
 
 				if (tableName    != null) sqlTable.PhysicalName = tableName;
 				if (databaseName != null) sqlTable.Database     = databaseName;

--- a/Source/LinqToDB/Linq/QueryRunner.Insert.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.Insert.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,7 +14,7 @@ namespace LinqToDB.Linq
 		{
 			static readonly ConcurrentDictionary<object,Query<int>> _queryCache = new ConcurrentDictionary<object,Query<int>>();
 
-			static Query<int> CreateQuery(IDataContext dataContext, string tableName, string databaseName, string schemaName)
+			static Query<int> CreateQuery(IDataContext dataContext, string tableName, string databaseName, string schemaName, Type type)
 			{
 				var sqlTable = new SqlTable<T>(dataContext.MappingSchema);
 
@@ -32,7 +33,7 @@ namespace LinqToDB.Linq
 				{
 					if (field.Value.IsInsertable)
 					{
-						var param = GetParameter(typeof(T), dataContext, field.Value);
+						var param = GetParameter(type, dataContext, field.Value);
 
 						ei.Queries[0].Parameters.Add(param);
 
@@ -58,8 +59,9 @@ namespace LinqToDB.Linq
 				if (Equals(default(T), obj))
 					return 0;
 
-				var key = new { dataContext.MappingSchema.ConfigurationID, dataContext.ContextID, tableName, databaseName, schemaName };
-				var ei  = _queryCache.GetOrAdd(key, o => CreateQuery(dataContext, tableName, databaseName, schemaName));
+				var type = obj.GetType();
+				var key = new { dataContext.MappingSchema.ConfigurationID, dataContext.ContextID, tableName, databaseName, schemaName, type };
+				var ei  = _queryCache.GetOrAdd(key, o => CreateQuery(dataContext, tableName, databaseName, schemaName, type));
 
 				return (int)ei.GetElement(dataContext, Expression.Constant(obj), null);
 			}
@@ -70,8 +72,9 @@ namespace LinqToDB.Linq
 				if (Equals(default(T), obj))
 					return 0;
 
-				var key = new { dataContext.MappingSchema.ConfigurationID, dataContext.ContextID, tableName, databaseName, schemaName };
-				var ei  = _queryCache.GetOrAdd(key, o => CreateQuery(dataContext, tableName, databaseName, schemaName));
+				var type = obj.GetType();
+				var key = new { dataContext.MappingSchema.ConfigurationID, dataContext.ContextID, tableName, databaseName, schemaName, type };
+				var ei  = _queryCache.GetOrAdd(key, o => CreateQuery(dataContext, tableName, databaseName, schemaName, type));
 
 				var result = await ei.GetElementAsync(dataContext, Expression.Constant(obj), null, token);
 

--- a/Source/LinqToDB/Linq/QueryRunner.InsertOrReplace.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.InsertOrReplace.cs
@@ -19,7 +19,7 @@ namespace LinqToDB.Linq
 			static Query<int> CreateQuery(IDataContext dataContext, string tableName, string databaseName, string schemaName, Type type)
 			{
 				var fieldDic = new Dictionary<SqlField, ParameterAccessor>();
-				var sqlTable = new SqlTable<T>(dataContext.MappingSchema);
+				var sqlTable = new SqlTable(dataContext.MappingSchema, type);
 
 				if (tableName    != null) sqlTable.PhysicalName = tableName;
 				if (databaseName != null) sqlTable.Database     = databaseName;

--- a/Source/LinqToDB/Linq/QueryRunner.InsertOrReplace.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.InsertOrReplace.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -15,7 +16,7 @@ namespace LinqToDB.Linq
 		{
 			static readonly ConcurrentDictionary<object,Query<int>> _queryCache = new ConcurrentDictionary<object,Query<int>>();
 
-			static Query<int> CreateQuery(IDataContext dataContext, string tableName = null, string databaseName = null, string schemaName = null)
+			static Query<int> CreateQuery(IDataContext dataContext, string tableName, string databaseName, string schemaName, Type type)
 			{
 				var fieldDic = new Dictionary<SqlField, ParameterAccessor>();
 				var sqlTable = new SqlTable<T>(dataContext.MappingSchema);
@@ -49,7 +50,7 @@ namespace LinqToDB.Linq
 					{
 						if (!supported || !fieldDic.TryGetValue(field, out param))
 						{
-							param = GetParameter(typeof(T), dataContext, field);
+							param = GetParameter(type, dataContext, field);
 							ei.Queries[0].Parameters.Add(param);
 
 							if (supported)
@@ -93,7 +94,7 @@ namespace LinqToDB.Linq
 				{
 					if (!supported || !fieldDic.TryGetValue(field, out param))
 					{
-						param = GetParameter(typeof(T), dataContext, field);
+						param = GetParameter(type, dataContext, field);
 						ei.Queries[0].Parameters.Add(param);
 
 						if (supported)
@@ -120,8 +121,9 @@ namespace LinqToDB.Linq
 				if (Equals(default(T), obj))
 					return 0;
 
-				var key = new { dataContext.MappingSchema.ConfigurationID, dataContext.ContextID, tableName, schema, databaseName };
-				var ei = _queryCache.GetOrAdd(key, o => CreateQuery(dataContext, tableName, databaseName, schema));
+				var type = obj.GetType();
+				var key = new { dataContext.MappingSchema.ConfigurationID, dataContext.ContextID, tableName, schema, databaseName, type };
+				var ei = _queryCache.GetOrAdd(key, o => CreateQuery(dataContext, tableName, databaseName, schema, type));
 
 				return ei == null ? 0 : (int)ei.GetElement(dataContext, Expression.Constant(obj), null);
 			}
@@ -131,8 +133,9 @@ namespace LinqToDB.Linq
 				if (Equals(default(T), obj))
 					return 0;
 
-				var key = new { dataContext.MappingSchema.ConfigurationID, dataContext.ContextID, tableName, databaseName, schema };
-				var ei = _queryCache.GetOrAdd(key, o => CreateQuery(dataContext, tableName, schema, databaseName));
+				var type = obj.GetType();
+				var key = new { dataContext.MappingSchema.ConfigurationID, dataContext.ContextID, tableName, databaseName, schema, type };
+				var ei = _queryCache.GetOrAdd(key, o => CreateQuery(dataContext, tableName, schema, databaseName, type));
 
 				var result = ei == null ? 0 : await ei.GetElementAsync(dataContext, Expression.Constant(obj), null, token);
 

--- a/Source/LinqToDB/Linq/QueryRunner.InsertWithIdentity.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.InsertWithIdentity.cs
@@ -16,7 +16,7 @@ namespace LinqToDB.Linq
 
 			static Query<object> CreateQuery(IDataContext dataContext, string tableName, string databaseName, string schemaName, Type type)
 			{
-				var sqlTable = new SqlTable<T>(dataContext.MappingSchema);
+				var sqlTable = new SqlTable(dataContext.MappingSchema, type);
 
 				if (tableName    != null) sqlTable.PhysicalName = tableName;
 				if (databaseName != null) sqlTable.Database     = databaseName;

--- a/Source/LinqToDB/Linq/QueryRunner.InsertWithIdentity.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.InsertWithIdentity.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,7 +14,7 @@ namespace LinqToDB.Linq
 		{
 			static readonly ConcurrentDictionary<object,Query<object>> _queryCache = new ConcurrentDictionary<object,Query<object>>();
 
-			static Query<object> CreateQuery(IDataContext dataContext, string tableName = null, string databaseName = null, string schemaName = null)
+			static Query<object> CreateQuery(IDataContext dataContext, string tableName, string databaseName, string schemaName, Type type)
 			{
 				var sqlTable = new SqlTable<T>(dataContext.MappingSchema);
 
@@ -36,7 +37,7 @@ namespace LinqToDB.Linq
 				{
 					if (field.Value.IsInsertable)
 					{
-						var param = GetParameter(typeof(T), dataContext, field.Value);
+						var param = GetParameter(type, dataContext, field.Value);
 
 						ei.Queries[0].Parameters.Add(param);
 
@@ -62,8 +63,9 @@ namespace LinqToDB.Linq
 				if (Equals(default(T), obj))
 					return 0;
 
-				var key = new { dataContext.MappingSchema.ConfigurationID, dataContext.ContextID, tableName, schemaName, databaseName };
-				var ei = _queryCache.GetOrAdd(key, o => CreateQuery(dataContext, tableName, databaseName, schemaName));
+				var type = obj.GetType();
+				var key = new { dataContext.MappingSchema.ConfigurationID, dataContext.ContextID, tableName, schemaName, databaseName, type };
+				var ei = _queryCache.GetOrAdd(key, o => CreateQuery(dataContext, tableName, databaseName, schemaName, type));
 
 				return ei.GetElement(dataContext, Expression.Constant(obj), null);
 			}
@@ -74,8 +76,9 @@ namespace LinqToDB.Linq
 				if (Equals(default(T), obj))
 					return 0;
 
-				var key = new { dataContext.MappingSchema.ConfigurationID, dataContext.ContextID, tableName, schemaName, databaseName };
-				var ei  = _queryCache.GetOrAdd(key, o => CreateQuery(dataContext, tableName, databaseName, schemaName));
+				var type = obj.GetType();
+				var key = new { dataContext.MappingSchema.ConfigurationID, dataContext.ContextID, tableName, schemaName, databaseName, type };
+				var ei  = _queryCache.GetOrAdd(key, o => CreateQuery(dataContext, tableName, databaseName, schemaName, type));
 
 				return await ei.GetElementAsync(dataContext, Expression.Constant(obj), null, token);
 			}

--- a/Source/LinqToDB/Linq/QueryRunner.Update.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.Update.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
@@ -15,7 +16,7 @@ namespace LinqToDB.Linq
 		{
 			static readonly ConcurrentDictionary<object,Query<int>> _queryCache = new ConcurrentDictionary<object,Query<int>>();
 
-			static Query<int> CreateQuery(IDataContext dataContext, string tableName = null, string databaseName = null, string schemaName = null)
+			static Query<int> CreateQuery(IDataContext dataContext, string tableName, string databaseName, string schemaName, Type type)
 			{
 				var sqlTable = new SqlTable<T>(dataContext.MappingSchema);
 
@@ -49,7 +50,7 @@ namespace LinqToDB.Linq
 
 				foreach (var field in fields)
 				{
-					var param = GetParameter(typeof(T), dataContext, field);
+					var param = GetParameter(type, dataContext, field);
 
 					ei.Queries[0].Parameters.Add(param);
 
@@ -58,7 +59,7 @@ namespace LinqToDB.Linq
 
 				foreach (var field in keys)
 				{
-					var param = GetParameter(typeof(T), dataContext, field);
+					var param = GetParameter(type, dataContext, field);
 
 					ei.Queries[0].Parameters.Add(param);
 
@@ -78,8 +79,9 @@ namespace LinqToDB.Linq
 				if (Equals(default(T), obj))
 					return 0;
 
-				var key = new { dataContext.MappingSchema.ConfigurationID, dataContext.ContextID, tableName, schemaName, databaseName };
-				var ei  = _queryCache.GetOrAdd(key, o => CreateQuery(dataContext, tableName, databaseName, schemaName));
+				var type = obj.GetType();
+				var key = new { dataContext.MappingSchema.ConfigurationID, dataContext.ContextID, tableName, schemaName, databaseName, type };
+				var ei  = _queryCache.GetOrAdd(key, o => CreateQuery(dataContext, tableName, databaseName, schemaName, type));
 
 				return ei == null ? 0 : (int)ei.GetElement(dataContext, Expression.Constant(obj), null);
 			}
@@ -89,9 +91,10 @@ namespace LinqToDB.Linq
 			{
 				if (Equals(default, obj))
 					return 0;
-						
-				var key = new { dataContext.MappingSchema.ConfigurationID, dataContext.ContextID, tableName, schemaName, databaseName };
-				var ei  = _queryCache.GetOrAdd(key, o => CreateQuery(dataContext, tableName, databaseName, schemaName));
+
+				var type = obj.GetType();						
+				var key = new { dataContext.MappingSchema.ConfigurationID, dataContext.ContextID, tableName, schemaName, databaseName, type };
+				var ei  = _queryCache.GetOrAdd(key, o => CreateQuery(dataContext, tableName, databaseName, schemaName, type));
 
 				var result = ei == null ? 0 : await ei.GetElementAsync(dataContext, Expression.Constant(obj), null, token);
 

--- a/Source/LinqToDB/LinqExtensions.cs
+++ b/Source/LinqToDB/LinqExtensions.cs
@@ -235,6 +235,36 @@ namespace LinqToDB
 			return table;
 		}
 
+		/// <summary>
+		/// Specifies associations, that should be loaded for each loaded record from current table.
+		/// You need to use this method, if you use inheritance and need to specify wich data should be loaded from derived entities.
+		/// All associations, specified in <paramref name="selector"/> expression, will be loaded.
+		/// Take into account that use of this method could require multiple queries to load all requested associations.
+		/// Some usage examples:
+		/// <code>
+		/// // loads records from Table1 with Reference association loaded for each Table1 record
+		/// db.Table1.LoadWithDerived&lt;BaseT, DerivedT&gt;(r => r.Reference);
+		///
+		/// // loads records from Table1 with Reference1 association loaded for each Table1 record
+		/// // loads records from Reference2 association for each loaded Reference1 record
+		/// db.Table1.LoadWithDerived&lt;BaseT, DerivedT&gt;(r => r.Reference1.Reference2);
+		///
+		/// // loads records from Table1 with References collection association loaded for each Table1 record
+		/// db.Table1.LoadWithDerived&lt;BaseT, DerivedT&gt;(r => r.References);
+		///
+		/// // loads records from Table1 with Reference1 collection association loaded for each Table1 record
+		/// // loads records from Reference2 collection association for each loaded Reference1 record
+		/// // loads records from Reference3 association for each loaded Reference2 record
+		/// // note that a way you access collection association record (by index, using First() method) doesn't affect
+		/// // query results and allways select all records
+		/// db.Table1.LoadWithDerived&lt;BaseT, DerivedT&gt;(r => r.References1[0].References2.First().Reference3);
+		/// </code>
+		/// </summary>
+		/// <typeparam name="T">Table record mapping class.</typeparam>
+		/// <typeparam name="Tr">Derived record mapping class.</typeparam>
+		/// <param name="table">Table-like query source.</param>
+		/// <param name="selector">Association selection expression.</param>
+		/// <returns>Table-like query source.</returns>
 		[LinqTunnel]
 		[Pure]
 		public static ITable<T> LoadWithDerived<T, Tr>(

--- a/Source/LinqToDB/LinqExtensions.cs
+++ b/Source/LinqToDB/LinqExtensions.cs
@@ -189,6 +189,7 @@ namespace LinqToDB
 		#region LoadWith
 
 		static readonly MethodInfo _loadWithMethodInfo = MemberHelper.MethodOf(() => LoadWith<int>(null, null)).GetGenericMethodDefinition();
+		static readonly MethodInfo _loadWithDerivedMethodInfo = MemberHelper.MethodOf(() => LoadWithDerived<int, int>(null, null)).GetGenericMethodDefinition();
 
 		/// <summary>
 		/// Specifies associations, that should be loaded for each loaded record from current table.
@@ -229,6 +230,22 @@ namespace LinqToDB
 			table.Expression = Expression.Call(
 				null,
 				_loadWithMethodInfo.MakeGenericMethod(typeof(T)),
+				new[] { table.Expression, Expression.Quote(selector) });
+
+			return table;
+		}
+
+		[LinqTunnel]
+		[Pure]
+		public static ITable<T> LoadWithDerived<T, Tr>(
+			[NotNull]                this ITable<T> table,
+			[NotNull, InstantHandle] Expression<Func<Tr, object>> selector)
+		{
+			if (table == null) throw new ArgumentNullException(nameof(table));
+
+			table.Expression = Expression.Call(
+				null,
+				_loadWithDerivedMethodInfo.MakeGenericMethod(typeof(T), typeof(Tr)),
 				new[] { table.Expression, Expression.Quote(selector) });
 
 			return table;

--- a/Source/LinqToDB/LinqExtensions.cs
+++ b/Source/LinqToDB/LinqExtensions.cs
@@ -189,7 +189,6 @@ namespace LinqToDB
 		#region LoadWith
 
 		static readonly MethodInfo _loadWithMethodInfo = MemberHelper.MethodOf(() => LoadWith<int>(null, null)).GetGenericMethodDefinition();
-		static readonly MethodInfo _loadWithDerivedMethodInfo = MemberHelper.MethodOf(() => LoadWithDerived<int, int>(null, null)).GetGenericMethodDefinition();
 
 		/// <summary>
 		/// Specifies associations, that should be loaded for each loaded record from current table.
@@ -230,52 +229,6 @@ namespace LinqToDB
 			table.Expression = Expression.Call(
 				null,
 				_loadWithMethodInfo.MakeGenericMethod(typeof(T)),
-				new[] { table.Expression, Expression.Quote(selector) });
-
-			return table;
-		}
-
-		/// <summary>
-		/// Specifies associations, that should be loaded for each loaded record from current table.
-		/// You need to use this method, if you use inheritance and need to specify wich data should be loaded from derived entities.
-		/// All associations, specified in <paramref name="selector"/> expression, will be loaded.
-		/// Take into account that use of this method could require multiple queries to load all requested associations.
-		/// Some usage examples:
-		/// <code>
-		/// // loads records from Table1 with Reference association loaded for each Table1 record
-		/// db.Table1.LoadWithDerived&lt;BaseT, DerivedT&gt;(r => r.Reference);
-		///
-		/// // loads records from Table1 with Reference1 association loaded for each Table1 record
-		/// // loads records from Reference2 association for each loaded Reference1 record
-		/// db.Table1.LoadWithDerived&lt;BaseT, DerivedT&gt;(r => r.Reference1.Reference2);
-		///
-		/// // loads records from Table1 with References collection association loaded for each Table1 record
-		/// db.Table1.LoadWithDerived&lt;BaseT, DerivedT&gt;(r => r.References);
-		///
-		/// // loads records from Table1 with Reference1 collection association loaded for each Table1 record
-		/// // loads records from Reference2 collection association for each loaded Reference1 record
-		/// // loads records from Reference3 association for each loaded Reference2 record
-		/// // note that a way you access collection association record (by index, using First() method) doesn't affect
-		/// // query results and allways select all records
-		/// db.Table1.LoadWithDerived&lt;BaseT, DerivedT&gt;(r => r.References1[0].References2.First().Reference3);
-		/// </code>
-		/// </summary>
-		/// <typeparam name="T">Table record mapping class.</typeparam>
-		/// <typeparam name="Tr">Derived record mapping class.</typeparam>
-		/// <param name="table">Table-like query source.</param>
-		/// <param name="selector">Association selection expression.</param>
-		/// <returns>Table-like query source.</returns>
-		[LinqTunnel]
-		[Pure]
-		public static ITable<T> LoadWithDerived<T, Tr>(
-			[NotNull]                this ITable<T> table,
-			[NotNull, InstantHandle] Expression<Func<Tr, object>> selector)
-		{
-			if (table == null) throw new ArgumentNullException(nameof(table));
-
-			table.Expression = Expression.Call(
-				null,
-				_loadWithDerivedMethodInfo.MakeGenericMethod(typeof(T), typeof(Tr)),
 				new[] { table.Expression, Expression.Quote(selector) });
 
 			return table;

--- a/Source/LinqToDB/Mapping/EntityDescriptor.cs
+++ b/Source/LinqToDB/Mapping/EntityDescriptor.cs
@@ -129,21 +129,24 @@ namespace LinqToDB.Mapping
 					continue;
 				}
 
-				var ca = mappingSchema.GetAttribute<ColumnAttribute>(TypeAccessor.Type, member.MemberInfo, attr => attr.Configuration);
+				var cas = mappingSchema.GetAttributes<ColumnAttribute>(TypeAccessor.Type, member.MemberInfo, attr => attr.Configuration);
 
-				if (ca != null)
+				if (cas != null && cas.Length > 0)
 				{
-					if (ca.IsColumn)
+					foreach (var ca in cas)
 					{
-						if (ca.MemberName != null)
+						if (ca.IsColumn)
 						{
-							attrs.Add(new ColumnAttribute(member.Name, ca));
-						}
-						else
-						{
-							var cd = new ColumnDescriptor(mappingSchema, ca, member);
-							Columns.Add(cd);
-							_columnNames.Add(member.Name, cd);
+							if (ca.MemberName != null)
+							{
+								attrs.Add(new ColumnAttribute(member.Name, ca));
+							}
+							else
+							{
+								var cd = new ColumnDescriptor(mappingSchema, ca, member);
+								Columns.Add(cd);
+								_columnNames.Add(member.Name, cd);
+							}
 						}
 					}
 				}

--- a/Source/LinqToDB/Mapping/EntityDescriptor.cs
+++ b/Source/LinqToDB/Mapping/EntityDescriptor.cs
@@ -144,8 +144,11 @@ namespace LinqToDB.Mapping
 							else
 							{
 								var cd = new ColumnDescriptor(mappingSchema, ca, member);
-								Columns.Add(cd);
-								_columnNames.Add(member.Name, cd);
+								if (!_columnNames.ContainsKey(member.Name))
+								{
+									Columns.Add(cd);
+									_columnNames.Add(member.Name, cd);
+								}
 							}
 						}
 					}

--- a/Source/LinqToDB/Mapping/MappingSchema.cs
+++ b/Source/LinqToDB/Mapping/MappingSchema.cs
@@ -758,6 +758,12 @@ namespace LinqToDB.Mapping
 			lock (_metadataReadersSyncRoot)
 			{
 				var currentReader = MetadataReader;
+				if (currentReader is MetadataReader metadataReader)
+				{
+					metadataReader.AddReader(reader);
+					return;
+				}
+
 				MetadataReader = currentReader == null ? reader : new MetadataReader(reader, currentReader);
 			}
 		}

--- a/Source/LinqToDB/Mapping/MappingSchema.cs
+++ b/Source/LinqToDB/Mapping/MappingSchema.cs
@@ -499,7 +499,7 @@ namespace LinqToDB.Mapping
 			return expr;
 		}
 
-		ConvertInfo.LambdaInfo GetConverter(Type from, Type to, bool create)
+		internal ConvertInfo.LambdaInfo GetConverter(Type from, Type to, bool create)
 		{
 			for (var i = 0; i < Schemas.Length; i++)
 			{

--- a/Source/LinqToDB/Metadata/FluentMetadataReader.cs
+++ b/Source/LinqToDB/Metadata/FluentMetadataReader.cs
@@ -9,7 +9,7 @@ namespace LinqToDB.Metadata
 {
 	using Common;
 
-	public class FluentMetadataReader : IMetadataReader, ITypelistMetadataReader
+	public class FluentMetadataReader : IMetadataReader, ITypeListMetadataReader
 	{
 		readonly ConcurrentDictionary<Type,List<Attribute>> _types = new ConcurrentDictionary<Type,List<Attribute>>();
 

--- a/Source/LinqToDB/Metadata/FluentMetadataReader.cs
+++ b/Source/LinqToDB/Metadata/FluentMetadataReader.cs
@@ -9,7 +9,7 @@ namespace LinqToDB.Metadata
 {
 	using Common;
 
-	public class FluentMetadataReader : IMetadataReader
+	public class FluentMetadataReader : IMetadataReader, ITypelistMetadataReader
 	{
 		readonly ConcurrentDictionary<Type,List<Attribute>> _types = new ConcurrentDictionary<Type,List<Attribute>>();
 
@@ -49,6 +49,11 @@ namespace LinqToDB.Metadata
 				return Array<T>.Empty;
 
 			return GetAttributes<T>(parent, mi, inherit);
+		}
+
+		public IEnumerable<Type> GetMappedTypes()
+		{
+			return _types.Keys;
 		}
 
 		public void AddAttribute(MemberInfo memberInfo, Attribute attribute)

--- a/Source/LinqToDB/Metadata/ITypelistMetadataReader.cs
+++ b/Source/LinqToDB/Metadata/ITypelistMetadataReader.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace LinqToDB.Metadata
+{
+	public interface ITypelistMetadataReader
+	{
+		IEnumerable<Type> GetMappedTypes();
+	}
+}

--- a/Source/LinqToDB/Metadata/ITypelistMetadataReader.cs
+++ b/Source/LinqToDB/Metadata/ITypelistMetadataReader.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace LinqToDB.Metadata
 {
-	public interface ITypelistMetadataReader
+	public interface ITypeListMetadataReader
 	{
 		IEnumerable<Type> GetMappedTypes();
 	}

--- a/Source/LinqToDB/Metadata/MetadataReader.cs
+++ b/Source/LinqToDB/Metadata/MetadataReader.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
@@ -6,7 +7,7 @@ using JetBrains.Annotations;
 
 namespace LinqToDB.Metadata
 {
-	public class MetadataReader : IMetadataReader
+	public class MetadataReader : IMetadataReader, ITypelistMetadataReader
 	{
 		public static MetadataReader Default = new MetadataReader(
 			new AttributeReader()
@@ -35,6 +36,11 @@ namespace LinqToDB.Metadata
 			where T : Attribute
 		{
 			return _readers.SelectMany(r => r.GetAttributes<T>(type, memberInfo, inherit)).ToArray();
+		}
+
+		public IEnumerable<Type> GetMappedTypes()
+		{
+			return _readers.OfType<ITypelistMetadataReader>().SelectMany(x => x.GetMappedTypes());
 		}
 	}
 }

--- a/Source/LinqToDB/Metadata/MetadataReader.cs
+++ b/Source/LinqToDB/Metadata/MetadataReader.cs
@@ -7,6 +7,9 @@ using JetBrains.Annotations;
 
 namespace LinqToDB.Metadata
 {
+	/// <summary>
+	/// Aggregation metadata reader, that just delegates all calls to nested readers.
+	/// </summary>
 	public class MetadataReader : IMetadataReader, ITypeListMetadataReader
 	{
 		public static MetadataReader Default = new MetadataReader(
@@ -21,10 +24,16 @@ namespace LinqToDB.Metadata
 
 		public MetadataReader([NotNull] params IMetadataReader[] readers)
 		{
-			_readers = readers ?? throw new ArgumentNullException(nameof(readers));
+			_readers = new List<IMetadataReader>(readers) ?? throw new ArgumentNullException(nameof(readers));
 		}
 
-		readonly IMetadataReader[] _readers;
+		IList<IMetadataReader> _readers;
+
+		internal void AddReader(IMetadataReader reader)
+		{
+			// creation of new list is cheaper than lock on each method call
+			_readers = new[] { reader }.Concat(_readers).ToList();
+		}
 
 		public T[] GetAttributes<T>(Type type, bool inherit)
 			where T : Attribute

--- a/Source/LinqToDB/Metadata/MetadataReader.cs
+++ b/Source/LinqToDB/Metadata/MetadataReader.cs
@@ -7,7 +7,7 @@ using JetBrains.Annotations;
 
 namespace LinqToDB.Metadata
 {
-	public class MetadataReader : IMetadataReader, ITypelistMetadataReader
+	public class MetadataReader : IMetadataReader, ITypeListMetadataReader
 	{
 		public static MetadataReader Default = new MetadataReader(
 			new AttributeReader()
@@ -40,7 +40,7 @@ namespace LinqToDB.Metadata
 
 		public IEnumerable<Type> GetMappedTypes()
 		{
-			return _readers.OfType<ITypelistMetadataReader>().SelectMany(x => x.GetMappedTypes());
+			return _readers.OfType<ITypeListMetadataReader>().SelectMany(x => x.GetMappedTypes());
 		}
 	}
 }

--- a/Tests/Linq/Linq/InheritanceTests.cs
+++ b/Tests/Linq/Linq/InheritanceTests.cs
@@ -114,7 +114,9 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 			{
 				var q = from p in db.ParentInheritance3 where p is ParentInheritance13 select p;
-				q.ToList();
+				var lst = q.ToList();
+
+				Assert.AreEqual(2, lst.Count);
 			}
 		}
 

--- a/Tests/Linq/Linq/SelectTests.cs
+++ b/Tests/Linq/Linq/SelectTests.cs
@@ -631,8 +631,10 @@ namespace Tests.Linq
 				var r = db.GetTable<ComplexPerson>().First(_ => _.ID == 1);
 
 				Assert.IsNotEmpty(r.Name.FirstName);
+				Assert.IsNotNull(r.Name.FirstName);
 				Assert.IsNotEmpty(r.Name.MiddleName);
 				Assert.IsNotEmpty(r.Name.LastName);
+				Assert.IsNotNull(r.Name.LastName);
 			}
 		}
 
@@ -644,8 +646,10 @@ namespace Tests.Linq
 				var r = db.GetTable<ComplexPerson2>().First(_ => _.ID == 1);
 
 				Assert.IsNotEmpty(r.Name.FirstName);
+				Assert.IsNotNull(r.Name.FirstName);
 				Assert.IsNotEmpty(r.Name.MiddleName);
 				Assert.IsNotEmpty(r.Name.LastName);
+				Assert.IsNotNull(r.Name.LastName);
 			}
 		}
 
@@ -667,8 +671,10 @@ namespace Tests.Linq
 				var r = db.GetTable<ComplexPerson3>().First(_ => _.ID == 1);
 
 				Assert.IsNotEmpty(r.Name.FirstName);
+				Assert.IsNotNull(r.Name.FirstName);
 				Assert.IsNotEmpty(r.Name.MiddleName);
 				Assert.IsNotEmpty(r.Name.LastName);
+				Assert.IsNotNull(r.Name.LastName);
 			}
 		}
 

--- a/Tests/Linq/UserTests/Issue994Tests.cs
+++ b/Tests/Linq/UserTests/Issue994Tests.cs
@@ -91,8 +91,12 @@ public class Issue994Tests : TestBase
 
 		Assert.Null(listTest3.First().TestAnimal);
 		Assert.NotNull(((Dog)listTest3.Skip(1).First().TestAnimal).Bla);
+		Assert.NotNull(((Dog)listTest3.Skip(1).First().TestAnimal).DogName.First);
+		Assert.NotNull(((Dog)listTest3.Skip(1).First().TestAnimal).DogName.Second);
 
 		var listTest4 = LoadTest4();
+		Assert.NotNull(listTest4[0].DogName.First);
+		Assert.NotNull(listTest4[0].DogName.Second);
 	}
 
 	private void InsertData()
@@ -174,9 +178,7 @@ public class Issue994Tests : TestBase
 	{
 		using (var db = new TestDataConnection())
 		{
-			var a = db.GetTable<Dog>().ToList();
-			var sql = db.LastQuery;
-			return a;
+			return db.GetTable<Dog>().ToList();
 		}
 	}
 

--- a/Tests/Linq/UserTests/Issue994Tests.cs
+++ b/Tests/Linq/UserTests/Issue994Tests.cs
@@ -20,6 +20,12 @@ public class Issue994Tests : TestBase
 		public string Xy { get; set; }
 	}
 
+	public class Name
+	{
+		public string First { get; set; }
+		public string Second { get; set; }
+	}
+
 	public class Animal
 	{
 		public int Id { get; set; }
@@ -55,6 +61,8 @@ public class Issue994Tests : TestBase
 		public Eye Bla { get; set; }
 
 		public int? EyeId { get; set; }
+
+		public Name DogName { get; set; }
 	}
 
 	public class Test
@@ -83,6 +91,8 @@ public class Issue994Tests : TestBase
 
 		Assert.Null(listTest3.First().TestAnimal);
 		Assert.NotNull(((Dog)listTest3.Skip(1).First().TestAnimal).Bla);
+
+		var listTest4 = LoadTest4();
 	}
 
 	private void InsertData()
@@ -98,7 +108,8 @@ public class Issue994Tests : TestBase
 			Id = 1,
 			Discriminator = "Dog",
 			EyeId = 1,
-			Name = "FirstDog"
+			Name = "FirstDog",
+			DogName = new Name {First = "a", Second = "b"}
 		};
 
 		var test = new Test
@@ -118,7 +129,7 @@ public class Issue994Tests : TestBase
 			db.SetCommand("DROP TABLE IF EXISTS `Animals`").Execute();
 			db.SetCommand("DROP TABLE IF EXISTS `Eyes`").Execute();
 			db.SetCommand("DROP TABLE IF EXISTS `Test`").Execute();
-			db.SetCommand("CREATE TABLE `Animals` ( `Id` INTEGER NOT NULL PRIMARY KEY, `Name` TEXT,`Discriminator` TEXT, `EyeId` INTEGER )").Execute();
+			db.SetCommand("CREATE TABLE `Animals` ( `Id` INTEGER NOT NULL PRIMARY KEY, `Name` TEXT,`Discriminator` TEXT, `EyeId` INTEGER, `First` TEXT, `Second` TEXT )").Execute();
 			db.SetCommand("CREATE TABLE `Eyes` ( `Id` INTEGER NOT NULL PRIMARY KEY, `Xy` TEXT )").Execute();
 			db.SetCommand("CREATE TABLE `Test` ( `Id` INTEGER NOT NULL PRIMARY KEY, `TestAnimalId` INTEGER NULL )").Execute();
 		}
@@ -159,6 +170,16 @@ public class Issue994Tests : TestBase
 		}
 	}
 
+	private List<Dog> LoadTest4()
+	{
+		using (var db = new TestDataConnection())
+		{
+			var a = db.GetTable<Dog>().ToList();
+			var sql = db.LastQuery;
+			return a;
+		}
+	}
+
 	private void SetMappings()
 	{
 		var mappingBuilder = MappingSchema.Default.GetFluentMappingBuilder();
@@ -175,6 +196,8 @@ public class Issue994Tests : TestBase
 			.HasTableName("Animals")
 			.Property(x => x.Bla).IsNotColumn()
 			.Property(x => x.EyeId).IsColumn().IsNullable().HasColumnName("EyeId")
+			.Property(x => x.DogName.Second).HasColumnName("Second")
+			.Property(x => x.DogName.First).HasColumnName("First")
 			.Association(x => x.Bla, x => x.EyeId, x => x.Id);
 
 		mappingBuilder.Entity<WildAnimal>()

--- a/Tests/Linq/UserTests/Issue994Tests.cs
+++ b/Tests/Linq/UserTests/Issue994Tests.cs
@@ -22,6 +22,8 @@ public class Issue994Tests : TestBase
 
 	public class Animal
 	{
+		public int Id { get; set; }
+
 		public string Name { get; set; }
 
 		public string Discriminator { get; set; }
@@ -29,17 +31,37 @@ public class Issue994Tests : TestBase
 
 	public class WildAnimal : Animal
 	{
+		public WildAnimal()
+		{
+			Discriminator = "WildAnimal";
+		}
 	}
 
 	public class SuperWildAnimal : WildAnimal
 	{
+		public SuperWildAnimal()
+		{
+			Discriminator = "SuperWildAnimal";
+		}
 	}
 
 	public class Dog : SuperWildAnimal
 	{
+		public Dog()
+		{
+			Discriminator = "Dog";
+		}
+
 		public Eye Bla { get; set; }
 
 		public int? EyeId { get; set; }
+	}
+
+	public class Test
+	{
+		public int Id { get; set; }
+		public int? TestAnimalId { get; set; }
+		public Animal TestAnimal { get; set; }
 	}
 
 	[Test]
@@ -56,6 +78,10 @@ public class Issue994Tests : TestBase
 		var listTest2 = LoadTest2();
 
 		Assert.NotNull(((Dog)listTest2.First()).Bla);
+
+		var listTest3 = LoadTest3();
+
+		//Assert.NotNull(((Dog)listTest2.First()).Bla);
 	}
 
 	private void InsertData()
@@ -68,17 +94,32 @@ public class Issue994Tests : TestBase
 
 		var dog = new Dog
 		{
+			Id = 1,
 			Discriminator = "Dog",
 			EyeId = 1,
 			Name = "FirstDog"
+		};
+
+		var test = new Test
+		{
+			Id = 1,
+			TestAnimalId = null
+		};
+
+		var test2 = new Test
+		{
+			Id = 2,
+			TestAnimalId = 1
 		};
 
 		using (var db = new TestDataConnection())
 		{
 			db.SetCommand("DROP TABLE IF EXISTS `Animals`").Execute();
 			db.SetCommand("DROP TABLE IF EXISTS `Eyes`").Execute();
-			db.SetCommand("CREATE TABLE `Animals` ( `Name` TEXT,`Discriminator` TEXT, `EyeId` INTEGER )").Execute();
+			db.SetCommand("DROP TABLE IF EXISTS `Test`").Execute();
+			db.SetCommand("CREATE TABLE `Animals` ( `Id` INTEGER NOT NULL PRIMARY KEY, `Name` TEXT,`Discriminator` TEXT, `EyeId` INTEGER )").Execute();
 			db.SetCommand("CREATE TABLE `Eyes` ( `Id` INTEGER NOT NULL PRIMARY KEY, `Xy` TEXT )").Execute();
+			db.SetCommand("CREATE TABLE `Test` ( `Id` INTEGER NOT NULL PRIMARY KEY, `TestAnimalId` INTEGER )").Execute();
 		}
 
 		using (var db = new TestDataConnection())
@@ -88,6 +129,8 @@ public class Issue994Tests : TestBase
 
 			db.Insert(eye);
 			db.Insert(dog);
+			db.Insert(test);
+			db.Insert(test2);
 		}
 	}
 
@@ -107,6 +150,14 @@ public class Issue994Tests : TestBase
 		}
 	}
 
+	private List<Test> LoadTest3()
+	{
+		using (var db = new TestDataConnection())
+		{
+			return db.GetTable<Test>().LoadWith(x => ((Dog)x.TestAnimal).Bla).ToList();
+		}
+	}
+
 	private void SetMappings()
 	{
 		var mappingBuilder = MappingSchema.Default.GetFluentMappingBuilder();
@@ -116,7 +167,8 @@ public class Issue994Tests : TestBase
 			.Inheritance(x => x.Discriminator, "WildAnimal", typeof(WildAnimal))
 			.Inheritance(x => x.Discriminator, "SuperWildAnimal", typeof(SuperWildAnimal))
 			.Property(x => x.Name).IsColumn().IsNullable().HasColumnName("Name")
-			.Property(x => x.Discriminator).IsDiscriminator().IsColumn().IsNullable(false).HasColumnName("Discriminator");
+			.Property(x => x.Discriminator).IsDiscriminator().IsColumn().IsNullable(false).HasColumnName("Discriminator")
+			.Property(x => x.Id).IsColumn().IsNullable(false).HasColumnName("Id");
 
 		mappingBuilder.Entity<Dog>()
 			.HasTableName("Animals")
@@ -133,5 +185,11 @@ public class Issue994Tests : TestBase
 			.HasTableName("Eyes")
 			.Property(x => x.Id).IsColumn().HasColumnName("Xy")
 			.Property(x => x.Xy).IsColumn().IsNullable().HasColumnName("Xy");
+
+		mappingBuilder.Entity<Test>()
+			.HasTableName("Test")
+			.Association(x => x.TestAnimal, x => x.TestAnimalId, x => x.Id)
+			.Property(x => x.TestAnimalId).IsColumn().IsNullable().HasColumnName("TestAnimalId")
+			.Property(x => x.TestAnimal).IsNotColumn();
 	}
 }

--- a/Tests/Linq/UserTests/Issue994Tests.cs
+++ b/Tests/Linq/UserTests/Issue994Tests.cs
@@ -116,6 +116,8 @@ public class Issue994Tests : TestBase
 		Assert.NotNull(listTest4[0].DogName.Second);
 
 		LoadTest5();
+
+		Test6();
 	}
 
 	private void InsertData()
@@ -221,6 +223,16 @@ public class Issue994Tests : TestBase
 		}
 	}
 
+	private void Test6()
+	{
+		using (var db = new TestDataConnection())
+		{
+			var dog = db.GetTable<Dog>().First();
+			db.Update(dog);
+			db.Update((Animal)dog);
+		}
+	}
+
 	private void SetMappings()
 	{
 		MappingSchema.Default.SetConverter<AnimalType, string>((obj) =>
@@ -247,7 +259,7 @@ public class Issue994Tests : TestBase
 			.Property(x => x.Name).IsColumn().IsNullable().HasColumnName("Name")
 			.Property(x => x.AnimalType).IsColumn().HasColumnName("AnimalType")
 			.Property(x => x.Discriminator).IsDiscriminator().IsColumn().IsNullable(false).HasColumnName("Discriminator")
-			.Property(x => x.Id).IsColumn().IsNullable(false).HasColumnName("Id");
+			.Property(x => x.Id).IsColumn().IsNullable(false).HasColumnName("Id").IsPrimaryKey();
 
 		mappingBuilder.Entity<Dog>()
 			.HasTableName("Animals")

--- a/Tests/Linq/UserTests/Issue994Tests.cs
+++ b/Tests/Linq/UserTests/Issue994Tests.cs
@@ -81,7 +81,8 @@ public class Issue994Tests : TestBase
 
 		var listTest3 = LoadTest3();
 
-		//Assert.NotNull(((Dog)listTest2.First()).Bla);
+		Assert.Null(listTest3.First().TestAnimal);
+		Assert.NotNull(((Dog)listTest3.Skip(1).First().TestAnimal).Bla);
 	}
 
 	private void InsertData()
@@ -119,7 +120,7 @@ public class Issue994Tests : TestBase
 			db.SetCommand("DROP TABLE IF EXISTS `Test`").Execute();
 			db.SetCommand("CREATE TABLE `Animals` ( `Id` INTEGER NOT NULL PRIMARY KEY, `Name` TEXT,`Discriminator` TEXT, `EyeId` INTEGER )").Execute();
 			db.SetCommand("CREATE TABLE `Eyes` ( `Id` INTEGER NOT NULL PRIMARY KEY, `Xy` TEXT )").Execute();
-			db.SetCommand("CREATE TABLE `Test` ( `Id` INTEGER NOT NULL PRIMARY KEY, `TestAnimalId` INTEGER )").Execute();
+			db.SetCommand("CREATE TABLE `Test` ( `Id` INTEGER NOT NULL PRIMARY KEY, `TestAnimalId` INTEGER NULL )").Execute();
 		}
 
 		using (var db = new TestDataConnection())
@@ -146,7 +147,7 @@ public class Issue994Tests : TestBase
 	{
 		using (var db = new TestDataConnection())
 		{
-			return db.GetTable<Animal>().LoadWithDerived<Animal, Dog>(x => x.Bla).ToList();
+			return db.GetTable<Animal>().LoadWith(x => ((Dog)x).Bla).ToList();
 		}
 	}
 
@@ -173,6 +174,7 @@ public class Issue994Tests : TestBase
 		mappingBuilder.Entity<Dog>()
 			.HasTableName("Animals")
 			.Property(x => x.Bla).IsNotColumn()
+			.Property(x => x.EyeId).IsColumn().IsNullable().HasColumnName("EyeId")
 			.Association(x => x.Bla, x => x.EyeId, x => x.Id);
 
 		mappingBuilder.Entity<WildAnimal>()
@@ -183,7 +185,7 @@ public class Issue994Tests : TestBase
 
 		mappingBuilder.Entity<Eye>()
 			.HasTableName("Eyes")
-			.Property(x => x.Id).IsColumn().HasColumnName("Xy")
+			.Property(x => x.Id).IsColumn().HasColumnName("Id")
 			.Property(x => x.Xy).IsColumn().IsNullable().HasColumnName("Xy");
 
 		mappingBuilder.Entity<Test>()

--- a/Tests/Linq/UserTests/Issue994Tests.cs
+++ b/Tests/Linq/UserTests/Issue994Tests.cs
@@ -27,7 +27,15 @@ public class Issue994Tests : TestBase
 		public string Discriminator { get; set; }
 	}
 
-	public class Dog : Animal
+	public class WildAnimal : Animal
+	{
+	}
+
+	public class SuperWildAnimal : WildAnimal
+	{
+	}
+
+	public class Dog : SuperWildAnimal
 	{
 		public Eye Bla { get; set; }
 
@@ -68,7 +76,6 @@ public class Issue994Tests : TestBase
 		using (var db = new TestDataConnection())
 		{
 			db.SetCommand("DROP TABLE IF EXISTS `Animals`").Execute();
-			db.SetCommand("DROP TABLE IF EXISTS `Dogs`").Execute();
 			db.SetCommand("DROP TABLE IF EXISTS `Eyes`").Execute();
 			db.SetCommand("CREATE TABLE `Animals` ( `Name` TEXT,`Discriminator` TEXT, `EyeId` INTEGER )").Execute();
 			db.SetCommand("CREATE TABLE `Eyes` ( `Id` INTEGER NOT NULL PRIMARY KEY, `Xy` TEXT )").Execute();
@@ -106,6 +113,8 @@ public class Issue994Tests : TestBase
 		mappingBuilder.Entity<Animal>()
 			.HasTableName("Animals")
 			.Inheritance(x => x.Discriminator, "Dog", typeof(Dog))
+			.Inheritance(x => x.Discriminator, "WildAnimal", typeof(WildAnimal))
+			.Inheritance(x => x.Discriminator, "SuperWildAnimal", typeof(SuperWildAnimal))
 			.Property(x => x.Name).IsColumn().IsNullable().HasColumnName("Name")
 			.Property(x => x.Discriminator).IsDiscriminator().IsColumn().IsNullable(false).HasColumnName("Discriminator");
 
@@ -113,6 +122,12 @@ public class Issue994Tests : TestBase
 			.HasTableName("Animals")
 			.Property(x => x.Bla).IsNotColumn()
 			.Association(x => x.Bla, x => x.EyeId, x => x.Id);
+
+		mappingBuilder.Entity<WildAnimal>()
+			.HasTableName("Animals");
+
+		mappingBuilder.Entity<SuperWildAnimal>()
+			.HasTableName("Animals");
 
 		mappingBuilder.Entity<Eye>()
 			.HasTableName("Eyes")

--- a/Tests/Linq/UserTests/Issue994Tests.cs
+++ b/Tests/Linq/UserTests/Issue994Tests.cs
@@ -213,6 +213,11 @@ public class Issue994Tests : TestBase
 
 			var test3 = db.GetTable<Dog>().First(x => x.AnimalType2 == AnimalType2.Big);
 			var test4 = db.GetTable<Dog>().First(x => x.AnimalType2 == d.AnimalType2);
+
+			var test6 = db.GetTable<Animal>().First(x => x is SuperWildAnimal);
+
+			var test7 = db.GetTable<Test>().First(x => x.TestAnimal is Dog && ((Dog)x.TestAnimal).EyeId == 1);
+			var sql = db.LastQuery;
 		}
 	}
 

--- a/Tests/Linq/UserTests/Issue994Tests.cs
+++ b/Tests/Linq/UserTests/Issue994Tests.cs
@@ -1,0 +1,122 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+using LinqToDB;
+using LinqToDB.Data;
+using LinqToDB.Mapping;
+
+using NUnit.Framework;
+
+using Tests;
+using Tests.Model;
+
+
+[TestFixture]
+public class Issue994Tests : TestBase
+{
+	public class Eye
+	{
+		public int Id { get; set; }
+		public string Xy { get; set; }
+	}
+
+	public class Animal
+	{
+		public string Name { get; set; }
+
+		public string Discriminator { get; set; }
+	}
+
+	public class Dog : Animal
+	{
+		public Eye Bla { get; set; }
+
+		public int? EyeId { get; set; }
+	}
+
+	[Test]
+	public void TestIssue()
+	{
+		SetMappings();
+
+		InsertData();
+
+		var listTest = LoadTest();
+
+		Assert.Null(((Dog)listTest.First()).Bla);
+
+		var listTest2 = LoadTest2();
+
+		Assert.NotNull(((Dog)listTest2.First()).Bla);
+	}
+
+	private void InsertData()
+	{
+		var eye = new Eye
+		{
+			Id = 1,
+			Xy = "Hallo"
+		};
+
+		var dog = new Dog
+		{
+			Discriminator = "Dog",
+			EyeId = 1,
+			Name = "FirstDog"
+		};
+
+		using (var db = new TestDataConnection())
+		{
+			db.SetCommand("DROP TABLE IF EXISTS `Animals`").Execute();
+			db.SetCommand("DROP TABLE IF EXISTS `Dogs`").Execute();
+			db.SetCommand("DROP TABLE IF EXISTS `Eyes`").Execute();
+			db.SetCommand("CREATE TABLE `Animals` ( `Name` TEXT,`Discriminator` TEXT, `EyeId` INTEGER )").Execute();
+			db.SetCommand("CREATE TABLE `Eyes` ( `Id` INTEGER NOT NULL PRIMARY KEY, `Xy` TEXT )").Execute();
+		}
+
+		using (var db = new TestDataConnection())
+		{
+			db.GetTable<Eye>().Delete();
+			db.GetTable<Animal>().Delete();
+
+			db.Insert(eye);
+			db.Insert(dog);
+		}
+	}
+
+	private List<Animal> LoadTest()
+	{
+		using (var db = new TestDataConnection())
+		{
+			return db.GetTable<Animal>().ToList();
+		}
+	}
+
+	private List<Animal> LoadTest2()
+	{
+		using (var db = new TestDataConnection())
+		{
+			return db.GetTable<Animal>().LoadWithDerived<Animal, Dog>(x => x.Bla).ToList();
+		}
+	}
+
+	private void SetMappings()
+	{
+		var mappingBuilder = MappingSchema.Default.GetFluentMappingBuilder();
+		mappingBuilder.Entity<Animal>()
+			.HasTableName("Animals")
+			.Inheritance(x => x.Discriminator, "Dog", typeof(Dog))
+			.Property(x => x.Name).IsColumn().IsNullable().HasColumnName("Name")
+			.Property(x => x.Discriminator).IsDiscriminator().IsColumn().IsNullable(false).HasColumnName("Discriminator");
+
+		mappingBuilder.Entity<Dog>()
+			.HasTableName("Animals")
+			.Property(x => x.Bla).IsNotColumn()
+			.Association(x => x.Bla, x => x.EyeId, x => x.Id);
+
+		mappingBuilder.Entity<Eye>()
+			.HasTableName("Eyes")
+			.Property(x => x.Id).IsColumn().HasColumnName("Xy")
+			.Property(x => x.Xy).IsColumn().IsNullable().HasColumnName("Xy");
+	}
+}

--- a/Tests/Linq/UserTests/Issue994Tests.cs
+++ b/Tests/Linq/UserTests/Issue994Tests.cs
@@ -82,6 +82,14 @@ public class Issue994Tests : TestBase
 		public Name DogName { get; set; }
 	}
 
+	public class BadDog : Dog
+	{
+	}
+
+	public class SuperBadDog : BadDog
+	{
+	}
+
 	public class Test
 	{
 		public int Id { get; set; }
@@ -230,6 +238,9 @@ public class Issue994Tests : TestBase
 			var dog = db.GetTable<Dog>().First();
 			db.Update(dog);
 			db.Update((Animal)dog);
+
+			//var bdog = new SuperBadDog();
+			//db.Insert((Dog)bdog);   //this is not possible with my change -> ;-( should it be?
 		}
 	}
 

--- a/Tests/Linq/UserTests/Issue994Tests.cs
+++ b/Tests/Linq/UserTests/Issue994Tests.cs
@@ -1,301 +1,300 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-using LinqToDB;
+﻿using LinqToDB;
 using LinqToDB.Data;
 using LinqToDB.Mapping;
-
 using NUnit.Framework;
-
-using Tests;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Tests.Model;
 
 
-[TestFixture]
-public class Issue994Tests : TestBase
+namespace Tests.UserTests
 {
-	public enum AnimalType
+	[TestFixture]
+	public class Issue994Tests : TestBase
 	{
-		Small,
-		Big
-	}
-
-	public enum AnimalType2
-	{
-		Small,
-		Big
-	}
-
-	public class Eye
-	{
-		public int Id { get; set; }
-		public string Xy { get; set; }
-	}
-
-	public class Name
-	{
-		public string First { get; set; }
-		public string Second { get; set; }
-	}
-
-	public class Animal
-	{
-		public AnimalType AnimalType { get; set; }
-
-		public AnimalType2 AnimalType2 { get; set; }
-
-		public int Id { get; set; }
-
-		public string Name { get; set; }
-
-		public string Discriminator { get; set; }
-	}
-
-	public class WildAnimal : Animal
-	{
-		public WildAnimal()
+		public enum AnimalType
 		{
-			Discriminator = "WildAnimal";
-		}
-	}
-
-	public class SuperWildAnimal : WildAnimal
-	{
-		public SuperWildAnimal()
-		{
-			Discriminator = "SuperWildAnimal";
-		}
-	}
-
-	public class Dog : SuperWildAnimal
-	{
-		public Dog()
-		{
-			Discriminator = "Dog";
+			Small,
+			Big
 		}
 
-		public Eye Bla { get; set; }
-
-		public int? EyeId { get; set; }
-
-		public Name DogName { get; set; }
-	}
-
-	public class BadDog : Dog
-	{
-	}
-
-	public class SuperBadDog : BadDog
-	{
-	}
-
-	public class Test
-	{
-		public int Id { get; set; }
-		public int? TestAnimalId { get; set; }
-		public Animal TestAnimal { get; set; }
-	}
-
-	[Test]
-	public void TestIssue()
-	{
-		SetMappings();
-
-		InsertData();
-
-		var listTest = LoadTest();
-
-		Assert.Null(((Dog)listTest.First()).Bla);
-
-		var listTest2 = LoadTest2();
-
-		Assert.NotNull(((Dog)listTest2.First()).Bla);
-
-		var listTest3 = LoadTest3();
-
-		Assert.Null(listTest3.First().TestAnimal);
-		Assert.NotNull(((Dog)listTest3.Skip(1).First().TestAnimal).Bla);
-		Assert.NotNull(((Dog)listTest3.Skip(1).First().TestAnimal).DogName.First);
-		Assert.NotNull(((Dog)listTest3.Skip(1).First().TestAnimal).DogName.Second);
-
-		var listTest4 = LoadTest4();
-		Assert.NotNull(listTest4[0].DogName.First);
-		Assert.NotNull(listTest4[0].DogName.Second);
-
-		LoadTest5();
-
-		Test6();
-	}
-
-	private void InsertData()
-	{
-		var eye = new Eye
+		public enum AnimalType2
 		{
-			Id = 1,
-			Xy = "Hallo"
-		};
-
-		var dog = new Dog
-		{
-			Id = 1,
-			Discriminator = "Dog",
-			EyeId = 1,
-			Name = "FirstDog",
-			DogName = new Name {First = "a", Second = "b"},
-			AnimalType = AnimalType.Big,
-			AnimalType2 = AnimalType2.Big
-		};
-
-		var test = new Test
-		{
-			Id = 1,
-			TestAnimalId = null
-		};
-
-		var test2 = new Test
-		{
-			Id = 2,
-			TestAnimalId = 1
-		};
-
-		using (var db = new TestDataConnection())
-		{
-			db.SetCommand("DROP TABLE IF EXISTS `Animals`").Execute();
-			db.SetCommand("DROP TABLE IF EXISTS `Eyes`").Execute();
-			db.SetCommand("DROP TABLE IF EXISTS `Test`").Execute();
-			db.SetCommand("CREATE TABLE `Animals` ( `Id` INTEGER NOT NULL PRIMARY KEY, `AnimalType` TEXT, `AnimalType2` TEXT, `Name` TEXT, `Discriminator` TEXT, `EyeId` INTEGER, `First` TEXT, `Second` TEXT )").Execute();
-			db.SetCommand("CREATE TABLE `Eyes` ( `Id` INTEGER NOT NULL PRIMARY KEY, `Xy` TEXT )").Execute();
-			db.SetCommand("CREATE TABLE `Test` ( `Id` INTEGER NOT NULL PRIMARY KEY, `TestAnimalId` INTEGER NULL )").Execute();
+			Small,
+			Big
 		}
 
-		using (var db = new TestDataConnection())
+		public class Eye
 		{
-			db.GetTable<Eye>().Delete();
-			db.GetTable<Animal>().Delete();
-
-			db.Insert(eye);
-			db.Insert(dog);
-			db.Insert(test);
-			db.Insert(test2);
+			public int Id { get; set; }
+			public string Xy { get; set; }
 		}
-	}
 
-	private List<Animal> LoadTest()
-	{
-		using (var db = new TestDataConnection())
+		public class Name
 		{
-			return db.GetTable<Animal>().ToList();
+			public string First { get; set; }
+			public string Second { get; set; }
 		}
-	}
 
-	private List<Animal> LoadTest2()
-	{
-		using (var db = new TestDataConnection())
+		public class Animal
 		{
-			return db.GetTable<Animal>().LoadWith(x => ((Dog)x).Bla).ToList();
+			public AnimalType AnimalType { get; set; }
+
+			public AnimalType2 AnimalType2 { get; set; }
+
+			public int Id { get; set; }
+
+			public string Name { get; set; }
+
+			public string Discriminator { get; set; }
 		}
-	}
 
-	private List<Test> LoadTest3()
-	{
-		using (var db = new TestDataConnection())
+		public class WildAnimal : Animal
 		{
-			return db.GetTable<Test>().LoadWith(x => ((Dog)x.TestAnimal).Bla).ToList();
+			public WildAnimal()
+			{
+				Discriminator = "WildAnimal";
+			}
 		}
-	}
 
-	private List<Dog> LoadTest4()
-	{
-		using (var db = new TestDataConnection())
+		public class SuperWildAnimal : WildAnimal
 		{
-			return db.GetTable<Dog>().ToList();
+			public SuperWildAnimal()
+			{
+				Discriminator = "SuperWildAnimal";
+			}
 		}
-	}
-	private void LoadTest5()
-	{
-		using (var db = new TestDataConnection())
+
+		public class Dog : SuperWildAnimal
 		{
-			var d = new Dog() { AnimalType = AnimalType.Big, AnimalType2 = AnimalType2.Big };
+			public Dog()
+			{
+				Discriminator = "Dog";
+			}
 
-			var test1 =  db.GetTable<Dog>().First(x => x.AnimalType == AnimalType.Big);
-			var test2 = db.GetTable<Dog>().First(x => x.AnimalType == d.AnimalType);
+			public Eye Bla { get; set; }
 
-			var test3 = db.GetTable<Dog>().First(x => x.AnimalType2 == AnimalType2.Big);
-			var test4 = db.GetTable<Dog>().First(x => x.AnimalType2 == d.AnimalType2);
+			public int? EyeId { get; set; }
 
-			var test6 = db.GetTable<Animal>().First(x => x is SuperWildAnimal);
-
-			var test7 = db.GetTable<Test>().First(x => x.TestAnimal is Dog && ((Dog)x.TestAnimal).EyeId == 1);
-			var sql = db.LastQuery;
+			public Name DogName { get; set; }
 		}
-	}
 
-	private void Test6()
-	{
-		using (var db = new TestDataConnection())
+		public class BadDog : Dog
 		{
-			var dog = db.GetTable<Dog>().First();
-			db.Update(dog);
-			db.Update((Animal)dog);
-
-			//var bdog = new SuperBadDog();
-			//db.Insert((Dog)bdog);   //this is not possible with my change -> ;-( should it be?
 		}
-	}
 
-	private void SetMappings()
-	{
-		MappingSchema.Default.SetConverter<AnimalType, string>((obj) =>
+		public class SuperBadDog : BadDog
 		{
-			return obj.ToString();
-		});
-		MappingSchema.Default.SetConverter<AnimalType, DataParameter>((obj) =>
+		}
+
+		public class Test
 		{
-			return new DataParameter { Value = obj.ToString() };
-		});
-		MappingSchema.Default.SetConverter<string, AnimalType>((txt) =>
+			public int Id { get; set; }
+			public int? TestAnimalId { get; set; }
+			public Animal TestAnimal { get; set; }
+		}
+
+		[Test]
+		public void TestIssue()
 		{
-			return (AnimalType)Enum.Parse(typeof(AnimalType), txt, true);
-		});
-		MappingSchema.Default.SetDefaultFromEnumType(typeof(AnimalType2), typeof(string));
+			SetMappings();
+
+			InsertData();
+
+			var listTest = LoadTest();
+
+			Assert.Null(((Dog)listTest.First()).Bla);
+
+			var listTest2 = LoadTest2();
+
+			Assert.NotNull(((Dog)listTest2.First()).Bla);
+
+			var listTest3 = LoadTest3();
+
+			Assert.Null(listTest3.First().TestAnimal);
+			Assert.NotNull(((Dog)listTest3.Skip(1).First().TestAnimal).Bla);
+			Assert.NotNull(((Dog)listTest3.Skip(1).First().TestAnimal).DogName.First);
+			Assert.NotNull(((Dog)listTest3.Skip(1).First().TestAnimal).DogName.Second);
+
+			var listTest4 = LoadTest4();
+			Assert.NotNull(listTest4[0].DogName.First);
+			Assert.NotNull(listTest4[0].DogName.Second);
+
+			LoadTest5();
+
+			Test6();
+		}
+
+		private void InsertData()
+		{
+			var eye = new Eye
+			{
+				Id = 1,
+				Xy = "Hallo"
+			};
+
+			var dog = new Dog
+			{
+				Id = 1,
+				Discriminator = "Dog",
+				EyeId = 1,
+				Name = "FirstDog",
+				DogName = new Name { First = "a", Second = "b" },
+				AnimalType = AnimalType.Big,
+				AnimalType2 = AnimalType2.Big
+			};
+
+			var test = new Test
+			{
+				Id = 1,
+				TestAnimalId = null
+			};
+
+			var test2 = new Test
+			{
+				Id = 2,
+				TestAnimalId = 1
+			};
+
+			using (var db = new TestDataConnection())
+			{
+				db.SetCommand("DROP TABLE IF EXISTS `Animals`").Execute();
+				db.SetCommand("DROP TABLE IF EXISTS `Eyes`").Execute();
+				db.SetCommand("DROP TABLE IF EXISTS `Test`").Execute();
+				db.SetCommand("CREATE TABLE `Animals` ( `Id` INTEGER NOT NULL PRIMARY KEY, `AnimalType` TEXT, `AnimalType2` TEXT, `Name` TEXT, `Discriminator` TEXT, `EyeId` INTEGER, `First` TEXT, `Second` TEXT )").Execute();
+				db.SetCommand("CREATE TABLE `Eyes` ( `Id` INTEGER NOT NULL PRIMARY KEY, `Xy` TEXT )").Execute();
+				db.SetCommand("CREATE TABLE `Test` ( `Id` INTEGER NOT NULL PRIMARY KEY, `TestAnimalId` INTEGER NULL )").Execute();
+			}
+
+			using (var db = new TestDataConnection())
+			{
+				db.GetTable<Eye>().Delete();
+				db.GetTable<Animal>().Delete();
+
+				db.Insert(eye);
+				db.Insert(dog);
+				db.Insert(test);
+				db.Insert(test2);
+			}
+		}
+
+		private List<Animal> LoadTest()
+		{
+			using (var db = new TestDataConnection())
+			{
+				return db.GetTable<Animal>().ToList();
+			}
+		}
+
+		private List<Animal> LoadTest2()
+		{
+			using (var db = new TestDataConnection())
+			{
+				return db.GetTable<Animal>().LoadWith(x => ((Dog)x).Bla).ToList();
+			}
+		}
+
+		private List<Test> LoadTest3()
+		{
+			using (var db = new TestDataConnection())
+			{
+				return db.GetTable<Test>().LoadWith(x => ((Dog)x.TestAnimal).Bla).ToList();
+			}
+		}
+
+		private List<Dog> LoadTest4()
+		{
+			using (var db = new TestDataConnection())
+			{
+				return db.GetTable<Dog>().ToList();
+			}
+		}
+		private void LoadTest5()
+		{
+			using (var db = new TestDataConnection())
+			{
+				var d = new Dog() { AnimalType = AnimalType.Big, AnimalType2 = AnimalType2.Big };
+
+				var test1 = db.GetTable<Dog>().First(x => x.AnimalType == AnimalType.Big);
+				var test2 = db.GetTable<Dog>().First(x => x.AnimalType == d.AnimalType);
+
+				var test3 = db.GetTable<Dog>().First(x => x.AnimalType2 == AnimalType2.Big);
+				var test4 = db.GetTable<Dog>().First(x => x.AnimalType2 == d.AnimalType2);
+
+				var test6 = db.GetTable<Animal>().First(x => x is SuperWildAnimal);
+
+				var test7 = db.GetTable<Test>().First(x => x.TestAnimal is Dog && ((Dog)x.TestAnimal).EyeId == 1);
+				var sql = db.LastQuery;
+			}
+		}
+
+		private void Test6()
+		{
+			using (var db = new TestDataConnection())
+			{
+				var dog = db.GetTable<Dog>().First();
+				db.Update(dog);
+				db.Update((Animal)dog);
+
+				//var bdog = new SuperBadDog();
+				//db.Insert((Dog)bdog);   //this is not possible with my change -> ;-( should it be?
+			}
+		}
+
+		private void SetMappings()
+		{
+			MappingSchema.Default.SetConverter<AnimalType, string>((obj) =>
+			{
+				return obj.ToString();
+			});
+			MappingSchema.Default.SetConverter<AnimalType, DataParameter>((obj) =>
+			{
+				return new DataParameter { Value = obj.ToString() };
+			});
+			MappingSchema.Default.SetConverter<string, AnimalType>((txt) =>
+			{
+				return (AnimalType)Enum.Parse(typeof(AnimalType), txt, true);
+			});
+			MappingSchema.Default.SetDefaultFromEnumType(typeof(AnimalType2), typeof(string));
 
 
-		var mappingBuilder = MappingSchema.Default.GetFluentMappingBuilder();
-		mappingBuilder.Entity<Animal>()
-			.HasTableName("Animals")
-			.Inheritance(x => x.Discriminator, "Dog", typeof(Dog))
-			.Inheritance(x => x.Discriminator, "WildAnimal", typeof(WildAnimal))
-			.Inheritance(x => x.Discriminator, "SuperWildAnimal", typeof(SuperWildAnimal))
-			.Property(x => x.Name).IsColumn().IsNullable().HasColumnName("Name")
-			.Property(x => x.AnimalType).IsColumn().HasColumnName("AnimalType").HasDataType(DataType.NVarChar)
-			.Property(x => x.AnimalType2).IsColumn().HasColumnName("AnimalType2").HasDataType(DataType.NVarChar)
-			.Property(x => x.Discriminator).IsDiscriminator().IsColumn().IsNullable(false).HasColumnName("Discriminator")
-			.Property(x => x.Id).IsColumn().IsNullable(false).HasColumnName("Id").IsPrimaryKey();
+			var mappingBuilder = MappingSchema.Default.GetFluentMappingBuilder();
+			mappingBuilder.Entity<Animal>()
+				.HasTableName("Animals")
+				.Inheritance(x => x.Discriminator, "Dog", typeof(Dog))
+				.Inheritance(x => x.Discriminator, "WildAnimal", typeof(WildAnimal))
+				.Inheritance(x => x.Discriminator, "SuperWildAnimal", typeof(SuperWildAnimal))
+				.Property(x => x.Name).IsColumn().IsNullable().HasColumnName("Name")
+				.Property(x => x.AnimalType).IsColumn().HasColumnName("AnimalType").HasDataType(DataType.NVarChar)
+				.Property(x => x.AnimalType2).IsColumn().HasColumnName("AnimalType2").HasDataType(DataType.NVarChar)
+				.Property(x => x.Discriminator).IsDiscriminator().IsColumn().IsNullable(false).HasColumnName("Discriminator")
+				.Property(x => x.Id).IsColumn().IsNullable(false).HasColumnName("Id").IsPrimaryKey();
 
-		mappingBuilder.Entity<Dog>()
-			.HasTableName("Animals")
-			.Property(x => x.Bla).IsNotColumn()
-			.Property(x => x.EyeId).IsColumn().IsNullable().HasColumnName("EyeId")
-			.Property(x => x.DogName.Second).HasColumnName("Second")
-			.Property(x => x.DogName.First).HasColumnName("First")
-			.Association(x => x.Bla, x => x.EyeId, x => x.Id);
+			mappingBuilder.Entity<Dog>()
+				.HasTableName("Animals")
+				.Property(x => x.Bla).IsNotColumn()
+				.Property(x => x.EyeId).IsColumn().IsNullable().HasColumnName("EyeId")
+				.Property(x => x.DogName.Second).HasColumnName("Second")
+				.Property(x => x.DogName.First).HasColumnName("First")
+				.Association(x => x.Bla, x => x.EyeId, x => x.Id);
 
-		mappingBuilder.Entity<WildAnimal>()
-			.HasTableName("Animals");
+			mappingBuilder.Entity<WildAnimal>()
+				.HasTableName("Animals");
 
-		mappingBuilder.Entity<SuperWildAnimal>()
-			.HasTableName("Animals");
+			mappingBuilder.Entity<SuperWildAnimal>()
+				.HasTableName("Animals");
 
-		mappingBuilder.Entity<Eye>()
-			.HasTableName("Eyes")
-			.Property(x => x.Id).IsColumn().HasColumnName("Id")
-			.Property(x => x.Xy).IsColumn().IsNullable().HasColumnName("Xy");
+			mappingBuilder.Entity<Eye>()
+				.HasTableName("Eyes")
+				.Property(x => x.Id).IsColumn().HasColumnName("Id")
+				.Property(x => x.Xy).IsColumn().IsNullable().HasColumnName("Xy");
 
-		mappingBuilder.Entity<Test>()
-			.HasTableName("Test")
-			.Association(x => x.TestAnimal, x => x.TestAnimalId, x => x.Id)
-			.Property(x => x.TestAnimalId).IsColumn().IsNullable().HasColumnName("TestAnimalId")
-			.Property(x => x.TestAnimal).IsNotColumn();
+			mappingBuilder.Entity<Test>()
+				.HasTableName("Test")
+				.Association(x => x.TestAnimal, x => x.TestAnimalId, x => x.Id)
+				.Property(x => x.TestAnimalId).IsColumn().IsNullable().HasColumnName("TestAnimalId")
+				.Property(x => x.TestAnimal).IsNotColumn();
+		}
 	}
 }

--- a/Tests/Linq/UserTests/Issue994Tests.cs
+++ b/Tests/Linq/UserTests/Issue994Tests.cs
@@ -257,7 +257,8 @@ public class Issue994Tests : TestBase
 			.Inheritance(x => x.Discriminator, "WildAnimal", typeof(WildAnimal))
 			.Inheritance(x => x.Discriminator, "SuperWildAnimal", typeof(SuperWildAnimal))
 			.Property(x => x.Name).IsColumn().IsNullable().HasColumnName("Name")
-			.Property(x => x.AnimalType).IsColumn().HasColumnName("AnimalType")
+			.Property(x => x.AnimalType).IsColumn().HasColumnName("AnimalType").HasDataType(DataType.NVarChar)
+			.Property(x => x.AnimalType2).IsColumn().HasColumnName("AnimalType2").HasDataType(DataType.NVarChar)
 			.Property(x => x.Discriminator).IsDiscriminator().IsColumn().IsNullable(false).HasColumnName("Discriminator")
 			.Property(x => x.Id).IsColumn().IsNullable(false).HasColumnName("Id").IsPrimaryKey();
 

--- a/Tests/Linq/UserTests/Issue994Tests.cs
+++ b/Tests/Linq/UserTests/Issue994Tests.cs
@@ -21,6 +21,12 @@ public class Issue994Tests : TestBase
 		Big
 	}
 
+	public enum AnimalType2
+	{
+		Small,
+		Big
+	}
+
 	public class Eye
 	{
 		public int Id { get; set; }
@@ -36,6 +42,8 @@ public class Issue994Tests : TestBase
 	public class Animal
 	{
 		public AnimalType AnimalType { get; set; }
+
+		public AnimalType2 AnimalType2 { get; set; }
 
 		public int Id { get; set; }
 
@@ -107,7 +115,7 @@ public class Issue994Tests : TestBase
 		Assert.NotNull(listTest4[0].DogName.First);
 		Assert.NotNull(listTest4[0].DogName.Second);
 
-		var l5 = LoadTest5();
+		LoadTest5();
 	}
 
 	private void InsertData()
@@ -125,7 +133,8 @@ public class Issue994Tests : TestBase
 			EyeId = 1,
 			Name = "FirstDog",
 			DogName = new Name {First = "a", Second = "b"},
-			AnimalType = AnimalType.Big
+			AnimalType = AnimalType.Big,
+			AnimalType2 = AnimalType2.Big
 		};
 
 		var test = new Test
@@ -145,7 +154,7 @@ public class Issue994Tests : TestBase
 			db.SetCommand("DROP TABLE IF EXISTS `Animals`").Execute();
 			db.SetCommand("DROP TABLE IF EXISTS `Eyes`").Execute();
 			db.SetCommand("DROP TABLE IF EXISTS `Test`").Execute();
-			db.SetCommand("CREATE TABLE `Animals` ( `Id` INTEGER NOT NULL PRIMARY KEY, `AnimalType` TEXT, `Name` TEXT, `Discriminator` TEXT, `EyeId` INTEGER, `First` TEXT, `Second` TEXT )").Execute();
+			db.SetCommand("CREATE TABLE `Animals` ( `Id` INTEGER NOT NULL PRIMARY KEY, `AnimalType` TEXT, `AnimalType2` TEXT, `Name` TEXT, `Discriminator` TEXT, `EyeId` INTEGER, `First` TEXT, `Second` TEXT )").Execute();
 			db.SetCommand("CREATE TABLE `Eyes` ( `Id` INTEGER NOT NULL PRIMARY KEY, `Xy` TEXT )").Execute();
 			db.SetCommand("CREATE TABLE `Test` ( `Id` INTEGER NOT NULL PRIMARY KEY, `TestAnimalId` INTEGER NULL )").Execute();
 		}
@@ -193,14 +202,17 @@ public class Issue994Tests : TestBase
 			return db.GetTable<Dog>().ToList();
 		}
 	}
-	private Dog LoadTest5()
+	private void LoadTest5()
 	{
 		using (var db = new TestDataConnection())
 		{
+			var d = new Dog() { AnimalType = AnimalType.Big, AnimalType2 = AnimalType2.Big };
+
 			var test1 =  db.GetTable<Dog>().First(x => x.AnimalType == AnimalType.Big);
-			var d = new Dog() {AnimalType = AnimalType.Big};
 			var test2 = db.GetTable<Dog>().First(x => x.AnimalType == d.AnimalType);
-			return test1;
+
+			var test3 = db.GetTable<Dog>().First(x => x.AnimalType2 == AnimalType2.Big);
+			var test4 = db.GetTable<Dog>().First(x => x.AnimalType2 == d.AnimalType2);
 		}
 	}
 
@@ -218,6 +230,8 @@ public class Issue994Tests : TestBase
 		{
 			return (AnimalType)Enum.Parse(typeof(AnimalType), txt, true);
 		});
+		MappingSchema.Default.SetDefaultFromEnumType(typeof(AnimalType2), typeof(string));
+
 
 		var mappingBuilder = MappingSchema.Default.GetFluentMappingBuilder();
 		mappingBuilder.Entity<Animal>()

--- a/Tests/Linq/UserTests/Issue996Tests.cs
+++ b/Tests/Linq/UserTests/Issue996Tests.cs
@@ -53,7 +53,7 @@ public class Issue996Tests : TestBase
 	}
 
 	[Test]
-	public void LinqToDbIssue()
+	public void TestIssue()
 	{
 		SetMappings();
 
@@ -62,7 +62,7 @@ public class Issue996Tests : TestBase
 		// we can load all rows from A - everything is fine
 		var listA = LoadA();
 
-		// exception
+		// should not throw an exception
 		var listTest = LoadTest();
 	}
 

--- a/Tests/Linq/UserTests/Issue996Tests.cs
+++ b/Tests/Linq/UserTests/Issue996Tests.cs
@@ -1,163 +1,162 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-
-using LinqToDB;
+﻿using LinqToDB;
 using LinqToDB.Data;
 using LinqToDB.Mapping;
-
 using NUnit.Framework;
-
-using Tests;
+using System.Collections.Generic;
+using System.Linq;
 using Tests.Model;
 
-[TestFixture]
-public class Issue996Tests : TestBase
+namespace Tests.UserTests
 {
-	public class A
+	[TestFixture]
+	public class Issue996Tests : TestBase
 	{
-		public A()
+		public class A
 		{
-			Discriminator = "A";
+			public A()
+			{
+				Discriminator = "A";
+			}
+
+			public int Id { get; set; }
+			public string PropA { get; set; }
+			public string Discriminator { get; set; }
 		}
 
-		public int Id { get; set; }
-		public string PropA { get; set; }
-		public string Discriminator { get; set; }
-	}
-
-	public class B : A
-	{
-		public B()
+		public class B : A
 		{
-			Discriminator = "B";
+			public B()
+			{
+				Discriminator = "B";
+			}
+
+			public string PropB { get; set; }
 		}
 
-		public string PropB { get; set; }
-	}
-
-	public class C : B
-	{
-		public C()
+		public class C : B
 		{
-			Discriminator = "C";
+			public C()
+			{
+				Discriminator = "C";
+			}
+
+			public string PropC { get; set; }
 		}
 
-		public string PropC { get; set; }
-	}
-
-	public class Test
-	{
-		public int Id { get; set; }
-		public int? TestAId { get; set; }
-		public A TestA { get; set; }
-	}
-
-	[Test]
-	public void TestIssue()
-	{
-		SetMappings();
-
-		InsertData();
-
-		// we can load all rows from A - everything is fine
-		var listA = LoadA();
-
-		// should not throw an exception
-		var listTest = LoadTest();
-	}
-
-	private void InsertData()
-	{
-		var b = new B
+		public class Test
 		{
-			Id = 2,
-			PropA = "Test B",
-			PropB = "Test B",
-			Discriminator = "B"
-		};
-
-		var c = new C
-		{
-			Id = 3,
-			PropA = "Test C",
-			PropB = "Test C",
-			PropC = "Test C",
-			Discriminator = "C"
-		};
-
-		var test = new Test
-		{
-			Id = 1,
-			TestAId = null
-		};
-
-		var test2 = new Test
-		{
-			Id = 2,
-			TestAId = 2
-		};
-
-
-		using (var db = new TestDataConnection())
-		{
-			db.SetCommand("DROP TABLE IF EXISTS `A`").Execute();
-			db.SetCommand("DROP TABLE IF EXISTS `Test`").Execute();
-			db.SetCommand("CREATE TABLE `A` ( `Id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT UNIQUE, `PropA` TEXT, `PropB` TEXT, `PropC` TEXT,`Discriminator` TEXT )").Execute();
-			db.SetCommand("CREATE TABLE `Test` ( `Id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT UNIQUE, `TestAId` INTEGER )").Execute();
+			public int Id { get; set; }
+			public int? TestAId { get; set; }
+			public A TestA { get; set; }
 		}
 
-		using (var db = new TestDataConnection())
+		[Test]
+		public void TestIssue()
 		{
-			db.GetTable<A>().Delete();
-			db.GetTable<Test>().Delete();
+			SetMappings();
 
-			db.Insert(b);
-			db.Insert(c);
-			db.Insert(test);
-			db.Insert(test2);
+			InsertData();
+
+			// we can load all rows from A - everything is fine
+			var listA = LoadA();
+
+			// should not throw an exception
+			var listTest = LoadTest();
 		}
-	}
 
-	private List<A> LoadA()
-	{
-		using (var db = new TestDataConnection())
+		private void InsertData()
 		{
-			return db.GetTable<A>().ToList();
-		}
-	}
+			var b = new B
+			{
+				Id = 2,
+				PropA = "Test B",
+				PropB = "Test B",
+				Discriminator = "B"
+			};
 
-	private List<Test> LoadTest()
-	{
-		using (var db = new TestDataConnection())
+			var c = new C
+			{
+				Id = 3,
+				PropA = "Test C",
+				PropB = "Test C",
+				PropC = "Test C",
+				Discriminator = "C"
+			};
+
+			var test = new Test
+			{
+				Id = 1,
+				TestAId = null
+			};
+
+			var test2 = new Test
+			{
+				Id = 2,
+				TestAId = 2
+			};
+
+
+			using (var db = new TestDataConnection())
+			{
+				db.SetCommand("DROP TABLE IF EXISTS `A`").Execute();
+				db.SetCommand("DROP TABLE IF EXISTS `Test`").Execute();
+				db.SetCommand("CREATE TABLE `A` ( `Id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT UNIQUE, `PropA` TEXT, `PropB` TEXT, `PropC` TEXT,`Discriminator` TEXT )").Execute();
+				db.SetCommand("CREATE TABLE `Test` ( `Id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT UNIQUE, `TestAId` INTEGER )").Execute();
+			}
+
+			using (var db = new TestDataConnection())
+			{
+				db.GetTable<A>().Delete();
+				db.GetTable<Test>().Delete();
+
+				db.Insert(b);
+				db.Insert(c);
+				db.Insert(test);
+				db.Insert(test2);
+			}
+		}
+
+		private List<A> LoadA()
 		{
-			return db.GetTable<Test>().LoadWith(x => x.TestA).ToList();
+			using (var db = new TestDataConnection())
+			{
+				return db.GetTable<A>().ToList();
+			}
 		}
-	}
 
-	private void SetMappings()
-	{
-		var mappingBuilder = MappingSchema.Default.GetFluentMappingBuilder();
-		mappingBuilder.Entity<A>()
-			.HasTableName("A")
-			.Inheritance(x => x.Discriminator, "A", typeof(A))
-			.Inheritance(x => x.Discriminator, "B", typeof(B))
-			.Inheritance(x => x.Discriminator, "C", typeof(C))
-			.Property(x => x.PropA).IsColumn().IsNullable().HasColumnName("PropA")
-			.Property(x => x.Discriminator).IsDiscriminator().IsColumn().IsNullable(false).HasColumnName("Discriminator")
-			.Property(x => x.Id).IsColumn().IsNullable(false).HasColumnName("Id");
+		private List<Test> LoadTest()
+		{
+			using (var db = new TestDataConnection())
+			{
+				return db.GetTable<Test>().LoadWith(x => x.TestA).ToList();
+			}
+		}
 
-		mappingBuilder.Entity<B>()
-			.HasTableName("A")
-			.Property(x => x.PropB).IsColumn().IsNullable().HasColumnName("PropB");
+		private void SetMappings()
+		{
+			var mappingBuilder = MappingSchema.Default.GetFluentMappingBuilder();
+			mappingBuilder.Entity<A>()
+				.HasTableName("A")
+				.Inheritance(x => x.Discriminator, "A", typeof(A))
+				.Inheritance(x => x.Discriminator, "B", typeof(B))
+				.Inheritance(x => x.Discriminator, "C", typeof(C))
+				.Property(x => x.PropA).IsColumn().IsNullable().HasColumnName("PropA")
+				.Property(x => x.Discriminator).IsDiscriminator().IsColumn().IsNullable(false).HasColumnName("Discriminator")
+				.Property(x => x.Id).IsColumn().IsNullable(false).HasColumnName("Id");
 
-		mappingBuilder.Entity<C>()
-			.HasTableName("A")
-			.Property(x => x.PropC).IsColumn().IsNullable().HasColumnName("PropC");
+			mappingBuilder.Entity<B>()
+				.HasTableName("A")
+				.Property(x => x.PropB).IsColumn().IsNullable().HasColumnName("PropB");
 
-		mappingBuilder.Entity<Test>()
-			.HasTableName("Test")
-			.Association(x => x.TestA, x => x.TestAId, x => x.Id)
-			.Property(x => x.TestAId).IsColumn().IsNullable().HasColumnName("TestAId")
-			.Property(x => x.TestA).IsNotColumn();
+			mappingBuilder.Entity<C>()
+				.HasTableName("A")
+				.Property(x => x.PropC).IsColumn().IsNullable().HasColumnName("PropC");
+
+			mappingBuilder.Entity<Test>()
+				.HasTableName("Test")
+				.Association(x => x.TestA, x => x.TestAId, x => x.Id)
+				.Property(x => x.TestAId).IsColumn().IsNullable().HasColumnName("TestAId")
+				.Property(x => x.TestA).IsNotColumn();
+		}
 	}
 }

--- a/Tests/Linq/UserTests/Issue996Tests.cs
+++ b/Tests/Linq/UserTests/Issue996Tests.cs
@@ -1,0 +1,163 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+using LinqToDB;
+using LinqToDB.Data;
+using LinqToDB.Mapping;
+
+using NUnit.Framework;
+
+using Tests;
+using Tests.Model;
+
+[TestFixture]
+public class Issue996Tests : TestBase
+{
+	public class A
+	{
+		public A()
+		{
+			Discriminator = "A";
+		}
+
+		public int Id { get; set; }
+		public string PropA { get; set; }
+		public string Discriminator { get; set; }
+	}
+
+	public class B : A
+	{
+		public B()
+		{
+			Discriminator = "B";
+		}
+
+		public string PropB { get; set; }
+	}
+
+	public class C : B
+	{
+		public C()
+		{
+			Discriminator = "C";
+		}
+
+		public string PropC { get; set; }
+	}
+
+	public class Test
+	{
+		public int Id { get; set; }
+		public int? TestAId { get; set; }
+		public A TestA { get; set; }
+	}
+
+	[Test]
+	public void LinqToDbIssue()
+	{
+		SetMappings();
+
+		InsertData();
+
+		// we can load all rows from A - everything is fine
+		var listA = LoadA();
+
+		// exception
+		var listTest = LoadTest();
+	}
+
+	private void InsertData()
+	{
+		var b = new B
+		{
+			Id = 2,
+			PropA = "Test B",
+			PropB = "Test B",
+			Discriminator = "B"
+		};
+
+		var c = new C
+		{
+			Id = 3,
+			PropA = "Test C",
+			PropB = "Test C",
+			PropC = "Test C",
+			Discriminator = "C"
+		};
+
+		var test = new Test
+		{
+			Id = 1,
+			TestAId = null
+		};
+
+		var test2 = new Test
+		{
+			Id = 2,
+			TestAId = 2
+		};
+
+
+		using (var db = new TestDataConnection())
+		{
+			db.SetCommand("DROP TABLE IF EXISTS `A`").Execute();
+			db.SetCommand("DROP TABLE IF EXISTS `Test`").Execute();
+			db.SetCommand("CREATE TABLE `A` ( `Id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT UNIQUE, `PropA` TEXT, `PropB` TEXT, `PropC` TEXT,`Discriminator` TEXT )").Execute();
+			db.SetCommand("CREATE TABLE `Test` ( `Id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT UNIQUE, `TestAId` INTEGER )").Execute();
+		}
+
+		using (var db = new TestDataConnection())
+		{
+			db.GetTable<A>().Delete();
+			db.GetTable<Test>().Delete();
+
+			db.Insert(b);
+			db.Insert(c);
+			db.Insert(test);
+			db.Insert(test2);
+		}
+	}
+
+	private List<A> LoadA()
+	{
+		using (var db = new TestDataConnection())
+		{
+			return db.GetTable<A>().ToList();
+		}
+	}
+
+	private List<Test> LoadTest()
+	{
+		using (var db = new TestDataConnection())
+		{
+			return db.GetTable<Test>().LoadWith(x => x.TestA).ToList();
+		}
+	}
+
+	private void SetMappings()
+	{
+		var mappingBuilder = MappingSchema.Default.GetFluentMappingBuilder();
+		mappingBuilder.Entity<A>()
+			.HasTableName("A")
+			.Inheritance(x => x.Discriminator, "A", typeof(A))
+			.Inheritance(x => x.Discriminator, "B", typeof(B))
+			.Inheritance(x => x.Discriminator, "C", typeof(C))
+			.Property(x => x.PropA).IsColumn().IsNullable().HasColumnName("PropA")
+			.Property(x => x.Discriminator).IsDiscriminator().IsColumn().IsNullable(false).HasColumnName("Discriminator")
+			.Property(x => x.Id).IsColumn().IsNullable(false).HasColumnName("Id");
+
+		mappingBuilder.Entity<B>()
+			.HasTableName("A")
+			.Property(x => x.PropB).IsColumn().IsNullable().HasColumnName("PropB");
+
+		mappingBuilder.Entity<C>()
+			.HasTableName("A")
+			.Property(x => x.PropC).IsColumn().IsNullable().HasColumnName("PropC");
+
+		mappingBuilder.Entity<Test>()
+			.HasTableName("Test")
+			.Association(x => x.TestA, x => x.TestAId, x => x.Id)
+			.Property(x => x.TestAId).IsColumn().IsNullable().HasColumnName("TestAId")
+			.Property(x => x.TestA).IsNotColumn();
+	}
+}

--- a/Tests/Model/ParentChild.cs
+++ b/Tests/Model/ParentChild.cs
@@ -507,7 +507,7 @@ namespace Tests.Model
 	#region Inheritance3
 
 	[Table(Name="Parent")]
-	[InheritanceMapping(Code = null, Type = typeof(ParentInheritanceBase3))]
+	//[InheritanceMapping(Code = null, Type = typeof(ParentInheritanceBase3))]
 	[InheritanceMapping(Code = 1,    Type = typeof(ParentInheritance13))]
 	[InheritanceMapping(Code = 2,    Type = typeof(ParentInheritance13))]
 	public abstract class ParentInheritanceBase3


### PR DESCRIPTION
This adds Tests for #994 and #996 and a fix for #994 
#996 still needs to be fixed correctly

--
edited by @MaceWindu

List of remaining tasks
- [x] create isolated test for incorrect table name generated when #994 and #996 tests run in parallel and fix it
- [ ] extract #924 changes to separate PR
- [ ] extract #994 changes to separate PR
- [ ] extract #996 changes to separate PR
- [ ] extract #1006 changes to separate PR
- [ ] test for flag enums

List of remaining questions
- [ ] if we map an enum to a string column, should we use ToString() as default? If not it should be configurable or the GetDefaultMappingFromEnumType is nearly useless
- [ ] how should we get the converter in ExpressionBuilder.SqlBuilder, and should we cache the expression?
- [ ] to fix #966 I'll check in TableBuilder.TableContext.cs if tableContext is AssociatedTableContext and then i remove the exception throwing, is this enough? wrong values in the column then also throw no exception