### PR TITLE
fix execute cmd outside of script folder

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -1,3 +1,4 @@
-"%ProgramFiles(x86)%\\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe" linq2db.sln /p:Configuration=Release  /t:Restore;Rebuild /v:m
-"%ProgramFiles(x86)%\\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe" linq2db.sln /p:Configuration=Debug    /t:Restore;Rebuild /v:m
-"%ProgramFiles(x86)%\\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe" linq2db.sln /p:Configuration=AppVeyor /t:Restore;Rebuild /v:m
+SET scriptpath=%~dp0
+"%ProgramFiles(x86)%\\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe" %scriptpath%linq2db.sln /p:Configuration=Release  /t:Restore;Rebuild /v:m
+"%ProgramFiles(x86)%\\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe" %scriptpath%linq2db.sln /p:Configuration=Debug    /t:Restore;Rebuild /v:m
+"%ProgramFiles(x86)%\\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe" %scriptpath%linq2db.sln /p:Configuration=AppVeyor /t:Restore;Rebuild /v:m

--- a/Source/LinqToDB/Compile.cmd
+++ b/Source/LinqToDB/Compile.cmd
@@ -1,4 +1,6 @@
-"%ProgramFiles(x86)%\\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe" /v:m /target:Clean LinqToDB.csproj /property:Configuration=Debug
-"%ProgramFiles(x86)%\\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe" /v:m /target:Clean LinqToDB.csproj /property:Configuration=Release
-"%ProgramFiles(x86)%\\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe" /v:m LinqToDB.csproj /property:Configuration=Debug   
-"%ProgramFiles(x86)%\\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe" /v:m LinqToDB.csproj /property:Configuration=Release 
+SET scriptpath=%~dp0
+::echo %scriptpath%
+"%ProgramFiles(x86)%\\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe" /v:m /target:Clean %scriptpath%LinqToDB.csproj /property:Configuration=Debug
+"%ProgramFiles(x86)%\\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe" /v:m /target:Clean %scriptpath%LinqToDB.csproj /property:Configuration=Release
+"%ProgramFiles(x86)%\\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe" /v:m %scriptpath%LinqToDB.csproj /property:Configuration=Debug   
+"%ProgramFiles(x86)%\\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe" /v:m %scriptpath%LinqToDB.csproj /property:Configuration=Release 

--- a/Source/LinqToDB/Compile.cmd
+++ b/Source/LinqToDB/Compile.cmd
@@ -1,5 +1,4 @@
 SET scriptpath=%~dp0
-::echo %scriptpath%
 "%ProgramFiles(x86)%\\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe" /v:m /target:Clean %scriptpath%LinqToDB.csproj /property:Configuration=Debug
 "%ProgramFiles(x86)%\\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe" /v:m /target:Clean %scriptpath%LinqToDB.csproj /property:Configuration=Release
 "%ProgramFiles(x86)%\\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe" /v:m %scriptpath%LinqToDB.csproj /property:Configuration=Debug   

--- a/Source/LinqToDB/Compile.cmd
+++ b/Source/LinqToDB/Compile.cmd
@@ -1,4 +1,3 @@
-SET scriptpath=%~dp0
 "%ProgramFiles(x86)%\\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe" /v:m /target:Clean %scriptpath%LinqToDB.csproj /property:Configuration=Debug
 "%ProgramFiles(x86)%\\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe" /v:m /target:Clean %scriptpath%LinqToDB.csproj /property:Configuration=Release
 "%ProgramFiles(x86)%\\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe" /v:m %scriptpath%LinqToDB.csproj /property:Configuration=Debug   

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -289,7 +289,8 @@ namespace LinqToDB.SqlProvider
 				AppendIndent();
 				StringBuilder
 					.Append(cte.Name)
-					.Append(" (");
+					.Append(" ");
+					//.Append(" (");
 
 				var firstField = true;
 				foreach (var field in cte.Fields.Values)
@@ -300,7 +301,7 @@ namespace LinqToDB.SqlProvider
 					StringBuilder.Append(Convert(field.PhysicalName, ConvertType.NameToQueryField));
 				}
 
-				StringBuilder.AppendLine(")");
+				//StringBuilder.AppendLine(")");
 				Indent--;
 				AppendIndent();
 				StringBuilder.AppendLine("AS");

--- a/Source/LinqToDB/SqlQuery/SqlCteTable.cs
+++ b/Source/LinqToDB/SqlQuery/SqlCteTable.cs
@@ -8,7 +8,7 @@ namespace LinqToDB.SqlQuery
 	public class SqlCteTable : SqlTable
 	{
 		[JetBrains.Annotations.NotNull]
-		public          CteClause Cte  { get; }
+		public          CteClause Cte  { get; protected set; }
 
 		public override string    Name
 		{
@@ -18,9 +18,9 @@ namespace LinqToDB.SqlQuery
 
 		public SqlCteTable(
 			[JetBrains.Annotations.NotNull] MappingSchema mappingSchema,
-			[JetBrains.Annotations.NotNull] CteClause cte) : base(mappingSchema, cte.ObjectType)
+			[JetBrains.Annotations.NotNull] CteClause cte) : base(mappingSchema, cte.ObjectType, cte.Name)
 		{
-			Cte = cte ?? throw new ArgumentNullException(nameof(cte));
+			
 		}
 
 		internal SqlCteTable(int id, string alias, SqlField[] fields, [JetBrains.Annotations.NotNull] CteClause cte)
@@ -31,15 +31,15 @@ namespace LinqToDB.SqlQuery
 
 		public SqlCteTable(SqlCteTable table, IEnumerable<SqlField> fields, CteClause cte)
 		{
-			Alias              = table.Alias;
-			Database           = table.Database;
-			Schema             = table.Schema;
+			Alias = table.Alias;
+			Database = table.Database;
+			Schema = table.Schema;
 
-			PhysicalName       = table.PhysicalName;
-			ObjectType         = table.ObjectType;
+			PhysicalName = table.PhysicalName;
+			ObjectType = table.ObjectType;
 			SequenceAttributes = table.SequenceAttributes;
 
-			Cte                = cte;
+			Cte = cte;
 
 			AddRange(fields);
 		}

--- a/Source/LinqToDB/SqlQuery/SqlTable.cs
+++ b/Source/LinqToDB/SqlQuery/SqlTable.cs
@@ -58,7 +58,7 @@ namespace LinqToDB.SqlQuery
 
 		#region Init from type
 
-		public SqlTable([JetBrains.Annotations.NotNull] MappingSchema mappingSchema, Type objectType) : this()
+		public SqlTable([JetBrains.Annotations.NotNull] MappingSchema mappingSchema, Type objectType, string physicalName=null) : this()
 		{
 			if (mappingSchema == null) throw new ArgumentNullException(nameof(mappingSchema));
 
@@ -68,7 +68,7 @@ namespace LinqToDB.SqlQuery
 			Schema       = ed.SchemaName;
 			Name         = ed.TableName;
 			ObjectType   = objectType;
-			PhysicalName = Name;
+			PhysicalName = physicalName??Name;
 
 			foreach (var column in ed.Columns)
 			{


### PR DESCRIPTION
According to documentation:
[https://github.com/linq2db/linq2db/blob/538a1f2a2c632f3a56206559d1f5dad5a189c284/CONTRIBUTING.md#building](url)
Two batch files can be run to build the project but if Build.cmd or Compiled.cmd are executed not from within script folder, there is error
```
C:\Git\linq2db>.\Source\LinqToDB\Compile.cmd
MSBUILD : error MSB1009: Project file does not exist.
Switch: linq2db.sln
```

