### PR TITLE
Proposal for Fix GetCteTable

### DIFF
--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -289,7 +289,8 @@ namespace LinqToDB.SqlProvider
 				AppendIndent();
 				StringBuilder
 					.Append(cte.Name)
-					.Append(" (");
+					.Append(" ");
+					//.Append(" (");
 
 				var firstField = true;
 				foreach (var field in cte.Fields.Values)
@@ -300,7 +301,7 @@ namespace LinqToDB.SqlProvider
 					StringBuilder.Append(Convert(field.PhysicalName, ConvertType.NameToQueryField));
 				}
 
-				StringBuilder.AppendLine(")");
+				//StringBuilder.AppendLine(")");
 				Indent--;
 				AppendIndent();
 				StringBuilder.AppendLine("AS");

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -287,10 +287,9 @@ namespace LinqToDB.SqlProvider
 				first = false;
 
 				AppendIndent();
-				StringBuilder
-					.Append(cte.Name)
-					.Append(" ");
-					//.Append(" (");
+				StringBuilder.Append(cte.Name);
+				if (cte.Fields.Count > 0) 
+					StringBuilder.Append(" (");
 
 				var firstField = true;
 				foreach (var field in cte.Fields.Values)
@@ -300,11 +299,13 @@ namespace LinqToDB.SqlProvider
 					firstField = false;
 					StringBuilder.Append(Convert(field.PhysicalName, ConvertType.NameToQueryField));
 				}
+				
+				if (cte.Fields.Count > 0) 
+					StringBuilder.AppendLine(")");
 
-				//StringBuilder.AppendLine(")");
 				Indent--;
 				AppendIndent();
-				StringBuilder.AppendLine("AS");
+				StringBuilder.AppendLine(" AS");
 				AppendIndent();
 				StringBuilder.AppendLine("(");
 

--- a/Source/LinqToDB/SqlQuery/SqlCteTable.cs
+++ b/Source/LinqToDB/SqlQuery/SqlCteTable.cs
@@ -18,7 +18,7 @@ namespace LinqToDB.SqlQuery
 
 		public SqlCteTable(
 			[JetBrains.Annotations.NotNull] MappingSchema mappingSchema,
-			[JetBrains.Annotations.NotNull] CteClause cte) : base(mappingSchema, cte.ObjectType)
+			[JetBrains.Annotations.NotNull] CteClause cte) : base(mappingSchema, cte.ObjectType, cte.Name)
 		{
 			Cte = cte ?? throw new ArgumentNullException(nameof(cte));
 		}

--- a/Source/LinqToDB/SqlQuery/SqlTable.cs
+++ b/Source/LinqToDB/SqlQuery/SqlTable.cs
@@ -58,7 +58,7 @@ namespace LinqToDB.SqlQuery
 
 		#region Init from type
 
-		public SqlTable([JetBrains.Annotations.NotNull] MappingSchema mappingSchema, Type objectType) : this()
+		public SqlTable([JetBrains.Annotations.NotNull] MappingSchema mappingSchema, Type objectType, string physicalName=null) : this()
 		{
 			if (mappingSchema == null) throw new ArgumentNullException(nameof(mappingSchema));
 
@@ -68,7 +68,7 @@ namespace LinqToDB.SqlQuery
 			Schema       = ed.SchemaName;
 			Name         = ed.TableName;
 			ObjectType   = objectType;
-			PhysicalName = Name;
+			PhysicalName = physicalName??Name;
 
 			foreach (var column in ed.Columns)
 			{

--- a/Source/LinqToDB/SqlQuery/SqlTable.cs
+++ b/Source/LinqToDB/SqlQuery/SqlTable.cs
@@ -58,7 +58,7 @@ namespace LinqToDB.SqlQuery
 
 		#region Init from type
 
-		public SqlTable([JetBrains.Annotations.NotNull] MappingSchema mappingSchema, Type objectType, string physicalName=null) : this()
+		public SqlTable([JetBrains.Annotations.NotNull] MappingSchema mappingSchema, Type objectType, string physicalName = null) : this()
 		{
 			if (mappingSchema == null) throw new ArgumentNullException(nameof(mappingSchema));
 
@@ -68,7 +68,7 @@ namespace LinqToDB.SqlQuery
 			Schema       = ed.SchemaName;
 			Name         = ed.TableName;
 			ObjectType   = objectType;
-			PhysicalName = physicalName??Name;
+			PhysicalName = physicalName ?? Name;
 
 			foreach (var column in ed.Columns)
 			{


### PR DESCRIPTION
If following method is called:
```
return this.GetCte<CmsDictionary>(employeeHierarchy =>
			{
				return
				(
					from f in query
					select f
				).Concat( 
					from f in query
					join x in employeeHierarchy on f.Id equals x.Id
					select f
				);
			});
```

there is exception because 
SqlCteTable(mapping, Cte) calls base constructor of SqlTable, inside of base constructor body is referenced property "Name" which is overriden inside upper class (SqlCteTable)
Name property returns Name of CTE which is initializes after base init is finished.