### PR TITLE
Add new options in T4 templates.

### DIFF
--- a/Source/LinqToDB.Templates/DataModel.ttinclude
+++ b/Source/LinqToDB.Templates/DataModel.ttinclude
@@ -35,6 +35,8 @@ bool     GenerateAssociationExtensions = false;
 bool     ReplaceSimilarTables          = true;
 bool     IncludeDefaultSchema          = true;
 
+bool     ParameterlessConstructor     = true;
+
 Class    DataContextObject;
 
 bool PluralizeClassNames                 = false;

--- a/Source/LinqToDB.Templates/LinqToDB.SqlServer.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.SqlServer.ttinclude
@@ -16,8 +16,9 @@ void DoGenerateSqlServerFreeText()
 {
 	if (!GenerateSqlServerFreeText)
 		return;
-
+	
 	Model.Usings.Add("System.Collections.Generic");
+	Model.Usings.Add("System.Linq");
 	Model.Usings.Add("System.Linq.Expressions");
 	Model.Usings.Add("System.Reflection");
 	Model.Usings.Add("LinqToDB");

--- a/Source/LinqToDB.Templates/LinqToDB.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.ttinclude
@@ -1,8 +1,9 @@
-<#@ assembly name="System.Data"        #>
-<#@ import namespace="System.Data"     #>
-<#@ import namespace="LinqToDB.Data"   #>
-<#@ import namespace="System.Text" #>
-<#@ include file="DataModel.ttinclude" #>
+<#@ assembly name="System.Data"                       #>
+<#@ import namespace="System.Data"                    #>
+<#@ import namespace="LinqToDB.Data"                  #>
+<#@ import namespace="System.Text"                    #>
+<#@ import namespace="System.Text.RegularExpressions" #>
+<#@ include file="DataModel.ttinclude"                #>
 <#
 	if (BaseDataContextClass == null)
 		BaseDataContextClass = "LinqToDB.Data.DataConnection";
@@ -24,19 +25,25 @@ bool?  GenerateScaleProperty     = null;
 bool   GenerateDbTypes           = false;
 bool   GenerateSchemaAsType      = false;
 bool   GenerateViews             = true;
+string ReferenceMainPattern		 = null;
+string ReferenceManyPattern		 = null;
 string SchemaNameSuffix          = "Schema";
 string SchemaDataContextTypeName = "DataContext";
 
 Dictionary<string,string> SchemaNameMapping = new Dictionary<string,string>();
 
-Func<string,string,IEnumerable<Method>> GetConstructors =  (conf, name) => GetConstructorsImpl(conf, name);
+Func<bool,string,string,IEnumerable<Method>> GetConstructors =  (parameterless, conf, name) => GetConstructorsImpl(parameterless, conf, name);
 
-static IEnumerable<Method> GetConstructorsImpl(string defaultConfiguration, string name)
+static IEnumerable<Method> GetConstructorsImpl(bool parameterlessConstructor, string defaultConfiguration, string name)
 {
-	if (defaultConfiguration == null)
-		yield return new Method(null, name);
-	else
-		yield return new Method(null, name) { AfterSignature = { ": base(\"" + defaultConfiguration + "\")" } };
+	if (parameterlessConstructor == true)
+    {
+		if (defaultConfiguration == null)
+			yield return new Method(null, name);
+		else
+			yield return new Method(null, name) { AfterSignature = { ": base(\"" + defaultConfiguration + "\")" } };
+    }
+
 	yield return new Method(null, name, new[] { "string configuration" }) { AfterSignature = { ": base(configuration)" } };
 }
 
@@ -107,7 +114,7 @@ void GenerateTypesFromMetadata()
 
 	if (GenerateConstructors)
 	{
-		foreach (var c in GetConstructors(DefaultConfiguration, DataContextObject.Name))
+		foreach (var c in GetConstructors(ParameterlessConstructor, DefaultConfiguration, DataContextObject.Name))
 		{
 			if (c.Body.Count > 0)
 				c.Body.Add("");
@@ -424,7 +431,16 @@ void GenerateTypesFromMetadata()
 						key.Type = string.Format(OneToManyAssociationType, key.OtherTable.TypePrefix + key.OtherTable.TypeName);
 					else
 						key.Type = key.OtherTable.TypePrefix + key.OtherTable.TypeName;
+                }
 
+				var duplicates = keys.GroupBy(item => item.Type)
+								     .Select(item => new { Type = item.Key, Count = item.Count() })
+								     .Where(item => item.Count >= 2)
+								     .Select(item => item.Type)
+								     .ToList();
+
+				foreach (var key in keys.OrderBy(k => k.MemberName))
+                {
 					var aa = new Attribute("Association");
 
 					aa.Parameters.Add("ThisKey=\""   + string.Join(", ", (from c in key.ThisColumns  select c.MemberName).ToArray()) + "\"");
@@ -454,6 +470,35 @@ void GenerateTypesFromMetadata()
 
 					SetPropertyValue(key, "IsNotifying", true);
 					SetPropertyValue(key, "IsEditable",  true);
+
+					if (key.AssociationType == AssociationType.ManyToOne || key.AssociationType == AssociationType.OneToOne)
+					{
+						if (ReferenceMainPattern != null)
+						{
+							Regex pattern = new Regex(ReferenceMainPattern);
+							Match match = pattern.Match(key.KeyName);
+
+							string target = match.Groups["target"].Value;
+					
+							if (match.Success == true)
+								key.MemberName = target;
+						}
+					}
+
+					if (key.AssociationType == AssociationType.OneToMany)
+					{
+						if (ReferenceManyPattern != null)
+						{
+							Regex pattern = new Regex(ReferenceManyPattern);
+							Match match = pattern.Match(key.KeyName);
+
+							string target = match.Groups["target"].Value;
+							string column = match.Groups["column"].Value;
+					
+							if (match.Success == true)
+								key.MemberName = duplicates.Contains(key.Type) ? column + ToPlural(target) : ToPlural(target);
+						}
+					}
 
 					associations.Members.Add(key);
 

--- a/Source/LinqToDB.Templates/T4Model.ttinclude
+++ b/Source/LinqToDB.Templates/T4Model.ttinclude
@@ -1,4 +1,5 @@
 <#@ assembly name="System.Core"                   #>
+<#@ assembly name="System.Core"                   #>
 <#@ import namespace="System"                     #>
 <#@ import namespace="System.Collections.Generic" #>
 <#@ import namespace="System.Linq"                #>
@@ -7,7 +8,9 @@ static Action<GeneratedTextTransformation,string> WriteComment    = (tt,s) => tt
 
 Action BeforeGenerateModel = () => {};
 
+int  UsingsBlankLines = 1;
 bool GenerateProcedureErrors = true;
+AccessModifier DefaultAccessModifier = AccessModifier.Public;
 
 void GenerateModel()
 {
@@ -84,7 +87,11 @@ public partial class ModelSource : ITree
 	public virtual void Render(GeneratedTextTransformation tt)
 	{
 		tt.RenderUsings(Usings);
-		tt.WriteLine("");
+		
+        for (int line = 0; line < tt.UsingsBlankLines; line++)
+        {
+			 tt.WriteLine("");
+        }
 
 		foreach (var nm in Namespaces)
 		{
@@ -161,6 +168,7 @@ public interface IClassMember : ITree
 
 public enum AccessModifier
 {
+	None = 0,
 	Public,
 	Protected,
 	Internal,
@@ -170,17 +178,26 @@ public enum AccessModifier
 
 public abstract partial class TypeBase : IClassMember
 {
-	public AccessModifier  AccessModifier = AccessModifier.Public;
+	private AccessModifier accessModifier = AccessModifier.None;
+
 	public string          Name;
 	public bool            IsPartial  = true;
 	public List<string>    Comment    = new List<string>();
 	public List<Attribute> Attributes = new List<Attribute>();
 	public string          Conditional;
 
+	public AccessModifier  AccessModifier {
+		get { return accessModifier != AccessModifier.None ? accessModifier : AccessModifier.Public; }
+		set { accessModifier = value; }
+	} 
+
 	public abstract void Render(GeneratedTextTransformation tt);
 
 	protected virtual void BeginConditional(GeneratedTextTransformation tt)
 	{
+		if (accessModifier == AccessModifier.None)
+			accessModifier = tt.DefaultAccessModifier;
+
 		if (Conditional != null)
 		{
 			tt.RemoveSpace();


### PR DESCRIPTION
Update the following templates:

**T4Model.ttinclude**
```C#  
  UsingsBlankLines = 1; // Count of blank lines after "usings" block.
  DefaultAccessModifier = AccessModifier.Public; // Desired access modifier for each class.
```

**DataModel.ttinclude**
```C#
  ParameterlessConstructor = true; // Generate or not parameterless constructor of database context class.
```
**LinqToDB.ttinclude**

Regex to extract `<table>` and `<target>` to use in column name
Example: `@"FK_(?<table>.+)_(?<target>.+)Id";`
```C#
string ReferenceMainPattern = null; // Default
```
Regex to extract <target> and <column> to use in column name
Example: `@"FK_(?<target>.+)_(?<column>.+)Id_BackReference";`
Instead of `IEnumerable<Comment> FKCommentAuthorIds` it will generate `IEnumerable<Comment> AuthorComments`
```C#
string ReferenceManyPattern = null; // Default
```
**LinqToDB.SqlServer.ttinclude**

Add System.Linq namespace to SqlServer script because it is required by FreeText generated code.
