### PR TITLE
Fix incorrect processing order in query visitor

### DIFF
--- a/NuGet/Readme.txt
+++ b/NuGet/Readme.txt
@@ -55,6 +55,7 @@ LINQ to DB 2.0.0  Release Notes
 - fix: LoadWith do not support type casts in load expression (#1069)
 - fix: [Inheritance mapping] Support for loading of derived entities in LoadWith (#994)
 - fix: [Inheritance mapping] Fixed support for `is` operator in filters (#1065)
+- fix: Fix issue when insert query from subquery data source with nullable parameter called first with null value fails for subsequential calls with non-null parameters
 
 - other changes: t4models repository moved to main repository
 - other changes: [Firebird] Made changes to Firebird provider/sql optimizer to allow subclassing (#1000)

--- a/Source/LinqToDB/SqlQuery/QueryVisitor.cs
+++ b/Source/LinqToDB/SqlQuery/QueryVisitor.cs
@@ -1471,8 +1471,8 @@ namespace LinqToDB.SqlQuery
 				case QueryElementType.InsertStatement:
 					{
 						var s = (SqlInsertStatement)element;
-						var insert      = s.Insert      != null ? (SqlInsertClause)ConvertInternal(s.Insert,      action) : null;
 						var selectQuery = s.SelectQuery != null ? (SelectQuery)    ConvertInternal(s.SelectQuery, action) : null;
+						var insert      = s.Insert      != null ? (SqlInsertClause)ConvertInternal(s.Insert,      action) : null;
 						var ps          = ConvertSafe(s.Parameters, action);
 
 						if (insert      != null && !ReferenceEquals(s.Insert,      insert)       ||
@@ -1492,8 +1492,8 @@ namespace LinqToDB.SqlQuery
 				case QueryElementType.UpdateStatement:
 					{
 						var s = (SqlUpdateStatement)element;
-						var update      = s.Update      != null ? (SqlUpdateClause) ConvertInternal(s.Update, action) : null;
-						var selectQuery = s.SelectQuery != null ? (SelectQuery)     ConvertInternal(s.SelectQuery, action) : null;
+						var update      = s.Update      != null ? (SqlUpdateClause)ConvertInternal(s.Update, action) : null;
+						var selectQuery = s.SelectQuery != null ? (SelectQuery)    ConvertInternal(s.SelectQuery, action) : null;
 						var ps          = ConvertSafe(s.Parameters, action);
 
 						if (update      != null && !ReferenceEquals(s.Update,      update)       ||
@@ -1513,9 +1513,11 @@ namespace LinqToDB.SqlQuery
 				case QueryElementType.InsertOrUpdateStatement:
 					{
 						var s = (SqlInsertOrUpdateStatement)element;
-						var insert      = s.Insert      != null ? (SqlInsertClause) ConvertInternal(s.Insert, action) : null;
-						var update      = s.Update      != null ? (SqlUpdateClause) ConvertInternal(s.Update, action) : null;
-						var selectQuery = s.SelectQuery != null ? (SelectQuery)     ConvertInternal(s.SelectQuery, action) : null;
+
+						// is it even possible to have SelectQuery for InsertOrUpdate?
+						var selectQuery = s.SelectQuery != null ? (SelectQuery)    ConvertInternal(s.SelectQuery, action) : null;
+						var insert      = s.Insert      != null ? (SqlInsertClause)ConvertInternal(s.Insert, action) : null;
+						var update      = s.Update      != null ? (SqlUpdateClause)ConvertInternal(s.Update, action) : null;
 						var ps          = ConvertSafe(s.Parameters, action);
 
 						if (insert      != null && !ReferenceEquals(s.Insert,      insert)       ||


### PR DESCRIPTION
Fixes issue for insert from select query when select contains nullable parameter and first call of query is done with null value. It leads to failures on next calls with non-null parameters.

Except insert statement fix, also fixed order for update/insertOrUpdate statements and tried to create tests update/insertOrUpdate, but update case generates bogus sql, and for insertOrUpdate don't see how it is possible to create such query.