### PR TITLE
Working on failing tests

### DIFF
--- a/NuGet/Readme.txt
+++ b/NuGet/Readme.txt
@@ -4,6 +4,7 @@ LINQ to DB 2.0.0  Release Notes
 - breaking change: dropped support for .NET 4.0, Silverlight 4-5 and Windows 8 Store frameworks. New target frameworks list is netcoreapp2.0, netstandard1.6, netstandard2.0 and net45
 - breaking change: behavior of enum mapping to a text type for enum without configured mappings changed to use ToString() instead of (enum underlying type).ToString(). To return old behavior, you should set Configuration.UseEnumValueNameForStringColumns to false (#1006, #1071)
 - breaking change: [PostgreSQL] If you used BulkCopy with ProviderSpecific method specified, check https://github.com/linq2db/linq2db/wiki/Bulk-Copy for important notes regarding provider-specific support notes
+- breaking change: [Firebird] Changed default identifier quotation mode to FirebirdIdentifierQuoteMode.Auto from None (#1120)
 
 - feature: predicate expression support added for associations configuration using fluent mapping (#961)
 - feature: support creation of query parameters in extension builders (#964)
@@ -34,6 +35,7 @@ LINQ to DB 2.0.0  Release Notes
 - improvement: Allow basic mappings modifications using MappingSchema.EntityDescriptorCreatedCallback callback (#1074)
 - improvement: Exception during column mapping will be wrappped into LinqToDBException with information which column failed with original error as InnerException (#1065)
 - improvement: [PostgreSQL] Improved suppport for some types (#1091)
+- improvement: [Firebird] Check table existence in DropTable (#1120)
 
 - fix: fixed another case of defect #170, where default(T) value could be selected for non-nullable field instead of NULL from left join, if SelectMany() call used in source (#1012)
 - fix: [MS SQL, Sybase] updated Merge insert operation to respect SkipOnInsert mapping flag for identity fields when no custom insert expression specified. With this fix merge operation will allow database to generate identity value instead of use of value from source (#914)
@@ -71,6 +73,7 @@ LINQ to DB 2.0.0  Release Notes
 - fix: Fixed T4 templates to work with .NET Core projects out-of-box using nuget package (#1067)
 - fix: [Access] Fixed schema read failure when ACE OleDb provider used (https://github.com/linq2db/linq2db.LINQPad/issues/10)
 - fix: [Access] Schema provider will now return system tables too (TableInfo.IsProviderSpecific == true) (#1119)
+- fix: [Firebird] Use proper identifiers quotation for create/drop/truncate table for tables with generators and fix detection of cases when quotation is required (#1120)
 
 - other changes: t4models repository moved to main repository
 - other changes: [Firebird] Made changes to Firebird provider/sql optimizer to allow subclassing (#1000)

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdIdentifierQuoteMode.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdIdentifierQuoteMode.cs
@@ -3,20 +3,35 @@
 namespace LinqToDB.DataProvider.Firebird
 {
 	/// <summary>
-	/// Possible modes for Firebird identifier quotes.
+	/// Possible modes for Firebird identifier quotes. This enumeration covers only identifier quotation logic
+	/// and don't handle identifier length limits.
 	/// </summary>
 	public enum FirebirdIdentifierQuoteMode
 	{
 		/// <summary>
 		/// Do not quote identifiers.
+		/// LINQ To DB will not check identifiers for validity (spaces, reserved words) is this mode.
+		/// This mode should be used only for SQL Dialect &lt; 3 and it is developer's responsibility to
+		/// ensure that there is no identifiers in use that require quotation.
 		/// </summary>
 		None,
 		/// <summary>
 		/// Always quote identifiers.
+		/// LINQ To DB will quote all identifiers, even if it is not required.
+		/// Select this mode, if you need to preserve identifiers casing.
+		/// Quoted identifiers not supported by SQL Dialect &lt; 3.
 		/// </summary>
 		Quote,
 		/// <summary>
-		/// quote identifiers if needed.
+		/// Quote identifiers if needed.
+		/// LINQ To DB will quote identifiers, if they are not valid without quotation.
+		/// This includes:
+		/// - use of reserved words;
+		/// - use of any characters except latin letters, digits, _ and $;
+		/// - use digit, _ or $ as first character.
+		/// This is default mode.
+		/// Note that if you need to preserve casing of identifiers, you should use <see cref="Quote"/> mode.
+		/// Quoted identifiers not supported by SQL Dialect &lt; 3.
 		/// </summary>
 		Auto
 	}

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdSqlBuilder.cs
@@ -181,9 +181,25 @@ namespace LinqToDB.DataProvider.Firebird
 		/// Specifies how identifiers like table and field names should be quoted.
 		/// </summary>
 		/// <remarks>
-		/// By default identifiers will not be quoted.
+		/// Default value: <see cref="FirebirdIdentifierQuoteMode.Auto"/>.
 		/// </remarks>
-		public static FirebirdIdentifierQuoteMode IdentifierQuoteMode = FirebirdIdentifierQuoteMode.None;
+		public static FirebirdIdentifierQuoteMode IdentifierQuoteMode = FirebirdIdentifierQuoteMode.Auto;
+
+		/// <summary>
+		/// Check if identifier is valid without quotation. Expects non-zero length string as input.
+		/// </summary>
+		private bool IsValidIdentifier(string name)
+		{
+			// https://firebirdsql.org/file/documentation/reference_manuals/fblangref25-en/html/fblangref25-structure-identifiers.html
+			return !IsReserved(name) &&
+				((name[0] >= 'a' && name[0] <= 'z') || (name[0] >= 'A' && name[0] <= 'Z')) && 
+				name.All(c =>
+					(c >= 'a' && c <= 'z') ||
+					(c >= 'A' && c <= 'Z') ||
+					(c >= '0' && c <= '9') ||
+					c == '$' ||
+					c == '_');
+		}
 
 		public override object Convert(object value, ConvertType convertType)
 		{
@@ -195,17 +211,11 @@ namespace LinqToDB.DataProvider.Firebird
 					if (value != null)
 					{
 						var name = value.ToString();
-						var reserved = IsReserved(name);
-						if (IdentifierQuoteMode != FirebirdIdentifierQuoteMode.None || reserved)
+						if (IdentifierQuoteMode == FirebirdIdentifierQuoteMode.Quote ||
+						   (IdentifierQuoteMode == FirebirdIdentifierQuoteMode.Auto && !IsValidIdentifier(name)))
 						{
-							if (name.Length > 0 && name[0] == '"')
-								return name;
-
-							if (IdentifierQuoteMode == FirebirdIdentifierQuoteMode.Quote ||
-								name.StartsWith("_") ||
-								reserved ||
-								name.Any(c => char.IsLower(c) || char.IsWhiteSpace(c)))
-								return '"' + name + '"';
+							// I wonder what to do if identifier has " in name?
+							return '"' + name + '"';
 						}
 					}
 
@@ -257,8 +267,6 @@ namespace LinqToDB.DataProvider.Firebird
 
 				case SqlDropTableStatement dropTable:
 					_identityField = dropTable.Table.Fields.Values.FirstOrDefault(f => f.IsIdentity);
-					if (_identityField != null)
-						return 3;
 					break;
 			}
 
@@ -267,63 +275,97 @@ namespace LinqToDB.DataProvider.Firebird
 
 		protected override void BuildDropTableStatement(SqlDropTableStatement dropTable)
 		{
-			if (_identityField == null)
+			// implementation use following approach: http://www.firebirdfaq.org/faq69/
+			StringBuilder
+				.AppendLine("EXECUTE BLOCK AS BEGIN");
+
+			Indent++;
+
+			if (_identityField != null)
 			{
-				base.BuildDropTableStatement(dropTable);
+				BuildDropWithSchemaCheck("TRIGGER"  , "rdb$triggers"  , "rdb$trigger_name"  , "TIDENTITY_" + dropTable.Table.PhysicalName);
+				BuildDropWithSchemaCheck("GENERATOR", "rdb$generators", "rdb$generator_name", "GIDENTITY_" + dropTable.Table.PhysicalName);
 			}
-			else
-			{
-				StringBuilder
-					.Append("DROP TRIGGER TIDENTITY_")
-					.Append(dropTable.Table.PhysicalName)
-					.AppendLine();
-			}
+
+			BuildDropWithSchemaCheck("TABLE", "rdb$relations", "rdb$relation_name", dropTable.Table.PhysicalName);
+
+			Indent--;
+
+			StringBuilder
+				.AppendLine("END");
+		}
+
+		private void BuildDropWithSchemaCheck(string objectName, string schemaTable, string nameColumn, string identifier)
+		{
+			AppendIndent().AppendFormat("IF (EXISTS(SELECT 1 FROM {0} WHERE {1} = ", schemaTable, nameColumn);
+
+			var identifierValue = identifier;
+
+			// if identifier is not quoted, it must be converted to upper case to match record in rdb$relation_name
+			if (IdentifierQuoteMode == FirebirdIdentifierQuoteMode.None ||
+				IdentifierQuoteMode == FirebirdIdentifierQuoteMode.Auto && IsValidIdentifier(identifierValue))
+				identifierValue = identifierValue.ToUpper();
+
+			BuildValue(null, identifierValue);
+
+			StringBuilder
+				.AppendLine(")) THEN");
+
+			Indent++;
+
+			AppendIndent().Append("EXECUTE STATEMENT ");
+
+			var dropCommand = new StringBuilder();
+
+			dropCommand
+				.Append("DROP ")
+				.Append(objectName)
+				.Append(" ")
+				.Append(Convert(identifier, ConvertType.NameToQueryTable));
+
+			BuildValue(null, dropCommand.ToString());
+
+			StringBuilder.AppendLine(";");
+
+			Indent--;
 		}
 
 		protected override void BuildCommand(SqlStatement statement, int commandNumber)
 		{
+			// should we introduce new converstion types like NameToGeneratorName/NameToTriggerName?
 			switch (Statement)
 			{
 				case SqlTruncateTableStatement truncate:
 					StringBuilder
-						.Append("SET GENERATOR GIDENTITY_")
-						.Append(truncate.Table.PhysicalName)
+						.Append("SET GENERATOR ")
+						.Append(Convert("GIDENTITY_" + truncate.Table.PhysicalName, ConvertType.NameToQueryTable))
 						.AppendLine(" TO 0")
 						;
 					break;
-
-				case SqlDropTableStatement dropTable:
-					{
-						if (commandNumber == 1)
-						{
-							StringBuilder
-								.Append("DROP GENERATOR GIDENTITY_")
-								.Append(dropTable.Table.PhysicalName)
-								.AppendLine();
-						}
-						else
-							base.BuildDropTableStatement(dropTable);
-
-						break;
-					}
 
 				case SqlCreateTableStatement createTable:
 					{
 						if (commandNumber == 1)
 						{
 							StringBuilder
-								.Append("CREATE GENERATOR GIDENTITY_")
-								.Append(createTable.Table.PhysicalName)
+								.Append("CREATE GENERATOR ")
+								.Append(Convert("GIDENTITY_" + createTable.Table.PhysicalName, ConvertType.NameToQueryTable))
 								.AppendLine();
 						}
 						else
 						{
 							StringBuilder
-								.AppendFormat("CREATE TRIGGER TIDENTITY_{0} FOR {0}", createTable.Table.PhysicalName)
+								.AppendFormat(
+									"CREATE TRIGGER {0} FOR {1}",
+									Convert("TIDENTITY_" + createTable.Table.PhysicalName, ConvertType.NameToQueryTable),
+									Convert(createTable.Table.PhysicalName, ConvertType.NameToQueryTable))
 								.AppendLine  ()
 								.AppendLine  ("BEFORE INSERT POSITION 0")
 								.AppendLine  ("AS BEGIN")
-								.AppendFormat("\tNEW.{0} = GEN_ID(GIDENTITY_{1}, 1);", _identityField.PhysicalName, createTable.Table.PhysicalName)
+								.AppendFormat(
+									"\tNEW.{0} = GEN_ID({1}, 1);",
+									Convert(_identityField.PhysicalName, ConvertType.NameToQueryField),
+									Convert("GIDENTITY_" + createTable.Table.PhysicalName, ConvertType.NameToQueryTable))
 								.AppendLine  ()
 								.AppendLine  ("END");
 						}

--- a/Source/LinqToDB/Linq/QueryRunner.Delete.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.Delete.cs
@@ -59,7 +59,7 @@ namespace LinqToDB.Linq
 				if (Equals(default(T), obj))
 					return 0;
 
-                var type = obj.GetType();
+				var type = obj.GetType();
 				var key = new { dataContext.MappingSchema.ConfigurationID, dataContext.ContextID, tableName, schemaName, databaseName, type };
 				var ei = _queryCache.GetOrAdd(key, o => CreateQuery(dataContext, tableName, databaseName, schemaName, type));
 

--- a/Tests/Base/ScopedSettings.cs
+++ b/Tests/Base/ScopedSettings.cs
@@ -1,0 +1,37 @@
+﻿using LinqToDB.DataProvider.Firebird;
+using System;
+
+namespace Tests
+{
+	public class Scope : IDisposable
+	{
+		private readonly Action _onExit;
+
+		public Scope(Action onEnter, Action onExit)
+		{
+			onEnter();
+			_onExit = onExit;
+		}
+
+		void IDisposable.Dispose()
+		{
+			_onExit();
+		}
+	}
+
+	public class FirebirdQuoteMode : IDisposable
+	{
+		private readonly FirebirdIdentifierQuoteMode _oldMode;
+
+		public FirebirdQuoteMode(FirebirdIdentifierQuoteMode mode)
+		{
+			_oldMode = FirebirdSqlBuilder.IdentifierQuoteMode;
+			FirebirdSqlBuilder.IdentifierQuoteMode = mode;
+		}
+
+		void IDisposable.Dispose()
+		{
+			FirebirdSqlBuilder.IdentifierQuoteMode = _oldMode;
+		}
+	}
+}

--- a/Tests/Base/TestBase.cs
+++ b/Tests/Base/TestBase.cs
@@ -1116,7 +1116,7 @@ namespace Tests
 
 		public void Dispose()
 		{
-			_db.DropTable<T>();
+			_db.DropTable<T>(throwExceptionIfNotExists: false);
 		}
 	}
 

--- a/Tests/Linq/DataProvider/FirebirdTests.cs
+++ b/Tests/Linq/DataProvider/FirebirdTests.cs
@@ -478,41 +478,73 @@ namespace Tests.DataProvider
 			[Column] public string Caption   { get; set; } 
 			[Column] public long?  ParentId  { get; set; } 
 
-			         public bool HasChildren { get; set; }
+					 public bool HasChildren { get; set; }
 		}
 
 		[Test, IncludeDataContextSource(ProviderName.Firebird, TestProvName.Firebird3)]
 		public void Issue76(string context)
 		{
-			var saveQuoteIdentifiers = FirebirdSqlBuilder.IdentifierQuoteMode;
-			FirebirdSqlBuilder.IdentifierQuoteMode = FirebirdIdentifierQuoteMode.Quote;
-
-			try
+			using (new FirebirdQuoteMode(FirebirdIdentifierQuoteMode.Quote))
+			using (var db = GetDataContext(context))
+			using (new LocalTable<Issue76Entity>(db))
 			{
-				using (var db = GetDataContext(context))
-				using (new LocalTable<Issue76Entity>(db))
+				var folders = db.GetTable<Issue76Entity>().Select(f => new Issue76Entity()
 				{
-					var folders = db.GetTable<Issue76Entity>().Select(f => new Issue76Entity()
-					{
-						Id          = f.Id,
-						Caption     = f.Caption,
-						HasChildren = db.GetTable<Issue76Entity>().Any(f2 => f2.ParentId == f.Id)
-					});
+					Id          = f.Id,
+					Caption     = f.Caption,
+					HasChildren = db.GetTable<Issue76Entity>().Any(f2 => f2.ParentId == f.Id)
+				});
 
-					folders =
-						from folder  in folders
-						join folder2 in db.GetTable<Issue76Entity>() on folder.ParentId equals folder2.Id
-						where folder2.Caption == "dewde"
-						select folder;
+				folders =
+					from folder in folders
+					join folder2 in db.GetTable<Issue76Entity>() on folder.ParentId equals folder2.Id
+					where folder2.Caption == "dewde"
+					select folder;
 
 
-					Assert.DoesNotThrow(() => folders.ToList());
-				}
+				Assert.DoesNotThrow(() => folders.ToList());
 			}
-			finally
+		}
+
+		[Table]
+		class TestDropTable
+		{
+			[Column]
+			public int Field;
+		}
+
+		[Table]
+		class TestIdentityDropTable
+		{
+			[Column, Identity]
+			public int Field;
+		}
+
+		[Test]
+		[Combinatorial]
+		public void DropTableTest(
+			[IncludeDataSources(ProviderName.Firebird, TestProvName.Firebird3)] string context,
+			[Values] FirebirdIdentifierQuoteMode quoteMode,
+			[Values] bool withIdentity,
+			[Values] bool throwIfNotExists)
+		{
+			using (new FirebirdQuoteMode(quoteMode))
+			using (var db = GetDataContext(context))
 			{
-				FirebirdSqlBuilder.IdentifierQuoteMode = saveQuoteIdentifiers;
-				
+				if (withIdentity)
+					test<TestIdentityDropTable>();
+				else
+					test<TestDropTable>();
+
+				void test<TTable>()
+				{
+					// first drop deletes table if it remains from previous test run
+					// second drop deletes non-existing table
+					db.DropTable<TTable>(throwExceptionIfNotExists: throwIfNotExists);
+					db.DropTable<TTable>(throwExceptionIfNotExists: throwIfNotExists);
+					db.CreateTable<TTable>();
+					db.DropTable<TTable>(throwExceptionIfNotExists: throwIfNotExists);
+				}
 			}
 		}
 	}

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -496,7 +496,9 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 			{
-				AreEqual(Types.Select(t => t.DateTimeValue.AddDays(t.SmallIntValue)),
+				var needsFix = db.ProviderNeedsTimeFix(context);
+
+				AreEqual(Types.Select(t => TestUtils.FixTime(t.DateTimeValue.AddDays(t.SmallIntValue), needsFix)),
 					db.Types.Select(t => t.DateTimeValue.AddDays(t.SmallIntValue)));
 			}
 		}

--- a/Tests/Linq/Linq/DynamicColumnsTests.cs
+++ b/Tests/Linq/Linq/DynamicColumnsTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using LinqToDB;
+using LinqToDB.DataProvider.Firebird;
 using LinqToDB.Mapping;
 using NUnit.Framework;
 using Tests.Model;
@@ -364,20 +365,14 @@ namespace Tests.Linq
 
 		public void CreateTestTable<T>(IDataContext db, string tableName = null)
 		{
-			try
-			{
-				db.CreateTable<T>(tableName);
-			}
-			catch 
-			{
-				db.DropTable<T>();
-				db.CreateTable<T>(tableName);
-			}
+			db.DropTable<T>(tableName, throwExceptionIfNotExists: false);
+			db.CreateTable<T>(tableName);
 		}
 
 		[Test, DataContextSource]
 		public void SqlPropertyNoStoreNonIdentifier(string context)
 		{
+			using (new FirebirdQuoteMode(FirebirdIdentifierQuoteMode.Auto))
 			using (var db = GetDataContext(context))
 			{
 				CreateTestTable<DynamicTablePrototype>(db);
@@ -406,13 +401,14 @@ namespace Tests.Linq
 		[Test, DataContextSource]
 		public void SqlPropertyNoStoreNonIdentifierGrouping(string context)
 		{
+			using (new FirebirdQuoteMode(FirebirdIdentifierQuoteMode.Auto))
 			using (var db = GetDataContext(context))
 			{
 				CreateTestTable<DynamicTablePrototype>(db);
 				try
 				{
-					db.Insert(new DynamicTablePrototype { NotIdentifier = 77, Value = 5});
-					db.Insert(new DynamicTablePrototype { NotIdentifier = 77, Value = 5});
+					db.Insert(new DynamicTablePrototype { NotIdentifier = 77, Value = 5 });
+					db.Insert(new DynamicTablePrototype { NotIdentifier = 77, Value = 5 });
 
 					var query =
 						from d in db.GetTable<DynamicTable>()
@@ -424,7 +420,7 @@ namespace Tests.Linq
 							Count = g.Count(),
 							Sum = g.Sum(i => Sql.Property<int>(i, "Some Value"))
 						};
-					
+
 					var result = query.ToArray();
 
 					Assert.AreEqual(77, result[0].NI);

--- a/Tests/Linq/Update/UpdateTests.cs
+++ b/Tests/Linq/Update/UpdateTests.cs
@@ -1189,6 +1189,11 @@ namespace Tests.xUpdate
 
 			using (var db = GetDataContext(context))
 			{
+				db.DropTable<Patient>(tableName, schemaName: schemaName, throwExceptionIfNotExists: false);
+			}
+
+			using (var db = GetDataContext(context))
+			{
 				var table = db.CreateTable<Person>(tableName, schemaName: schemaName);
 
 				Assert.AreEqual(tableName,  table.TableName);
@@ -1224,6 +1229,11 @@ namespace Tests.xUpdate
 		{
 			const string schemaName = null;
 			const string tableName  = "xxPerson";
+
+			using (var db = GetDataContext(context))
+			{
+				await db.DropTableAsync<Patient>(tableName, schemaName: schemaName, throwExceptionIfNotExists: false);
+			}
 
 			using (var db = GetDataContext(context))
 			{

--- a/Tests/Linq/UserTests/Issue1057Tests.cs
+++ b/Tests/Linq/UserTests/Issue1057Tests.cs
@@ -47,7 +47,8 @@ namespace Tests.UserTests
 			public int TaskId { get; set; }
 
 			[Column]
-			[Column(Configuration = ProviderName.DB2, DbType = "char")]
+			[Column(Configuration = ProviderName.DB2     , DbType = "char")]
+			[Column(Configuration = ProviderName.Firebird, DbType = "char(1)")]
 			public bool Actual { get; set; }
 		}
 

--- a/Tests/Linq/UserTests/Issue1110Tests.cs
+++ b/Tests/Linq/UserTests/Issue1110Tests.cs
@@ -18,7 +18,6 @@ namespace Tests.UserTests
 			public DateTime TimeStamp { get; set; }
 		}
 
-
 		[Test, DataContextSource]
 		public void Test(string configuration)
 		{
@@ -26,9 +25,16 @@ namespace Tests.UserTests
 			{
 				db.DropTable<Issue1110TestsClass>(throwExceptionIfNotExists: false);
 
-				db.CreateTable<Issue1110TestsClass>();
+				try
+				{
+					db.CreateTable<Issue1110TestsClass>();
 
-				db.Insert(new Issue1110TestsClass() { Id = 10, TimeStamp = DateTime.UtcNow });
+					db.Insert(new Issue1110TestsClass() { Id = 10, TimeStamp = DateTime.UtcNow });
+				}
+				finally
+				{
+					db.DropTable<Issue1110TestsClass>(throwExceptionIfNotExists: false);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
We have some tests added recently, that fail for one or another provider.
This PR will try to fix it.

 - [x] AddDaysFromColumn test failure for MySQL < 5.6.4
 - [ ] Unstable ConcurentTest2 sqlite test
 - [x] Firebird3: ComplexTests2 fail to drop table over WCF
 - [x] Firebird: SqlPropertyNoStoreNonIdentifier* tests cannot find table
 - [x] Firebird: Issue1057Tests cannot create table with boolean field
 - [x] Firebird: InsertOrReplaceByTableName unstable lock metadata errors
 - [x] Firebird: InsertOrReplaceByTableNameAsync table exists on create
 - [x] Firebird quotation logic slightly broken by reserved words handling

Fixes #1095 remaining failures