### PR TITLE
Release 2.0 - Make SqlExtensions public

### DIFF
--- a/Source/LinqToDB/SqlQuery/SqlExtensions.cs
+++ b/Source/LinqToDB/SqlQuery/SqlExtensions.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace LinqToDB.SqlQuery
 {
-	static class SqlExtensions
+	public static class SqlExtensions
 	{
 		public static bool IsInsert(this SqlStatement statement)
 		{


### PR DESCRIPTION
I use the SqlExtensions class in the DB2 iSeries provider but it needs to be explicitly scoped public.