### PR TITLE
Fix merge with empty source

### DIFF
--- a/Source/LinqToDB/DataProvider/BasicMergeBuilder.cs
+++ b/Source/LinqToDB/DataProvider/BasicMergeBuilder.cs
@@ -291,7 +291,7 @@ namespace LinqToDB.DataProvider
 
 			var columnTypes = GetSourceColumnTypes();
 
-			for (var i = 0; i < TargetDescriptor.Columns.Count; i++)
+			for (var i = 0; i < _sourceDescriptor.Columns.Count; i++)
 			{
 				if (i > 0)
 					Command.Append(", ");
@@ -304,7 +304,7 @@ namespace LinqToDB.DataProvider
 
 				Command
 					.Append(" ")
-					.Append(CreateSourceColumnAlias(TargetDescriptor.Columns[i].ColumnName, true));
+					.Append(CreateSourceColumnAlias(_sourceDescriptor.Columns[i].ColumnName, true));
 			}
 
 			Command

--- a/Source/LinqToDB/DataProvider/BasicMergeBuilder.cs
+++ b/Source/LinqToDB/DataProvider/BasicMergeBuilder.cs
@@ -309,8 +309,14 @@ namespace LinqToDB.DataProvider
 
 			Command
 				.AppendLine()
-				.Append("\tFROM ")
-				.AppendLine(TargetTableName)
+				.Append("\tFROM ");
+
+			if (FakeSourceTable != null)
+				AddFakeSourceTableName();
+			else // we don't select anything, so it is ok to use target table
+				Command.AppendLine(TargetTableName);
+
+			Command
 				.AppendLine("\tWHERE 1 = 0")
 				.Append(") ")
 				.AppendLine((string)SqlBuilder.Convert(SourceAlias, ConvertType.NameToQueryTableAlias));

--- a/Tests/Linq/Update/MergeTests.EmptySource.cs
+++ b/Tests/Linq/Update/MergeTests.EmptySource.cs
@@ -1,0 +1,80 @@
+﻿
+using NUnit.Framework;
+
+namespace Tests.xUpdate
+{
+	using LinqToDB;
+	using LinqToDB.Common;
+	using Model;
+	using System;
+	using System.Linq;
+
+	// tests for empty enumerable source
+	public partial class MergeTests
+	{
+		[Test, MergeDataContextSource]
+		public void MergeEmptyLocalSourceSameType(string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.BeginTransaction())
+			{
+
+				PrepareData(db);
+
+				var table = GetTarget(db);
+
+				var rows = table
+					.Merge()
+					.Using(Array<TestMapping1>.Empty)
+					.OnTargetKey()
+					.InsertWhenNotMatched()
+					.Merge();
+
+				var result = table.OrderBy(_ => _.Id).ToList();
+
+				AssertRowCount(0, rows, context);
+
+				Assert.AreEqual(4, result.Count);
+
+				AssertRow(InitialTargetData[0], result[0], null, null);
+				AssertRow(InitialTargetData[1], result[1], null, null);
+				AssertRow(InitialTargetData[2], result[2], null, 203);
+				AssertRow(InitialTargetData[3], result[3], null, null);
+			}
+		}
+
+		[Test, MergeDataContextSource]
+		public void MergeEmptyLocalSourceDifferentTypes(string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.BeginTransaction())
+			{
+
+				PrepareData(db);
+
+				var table = GetTarget(db);
+
+				var rows = table
+					.Merge()
+					.Using(Array<Person>.Empty)
+					.On((t, s) => t.Id == s.ID)
+					.InsertWhenNotMatched(s => new TestMapping1()
+					{
+						Id = s.ID
+					})
+					.Merge();
+
+				var result = table.OrderBy(_ => _.Id).ToList();
+
+				AssertRowCount(0, rows, context);
+
+				Assert.AreEqual(4, result.Count);
+
+				AssertRow(InitialTargetData[0], result[0], null, null);
+				AssertRow(InitialTargetData[1], result[1], null, null);
+				AssertRow(InitialTargetData[2], result[2], null, 203);
+				AssertRow(InitialTargetData[3], result[3], null, null);
+			}
+		}
+	}
+}

--- a/Tests/Linq/Update/MergeTests.Operations.Insert.cs
+++ b/Tests/Linq/Update/MergeTests.Operations.Insert.cs
@@ -1620,7 +1620,6 @@ namespace Tests.xUpdate
 		}
 		#endregion
 
-
 		[Test, MergeDataContextSource]//(ProviderName.Sybase)]
 		public void CrossJoinedSourceWithSingleFieldSelection(string context)
 		{


### PR DESCRIPTION
Fixes case, when merge performed over empty local source with source type != target type