### PR TITLE
Added SqlProviderFlags.CustomFlags

### DIFF
--- a/Source/LinqToDB/SqlProvider/SqlProviderFlags.cs
+++ b/Source/LinqToDB/SqlProvider/SqlProviderFlags.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace LinqToDB.SqlProvider
 {
@@ -60,5 +61,10 @@ namespace LinqToDB.SqlProvider
 
 			return (TakeHintsSupported.Value & hints) == hints;
 		}
+
+		/// <summary>
+		/// Flags for use by external providers
+		/// </summary>
+		public List<string> CustomFlags => new List<string>();
 	}
 }


### PR DESCRIPTION
The DB2 iSeries provider has options as to how it handles Guids as they are not available natively in DB2 (handle them as a string or a blob).  This setting needs to be available in the SqlBuilder.  I used a constructor overload to set this value when creating the SqlBuilder in the provider but the LinqService directly instantiates the SqlBuilder therefore in the LinqService the option is not available.

This change simply adds a CustomFlags list into  SqlProviderFlags allowing me to set my custom options which are then applied when the Linq service creates the SqlBuilder.