### PR TITLE
Fix #1165

### DIFF
--- a/Data/Create Scripts/SqlServer.sql
+++ b/Data/Create Scripts/SqlServer.sql
@@ -927,12 +927,14 @@ GO
 
 CREATE TABLE [TestSchema].[TestSchemaB]
 (
-	[TestSchemaBID]       INT NOT NULL,
-	[OriginTestSchemaAID] INT NOT NULL,
-	[TargetTestSchemaAID] INT NOT NULL,
+	[TestSchemaBID]           INT NOT NULL,
+	[OriginTestSchemaAID]     INT NOT NULL,
+	[TargetTestSchemaAID]     INT NOT NULL,
+	[Target_Test_Schema_A_ID] INT NOT NULL,
 	CONSTRAINT [PK_TestSchema_TestSchemaB] PRIMARY KEY (TestSchemaBID),
-	CONSTRAINT [FK_TestSchema_TestSchemaBY_OriginTestSchemaA] FOREIGN KEY (OriginTestSchemaAID) REFERENCES [TestSchema].[TestSchemaA] ([TestSchemaAID]),
-	CONSTRAINT [FK_TestSchema_TestSchemaBY_TargetTestSchemaA] FOREIGN KEY (TargetTestSchemaAID) REFERENCES [TestSchema].[TestSchemaA] ([TestSchemaAID])
+	CONSTRAINT [FK_TestSchema_TestSchemaBY_OriginTestSchemaA]  FOREIGN KEY (OriginTestSchemaAID)       REFERENCES [TestSchema].[TestSchemaA] ([TestSchemaAID]),
+	CONSTRAINT [FK_TestSchema_TestSchemaBY_TargetTestSchemaA]  FOREIGN KEY (TargetTestSchemaAID)       REFERENCES [TestSchema].[TestSchemaA] ([TestSchemaAID]),
+	CONSTRAINT [FK_TestSchema_TestSchemaBY_TargetTestSchemaA2] FOREIGN KEY ([Target_Test_Schema_A_ID]) REFERENCES [TestSchema].[TestSchemaA] ([TestSchemaAID])
 );
 GO
 

--- a/Source/LinqToDB.Templates/README.md
+++ b/Source/LinqToDB.Templates/README.md
@@ -88,6 +88,10 @@ GetSchemaOptions.IncludedSchemas = new[] { "TestUser", "SYS" };     // Defines o
 GetSchemaOptions.ExcludedCatalogs = new[] { "TestUser", "SYSSTAT" }; // Defines excluded catalogs.
 GetSchemaOptions.IncludedCatalogs = new[] { "TestUser", "SYS" };     // Defines only included catalogs.
 
+GetSchemaOptions.GetAssociationMemberName = key => "Association_" + key.MemberName;     // Defines custom naming logic for generated associations.
+
+// check GetSchemaOptions class for more options
+
 Func<string, bool, string> ToValidName         = ToValidNameDefault;          // Defines function to convert names to valid (My_Table to MyTable) 
 Func<string, bool, string> ConvertToCompilable = ConvertToCompilableDefault;  // Converts name to c# compatible. By default removes uncompatible symbols and converts result with ToValidName
 

--- a/Source/LinqToDB/SchemaProvider/GetSchemaOptions.cs
+++ b/Source/LinqToDB/SchemaProvider/GetSchemaOptions.cs
@@ -2,19 +2,57 @@
 
 namespace LinqToDB.SchemaProvider
 {
+	/// <summary>
+	/// Defines schema load options.
+	/// </summary>
 	public class GetSchemaOptions
 	{
+		/// <summary>
+		/// Enable or disable read of table schema. Default - enabled (<c>true</c>).
+		/// </summary>
 		public bool     GetTables             = true;
+		/// <summary>
+		/// Enable or disable read of procedures and functions metadata. Default - enabled (<c>true</c>).
+		/// </summary>
 		public bool     GetProcedures         = true;
+		/// <summary>
+		/// Should linq2db use <see cref="string"/> for char(1) type or <see cref="char"/>. Default type: <see cref="char"/> (<c>false</c>).
+		/// </summary>
 		public bool     GenerateChar1AsString = false;
+		/// <summary>
+		/// List of allowed schemas/owners.
+		/// </summary>
 		public string[] IncludedSchemas;
+		/// <summary>
+		/// List of disallowed schemas/owners.
+		/// </summary>
 		public string[] ExcludedSchemas;
+		/// <summary>
+		/// List of allowed databases/catalogs.
+		/// </summary>
 		public string[] IncludedCatalogs;
+		/// <summary>
+		/// List of disallowed databases/catalogs.
+		/// </summary>
 		public string[] ExcludedCatalogs;
 
+		/// <summary>
+		/// String comparison logic for <see cref="IncludedSchemas"/>, <see cref="ExcludedSchemas"/>, <see cref="IncludedCatalogs"/> and <see cref="ExcludedCatalogs"/> values.
+		/// Default is <see cref="StringComparer.OrdinalIgnoreCase"/>.
+		/// </summary>
 		public StringComparer                StringComparer           = StringComparer.OrdinalIgnoreCase;
+		/// <summary>
+		/// Optional procedure metadata load filter. By default all procedures loaded.
+		/// </summary>
 		public Func<ProcedureSchema,bool>    LoadProcedure            = _ => true;
+		/// <summary>
+		/// Optional custom name generation logic for association property.
+		/// </summary>
 		public Func<ForeignKeySchema,string> GetAssociationMemberName = null;
+		/// <summary>
+		/// Optional callback to report procedure metadata load progress. First parameter contains total number of
+		/// discovered procedires. Second parameter provides position of currently loaded procedure.
+		/// </summary>
 		public Action<int,int>               ProcedureLoadingProgress = (outOf,current) => {};
 	}
 }

--- a/Source/LinqToDB/SchemaProvider/SchemaProviderBase.cs
+++ b/Source/LinqToDB/SchemaProvider/SchemaProviderBase.cs
@@ -681,7 +681,7 @@ namespace LinqToDB.SchemaProvider
 				if (key.BackReference != null && key.ThisColumns.Count == 1 && key.ThisColumns[0].MemberName.ToLower().EndsWith("id"))
 				{
 					name = key.ThisColumns[0].MemberName;
-					name = name.Substring(0, name.Length - "id".Length);
+					name = name.Substring(0, name.Length - "id".Length).TrimEnd('_');
 
 					if (table.ForeignKeys.Select(_ => _.MemberName). Concat(
 						table.Columns.    Select(_ => _.MemberName)).Concat(

--- a/Tests/Linq/SchemaProvider/SchemaProviderTests.cs
+++ b/Tests/Linq/SchemaProvider/SchemaProviderTests.cs
@@ -351,7 +351,7 @@ namespace Tests.SchemaProvider
 				table = s.Tables.Single(t => t.TableName == "TestSchemaB");
 				fks   = table.ForeignKeys.Select(fk => fk.MemberName).ToArray();
 
-				Assert.That(fks, Is.EqualTo(new[] { "OriginTestSchemaA", "TargetTestSchemaA" }));
+				Assert.That(fks, Is.EqualTo(new[] { "OriginTestSchemaA", "TargetTestSchemaA", "Target_Test_Schema_A" }));
 			}
 		}
 


### PR DESCRIPTION
Fix #1165:

- [x] fix trailing underscore in association properties
- [x] ~add option to generate association names based on FK name~ user already can set custom naming strategy