### PR TITLE
Use compatibility level to detect Sql Server provider

### DIFF
--- a/Tests/Linq/DataProvider/MySqlTests.cs
+++ b/Tests/Linq/DataProvider/MySqlTests.cs
@@ -733,6 +733,7 @@ namespace Tests.DataProvider
 			throw new NotImplementedException();
 		}
 
+		[Description("https://stackoverflow.com/questions/50858172/linq2db-mysql-set-row-index/50958483")]
 		[Test, MySqlDataContext]
 		public void RowIndexTest(string context)
 		{


### PR DESCRIPTION
Current implementation uses Sql Server version to detect an appropriate data provider. Compatibility level should be used instead.