### PR TITLE
Add linq2db.sqlite.ms nuget for Microsoft.Data.Sqlite provider

### DIFF
--- a/NuGet/Pack.bat
+++ b/NuGet/Pack.bat
@@ -17,6 +17,7 @@ del *.nupkg
 ..\Redist\NuGet Pack linq2db.SapHana.nuspec
 ..\Redist\NuGet Pack linq2db.SqlCe.nuspec
 ..\Redist\NuGet Pack linq2db.SQLite.nuspec
+..\Redist\NuGet Pack linq2db.SQLite.MS.nuspec
 ..\Redist\NuGet Pack linq2db.SqlServer.nuspec
 ..\Redist\NuGet Pack linq2db.Sybase.nuspec
 ..\Redist\NuGet Pack linq2db.Sybase.DataAction.nuspec

--- a/NuGet/PackAV.bat
+++ b/NuGet/PackAV.bat
@@ -14,6 +14,7 @@ del *.nupkg
 ..\Redist\NuGet Pack linq2db.SapHana.nuspec
 ..\Redist\NuGet Pack linq2db.SqlCe.nuspec
 ..\Redist\NuGet Pack linq2db.SQLite.nuspec
+..\Redist\NuGet Pack linq2db.SQLite.MS.nuspec
 ..\Redist\NuGet Pack linq2db.SqlServer.nuspec
 ..\Redist\NuGet Pack linq2db.Sybase.nuspec
 ..\Redist\NuGet Pack linq2db.Sybase.DataAction.nuspec

--- a/NuGet/linq2db.SQLite.MS.nuspec
+++ b/NuGet/linq2db.SQLite.MS.nuspec
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+	<metadata minClientVersion="3.3.0">
+		<id>linq2db.SQLite.MS</id>
+		<version>2.3.0</version>
+		<title>LINQ to SQLite</title>
+		<authors>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</authors>
+		<owners>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</owners>
+		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
+		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
+		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
+		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<description>
+			LINQ to SQLite is a data access technology that provides a run-time infrastructure for managing relational data as objects.
+		</description>
+		<summary>
+			This package includes a T4 template to generate data models for SQLite database and references to the linq2db and Microsoft.Data.SQLite nugets.
+		</summary>
+		<tags>linq linq2db SQLite LinqToDB ORM database DB SQL</tags>
+		<dependencies>
+			<dependency id="linq2db"                     version="2.3.0"/>
+			<dependency id="Microsoft.Data.Sqlite.Core"  version="2.1.0"/>
+		</dependencies>
+		<contentFiles>
+			<files include="**\*" buildAction="None"/>
+		</contentFiles>
+	</metadata>
+	<files>
+		<file src="..\Tests\Linq\bin\AppVeyor\net46\System.Data.SQLite.dll"  target="tools" />
+		<file src="..\Tests\Linq\bin\AppVeyor\net46\x86\SQLite.Interop.dll"  target="tools" />
+		<file src="..\Source\LinqToDB\bin\Release\net45\linq2db.dll"         target="tools" />
+		
+		<file src="SQLite\linq2db.SQLite.props"                              target="build\linq2db.SQLite.MS.props" />
+		
+		<file src="SQLite\*.*"                                               target="contentFiles\any\any\LinqToDB.Templates" exclude="**\*.props" />
+		<file src="t4models\*.ttinclude"                                     target="contentFiles\any\any\LinqToDB.Templates"/>
+		<file src="..\Source\LinqToDB.Templates\*.ttinclude"                 target="contentFiles\any\any\LinqToDB.Templates" exclude="**\LinqToDB.*.ttinclude"/>
+		<file src="..\Source\LinqToDB.Templates\*.SQLite.ttinclude"          target="contentFiles\any\any\LinqToDB.Templates" />
+		
+		<file src="SQLite\*.*"                                               target="content\LinqToDB.Templates" exclude="**\*.props" />
+		<file src="t4models\*.ttinclude"                                     target="content\LinqToDB.Templates"/>
+		<file src="..\Source\LinqToDB.Templates\*.ttinclude"                 target="content\LinqToDB.Templates" exclude="**\LinqToDB.*.ttinclude"/>
+		<file src="..\Source\LinqToDB.Templates\*.SQLite.ttinclude"          target="content\LinqToDB.Templates" />
+	</files>
+</package>

--- a/NuGet/linq2db.SQLite.nuspec
+++ b/NuGet/linq2db.SQLite.nuspec
@@ -18,8 +18,14 @@
 		</summary>
 		<tags>linq linq2db SQLite LinqToDB ORM database DB SQL</tags>
 		<dependencies>
-			<dependency id="System.Data.SQLite.Core" version="1.0.107"  />
-			<dependency id="linq2db"                 version="2.3.0"/>
+			<group targetFramework="net45">
+				<dependency id="linq2db"                  version="2.3.0"/>
+				<dependency id="System.Data.SQLite.Core"  version="1.0.107"/>
+			</group>
+			<group targetFramework="netstandard2.0">
+				<dependency id="linq2db"                  version="2.3.0"/>
+				<dependency id="Microsoft.Data.Sqlite.Core"  version="2.1.0"/>
+			</group>
 		</dependencies>
 		<contentFiles>
 			<files include="**\*" buildAction="None"/>

--- a/NuGet/linq2db.SQLite.nuspec
+++ b/NuGet/linq2db.SQLite.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 	<metadata minClientVersion="3.3.0">
 		<id>linq2db.SQLite</id>
-		<version>2.3.0</version>
+		<version>2.3.1</version>
 		<title>LINQ to SQLite</title>
 		<authors>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</authors>
 		<owners>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</owners>
@@ -18,14 +18,8 @@
 		</summary>
 		<tags>linq linq2db SQLite LinqToDB ORM database DB SQL</tags>
 		<dependencies>
-			<group targetFramework="net45">
-				<dependency id="linq2db"                  version="2.3.0"/>
-				<dependency id="System.Data.SQLite.Core"  version="1.0.107"/>
-			</group>
-			<group targetFramework="netstandard2.0">
-				<dependency id="linq2db"                  version="2.3.0"/>
-				<dependency id="Microsoft.Data.Sqlite.Core"  version="2.1.0"/>
-			</group>
+			<dependency id="linq2db"                  version="2.3.0"/>
+			<dependency id="System.Data.SQLite.Core"  version="1.0.107"/>
 		</dependencies>
 		<contentFiles>
 			<files include="**\*" buildAction="None"/>

--- a/linq2db.sln
+++ b/linq2db.sln
@@ -87,6 +87,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NuGet", "NuGet", "{3A081B6E
 		NuGet\linq2db.PostgreSQL.nuspec = NuGet\linq2db.PostgreSQL.nuspec
 		NuGet\linq2db.SapHana.nuspec = NuGet\linq2db.SapHana.nuspec
 		NuGet\linq2db.SqlCe.nuspec = NuGet\linq2db.SqlCe.nuspec
+		NuGet\linq2db.SQLite.MS.nuspec = NuGet\linq2db.SQLite.MS.nuspec
 		NuGet\linq2db.SQLite.nuspec = NuGet\linq2db.SQLite.nuspec
 		NuGet\linq2db.SqlServer.nuspec = NuGet\linq2db.SqlServer.nuspec
 		NuGet\linq2db.Sybase.DataAction.nuspec = NuGet\linq2db.Sybase.DataAction.nuspec

--- a/linq2db.sln
+++ b/linq2db.sln
@@ -89,6 +89,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NuGet", "NuGet", "{3A081B6E
 		NuGet\linq2db.SqlCe.nuspec = NuGet\linq2db.SqlCe.nuspec
 		NuGet\linq2db.SQLite.nuspec = NuGet\linq2db.SQLite.nuspec
 		NuGet\linq2db.SqlServer.nuspec = NuGet\linq2db.SqlServer.nuspec
+		NuGet\linq2db.Sybase.DataAction.nuspec = NuGet\linq2db.Sybase.DataAction.nuspec
 		NuGet\linq2db.Sybase.nuspec = NuGet\linq2db.Sybase.nuspec
 		NuGet\linq2db.t4models.nuspec = NuGet\linq2db.t4models.nuspec
 		NuGet\Pack.bat = NuGet\Pack.bat


### PR DESCRIPTION
Fix #1175 

I'm a bit tired how contentFiles work in different types of projects:
- for old projects they added as files
- for new projects like .net core they added as links
- for xamarin projects they don't added at all, but work

Remaining issues:
- [x] template files are not added to project tree for xamarin projects, so user need to add tt file using copy of sample file extracted from nuget/non-xamarin project