### PR TITLE
MERGE target hints support

### DIFF
--- a/Source/LinqToDB/DataProvider/BasicMergeBuilder.cs
+++ b/Source/LinqToDB/DataProvider/BasicMergeBuilder.cs
@@ -298,7 +298,7 @@ namespace LinqToDB.DataProvider
 
 		private void BuildSource()
 		{
-			Command.AppendLine("USING");
+			Command.AppendLine(" USING");
 
 			if (Merge.QueryableSource != null && SupportsSourceSubQuery)
 				BuildSourceSubQuery(Merge.QueryableSource);
@@ -595,11 +595,13 @@ namespace LinqToDB.DataProvider
 
 		protected virtual void BuildMergeInto()
 		{
-			Command
-				.Append("MERGE INTO ")
-				.Append(TargetTableName)
-				.Append(" ")
-				.AppendLine((string)SqlBuilder.Convert(_targetAlias, ConvertType.NameToQueryTableAlias));
+			var ctx = Merge.Target.GetMergeContext();
+			
+			var target = ctx.GetResultStatement().SelectQuery.Select.From.Tables[0];
+
+			Command.Append("MERGE INTO ");
+
+			SqlBuilder.BuildPhysicalTableHelper(target, _targetAlias, Command);
 		}
 
 		protected virtual void BuildOperation(MergeDefinition<TTarget, TSource>.Operation operation)
@@ -1256,6 +1258,7 @@ namespace LinqToDB.DataProvider
 
 		/// <summary>
 		/// Target table name, ready for use in SQL. Could include database/schema names or/and escaping.
+		/// Doesn't include any hints.
 		/// </summary>
 		protected string TargetTableName { get; private set; }
 

--- a/Source/LinqToDB/DataProvider/Informix/InformixMergeBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixMergeBuilder.cs
@@ -16,51 +16,21 @@ namespace LinqToDB.DataProvider.Informix
 		{
 		}
 
-		protected override bool ProviderUsesAlternativeUpdate
-		{
-			get
-			{
-				// Informix doesn't support INSERT FROM
-				return true;
-			}
-		}
+		// Informix doesn't support INSERT FROM
+		protected override bool ProviderUsesAlternativeUpdate => true;
 
-		protected override bool OperationPredicateSupported
-		{
-			get
-			{
-				// operation conditions not supported
-				return false;
-			}
-		}
+		// operation conditions not supported
+		protected override bool OperationPredicateSupported => false;
 
-		protected override bool SupportsSourceDirectValues
-		{
-			get
-			{
-				// VALUES(...) syntax not supported in MERGE source
-				return false;
-			}
-		}
+		// VALUES(...) syntax not supported in MERGE source
+		protected override bool SupportsSourceDirectValues => false;
 
-		protected override string FakeSourceTable
-		{
-			get
-			{
-				// or
-				// sysmaster:'informix'.sysdual
-				return "table(set{1})";
-			}
-		}
+		// or
+		// sysmaster:'informix'.sysdual
+		protected override string FakeSourceTable => "table(set{1})";
 
-		protected override bool SupportsParametersInSource
-		{
-			get
-			{
-				// parameters in source select list not supported
-				return false;
-			}
-		}
+		// parameters in source select list not supported
+		protected override bool SupportsParametersInSource => false;
 
 		protected override void AddFakeSourceTableName()
 		{
@@ -125,6 +95,26 @@ namespace LinqToDB.DataProvider.Informix
 			BuildColumnType(column, columnType);
 		}
 
-		
+		protected override bool MergeHintsSupported => true;
+
+		protected override void BuildMergeInto()
+		{
+			Command
+				.Append("MERGE ");
+
+			if (Merge.Hint != null)
+			{
+				Command
+					.Append("{+ ")
+					.Append(Merge.Hint)
+					.Append(" } ");
+			}
+
+			Command
+				.Append("INTO ")
+				.Append(TargetTableName)
+				.Append(" ")
+				.AppendLine((string)SqlBuilder.Convert(TargetAlias, ConvertType.NameToQueryTableAlias));
+		}
 	}
 }

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerMergeBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerMergeBuilder.cs
@@ -17,41 +17,17 @@ namespace LinqToDB.DataProvider.SqlServer
 		{
 		}
 
-		protected override bool BySourceOperationsSupported
-		{
-			get
-			{
-				// SQL Server-only commands
-				return true;
-			}
-		}
+		// SQL Server-only commands
+		protected override bool BySourceOperationsSupported => true;
 
-		protected override bool IsIdentityInsertSupported
-		{
-			get
-			{
-				// SQL Server supports explicit identity insert
-				return true;
-			}
-		}
+		// SQL Server supports explicit identity insert
+		protected override bool IsIdentityInsertSupported => true;
 
-		protected override int MaxOperationsCount
-		{
-			get
-			{
-				// Only 3 operations per command supported
-				return 3;
-			}
-		}
+		// Only 3 operations per command supported
+		protected override int MaxOperationsCount => 3;
 
-		protected override bool SameTypeOperationsAllowed
-		{
-			get
-			{
-				// all operations should have different types
-				return false;
-			}
-		}
+		// all operations should have different types
+		protected override bool SameTypeOperationsAllowed => false;
 
 		protected override void BuildTerminator()
 		{
@@ -98,6 +74,26 @@ namespace LinqToDB.DataProvider.SqlServer
 			}
 
 			base.AddSourceValue(valueConverter, column, columnType, value, isFirstRow, isLastRow);
+		}
+
+		protected override bool MergeHintsSupported => true;
+
+		protected override void BuildMergeInto()
+		{
+			Command
+				.Append("MERGE INTO ")
+				.Append(TargetTableName)
+				.Append(" ");
+
+			if (Merge.Hint != null)
+			{
+				Command
+					.Append("WITH(")
+					.Append(Merge.Hint)
+					.Append(") ");
+			}
+
+			Command.AppendLine((string)SqlBuilder.Convert(TargetAlias, ConvertType.NameToQueryTableAlias));
 		}
 	}
 }

--- a/Source/LinqToDB/Merge.cs
+++ b/Source/LinqToDB/Merge.cs
@@ -27,10 +27,25 @@ namespace LinqToDB
 		public static IMergeableUsing<TTarget> Merge<TTarget>(this ITable<TTarget> target)
 				where TTarget : class
 		{
-			if (target == null)
-				throw new ArgumentNullException(nameof(target));
+			if (target == null) throw new ArgumentNullException(nameof(target));
 
 			return new MergeDefinition<TTarget, TTarget>(target);
+		}
+
+		/// <summary>
+		/// Starts merge operation definition from target table.
+		/// </summary>
+		/// <typeparam name="TTarget">Target record type.</typeparam>
+		/// <param name="target">Target table.</param>
+		/// <param name="hint">Database-specific merge hint.</param>
+		/// <returns>Returns merge command builder, that contains only target.</returns>
+		public static IMergeableUsing<TTarget> Merge<TTarget>(this ITable<TTarget> target, string hint)
+				where TTarget : class
+		{
+			if (target == null) throw new ArgumentNullException(nameof(target));
+			if (hint   == null) throw new ArgumentNullException(nameof(hint));
+
+			return new MergeDefinition<TTarget, TTarget>(target, hint);
 		}
 
 		/// <summary>
@@ -43,14 +58,37 @@ namespace LinqToDB
 		/// <returns>Returns merge command builder with source and target set.</returns>
 		public static IMergeableOn<TTarget, TSource> MergeInto<TTarget, TSource>(
 			this IQueryable<TSource> source,
-			ITable<TTarget> target)
+			ITable<TTarget>          target)
 				where TTarget : class
 				where TSource : class
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (target == null) throw new ArgumentNullException(nameof(target));
 
-			return new MergeDefinition<TTarget, TSource>(target, source);
+			return new MergeDefinition<TTarget, TSource>(target, source, null);
+		}
+
+		/// <summary>
+		/// Starts merge operation definition from source query.
+		/// </summary>
+		/// <typeparam name="TTarget">Target record type.</typeparam>
+		/// <typeparam name="TSource">Source record type.</typeparam>
+		/// <param name="source">Source data query.</param>
+		/// <param name="target">Target table.</param>
+		/// <param name="hint">Database-specific merge hint.</param>
+		/// <returns>Returns merge command builder with source and target set.</returns>
+		public static IMergeableOn<TTarget, TSource> MergeInto<TTarget, TSource>(
+			this IQueryable<TSource> source,
+			ITable<TTarget>          target,
+			string                   hint)
+				where TTarget : class
+				where TSource : class
+		{
+			if (source == null) throw new ArgumentNullException(nameof(source));
+			if (target == null) throw new ArgumentNullException(nameof(target));
+			if (hint   == null) throw new ArgumentNullException(nameof(hint));
+
+			return new MergeDefinition<TTarget, TSource>(target, source, hint);
 		}
 
 		/// <summary>
@@ -63,7 +101,7 @@ namespace LinqToDB
 		/// <returns>Returns merge command builder with source and target set.</returns>
 		public static IMergeableOn<TTarget, TSource> Using<TTarget, TSource>(
 			this IMergeableUsing<TTarget> merge,
-			IQueryable<TSource> source)
+			IQueryable<TSource>           source)
 				where TTarget : class
 				where TSource : class
 		{
@@ -83,7 +121,7 @@ namespace LinqToDB
 		/// <returns>Returns merge command builder with source and target set.</returns>
 		public static IMergeableOn<TTarget, TSource> Using<TTarget, TSource>(
 			this IMergeableUsing<TTarget> merge,
-			IEnumerable<TSource> source)
+			IEnumerable<TSource>          source)
 				where TTarget : class
 				where TSource : class
 		{
@@ -122,8 +160,8 @@ namespace LinqToDB
 		/// <returns>Returns merge command builder with source, target and match (ON) set.</returns>
 		public static IMergeableSource<TTarget, TSource> On<TTarget, TSource, TKey>(
 			this IMergeableOn<TTarget, TSource> merge,
-			Expression<Func<TTarget, TKey>> targetKey,
-			Expression<Func<TSource, TKey>> sourceKey)
+			Expression<Func<TTarget, TKey>>     targetKey,
+			Expression<Func<TSource, TKey>>     sourceKey)
 				where TTarget : class
 				where TSource : class
 		{
@@ -143,7 +181,7 @@ namespace LinqToDB
 		/// <param name="matchCondition">Rule to match/join target and source records.</param>
 		/// <returns>Returns merge command builder with source, target and match (ON) set.</returns>
 		public static IMergeableSource<TTarget, TSource> On<TTarget, TSource>(
-			this IMergeableOn<TTarget, TSource> merge,
+			this IMergeableOn<TTarget, TSource>      merge,
 			Expression<Func<TTarget, TSource, bool>> matchCondition)
 				where TTarget : class
 				where TSource : class
@@ -199,7 +237,7 @@ namespace LinqToDB
 		/// <returns>Returns new merge command builder with new operation.</returns>
 		public static IMergeable<TTarget, TTarget> InsertWhenNotMatchedAnd<TTarget>(
 			this IMergeableSource<TTarget, TTarget> merge,
-			Expression<Func<TTarget, bool>> searchCondition)
+			Expression<Func<TTarget, bool>>         searchCondition)
 				where TTarget : class
 		{
 			if (merge           == null) throw new ArgumentNullException(nameof(merge));
@@ -222,7 +260,7 @@ namespace LinqToDB
 		/// <returns>Returns new merge command builder with new operation.</returns>
 		public static IMergeable<TTarget, TSource> InsertWhenNotMatched<TTarget, TSource>(
 			this IMergeableSource<TTarget, TSource> merge,
-			Expression<Func<TSource, TTarget>> setter)
+			Expression<Func<TSource, TTarget>>      setter)
 				where TTarget : class
 				where TSource : class
 		{
@@ -248,8 +286,8 @@ namespace LinqToDB
 		/// <returns>Returns new merge command builder with new operation.</returns>
 		public static IMergeable<TTarget, TSource> InsertWhenNotMatchedAnd<TTarget, TSource>(
 			this IMergeableSource<TTarget, TSource> merge,
-			Expression<Func<TSource, bool>> searchCondition,
-			Expression<Func<TSource, TTarget>> setter)
+			Expression<Func<TSource, bool>>         searchCondition,
+			Expression<Func<TSource, TTarget>>      setter)
 				where TTarget : class
 				where TSource : class
 		{
@@ -291,7 +329,7 @@ namespace LinqToDB
 		/// <param name="searchCondition">Operation execution condition over target and source records.</param>
 		/// <returns>Returns new merge command builder with new operation.</returns>
 		public static IMergeable<TTarget, TTarget> UpdateWhenMatchedAnd<TTarget>(
-			this IMergeableSource<TTarget, TTarget> merge,
+			this IMergeableSource<TTarget, TTarget>  merge,
 			Expression<Func<TTarget, TTarget, bool>> searchCondition)
 				where TTarget : class
 		{
@@ -314,7 +352,7 @@ namespace LinqToDB
 		/// Expression should be a call to target record constructor with field/properties initializers to be recognized by API.</param>
 		/// <returns>Returns new merge command builder with new operation.</returns>
 		public static IMergeable<TTarget, TSource> UpdateWhenMatched<TTarget, TSource>(
-			this IMergeableSource<TTarget, TSource> merge,
+			this IMergeableSource<TTarget, TSource>     merge,
 			Expression<Func<TTarget, TSource, TTarget>> setter)
 				where TTarget : class
 				where TSource : class
@@ -340,8 +378,8 @@ namespace LinqToDB
 		/// Expression should be a call to target record constructor with field/properties initializers to be recognized by API.</param>
 		/// <returns>Returns new merge command builder with new operation.</returns>
 		public static IMergeable<TTarget, TSource> UpdateWhenMatchedAnd<TTarget, TSource>(
-			this IMergeableSource<TTarget, TSource> merge,
-			Expression<Func<TTarget, TSource, bool>> searchCondition,
+			this IMergeableSource<TTarget, TSource>     merge,
+			Expression<Func<TTarget, TSource, bool>>    searchCondition,
 			Expression<Func<TTarget, TSource, TTarget>> setter)
 				where TTarget : class
 				where TSource : class
@@ -368,7 +406,7 @@ namespace LinqToDB
 		/// <param name="deleteCondition">Delete execution condition over updated target and source records.</param>
 		/// <returns>Returns new merge command builder with new operation.</returns>
 		public static IMergeable<TTarget, TTarget> UpdateWhenMatchedThenDelete<TTarget>(
-			this IMergeableSource<TTarget, TTarget> merge,
+			this IMergeableSource<TTarget, TTarget>  merge,
 			Expression<Func<TTarget, TTarget, bool>> deleteCondition)
 				where TTarget : class
 		{
@@ -393,7 +431,7 @@ namespace LinqToDB
 		/// <param name="deleteCondition">Delete execution condition over updated target and source records.</param>
 		/// <returns>Returns new merge command builder with new operation.</returns>
 		public static IMergeable<TTarget, TTarget> UpdateWhenMatchedAndThenDelete<TTarget>(
-			this IMergeableSource<TTarget, TTarget> merge,
+			this IMergeableSource<TTarget, TTarget>  merge,
 			Expression<Func<TTarget, TTarget, bool>> searchCondition,
 			Expression<Func<TTarget, TTarget, bool>> deleteCondition)
 				where TTarget : class
@@ -421,9 +459,9 @@ namespace LinqToDB
 		/// <param name="deleteCondition">Delete execution condition over updated target and source records.</param>
 		/// <returns>Returns new merge command builder with new operation.</returns>
 		public static IMergeable<TTarget, TSource> UpdateWhenMatchedThenDelete<TTarget, TSource>(
-			this IMergeableSource<TTarget, TSource> merge,
+			this IMergeableSource<TTarget, TSource>     merge,
 			Expression<Func<TTarget, TSource, TTarget>> setter,
-			Expression<Func<TTarget, TSource, bool>> deleteCondition)
+			Expression<Func<TTarget, TSource, bool>>    deleteCondition)
 				where TTarget : class
 				where TSource : class
 		{
@@ -452,10 +490,10 @@ namespace LinqToDB
 		/// <param name="deleteCondition">Delete execution condition over updated target and source records.</param>
 		/// <returns>Returns new merge command builder with new operation.</returns>
 		public static IMergeable<TTarget, TSource> UpdateWhenMatchedAndThenDelete<TTarget, TSource>(
-			this IMergeableSource<TTarget, TSource> merge,
-			Expression<Func<TTarget, TSource, bool>> searchCondition,
+			this IMergeableSource<TTarget, TSource>     merge,
+			Expression<Func<TTarget, TSource, bool>>    searchCondition,
 			Expression<Func<TTarget, TSource, TTarget>> setter,
-			Expression<Func<TTarget, TSource, bool>> deleteCondition)
+			Expression<Func<TTarget, TSource, bool>>    deleteCondition)
 				where TTarget : class
 				where TSource : class
 		{
@@ -501,7 +539,7 @@ namespace LinqToDB
 		/// <param name="searchCondition">Operation execution condition over target and source records.</param>
 		/// <returns>Returns new merge command builder with new operation.</returns>
 		public static IMergeable<TTarget, TSource> DeleteWhenMatchedAnd<TTarget, TSource>(
-			this IMergeableSource<TTarget, TSource> merge,
+			this IMergeableSource<TTarget, TSource>  merge,
 			Expression<Func<TTarget, TSource, bool>> searchCondition)
 				where TTarget : class
 				where TSource : class
@@ -529,7 +567,7 @@ namespace LinqToDB
 		/// <returns>Returns new merge command builder with new operation.</returns>
 		public static IMergeable<TTarget, TSource> UpdateWhenNotMatchedBySource<TTarget, TSource>(
 			this IMergeableSource<TTarget, TSource> merge,
-			Expression<Func<TTarget, TTarget>> setter)
+			Expression<Func<TTarget, TTarget>>      setter)
 				where TTarget : class
 				where TSource : class
 		{
@@ -556,8 +594,8 @@ namespace LinqToDB
 		/// <returns>Returns new merge command builder with new operation.</returns>
 		public static IMergeable<TTarget, TSource> UpdateWhenNotMatchedBySourceAnd<TTarget, TSource>(
 			this IMergeableSource<TTarget, TSource> merge,
-			Expression<Func<TTarget, bool>> searchCondition,
-			Expression<Func<TTarget, TTarget>> setter)
+			Expression<Func<TTarget, bool>>         searchCondition,
+			Expression<Func<TTarget, TTarget>>      setter)
 				where TTarget : class
 				where TSource : class
 		{
@@ -605,7 +643,7 @@ namespace LinqToDB
 		/// <returns>Returns new merge command builder with new operation.</returns>
 		public static IMergeable<TTarget, TSource> DeleteWhenNotMatchedBySourceAnd<TTarget, TSource>(
 			this IMergeableSource<TTarget, TSource> merge,
-			Expression<Func<TTarget, bool>> searchCondition)
+			Expression<Func<TTarget, bool>>         searchCondition)
 				where TTarget : class
 				where TSource : class
 		{
@@ -658,12 +696,11 @@ namespace LinqToDB
 		/// <returns>Returns number of target table records, affected by merge comand.</returns>
 		public static async Task<int> MergeAsync<TTarget, TSource>(
 			this IMergeable<TTarget, TSource> merge,
-			CancellationToken token = default)
+			CancellationToken                 token = default)
 				where TTarget : class
 				where TSource : class
 		{
-			if (merge == null)
-				throw new ArgumentNullException(nameof(merge));
+			if (merge == null) throw new ArgumentNullException(nameof(merge));
 
 			var definition = (MergeDefinition<TTarget, TSource>)merge;
 

--- a/Source/LinqToDB/MergeDefinition.cs
+++ b/Source/LinqToDB/MergeDefinition.cs
@@ -25,65 +25,75 @@ namespace LinqToDB
 			Target = target;
 		}
 
-		public MergeDefinition(ITable<TTarget> target, IQueryable<TSource> source)
+		public MergeDefinition(ITable<TTarget> target, string hint)
 		{
 			Target = target;
+			Hint   = hint;
+		}
+
+		public MergeDefinition(ITable<TTarget> target, IQueryable<TSource> source)
+		{
+			Target          = target;
 			QueryableSource = source;
 		}
 
-		private MergeDefinition(
-			ITable<TTarget> target,
-			IEnumerable<TSource> enumerableSource,
-			IQueryable<TSource> queryableSource,
-			Expression<Func<TTarget, TSource, bool>> matchPredicate,
-			Expression targetKey,
-			Expression sourceKey,
-			Type keyType,
-			Operation[] operations)
+		public MergeDefinition(ITable<TTarget> target, IQueryable<TSource> source, string hint)
 		{
-			Target = target;
-			EnumerableSource = enumerableSource;
-			QueryableSource = queryableSource;
-			MatchPredicate = matchPredicate;
-			TargetKey = targetKey;
-			SourceKey = sourceKey;
-			KeyType = keyType;
-
-			Operations = operations ?? new Operation[0];
+			Target          = target;
+			QueryableSource = source;
+			Hint            = hint;
 		}
 
-		public IEnumerable<TSource> EnumerableSource { get; }
+		private MergeDefinition(
+			ITable<TTarget>                          target,
+			string                                   hint,
+			IEnumerable<TSource>                     enumerableSource,
+			IQueryable<TSource>                      queryableSource,
+			Expression<Func<TTarget, TSource, bool>> matchPredicate,
+			Expression                               targetKey,
+			Expression                               sourceKey,
+			Type                                     keyType,
+			Operation[]                              operations)
+		{
+			Target           = target;
+			Hint             = hint;
+			EnumerableSource = enumerableSource;
+			QueryableSource  = queryableSource;
+			MatchPredicate   = matchPredicate;
+			TargetKey        = targetKey;
+			SourceKey        = sourceKey;
+			KeyType          = keyType;
 
-		public Expression<Func<TTarget, TSource, bool>> MatchPredicate { get; }
+			Operations       = operations ?? new Operation[0];
+		}
 
-		public Operation[] Operations { get; }
-
-		public IQueryable<TSource> QueryableSource { get; }
-
-		public ITable<TTarget> Target { get; }
-
-		public Expression TargetKey { get; }
-
-		public Expression SourceKey { get; }
-
-		public Type KeyType { get; }
+		public IEnumerable<TSource>                     EnumerableSource { get; }
+		public Expression<Func<TTarget, TSource, bool>> MatchPredicate   { get; }
+		public Operation[]                              Operations       { get; }
+		public IQueryable<TSource>                      QueryableSource  { get; }
+		public string                                   Hint             { get; }
+		public ITable<TTarget>                          Target           { get; }
+		public Expression                               TargetKey        { get; }
+		public Expression                               SourceKey        { get; }
+		public Type                                     KeyType          { get; }
 
 		public MergeDefinition<TTarget, TNewSource> AddSource<TNewSource>(IQueryable<TNewSource> source)
 			where TNewSource : class
 		{
-			return new MergeDefinition<TTarget, TNewSource>(Target, null, source, null, null, null, null, null);
+			return new MergeDefinition<TTarget, TNewSource>(Target, Hint, null, source, null, null, null, null, null);
 		}
 
 		public MergeDefinition<TTarget, TNewSource> AddSource<TNewSource>(IEnumerable<TNewSource> source)
 			where TNewSource : class
 		{
-			return new MergeDefinition<TTarget, TNewSource>(Target, source, null, null, null, null, null, null);
+			return new MergeDefinition<TTarget, TNewSource>(Target, Hint, source, null, null, null, null, null, null);
 		}
 
 		public MergeDefinition<TTarget, TSource> AddOperation(Operation operation)
 		{
 			return new MergeDefinition<TTarget, TSource>(
 				Target,
+				Hint,
 				EnumerableSource,
 				QueryableSource,
 				MatchPredicate,
@@ -97,6 +107,7 @@ namespace LinqToDB
 		{
 			return new MergeDefinition<TTarget, TSource>(
 				Target,
+				Hint,
 				EnumerableSource,
 				QueryableSource,
 				matchPredicate,
@@ -112,6 +123,7 @@ namespace LinqToDB
 		{
 			return new MergeDefinition<TTarget, TSource>(
 				Target,
+				Hint,
 				EnumerableSource,
 				QueryableSource,
 				null,
@@ -124,30 +136,27 @@ namespace LinqToDB
 		public class Operation
 		{
 			private Operation(
-				MergeOperationType type,
-				Expression<Func<TSource, bool>> notMatchedPredicate,
-				Expression<Func<TTarget, TSource, bool>> matchedPredicate1,
-				Expression<Func<TTarget, TSource, bool>> matchedPredicate2,
-				Expression<Func<TTarget, bool>> bySourcePredicate,
-				Expression<Func<TSource, TTarget>> create,
+				MergeOperationType                          type,
+				Expression<Func<TSource, bool>>             notMatchedPredicate,
+				Expression<Func<TTarget, TSource, bool>>    matchedPredicate1,
+				Expression<Func<TTarget, TSource, bool>>    matchedPredicate2,
+				Expression<Func<TTarget, bool>>             bySourcePredicate,
+				Expression<Func<TSource, TTarget>>          create,
 				Expression<Func<TTarget, TSource, TTarget>> update,
-				Expression<Func<TTarget, TTarget>> updateBySource)
+				Expression<Func<TTarget, TTarget>>          updateBySource)
 			{
-				Type = type;
+				Type                     = type;
 
-				NotMatchedPredicate = notMatchedPredicate;
-				MatchedPredicate = matchedPredicate1;
-				MatchedPredicate2 = matchedPredicate2;
-				BySourcePredicate = bySourcePredicate;
+				NotMatchedPredicate      = notMatchedPredicate;
+				MatchedPredicate         = matchedPredicate1;
+				MatchedPredicate2        = matchedPredicate2;
+				BySourcePredicate        = bySourcePredicate;
 
-				CreateExpression = create;
-				UpdateExpression = update;
+				CreateExpression         = create;
+				UpdateExpression         = update;
 				UpdateBySourceExpression = updateBySource;
 			}
 
-			public Expression<Func<TTarget, bool>> BySourcePredicate { get; }
-
-			public Expression<Func<TSource, TTarget>> CreateExpression { get; }
 
 			public bool HasCondition
 			{
@@ -171,17 +180,14 @@ namespace LinqToDB
 				}
 			}
 
-			public Expression<Func<TTarget, TSource, bool>> MatchedPredicate { get; }
-
-			public Expression<Func<TTarget, TSource, bool>> MatchedPredicate2 { get; }
-
-			public Expression<Func<TSource, bool>> NotMatchedPredicate { get; }
-
-			public MergeOperationType Type { get; }
-
-			public Expression<Func<TTarget, TTarget>> UpdateBySourceExpression { get; }
-
-			public Expression<Func<TTarget, TSource, TTarget>> UpdateExpression { get; private set; }
+			public Expression<Func<TTarget, bool>>             BySourcePredicate        { get; }
+			public Expression<Func<TSource, TTarget>>          CreateExpression         { get; }
+			public Expression<Func<TTarget, TSource, bool>>    MatchedPredicate         { get; }
+			public Expression<Func<TTarget, TSource, bool>>    MatchedPredicate2        { get; }
+			public Expression<Func<TSource, bool>>             NotMatchedPredicate      { get; }
+			public MergeOperationType                          Type                     { get; }
+			public Expression<Func<TTarget, TTarget>>          UpdateBySourceExpression { get; }
+			public Expression<Func<TTarget, TSource, TTarget>> UpdateExpression         { get; private set; }
 
 			public static Operation Delete(
 				Expression<Func<TTarget, TSource, bool>> predicate)
@@ -196,29 +202,29 @@ namespace LinqToDB
 			}
 
 			public static Operation Insert(
-				Expression<Func<TSource, bool>> predicate,
+				Expression<Func<TSource, bool>>    predicate,
 				Expression<Func<TSource, TTarget>> create)
 			{
 				return new Operation(MergeOperationType.Insert, predicate, null, null, null, create, null, null);
 			}
 
 			public static Operation Update(
-				Expression<Func<TTarget, TSource, bool>> predicate,
+				Expression<Func<TTarget, TSource, bool>>    predicate,
 				Expression<Func<TTarget, TSource, TTarget>> udpate)
 			{
 				return new Operation(MergeOperationType.Update, null, predicate, null, null, null, udpate, null);
 			}
 
 			public static Operation UpdateWithDelete(
-				Expression<Func<TTarget, TSource, bool>> updatePredicate,
+				Expression<Func<TTarget, TSource, bool>>    updatePredicate,
 				Expression<Func<TTarget, TSource, TTarget>> udpate,
-				Expression<Func<TTarget, TSource, bool>> deletePredicate)
+				Expression<Func<TTarget, TSource, bool>>    deletePredicate)
 			{
 				return new Operation(MergeOperationType.UpdateWithDelete, null, updatePredicate, deletePredicate, null, null, udpate, null);
 			}
 
 			public static Operation UpdateBySource(
-				Expression<Func<TTarget, bool>> predicate,
+				Expression<Func<TTarget, bool>>    predicate,
 				Expression<Func<TTarget, TTarget>> udpate)
 			{
 				return new Operation(MergeOperationType.UpdateBySource, null, null, null, predicate, null, null, udpate);

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -1254,6 +1254,12 @@ namespace LinqToDB.SqlProvider
 			StringBuilder.AppendLine();
 		}
 
+		internal void BuildPhysicalTableHelper(ISqlTableSource table, string alias, StringBuilder sb)
+		{
+			StringBuilder = sb;
+			BuildPhysicalTable(table, alias);
+		}
+
 		protected void BuildPhysicalTable(ISqlTableSource table, string alias)
 		{
 			switch (table.ElementType)

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -1254,12 +1254,6 @@ namespace LinqToDB.SqlProvider
 			StringBuilder.AppendLine();
 		}
 
-		internal void BuildPhysicalTableHelper(ISqlTableSource table, string alias, StringBuilder sb)
-		{
-			StringBuilder = sb;
-			BuildPhysicalTable(table, alias);
-		}
-
 		protected void BuildPhysicalTable(ISqlTableSource table, string alias)
 		{
 			switch (table.ElementType)

--- a/Tests/Linq/Update/MergeTests.ApiParametersValidation.cs
+++ b/Tests/Linq/Update/MergeTests.ApiParametersValidation.cs
@@ -26,8 +26,15 @@ namespace Tests.xUpdate
 				{
 					() => MergeExtensions.Merge<Child>(null),
 
+					() => MergeExtensions.Merge<Child>(null, "hint"),
+					() => MergeExtensions.Merge<Child>(new FakeTable<Child>(), null),
+
 					() => MergeExtensions.MergeInto<Child, Child>(null, new FakeTable<Child>()),
 					() => MergeExtensions.MergeInto<Child, Child>(new Child[0].AsQueryable(), null),
+
+					() => MergeExtensions.MergeInto<Child, Child>(null, new FakeTable<Child>(), "hint"),
+					() => MergeExtensions.MergeInto<Child, Child>(new Child[0].AsQueryable(), null, "hint"),
+					() => MergeExtensions.MergeInto<Child, Child>(new Child[0].AsQueryable(), new FakeTable<Child>(), null),
 
 					() => MergeExtensions.Using<Child, Child>(null, new Child[0].AsQueryable()),
 					() => MergeExtensions.Using<Child, Child>(new FakeMergeUsing<Child>(), null),

--- a/Tests/Linq/Update/MergeTests.CommandValidation.cs
+++ b/Tests/Linq/Update/MergeTests.CommandValidation.cs
@@ -71,6 +71,11 @@ namespace Tests.xUpdate
 					new object[] { new ValidationTestMergeBuilder(merge.UpdateWhenMatchedAndThenDelete((t, s) => true, (t, s) => true)), "UpdateWithDelete operation not supported by TestProvider provider." },
 					new object[] { new ValidationTestMergeBuilder(merge.UpdateWhenMatchedAndThenDelete((t, s) => true, (t, s) => true).UpdateWhenMatched((t, s) => t)).WithUpdateWithDelete(), "Update operation with UpdateWithDelete operation in the same Merge command not supported by TestProvider provider." },
 					new object[] { new ValidationTestMergeBuilder(merge.UpdateWhenMatchedAndThenDelete((t, s) => true, (t, s) => true).DeleteWhenMatchedAnd((t, s) => true)).WithUpdateWithDelete(), "Delete operation with UpdateWithDelete operation in the same Merge command not supported by TestProvider provider." },
+
+					// hint specified for unsupported provider
+					new object[] { new ValidationTestMergeBuilder(new FakeTable<Child>().Merge("hint").Using(new Child[0]).OnTargetKey().InsertWhenNotMatched()), "Merge hints not supported by TestProvider provider." },
+					new object[] { new ValidationTestMergeBuilder(new FakeTable<Child>().MergeInto(new FakeTable<Child>(), "hint").OnTargetKey().InsertWhenNotMatched()), "Merge hints not supported by TestProvider provider." },
+					
 				}.Select((data, i) => new TestCaseData(data).SetName($"Merge.Validation.Negative.{i}"));
 			}
 		}
@@ -126,6 +131,11 @@ namespace Tests.xUpdate
 					// UpdateWithDelete validation
 					new ValidationTestMergeBuilder(merge.UpdateWhenMatchedAnd((t, s) => true).DeleteWhenMatched()),
 					new ValidationTestMergeBuilder(merge.UpdateWhenMatchedThenDelete((t, s) => true)).WithUpdateWithDelete(),
+
+					// hint specified for supported provider
+					new ValidationTestMergeBuilder(new FakeTable<Child>().Merge("hint").Using(new Child[0]).OnTargetKey().InsertWhenNotMatched()).WithHints(),
+					new ValidationTestMergeBuilder(new FakeTable<Child>().MergeInto(new FakeTable<Child>(), "hint").OnTargetKey().InsertWhenNotMatched()).WithHints(),
+
 				}.Select((data, i) => new TestCaseData(data).SetName($"Merge.Validation.Positive.{i}"));
 			}
 		}
@@ -146,142 +156,55 @@ namespace Tests.xUpdate
 		{
 			private class FakeDataProvider : IDataProvider
 			{
-				string IDataProvider.ConnectionNamespace
-				{
-					get
-					{
-						throw new NotImplementedException();
-					}
-				}
+				string IDataProvider.ConnectionNamespace => throw new NotImplementedException();
 
-				Type IDataProvider.DataReaderType
-				{
-					get
-					{
-						throw new NotImplementedException();
-					}
-				}
+				Type IDataProvider.DataReaderType => throw new NotImplementedException();
 
-				MappingSchema IDataProvider.MappingSchema
-				{
-					get
-					{
-						return null;
-					}
-				}
+				MappingSchema IDataProvider.MappingSchema => null;
 
-				string IDataProvider.Name
-				{
-					get
-					{
-						return "TestProvider";
-					}
-				}
+				string IDataProvider.Name => "TestProvider";
 
-				SqlProviderFlags IDataProvider.SqlProviderFlags
-				{
-					get
-					{
-						throw new NotImplementedException();
-					}
-				}
+				SqlProviderFlags IDataProvider.SqlProviderFlags => throw new NotImplementedException();
 
-				BulkCopyRowsCopied IDataProvider.BulkCopy<T>(DataConnection dataConnection, BulkCopyOptions options, IEnumerable<T> source)
-				{
-					throw new NotImplementedException();
-				}
+				BulkCopyRowsCopied IDataProvider.BulkCopy<T>(DataConnection dataConnection, BulkCopyOptions options, IEnumerable<T> source) => throw new NotImplementedException();
 
-				Type IDataProvider.ConvertParameterType(Type type, DataType dataType)
-				{
-					throw new NotImplementedException();
-				}
+				Type IDataProvider.ConvertParameterType(Type type, DataType dataType) => throw new NotImplementedException();
 
-				IDbConnection IDataProvider.CreateConnection(string connectionString)
-				{
-					throw new NotImplementedException();
-				}
+				IDbConnection IDataProvider.CreateConnection(string connectionString) => throw new NotImplementedException();
 
-				ISqlBuilder IDataProvider.CreateSqlBuilder()
-				{
-					throw new NotImplementedException();
-				}
+				ISqlBuilder IDataProvider.CreateSqlBuilder() => throw new NotImplementedException();
 
-				void IDataProvider.DisposeCommand(DataConnection dataConnection)
-				{
-					throw new NotImplementedException();
-				}
+				void IDataProvider.DisposeCommand(DataConnection dataConnection) => throw new NotImplementedException();
 
-				IDisposable IDataProvider.ExecuteScope()
-				{
-					throw new NotImplementedException();
-				}
+				IDisposable IDataProvider.ExecuteScope() => throw new NotImplementedException();
 
-				CommandBehavior IDataProvider.GetCommandBehavior(CommandBehavior commandBehavior)
-				{
-					throw new NotImplementedException();
-				}
+				CommandBehavior IDataProvider.GetCommandBehavior(CommandBehavior commandBehavior) => throw new NotImplementedException();
 
-				object IDataProvider.GetConnectionInfo(DataConnection dataConnection, string parameterName)
-				{
-					throw new NotImplementedException();
-				}
+				object IDataProvider.GetConnectionInfo(DataConnection dataConnection, string parameterName) => throw new NotImplementedException();
 
-				Expression IDataProvider.GetReaderExpression(MappingSchema mappingSchema, IDataReader reader, int idx, Expression readerExpression, Type toType)
-				{
-					throw new NotImplementedException();
-				}
+				Expression IDataProvider.GetReaderExpression(MappingSchema mappingSchema, IDataReader reader, int idx, Expression readerExpression, Type toType) => throw new NotImplementedException();
 
 #if !NETSTANDARD1_6
-				ISchemaProvider IDataProvider.GetSchemaProvider()
-				{
-					throw new NotImplementedException();
-				}
+				ISchemaProvider IDataProvider.GetSchemaProvider() => throw new NotImplementedException();
 #endif
 
-				ISqlOptimizer IDataProvider.GetSqlOptimizer()
-				{
-					throw new NotImplementedException();
-				}
+				ISqlOptimizer IDataProvider.GetSqlOptimizer() => throw new NotImplementedException();
 
-				void IDataProvider.InitCommand(DataConnection dataConnection, CommandType commandType, string commandText, DataParameter[] parameters)
-				{
-					throw new NotImplementedException();
-				}
+				void IDataProvider.InitCommand(DataConnection dataConnection, CommandType commandType, string commandText, DataParameter[] parameters) => throw new NotImplementedException();
 
-				bool IDataProvider.IsCompatibleConnection(IDbConnection connection)
-				{
-					throw new NotImplementedException();
-				}
+				bool IDataProvider.IsCompatibleConnection(IDbConnection connection) => throw new NotImplementedException();
 
-				bool? IDataProvider.IsDBNullAllowed(IDataReader reader, int idx)
-				{
-					throw new NotImplementedException();
-				}
+				bool? IDataProvider.IsDBNullAllowed(IDataReader reader, int idx) => throw new NotImplementedException();
 
-				int IDataProvider.Merge<T>(DataConnection dataConnection, Expression<Func<T, bool>> predicate, bool delete, IEnumerable<T> source, string tableName, string databaseName, string schemaName)
-				{
-					throw new NotImplementedException();
-				}
+				int IDataProvider.Merge<T>(DataConnection dataConnection, Expression<Func<T, bool>> predicate, bool delete, IEnumerable<T> source, string tableName, string databaseName, string schemaName) => throw new NotImplementedException();
 
-				int IDataProvider.Merge<TTarget, TSource>(DataConnection dataConnection, IMergeable<TTarget, TSource> merge)
-				{
-					throw new NotImplementedException();
-				}
+				int IDataProvider.Merge<TTarget, TSource>(DataConnection dataConnection, IMergeable<TTarget, TSource> merge) => throw new NotImplementedException();
 
-				Task<int> IDataProvider.MergeAsync<T>(DataConnection dataConnection, Expression<Func<T, bool>> predicate, bool delete, IEnumerable<T> source, string tableName, string databaseName, string schemaName, CancellationToken token)
-				{
-					throw new NotImplementedException();
-				}
+				Task<int> IDataProvider.MergeAsync<T>(DataConnection dataConnection, Expression<Func<T, bool>> predicate, bool delete, IEnumerable<T> source, string tableName, string databaseName, string schemaName, CancellationToken token) => throw new NotImplementedException();
 
-				Task<int> IDataProvider.MergeAsync<TTarget, TSource>(DataConnection dataConnection, IMergeable<TTarget, TSource> merge, CancellationToken token)
-				{
-					throw new NotImplementedException();
-				}
+				Task<int> IDataProvider.MergeAsync<TTarget, TSource>(DataConnection dataConnection, IMergeable<TTarget, TSource> merge, CancellationToken token) => throw new NotImplementedException();
 
-				void IDataProvider.SetParameter(IDbDataParameter parameter, string name, DataType dataType, object value)
-				{
-					throw new NotImplementedException();
-				}
+				void IDataProvider.SetParameter(IDbDataParameter parameter, string name, DataType dataType, object value) => throw new NotImplementedException();
 			}
 
 			private bool _bySourceOperationsSupported = false;
@@ -294,6 +217,8 @@ namespace Tests.xUpdate
 
 			private bool _updateWithDeleteOperationSupported = false;
 
+			private bool _mergeHintsSupported = false;
+
 			// initialize with SQL:2008 defaults (same as base class)
 			private int _operationsLimit = 0;
 
@@ -302,53 +227,19 @@ namespace Tests.xUpdate
 			{
 			}
 
-			protected override bool BySourceOperationsSupported
-			{
-				get
-				{
-					return _bySourceOperationsSupported;
-				}
-			}
+			protected override bool BySourceOperationsSupported => _bySourceOperationsSupported;
 
-			protected override bool DeleteOperationSupported
-			{
-				get
-				{
-					return _deleteOperationSupported;
-				}
-			}
+			protected override bool DeleteOperationSupported => _deleteOperationSupported;
 
-			protected override int MaxOperationsCount
-			{
-				get
-				{
-					return _operationsLimit;
-				}
-			}
+			protected override int MaxOperationsCount => _operationsLimit;
 
-			protected override bool OperationPredicateSupported
-			{
-				get
-				{
-					return _conditionsSupported;
-				}
-			}
+			protected override bool OperationPredicateSupported => _conditionsSupported;
 
-			protected override bool SameTypeOperationsAllowed
-			{
-				get
-				{
-					return _duplicateSameTypeOperations;
-				}
-			}
+			protected override bool SameTypeOperationsAllowed => _duplicateSameTypeOperations;
 
-			protected override bool UpdateWithDeleteOperationSupported
-			{
-				get
-				{
-					return _updateWithDeleteOperationSupported;
-				}
-			}
+			protected override bool UpdateWithDeleteOperationSupported => _updateWithDeleteOperationSupported;
+
+			protected override bool MergeHintsSupported => _mergeHintsSupported;
 
 			public ValidationTestMergeBuilder WithUpdateWithDelete()
 			{
@@ -383,6 +274,12 @@ namespace Tests.xUpdate
 			public ValidationTestMergeBuilder WithoutDuplicates()
 			{
 				_duplicateSameTypeOperations = false;
+				return this;
+			}
+
+			public ValidationTestMergeBuilder WithHints()
+			{
+				_mergeHintsSupported = true;
 				return this;
 			}
 		}

--- a/Tests/Linq/Update/MergeTests.Hints.cs
+++ b/Tests/Linq/Update/MergeTests.Hints.cs
@@ -10,7 +10,7 @@ namespace Tests.xUpdate
 	public partial class MergeTests
 	{
 		[Test, IncludeDataContextSource(false, TestProvName.SqlAzure, ProviderName.SqlServer2008, ProviderName.SqlServer2012, ProviderName.SqlServer2014)]
-		public void MergeIntoWithTargetHint(string context)
+		public void MergeIntoWithTargetHintSqlServer(string context)
 		{
 			using (var db = new TestDataConnection(context))
 			{
@@ -19,12 +19,12 @@ namespace Tests.xUpdate
 				var table = GetTarget(db);
 
 				var rows = GetSource1(db)
-					.MergeInto(GetTarget(db).WithTableExpression("{0} WITH (HOLDLOCK) {1}"))
+					.MergeInto(GetTarget(db), "HOLDLOCK")
 					.OnTargetKey()
 					.InsertWhenNotMatched()
 					.Merge();
 
-				Assert.True(db.LastQuery.Contains("MERGE INTO [TestMerge1] WITH (HOLDLOCK) [Target]"));
+				Assert.True(db.LastQuery.Contains("MERGE INTO [TestMerge1] WITH(HOLDLOCK) [Target]"));
 
 				var result = table.OrderBy(_ => _.Id).ToList();
 
@@ -42,7 +42,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test, IncludeDataContextSource(false, TestProvName.SqlAzure, ProviderName.SqlServer2008, ProviderName.SqlServer2012, ProviderName.SqlServer2014)]
-		public void UsingTargetWithTargetHint(string context)
+		public void UsingTargetWithTargetHintSqlServer(string context)
 		{
 			using (var db = new TestDataConnection(context))
 			{
@@ -50,8 +50,8 @@ namespace Tests.xUpdate
 
 				var table = GetTarget(db);
 
-				var rows = GetTarget(db).WithTableExpression("{0} WITH (HOLDLOCK) {1}")
-					.Merge()
+				var rows = GetTarget(db)
+					.Merge("HOLDLOCK")
 					.UsingTarget()
 					.OnTargetKey()
 					.UpdateWhenMatched((t, s) => new TestMapping1()
@@ -60,7 +60,7 @@ namespace Tests.xUpdate
 					})
 					.Merge();
 
-				Assert.True(db.LastQuery.Contains("MERGE INTO [TestMerge1] WITH (HOLDLOCK) [Target]"));
+				Assert.True(db.LastQuery.Contains("MERGE INTO [TestMerge1] WITH(HOLDLOCK) [Target]"));
 
 				var result = table.OrderBy(_ => _.Id).ToList();
 
@@ -99,7 +99,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test, IncludeDataContextSource(false, TestProvName.SqlAzure, ProviderName.SqlServer2008, ProviderName.SqlServer2012, ProviderName.SqlServer2014)]
-		public void MergeWithTargetHint(string context)
+		public void MergeWithTargetHintSqlServer(string context)
 		{
 			using (var db = new TestDataConnection(context))
 			{
@@ -107,8 +107,8 @@ namespace Tests.xUpdate
 
 				var table = GetTarget(db);
 
-				var rows = GetTarget(db).WithTableExpression("{0} WITH (HOLDLOCK) {1}")
-					.Merge()
+				var rows = GetTarget(db)
+					.Merge("HOLDLOCK")
 					.Using(GetSource1(db).Where(s => s.Field1 != null && s.Field2 != null))
 					.On(t => new { t.Field1, t.Field2 }, s => new { s.Field1, Field2 = (int?)6 })
 					.UpdateWhenMatched((t, s) => new TestMapping1()
@@ -117,7 +117,7 @@ namespace Tests.xUpdate
 					})
 					.Merge();
 
-				Assert.True(db.LastQuery.Contains("MERGE INTO [TestMerge1] WITH (HOLDLOCK) [Target]"));
+				Assert.True(db.LastQuery.Contains("MERGE INTO [TestMerge1] WITH(HOLDLOCK) [Target]"));
 
 				var result = table.OrderBy(_ => _.Id).ToList();
 
@@ -135,6 +135,70 @@ namespace Tests.xUpdate
 				Assert.AreEqual(321, result[3].Field3);
 				Assert.AreEqual(InitialTargetData[3].Field4, result[3].Field4);
 				Assert.IsNull(result[3].Field5);
+			}
+		}
+
+		[Test, IncludeDataContextSource(false, ProviderName.Oracle, ProviderName.OracleNative, ProviderName.OracleManaged)]
+		public void MergeIntoWithTargetHintOracle(string context)
+		{
+			using (var db = new TestDataConnection(context))
+			{
+				PrepareData(db);
+
+				var table = GetTarget(db);
+
+				var rows = GetSource1(db)
+					.MergeInto(GetTarget(db), "append")
+					.OnTargetKey()
+					.InsertWhenNotMatched()
+					.Merge();
+
+				Assert.True(db.LastQuery.Contains("MERGE /*+ append */ INTO TestMerge1 Target"));
+
+				var result = table.OrderBy(_ => _.Id).ToList();
+
+				AssertRowCount(2, rows, context);
+
+				Assert.AreEqual(6, result.Count);
+
+				AssertRow(InitialTargetData[0], result[0], null, null);
+				AssertRow(InitialTargetData[1], result[1], null, null);
+				AssertRow(InitialTargetData[2], result[2], null, 203);
+				AssertRow(InitialTargetData[3], result[3], null, null);
+				AssertRow(InitialSourceData[2], result[4], null, null);
+				AssertRow(InitialSourceData[3], result[5], null, 216);
+			}
+		}
+
+		[Test, IncludeDataContextSource(false, ProviderName.Informix)]
+		public void MergeIntoWithTargetHintInformix(string context)
+		{
+			using (var db = new TestDataConnection(context))
+			{
+				PrepareData(db);
+
+				var table = GetTarget(db);
+
+				var rows = GetSource1(db)
+					.MergeInto(GetTarget(db), "AVOID_STMT_CACHE")
+					.OnTargetKey()
+					.InsertWhenNotMatched()
+					.Merge();
+
+				Assert.True(db.LastQuery.Contains("MERGE {+ AVOID_STMT_CACHE } INTO TestMerge1 Target"));
+
+				var result = table.OrderBy(_ => _.Id).ToList();
+
+				AssertRowCount(2, rows, context);
+
+				Assert.AreEqual(6, result.Count);
+
+				AssertRow(InitialTargetData[0], result[0], null, null);
+				AssertRow(InitialTargetData[1], result[1], null, null);
+				AssertRow(InitialTargetData[2], result[2], null, 203);
+				AssertRow(InitialTargetData[3], result[3], null, null);
+				AssertRow(InitialSourceData[2], result[4], null, null);
+				AssertRow(InitialSourceData[3], result[5], null, 216);
 			}
 		}
 	}

--- a/Tests/Linq/Update/MergeTests.Hints.cs
+++ b/Tests/Linq/Update/MergeTests.Hints.cs
@@ -1,0 +1,141 @@
+﻿using NUnit.Framework;
+using System.Linq;
+
+namespace Tests.xUpdate
+{
+	using LinqToDB;
+	using Model;
+
+	// tests for query hints
+	public partial class MergeTests
+	{
+		[Test, IncludeDataContextSource(false, TestProvName.SqlAzure, ProviderName.SqlServer2008, ProviderName.SqlServer2012, ProviderName.SqlServer2014)]
+		public void MergeIntoWithTargetHint(string context)
+		{
+			using (var db = new TestDataConnection(context))
+			{
+				PrepareData(db);
+
+				var table = GetTarget(db);
+
+				var rows = GetSource1(db)
+					.MergeInto(GetTarget(db).WithTableExpression("{0} WITH (HOLDLOCK) {1}"))
+					.OnTargetKey()
+					.InsertWhenNotMatched()
+					.Merge();
+
+				Assert.True(db.LastQuery.Contains("MERGE INTO [TestMerge1] WITH (HOLDLOCK) [Target]"));
+
+				var result = table.OrderBy(_ => _.Id).ToList();
+
+				AssertRowCount(2, rows, context);
+
+				Assert.AreEqual(6, result.Count);
+
+				AssertRow(InitialTargetData[0], result[0], null, null);
+				AssertRow(InitialTargetData[1], result[1], null, null);
+				AssertRow(InitialTargetData[2], result[2], null, 203);
+				AssertRow(InitialTargetData[3], result[3], null, null);
+				AssertRow(InitialSourceData[2], result[4], null, null);
+				AssertRow(InitialSourceData[3], result[5], null, 216);
+			}
+		}
+
+		[Test, IncludeDataContextSource(false, TestProvName.SqlAzure, ProviderName.SqlServer2008, ProviderName.SqlServer2012, ProviderName.SqlServer2014)]
+		public void UsingTargetWithTargetHint(string context)
+		{
+			using (var db = new TestDataConnection(context))
+			{
+				PrepareData(db);
+
+				var table = GetTarget(db);
+
+				var rows = GetTarget(db).WithTableExpression("{0} WITH (HOLDLOCK) {1}")
+					.Merge()
+					.UsingTarget()
+					.OnTargetKey()
+					.UpdateWhenMatched((t, s) => new TestMapping1()
+					{
+						Field1 = t.Field1 + s.Field2
+					})
+					.Merge();
+
+				Assert.True(db.LastQuery.Contains("MERGE INTO [TestMerge1] WITH (HOLDLOCK) [Target]"));
+
+				var result = table.OrderBy(_ => _.Id).ToList();
+
+				AssertRowCount(4, rows, context);
+
+				Assert.AreEqual(4, result.Count);
+
+				Assert.AreEqual(InitialTargetData[0].Id, result[0].Id);
+				Assert.AreEqual(InitialTargetData[0].Field1 + InitialTargetData[0].Field2, result[0].Field1);
+				Assert.AreEqual(InitialTargetData[0].Field2, result[0].Field2);
+				Assert.IsNull(result[0].Field3);
+				Assert.IsNull(result[0].Field4);
+				Assert.IsNull(result[0].Field5);
+
+				Assert.AreEqual(InitialTargetData[1].Id, result[1].Id);
+				Assert.AreEqual(InitialTargetData[1].Field1 + InitialTargetData[1].Field2, result[1].Field1);
+				Assert.AreEqual(InitialTargetData[1].Field2, result[1].Field2);
+				Assert.IsNull(result[1].Field3);
+				Assert.IsNull(result[1].Field4);
+				Assert.IsNull(result[1].Field5);
+
+				Assert.AreEqual(InitialTargetData[2].Id, result[2].Id);
+				Assert.AreEqual(InitialTargetData[2].Field1 + InitialTargetData[2].Field2, result[2].Field1);
+				Assert.AreEqual(InitialTargetData[2].Field2, result[2].Field2);
+				Assert.IsNull(result[2].Field3);
+				Assert.AreEqual(203, result[2].Field4);
+				Assert.IsNull(result[2].Field5);
+
+				Assert.AreEqual(InitialTargetData[3].Id, result[3].Id);
+				Assert.AreEqual(InitialTargetData[3].Field1 + InitialTargetData[3].Field2, result[3].Field1);
+				Assert.AreEqual(InitialTargetData[3].Field2, result[3].Field2);
+				Assert.IsNull(result[3].Field3);
+				Assert.IsNull(result[3].Field4);
+				Assert.IsNull(result[3].Field5);
+			}
+		}
+
+		[Test, IncludeDataContextSource(false, TestProvName.SqlAzure, ProviderName.SqlServer2008, ProviderName.SqlServer2012, ProviderName.SqlServer2014)]
+		public void MergeWithTargetHint(string context)
+		{
+			using (var db = new TestDataConnection(context))
+			{
+				PrepareData(db);
+
+				var table = GetTarget(db);
+
+				var rows = GetTarget(db).WithTableExpression("{0} WITH (HOLDLOCK) {1}")
+					.Merge()
+					.Using(GetSource1(db).Where(s => s.Field1 != null && s.Field2 != null))
+					.On(t => new { t.Field1, t.Field2 }, s => new { s.Field1, Field2 = (int?)6 })
+					.UpdateWhenMatched((t, s) => new TestMapping1()
+					{
+						Field3 = 321
+					})
+					.Merge();
+
+				Assert.True(db.LastQuery.Contains("MERGE INTO [TestMerge1] WITH (HOLDLOCK) [Target]"));
+
+				var result = table.OrderBy(_ => _.Id).ToList();
+
+				AssertRowCount(1, rows, context);
+
+				Assert.AreEqual(4, result.Count);
+
+				AssertRow(InitialTargetData[0], result[0], null, null);
+				AssertRow(InitialTargetData[1], result[1], null, null);
+				AssertRow(InitialTargetData[2], result[2], null, 203);
+
+				Assert.AreEqual(InitialTargetData[3].Id, result[3].Id);
+				Assert.AreEqual(InitialTargetData[3].Field1, result[3].Field1);
+				Assert.AreEqual(InitialTargetData[3].Field2, result[3].Field2);
+				Assert.AreEqual(321, result[3].Field3);
+				Assert.AreEqual(InitialTargetData[3].Field4, result[3].Field4);
+				Assert.IsNull(result[3].Field5);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fix #1272

SQL Server supports hints on target table, this PR adds support for hints generation.

~Because merge uses different ordering of hint and table alias, you cannot use `With` method, which will put hint after alias and need to use `WithTableExpression` method to specify proper ordering:~
```cs
// {0} is a table
// {1} is an alias
// for merge target alias must go after hint
table.WithTableExpression("{0} WITH (HOLDLOCK) {1}")
```

TODO:
- ~[ ] `UsingTarget` method produce bad sql. We should remove hint from target table, when it used as source~

Edit:
code above shouldn't be used for merge-specific hints, see below