### PR TITLE
[DO NOT MERGE BEFORE 3.0] Fix typo in MappingSchema and MappingSchemaInfo

### DIFF
--- a/Source/LinqToDB/Mapping/MappingSchema.cs
+++ b/Source/LinqToDB/Mapping/MappingSchema.cs
@@ -1379,9 +1379,9 @@ namespace LinqToDB.Mapping
 		/// <returns>
 		/// Mapping types.
 		/// </returns>
-		public Type[] GetEntites()
+		public Type[] GetEntities()
 		{
-			return Schemas[0].GetEntites();
+			return Schemas[0].GetEntities();
 		}
 
 		internal void ResetEntityDescriptor(Type type)

--- a/Source/LinqToDB/Mapping/MappingSchemaInfo.cs
+++ b/Source/LinqToDB/Mapping/MappingSchemaInfo.cs
@@ -264,7 +264,7 @@ namespace LinqToDB.Mapping
 		/// <returns>
 		///     <see cref="Array{Type}" />
 		/// </returns>
-		public Type[] GetEntites()
+		public Type[] GetEntities()
 		{
 			return _entityDescriptors.Keys.ToArray();
 		}


### PR DESCRIPTION
Nothing fancy, just fixes two or three typos.