### PR TITLE
Fix char constants support in compare operations with char? operands in expressions

### DIFF
--- a/Data/Create Scripts/SapHana.sql
+++ b/Data/Create Scripts/SapHana.sql
@@ -351,7 +351,7 @@ INSERT INTO "AllTypes"
 ) VALUES( 
 	123456789123456789, 12345, 1234.567, 123.456, 123456789, 123, 1234.567, 1234.567,
 	'2012-12-12', '12:12:12', '2012-12-12 12:12:12', '2012-12-12 12:12:12.123',	           
-	'a', 'bcd', 'abcdefgh', 'def', 'ą',  'ąčęėįš', 'qwert123QWE',
+	'1', 'bcd', 'abcdefgh', 'def', 'ą',  'ąčęėįš', 'qwert123QWE',
 	CAST( 'abcdefgh' AS BINARY), CAST( 'abcdefgh' AS VARBINARY),
 	'abcdefgh', 'qwertyuiop', 'ąčęėįšqwerty123456' );;
 

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -1525,6 +1525,19 @@ namespace LinqToDB.Linq.Builder
 				}
 			}
 
+			if (left.NodeType == ExpressionType.Convert && left.Type == typeof(int?) && (right.NodeType == ExpressionType.Constant || (right.NodeType == ExpressionType.Convert && ((UnaryExpression)right).Operand.NodeType == ExpressionType.Convert)))
+			{
+				var conv = (UnaryExpression)left;
+
+				if (conv.Operand.Type == typeof(char?))
+				{
+					left = conv.Operand;
+					right = right.NodeType == ExpressionType.Constant
+						? Expression.Constant(ConvertTo<char>.From(((ConstantExpression)right).Value))
+						: ((UnaryExpression)((UnaryExpression)right).Operand).Operand;
+				}
+			}
+
 			if (right.NodeType == ExpressionType.Convert && right.Type == typeof(int) && (left.NodeType == ExpressionType.Constant || left.NodeType == ExpressionType.Convert))
 			{
 				var conv = (UnaryExpression)right;
@@ -1535,6 +1548,19 @@ namespace LinqToDB.Linq.Builder
 					left  = left.NodeType == ExpressionType.Constant
 						? Expression.Constant(ConvertTo<char>.From(((ConstantExpression) left).Value))
 						: ((UnaryExpression) left).Operand;
+				}
+			}
+
+			if (right.NodeType == ExpressionType.Convert && right.Type == typeof(int?) && (left.NodeType == ExpressionType.Constant || (left.NodeType == ExpressionType.Convert && ((UnaryExpression)left).Operand.NodeType == ExpressionType.Convert)))
+			{
+				var conv = (UnaryExpression)right;
+
+				if (conv.Operand.Type == typeof(char?))
+				{
+					right = conv.Operand;
+					left = left.NodeType == ExpressionType.Constant
+						? Expression.Constant(ConvertTo<char>.From(((ConstantExpression)left).Value))
+						: ((UnaryExpression)((UnaryExpression)left).Operand).Operand;
 				}
 			}
 

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -1512,7 +1512,9 @@ namespace LinqToDB.Linq.Builder
 
 		ISqlPredicate ConvertCompare(IBuildContext context, ExpressionType nodeType, Expression left, Expression right)
 		{
-			if (left.NodeType == ExpressionType.Convert && left.Type == typeof(int) && (right.NodeType == ExpressionType.Constant || right.NodeType == ExpressionType.Convert))
+			if (left.NodeType == ExpressionType.Convert
+				&& left.Type == typeof(int)
+				&& (right.NodeType == ExpressionType.Constant || right.NodeType == ExpressionType.Convert))
 			{
 				var conv  = (UnaryExpression)left;
 
@@ -1525,7 +1527,11 @@ namespace LinqToDB.Linq.Builder
 				}
 			}
 
-			if (left.NodeType == ExpressionType.Convert && left.Type == typeof(int?) && (right.NodeType == ExpressionType.Constant || (right.NodeType == ExpressionType.Convert && ((UnaryExpression)right).Operand.NodeType == ExpressionType.Convert)))
+			if (left.NodeType == ExpressionType.Convert
+				&& left.Type == typeof(int?)
+				&& (right.NodeType == ExpressionType.Constant
+					|| (right.NodeType == ExpressionType.Convert
+						&& ((UnaryExpression)right).Operand.NodeType == ExpressionType.Convert)))
 			{
 				var conv = (UnaryExpression)left;
 
@@ -1538,7 +1544,9 @@ namespace LinqToDB.Linq.Builder
 				}
 			}
 
-			if (right.NodeType == ExpressionType.Convert && right.Type == typeof(int) && (left.NodeType == ExpressionType.Constant || left.NodeType == ExpressionType.Convert))
+			if (right.NodeType == ExpressionType.Convert
+				&& right.Type == typeof(int)
+				&& (left.NodeType == ExpressionType.Constant || left.NodeType == ExpressionType.Convert))
 			{
 				var conv = (UnaryExpression)right;
 
@@ -1551,7 +1559,11 @@ namespace LinqToDB.Linq.Builder
 				}
 			}
 
-			if (right.NodeType == ExpressionType.Convert && right.Type == typeof(int?) && (left.NodeType == ExpressionType.Constant || (left.NodeType == ExpressionType.Convert && ((UnaryExpression)left).Operand.NodeType == ExpressionType.Convert)))
+			if (right.NodeType == ExpressionType.Convert
+				&& right.Type == typeof(int?)
+				&& (left.NodeType == ExpressionType.Constant
+					|| (left.NodeType == ExpressionType.Convert
+						&& ((UnaryExpression)left).Operand.NodeType == ExpressionType.Convert)))
 			{
 				var conv = (UnaryExpression)right;
 

--- a/Source/LinqToDB/SqlProvider/ValueToSqlConverter.cs
+++ b/Source/LinqToDB/SqlProvider/ValueToSqlConverter.cs
@@ -152,8 +152,7 @@ namespace LinqToDB.SqlProvider
 
 		bool TryConvertImpl(StringBuilder stringBuilder, SqlDataType dataType, object value, bool tryBase)
 		{
-			if (value == null || value is INullable && ((INullable)value).IsNull
-				)
+			if (value == null || value is INullable && ((INullable)value).IsNull)
 			{
 				stringBuilder.Append("NULL");
 				return true;

--- a/Tests/Linq/UserTests/Issue1287Tests.cs
+++ b/Tests/Linq/UserTests/Issue1287Tests.cs
@@ -1,0 +1,53 @@
+﻿using System.Linq;
+using LinqToDB;
+using LinqToDB.Mapping;
+using NUnit.Framework;
+
+namespace Tests.UserTests
+{
+	[TestFixture]
+	public class Issue1287Tests : TestBase
+	{
+		[Table]
+		[Table("ALLTYPES", Configuration = ProviderName.DB2)]
+		private class AllTypes
+		{
+			[Column]
+			[Column("CHARDATATYPE", Configuration = ProviderName.DB2)]
+			public char charDataType { get; set; }
+		}
+
+		[Table("AllTypes")]
+		[Table("ALLTYPES", Configuration = ProviderName.DB2)]
+		private class AllTypesNullable
+		{
+			[Column]
+			[Column("CHARDATATYPE", Configuration = ProviderName.DB2)]
+			public char? charDataType { get; set; }
+		}
+
+		[Test, DataContextSource(ProviderName.SqlCe)]
+		public void TestNullableChar(string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var list = db.GetTable<AllTypesNullable>().Where(_ => _.charDataType == '1').ToList();
+
+				Assert.AreEqual(1, list.Count);
+				Assert.AreEqual('1', list[0].charDataType);
+			}
+		}
+
+		[Test, DataContextSource(ProviderName.SqlCe)]
+		public void TestChar(string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var list = db.GetTable<AllTypes>().Where(_ => _.charDataType == '1').ToList();
+
+				Assert.AreEqual(1, list.Count);
+				Assert.AreEqual('1', list[0].charDataType);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fix #1287

Actually it is overoptimization from compiler that we reverted for char but missed same logic for char?