### PR TITLE
Fix serialization issues in WCF

### DIFF
--- a/NuGet/linq2db.SQLite.MS.nuspec
+++ b/NuGet/linq2db.SQLite.MS.nuspec
@@ -18,8 +18,8 @@
 		</summary>
 		<tags>linq linq2db SQLite LinqToDB ORM database DB SQL</tags>
 		<dependencies>
-			<dependency id="linq2db"                     version="2.3.0"/>
-			<dependency id="Microsoft.Data.Sqlite.Core"  version="2.1.0"/>
+			<dependency id="linq2db"                version="2.3.0"/>
+			<dependency id="Microsoft.Data.Sqlite"  version="2.1.0"/>
 		</dependencies>
 		<contentFiles>
 			<files include="**\*" buildAction="None"/>

--- a/Source/LinqToDB/DataProvider/Informix/InformixBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixBulkCopy.cs
@@ -9,7 +9,7 @@ namespace LinqToDB.DataProvider.Informix
 		protected override BulkCopyRowsCopied MultipleRowsCopy<T>(
 			DataConnection dataConnection, BulkCopyOptions options, IEnumerable<T> source)
 		{
-			using (new InformixCultureFixRegion())
+			using (new InvariantCultureRegion())
 				return base.MultipleRowsCopy(dataConnection, options, source);
 
 			//return MultipleRowsCopy3(dataConnection, options, source, " FROM table(set{1})");

--- a/Source/LinqToDB/DataProvider/Informix/InformixDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixDataProvider.cs
@@ -55,19 +55,19 @@ namespace LinqToDB.DataProvider.Informix
 
 		static float GetFloat(IDataReader dr, int idx)
 		{
-			using (new InformixCultureFixRegion())
+			using (new InvariantCultureRegion())
 				return dr.GetFloat(idx);
 		}
 
 		static double GetDouble(IDataReader dr, int idx)
 		{
-			using (new InformixCultureFixRegion())
+			using (new InvariantCultureRegion())
 				return dr.GetDouble(idx);
 		}
 
 		static decimal GetDecimal(IDataReader dr, int idx)
 		{
-			using (new InformixCultureFixRegion())
+			using (new InvariantCultureRegion())
 				return dr.GetDecimal(idx);
 		}
 
@@ -79,7 +79,7 @@ namespace LinqToDB.DataProvider.Informix
 
 		public override IDisposable ExecuteScope()
 		{
-			return new InformixCultureFixRegion();
+			return new InvariantCultureRegion();
 		}
 
 		protected override void OnConnectionTypeCreated(Type connectionType)

--- a/Source/LinqToDB/DataProvider/InvariantCultureRegion.cs
+++ b/Source/LinqToDB/DataProvider/InvariantCultureRegion.cs
@@ -2,18 +2,18 @@
 using System.Globalization;
 using System.Threading;
 
-namespace LinqToDB.DataProvider.Informix
+namespace LinqToDB
 {
-	internal class InformixCultureFixRegion : IDisposable
+	internal class InvariantCultureRegion : IDisposable
 	{
 #if !NETSTANDARD1_6
 		private readonly CultureInfo _original;
 #endif
 
-		public InformixCultureFixRegion()
+		public InvariantCultureRegion()
 		{
 #if !NETSTANDARD1_6
-			if (Thread.CurrentThread.CurrentCulture.NumberFormat.CurrencyDecimalSeparator != ".")
+			if (!Thread.CurrentThread.CurrentCulture.Equals(CultureInfo.InvariantCulture))
 			{
 				_original = Thread.CurrentThread.CurrentCulture;
 				Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;

--- a/Source/LinqToDB/ServiceModel/LinqService.cs
+++ b/Source/LinqToDB/ServiceModel/LinqService.cs
@@ -78,6 +78,7 @@ namespace LinqToDB.ServiceModel
 				ValidateQuery(query);
 
 				using (var db = CreateDataContext(configuration))
+				using (db.DataProvider.ExecuteScope())
 				{
 					return DataConnection.QueryRunner.ExecuteNonQuery(db, new QueryContext
 					{
@@ -104,12 +105,13 @@ namespace LinqToDB.ServiceModel
 				ValidateQuery(query);
 
 				using (var db = CreateDataContext(configuration))
+				using (db.DataProvider.ExecuteScope())
 				{
 					return DataConnection.QueryRunner.ExecuteScalar(db, new QueryContext
 					{
-						Statement = query.Statement,
-						Parameters  = query.Parameters,
-						QueryHints  = query.QueryHints
+						Statement  = query.Statement,
+						Parameters = query.Parameters,
+						QueryHints = query.QueryHints
 					});
 				}
 			}
@@ -130,6 +132,7 @@ namespace LinqToDB.ServiceModel
 				ValidateQuery(query);
 
 				using (var db = CreateDataContext(configuration))
+				using (db.DataProvider.ExecuteScope())
 				{
 					using (var rd = DataConnection.QueryRunner.ExecuteReader(db, new QueryContext
 					{
@@ -260,6 +263,7 @@ namespace LinqToDB.ServiceModel
 					ValidateQuery(query);
 
 				using (var db = CreateDataContext(configuration))
+				using (db.DataProvider.ExecuteScope())
 				{
 					db.BeginTransaction();
 

--- a/Source/LinqToDB/ServiceModel/LinqServiceSerializer.cs
+++ b/Source/LinqToDB/ServiceModel/LinqServiceSerializer.cs
@@ -65,7 +65,7 @@ namespace LinqToDB.ServiceModel
 
 			static string ConvertToString(Type type, object value)
 			{
-				switch (type.GetTypeCodeEx())
+				switch (type.ToNullableUnderlying().GetTypeCodeEx())
 				{
 					case TypeCode.Decimal  : return ((decimal) value).ToString(CultureInfo.InvariantCulture);
 					case TypeCode.Double   : return ((double)  value).ToString(CultureInfo.InvariantCulture);
@@ -494,7 +494,7 @@ namespace LinqToDB.ServiceModel
 				if (str == null)
 					return null;
 
-				switch (type.GetTypeCodeEx())
+				switch (type.ToNullableUnderlying().GetTypeCodeEx())
 				{
 					case TypeCode.Decimal  : return decimal. Parse(str, CultureInfo.InvariantCulture);
 					case TypeCode.Double   : return double.  Parse(str, CultureInfo.InvariantCulture);

--- a/Source/LinqToDB/ServiceModel/RemoteDataContextBase.cs
+++ b/Source/LinqToDB/ServiceModel/RemoteDataContextBase.cs
@@ -158,7 +158,7 @@ namespace LinqToDB.ServiceModel
 
 		static MethodInfo GetReaderMethodInfo(Type type)
 		{
-			switch (type.GetTypeCodeEx())
+			switch (type.ToNullableUnderlying().GetTypeCodeEx())
 			{
 				case TypeCode.Boolean  : return MemberHelper.MethodOf<IDataReader>(r => r.GetBoolean (0));
 				case TypeCode.Byte     : return MemberHelper.MethodOf<IDataReader>(r => r.GetByte    (0));

--- a/Source/LinqToDB/ServiceModel/ServiceModelDataReader.cs
+++ b/Source/LinqToDB/ServiceModel/ServiceModelDataReader.cs
@@ -219,23 +219,17 @@ namespace LinqToDB.ServiceModel
 			if (type.IsArray && type == typeof(byte[]))
 				return ConvertTo<byte[]>.From(value);
 
-			switch (type.GetTypeCodeEx())
+			switch (type.ToNullableUnderlying().GetTypeCodeEx())
 			{
 				case TypeCode.String   : return value;
 				case TypeCode.Double   : return double.  Parse(value, CultureInfo.InvariantCulture);
 				case TypeCode.Decimal  : return decimal. Parse(value, CultureInfo.InvariantCulture);
 				case TypeCode.Single   : return float.   Parse(value, CultureInfo.InvariantCulture);
 				case TypeCode.DateTime : return DateTime.Parse(value, CultureInfo.InvariantCulture);
-				case TypeCode.Object   :
-					if (type == typeof(double?))   return double.        Parse(value, CultureInfo.InvariantCulture);
-					if (type == typeof(decimal?))  return decimal.       Parse(value, CultureInfo.InvariantCulture);
-					if (type == typeof(float?))    return float.         Parse(value, CultureInfo.InvariantCulture);
-					if (type == typeof(DateTime?)) return DateTime.      Parse(value, CultureInfo.InvariantCulture);
-
-					if (type == typeof(DateTimeOffset) || type == typeof(DateTimeOffset?))
-						return DateTimeOffset.Parse(value, CultureInfo.InvariantCulture);
-					break;
 			}
+
+			if (type == typeof(DateTimeOffset) || type == typeof(DateTimeOffset?))
+				return DateTimeOffset.Parse(value, CultureInfo.InvariantCulture);
 
 			return Converter.ChangeType(value, type, _mappingSchema);
 		}

--- a/Tests/Linq/DataProvider/SQLiteTests.cs
+++ b/Tests/Linq/DataProvider/SQLiteTests.cs
@@ -88,9 +88,18 @@ namespace Tests.DataProvider
 			}
 		}
 
+		// this adds type as string using single quotes, but sqlite understands such syntax
+		[Sql.Expression("CAST({0} as {1})", ServerSideOnly = true)]
+		static TValue Cast<TValue>(TValue value, string type)
+		{
+			throw new InvalidOperationException();
+		}
+
 		static void TestNumeric<T>(DataConnection conn, T expectedValue, DataType dataType, string skip = "")
 		{
 			var skipTypes = skip.Split(' ');
+
+			conn.InlineParameters = true;
 
 			foreach (var sqlType in new[]
 				{
@@ -107,14 +116,21 @@ namespace Tests.DataProvider
 					"real"
 				}.Except(skipTypes))
 			{
-				var sqlValue = expectedValue is bool ? (bool)(object)expectedValue? 1 : 0 : (object)expectedValue;
+				var result = conn.Select(() => Cast(expectedValue, sqlType));
 
-				var sql = string.Format(CultureInfo.InvariantCulture, "SELECT Cast({0} as {1})", sqlValue ?? "NULL", sqlType);
-
-				Debug.WriteLine(sql + " -> " + typeof(T));
-
-				Assert.That(conn.Execute<T>(sql), Is.EqualTo(expectedValue));
+				// sqlite floating point parser doesn't restore roundtrip values properly
+				// and also deviation could differ for different versions of engine
+				// see https://system.data.sqlite.org/index.html/tktview/fb9e4b30874d83042e09c2f791d6065fc5e73a4b
+				// and TestDoubleRoundTrip test
+				if (expectedValue is double doubleValue)
+					Assert.AreEqual(doubleValue, (double)(object)result, Math.Abs(doubleValue) * 1e-15);
+				else if (expectedValue is float floatValue)
+					Assert.AreEqual(floatValue, (float)(object)result, Math.Abs(floatValue) * 1e-9);
+				else
+					Assert.That(result, Is.EqualTo(expectedValue));
 			}
+
+			conn.InlineParameters = false;
 
 			Debug.WriteLine("{0} -> DataType.{1}",  typeof(T), dataType);
 			Assert.That(conn.Execute<T>("SELECT @p", new DataParameter { Name = "p", DataType = dataType, Value = expectedValue }), Is.EqualTo(expectedValue));
@@ -124,12 +140,12 @@ namespace Tests.DataProvider
 			Assert.That(conn.Execute<T>("SELECT @p", new { p = expectedValue }), Is.EqualTo(expectedValue));
 		}
 
-		static void TestSimple<T>(DataConnection conn, T expectedValue, DataType dataType)
+		static void TestSimple<T>(DataConnection conn, T expectedValue, DataType dataType, string skip = "")
 			where T : struct
 		{
-			TestNumeric<T> (conn, expectedValue, dataType);
-			TestNumeric<T?>(conn, expectedValue, dataType);
-			TestNumeric<T?>(conn, (T?)null,      dataType);
+			TestNumeric<T> (conn, expectedValue, dataType, skip);
+			TestNumeric<T?>(conn, expectedValue, dataType, skip);
+			TestNumeric<T?>(conn, (T?)null,      dataType, skip);
 		}
 
 		[Test, IncludeDataContextSource(ProviderName.SQLiteClassic, ProviderName.SQLiteMS)]
@@ -146,12 +162,18 @@ namespace Tests.DataProvider
 				TestSimple<ushort> (conn, 1,    DataType.UInt16);
 				TestSimple<uint>   (conn, 1u,   DataType.UInt32);
 				TestSimple<ulong>  (conn, 1ul,  DataType.UInt64);
-				TestSimple<float>  (conn, 1,    DataType.Single);
+				TestSimple<float>  (conn, 1f,   DataType.Single);
+				TestSimple<float>  (conn, 1.1f, DataType.Single,      "bigint int smallint tinyint");
 				TestSimple<double> (conn, 1d,   DataType.Double);
+				TestSimple<double> (conn, 1.1d, DataType.Double,      "bigint int smallint tinyint");
 				TestSimple<decimal>(conn, 1m,   DataType.Decimal);
+				//TestSimple<decimal>(conn, 1.1m, DataType.Decimal,     "bigint int smallint tinyint");
 				TestSimple<decimal>(conn, 1m,   DataType.VarNumeric);
+				//TestSimple<decimal>(conn, 1.1m, DataType.VarNumeric,  "bigint int smallint tinyint");
 				TestSimple<decimal>(conn, 1m,   DataType.Money);
+				//TestSimple<decimal>(conn, 1.1m, DataType.Money,       "bigint int smallint tinyint");
 				TestSimple<decimal>(conn, 1m,   DataType.SmallMoney);
+				//TestSimple<decimal>(conn, 1.1m, DataType.SmallMoney,  "bigint int smallint tinyint");
 
 				TestNumeric(conn, sbyte.MinValue,    DataType.SByte);
 				TestNumeric(conn, sbyte.MaxValue,    DataType.SByte);
@@ -184,13 +206,37 @@ namespace Tests.DataProvider
 			}
 		}
 
-		[Test, IncludeDataContextSource(ProviderName.SQLiteClassic, ProviderName.SQLiteMS), Category("WindowsOnly")]
+		[ActiveIssue("https://system.data.sqlite.org/index.html/tktview/fb9e4b30874d83042e09c2f791d6065fc5e73a4b")]
+		[Test, IncludeDataContextSource(ProviderName.SQLiteClassic, ProviderName.SQLiteMS)]
+		public void TestDoubleRoundTrip(string context)
+		{
+			using (var conn = new DataConnection(context))
+			{
+				var cmd = conn.CreateCommand();
+				var value = -1.7900000000000002E+308;
+
+				// SELECT CAST(-1.7900000000000002E+308 as real)
+				cmd.CommandText = FormattableString.Invariant($"SELECT CAST({value:G17} as real)");
+				using (var rd = cmd.ExecuteReader())
+				{
+					rd.Read();
+					var valueFromDB = rd.GetDouble(0);
+
+					// -1.790000000000001E+308d != -1.7900000000000002E+308
+					Assert.AreEqual(value, valueFromDB);
+				}
+			}
+		}
+
+		[Test, IncludeDataContextSource(ProviderName.SQLiteClassic, ProviderName.SQLiteMS)]
 		public void TestNumericsDouble(string context)
 		{
 			using (var conn = new DataConnection(context))
 			{
+				TestNumeric(conn, -1.7900000000000002E+308d, DataType.Double, "bigint int smallint tinyint");
 				TestNumeric(conn, -1.7900000000000008E+308d, DataType.Double, "bigint int smallint tinyint");
-				TestNumeric(conn, 1.7900000000000008E+308d, DataType.Double, "bigint int smallint tinyint");
+				TestNumeric(conn,  1.7900000000000002E+308d, DataType.Double, "bigint int smallint tinyint");
+				TestNumeric(conn,  1.7900000000000008E+308d, DataType.Double, "bigint int smallint tinyint");
 			}
 		}
 

--- a/Tests/Linq/Tests.csproj
+++ b/Tests/Linq/Tests.csproj
@@ -188,7 +188,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-		<PackageReference Include="Microsoft.Data.SQLite" Version="2.0.1" />
+		<PackageReference Include="Microsoft.Data.SQLite" Version="2.1.0" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' OR '$(TargetFramework)' == 'netcoreapp2.0' ">


### PR DESCRIPTION
just copied fixes from #1286 

- fix serialization to use invariant culture for nullable types
- use provider execution scope for WCF (this fix Informix over WCF queries on systems with non-invariant decimal format)