### PR TITLE
Fix char parameters for microsoft.data.sqlite

### DIFF
--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteDataProvider.cs
@@ -107,8 +107,7 @@ namespace LinqToDB.DataProvider.SQLite
 
 		public override void SetParameter(IDbDataParameter parameter, string name, DataType dataType, object value)
 		{
-			if (Name == ProviderName.SQLiteMS && value is char
-				&& (dataType == DataType.Char || dataType == DataType.NChar))
+			if (Name == ProviderName.SQLiteMS && value is char)
 			{
 				value = value.ToString();
 			}

--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteDataProvider.cs
@@ -107,6 +107,12 @@ namespace LinqToDB.DataProvider.SQLite
 
 		public override void SetParameter(IDbDataParameter parameter, string name, DataType dataType, object value)
 		{
+			if (Name == ProviderName.SQLiteMS && value is char
+				&& (dataType == DataType.Char || dataType == DataType.NChar))
+			{
+				value = value.ToString();
+			}
+
 			base.SetParameter(parameter, "@" + name, dataType, value);
 		}
 

--- a/Tests/Linq/UserTests/Issue1279Tests.cs
+++ b/Tests/Linq/UserTests/Issue1279Tests.cs
@@ -1,0 +1,35 @@
+﻿using LinqToDB;
+using LinqToDB.Mapping;
+using NUnit.Framework;
+using System.Linq;
+
+namespace Tests.UserTests
+{
+	[TestFixture]
+	public class Issue1279Tests : TestBase
+	{
+		class Issue1279Table
+		{
+			[PrimaryKey(1)]
+			[Identity] public int Id { get; set; }
+
+			public char CharFld { get; set; }
+		}
+
+		[Test, DataContextSource]
+		public void Test(string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var table = db.CreateTempTable<Issue1279Table>())
+			{
+				var val = 'P';
+
+				db.Insert(new Issue1279Table { CharFld = val });
+
+				var result = db.GetTable<Issue1279Table>().First().CharFld;
+
+				Assert.AreEqual(val, result);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fix #1279

Confirm that only microsoft's sqlite provider returns wrong value (both 1.x and 2.x)
