### PR TITLE
Add unicode test for sybase

### DIFF
--- a/Data/Create Scripts/Sybase.sql
+++ b/Data/Create Scripts/Sybase.sql
@@ -11,6 +11,8 @@ GO
 USE {DBNAME}
 GO
 
+sp_configure 'enable unicode normalization', 0
+GO
 CREATE TABLE InheritanceParent
 (
 	InheritanceParentId int          NOT NULL,

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseMappingSchema.cs
@@ -51,18 +51,12 @@ namespace LinqToDB.DataProvider.Sybase
 
 		static void ConvertStringToSql(StringBuilder stringBuilder, string value)
 		{
-			string startPrefix = null;
-
-			if (value.Any(ch => ch > 127))
-				startPrefix = "N";
-
-			DataTools.ConvertStringToSql(stringBuilder, "+", startPrefix, AppendConversion, value, null);
+			DataTools.ConvertStringToSql(stringBuilder, "+", null, AppendConversion, value, null);
 		}
 
 		static void ConvertCharToSql(StringBuilder stringBuilder, char value)
 		{
-			var start = value > 127 ? "N'" : "'";
-			DataTools.ConvertCharToSql(stringBuilder, start, AppendConversion, value);
+			DataTools.ConvertCharToSql(stringBuilder, "'", AppendConversion, value);
 		}
 
 		internal static readonly SybaseMappingSchema Instance = new SybaseMappingSchema();

--- a/Tests/Linq/DataProvider/SybaseTests.cs
+++ b/Tests/Linq/DataProvider/SybaseTests.cs
@@ -316,38 +316,77 @@ namespace Tests.DataProvider
 		{
 			using (var conn = new DataConnection(context))
 			{
-				Assert.That(conn.Execute<string>("SELECT Cast('12345' as char)"),          Is.EqualTo("12345"));
-				Assert.That(conn.Execute<string>("SELECT Cast('12345' as char(20))"),      Is.EqualTo("12345"));
-				Assert.That(conn.Execute<string>("SELECT Cast(NULL    as char(20))"),      Is.Null);
+				Assert.That(conn.Execute<string>("SELECT Cast('12345' as char)"),                       Is.EqualTo("12345"));
+				Assert.That(conn.Execute<string>("SELECT Cast('12345' as char(20))"),                   Is.EqualTo("12345"));
+				Assert.That(conn.Execute<string>("SELECT Cast('12345' as char(20))"),                   Is.EqualTo("12345"));
+				Assert.That(conn.Execute<string>("SELECT Cast(NULL    as char(20))"),                   Is.Null);
 
-				Assert.That(conn.Execute<string>("SELECT Cast('12345' as varchar)"),       Is.EqualTo("12345"));
-				Assert.That(conn.Execute<string>("SELECT Cast('12345' as varchar(20))"),   Is.EqualTo("12345"));
-				Assert.That(conn.Execute<string>("SELECT Cast(NULL    as varchar(20))"),   Is.Null);
+				Assert.That(conn.Execute<string>("SELECT Cast('12345' as varchar)"),                    Is.EqualTo("12345"));
+				Assert.That(conn.Execute<string>("SELECT Cast('12345' as varchar(20))"),                Is.EqualTo("12345"));
+				Assert.That(conn.Execute<string>("SELECT Cast(NULL    as varchar(20))"),                Is.Null);
 
-				Assert.That(conn.Execute<string>("SELECT Cast('12345' as text)"),          Is.EqualTo("12345"));
-				Assert.That(conn.Execute<string>("SELECT Cast(NULL    as text)"),          Is.Null);
+				Assert.That(conn.Execute<string>("SELECT Cast('12345' as text)"),                       Is.EqualTo("12345"));
+				Assert.That(conn.Execute<string>("SELECT Cast(NULL    as text)"),                       Is.Null);
 
-				Assert.That(conn.Execute<string>("SELECT Cast('12345' as nchar)"),         Is.EqualTo("12345"));
-				Assert.That(conn.Execute<string>("SELECT Cast('12345' as nchar(20))"),     Is.EqualTo("12345"));
-				Assert.That(conn.Execute<string>("SELECT Cast(NULL    as nchar(20))"),     Is.Null);
+				Assert.That(conn.Execute<string>("SELECT Cast('12345' as nchar)"),                      Is.EqualTo("12345"));
+				Assert.That(conn.Execute<string>("SELECT Cast('12345' as nchar(20))"),                  Is.EqualTo("12345"));
+				Assert.That(conn.Execute<string>("SELECT Cast(NULL    as nchar(20))"),                  Is.Null);
 
-				Assert.That(conn.Execute<string>("SELECT Cast('12345' as nvarchar)"),      Is.EqualTo("12345"));
-				Assert.That(conn.Execute<string>("SELECT Cast('12345' as nvarchar(20))"),  Is.EqualTo("12345"));
-				Assert.That(conn.Execute<string>("SELECT Cast(NULL    as nvarchar(20))"),  Is.Null);
+				Assert.That(conn.Execute<string>("SELECT Cast('12345' as nvarchar)"),                   Is.EqualTo("12345"));
+				Assert.That(conn.Execute<string>("SELECT Cast('12345' as nvarchar(20))"),               Is.EqualTo("12345"));
+				Assert.That(conn.Execute<string>("SELECT Cast(NULL    as nvarchar(20))"),               Is.Null);
 
-				Assert.That(conn.Execute<string>("SELECT Cast('12345' as unitext)"),       Is.EqualTo("12345"));
-				Assert.That(conn.Execute<string>("SELECT Cast(NULL    as unitext)"),       Is.Null);
+				Assert.That(conn.Execute<string>("SELECT Cast('12345' as unitext)"),                    Is.EqualTo("12345"));
+				Assert.That(conn.Execute<string>("SELECT Cast(NULL    as unitext)"),                    Is.Null);
 
-				Assert.That(conn.Execute<string>("SELECT @p", DataParameter.Char    ("p", "123")), Is.EqualTo("123"));
-				Assert.That(conn.Execute<string>("SELECT @p", DataParameter.VarChar ("p", "123")), Is.EqualTo("123"));
-				Assert.That(conn.Execute<string>("SELECT @p", DataParameter.Text    ("p", "123")), Is.EqualTo("123"));
-				Assert.That(conn.Execute<string>("SELECT @p", DataParameter.NChar   ("p", "123")), Is.EqualTo("123"));
-				Assert.That(conn.Execute<string>("SELECT @p", DataParameter.NVarChar("p", "123")), Is.EqualTo("123"));
-				Assert.That(conn.Execute<string>("SELECT @p", DataParameter.NText   ("p", "123")), Is.EqualTo("123"));
-				Assert.That(conn.Execute<string>("SELECT @p", DataParameter.Create  ("p", "123")), Is.EqualTo("123"));
+				Assert.That(conn.Execute<string>("SELECT @p", DataParameter.Char    ("p", "123")),      Is.EqualTo("123"));
+				Assert.That(conn.Execute<string>("SELECT @p", DataParameter.VarChar ("p", "123")),      Is.EqualTo("123"));
+				Assert.That(conn.Execute<string>("SELECT @p", DataParameter.Text    ("p", "123")),      Is.EqualTo("123"));
+				Assert.That(conn.Execute<string>("SELECT @p", DataParameter.NChar   ("p", "123")),      Is.EqualTo("123"));
+				Assert.That(conn.Execute<string>("SELECT @p", DataParameter.NVarChar("p", "123")),      Is.EqualTo("123"));
+				Assert.That(conn.Execute<string>("SELECT @p", DataParameter.NText   ("p", "123")),      Is.EqualTo("123"));
+				Assert.That(conn.Execute<string>("SELECT @p", DataParameter.Create  ("p", "123")),      Is.EqualTo("123"));
 
-				Assert.That(conn.Execute<string>("SELECT @p", DataParameter.Create("p", (string)null)), Is.EqualTo(null));
-				Assert.That(conn.Execute<string>("SELECT @p", new DataParameter { Name = "p", Value = "1" }), Is.EqualTo("1"));
+				Assert.That(conn.Execute<string>("SELECT @p", DataParameter.Create("p", (string)null)),         Is.EqualTo(null));
+				Assert.That(conn.Execute<string>("SELECT @p", new DataParameter { Name = "p", Value = "1" }),   Is.EqualTo("1"));
+			}
+		}
+
+		[ActiveIssue]
+		[Test, IncludeDataContextSource(CurrentProvider, CurrentProviderCore)]
+		public void TestUnicodeString(string context)
+		{
+			// some notes why unicode tests below doesn't work:
+			// - sybase reference driver replaces \u2000 with \u2002 in literals (but not in parameters without N prefix)
+			// - managed driver replaces \u2000 with \u2002 with spaces in literals
+			// - managed driver use latin1 encoding on read and return ? for non-latin1 characters
+			// - both drivers doesn't like \x0 in parameter value
+			using (var conn = new DataConnection(context))
+			{
+				var unicodeString = "\x00'\u2000\u2001\u2002\u2003\uabab\u03bctесt";
+				var unicodeLiteral = "u&'\\0000\'\\2000\\2001\\2002\\2003\\abab\\03bctесt'";
+				
+				// test raw literals queries
+				Assert.That(conn.Execute<string>($"SELECT Cast({unicodeLiteral} as char)"),                Is.EqualTo(unicodeString));
+				Assert.That(conn.Execute<string>($"SELECT Cast({unicodeLiteral} as varchar)"),             Is.EqualTo(unicodeString));
+				Assert.That(conn.Execute<string>($"SELECT Cast({unicodeLiteral} as text)"),                Is.EqualTo(unicodeString));
+				Assert.That(conn.Execute<string>($"SELECT Cast({unicodeLiteral} as nchar)"),               Is.EqualTo(unicodeString));
+				Assert.That(conn.Execute<string>($"SELECT Cast({unicodeLiteral} as nvarchar)"),            Is.EqualTo(unicodeString));
+				Assert.That(conn.Execute<string>($"SELECT Cast({unicodeLiteral} as unitext)"),             Is.EqualTo(unicodeString));
+
+				// test parameters
+				Assert.That(conn.Execute<string>("SELECT @p", DataParameter.Char    ("p", unicodeString)), Is.EqualTo(unicodeString));
+				Assert.That(conn.Execute<string>("SELECT @p", DataParameter.VarChar ("p", unicodeString)), Is.EqualTo(unicodeString));
+				Assert.That(conn.Execute<string>("SELECT @p", DataParameter.Text    ("p", unicodeString)), Is.EqualTo(unicodeString));
+				Assert.That(conn.Execute<string>("SELECT @p", DataParameter.NChar   ("p", unicodeString)), Is.EqualTo(unicodeString));
+				Assert.That(conn.Execute<string>("SELECT @p", DataParameter.NVarChar("p", unicodeString)), Is.EqualTo(unicodeString));
+				Assert.That(conn.Execute<string>("SELECT @p", DataParameter.NText   ("p", unicodeString)), Is.EqualTo(unicodeString));
+				Assert.That(conn.Execute<string>("SELECT @p", DataParameter.Create  ("p", unicodeString)), Is.EqualTo(unicodeString));
+
+				// test default linq2db behavior for parameter and literal
+				Assert.That(conn.Select(() => unicodeString), Is.EqualTo(unicodeString));
+				conn.InlineParameters = true;
+				Assert.That(conn.Select(() => unicodeString), Is.EqualTo(unicodeString));
 			}
 		}
 

--- a/Tests/Linq/Linq/CharTypesTests.cs
+++ b/Tests/Linq/Linq/CharTypesTests.cs
@@ -130,15 +130,7 @@ namespace Tests.Linq
 						if (!SkipChar(context))
 							Assert.AreEqual(testData[i].String?.TrimEnd(' '), records[i].String);
 
-						if (   context == ProviderName.Sybase
-							|| context == ProviderName.Sybase + ".LinqService")
-							// this kind of replacement is allowed in unicode, but dunno why it is done for sybase
-							Assert.AreEqual(
-								testData[i].NString?.TrimEnd(' ')
-									.Replace('\u2000', '\u2002')
-									.Replace('\u2001', '\u2003'),
-								records[i].NString);
-						else if (context != ProviderName.Firebird
+						if (context != ProviderName.Firebird
 							  && context != ProviderName.Firebird + ".LinqService"
 							  && context != TestProvName.Firebird3
 							  && context != TestProvName.Firebird3 + ".LinqService")
@@ -292,14 +284,7 @@ namespace Tests.Linq
 						if (!SkipChar(context))
 							Assert.AreEqual(testData[i].Char, records[i].Char);
 
-						if (   context == ProviderName.Sybase
-							|| context == ProviderName.Sybase + ".LinqService")
-							// this kind of replacement is allowed in unicode, but dunno why it is done for sybase
-							Assert.AreEqual(
-								testData[i].NChar == '\u2000' || testData[i].NChar == '\u2001'
-									? (char)(testData[i].NChar + 2) : testData[i].NChar,
-								records[i].NChar);
-						else if (context == ProviderName.MySql
+						if (context == ProviderName.MySql
 							  || context == ProviderName.MySql + ".LinqService"
 							  || context == TestProvName.MySql57
 							  || context == TestProvName.MySql57 + ".LinqService"

--- a/Tests/Linq/Update/MergeTests.Types.cs
+++ b/Tests/Linq/Update/MergeTests.Types.cs
@@ -384,7 +384,7 @@ namespace Tests.xUpdate
 			if (context != ProviderName.Access)
 				Assert.AreEqual(expected.FieldInt64, actual.FieldInt64);
 
-			if (context != ProviderName.Sybase)
+			if (context != ProviderName.Sybase && context != ProviderName.SybaseManaged)
 				if (context != ProviderName.Access)
 					Assert.AreEqual(expected.FieldBoolean, actual.FieldBoolean);
 				else
@@ -440,7 +440,7 @@ namespace Tests.xUpdate
 		{
 			if (expected != null)
 			{
-				if (context == ProviderName.Sybase)
+				if (context == ProviderName.Sybase || context == ProviderName.SybaseManaged)
 					expected = expected.TrimEnd(' ');
 			}
 
@@ -460,7 +460,7 @@ namespace Tests.xUpdate
 
 			if (expected != null)
 			{
-				if (context == ProviderName.Sybase)
+				if (context == ProviderName.Sybase || context == ProviderName.SybaseManaged)
 				{
 					while (expected.Length > 1 && expected[expected.Length - 1] == 0)
 						expected = expected.Take(expected.Length - 1).ToArray();
@@ -505,6 +505,7 @@ namespace Tests.xUpdate
 				&& context != ProviderName.SQLiteClassic
 				&& context != ProviderName.SQLiteMS
 				&& context != ProviderName.Sybase
+				&& context != ProviderName.SybaseManaged
 				&& context != ProviderName.DB2
 				&& context != ProviderName.SapHana)
 				Assert.AreEqual(expected, actual);
@@ -545,7 +546,7 @@ namespace Tests.xUpdate
 				if (context == TestProvName.MySql57 && expected.Value.Millisecond > 500)
 					expected = expected.Value.AddSeconds(1);
 
-				if (context == ProviderName.Sybase)
+				if (context == ProviderName.Sybase || context == ProviderName.SybaseManaged)
 				{
 					switch (expected.Value.Millisecond % 10)
 					{
@@ -584,6 +585,7 @@ namespace Tests.xUpdate
 				switch (context)
 				{
 					case ProviderName.Sybase:
+					case ProviderName.SybaseManaged:
 						expected = expected.TrimEnd(' ');
 						break;
 					case ProviderName.Informix:
@@ -618,6 +620,7 @@ namespace Tests.xUpdate
 				switch (context)
 				{
 					case ProviderName.Sybase:
+					case ProviderName.SybaseManaged:
 						expected = TimeSpan.FromTicks((expected.Value.Ticks / 10000) * 10000);
 						switch (expected.Value.Milliseconds % 10)
 						{


### PR DESCRIPTION
Nothing fancy, just more tests, fix for unicode normalization in tests and removal N prefix from string literals as it is not supported by Sybase and just ignored