### PR TITLE
[WIP] Fix: Convert Firebird UInt32 to Int32 when dialect is 1

### DIFF
--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdConfiguration.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdConfiguration.cs
@@ -4,6 +4,20 @@ namespace LinqToDB.DataProvider.Firebird
 {
 	public static class FirebirdConfiguration
 	{
+		/// <summary>  Values that represent fb dialects. 
+		/// <see href="https://www.firebirdsql.org/pdfmanual/html/isql-dialects.html">Firbird-Dialects</see></summary>
+		public enum FbDialect
+		{
+         /// <summary>  There is no specific dialect defined. </summary>
+			Undefined = 0,
+         /// <summary> dialect 1. </summary>
+			Dialect1 = 1,
+         /// <summary>  dialect 2. </summary>
+			Dialect2 = 2,
+         /// <summary>  dialect 3. </summary>
+			Dialect3 = 3
+		}
+
 		[Obsolete("Use FirebirdSqlBuilder.IdentifierQuoteMode instead.")]
 		public static bool QuoteIdentifiers
 		{
@@ -22,5 +36,9 @@ namespace LinqToDB.DataProvider.Firebird
 		/// Specifies that Firebird supports literal encoding. Availiable from version 2.5.
 		/// </summary>
 		public static bool IsLiteralEncodingSupported = true;
+
+      /// <summary>  The current used Firebird dialect. This is not a connection configuration. 
+      ///            It is more a global information to handle dialect specific conversions (e.g. bigint in dialect 1).</summary>
+		public static FbDialect UsedDialect = FbDialect.Undefined;
 	}
 }

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdDataProvider.cs
@@ -94,6 +94,11 @@ namespace LinqToDB.DataProvider.Firebird
 				dataType = DataType.Char;
 			}
 
+			if (FirebirdConfiguration.UsedDialect == FirebirdConfiguration.FbDialect.Dialect1 && (value is Int64 || value is UInt64))
+			{
+				value = Convert.ToInt32(value);
+				dataType = DataType.Int32;
+			}
 			base.SetParameter(parameter, name, dataType, value);
 		}
 

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdSqlBuilder.cs
@@ -93,6 +93,17 @@ namespace LinqToDB.DataProvider.Firebird
 					break;
 				case DataType.SByte         :
 				case DataType.Byte          : StringBuilder.Append("SmallInt");        break;
+				case DataType.Int64:
+				case DataType.UInt64:
+					if (FirebirdConfiguration.UsedDialect == FirebirdConfiguration.FbDialect.Dialect1)
+					{
+						StringBuilder.Append("Int");
+					}
+					else
+					{
+						base.BuildDataType(type, createDbType);
+					}
+					break;
 				case DataType.Money         : StringBuilder.Append("Decimal(18,4)");   break;
 				case DataType.SmallMoney    : StringBuilder.Append("Decimal(10,4)");   break;
 				case DataType.DateTime2     :


### PR DESCRIPTION
Fix #1318
- New configuration to set a dialect in FirebirdConfiguration
- If the dialect is set to 1 then convert UInt32 to Int32