### PR TITLE
Introduced expanding expression. Fixed problem with local function evaluation.

### DIFF
--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
@@ -496,15 +496,15 @@ namespace LinqToDB.Linq.Builder
 									{
 										newArg = argUnwrapped.EvaluateExpression() as LambdaExpression;
 									}
+								}
 
-									if (newArg == null)
-										newArgs?.Add(arg);
-									else
-									{
-										if (newArgs == null)
-											newArgs = new List<Expression>(mc.Arguments.Take(index));
-										newArgs.Add(newArg);
-									}
+								if (newArg == null)
+									newArgs?.Add(arg);
+								else
+								{
+									if (newArgs == null)
+										newArgs = new List<Expression>(mc.Arguments.Take(index));
+									newArgs.Add(newArg);
 								}
 							}
 
@@ -527,19 +527,19 @@ namespace LinqToDB.Linq.Builder
 
 					case ExpressionType.Invoke:
 						{
-							var invokation = (InvocationExpression)expr;
-							if (invokation.Expression.NodeType == ExpressionType.Call)
+							var invocation = (InvocationExpression)expr;
+							if (invocation.Expression.NodeType == ExpressionType.Call)
 							{
-								var mc = (MethodCallExpression)invokation.Expression;
+								var mc = (MethodCallExpression)invocation.Expression;
 								if (mc.Method.Name == "Compile" &&
 								    typeof(LambdaExpression).IsSameOrParentOf(mc.Method.DeclaringType))
 								{
 									if (mc.Object.EvaluateExpression() is LambdaExpression lambds)
 									{
 										var map = new Dictionary<Expression, Expression>();
-										for (int i = 0; i < invokation.Arguments.Count; i++)
+										for (int i = 0; i < invocation.Arguments.Count; i++)
 										{
-											map.Add(lambds.Parameters[i], invokation.Arguments[i]);
+											map.Add(lambds.Parameters[i], invocation.Arguments[i]);
 										}
 
 										var newBody = lambds.Body.Transform(se =>

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
@@ -236,7 +236,6 @@ namespace LinqToDB.Linq.Builder
 			var expr = expression;
 
 			expr = ConvertParameters (expr);
-			expr = ExposeExpression  (expr);
 			expr = OptimizeExpression(expr);
 
 			var paramType   = expr.Type;
@@ -479,6 +478,85 @@ namespace LinqToDB.Linq.Builder
 
 							break;
 						}
+
+					case ExpressionType.Call:
+						{
+							var mc = (MethodCallExpression)expr;
+
+							List<Expression> newArgs = null;
+							for (var index = 0; index < mc.Arguments.Count; index++)
+							{
+								var arg = mc.Arguments[index];
+								Expression newArg = null;
+								if (typeof(LambdaExpression).IsSameOrParentOf(arg.Type))
+								{
+									var argUnwrapped = arg.Unwrap();
+									if (argUnwrapped.NodeType == ExpressionType.MemberAccess ||
+									    argUnwrapped.NodeType == ExpressionType.Call)
+									{
+										newArg = argUnwrapped.EvaluateExpression() as LambdaExpression;
+									}
+
+									if (newArg == null)
+										newArgs?.Add(arg);
+									else
+									{
+										if (newArgs == null)
+											newArgs = new List<Expression>(mc.Arguments.Take(index));
+										newArgs.Add(newArg);
+									}
+								}
+							}
+
+							if (newArgs != null)
+							{
+								mc = mc.Update(mc.Object, newArgs);
+							}
+
+
+							if (mc.Method.Name == "Compile" && typeof(LambdaExpression).IsSameOrParentOf(mc.Method.DeclaringType))
+							{
+								if (mc.Object.EvaluateExpression() is LambdaExpression lambda)
+								{
+									return lambda;
+								}
+							}
+							
+							return mc;
+						}
+
+					case ExpressionType.Invoke:
+						{
+							var invokation = (InvocationExpression)expr;
+							if (invokation.Expression.NodeType == ExpressionType.Call)
+							{
+								var mc = (MethodCallExpression)invokation.Expression;
+								if (mc.Method.Name == "Compile" &&
+								    typeof(LambdaExpression).IsSameOrParentOf(mc.Method.DeclaringType))
+								{
+									if (mc.Object.EvaluateExpression() is LambdaExpression lambds)
+									{
+										var map = new Dictionary<Expression, Expression>();
+										for (int i = 0; i < invokation.Arguments.Count; i++)
+										{
+											map.Add(lambds.Parameters[i], invokation.Arguments[i]);
+										}
+
+										var newBody = lambds.Body.Transform(se =>
+										{
+											if (se.NodeType == ExpressionType.Parameter &&
+											    map.TryGetValue(se, out var newExpr))
+												return newExpr;
+											return se;
+										});
+
+										return ExposeExpression(newBody);
+									}
+								}
+							}
+							break;
+						}
+
 				}
 
 				return expr;
@@ -502,7 +580,10 @@ namespace LinqToDB.Linq.Builder
 			if (_optimizedExpressions.TryGetValue(expression, out var expr))
 				return expr;
 
-			_optimizedExpressions[expression] = expr = expression.Transform((Func<Expression,TransformInfo>)OptimizeExpressionImpl);
+			expr = ExposeExpression(expression);
+			expr = expr.Transform((Func<Expression,TransformInfo>)OptimizeExpressionImpl);
+
+			_optimizedExpressions[expression] = expr;
 
 			return expr;
 		}

--- a/Tests/Base/TestBase.cs
+++ b/Tests/Base/TestBase.cs
@@ -1193,9 +1193,15 @@ namespace Tests
 		{
 			return Providers.Where(TestBase.UserProviders.Contains);
 		}
-
 	}
 
+	public class SQLiteDataSourcesAttribute : IncludeDataSourcesAttribute
+	{
+		public SQLiteDataSourcesAttribute(bool includeLinqService = false) : base(includeLinqService, 
+			ProviderName.SQLiteClassic, ProviderName.SQLite, ProviderName.SQLiteMS)
+		{
+		}
+	}
 
 	[AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
 	public class SkipCategoryAttribute : NUnitAttribute, IApplyToTest

--- a/Tests/Linq/Linq/ExpandTests.cs
+++ b/Tests/Linq/Linq/ExpandTests.cs
@@ -35,7 +35,7 @@ namespace Tests.Playground
 		}
 
 		[Test, Combinatorial]
-		public void InvokationTestLocal([SQLiteDataSources] string context)
+		public void InvocationTestLocal([SQLiteDataSources] string context)
 		{
 			Expression<Func<SampleClass, bool>> predicate = c => c.Value > 1;
 			var sampleData = GenerateData();
@@ -97,7 +97,7 @@ namespace Tests.Playground
 		}
 
 		[Test, Combinatorial]
-		public void InvokationTestFunction([SQLiteDataSources] string context)
+		public void InvocationTestFunction([SQLiteDataSources] string context)
 		{
 			var sampleData = GenerateData();
 
@@ -116,7 +116,7 @@ namespace Tests.Playground
 		}
 
 		[Test, Combinatorial]
-		public void LocalInvokation([SQLiteDataSources] string context)
+		public void LocalInvocation([SQLiteDataSources] string context)
 		{
 			var sampleData = GenerateData();
 

--- a/Tests/Linq/Linq/ExpandTests.cs
+++ b/Tests/Linq/Linq/ExpandTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Linq.Expressions;
+using LinqToDB;
 using LinqToDB.Mapping;
 using NUnit.Framework;
 using Tests.Tools;
@@ -114,11 +115,6 @@ namespace Tests.Playground
 			}
 		}
 
-		int SomeFunc(int value)
-		{
-			return value;
-		}
-
 		[Test, Combinatorial]
 		public void LocalInvokation([SQLiteDataSources] string context)
 		{
@@ -127,16 +123,19 @@ namespace Tests.Playground
 			using (var db = GetDataContext(context))
 			using (var table = db.CreateLocalTable(sampleData))
 			{
+				var ids = new[] { 1, 2, 3, 4, 5, 6 };
+
 				var query = from t in table
-					where t.Value == SomeFunc(1)
+					where ids.Where(i => i < 3).GroupBy(i => i).Select(i => i.Key).Contains(t.Id)
 					select t;
 				var expected = from t in sampleData
-					where t.Value == SomeFunc(1)
+					where ids.Where(i => i < 3).GroupBy(i => i).Select(i => i.Key).Contains(t.Id)
 					select t;
 
 				AreEqual(expected, query, ComparerBuilder<SampleClass>.GetEqualityComparer());
 			}
 		}
+
 
 	}
 }

--- a/Tests/Tests.Playground/ExpandTests.cs
+++ b/Tests/Tests.Playground/ExpandTests.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using LinqToDB.Mapping;
+using NUnit.Framework;
+using Tests.Tools;
+
+namespace Tests.Playground
+{
+	[TestFixture]
+	public class ExpandTests : TestBase
+	{
+		[Table]
+		class SampleClass
+		{
+			[Column] public int Id    { get; set; }
+			[Column] public int Value { get; set; }
+		}
+
+		private static SampleClass[] GenerateData()
+		{
+			var sampleData = new[]
+			{
+				new SampleClass { Id = 1, Value = 1 },
+				new SampleClass { Id = 2, Value = 2 },
+				new SampleClass { Id = 3, Value = 3 },
+			};
+			return sampleData;
+		}
+
+		Expression<Func<SampleClass, bool>> GetTestPredicate(int v)
+		{
+			return c => c.Value == v;
+		}
+
+		[Test, Combinatorial]
+		public void InvokationTestLocal([SQLiteDataSources] string context)
+		{
+			Expression<Func<SampleClass, bool>> predicate = c => c.Value > 1;
+			var sampleData = GenerateData();
+
+			using (var db = GetDataContext(context))
+			using (var table = db.CreateLocalTable(sampleData))
+			{
+				var query = from t in table
+					where predicate.Compile()(t)
+					select t;
+				var expected = from t in sampleData
+					where predicate.Compile()(t)
+					select t;
+
+				AreEqual(expected, query, ComparerBuilder<SampleClass>.GetEqualityComparer());
+			}
+		}
+
+		[Test, Combinatorial]
+		public void CompileTestLocal([SQLiteDataSources] string context)
+		{
+			Expression<Func<SampleClass, bool>> predicate = c => c.Value > 1;
+			var sampleData = GenerateData();
+
+			using (var db = GetDataContext(context))
+			using (var table = db.CreateLocalTable(sampleData))
+			{
+				var query = from t in table
+					from t2 in table.Where(predicate.Compile())
+					select t;
+
+				var expected = from t in sampleData
+					from t2 in table.Where(predicate.Compile())
+					select t;
+
+				AreEqual(expected, query, ComparerBuilder<SampleClass>.GetEqualityComparer());
+			}
+		}
+
+		[Test, Combinatorial]
+		public void NonCompileTestLocal([SQLiteDataSources] string context)
+		{
+			Expression<Func<SampleClass, bool>> predicate = c => c.Value > 1;
+			var sampleData = GenerateData();
+
+			using (var db = GetDataContext(context))
+			using (var table = db.CreateLocalTable(sampleData))
+			{
+				var query = from t in table
+					from t2 in table.Where(predicate)
+					select t;
+
+				var expected = from t in sampleData
+					from t2 in table.Where(predicate)
+					select t;
+
+				AreEqual(expected, query, ComparerBuilder<SampleClass>.GetEqualityComparer());
+			}
+		}
+
+		[Test, Combinatorial]
+		public void InvokationTestFunction([SQLiteDataSources] string context)
+		{
+			var sampleData = GenerateData();
+
+			using (var db = GetDataContext(context))
+			using (var table = db.CreateLocalTable(sampleData))
+			{
+				var query = from t in table
+					where GetTestPredicate(1).Compile()(t)
+					select t;
+				var expected = from t in sampleData
+					where GetTestPredicate(1).Compile()(t)
+					select t;
+
+				AreEqual(expected, query, ComparerBuilder<SampleClass>.GetEqualityComparer());
+			}
+		}
+
+		int SomeFunc(int value)
+		{
+			return value;
+		}
+
+		[Test, Combinatorial]
+		public void LocalInvokation([SQLiteDataSources] string context)
+		{
+			var sampleData = GenerateData();
+
+			using (var db = GetDataContext(context))
+			using (var table = db.CreateLocalTable(sampleData))
+			{
+				var query = from t in table
+					where t.Value == SomeFunc(1)
+					select t;
+				var expected = from t in sampleData
+					where t.Value == SomeFunc(1)
+					select t;
+
+				AreEqual(expected, query, ComparerBuilder<SampleClass>.GetEqualityComparer());
+			}
+		}
+
+	}
+}

--- a/Tests/Tests.Playground/Tests.Playground.csproj
+++ b/Tests/Tests.Playground/Tests.Playground.csproj
@@ -112,7 +112,7 @@
     <PackageReference Include="Mono.Cecil" Version="0.10.0" />
     <PackageReference Include="MySql.Data" Version="6.10.6" />
     <PackageReference Include="Humanizer.Core" Version="2.2.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.3" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.5.1" />
 
 
   </ItemGroup>

--- a/linq2db.playground.sln.DotSettings
+++ b/linq2db.playground.sln.DotSettings
@@ -1,0 +1,26 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp71</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseNameofExpression/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGNMENT_TAB_FILL_STYLE/@EntryValue">USE_SPACES</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/CASE_BLOCK_BRACES/@EntryValue">NEXT_LINE_SHIFTED_2</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AFTER_TYPECAST_PARENTHESES/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CSharpUsing/KeepImports/=System/@EntryIndexedValue">System</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DB/@EntryIndexedValue">DB</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=ID/@EntryIndexedValue">ID</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LUW/@EntryIndexedValue">LUW</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=MS/@EntryIndexedValue">MSSQ</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=OK/@EntryIndexedValue">OK</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SQL/@EntryIndexedValue">SQL</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SQLite/@EntryIndexedValue">SQLite</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Constantable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Northwind/@EntryIndexedValue">True</s:Boolean>
+</wpf:ResourceDictionary>


### PR DESCRIPTION
For now developer can use expression tree variable inside LINQ Query.
Idea was borrowed from LinqKit library.

For example if you have variable
```cs
Expression<Func<SampleClass, bool>> predicate = c => c.Value > 1;
```
It is difficult to use it in linq. For now you can use it in the following way (using `Compile()`):
```cs
var query = from t in table
	from t2 in table.Where(predicate.Compile())
	select t;
```
Or compile with invokation:
```cs
var query = from t in table
	where predicate.Compile()(t)
	select t;
```
-----------
Also this PR contains fix with bad evaluation of functions that have Lambda as parameter. For now the following query should work:
```cs
var ids = new[] { 1, 2, 3, 4, 5, 6 };
var query = from t in table
	where ids.Where(i => i < 3).GroupBy(i => i).Select(i => i.Key).Contains(t.Id)
	select t;
```
Grouping and projection will be evaluated on client side.

