### PR TITLE
Issue 1144 fixes

### DIFF
--- a/Data/Create Scripts/SqlServer.sql
+++ b/Data/Create Scripts/SqlServer.sql
@@ -949,3 +949,17 @@ END
 GO
 GRANT EXEC ON AddIssue792Record TO PUBLIC
 GO
+
+IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID('Issue1144') AND type in (N'U'))
+BEGIN DROP TABLE Issue1144 END
+GO
+CREATE TABLE Issue1144
+(
+	id	INT
+	CONSTRAINT PK_Issue1144 PRIMARY KEY CLUSTERED (id ASC)
+)
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Column description' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1name=N'Issue1144', @level2type=N'COLUMN',@level2name=N'id'
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Index description' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1name=N'Issue1144', @level2type=N'INDEX',@level2name=N'PK_Issue1144'
+
+GO

--- a/Source/LinqToDB.Templates/LinqToDB.SqlServer.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.SqlServer.ttinclude
@@ -41,7 +41,7 @@ void DoGenerateSqlServerFreeText()
 						}
 					})
 				{
-					GenericArguments = "<T>",
+					GenericArguments = { "T" },
 					IsPartial        = false
 				},
 
@@ -63,7 +63,7 @@ void DoGenerateSqlServerFreeText()
 						"	text);",
 					})
 				{
-					GenericArguments = "<TTable,TKey>",
+					GenericArguments = new List<string>() { "TTable", "TKey" },
 					Attributes = { new Attribute("FreeTextTableExpression") }
 				},
 
@@ -90,8 +90,8 @@ void DoGenerateSqlServerFreeText()
 						"	text);",
 					})
 				{
-					GenericArguments = "<TTable,TKey>",
-					Attributes = { new Attribute("FreeTextTableExpression") }
+					GenericArguments = { "TTable", "TKey" },
+					Attributes       = { new Attribute("FreeTextTableExpression") }
 				},
 			}
 		}

--- a/Source/LinqToDB.Templates/LinqToDB.SqlServer.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.SqlServer.ttinclude
@@ -30,7 +30,7 @@ void DoGenerateSqlServerFreeText()
 			Region  = "FreeTextTable",
 			Members =
 			{
-				new Class("FreeTextKey<T>",
+				new Class("FreeTextKey",
 					new MemberGroup
 					{
 						IsCompact = true,
@@ -41,7 +41,8 @@ void DoGenerateSqlServerFreeText()
 						}
 					})
 				{
-					IsPartial = false
+					GenericArguments = "<T>",
+					IsPartial        = false
 				},
 
 				new Field("MethodInfo", "_freeTextTableMethod1")
@@ -51,7 +52,7 @@ void DoGenerateSqlServerFreeText()
 					InitValue      = "typeof(" + DataContextObject.Name + ").GetMethod(\"FreeTextTable\", new Type[] { typeof(string), typeof(string) })"
 				},
 
-				new Method("ITable<FreeTextKey<TKey>>", "FreeTextTable<TTable,TKey>",
+				new Method("ITable<FreeTextKey<TKey>>", "FreeTextTable",
 					new[] { "string field", "string text" },
 					new[]
 					{
@@ -62,6 +63,7 @@ void DoGenerateSqlServerFreeText()
 						"	text);",
 					})
 				{
+					GenericArguments = "<TTable,TKey>",
 					Attributes = { new Attribute("FreeTextTableExpression") }
 				},
 
@@ -77,7 +79,7 @@ void DoGenerateSqlServerFreeText()
 					"		.Single()"
 				},
 
-				new Method("ITable<FreeTextKey<TKey>>", "FreeTextTable<TTable,TKey>",
+				new Method("ITable<FreeTextKey<TKey>>", "FreeTextTable",
 					new[] { "Expression<Func<TTable,string>> fieldSelector", "string text" },
 					new[]
 					{
@@ -88,6 +90,7 @@ void DoGenerateSqlServerFreeText()
 						"	text);",
 					})
 				{
+					GenericArguments = "<TTable,TKey>",
 					Attributes = { new Attribute("FreeTextTableExpression") }
 				},
 			}

--- a/Source/LinqToDB.Templates/T4Model.ttinclude
+++ b/Source/LinqToDB.Templates/T4Model.ttinclude
@@ -210,7 +210,7 @@ static Action<GeneratedTextTransformation,Class> WriteBeginClass = (tt,cl) =>
 	tt.Write(cl.AccessModifier.ToString().ToLower() + " ");
 	if (cl.IsStatic)  tt.Write("static ");
 	if (cl.IsPartial) tt.Write("partial ", cl.Name);
-	tt.Write("class {0}", cl.Name);
+	tt.Write("class {0}{1}", cl.Name, cl.GenericArguments);
 
 	if (!string.IsNullOrEmpty(cl.BaseClass) || cl.Interfaces.Count > 0)
 	{
@@ -231,6 +231,7 @@ static Action<GeneratedTextTransformation> WriteEndClass = tt => tt.WriteLine("}
 public partial class Class : TypeBase
 {
 	public string             BaseClass;
+	public string             GenericArguments;
 	public bool               IsStatic   = false;
 	public List<string>       Interfaces = new List<string>();
 	public List<IClassMember> Members    = new List<IClassMember>();
@@ -1176,13 +1177,14 @@ static Action<GeneratedTextTransformation,Method,bool> WriteMethod = (tt,m,compa
 		mlen--;
 	}
 
-	tt.Write("{0}{1}{2}{3}{4}{5}{6}{7}{8} {9}",
+	tt.Write("{0}{1}{2}{3}{4}{5}{6}{7}{8} {9}{10}",
 		am1,    LenDiff(len1, am1),
 		mdf,    LenDiff(mlen, mdf),
 		am2,    LenDiff(len2, am2),
 		m.Type == null ? "" : " ",
 		m.Type, LenDiff(m.TypeLen,     m.Type ?? ""),
-		m.Name);
+		m.Name,
+		m.GenericArguments);
 
 	Action writeComment = () =>
 	{
@@ -1282,6 +1284,7 @@ public partial class Method : MemberBase
 	public bool         IsVirtual;
 	public bool         IsOverride;
 	public bool         IsStatic;
+	public string       GenericArguments;
 	public List<string> AfterSignature = new List<string>();
 	public List<string> Parameters     = new List<string>();
 	public List<string> Body           = new List<string>();

--- a/Source/LinqToDB.Templates/T4Model.ttinclude
+++ b/Source/LinqToDB.Templates/T4Model.ttinclude
@@ -210,7 +210,7 @@ static Action<GeneratedTextTransformation,Class> WriteBeginClass = (tt,cl) =>
 	tt.Write(cl.AccessModifier.ToString().ToLower() + " ");
 	if (cl.IsStatic)  tt.Write("static ");
 	if (cl.IsPartial) tt.Write("partial ", cl.Name);
-	tt.Write("class {0}{1}", cl.Name, cl.GenericArguments);
+	tt.Write("class {0}{1}", cl.Name, cl.GenericArguments.Count > 0 ? $"<{string.Join(", ", cl.GenericArguments)}>" : string.Empty);
 
 	if (!string.IsNullOrEmpty(cl.BaseClass) || cl.Interfaces.Count > 0)
 	{
@@ -231,10 +231,10 @@ static Action<GeneratedTextTransformation> WriteEndClass = tt => tt.WriteLine("}
 public partial class Class : TypeBase
 {
 	public string             BaseClass;
-	public string             GenericArguments;
-	public bool               IsStatic   = false;
-	public List<string>       Interfaces = new List<string>();
-	public List<IClassMember> Members    = new List<IClassMember>();
+	public List<string>       GenericArguments = new List<string>();
+	public bool               IsStatic         = false;
+	public List<string>       Interfaces       = new List<string>();
+	public List<IClassMember> Members          = new List<IClassMember>();
 
 	public Class()
 	{
@@ -1184,7 +1184,7 @@ static Action<GeneratedTextTransformation,Method,bool> WriteMethod = (tt,m,compa
 		m.Type == null ? "" : " ",
 		m.Type, LenDiff(m.TypeLen,     m.Type ?? ""),
 		m.Name,
-		m.GenericArguments);
+		m.GenericArguments.Count > 0 ? $"<{string.Join(", ", m.GenericArguments)}>" : string.Empty);
 
 	Action writeComment = () =>
 	{
@@ -1284,10 +1284,10 @@ public partial class Method : MemberBase
 	public bool         IsVirtual;
 	public bool         IsOverride;
 	public bool         IsStatic;
-	public string       GenericArguments;
-	public List<string> AfterSignature = new List<string>();
-	public List<string> Parameters     = new List<string>();
-	public List<string> Body           = new List<string>();
+	public List<string> GenericArguments = new List<string>();
+	public List<string> AfterSignature   = new List<string>();
+	public List<string> Parameters       = new List<string>();
+	public List<string> Body             = new List<string>();
 
 	public Method()
 	{

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerSchemaProvider.cs
@@ -146,7 +146,7 @@ namespace LinqToDB.DataProvider.SqlServer
 						--OBJECT_ID('[' + TABLE_CATALOG + '].[' + TABLE_SCHEMA + '].[' + TABLE_NAME + ']') = x.major_id AND
 						OBJECT_ID('[' + TABLE_SCHEMA + '].[' + TABLE_NAME + ']') = x.major_id AND
 						COLUMNPROPERTY(OBJECT_ID('[' + TABLE_SCHEMA + '].[' + TABLE_NAME + ']'), COLUMN_NAME, 'ColumnID') = x.minor_id AND
-						x.name = 'MS_Description'")
+						x.name = 'MS_Description' AND x.class = 1")
 				.Select(c =>
 				{
 					DataTypeInfo dti;

--- a/Tests/Linq/DataProvider/SqlServerTests.cs
+++ b/Tests/Linq/DataProvider/SqlServerTests.cs
@@ -1324,5 +1324,19 @@ namespace Tests.DataProvider
 			}
 		}
 
+#if !NETSTANDARD1_6
+		[Test, SqlServerDataContext(false)]
+		public void TestIssue1144(string context)
+		{
+			using (var db = (DataConnection)GetDataContext(context))
+			{
+				var schema = db.DataProvider.GetSchemaProvider().GetSchema(db);
+
+				var table = schema.Tables.Where(_ => _.TableName == "Issue1144").Single();
+
+				Assert.AreEqual(1, table.Columns.Count);
+			}
+		}
+#endif
 	}
 }


### PR DESCRIPTION
Fixes #1144

- moved generic arguments list in T4 model from Name to separate GenericArguments field for Method and Class
- fixed double column selection when column used in index with desctiption on both column and index