### PR TITLE
Fixed invalid SQL generation for recursive CTE when using Count()

### DIFF
--- a/Source/LinqToDB/Linq/Builder/TableBuilder.CteTableContext.cs
+++ b/Source/LinqToDB/Linq/Builder/TableBuilder.CteTableContext.cs
@@ -61,6 +61,10 @@ namespace LinqToDB.Linq.Builder
 			var cteBuildInfo = new BuildInfo(buildInfo, bodyExpr, buildInfo.SelectQuery);
 			var cteContext   = new CteTableContext(builder, cteBuildInfo, cte.Item1, bodyExpr);
 
+			// populate all fields
+			if (isRecursive)
+				cteContext.ConvertToSql(null, 0, ConvertFlags.All);
+
 			return cteContext;
 		}
 
@@ -114,11 +118,6 @@ namespace LinqToDB.Linq.Builder
 					}
 
 					return baseInfos;
-				}
-
-				if (_cte.IsRecursive)
-				{
-					ConvertConvertToSqlAndRegister(null, 0, ConvertFlags.All);
 				}
 
 				var result = ConvertConvertToSqlAndRegister(expression, level, flags);

--- a/Source/LinqToDB/SqlQuery/SqlDeleteStatement.cs
+++ b/Source/LinqToDB/SqlQuery/SqlDeleteStatement.cs
@@ -49,6 +49,7 @@ namespace LinqToDB.SqlQuery
 
 		public override ISqlExpression Walk(bool skipColumns, Func<ISqlExpression,ISqlExpression> func)
 		{
+			With?.Walk(skipColumns, func);
 			Table = ((ISqlExpressionWalkable)Table)?.Walk(skipColumns, func) as SqlTable;
 			SelectQuery = (SelectQuery)SelectQuery.Walk(skipColumns, func);
 

--- a/Source/LinqToDB/SqlQuery/SqlInsertOrUpdateStatement.cs
+++ b/Source/LinqToDB/SqlQuery/SqlInsertOrUpdateStatement.cs
@@ -37,6 +37,7 @@ namespace LinqToDB.SqlQuery
 
 		public override ISqlExpression Walk(bool skipColumns, Func<ISqlExpression, ISqlExpression> func)
 		{
+			With?.Walk(skipColumns, func);
 			((ISqlExpressionWalkable)_insert)?.Walk(skipColumns, func);
 			((ISqlExpressionWalkable)_update)?.Walk(skipColumns, func);
 

--- a/Source/LinqToDB/SqlQuery/SqlInsertStatement.cs
+++ b/Source/LinqToDB/SqlQuery/SqlInsertStatement.cs
@@ -38,6 +38,7 @@ namespace LinqToDB.SqlQuery
 
 		public override ISqlExpression Walk(bool skipColumns, Func<ISqlExpression, ISqlExpression> func)
 		{
+			With?.Walk(skipColumns, func);
 			((ISqlExpressionWalkable)_insert)?.Walk(skipColumns, func);
 
 			SelectQuery = (SelectQuery)SelectQuery.Walk(skipColumns, func);

--- a/Source/LinqToDB/SqlQuery/SqlUpdateStatement.cs
+++ b/Source/LinqToDB/SqlQuery/SqlUpdateStatement.cs
@@ -30,6 +30,7 @@ namespace LinqToDB.SqlQuery
 
 		public override ISqlExpression Walk(bool skipColumns, Func<ISqlExpression, ISqlExpression> func)
 		{
+			With?.Walk(skipColumns, func);
 			((ISqlExpressionWalkable)_update)?.Walk(skipColumns, func);
 
 			SelectQuery = (SelectQuery)SelectQuery.Walk(skipColumns, func);


### PR DESCRIPTION
Fixed invalid SQL generation for recursive CTE when using Count() function. 
Fixed missed Walk calls which cause invalid AST generation.