### PR TITLE
Fix for #1354. Synchronizing CommandTimeout properties.

### DIFF
--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -994,7 +994,12 @@ namespace LinqToDB.Data
 		public  int   CommandTimeout
 		{
 			get => _commandTimeout ?? 0;
-			set => _commandTimeout = value;
+			set
+			{
+				_commandTimeout = value;
+				if (_command != null)
+					_command.CommandTimeout = value;
+			}
 		}
 
 		private IDbCommand _command;


### PR DESCRIPTION
Fix for #1354. 
Added code for synchronizing already created Command object with DataConnection's CommandTimeout property.