### PR TITLE
[postgresql] Fix schema provider for postgresql when used with npgsql 4.x

### DIFF
--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLSchemaProvider.cs
@@ -534,7 +534,7 @@ SELECT	r.ROUTINE_CATALOG,
 					let length       = r.IsNull("ColumnSize")       ? (int?)null : r.Field<int>("ColumnSize")
 					let precision    = r.IsNull("NumericPrecision") ? (int?)null : r.Field<int>("NumericPrecision")
 					let scale        = r.IsNull("NumericScale")     ? (int?)null : r.Field<int>("NumericScale")
-					let providerType = r.IsNull("ProviderType")     ? null       : r.Field<Type>("ProviderType")
+					let providerType = r.IsNull("DataType")         ? null       : r.Field<Type>("DataType")
 					let systemType   =  GetSystemType(columnType, null, dataType, length, precision, scale) ?? providerType ?? typeof(object)
 
 					select new ColumnSchema


### PR DESCRIPTION
npgsql 4.0 changed type of schema column ProviderType to enum: https://github.com/npgsql/npgsql/commit/0d1af7ef87be4962bd5889cf9037ae3c7fee77d2#diff-922404367f708ad04718b3837fa6168dR1192
switching to DataType schema column, which still contains same value as npgsql 3.x