### PR TITLE
[WIP] Fix multiple T4/SchemaProvider code generation issues

### DIFF
--- a/Data/Create Scripts/SqlServer.sql
+++ b/Data/Create Scripts/SqlServer.sql
@@ -963,3 +963,62 @@ EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Column descrip
 EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Index description' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1name=N'Issue1144', @level2type=N'INDEX',@level2name=N'PK_Issue1144'
 
 GO
+
+-- T4/LINQPad naming test-cases
+IF EXISTS (SELECT * FROM sys.objects WHERE type = 'P' AND name = 'proc@t4')
+	DROP Procedure proc@t4
+IF EXISTS (SELECT * FROM sys.objects WHERE type = 'P' AND name = 'delegate')
+	DROP Procedure delegate
+IF EXISTS (SELECT * FROM sys.objects WHERE type = 'P' AND name = 't4''"\proc')
+	DROP Procedure [t4'"\proc]
+
+IF EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID('FK_t4@test') AND parent_object_id = OBJECT_ID('t4@test'))
+  ALTER TABLE t4@test DROP CONSTRAINT FK_t4@test
+IF EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID('enum') AND parent_object_id = OBJECT_ID('class'))
+  ALTER TABLE class DROP CONSTRAINT enum
+IF EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID('[FK_t4''"\fail]') AND parent_object_id = OBJECT_ID('[t4''"\table]'))
+  ALTER TABLE [t4'"\table] DROP CONSTRAINT [FK_t4'"\fail]
+
+IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID('t4@test') AND type in (N'U'))
+	DROP TABLE t4@test
+IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID('class') AND type in (N'U'))
+	DROP TABLE class
+IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID('[t4''"\table]') AND type in (N'U'))
+	DROP TABLE [t4'"\table]
+
+CREATE TABLE t4@test(
+t4@test INT NOT NULL
+)
+
+CREATE TABLE class(
+class INT NOT NULL
+)
+
+CREATE TABLE [t4'"\table](
+[t4'"\column] INT NOT NULL
+)
+ALTER TABLE t4@test ADD CONSTRAINT PK_t4@test PRIMARY KEY NONCLUSTERED (t4@test)
+ALTER TABLE class ADD CONSTRAINT struct PRIMARY KEY NONCLUSTERED (class)
+ALTER TABLE [t4'"\table] ADD CONSTRAINT [PK_t4'"\fail] PRIMARY KEY NONCLUSTERED ([t4'"\column])
+
+ALTER TABLE t4@test ADD CONSTRAINT FK_t4@test FOREIGN KEY(t4@test) REFERENCES class(class)
+ALTER TABLE class ADD CONSTRAINT enum FOREIGN KEY(class) REFERENCES [t4'"\table]([t4'"\column])
+ALTER TABLE [t4'"\table] ADD CONSTRAINT [FK_t4'"\fail] FOREIGN KEY([t4'"\column]) REFERENCES t4@test(t4@test)
+GO
+CREATE PROCEDURE proc@t4
+ @param@t4 INT
+AS
+SELECT * FROM t4@test
+GO
+CREATE PROCEDURE delegate
+ @object INT
+AS
+SELECT * FROM class
+GO
+CREATE PROCEDURE [t4'"\proc]
+ --[@t4'"\param] INT
+ @t4 INT
+AS
+SELECT * FROM [t4'"\table]
+GO
+

--- a/Source/LinqToDB.Templates/DataAnnotations.ttinclude
+++ b/Source/LinqToDB.Templates/DataAnnotations.ttinclude
@@ -17,7 +17,7 @@ void DataAnnotationsImpl()
 		{
 			if (p.DisplayName != null)
 			{
-				p.Attributes.Add(new Attribute("Display", "Name=\"" + p.DisplayName + "\"") { IsSeparated = true });
+				p.Attributes.Add(new Attribute("Display", "Name=" + LinqToDB.SchemaProvider.CSharpTools.ToStringLiteral(p.DisplayName) + "") { IsSeparated = true });
 			}
 
 			if (p.IsRequired)
@@ -25,7 +25,7 @@ void DataAnnotationsImpl()
 				var attr = new Attribute("Required") { IsSeparated = true };
 
 				if (p.IsRequiredMessage != null)
-					attr.Parameters.Add(string.Format("ErrorMessage=\"" + p.IsRequiredMessage + "\"", p.DisplayName ?? p.Name));
+					attr.Parameters.Add(string.Format("ErrorMessage=" + LinqToDB.SchemaProvider.CSharpTools.ToStringLiteral(p.IsRequiredMessage) + "", p.DisplayName ?? p.Name));
 
 				p.Attributes.Add(attr);
 			}
@@ -35,7 +35,7 @@ void DataAnnotationsImpl()
 				var attr = new Attribute("StringLength", p.StringLength.ToString()) { IsSeparated = true };
 
 				if (p.StringLengthMessage != null)
-					attr.Parameters.Add(string.Format("ErrorMessage=\"" + p.StringLengthMessage + "\"", p.DisplayName ?? p.Name));
+					attr.Parameters.Add(string.Format("ErrorMessage=" + LinqToDB.SchemaProvider.CSharpTools.ToStringLiteral(p.StringLengthMessage) + "", p.DisplayName ?? p.Name));
 
 				p.Attributes.Add(attr);
 
@@ -43,7 +43,7 @@ void DataAnnotationsImpl()
 //					new Attribute("StringLength",
 //						p.StringLength.ToString(),
 //						string.Format(
-//							"ErrorMessage=\"The {0} must be a string with a maximum lenfth of {1}.\"",
+//							"ErrorMessage=\"The {0} must be a string with a maximum length of {1}.\"",
 //							p.DisplayName ?? "field",
 //							p.StringLength))
 //					{

--- a/Source/LinqToDB.Templates/DataModel.ttinclude
+++ b/Source/LinqToDB.Templates/DataModel.ttinclude
@@ -51,13 +51,6 @@ Func<string, bool, string> ToValidName
 	set { _toValidName = value; }
 }
 
-private Func<string, bool, string> _convertToCompilabl;
-Func<string, bool, string> ConvertToCompilable
-{
-	get { return _convertToCompilabl ?? ConvertToCompilableDefault; }
-	set { _convertToCompilabl = value; }
-}
-
 private Func<ForeignKey, string> _getAssociationExtensionPluralName;
 Func<ForeignKey, string> GetAssociationExtensionPluralName
 {
@@ -82,18 +75,6 @@ Func<TableSchema,Table> LoadProviderSpecificTable = tableSchema => null;
 static Func<ColumnSchema,string>                 ConvertColumnMemberType          = (c) => c.MemberType;
 static Func<TableSchema,ColumnSchema,string>     ConvertTableColumnMemberType     = (t,c) => ConvertColumnMemberType(c);
 static Func<ProcedureSchema,ColumnSchema,string> ConvertProcedureColumnMemberType = (t,c) => ConvertColumnMemberType(c);
-
-HashSet<string> KeyWords = new HashSet<string>
-{
-	"abstract", "as",       "base",     "bool",    "break",     "byte",     "case",       "catch",     "char",    "checked",
-	"class",    "const",    "continue", "decimal", "default",   "delegate", "do",         "double",    "else",    "enum",
-	"event",    "explicit", "extern",   "false",   "finally",   "fixed",    "float",      "for",       "foreach", "goto",
-	"if",       "implicit", "in",       "int",     "interface", "internal", "is",         "lock",      "long",    "new",
-	"null",     "object",   "operator", "out",     "override",  "params",   "private",    "protected", "public",  "readonly",
-	"ref",      "return",   "sbyte",    "sealed",  "short",     "sizeof",   "stackalloc", "static",    "struct",  "switch",
-	"this",     "throw",    "true",     "try",     "typeof",    "uint",     "ulong",      "unchecked", "unsafe",  "ushort",
-	"using",    "virtual",  "volatile", "void",    "while",     "namespace", "string"
-};
 
 void LoadServerMetadata(DataConnection dataConnection)
 {
@@ -282,7 +263,7 @@ void LoadServerMetadata(DataConnection dataConnection)
 								IsIdentity      = c.IsIdentity,
 								IsPrimaryKey    = c.IsPrimaryKey,
 								PrimaryKeyOrder = c.PrimaryKeyOrder,
-								MemberName      = CheckColumnName(CheckType(c.SystemType, c.MemberName)),
+								MemberName      = CheckType(c.SystemType, c.MemberName),
 								Type            = ConvertProcedureColumnMemberType(p, c),
 								SkipOnInsert    = c.SkipOnInsert,
 								SkipOnUpdate    = c.SkipOnUpdate,
@@ -358,33 +339,6 @@ string CheckType(Type type, string typeName)
 	return typeName;
 }
 
-string CheckColumnName(string memberName)
-{
-	if (string.IsNullOrEmpty(memberName))
-		memberName = "Empty";
-	else
-	{
-		memberName = memberName
-			.Replace("%", "Percent")
-			.Replace(">", "Greater")
-			.Replace("<", "Lower")
-			.Replace("+", "Plus")
-			.Replace('(', '_')
-			.Replace(')', '_')
-			.Replace('-', '_')
-			.Replace('|', '_')
-			.Replace(',', '_')
-			.Replace('"', '_')
-			.Replace("'", "_")
-			.Replace(".", "_")
-			.Replace("\u00A3", "Pound");
-
-		if (KeyWords.Contains(memberName))
-			memberName = "@" + memberName;
-	}
-	return memberName;
-}
-
 string CheckParameterName(string parameterName)
 {
 	var invalidParameterNames = new List<string>
@@ -418,33 +372,14 @@ void LoadMetadata(DataConnection dataConnection)
 
 	foreach (var t in Tables.Values)
 	{
-		if (KeyWords.Contains(t.TypeName))
-			t.TypeName = "@" + t.TypeName;
-
-		if (KeyWords.Contains(t.DataContextPropertyName))
-			t.DataContextPropertyName = "@" + t.DataContextPropertyName;
-
-		t.TypeName                = ConvertToCompilable(t.TypeName,                true);
-		t.DataContextPropertyName = ConvertToCompilable(t.DataContextPropertyName, true);
-
 		foreach (var col in t.Columns.Values)
 		{
-			if (KeyWords.Contains(col.MemberName))
-				col.MemberName = "@" + col.MemberName;
-
-			col.MemberName = ConvertToCompilable(col.MemberName, true);
-
 			if (col.MemberName == t.TypeName)
 				col.MemberName += "_Column";
 		}
 
 		foreach (var fk in t.ForeignKeys.Values)
 		{
-			if (KeyWords.Contains(fk.MemberName))
-				fk.MemberName = "@" + fk.MemberName;
-
-			fk.MemberName = ConvertToCompilable(fk.MemberName, true);
-
 			if (fk.MemberName == t.TypeName)
 				fk.MemberName += "_FK";
 		}
@@ -478,18 +413,6 @@ void LoadMetadata(DataConnection dataConnection)
 
 				col.MemberName = SuggestNoDuplicate(mayDuplicate, col.MemberName, null);
 			}
-		}
-	}
-
-	foreach (var proc in Procedures.Values)
-	{
-		if (KeyWords.Contains(proc.Name))
-			proc.Name = "@" + proc.Name;
-
-		foreach (var param in proc.ProcParameters)
-		{
-			if (KeyWords.Contains(param.ParameterName))
-				param.ParameterName = ConvertToCompilable("@" + param.ParameterName, true);
 		}
 	}
 
@@ -530,15 +453,6 @@ string SuggestNoDuplicate(IEnumerable<string> currentNames, string newName, stri
 	}
 
 	return result;
-}
-
-string ConvertToCompilableDefault(string name, bool mayRemoveUnderscore)
-{
-	var query =
-		from c in name
-		select char.IsLetterOrDigit(c) || c == '@' ? c : '_';
-
-	return ToValidName(new string(query.ToArray()), mayRemoveUnderscore);
 }
 
 Table GetTable(string name)
@@ -818,8 +732,6 @@ public class Parameter
 	public string   DataType      { get; set; }
 }
 
-private int _counter = 0;
-
 string ToValidNameDefault(string name, bool mayRemoveUnderscore)
 {
 	if (NormalizeNames && mayRemoveUnderscore && name.Contains("_"))
@@ -827,23 +739,7 @@ string ToValidNameDefault(string name, bool mayRemoveUnderscore)
 		name = SplitAndJoin(name, "", '_');
 	}
 
-	if (name.Contains("."))
-	{
-		name = SplitAndJoin(name, "", '.');
-	}
-
-	if (name.Length > 0 && char.IsDigit(name[0]))
-		name = "_" + name;
-
-	if (string.IsNullOrEmpty(name))
-		name = "_" + _counter++;
-
-	if (NormalizeNames)
-	{
-		name = char.ToUpper(name[0]) + name.Substring(1);
-	}
-
-	return name;
+	return SchemaProviderBase.ToValidName(name);
 }
 
 static string SplitAndJoin(string value, string join, params char[] split)

--- a/Source/LinqToDB.Templates/LinqToDB.Firebird.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.Firebird.ttinclude
@@ -21,7 +21,7 @@ void CheckNameCasing()
 
 		if (!name.StartsWith("\""))
 			if (name.StartsWith("_") || name.Any(c => char.IsLower(c) || char.IsWhiteSpace(c)))
-				t.TableName = "\\\"" + name + "\\\"";
+				t.TableName = "\"" + name + "\"";
 
 		foreach (var col in t.Columns.Values)
 		{
@@ -29,7 +29,7 @@ void CheckNameCasing()
 
 			if (!name.StartsWith("\""))
 				if (name.StartsWith("_") || name.Any(c => char.IsLower(c) || char.IsWhiteSpace(c)))
-					col.ColumnName = "\\\"" + name + "\\\"";
+					col.ColumnName = "\"" + name + "\"";
 		}
 	}
 }

--- a/Source/LinqToDB.Templates/LinqToDB.PostgreSQL.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.PostgreSQL.ttinclude
@@ -73,7 +73,7 @@ void FixFunctionNames()
 	foreach (var proc in Procedures.Values)
 	{
 		if (proc.ProcedureName.Any(char.IsUpper))
-			proc.ProcedureName = "\\\"" + proc.ProcedureName + "\\\"";
+			proc.ProcedureName = "\"" + proc.ProcedureName + "\"";
 	}
 }
 
@@ -108,12 +108,12 @@ void SetCaseSensitiveNames()
 		foreach (var t in Tables.Values)
 		{
 			if (t.TableName.Any(char.IsUpper))
-				t.TableName = "\\\"" + t.TableName + "\\\"";
+				t.TableName = "\"" + t.TableName + "\"";
 
 			foreach (var c in t.Columns.Values)
 			{
 				if (c.ColumnName.Any(char.IsUpper))
-					c.ColumnName = "\\\"" + c.ColumnName + "\\\"";
+					c.ColumnName = "\"" + c.ColumnName + "\"";
 			}
 		}
 	}

--- a/Source/LinqToDB.Templates/LinqToDB.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.ttinclude
@@ -1,12 +1,13 @@
-<#@ assembly name="System.Data"        #>
-<#@ import namespace="System.Data"     #>
-<#@ import namespace="LinqToDB.Data"   #>
-<#@ import namespace="System.Text" #>
-<#@ include file="DataModel.ttinclude" #>
+<#@ assembly name="System.Data"                #>
+<#@ import namespace="System.Data"             #>
+<#@ import namespace="LinqToDB.Data"           #>
+<#@ import namespace="LinqToDB.SchemaProvider" #>
+<#@ import namespace="System.Text"             #>
+<#@ include file="DataModel.ttinclude"         #>
 <#
 	if (BaseDataContextClass == null)
 		BaseDataContextClass = "LinqToDB.Data.DataConnection";
-#>
+											   #>
 <#+
 Action BeforeGenerateLinqToDBModel = () => {};
 Action AfterGenerateLinqToDBModel  = () => {};
@@ -36,7 +37,7 @@ static IEnumerable<Method> GetConstructorsImpl(string defaultConfiguration, stri
 	if (defaultConfiguration == null)
 		yield return new Method(null, name);
 	else
-		yield return new Method(null, name) { AfterSignature = { ": base(\"" + defaultConfiguration + "\")" } };
+		yield return new Method(null, name) { AfterSignature = { ": base(" + CSharpTools.ToStringLiteral(defaultConfiguration) + ")" } };
 	yield return new Method(null, name, new[] { "string configuration" }) { AfterSignature = { ": base(configuration)" } };
 }
 
@@ -224,17 +225,17 @@ void GenerateTypesFromMetadata()
 				null);
 
 			if (GenerateObsoleteAttributeForAliases)
-				aProp.Attributes.Add(new Attribute("Obsolete", "\"Use " + t.DataContextPropertyName + " instead.\""));
+				aProp.Attributes.Add(new Attribute("Obsolete", CSharpTools.ToStringLiteral("Use " + t.DataContextPropertyName + " instead.")));
 
 			aliases.Members.Add(aProp);
 		}
 
 		var tableAttrs = new List<string>();
 
-		if (DatabaseName != null) tableAttrs.Add("Database=" + '"' + DatabaseName + '"');
-		if (t.Schema     != null) tableAttrs.Add("Schema="   + '"' + t.Schema     + '"');
+		if (DatabaseName != null) tableAttrs.Add("Database=" + CSharpTools.ToStringLiteral(DatabaseName));
+		if (t.Schema     != null) tableAttrs.Add("Schema="   + CSharpTools.ToStringLiteral(t.Schema));
 
-		tableAttrs.Add((tableAttrs.Count == 0 ? "" : "Name=") + '"' + t.TableName + '"');
+		tableAttrs.Add((tableAttrs.Count == 0 ? "" : "Name=") + CSharpTools.ToStringLiteral(t.TableName));
 
 		if (t.IsView)
 			tableAttrs.Add("IsView=true");
@@ -266,7 +267,7 @@ void GenerateTypesFromMetadata()
 		var allNullable    = t.Columns.Values.All  (c => c.IsNullable || c.IsIdentity);
 		var nameMaxLen     = t.Columns.Values.Max  (c => (int?)(c.MemberName == c.ColumnName
 			? 0
-			: NormalizeStringName(c.ColumnName).Length)) ?? 0;
+			: CSharpTools.ToStringLiteral(c.ColumnName).Length)) ?? 0;
 		var dbTypeMaxLen   = t.Columns.Values.Max  (c => (int?)(c.ColumnType.Length)) ?? 0;
 		var dataTypeMaxLen = t.Columns.Values.Where(c => c.DataType != null).Max  (c => (int?)(c.DataType.Length)) ?? 0;
 		var dataTypePrefix = t.Columns.Values.Any  (c => c.MemberName == "DataType") ? "LinqToDB." : "";
@@ -280,7 +281,7 @@ void GenerateTypesFromMetadata()
 
 			if (c.MemberName != c.ColumnName)
 			{
-				var columnNameInAttr = NormalizeStringName(c.ColumnName);
+				var columnNameInAttr = CSharpTools.ToStringLiteral(c.ColumnName);
 
 				var space = new string(' ', nameMaxLen - columnNameInAttr.Length);
 
@@ -297,7 +298,7 @@ void GenerateTypesFromMetadata()
 			{
 				var space = new string(' ', dbTypeMaxLen - c.ColumnType.Length);
 
-				ca.Parameters.Add("DbType=\"" + c.ColumnType + '"' + space);
+				ca.Parameters.Add("DbType=" + CSharpTools.ToStringLiteral(c.ColumnType) + space);
 				canBeReplaced = false;
 			}
 
@@ -419,9 +420,9 @@ void GenerateTypesFromMetadata()
 				caProp.Comment.AddRange(columnComments);
 
 				if (GenerateObsoleteAttributeForAliases)
-					caProp.Attributes.Add(new Attribute("Obsolete", "\"Use " + c.MemberName + " instead.\""));
+					caProp.Attributes.Add(new Attribute("Obsolete", CSharpTools.ToStringLiteral("Use " + c.MemberName + " instead.")));
 
-				caProp.Attributes.Add(new Attribute("ColumnAlias", "\"" + c.MemberName + "\""));
+				caProp.Attributes.Add(new Attribute("ColumnAlias", CSharpTools.ToStringLiteral(c.MemberName)));
 
 				columnAliases.Members.Add(caProp);
 			}
@@ -457,8 +458,8 @@ void GenerateTypesFromMetadata()
 
 					var aa = new Attribute("Association");
 
-					aa.Parameters.Add("ThisKey=\""   + string.Join(", ", (from c in key.ThisColumns  select c.MemberName).ToArray()) + "\"");
-					aa.Parameters.Add("OtherKey=\""  + string.Join(", ", (from c in key.OtherColumns select c.MemberName).ToArray()) + "\"");
+					aa.Parameters.Add("ThisKey="   + CSharpTools.ToStringLiteral(string.Join(", ", (from c in key.ThisColumns  select c.MemberName).ToArray())));
+					aa.Parameters.Add("OtherKey="  + CSharpTools.ToStringLiteral(string.Join(", ", (from c in key.OtherColumns select c.MemberName).ToArray())));
 					aa.Parameters.Add("CanBeNull=" + (key.CanBeNull ? "true" : "false"));
 
 					switch (key.AssociationType)
@@ -471,9 +472,9 @@ void GenerateTypesFromMetadata()
 					if (key.BackReference != null)
 					{
 						if (!string.IsNullOrEmpty(key.KeyName))
-							aa.Parameters.Add("KeyName=\"" + key.KeyName + "\"");
+							aa.Parameters.Add("KeyName=" + CSharpTools.ToStringLiteral(key.KeyName));
 						if (GenerateBackReferences && !string.IsNullOrEmpty(key.BackReference.MemberName))
-							aa.Parameters.Add("BackReferenceName=\"" + key.BackReference.MemberName + "\"");
+							aa.Parameters.Add("BackReferenceName=" + CSharpTools.ToStringLiteral(key.BackReference.MemberName));
 					}
 					else
 					{
@@ -612,7 +613,7 @@ void GenerateTypesFromMetadata()
 				aClass.Comment.AddRange(comments);
 
 			if (GenerateObsoleteAttributeForAliases)
-				aClass.Attributes.Add(new Attribute("Obsolete", "\"Use " + t.TypeName + " instead.\""));
+				aClass.Attributes.Add(new Attribute("Obsolete", CSharpTools.ToStringLiteral("Use " + t.TypeName + " instead.")));
 
 			Model.Types.Add(aClass);
 		}
@@ -671,7 +672,7 @@ void GenerateTypesFromMetadata()
 
 			var proc = new MemberGroup { Region = p.Name };
 
-			     if (!p.IsFunction)     addProcs(proc);
+				 if (!p.IsFunction)     addProcs(proc);
 			else if (p.IsTableFunction) addTabfs(proc);
 			else                        addFuncs(proc);
 
@@ -687,10 +688,10 @@ void GenerateTypesFromMetadata()
 			{
 				var tableAttrs = new List<string>();
 
-				if (DatabaseName != null) tableAttrs.Add("Database=" + '"' + DatabaseName + '"');
-				if (p.Schema     != null) tableAttrs.Add("Schema="   + '"' + p.Schema     + '"');
+				if (DatabaseName != null) tableAttrs.Add("Database=" + CSharpTools.ToStringLiteral(DatabaseName));
+				if (p.Schema     != null) tableAttrs.Add("Schema="   + CSharpTools.ToStringLiteral(p.Schema));
 
-				tableAttrs.Add("Name=" + '"' + p.ProcedureName + '"');
+				tableAttrs.Add("Name=" + CSharpTools.ToStringLiteral(p.ProcedureName));
 
 				p.Attributes.Add(new Attribute("Sql.TableFunction", tableAttrs.ToArray()));
 
@@ -701,7 +702,7 @@ void GenerateTypesFromMetadata()
 				p.IsStatic = true;
 				p.Type = p.ProcParameters.Single(pr => pr.IsResult).ParameterType;
 				var paramCount = p.ProcParameters.Count(pr => !pr.IsResult);
-				p.Attributes.Add(new Attribute("Sql.Function", "Name=\"" + (p.Schema != null ? p.Schema + "." : null) + p.ProcedureName + "\"", "ServerSideOnly=true, IsAggregate = true" + (paramCount > 0 ? (", ArgIndices = new[] { " + string.Join(", ", Enumerable.Range(0, p.ProcParameters.Count(pr => !pr.IsResult))) + " }") : null)));
+				p.Attributes.Add(new Attribute("Sql.Function", "Name=" + CSharpTools.ToStringLiteral((p.Schema != null ? p.Schema + "." : null) + p.ProcedureName), "ServerSideOnly=true, IsAggregate = true" + (paramCount > 0 ? (", ArgIndices = new[] { " + string.Join(", ", Enumerable.Range(0, p.ProcParameters.Count(pr => !pr.IsResult))) + " }") : null)));
 
 				if (p.IsDefaultSchema || !GenerateSchemaAsType)
 					p.Parameters.Add("this IEnumerable<TSource> src");
@@ -717,7 +718,7 @@ void GenerateTypesFromMetadata()
 			{
 				p.IsStatic = true;
 				p.Type = p.ProcParameters.Single(pr => pr.IsResult).ParameterType;
-				p.Attributes.Add(new Attribute("Sql.Function", "Name=\"" + (p.Schema != null ? p.Schema + "." : null)  + p.ProcedureName + "\"", "ServerSideOnly=true"));
+				p.Attributes.Add(new Attribute("Sql.Function", "Name=" + CSharpTools.ToStringLiteral((p.Schema != null ? p.Schema + "." : null)  + p.ProcedureName), "ServerSideOnly=true"));
 			}
 			else
 			{
@@ -756,13 +757,13 @@ void GenerateTypesFromMetadata()
 						(string)SqlBuilder.Convert(p.ProcedureName, LinqToDB.SqlProvider.ConvertType.NameToQueryTable)
 					).ToString();
 
-				spName = "\"" + spName.Replace("\"", "\\\"") + "\"";
+				spName = CSharpTools.ToStringLiteral(spName);
 
 				var inputParameters      = p.ProcParameters.Where(pp => pp.IsIn).            ToList();
 				var outputParameters     = p.ProcParameters.Where(pp => pp.IsOut).           ToList();
 				var inOrOutputParameters = p.ProcParameters.Where(pp => pp.IsIn || pp.IsOut).ToList();
 
-				spName += inputParameters.Count == 0 ? ");" : ",";
+				spName += inOrOutputParameters.Count == 0 ? ");" : ",";
 
 				var retName = "ret";
 				var retNo   = 0;
@@ -814,9 +815,9 @@ void GenerateTypesFromMetadata()
 
 					var str = string.Format(
 						!pr.IsIn && pr.IsOut
-							? "\tnew DataParameter(\"{0}\", null, {3}{4})"
-							: "\tnew DataParameter(\"{0}\", {1}{2}, {3}{4})",
-						pr.SchemaName,
+							? "\tnew DataParameter({0}, null, {3}{4})"
+							: "\tnew DataParameter({0}, {1}{2}, {3}{4})",
+						CSharpTools.ToStringLiteral(pr.SchemaName),
 						LenDiff(maxLenSchema, pr.SchemaName),
 						pr.ParameterName,
 						LenDiff(maxLenParam, pr.ParameterName),
@@ -850,12 +851,12 @@ void GenerateTypesFromMetadata()
 
 					foreach (var pr in p.ProcParameters.Where(_ => _.IsOut))
 					{
-						var str = string.Format("{0} {1}= Converter.ChangeTypeTo<{2}>{3}(((IDbDataParameter)dataConnection.Command.Parameters[\"{4}\"]).{5}Value);",
+						var str = string.Format("{0} {1}= Converter.ChangeTypeTo<{2}>{3}(((IDbDataParameter)dataConnection.Command.Parameters[{4}]).{5}Value);",
 							pr.ParameterName,
 							LenDiff(maxLenParam,  pr.ParameterName),
 							pr.ParameterType,
 							LenDiff(maxLenType,   pr.ParameterType),
-							pr.SchemaName,
+							CSharpTools.ToStringLiteral(pr.SchemaName),
 							LenDiff(maxLenSchema, pr.SchemaName));
 
 						p.Body.Add(str);
@@ -873,7 +874,7 @@ void GenerateTypesFromMetadata()
 				foreach (var c in p.ResultTable.Columns.Values)
 				{
 					if (c.MemberName != c.ColumnName)
-						c.Attributes.Add(new Attribute("Column") { Parameters = { NormalizeStringName(c.ColumnName) } });
+						c.Attributes.Add(new Attribute("Column") { Parameters = { CSharpTools.ToStringLiteral(c.ColumnName) } });
 					columns.Members.Add(c);
 				}
 
@@ -966,13 +967,6 @@ IEnumerable<IClassMember> GetAllClassMembers(IEnumerable<IClassMember> members)
 		else
 			yield return member;
 	}
-}
-
-string NormalizeStringName(string name)
-{
-	if (name.Contains("\"") || name.Contains("\\"))
-		return @"@""" + name.Replace(@"""", @"""""") + @"""";
-	return "\"" + name + "\"";
 }
 
 #>

--- a/Source/LinqToDB.Templates/NotifyPropertyChanged.ttinclude
+++ b/Source/LinqToDB.Templates/NotifyPropertyChanged.ttinclude
@@ -88,7 +88,7 @@ void NotifyPropertyChangedImpl()
 			{
 				new Field("const string", "NameOf" + name)
 				{
-					InitValue      = "\"" + name + "\"",
+					InitValue      = LinqToDB.SchemaProvider.CSharpTools.ToStringLiteral(name),
 					AccessModifier = AccessModifier.Public,
 				},
 				new Field("PropertyChangedEventArgs", "_" + ToCamelCase(name) + "ChangedEventArgs")

--- a/Source/LinqToDB.Templates/README.md
+++ b/Source/LinqToDB.Templates/README.md
@@ -97,8 +97,7 @@ GetSchemaOptions.LoadProcedure = p => true; // Procedure/function load filter. B
 
 // check GetSchemaOptions class for more options
 
-Func<string, bool, string> ToValidName         = ToValidNameDefault;          // Defines function to convert names to valid (My_Table to MyTable) 
-Func<string, bool, string> ConvertToCompilable = ConvertToCompilableDefault;  // Converts name to c# compatible. By default removes uncompatible symbols and converts result with ToValidName
+Func<string, bool, string> ToValidName         = ToValidNameDefault;          // Defines function to convert names to valid C# identifier. Passing true to second parameter enables underscore removal. E.g. (cl_ass => class => @class).
 
 Func<ForeignKey, string> GetAssociationExtensionSinglularName = GetAssociationExtensionSinglularNameDefault; // Gets singular method extension method name for association 
 Func<ForeignKey, string> GetAssociationExtensionPluralName    = GetAssociationExtensionPluralNameDefault;    // Gets plural method extension method name for association 

--- a/Source/LinqToDB.Templates/Validation.ttinclude
+++ b/Source/LinqToDB.Templates/Validation.ttinclude
@@ -50,7 +50,7 @@ void ValidationImpl()
 				cl.Attributes.Add(
 					new Attribute("CustomValidation",
 						"typeof(" + cl.Name + ".CustomValidator)",
-						"\"" + mname + "\"")
+						LinqToDB.SchemaProvider.CSharpTools.ToStringLiteral(mname))
 						{
 							IsSeparated = true
 						});

--- a/Source/LinqToDB/SchemaProvider/CSharpTools.cs
+++ b/Source/LinqToDB/SchemaProvider/CSharpTools.cs
@@ -1,0 +1,166 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace LinqToDB.SchemaProvider
+{
+	public static class CSharpTools
+	{
+		/// <summary>
+		/// Reserved words taken from
+		/// <see href="https://msdn.microsoft.com/en-us/library/x53a06bb%28v=vs.140%29.aspx"/>.
+		/// List actual for C# 7.3.
+		/// Doesn't contain "using static",
+		/// </summary>
+		private static readonly ISet<string> _reservedWords
+			= new HashSet<string>()
+		{
+			"abstract",  "as",         "base",      "bool",     "break",    "byte",      "case",    "catch",
+			"char",      "checked",    "class",     "const",    "continue", "decimal",   "default", "delegate",
+			"do",        "double",     "else",      "enum",     "event",    "explicit",  "extern",  "false",
+			"finally",   "fixed",      "float",     "for",      "foreach",  "goto",      "if",      "implicit",
+			"in",        "int",        "interface", "internal", "is",       "lock",      "long",    "namespace",
+			"new",       "null",       "object",    "operator", "out",      "override",  "params",  "private",
+			"protected", "public",     "readonly",  "ref",      "return",   "sbyte",     "sealed",  "short",
+			"sizeof",    "stackalloc", "static",    "string",   "struct",   "switch",    "this",    "throw",
+			"true",      "try",        "typeof",    "uint",     "ulong",    "unchecked", "unsafe",  "ushort",
+			"using",     "virtual",    "void",      "volatile", "while"
+		};
+
+		/// <summary>
+		/// Contextual words taken from
+		/// <see href="https://msdn.microsoft.com/en-us/library/x53a06bb%28v=vs.140%29.aspx"/>.
+		/// List actual for C# 7.3.
+		/// </summary>
+		private static readonly ISet<string> _contextualWords
+			= new HashSet<string>()
+		{
+			"add",    "alias", "ascending", "async",   "await",  "by",     "descending", "dynamic",
+			"equals", "from",  "get",       "global",  "group",  "into",   "join",       "let",
+			"nameof", "on",    "orderby",   "partial", "remove", "select", "set",        "unmanaged",
+			"value",  "var",   "when",      "where",   "yield"
+		};
+
+		private static readonly ISet<UnicodeCategory> _otherCharsCategories;
+
+		private static readonly ISet<UnicodeCategory> _startCharCategories;
+
+		static CSharpTools()
+		{
+			_startCharCategories = new HashSet<UnicodeCategory>()
+			{
+				// Lu letter
+				UnicodeCategory.UppercaseLetter,
+				// Ll letter
+				UnicodeCategory.LowercaseLetter,
+				// Lt letter
+				UnicodeCategory.TitlecaseLetter,
+				// Lm letter
+				UnicodeCategory.ModifierLetter,
+				// Lo letter
+				UnicodeCategory.OtherLetter,
+				// Nl letter
+				UnicodeCategory.LetterNumber
+			};
+
+			_otherCharsCategories = new HashSet<UnicodeCategory>(_startCharCategories)
+			{
+				// Mn
+				UnicodeCategory.NonSpacingMark,
+				// Mc
+				UnicodeCategory.SpacingCombiningMark,
+				// Nd
+				UnicodeCategory.DecimalDigitNumber,
+				// Pc
+				UnicodeCategory.ConnectorPunctuation,
+				// Cf
+				UnicodeCategory.Format
+			};
+		}
+
+		/// <summary>
+		/// Converts <paramref name="name"/> to valid C# identifier.
+		/// </summary>
+		public static string ToValidIdentifier(string name)
+		{
+			if (name == null || name == string.Empty || name == "@")
+			{
+				return "_";
+			}
+
+			if (_reservedWords.Contains(name) || _contextualWords.Contains(name))
+			{
+				return "@" + name;
+			}
+
+			if (name.StartsWith("@"))
+			{
+				if (_reservedWords.Contains(name.Substring(1)) || _contextualWords.Contains(name.Substring(1)))
+				{
+					return name;
+				}
+				else
+				{
+					name = name.Substring(1);
+				}
+			}
+
+			var sb = new StringBuilder();
+
+			foreach (var chr in name)
+			{
+				var cat = CharUnicodeInfo.GetUnicodeCategory(chr);
+				if (sb.Length == 0 && !_startCharCategories.Contains(cat) && chr != '_')
+				{
+					sb.Append("_");
+				}
+
+				if (sb.Length != 0 && !_otherCharsCategories.Contains(cat))
+				{
+					sb.Append("_");
+				}
+				else
+				{
+					sb.Append(chr);
+				}
+			}
+
+			if (sb.Length >= 2 && sb[0] == '_' && sb[1] == '_' && (sb.Length == 2 || sb[2] != '_'))
+			{
+				sb.Insert(0, '_');
+			}
+
+			return sb.ToString();
+		}
+
+		public static string ToStringLiteral(string value)
+		{
+			if (value == null)
+				return "null";
+
+			var sb = new StringBuilder("\"");
+
+			foreach (var chr in value)
+			{
+				switch (chr)
+				{
+					case '\t':     sb.Append("\\t");            break;
+					case '\n':     sb.Append("\\n");            break;
+					case '\r':     sb.Append("\\r");            break;
+					case '\\':     sb.Append("\\\\");           break;
+					case '"' :     sb.Append("\\\"");           break;
+					case '\0':     sb.Append("\\0");            break;
+					case '\u0085':
+					case '\u2028':
+					case '\u2029':
+							 sb.Append($"\\u{(ushort)chr:X4}"); break;
+					default: sb.Append(chr);                    break;
+				}
+			}
+
+			sb.Append('"');
+
+			return sb.ToString();
+		}
+	}
+}

--- a/Source/LinqToDB/SchemaProvider/SchemaProviderBase.cs
+++ b/Source/LinqToDB/SchemaProvider/SchemaProviderBase.cs
@@ -10,6 +10,7 @@ namespace LinqToDB.SchemaProvider
 	using Common;
 	using Data;
 	using Extensions;
+	using System.Globalization;
 
 	public abstract class SchemaProviderBase : ISchemaProvider
 	{
@@ -568,26 +569,12 @@ namespace LinqToDB.SchemaProvider
 			return dbType;
 		}
 
+		/// <summary>
+		/// Converts <paramref name="name"/> to valid C# identifier.
+		/// </summary>
 		public static string ToValidName(string name)
 		{
-			if (name.Contains(" ") || name.Contains("\t"))
-			{
-				var ss = name.Split(new [] {' ', '\t'}, StringSplitOptions.RemoveEmptyEntries)
-					.Select(s => char.ToUpper(s[0]) + s.Substring(1));
-
-				name = string.Join("", ss.ToArray());
-			}
-
-			if (name.Length > 0 && char.IsDigit(name[0]))
-				name = "_" + name;
-
-			return name
-				.Replace('$',  '_')
-				.Replace('#',  '_')
-				.Replace('-',  '_')
-				.Replace('/',  '_')
-				.Replace('\\', '_')
-				;
+			return CSharpTools.ToValidIdentifier(name);
 		}
 
 		public static string ToTypeName(Type type, bool isNullable)

--- a/Tests/Linq/TestsInitialization.cs
+++ b/Tests/Linq/TestsInitialization.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using NUnit.Framework;
+﻿using NUnit.Framework;
 
 using Tests;
 


### PR DESCRIPTION
Fixes #1383, required for https://github.com/linq2db/linq2db.LINQPad/issues/16

- [x] fixes strange situation when schema provider returns invalid C# identifiers in model and we need to fix them in T4 and LinqPad integration. Now we have method to convert name to valid C# identifier in linq2db and use it for schema names generation
- [x] adds method to properly generate string literals and use it T4
- [x] add more naming tests for T4 templates
- [x] [T4] fix procedure generation for procedures only with output parameters
- [x] removed ConvertToCompilable delegate from T4, because we don't use it anymore with this change

Remaining tasks:
- [ ] I want to try and implement automated tests for T4 templates
- [ ] Still lacks more high-level generation logic for #1384 to share between T4 and LinqPad
- [ ] I think we should remove C# names from schema API as it is out-of-place here