### PR TITLE
Bump DataAction provider dependency

### DIFF
--- a/NuGet/linq2db.Sybase.DataAction.nuspec
+++ b/NuGet/linq2db.Sybase.DataAction.nuspec
@@ -19,7 +19,7 @@
 		<tags>linq linq2db SAP Sybase LinqToDB ORM database DB SQL</tags>
 		<dependencies>
 			<dependency id="linq2db"              version="2.6.0"  />
-			<dependency id="AdoNetCore.AseClient" version="0.11.0" />
+			<dependency id="AdoNetCore.AseClient" version="0.13.0" />
 		</dependencies>
 		<contentFiles>
 			<files include="**\*" buildAction="None"/>

--- a/Tests/Linq/Tests.csproj
+++ b/Tests/Linq/Tests.csproj
@@ -62,7 +62,7 @@
 		<ProjectReference Include="..\Model\Tests.Model.csproj" />
 		<ProjectReference Include="..\Base\Tests.Base.csproj" />
 		<ProjectReference Include="..\VisualBasic\Tests.VisualBasic.vbproj" />
-		<PackageReference Include="AdoNetCore.AseClient" Version="0.11.0" />
+		<PackageReference Include="AdoNetCore.AseClient" Version="0.13.0" />
 
 		<PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
 		<PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />


### PR DESCRIPTION
Updated Sybase DataAction provider dependency to recently released v0.13
It contains remaining fixes for issues we reported and makes all our sybase.managed tests green.