### PR TITLE
Better DbProviderFactories support

### DIFF
--- a/NuGet/DB2/LinqToDB.DB2.Tools.ttinclude
+++ b/NuGet/DB2/LinqToDB.DB2.Tools.ttinclude
@@ -1,3 +1,2 @@
-<#@ assembly name="$(LinqToDBT4DB2ToolsDirectory)IBM.Data.DB2.dll" #>
 <#@ include file="LinqToDB.Tools.ttinclude" #>
 <#@ include file="LinqToDB.DB2.ttinclude" #>

--- a/NuGet/Informix/LinqToDB.Informix.Tools.ttinclude
+++ b/NuGet/Informix/LinqToDB.Informix.Tools.ttinclude
@@ -1,3 +1,2 @@
-<#@ assembly name="$(LinqToDBT4InformixToolsDirectory)IBM.Data.Informix.dll" #>
 <#@ include file="LinqToDB.Tools.ttinclude" #>
 <#@ include file="LinqToDB.Informix.ttinclude" #>

--- a/NuGet/SapHana/LinqToDB.SapHana.Tools.ttinclude
+++ b/NuGet/SapHana/LinqToDB.SapHana.Tools.ttinclude
@@ -1,3 +1,2 @@
-<#@ assembly name="$(LinqToDBT4SapHanaToolsDirectory)Sap.Data.Hana.v4.5.dll" #>
 <#@ include file="LinqToDB.Tools.ttinclude" #>
 <#@ include file="LinqToDB.SapHana.ttinclude" #>

--- a/NuGet/SqlCe/LinqToDB.SqlCe.Tools.ttinclude
+++ b/NuGet/SqlCe/LinqToDB.SqlCe.Tools.ttinclude
@@ -1,3 +1,2 @@
-<#@ assembly name="$(LinqToDBT4SqlCeToolsDirectory)System.Data.SqlServerCe.dll" #>
 <#@ include file="LinqToDB.Tools.ttinclude" #>
 <#@ include file="LinqToDB.SqlCe.ttinclude" #>

--- a/NuGet/Sybase/LinqToDB.Sybase.Tools.ttinclude
+++ b/NuGet/Sybase/LinqToDB.Sybase.Tools.ttinclude
@@ -1,3 +1,2 @@
-<#@ assembly name="$(LinqToDBT4SybaseToolsDirectory)Sybase.AdoNet45.AseClient.dll" #>
 <#@ include file="LinqToDB.Tools.ttinclude" #>
 <#@ include file="LinqToDB.Sybase.ttinclude" #>

--- a/NuGet/linq2db.DB2.nuspec
+++ b/NuGet/linq2db.DB2.nuspec
@@ -26,7 +26,6 @@
 		</contentFiles>
 	</metadata>
 	<files>
-		<file src="..\Redist\IBM\IBM.Data.DB2.dll"                      target="tools" />
 		<file src="..\Source\LinqToDB\bin\Release\net45\linq2db.dll"    target="tools" />
 		
 		<file src="DB2\linq2db.DB2.props"                               target="build" />

--- a/NuGet/linq2db.Informix.nuspec
+++ b/NuGet/linq2db.Informix.nuspec
@@ -26,7 +26,6 @@
 		</contentFiles>
 	</metadata>
 	<files>
-		<file src="..\Redist\IBM\IBM.Data.Informix.dll"                           target="tools" />
 		<file src="..\Source\LinqToDB\bin\Release\net45\linq2db.dll"              target="tools" />
 		
 		<file src="Informix\linq2db.Informix.props"                               target="build" />

--- a/NuGet/linq2db.SqlCe.nuspec
+++ b/NuGet/linq2db.SqlCe.nuspec
@@ -25,7 +25,6 @@
 		</contentFiles>
 	</metadata>
 	<files>
-		<file src="..\Tests\Linq\bin\AppVeyor\net46\System.Data.SqlServerCe.dll"  target="tools" />
 		<file src="..\Source\LinqToDB\bin\Release\net45\linq2db.dll"              target="tools" />
 		
 		<file src="SqlCe\linq2db.SqlCe.props"                                     target="build" />

--- a/NuGet/linq2db.Sybase.nuspec
+++ b/NuGet/linq2db.Sybase.nuspec
@@ -26,7 +26,6 @@
 		</contentFiles>
 	</metadata>
 	<files>
-		<file src="..\Redist\Sybase\Sybase.AdoNet45.AseClient.dll"     target="tools" />
 		<file src="..\Source\LinqToDB\bin\Release\net45\linq2db.dll"   target="tools" />
 		
 		<file src="Sybase\linq2db.Sybase.props"                        target="build" />

--- a/Source/LinqToDB.Templates/LinqToDB.DB2.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.DB2.ttinclude
@@ -1,12 +1,8 @@
 <#@ include file="LinqToDB.ttinclude" #>
-<#
-	LinqToDB.DataProvider.DB2.DB2Tools.ResolveDB2(
-		typeof(IBM.Data.DB2.DB2Connection).Assembly);
-#><#+
-LinqToDB.Data.DataConnection GetDB2Connection(string connectionString)
+<#+
+LinqToDB.Data.DataConnection GetDB2Connection(string connectionString, LinqToDB.DataProvider.DB2.DB2Version version = LinqToDB.DataProvider.DB2.DB2Version.LUW)
 {
-	var conn = new IBM.Data.DB2.DB2Connection(connectionString);
-	return LinqToDB.DataProvider.DB2.DB2Tools.CreateDataConnection(conn);
+	return LinqToDB.DataProvider.DB2.DB2Tools.CreateDataConnection(connectionString, version);
 }
 
 LinqToDB.Data.DataConnection GetDB2Connection(string server, string port, string database, string uid, string password)

--- a/Source/LinqToDB.Templates/LinqToDB.Informix.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.Informix.ttinclude
@@ -1,12 +1,8 @@
 <#@ include file="LinqToDB.ttinclude" #>
-<#
-	LinqToDB.DataProvider.Informix.InformixTools.ResolveInformix(
-		typeof(IBM.Data.Informix.IfxConnection).Assembly);
-#><#+
+<#+
 LinqToDB.Data.DataConnection GetInformixConnection(string connectionString)
 {
-	var conn = new IBM.Data.Informix.IfxConnection(connectionString);
-	return LinqToDB.DataProvider.Informix.InformixTools.CreateDataConnection(conn);
+	return new LinqToDB.Data.DataConnection(new LinqToDB.DataProvider.Informix.InformixDataProvider(), connectionString);
 }
 
 LinqToDB.Data.DataConnection GetInformixConnection(string host, string port, string server, string database, string uid, string password)

--- a/Source/LinqToDB.Templates/LinqToDB.SapHana.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.SapHana.ttinclude
@@ -1,9 +1,6 @@
 <#@ include file="LinqToDB.ttinclude" #>
 <#@ import namespace="LinqToDB.DataProvider.SapHana"   #>
 <#
-	LinqToDB.DataProvider.SapHana.SapHanaTools.ResolveSapHana(
-		typeof(Sap.Data.Hana.HanaConnection).Assembly);
-
 	Model.Usings.Add("LinqToDB.DataProvider.SapHana");
 	Model.Usings.Add("System.Reflection");
 

--- a/Source/LinqToDB.Templates/LinqToDB.SqlCe.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.SqlCe.ttinclude
@@ -1,8 +1,4 @@
 <#@ include file="LinqToDB.ttinclude" #>
-<#
-	LinqToDB.DataProvider.SqlCe.SqlCeTools.ResolveSqlCe(
-		typeof(System.Data.SqlServerCe.SqlCeConnection).Assembly);
-#>
 <#+
 LinqToDB.Data.DataConnection GetSqlCeConnection(string connectionString)
 {

--- a/Source/LinqToDB/DataProvider/DB2/DB2DataProvider.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2DataProvider.cs
@@ -123,6 +123,10 @@ namespace LinqToDB.DataProvider.DB2
 		protected override string ConnectionTypeName  => DB2Tools.AssemblyName + ".DB2Connection, " + DB2Tools.AssemblyName;
 		protected override string DataReaderTypeName  => DB2Tools.AssemblyName + ".DB2DataReader, " + DB2Tools.AssemblyName;
 
+#if !NETSTANDARD1_6 && !NETSTANDARD2_0
+		public override string DbFactoryProviderName => "IBM.Data.DB2";
+#endif
+
 		public DB2Version Version { get; }
 
 		static class MappingSchemaInstance

--- a/Source/LinqToDB/DataProvider/Informix/InformixDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixDataProvider.cs
@@ -134,6 +134,10 @@ namespace LinqToDB.DataProvider.Informix
 		protected override string ConnectionTypeName  => "IBM.Data.Informix.IfxConnection, IBM.Data.Informix";
 		protected override string DataReaderTypeName  => "IBM.Data.Informix.IfxDataReader, IBM.Data.Informix";
 
+#if !NETSTANDARD1_6 && !NETSTANDARD2_0
+		public override string DbFactoryProviderName => "IBM.Data.Informix";
+#endif
+
 		public override ISqlBuilder CreateSqlBuilder()
 		{
 			return new InformixSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, MappingSchema.ValueToSqlConverter);

--- a/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
@@ -68,55 +68,7 @@ namespace LinqToDB.DataProvider.Oracle
 		Type _oracleXmlStream;
 
 #if !NETSTANDARD1_6 && !NETSTANDARD2_0
-		private Type _dataReaderType;
-		private volatile Type _connectionType;
-
-		public override Type DataReaderType
-		{
-			get
-			{
-				if (Name == ProviderName.OracleNative)
-				{
-					if (_dataReaderType != null)
-						return _dataReaderType;
-
-					_dataReaderType = Type.GetType(DataReaderTypeName, false);
-
-					if (_dataReaderType == null)
-					{
-						var assembly = DbProviderFactories.GetFactory(AssemblyName + ".Client").GetType().Assembly;
-						_dataReaderType = assembly.GetType(DataReaderTypeNameWithoutAssembly, true);
-					}
-
-					return _dataReaderType;
-				}
-
-				return base.DataReaderType;
-			}
-		}
-
-		protected override Type GetConnectionType()
-		{
-			if (Name == ProviderName.OracleNative)
-			{
-				if (_connectionType == null)
-					lock (SyncRoot)
-						if (_connectionType == null)
-						{
-							_connectionType = Type.GetType(ConnectionTypeName, false);
-
-							if (_connectionType == null)
-								using (var db = DbProviderFactories.GetFactory(AssemblyName + ".Client").CreateConnection())
-									_connectionType = db.GetType();
-
-							OnConnectionTypeCreated(_connectionType);
-						}
-
-				return _connectionType;
-			}
-
-			return base.GetConnectionType();
-		}
+		public override string DbFactoryProviderName => Name == ProviderName.OracleNative ? "Oracle.DataAccess.Client" : null;
 #endif
 		protected override void OnConnectionTypeCreated(Type connectionType)
 		{
@@ -451,8 +403,7 @@ namespace LinqToDB.DataProvider.Oracle
 
 		public    override string ConnectionNamespace               => $"{AssemblyName}.Client";
 		protected override string ConnectionTypeName                => $"{AssemblyName}.Client.OracleConnection, {AssemblyName}";
-		protected override string DataReaderTypeName                => $"{DataReaderTypeNameWithoutAssembly}, {AssemblyName}";
-		private            string DataReaderTypeNameWithoutAssembly => $"{AssemblyName}.Client.OracleDataReader";
+		protected override string DataReaderTypeName                => $"{AssemblyName}.Client.OracleDataReader, {AssemblyName}";
 
 		public             bool   IsXmlTypeSupported  => _oracleXmlType != null;
 

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaDataProvider.cs
@@ -49,45 +49,7 @@ namespace LinqToDB.DataProvider.SapHana
 		protected override string DataReaderTypeName  => $"{ConnectionNamespace}.HanaDataReader, {SapHanaTools.AssemblyName}";
 
 #if !NETSTANDARD1_6 && !NETSTANDARD2_0
-		private          Type _dataReaderType;
-		private volatile Type _connectionType;
-
-		public override Type DataReaderType
-		{
-			get
-			{
-				if (_dataReaderType != null)
-					return _dataReaderType;
-
-				_dataReaderType = Type.GetType(DataReaderTypeName, false);
-
-				if (_dataReaderType == null)
-				{
-					var assembly = DbProviderFactories.GetFactory("Sap.Data.Hana").GetType().Assembly;
-					_dataReaderType = Type.GetType($"{ConnectionNamespace}.HanaDataReader, {assembly.GetName()}", true);
-				}
-
-				return _dataReaderType;
-			}
-		}
-
-		protected override Type GetConnectionType()
-		{
-			if (_connectionType == null)
-				lock (SyncRoot)
-					if (_connectionType == null)
-					{
-						_connectionType = Type.GetType(ConnectionTypeName, false);
-
-						if (_connectionType == null)
-							using (var db = DbProviderFactories.GetFactory("Sap.Data.Hana").CreateConnection())
-								_connectionType = db.GetType();
-
-						OnConnectionTypeCreated(_connectionType);
-					}
-
-			return _connectionType;
-		}
+		public override string DbFactoryProviderName => "Sap.Data.Hana";
 #endif
 
 		static Action<IDbDataParameter> _setText;

--- a/Source/LinqToDB/DataProvider/SqlCe/SqlCeDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlCe/SqlCeDataProvider.cs
@@ -43,6 +43,10 @@ namespace LinqToDB.DataProvider.SqlCe
 		protected override string ConnectionTypeName  => $"{ConnectionNamespace}.SqlCeConnection, {ConnectionNamespace}";
 		protected override string DataReaderTypeName  => $"{ConnectionNamespace}.SqlCeDataReader, {ConnectionNamespace}";
 
+#if !NETSTANDARD1_6 && !NETSTANDARD2_0
+		public override string DbFactoryProviderName => "System.Data.SqlServerCe.4.0";
+#endif
+
 		protected override void OnConnectionTypeCreated(Type connectionType)
 		{
 			_setNText     = GetSetParameter(connectionType, SqlDbType.NText);

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseDataProvider.cs
@@ -50,6 +50,10 @@ namespace LinqToDB.DataProvider.Sybase
 		protected override string ConnectionTypeName  => $"{ConnectionNamespace}.AseConnection, {AssemblyName}";
 		protected override string DataReaderTypeName  => $"{ConnectionNamespace}.AseDataReader, {AssemblyName}";
 
+#if !NETSTANDARD1_6 && !NETSTANDARD2_0
+		public override string DbFactoryProviderName => "Sybase.Data.AseClient";
+#endif
+
 		static DateTime GetDateTime(IDataReader dr, int idx)
 		{
 			var value = dr.GetDateTime(idx);

--- a/Tests/Linq/Tests.csproj
+++ b/Tests/Linq/Tests.csproj
@@ -131,11 +131,9 @@
 
 		<Reference Include="IBM.Data.DB2">
 			<HintPath>..\..\Redist\IBM\IBM.Data.DB2.dll</HintPath>
-			<Private>false</Private>
 		</Reference>
 		<Reference Include="IBM.Data.Informix">
 			<HintPath>..\..\Redist\IBM\IBM.Data.Informix.dll</HintPath>
-			<Private>false</Private>
 		</Reference>
 
 		<PackageReference Include="Oracle.ManagedDataAccess" Version="12.2.1100" />

--- a/Tests/Linq/Tests.csproj
+++ b/Tests/Linq/Tests.csproj
@@ -131,9 +131,11 @@
 
 		<Reference Include="IBM.Data.DB2">
 			<HintPath>..\..\Redist\IBM\IBM.Data.DB2.dll</HintPath>
+			<Private>false</Private>
 		</Reference>
 		<Reference Include="IBM.Data.Informix">
 			<HintPath>..\..\Redist\IBM\IBM.Data.Informix.dll</HintPath>
+			<Private>false</Private>
 		</Reference>
 
 		<PackageReference Include="Oracle.ManagedDataAccess" Version="12.2.1100" />

--- a/Tests/Linq/Tests.csproj
+++ b/Tests/Linq/Tests.csproj
@@ -131,19 +131,14 @@
 
 		<Reference Include="IBM.Data.DB2">
 			<HintPath>..\..\Redist\IBM\IBM.Data.DB2.dll</HintPath>
+			<Private>false</Private>
 		</Reference>
 		<Reference Include="IBM.Data.Informix">
 			<HintPath>..\..\Redist\IBM\IBM.Data.Informix.dll</HintPath>
-		</Reference>
-		<Reference Include="Sybase.AdoNet45.AseClient">
-			<HintPath>..\..\Redist\Sybase\Sybase.AdoNet45.AseClient.dll</HintPath>
+			<Private>false</Private>
 		</Reference>
 
-		<!--
-		<PackageReference Include="Oracle.DataAccess.x86" Version="2.112.1.0" />
-		-->
 		<PackageReference Include="Oracle.ManagedDataAccess" Version="12.2.1100" />
-		<PackageReference Include="Microsoft.SqlServer.Compact" Version="4.0.8876.1" />
 		<PackageReference Include="Microsoft.SqlServer.Types" Version="14.0.314.76" />
 		<PackageReference Include="MiniProfiler" Version="3.2.0.157" />
 		<PackageReference Include="Microsoft.Data.SQLite" Version="1.1.1" />

--- a/Tests/Linq/TestsInitialization.cs
+++ b/Tests/Linq/TestsInitialization.cs
@@ -1,5 +1,6 @@
 ﻿using System;
-
+using System.Data.Common;
+using System.Reflection;
 using NUnit.Framework;
 
 using Tests;
@@ -14,6 +15,22 @@ public class TestsInitialization
 	[OneTimeSetUp]
 	public void TestAssemblySetup()
 	{
+#if !NETSTANDARD1_6 && !NETSTANDARD2_0
+		// configure assembly redirect for referenced assemblies to use version from GAC
+		// this solves exception from provider-specific tests, when it tries to load version from redist folder
+		// but loaded from GAC assembly has other version
+		AppDomain.CurrentDomain.AssemblyResolve += (sender, args) =>
+		{
+			var requestedAssembly = new AssemblyName(args.Name);
+			if (requestedAssembly.Name == "IBM.Data.DB2")
+				return DbProviderFactories.GetFactory("IBM.Data.DB2").GetType().Assembly;
+			if (requestedAssembly.Name == "IBM.Data.Informix")
+				return DbProviderFactories.GetFactory("IBM.Data.Informix").GetType().Assembly;
+
+			return null;
+		};
+#endif
+
 		// register test provider
 		TestNoopProvider.Init();
 	}

--- a/Tests/Tests.Playground/Tests.Playground.csproj
+++ b/Tests/Tests.Playground/Tests.Playground.csproj
@@ -67,9 +67,6 @@
     <Reference Include="IBM.Data.Informix">
       <HintPath>..\..\Redist\IBM\IBM.Data.Informix.dll</HintPath>
     </Reference>
-    <Reference Include="Sybase.AdoNet45.AseClient">
-      <HintPath>..\..\Redist\Sybase\Sybase.AdoNet45.AseClient.dll</HintPath>
-    </Reference>
 
     <None Include="..\..\Data\*">
         <Link>Database/%(FileName)%(Extension)</Link>


### PR DESCRIPTION
Fixes #1385
- [x] Move DbProviderFactories support code from SAP/Oracle providers to base DynamicDataProviderBase class
- [x] Enable DbProviderFactories for DB2
- [x] Enable DbProviderFactories for Sybase ASE
- [x] Enable DbProviderFactories for Informix
- [x] Maybe enable DbProviderFactories for SQL CE

Note that it is supported only for desktop framework for now, because we don't build netcoreapp2.1/netstandard2.1 targets yet.