### PR TITLE
CreateTable improvements

### DIFF
--- a/Source/LinqToDB/DataProvider/Access/AccessMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessMappingSchema.cs
@@ -16,7 +16,8 @@ namespace LinqToDB.DataProvider.Access
 
 		protected AccessMappingSchema(string configuration) : base(configuration)
 		{
-			SetDataType(typeof(DateTime), DataType.DateTime);
+			SetDataType(typeof(DateTime),  DataType.DateTime);
+			SetDataType(typeof(DateTime?), DataType.DateTime);
 
 			SetValueToSqlConverter(typeof(bool),     (sb,dt,v) => sb.Append(v));
 			SetValueToSqlConverter(typeof(Guid),     (sb,dt,v) => sb.Append("'").Append(((Guid)v).ToString("B")).Append("'"));

--- a/Source/LinqToDB/DataProvider/DB2/DB2SqlBuilderBase.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2SqlBuilderBase.cs
@@ -158,12 +158,23 @@ namespace LinqToDB.DataProvider.DB2
 		{
 			switch (type.DataType)
 			{
-				case DataType.DateTime  : StringBuilder.Append("timestamp");             break;
-				case DataType.DateTime2 : StringBuilder.Append("timestamp");             break;
-				case DataType.Boolean   : StringBuilder.Append("smallint");              break;
-				case DataType.Guid      : StringBuilder.Append("char(16) for bit data"); break;
-				default                 : base.BuildDataType(type, createDbType);        break;
+				case DataType.DateTime  : StringBuilder.Append("timestamp");             return;
+				case DataType.DateTime2 : StringBuilder.Append("timestamp");             return;
+				case DataType.Boolean   : StringBuilder.Append("smallint");              return;
+				case DataType.Guid      : StringBuilder.Append("char(16) for bit data"); return;
+				case DataType.NVarChar:
+					if (type.Length == null || type.Length > 8168 || type.Length < 1)
+					{
+						StringBuilder
+							.Append(type.DataType)
+							.Append("(8168)");
+						return;
+					}
+
+					break;
 			}
+
+			base.BuildDataType(type, createDbType);
 		}
 
 		public static DB2IdentifierQuoteMode IdentifierQuoteMode = DB2IdentifierQuoteMode.Auto;

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdSqlBuilder.cs
@@ -104,9 +104,10 @@ namespace LinqToDB.DataProvider.Firebird
 						StringBuilder.Append('(').Append(type.Length).Append(')');
 					StringBuilder.Append(" CHARACTER SET UNICODE_FSS");
 					break;
-				case DataType.VarBinary     :
-					StringBuilder.Append("BLOB");
-					break;
+				case DataType.VarBinary     : StringBuilder.Append("BLOB");            break;
+				// BOOLEAN type available since FB 3.0, but FirebirdDataProvider.SetParameter converts boolean to '1'/'0'
+				// so for now we will use type, compatible with SetParameter by default
+				case DataType.Boolean       : StringBuilder.Append("CHAR");            break;
 				default: base.BuildDataType(type, createDbType); break;
 			}
 		}

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdSqlBuilder.cs
@@ -100,8 +100,13 @@ namespace LinqToDB.DataProvider.Firebird
 				case DataType.DateTime      : StringBuilder.Append("TimeStamp");       break;
 				case DataType.NVarChar      :
 					StringBuilder.Append("VarChar");
-					if (type.Length > 0)
-						StringBuilder.Append('(').Append(type.Length).Append(')');
+
+					// 10921 is implementation  limit for UNICODE_FSS encoding
+					if (type.Length == null || type.Length > 10921 || type.Length < 1)
+						StringBuilder.Append("(10921)");
+					else
+						StringBuilder.Append($"({type.Length})");
+
 					StringBuilder.Append(" CHARACTER SET UNICODE_FSS");
 					break;
 				case DataType.VarBinary     : StringBuilder.Append("BLOB");            break;

--- a/Source/LinqToDB/DataProvider/Informix/InformixSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixSqlBuilder.cs
@@ -121,18 +121,18 @@ namespace LinqToDB.DataProvider.Informix
 		{
 			switch (type.DataType)
 			{
-				case DataType.VarBinary  : StringBuilder.Append("BYTE");                      break;
-				case DataType.Boolean    : StringBuilder.Append("BOOLEAN");                   break;
-				case DataType.DateTime   : StringBuilder.Append("datetime year to second");   break;
-				case DataType.DateTime2  : StringBuilder.Append("datetime year to fraction"); break;
+				case DataType.VarBinary  : StringBuilder.Append("BYTE");                      return;
+				case DataType.Boolean    : StringBuilder.Append("BOOLEAN");                   return;
+				case DataType.DateTime   : StringBuilder.Append("datetime year to second");   return;
+				case DataType.DateTime2  : StringBuilder.Append("datetime year to fraction"); return;
 				case DataType.Time       :
 					StringBuilder.Append("INTERVAL HOUR TO FRACTION");
 					StringBuilder.AppendFormat("({0})", (type.Length ?? 5).ToString(CultureInfo.InvariantCulture));
-					break;
-				case DataType.Date       : StringBuilder.Append("DATETIME YEAR TO DAY");      break;
+					return;
+				case DataType.Date       : StringBuilder.Append("DATETIME YEAR TO DAY");      return;
 				case DataType.SByte      :
-				case DataType.Byte       : StringBuilder.Append("SmallInt");                  break;
-				case DataType.SmallMoney : StringBuilder.Append("Decimal(10,4)");             break;
+				case DataType.Byte       : StringBuilder.Append("SmallInt");                  return;
+				case DataType.SmallMoney : StringBuilder.Append("Decimal(10,4)");             return;
 				case DataType.Decimal    :
 					StringBuilder.Append("Decimal");
 					if (type.Precision != null && type.Scale != null)
@@ -140,9 +140,20 @@ namespace LinqToDB.DataProvider.Informix
 							"({0}, {1})",
 							type.Precision.Value.ToString(CultureInfo.InvariantCulture),
 							type.Scale.Value.ToString(CultureInfo.InvariantCulture));
+					return;
+				case DataType.NVarChar:
+					if (type.Length == null || type.Length > 255 || type.Length < 1)
+					{
+						StringBuilder
+							.Append(type.DataType)
+							.Append("(255)");
+						return;
+					}
+
 					break;
-				default                  : base.BuildDataType(type, createDbType);            break;
 			}
+
+			base.BuildDataType(type, createDbType);
 		}
 
 		protected override void BuildFromClause(SqlStatement statement, SelectQuery selectQuery)

--- a/Source/LinqToDB/DataProvider/MySql/MySqlSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlSqlBuilder.cs
@@ -88,9 +88,11 @@ namespace LinqToDB.DataProvider.MySql
 				case DataType.Single        : base.BuildDataType(SqlDataType.Decimal, createDbType); break;
 				case DataType.VarChar       :
 				case DataType.NVarChar      :
-					StringBuilder.Append("Char");
-					if (type.Length > 0)
-						StringBuilder.Append('(').Append(type.Length).Append(')');
+					// yep, char(0) is allowed
+					if (type.Length == null || type.Length > 255 || type.Length < 0)
+						StringBuilder.Append("Char(255)");
+					else
+						StringBuilder.Append($"Char({type.Length})");
 					break;
 				default: base.BuildDataType(type, createDbType);                                     break;
 			}

--- a/Source/LinqToDB/DataProvider/Oracle/OracleMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleMappingSchema.cs
@@ -23,6 +23,7 @@ namespace LinqToDB.DataProvider.Oracle
 			ColumnNameComparer = StringComparer.OrdinalIgnoreCase;
 
 			SetDataType(typeof(Guid),   DataType.Guid);
+			SetDataType(typeof(Guid?),  DataType.Guid);
 			SetDataType(typeof(string), new SqlDataType(DataType.VarChar, typeof(string), 255));
 
 			SetConvertExpression<decimal,TimeSpan>(v => new TimeSpan((long)v));

--- a/Source/LinqToDB/DataProvider/Oracle/OracleSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleSqlBuilder.cs
@@ -219,9 +219,10 @@ namespace LinqToDB.DataProvider.Oracle
 				case DataType.Money          : StringBuilder.Append("Number(19,4)");              break;
 				case DataType.SmallMoney     : StringBuilder.Append("Number(10,4)");              break;
 				case DataType.NVarChar       :
-					StringBuilder.Append("VarChar2");
-					if (type.Length > 0)
-						StringBuilder.Append('(').Append(type.Length).Append(')');
+					if (type.Length == null || type.Length > 4000 || type.Length < 1)
+						StringBuilder.Append("VarChar2(4000)");
+					else
+						StringBuilder.Append($"VarChar2({type.Length})");
 					break;
 				case DataType.Boolean        : StringBuilder.Append("Char(1)");                   break;
 				case DataType.NText          : StringBuilder.Append("NClob");                     break;

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
@@ -17,8 +17,6 @@ namespace LinqToDB.DataProvider.PostgreSQL
 		{
 			ColumnNameComparer = StringComparer.OrdinalIgnoreCase;
 
-			SetDataType(typeof(string), DataType.Undefined);
-
 			AddScalarType(typeof(PhysicalAddress), DataType.Udt);
 
 			SetValueToSqlConverter(typeof(bool),   (sb,dt,v) => sb.Append(v));

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLSqlBuilder.cs
@@ -96,10 +96,6 @@ namespace LinqToDB.DataProvider.PostgreSQL
 					if (type.Length > 0)
 						StringBuilder.Append('(').Append(type.Length.Value.ToString(NumberFormatInfo.InvariantInfo)).Append(')');
 					break;
-				case DataType.Undefined      :
-					if (type.Type == typeof(string))
-						goto case DataType.NVarChar;
-					break;
 				case DataType.Json           : StringBuilder.Append("json");           break;
 				case DataType.BinaryJson     : StringBuilder.Append("jsonb");          break;
 				case DataType.Guid           : StringBuilder.Append("uuid");           break;

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaSqlBuilder.cs
@@ -119,7 +119,7 @@ namespace LinqToDB.DataProvider.SapHana
 					{
 						StringBuilder
 							.Append(type.DataType)
-							.Append("(Max)");
+							.Append("(5000)");
 						return;
 					}
 					break;

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaSqlBuilder.cs
@@ -115,7 +115,7 @@ namespace LinqToDB.DataProvider.SapHana
 				case DataType.NVarChar:
 				case DataType.VarChar:
 				case DataType.VarBinary:
-					if (type.Length == int.MaxValue || type.Length < 0)
+					if (type.Length == null || type.Length > 5000 || type.Length < 1)
 					{
 						StringBuilder
 							.Append(type.DataType)

--- a/Source/LinqToDB/DataProvider/SqlCe/SqlCeMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/SqlCe/SqlCeMappingSchema.cs
@@ -25,20 +25,33 @@ namespace LinqToDB.DataProvider.SqlCe
 
 			SetConvertExpression<string,SqlXml>(s => new SqlXml(new MemoryStream(Encoding.UTF8.GetBytes(s))));
 
-			AddScalarType(typeof(SqlBinary),   SqlBinary.  Null, true, DataType.VarBinary);
-			AddScalarType(typeof(SqlBoolean),  SqlBoolean. Null, true, DataType.Boolean);
-			AddScalarType(typeof(SqlByte),     SqlByte.    Null, true, DataType.Byte);
-			AddScalarType(typeof(SqlDateTime), SqlDateTime.Null, true, DataType.DateTime);
-			AddScalarType(typeof(SqlDecimal),  SqlDecimal. Null, true, DataType.Decimal);
-			AddScalarType(typeof(SqlDouble),   SqlDouble.  Null, true, DataType.Double);
-			AddScalarType(typeof(SqlGuid),     SqlGuid.    Null, true, DataType.Guid);
-			AddScalarType(typeof(SqlInt16),    SqlInt16.   Null, true, DataType.Int16);
-			AddScalarType(typeof(SqlInt32),    SqlInt32.   Null, true, DataType.Int32);
-			AddScalarType(typeof(SqlInt64),    SqlInt64.   Null, true, DataType.Int64);
-			AddScalarType(typeof(SqlMoney),    SqlMoney.   Null, true, DataType.Money);
-			AddScalarType(typeof(SqlSingle),   SqlSingle.  Null, true, DataType.Single);
-			AddScalarType(typeof(SqlString),   SqlString.  Null, true, DataType.NVarChar);
-			AddScalarType(typeof(SqlXml),      SqlXml.     Null, true, DataType.Xml);
+			AddScalarType(typeof(SqlBinary),    SqlBinary.  Null, true, DataType.VarBinary);
+			AddScalarType(typeof(SqlBinary?),   SqlBinary.  Null, true, DataType.VarBinary);
+			AddScalarType(typeof(SqlBoolean),   SqlBoolean. Null, true, DataType.Boolean);
+			AddScalarType(typeof(SqlBoolean?),  SqlBoolean. Null, true, DataType.Boolean);
+			AddScalarType(typeof(SqlByte),      SqlByte.    Null, true, DataType.Byte);
+			AddScalarType(typeof(SqlByte?),     SqlByte.    Null, true, DataType.Byte);
+			AddScalarType(typeof(SqlDateTime),  SqlDateTime.Null, true, DataType.DateTime);
+			AddScalarType(typeof(SqlDateTime?), SqlDateTime.Null, true, DataType.DateTime);
+			AddScalarType(typeof(SqlDecimal),   SqlDecimal. Null, true, DataType.Decimal);
+			AddScalarType(typeof(SqlDecimal?),  SqlDecimal. Null, true, DataType.Decimal);
+			AddScalarType(typeof(SqlDouble),    SqlDouble.  Null, true, DataType.Double);
+			AddScalarType(typeof(SqlDouble?),   SqlDouble.  Null, true, DataType.Double);
+			AddScalarType(typeof(SqlGuid),      SqlGuid.    Null, true, DataType.Guid);
+			AddScalarType(typeof(SqlGuid?),     SqlGuid.    Null, true, DataType.Guid);
+			AddScalarType(typeof(SqlInt16),     SqlInt16.   Null, true, DataType.Int16);
+			AddScalarType(typeof(SqlInt16?),    SqlInt16.   Null, true, DataType.Int16);
+			AddScalarType(typeof(SqlInt32),     SqlInt32.   Null, true, DataType.Int32);
+			AddScalarType(typeof(SqlInt32?),    SqlInt32.   Null, true, DataType.Int32);
+			AddScalarType(typeof(SqlInt64),     SqlInt64.   Null, true, DataType.Int64);
+			AddScalarType(typeof(SqlInt64?),    SqlInt64.   Null, true, DataType.Int64);
+			AddScalarType(typeof(SqlMoney),     SqlMoney.   Null, true, DataType.Money);
+			AddScalarType(typeof(SqlMoney?),    SqlMoney.   Null, true, DataType.Money);
+			AddScalarType(typeof(SqlSingle),    SqlSingle.  Null, true, DataType.Single);
+			AddScalarType(typeof(SqlSingle?),   SqlSingle.  Null, true, DataType.Single);
+			AddScalarType(typeof(SqlString),    SqlString.  Null, true, DataType.NVarChar);
+			AddScalarType(typeof(SqlString?),   SqlString.  Null, true, DataType.NVarChar);
+			AddScalarType(typeof(SqlXml),       SqlXml.     Null, true, DataType.Xml);
 
 			SetDataType(typeof(string), new SqlDataType(DataType.NVarChar, typeof(string), 255));
 

--- a/Source/LinqToDB/DataProvider/SqlCe/SqlCeSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlCe/SqlCeSqlBuilder.cs
@@ -74,15 +74,26 @@ namespace LinqToDB.DataProvider.SqlCe
 		{
 			switch (type.DataType)
 			{
-				case DataType.Char          : base.BuildDataType(new SqlDataType(DataType.NChar,    type.Length), createDbType); break;
-				case DataType.VarChar       : base.BuildDataType(new SqlDataType(DataType.NVarChar, type.Length), createDbType); break;
-				case DataType.SmallMoney    : StringBuilder.Append("Decimal(10,4)");                                             break;
+				case DataType.Char          : base.BuildDataType(new SqlDataType(DataType.NChar,    type.Length), createDbType); return;
+				case DataType.VarChar       : base.BuildDataType(new SqlDataType(DataType.NVarChar, type.Length), createDbType); return;
+				case DataType.SmallMoney    : StringBuilder.Append("Decimal(10,4)");                                             return;
 				case DataType.DateTime2     :
 				case DataType.Time          :
 				case DataType.Date          :
-				case DataType.SmallDateTime : StringBuilder.Append("DateTime");                                                  break;
-				default                     : base.BuildDataType(type, createDbType);                                            break;
+				case DataType.SmallDateTime : StringBuilder.Append("DateTime");                                                  return;
+				case DataType.NVarChar:
+					if (type.Length == null || type.Length > 4000 || type.Length < 1)
+					{
+						StringBuilder
+							.Append(type.DataType)
+							.Append("(4000)");
+						return;
+					}
+
+					break;
 			}
+
+			base.BuildDataType(type, createDbType);
 		}
 
 		protected override void BuildFromClause(SqlStatement statement, SelectQuery selectQuery)

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerMappingSchema.cs
@@ -25,20 +25,33 @@ namespace LinqToDB.DataProvider.SqlServer
 
 			SetConvertExpression<string,SqlXml>(s => new SqlXml(new MemoryStream(Encoding.UTF8.GetBytes(s))));
 
-			AddScalarType(typeof(SqlBinary),   SqlBinary.  Null, true, DataType.VarBinary);
-			AddScalarType(typeof(SqlBoolean),  SqlBoolean. Null, true, DataType.Boolean);
-			AddScalarType(typeof(SqlByte),     SqlByte.    Null, true, DataType.Byte);
-			AddScalarType(typeof(SqlDateTime), SqlDateTime.Null, true, DataType.DateTime);
-			AddScalarType(typeof(SqlDecimal),  SqlDecimal. Null, true, DataType.Decimal);
-			AddScalarType(typeof(SqlDouble),   SqlDouble.  Null, true, DataType.Double);
-			AddScalarType(typeof(SqlGuid),     SqlGuid.    Null, true, DataType.Guid);
-			AddScalarType(typeof(SqlInt16),    SqlInt16.   Null, true, DataType.Int16);
-			AddScalarType(typeof(SqlInt32),    SqlInt32.   Null, true, DataType.Int32);
-			AddScalarType(typeof(SqlInt64),    SqlInt64.   Null, true, DataType.Int64);
-			AddScalarType(typeof(SqlMoney),    SqlMoney.   Null, true, DataType.Money);
-			AddScalarType(typeof(SqlSingle),   SqlSingle.  Null, true, DataType.Single);
-			AddScalarType(typeof(SqlString),   SqlString.  Null, true, DataType.NVarChar);
-			AddScalarType(typeof(SqlXml),      SqlXml.     Null, true, DataType.Xml);
+			AddScalarType(typeof(SqlBinary),    SqlBinary.  Null, true, DataType.VarBinary);
+			AddScalarType(typeof(SqlBinary?),   SqlBinary.  Null, true, DataType.VarBinary);
+			AddScalarType(typeof(SqlBoolean),   SqlBoolean. Null, true, DataType.Boolean);
+			AddScalarType(typeof(SqlBoolean?),  SqlBoolean. Null, true, DataType.Boolean);
+			AddScalarType(typeof(SqlByte),      SqlByte.    Null, true, DataType.Byte);
+			AddScalarType(typeof(SqlByte?),     SqlByte.    Null, true, DataType.Byte);
+			AddScalarType(typeof(SqlDateTime),  SqlDateTime.Null, true, DataType.DateTime);
+			AddScalarType(typeof(SqlDateTime?), SqlDateTime.Null, true, DataType.DateTime);
+			AddScalarType(typeof(SqlDecimal),   SqlDecimal. Null, true, DataType.Decimal);
+			AddScalarType(typeof(SqlDecimal?),  SqlDecimal. Null, true, DataType.Decimal);
+			AddScalarType(typeof(SqlDouble),    SqlDouble.  Null, true, DataType.Double);
+			AddScalarType(typeof(SqlDouble?),   SqlDouble.  Null, true, DataType.Double);
+			AddScalarType(typeof(SqlGuid),      SqlGuid.    Null, true, DataType.Guid);
+			AddScalarType(typeof(SqlGuid?),     SqlGuid.    Null, true, DataType.Guid);
+			AddScalarType(typeof(SqlInt16),     SqlInt16.   Null, true, DataType.Int16);
+			AddScalarType(typeof(SqlInt16?),    SqlInt16.   Null, true, DataType.Int16);
+			AddScalarType(typeof(SqlInt32),     SqlInt32.   Null, true, DataType.Int32);
+			AddScalarType(typeof(SqlInt32?),    SqlInt32.   Null, true, DataType.Int32);
+			AddScalarType(typeof(SqlInt64),     SqlInt64.   Null, true, DataType.Int64);
+			AddScalarType(typeof(SqlInt64?),    SqlInt64.   Null, true, DataType.Int64);
+			AddScalarType(typeof(SqlMoney),     SqlMoney.   Null, true, DataType.Money);
+			AddScalarType(typeof(SqlMoney?),    SqlMoney.   Null, true, DataType.Money);
+			AddScalarType(typeof(SqlSingle),    SqlSingle.  Null, true, DataType.Single);
+			AddScalarType(typeof(SqlSingle?),   SqlSingle.  Null, true, DataType.Single);
+			AddScalarType(typeof(SqlString),    SqlString.  Null, true, DataType.NVarChar);
+			AddScalarType(typeof(SqlString?),   SqlString.  Null, true, DataType.NVarChar);
+			AddScalarType(typeof(SqlXml),       SqlXml.     Null, true, DataType.Xml);
 
 			try
 			{

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlBuilder.cs
@@ -293,10 +293,19 @@ namespace LinqToDB.DataProvider.SqlServer
 				case DataType.Guid      : StringBuilder.Append("UniqueIdentifier"); return;
 				case DataType.Variant   : StringBuilder.Append("Sql_Variant");      return;
 				case DataType.NVarChar  :
+					if (type.Length == null || type.Length > 4000 || type.Length < 1)
+					{
+						StringBuilder
+							.Append(type.DataType)
+							.Append("(Max)");
+						return;
+					}
+
+					break;
+
 				case DataType.VarChar   :
 				case DataType.VarBinary :
-
-					if (type.Length == int.MaxValue || type.Length < 0)
+					if (type.Length == null || type.Length > 8000 || type.Length < 1)
 					{
 						StringBuilder
 							.Append(type.DataType)

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseSqlBuilder.cs
@@ -85,15 +85,6 @@ namespace LinqToDB.DataProvider.Sybase
 			}
 		}
 
-		protected override void BuildCreateTableNullAttribute(SqlField field, DefaultNullable defaultNullable)
-		{
-			// Sybase doesn't support nullable bit fields
-			if (field.CanBeNull && field.DataType == DataType.Boolean)
-				field.CanBeNull = false;
-
-			base.BuildCreateTableNullAttribute(field, defaultNullable);
-		}
-
 		protected override void BuildDeleteClause(SqlDeleteStatement deleteStatement)
 		{
 			var selectQuery = deleteStatement.SelectQuery;

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseSqlBuilder.cs
@@ -80,9 +80,20 @@ namespace LinqToDB.DataProvider.Sybase
 		{
 			switch (type.DataType)
 			{
-				case DataType.DateTime2 : StringBuilder.Append("DateTime");       break;
-				default                 : base.BuildDataType(type, createDbType); break;
+				case DataType.DateTime2 : StringBuilder.Append("DateTime");       return;
+				case DataType.NVarChar:
+					// yep, 5461...
+					if (type.Length == null || type.Length > 5461 || type.Length < 1)
+					{
+						StringBuilder
+							.Append(type.DataType)
+							.Append("(5461)");
+						return;
+					}
+					break;
 			}
+
+			base.BuildDataType(type, createDbType);
 		}
 
 		protected override void BuildDeleteClause(SqlDeleteStatement deleteStatement)

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseSqlBuilder.cs
@@ -85,6 +85,15 @@ namespace LinqToDB.DataProvider.Sybase
 			}
 		}
 
+		protected override void BuildCreateTableNullAttribute(SqlField field, DefaultNullable defaultNullable)
+		{
+			// Sybase doesn't support nullable bit fields
+			if (field.CanBeNull && field.DataType == DataType.Boolean)
+				field.CanBeNull = false;
+
+			base.BuildCreateTableNullAttribute(field, defaultNullable);
+		}
+
 		protected override void BuildDeleteClause(SqlDeleteStatement deleteStatement)
 		{
 			var selectQuery = deleteStatement.SelectQuery;

--- a/Source/LinqToDB/Linq/QueryRunner.Delete.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.Delete.cs
@@ -15,6 +15,11 @@ namespace LinqToDB.Linq
 		{
 			static readonly ConcurrentDictionary<object,Query<int>> _queryCache = new ConcurrentDictionary<object,Query<int>>();
 
+			static Delete()
+			{
+				Linq.Query.CacheCleaners.Add(() => _queryCache.Clear());
+			}
+
 			static Query<int> CreateQuery(IDataContext dataContext, string tableName, string databaseName, string schemaName, Type type)
 			{
 				var sqlTable = new SqlTable(dataContext.MappingSchema, type);

--- a/Source/LinqToDB/Linq/QueryRunner.Insert.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.Insert.cs
@@ -14,6 +14,11 @@ namespace LinqToDB.Linq
 		{
 			static readonly ConcurrentDictionary<object,Query<int>> _queryCache = new ConcurrentDictionary<object,Query<int>>();
 
+			static Insert()
+			{
+				LinqToDB.Linq.Query.CacheCleaners.Add(() => _queryCache.Clear());
+			}
+
 			static Query<int> CreateQuery(IDataContext dataContext, string tableName, string databaseName, string schemaName, Type type)
 			{
 				var sqlTable = new SqlTable(dataContext.MappingSchema, type);

--- a/Source/LinqToDB/Linq/QueryRunner.InsertOrReplace.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.InsertOrReplace.cs
@@ -16,6 +16,11 @@ namespace LinqToDB.Linq
 		{
 			static readonly ConcurrentDictionary<object,Query<int>> _queryCache = new ConcurrentDictionary<object,Query<int>>();
 
+			static InsertOrReplace()
+			{
+				Linq.Query.CacheCleaners.Add(() => _queryCache.Clear());
+			}
+
 			static Query<int> CreateQuery(IDataContext dataContext, string tableName, string databaseName, string schemaName, Type type)
 			{
 				var fieldDic = new Dictionary<SqlField, ParameterAccessor>();

--- a/Source/LinqToDB/Linq/QueryRunner.InsertWithIdentity.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.InsertWithIdentity.cs
@@ -14,6 +14,11 @@ namespace LinqToDB.Linq
 		{
 			static readonly ConcurrentDictionary<object,Query<object>> _queryCache = new ConcurrentDictionary<object,Query<object>>();
 
+			static InsertWithIdentity()
+			{
+				Linq.Query.CacheCleaners.Add(() => _queryCache.Clear());
+			}
+
 			static Query<object> CreateQuery(IDataContext dataContext, string tableName, string databaseName, string schemaName, Type type)
 			{
 				var sqlTable = new SqlTable(dataContext.MappingSchema, type);

--- a/Source/LinqToDB/Linq/QueryRunner.Update.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.Update.cs
@@ -16,6 +16,11 @@ namespace LinqToDB.Linq
 		{
 			static readonly ConcurrentDictionary<object,Query<int>> _queryCache = new ConcurrentDictionary<object,Query<int>>();
 
+			static Update()
+			{
+				Linq.Query.CacheCleaners.Add(() => _queryCache.Clear());
+			}
+
 			static Query<int> CreateQuery(IDataContext dataContext, string tableName, string databaseName, string schemaName, Type type)
 			{
 				var sqlTable = new SqlTable<T>(dataContext.MappingSchema);

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -2458,6 +2458,9 @@ namespace LinqToDB.SqlProvider
 				case DataType.Int32  : StringBuilder.Append("Int");      return;
 				case DataType.Int64  : StringBuilder.Append("BigInt");   return;
 				case DataType.Boolean: StringBuilder.Append("Bit");      return;
+				case DataType.Undefined:
+					// give some hint to user that it is expected situation and he need to fix something on his side
+					throw new LinqToDBException("Database type cannot be determined automatically and must be specified explicitly");
 			}
 
 			StringBuilder.Append(type.DataType);

--- a/Source/LinqToDB/SqlQuery/SqlTable.cs
+++ b/Source/LinqToDB/SqlQuery/SqlTable.cs
@@ -7,6 +7,8 @@ using System.Threading;
 
 namespace LinqToDB.SqlQuery
 {
+	using LinqToDB.Common;
+	using LinqToDB.Data;
 	using Mapping;
 
 	public class SqlTable : ISqlTableSource
@@ -109,6 +111,24 @@ namespace LinqToDB.SqlQuery
 					}
 
 					field.DataType = dataType.DataType;
+
+					// try to get type from converter
+					if (field.DataType == DataType.Undefined)
+					{
+						try
+						{
+							var converter = mappingSchema.GetConverter(field.SystemType, typeof(DataParameter), true);
+							if (converter != null && converter.ConvertValueToParameter != null)
+							{
+								var parameter = converter.ConvertValueToParameter(DefaultValue.GetValue(field.SystemType, mappingSchema));
+								field.DataType = parameter.DataType;
+							}
+						}
+						catch
+						{
+							// converter cannot handle default value?
+						}
+					}
 
 					if (field.Length == null)
 						field.Length = dataType.Length;

--- a/Tests/Base/Tools/ComparerBuilder.cs
+++ b/Tests/Base/Tools/ComparerBuilder.cs
@@ -151,6 +151,9 @@ namespace Tests.Tools
 			if (type == typeof(BitArray))
 				return typeof(BitArrayEqualityComparer);
 
+			if (type != typeof(string) && typeof(IEnumerable).IsAssignableFromEx(type))
+				return typeof(EnumerableEqualityComparer);
+
 			return typeof(EqualityComparer<>).MakeGenericType(type);
 		}
 

--- a/Tests/Base/Tools/EnumerableEqualityComparer.cs
+++ b/Tests/Base/Tools/EnumerableEqualityComparer.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Tests.Tools
+{
+	internal class EnumerableEqualityComparer : EqualityComparer<IEnumerable>
+	{
+		public static new EnumerableEqualityComparer Default { get; } = new EnumerableEqualityComparer();
+
+		public override int GetHashCode(IEnumerable obj)
+		{
+			if (obj == null)
+				return 0;
+
+			return obj.Cast<object>().Aggregate(0, (acc, val) => acc ^ val.GetHashCode());
+		}
+
+		public override bool Equals(IEnumerable x, IEnumerable y)
+		{
+			if (x == null && y == null)
+				return true;
+
+			if (x == null || y == null)
+				return false;
+
+			return x.Cast<object>().SequenceEqual(y.Cast<object>());
+		}
+	}
+}

--- a/Tests/Linq/Tests.csproj
+++ b/Tests/Linq/Tests.csproj
@@ -75,6 +75,7 @@
 		<PackageReference Include="Mono.Cecil" Version="0.10.0" />
 		<PackageReference Include="MySql.Data" Version="6.10.6" />
 		<PackageReference Include="Humanizer.Core" Version="2.2.0" />
+		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 	</ItemGroup>
 
 

--- a/Tests/Linq/Update/CreateTableTypesTests.cs
+++ b/Tests/Linq/Update/CreateTableTypesTests.cs
@@ -1,0 +1,117 @@
+﻿using LinqToDB;
+using LinqToDB.Linq;
+using LinqToDB.Mapping;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Tests.Tools;
+
+namespace Tests.xUpdate
+{
+	using ColumnBuilder        = Action<EntityMappingBuilder<CreateTableTypesTests.CreateTableTypes>>;
+	using ValueBuilder         = Action<CreateTableTypesTests.CreateTableTypes>;
+	using DefaultValueBuilder  = Action<string, CreateTableTypesTests.CreateTableTypes>;
+
+	[TestFixture]
+	public class CreateTableTypesTests : TestBase
+	{
+		[Table]
+		public class CreateTableTypes
+		{
+			public int         Id                 { get; set; }
+			public int         Int32              { get; set; }
+			public int?        Int32Nullable      { get; set; }
+			public long        Int64              { get; set; }
+			public long?       Int64Nullable      { get; set; }
+			public double      Double             { get; set; }
+			public double?     DoubleNullable     { get; set; }
+			public bool        Boolean            { get; set; }
+			public bool?       BooleanNullable    { get; set; }
+			public DateTime    DateTime           { get; set; }
+			public DateTime?   DateTimeNullable   { get; set; }
+			public IntEnum     IntEnum            { get; set; }
+			public IntEnum?    IntEnumNullable    { get; set; }
+			public StringEnum  StringEnum         { get; set; }
+			public StringEnum? StringEnumNullable { get; set; }
+			public string      String             { get; set; }
+			public string      StringNullable     { get; set; }
+
+			public static IEqualityComparer<CreateTableTypes> Comparer = ComparerBuilder<CreateTableTypes>.GetEqualityComparer();
+		}
+
+		public enum IntEnum
+		{
+			[MapValue(11)]
+			Default,
+			[MapValue(60)]
+			Value = 50
+		}
+
+		public enum StringEnum
+		{
+			[MapValue("14")]
+			Default,
+			[MapValue("4")]
+			Value1 = 3,
+			[MapValue("40")]
+			Value2 = 30
+		}
+
+		// TODO: add more cases
+		// TODO: add length validation to fields with length (text/binary)
+		static IEnumerable<(ColumnBuilder columnBuilder, ValueBuilder valueBuilder, DefaultValueBuilder defaultValueBuilder)> TestCases
+		{
+			get
+			{
+				yield return (e => e.HasColumn(_ => _.Int32),                       v => v.Int32              = 1                                  , null);
+				yield return (e => e.HasColumn(_ => _.Int32Nullable),               v => v.Int32Nullable      = 2                                  , null);
+				yield return (e => e.HasColumn(_ => _.Int64),                       v => v.Int64              = 3                                  , null);
+				yield return (e => e.HasColumn(_ => _.Int64Nullable),               v => v.Int64Nullable      = 4                                  , null);
+				yield return (e => e.HasColumn(_ => _.Double),                      v => v.Double             = 3.14                               , null);
+				yield return (e => e.HasColumn(_ => _.DoubleNullable),              v => v.DoubleNullable     = 4.13                               , null);
+				yield return (e => e.HasColumn(_ => _.Boolean),                     v => v.Boolean            = true                               , null);
+				yield return (e => e.HasColumn(_ => _.BooleanNullable),             v => v.BooleanNullable    = true                               , (ctx, v) => { if (ctx.Contains("Sybase")) { v.BooleanNullable = false; } });
+				yield return (e => e.HasColumn(_ => _.DateTime),                    v => v.DateTime           = new DateTime(2018, 11, 24, 1, 2, 3), null);
+				yield return (e => e.HasColumn(_ => _.DateTimeNullable),            v => v.DateTimeNullable   = new DateTime(2018, 11, 25, 1, 2, 3), null);
+				yield return (e => e.HasColumn(_ => _.IntEnum),                     v => v.IntEnum            = IntEnum.Value                      , null);
+				yield return (e => e.HasColumn(_ => _.IntEnumNullable),             v => v.IntEnumNullable    = IntEnum.Value                      , null);
+				yield return (e => e.HasColumn(_ => _.StringEnum),                  v => v.StringEnum         = StringEnum.Value1                  , null);
+				yield return (e => e.HasColumn(_ => _.StringEnumNullable),          v => v.StringEnumNullable = StringEnum.Value2                  , null);
+				yield return (e => e.HasColumn(_ => _.String),                      v => v.String             = "test max value"                   , null);
+				yield return (e => e.Property (_ => _.StringNullable).IsNullable(), v => v.StringNullable     = "test max value nullable"          , null);
+				yield return (e => e.Property (_ => _.String).HasLength(10),        v => v.String             = "test 10"                          , null);
+				yield return (e => e.Property (_ => _.StringNullable).HasLength(10).IsNullable(), v => v.StringNullable = "test 10 n"              , null);
+			}
+		}
+
+		[Test]
+		public void TestCreateTableColumnType(
+			[DataSources] string context,
+			[ValueSource(nameof(TestCases))] (ColumnBuilder columnBuilder, ValueBuilder valueBuilder, DefaultValueBuilder defaultValueBuilder) testCase)
+		{
+			Query.ClearCaches();
+
+			var ms = new MappingSchema();
+			var entity = ms.GetFluentMappingBuilder()
+				.Entity<CreateTableTypes>()
+				.HasColumn(e => e.Id);
+			testCase.columnBuilder(entity);
+
+			using (var db = GetDataContext(context, ms))
+			using (var table = db.CreateLocalTable<CreateTableTypes>())
+			{
+				var defaultValue = new CreateTableTypes() { Id = 1 };
+				var testValue    = new CreateTableTypes() { Id = 2 };
+
+				testCase.defaultValueBuilder?.Invoke(context, defaultValue);
+				testCase.valueBuilder(testValue);
+
+				db.Insert(defaultValue);
+				db.Insert(testValue);
+
+				AreEqual(new[] { defaultValue, testValue }, table.OrderBy(_ => _.Id), CreateTableTypes.Comparer);
+			}
+		}
+	}
+}

--- a/Tests/Linq/Update/CreateTableTypesTests.cs
+++ b/Tests/Linq/Update/CreateTableTypesTests.cs
@@ -104,8 +104,8 @@ namespace Tests.xUpdate
 				yield return (e => e.Property (_ => _.String).IsNullable(false).HasLength(10), v => v.String             = "test 10"                           , (ctx, v) => { if (ctx.Contains("Oracle") || ctx.Contains("Sybase")) { v.String = " "; } else { v.String = string.Empty; } }, null,                            null);
 				yield return (e => e.Property (_ => _.String).HasLength(10),                   v => v.String = "test 10 n"                                     , null,                                                                                                                        null,                            null);
 
-				yield return (e => e.Property(_ => _.StringConverted).IsNullable(false).HasDataType(DataType.NVarChar), v => v.StringConverted = CreateTableTypes.StringConvertedTestValue, null, null, null);
-				yield return (e => e.Property(_ => _.StringConverted).HasDataType(DataType.NVarChar), v => v.StringConverted = CreateTableTypes.StringConvertedTestValue, null, null, null);
+				yield return (e => e.Property(_ => _.StringConverted).IsNullable(false).HasDataType(DataType.NVarChar), v => v.StringConverted = CreateTableTypes.StringConvertedTestValue, null,                                                                                             null,                            null);
+				yield return (e => e.Property(_ => _.StringConverted).HasDataType(DataType.NVarChar), v => v.StringConverted = CreateTableTypes.StringConvertedTestValue, null,                                                                                                               null,                            null);
 			}
 		}
 

--- a/Tests/Linq/Update/CreateTableTypesTests.cs
+++ b/Tests/Linq/Update/CreateTableTypesTests.cs
@@ -69,7 +69,7 @@ namespace Tests.xUpdate
 			Value2 = 30
 		}
 
-		// TODO: add more cases
+		// TODO: add more cases: other types, different DataType values
 		// TODO: add length validation to fields with length (text/binary)
 		static IEnumerable<(ColumnBuilder, ValueBuilder, DefaultValueBuilder, Func<string, bool>, Func<string, bool>)> TestCases
 		{
@@ -103,9 +103,12 @@ namespace Tests.xUpdate
 				// Sybase roundtrips empty string to " " (WAT?)
 				yield return (e => e.Property (_ => _.String).IsNullable(false).HasLength(10), v => v.String             = "test 10"                           , (ctx, v) => { if (ctx.Contains("Oracle") || ctx.Contains("Sybase")) { v.String = " "; } else { v.String = string.Empty; } }, null,                            null);
 				yield return (e => e.Property (_ => _.String).HasLength(10),                   v => v.String = "test 10 n"                                     , null,                                                                                                                        null,                            null);
-
+				// https://github.com/linq2db/linq2db/issues/1032 with DataType specified
 				yield return (e => e.Property(_ => _.StringConverted).IsNullable(false).HasDataType(DataType.NVarChar), v => v.StringConverted = CreateTableTypes.StringConvertedTestValue, null,                                                                                             null,                            null);
 				yield return (e => e.Property(_ => _.StringConverted).HasDataType(DataType.NVarChar), v => v.StringConverted = CreateTableTypes.StringConvertedTestValue, null,                                                                                                               null,                            null);
+				// https://github.com/linq2db/linq2db/issues/1032 without DataType specified
+				yield return (e => e.Property(_ => _.StringConverted).IsNullable(false),       v => v.StringConverted = CreateTableTypes.StringConvertedTestValue, null,                                                                                                                      null,                            null);
+				yield return (e => e.HasColumn(_ => _.StringConverted),                        v => v.StringConverted = CreateTableTypes.StringConvertedTestValue, null,                                                                                                                      null,                            null);
 			}
 		}
 


### PR DESCRIPTION
- [x] fix #1394 
- [x] fix #1032 
- [x] partial #749 fix (test for some types added, but more types should be tested. something for later releases as it takes a lot of time)


Summary of changes:
- Access: added missing mapping configuration for DateTime? type
- Firebird: added default boolean type support as CHAR for CreateTable
- Oracle: added missing mapping configuration for Guid? type
- Postgresql: changed mapping of string type from DataType.Unknown to DataType.NVarChar (fixes #1394)
- SQLCE/SQLServer: added missing mapping configuration for System.Data.SqlTypes.Sql* nullable struct types
- Query.CleanCaches() will also clean caches for IDataContext non-linq extension methods: Insert, Delete, InsertOrReplace, InsertWithIdentity, Update and their variations
- SAP HANA/SQL Server: properly generate (MAX) type specifier for varbinary/varchar/nvarchar types when length is not specified or outside of allowed range
- added IEnumerable-based properties comparison support for test comparer
- DB2, Informix, sqlce, sybase: correctly generate nvarchar type when length in not specified or out-of-rage
- Firebird: correctly generate varchar type when length in not specified or out-of-rage
- MySQL: correctly generate char type when length in not specified or out-of-rage
- Oracle: correctly generate varchar2 type when length in not specified or out-of-rage
- added LinqToDBException when we cannot generate db type with exlanatory (I hope) message
- added column type inferrence using mapping schema converter to DataParameter (fixes #1032)