### PR TITLE
Nuget metadata update

### DIFF
--- a/Build/AppVeyor.FixVersionNugets.ps1
+++ b/Build/AppVeyor.FixVersionNugets.ps1
@@ -12,6 +12,8 @@ if ($nugetVersion) {
 	$authors = 'Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko'
 	$ns = @{ns=$nsUri}
 	$dotlessVersion = $nugetVersion -replace '\.',''
+	$commit = (git rev-parse HEAD)
+	$branch = (git rev-parse --abbrev-ref HEAD)
 
 	Get-ChildItem $path | ForEach {
 		$xmlPath = Resolve-Path $_.FullName
@@ -45,6 +47,21 @@ if ($nugetVersion) {
 
 		$child = $xml.CreateElement('owners', $nsUri)
 		$child.InnerText = $authors
+		$xml.package.metadata.AppendChild($child)
+
+		$child = $xml.CreateElement('repository', $nsUri)
+		$attr = $xml.CreateAttribute('type')
+		$attr.Value = 'git'
+		$child.Attributes.Append($attr)
+		$attr = $xml.CreateAttribute('url')
+		$attr.Value = 'https://github.com/linq2db/linq2db.git'
+		$child.Attributes.Append($attr)
+		$attr = $xml.CreateAttribute('branch')
+		$attr.Value = $branch
+		$child.Attributes.Append($attr)
+		$attr = $xml.CreateAttribute('commit')
+		$attr.Value = $commit
+		$child.Attributes.Append($attr)
 		$xml.package.metadata.AppendChild($child)
 
 		Write-Host "Patched $xmlPath"

--- a/Build/AppVeyor.FixVersionNugets.ps1
+++ b/Build/AppVeyor.FixVersionNugets.ps1
@@ -33,6 +33,10 @@ if ($nugetVersion) {
 		Select -expand node |
 		ForEach { $_.Value = $nugetVersion }
 
+		$child = $xml.CreateElement('version', $nsUri)
+		$child.InnerText = $nugetVersion
+		$xml.package.metadata.AppendChild($child)
+
 		$child = $xml.CreateElement('releaseNotes', $nsUri)
 		$child.InnerText = 'https://github.com/linq2db/linq2db/wiki/releases-and-roadmap#release-' + $dotlessVersion
 		$xml.package.metadata.AppendChild($child)

--- a/Build/AppVeyor.FixVersionNugets.ps1
+++ b/Build/AppVeyor.FixVersionNugets.ps1
@@ -8,7 +8,9 @@ Set-StrictMode -Version Latest
 
 if ($nugetVersion) {
 
-	$ns = @{ns='http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd'}
+	$nsUri = 'http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd'
+	$authors = 'Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko'
+	$ns = @{ns=$nsUri}
 	$dotlessVersion = $nugetVersion -replace '\.',''
 
 	Get-ChildItem $path | ForEach {
@@ -29,9 +31,21 @@ if ($nugetVersion) {
 		Select -expand node |
 		ForEach { $_.Value = $nugetVersion }
 
-		Select-Xml -Xml $xml -XPath '//ns:releaseNotes' -Namespace $ns |
-		Select -expand node |
-		ForEach { $_.InnerText = 'https://github.com/linq2db/linq2db/wiki/Releases-and-Roadmap#release-' + $dotlessVersion }
+		$child = $xml.CreateElement('releaseNotes', $nsUri)
+		$child.InnerText = 'https://github.com/linq2db/linq2db/wiki/releases-and-roadmap#release-' + $dotlessVersion
+		$xml.package.metadata.AppendChild($child)
+
+		$child = $xml.CreateElement('copyright', $nsUri)
+		$child.InnerText = 'Copyright (c) 2018 ' + $authors
+		$xml.package.metadata.AppendChild($child)
+
+		$child = $xml.CreateElement('authors', $nsUri)
+		$child.InnerText = $authors
+		$xml.package.metadata.AppendChild($child)
+
+		$child = $xml.CreateElement('owners', $nsUri)
+		$child.InnerText = $authors
+		$xml.package.metadata.AppendChild($child)
 
 		Write-Host "Patched $xmlPath"
 		$xml.Save($xmlPath)

--- a/Build/AppVeyor.FixVersionNugets.ps1
+++ b/Build/AppVeyor.FixVersionNugets.ps1
@@ -49,6 +49,22 @@ if ($nugetVersion) {
 		$child.InnerText = $authors
 		$xml.package.metadata.AppendChild($child)
 
+		$child = $xml.CreateElement('licenseUrl', $nsUri)
+		$child.InnerText = 'https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt'
+		$xml.package.metadata.AppendChild($child)
+
+		$child = $xml.CreateElement('projectUrl', $nsUri)
+		$child.InnerText = 'https://github.com/linq2db/linq2db'
+		$xml.package.metadata.AppendChild($child)
+
+		$child = $xml.CreateElement('iconUrl', $nsUri)
+		$child.InnerText = 'http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320'
+		$xml.package.metadata.AppendChild($child)
+
+		$child = $xml.CreateElement('requireLicenseAcceptance', $nsUri)
+		$child.InnerText = 'false'
+		$xml.package.metadata.AppendChild($child)
+
 		$child = $xml.CreateElement('repository', $nsUri)
 		$attr = $xml.CreateAttribute('type')
 		$attr.Value = 'git'

--- a/Build/AppVeyor.FixVersionNugets.ps1
+++ b/Build/AppVeyor.FixVersionNugets.ps1
@@ -9,6 +9,7 @@ Set-StrictMode -Version Latest
 if ($nugetVersion) {
 
 	$ns = @{ns='http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd'}
+	$dotlessVersion = $nugetVersion -replace '\.',''
 
 	Get-ChildItem $path | ForEach {
 		$xmlPath = Resolve-Path $_.FullName
@@ -27,6 +28,10 @@ if ($nugetVersion) {
 		Select-Xml -Xml $xml -XPath '//ns:dependency[@id="linq2db"]/@version' -Namespace $ns |
 		Select -expand node |
 		ForEach { $_.Value = $nugetVersion }
+
+		Select-Xml -Xml $xml -XPath '//ns:releaseNotes' -Namespace $ns |
+		Select -expand node |
+		ForEach { $_.InnerText = 'https://github.com/linq2db/linq2db/wiki/Releases-and-Roadmap#release-' + $dotlessVersion }
 
 		Write-Host "Patched $xmlPath"
 		$xml.Save($xmlPath)

--- a/NuGet/PackLocal.cmd
+++ b/NuGet/PackLocal.cmd
@@ -1,0 +1,3 @@
+powershell ..\Build\AppVeyor.FixVersionNugets.ps1 -path *.nuspec -nugetVersion 2.6.0
+call Pack.bat
+

--- a/NuGet/linq2db.Access.nuspec
+++ b/NuGet/linq2db.Access.nuspec
@@ -4,10 +4,6 @@
 		<id>linq2db.Access</id>
 		<version>2.6.0</version>
 		<title>LINQ to Access</title>
-		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
-		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
-		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
-		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>
 			LINQ to Access is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.Access.nuspec
+++ b/NuGet/linq2db.Access.nuspec
@@ -10,6 +10,7 @@
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to Access is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>
@@ -17,6 +18,7 @@
 			This package includes a T4 template to generate data models for Access database and a reference to the linq2db nuget.
 		</summary>
 		<tags>linq linq2db Access LinqToDB ORM database DB SQL</tags>
+		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="linq2db" version="2.6.0"/>
 		</dependencies>

--- a/NuGet/linq2db.Access.nuspec
+++ b/NuGet/linq2db.Access.nuspec
@@ -2,7 +2,6 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 	<metadata minClientVersion="3.3.0">
 		<id>linq2db.Access</id>
-		<version>2.6.0</version>
 		<title>LINQ to Access</title>
 		<description>
 			LINQ to Access is a data access technology that provides a run-time infrastructure for managing relational data as objects.

--- a/NuGet/linq2db.Access.nuspec
+++ b/NuGet/linq2db.Access.nuspec
@@ -15,7 +15,6 @@
 			This package includes a T4 template to generate data models for Access database and a reference to the linq2db nuget.
 		</summary>
 		<tags>linq linq2db Access LinqToDB ORM database DB SQL</tags>
-		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="linq2db" version="2.6.0"/>
 		</dependencies>

--- a/NuGet/linq2db.Access.nuspec
+++ b/NuGet/linq2db.Access.nuspec
@@ -4,13 +4,10 @@
 		<id>linq2db.Access</id>
 		<version>2.6.0</version>
 		<title>LINQ to Access</title>
-		<authors>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</authors>
-		<owners>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</owners>
 		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to Access is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.DB2.nuspec
+++ b/NuGet/linq2db.DB2.nuspec
@@ -4,13 +4,10 @@
 		<id>linq2db.DB2</id>
 		<version>2.6.0</version>
 		<title>LINQ to IBM DB2</title>
-		<authors>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</authors>
-		<owners>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</owners>
 		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to DB2 is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.DB2.nuspec
+++ b/NuGet/linq2db.DB2.nuspec
@@ -2,7 +2,6 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 	<metadata minClientVersion="3.3.0">
 		<id>linq2db.DB2</id>
-		<version>2.6.0</version>
 		<title>LINQ to IBM DB2</title>
 		<description>
 			LINQ to DB2 is a data access technology that provides a run-time infrastructure for managing relational data as objects.

--- a/NuGet/linq2db.DB2.nuspec
+++ b/NuGet/linq2db.DB2.nuspec
@@ -10,6 +10,7 @@
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to DB2 is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>
@@ -18,6 +19,7 @@
 			IBM Data Server Provider for .NET will still need to be installed on the production or development machine in order to connect to DB2.
 		</summary>
 		<tags>linq linq2db DB2 LinqToDB ORM database DB SQL</tags>
+		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="linq2db" version="2.6.0"/>
 		</dependencies>

--- a/NuGet/linq2db.DB2.nuspec
+++ b/NuGet/linq2db.DB2.nuspec
@@ -4,10 +4,6 @@
 		<id>linq2db.DB2</id>
 		<version>2.6.0</version>
 		<title>LINQ to IBM DB2</title>
-		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
-		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
-		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
-		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>
 			LINQ to DB2 is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.DB2.nuspec
+++ b/NuGet/linq2db.DB2.nuspec
@@ -16,7 +16,6 @@
 			IBM Data Server Provider for .NET will still need to be installed on the production or development machine in order to connect to DB2.
 		</summary>
 		<tags>linq linq2db DB2 LinqToDB ORM database DB SQL</tags>
-		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="linq2db" version="2.6.0"/>
 		</dependencies>

--- a/NuGet/linq2db.Firebird.nuspec
+++ b/NuGet/linq2db.Firebird.nuspec
@@ -2,7 +2,6 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 	<metadata minClientVersion="3.3.0">
 		<id>linq2db.Firebird</id>
-		<version>2.6.0</version>
 		<title>LINQ to Firebird</title>
 		<description>
 			LINQ to Firebird is a data access technology that provides a run-time infrastructure for managing relational data as objects.

--- a/NuGet/linq2db.Firebird.nuspec
+++ b/NuGet/linq2db.Firebird.nuspec
@@ -4,13 +4,10 @@
 		<id>linq2db.Firebird</id>
 		<version>2.6.0</version>
 		<title>LINQ to Firebird</title>
-		<authors>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</authors>
-		<owners>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</owners>
 		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to Firebird is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.Firebird.nuspec
+++ b/NuGet/linq2db.Firebird.nuspec
@@ -4,10 +4,6 @@
 		<id>linq2db.Firebird</id>
 		<version>2.6.0</version>
 		<title>LINQ to Firebird</title>
-		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
-		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
-		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
-		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>
 			LINQ to Firebird is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.Firebird.nuspec
+++ b/NuGet/linq2db.Firebird.nuspec
@@ -10,6 +10,7 @@
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to Firebird is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>
@@ -17,6 +18,7 @@
 			This package includes a T4 template to generate data models for Firebird database and references to the linq2db and FirebirdSql.Data.FirebirdClient nugets.
 		</summary>
 		<tags>linq linq2db Firebird LinqToDB ORM database DB SQL</tags>
+		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="FirebirdSql.Data.FirebirdClient" version="5.12.1"/>
 			<dependency id="linq2db"                         version="2.6.0"/>

--- a/NuGet/linq2db.Firebird.nuspec
+++ b/NuGet/linq2db.Firebird.nuspec
@@ -15,7 +15,6 @@
 			This package includes a T4 template to generate data models for Firebird database and references to the linq2db and FirebirdSql.Data.FirebirdClient nugets.
 		</summary>
 		<tags>linq linq2db Firebird LinqToDB ORM database DB SQL</tags>
-		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="FirebirdSql.Data.FirebirdClient" version="5.12.1"/>
 			<dependency id="linq2db"                         version="2.6.0"/>

--- a/NuGet/linq2db.Informix.nuspec
+++ b/NuGet/linq2db.Informix.nuspec
@@ -4,10 +4,6 @@
 		<id>linq2db.Informix</id>
 		<version>2.6.0</version>
 		<title>LINQ to Informix</title>
-		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
-		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
-		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
-		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>
 			LINQ to Informix is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.Informix.nuspec
+++ b/NuGet/linq2db.Informix.nuspec
@@ -4,13 +4,10 @@
 		<id>linq2db.Informix</id>
 		<version>2.6.0</version>
 		<title>LINQ to Informix</title>
-		<authors>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</authors>
-		<owners>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</owners>
 		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to Informix is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.Informix.nuspec
+++ b/NuGet/linq2db.Informix.nuspec
@@ -10,6 +10,7 @@
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to Informix is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>
@@ -18,6 +19,7 @@
 			IBM Data Server Provider for .NET will still need to be installed on the production or development machine in order to connect to Informix.
 		</summary>
 		<tags>linq linq2db Informix LinqToDB ORM database DB SQL</tags>
+		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="linq2db" version="2.6.0"/>
 		</dependencies>

--- a/NuGet/linq2db.Informix.nuspec
+++ b/NuGet/linq2db.Informix.nuspec
@@ -16,7 +16,6 @@
 			IBM Data Server Provider for .NET will still need to be installed on the production or development machine in order to connect to Informix.
 		</summary>
 		<tags>linq linq2db Informix LinqToDB ORM database DB SQL</tags>
-		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="linq2db" version="2.6.0"/>
 		</dependencies>

--- a/NuGet/linq2db.Informix.nuspec
+++ b/NuGet/linq2db.Informix.nuspec
@@ -2,7 +2,6 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 	<metadata minClientVersion="3.3.0">
 		<id>linq2db.Informix</id>
-		<version>2.6.0</version>
 		<title>LINQ to Informix</title>
 		<description>
 			LINQ to Informix is a data access technology that provides a run-time infrastructure for managing relational data as objects.

--- a/NuGet/linq2db.MySql.nuspec
+++ b/NuGet/linq2db.MySql.nuspec
@@ -10,6 +10,7 @@
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to MySql is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>
@@ -17,6 +18,7 @@
 			This package includes a T4 template to generate data models for MySql database and references to the linq2db and MySql.Data nugets.
 		</summary>
 		<tags>linq linq2db MySql LinqToDB ORM database DB SQL</tags>
+		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="MySql.Data" version="6.10.6"   />
 			<dependency id="linq2db"    version="2.6.0"/>

--- a/NuGet/linq2db.MySql.nuspec
+++ b/NuGet/linq2db.MySql.nuspec
@@ -4,10 +4,6 @@
 		<id>linq2db.MySql</id>
 		<version>2.6.0</version>
 		<title>LINQ to MySql</title>
-		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
-		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
-		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
-		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>
 			LINQ to MySql is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.MySql.nuspec
+++ b/NuGet/linq2db.MySql.nuspec
@@ -4,13 +4,10 @@
 		<id>linq2db.MySql</id>
 		<version>2.6.0</version>
 		<title>LINQ to MySql</title>
-		<authors>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</authors>
-		<owners>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</owners>
 		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to MySql is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.MySql.nuspec
+++ b/NuGet/linq2db.MySql.nuspec
@@ -2,7 +2,6 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 	<metadata minClientVersion="3.3.0">
 		<id>linq2db.MySql</id>
-		<version>2.6.0</version>
 		<title>LINQ to MySql</title>
 		<description>
 			LINQ to MySql is a data access technology that provides a run-time infrastructure for managing relational data as objects.

--- a/NuGet/linq2db.MySql.nuspec
+++ b/NuGet/linq2db.MySql.nuspec
@@ -15,7 +15,6 @@
 			This package includes a T4 template to generate data models for MySql database and references to the linq2db and MySql.Data nugets.
 		</summary>
 		<tags>linq linq2db MySql LinqToDB ORM database DB SQL</tags>
-		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="MySql.Data" version="6.10.6"   />
 			<dependency id="linq2db"    version="2.6.0"/>

--- a/NuGet/linq2db.Oracle.Managed.nuspec
+++ b/NuGet/linq2db.Oracle.Managed.nuspec
@@ -4,10 +4,6 @@
 		<id>linq2db.Oracle.Managed</id>
 		<version>2.6.0</version>
 		<title>LINQ to Oracle (ODP.NET) Managed</title>
-		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
-		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
-		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
-		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>
 			LINQ to Oracle is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.Oracle.Managed.nuspec
+++ b/NuGet/linq2db.Oracle.Managed.nuspec
@@ -2,7 +2,6 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 	<metadata minClientVersion="3.3.0">
 		<id>linq2db.Oracle.Managed</id>
-		<version>2.6.0</version>
 		<title>LINQ to Oracle (ODP.NET) Managed</title>
 		<description>
 			LINQ to Oracle is a data access technology that provides a run-time infrastructure for managing relational data as objects.

--- a/NuGet/linq2db.Oracle.Managed.nuspec
+++ b/NuGet/linq2db.Oracle.Managed.nuspec
@@ -16,7 +16,6 @@
 			Oracle data provider for .NET will still need to be installed on the production or development machine in order to connect to Oracle.
 		</summary>
 		<tags>linq linq2db Oracle LinqToDB ORM database DB SQL</tags>
-		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<group targetFramework="net40">
 				<dependency id="linq2db"                  version="2.6.0"/>

--- a/NuGet/linq2db.Oracle.Managed.nuspec
+++ b/NuGet/linq2db.Oracle.Managed.nuspec
@@ -10,6 +10,7 @@
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to Oracle is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>
@@ -18,6 +19,7 @@
 			Oracle data provider for .NET will still need to be installed on the production or development machine in order to connect to Oracle.
 		</summary>
 		<tags>linq linq2db Oracle LinqToDB ORM database DB SQL</tags>
+		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<group targetFramework="net40">
 				<dependency id="linq2db"                  version="2.6.0"/>

--- a/NuGet/linq2db.Oracle.Managed.nuspec
+++ b/NuGet/linq2db.Oracle.Managed.nuspec
@@ -4,13 +4,10 @@
 		<id>linq2db.Oracle.Managed</id>
 		<version>2.6.0</version>
 		<title>LINQ to Oracle (ODP.NET) Managed</title>
-		<authors>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</authors>
-		<owners>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</owners>
 		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to Oracle is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.Oracle.Unmanaged.nuspec
+++ b/NuGet/linq2db.Oracle.Unmanaged.nuspec
@@ -16,7 +16,6 @@
 			Oracle data provider for .NET will still need to be installed on the production or development machine in order to connect to Oracle.
 		</summary>
 		<tags>linq linq2db Oracle ODP LinqToDB ORM database DB SQL</tags>
-		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="linq2db" version="2.6.0"/>
 		</dependencies>

--- a/NuGet/linq2db.Oracle.Unmanaged.nuspec
+++ b/NuGet/linq2db.Oracle.Unmanaged.nuspec
@@ -2,7 +2,6 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 	<metadata minClientVersion="3.3.0">
 		<id>linq2db.Oracle.Unmanaged</id>
-		<version>2.6.0</version>
 		<title>LINQ to Oracle (ODP.NET) unmanaged</title>
 		<description>
 			LINQ to Oracle is a data access technology that provides a run-time infrastructure for managing relational data as objects.

--- a/NuGet/linq2db.Oracle.Unmanaged.nuspec
+++ b/NuGet/linq2db.Oracle.Unmanaged.nuspec
@@ -4,13 +4,10 @@
 		<id>linq2db.Oracle.Unmanaged</id>
 		<version>2.6.0</version>
 		<title>LINQ to Oracle (ODP.NET) unmanaged</title>
-		<authors>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</authors>
-		<owners>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</owners>
 		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to Oracle is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.Oracle.Unmanaged.nuspec
+++ b/NuGet/linq2db.Oracle.Unmanaged.nuspec
@@ -10,6 +10,7 @@
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to Oracle is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>
@@ -18,6 +19,7 @@
 			Oracle data provider for .NET will still need to be installed on the production or development machine in order to connect to Oracle.
 		</summary>
 		<tags>linq linq2db Oracle ODP LinqToDB ORM database DB SQL</tags>
+		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="linq2db" version="2.6.0"/>
 		</dependencies>

--- a/NuGet/linq2db.Oracle.Unmanaged.nuspec
+++ b/NuGet/linq2db.Oracle.Unmanaged.nuspec
@@ -4,10 +4,6 @@
 		<id>linq2db.Oracle.Unmanaged</id>
 		<version>2.6.0</version>
 		<title>LINQ to Oracle (ODP.NET) unmanaged</title>
-		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
-		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
-		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
-		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>
 			LINQ to Oracle is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.PostgreSQL.nuspec
+++ b/NuGet/linq2db.PostgreSQL.nuspec
@@ -4,13 +4,10 @@
 		<id>linq2db.PostgreSQL</id>
 		<version>2.6.0</version>
 		<title>LINQ to PostgreSQL</title>
-		<authors>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</authors>
-		<owners>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</owners>
 		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to PostgreSQL is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.PostgreSQL.nuspec
+++ b/NuGet/linq2db.PostgreSQL.nuspec
@@ -2,7 +2,6 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 	<metadata minClientVersion="3.3.0">
 		<id>linq2db.PostgreSQL</id>
-		<version>2.6.0</version>
 		<title>LINQ to PostgreSQL</title>
 		<description>
 			LINQ to PostgreSQL is a data access technology that provides a run-time infrastructure for managing relational data as objects.

--- a/NuGet/linq2db.PostgreSQL.nuspec
+++ b/NuGet/linq2db.PostgreSQL.nuspec
@@ -15,7 +15,6 @@
 			This package includes a T4 template to generate data models for PostgreSQL database and references to the linq2db and Npgsql nugets.
 		</summary>
 		<tags>linq linq2db Npgsql PostgreSQL LinqToDB ORM database DB SQL</tags>
-		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="Npgsql"  version="3.2.5" />
 			<dependency id="linq2db" version="2.6.0" />

--- a/NuGet/linq2db.PostgreSQL.nuspec
+++ b/NuGet/linq2db.PostgreSQL.nuspec
@@ -10,6 +10,7 @@
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to PostgreSQL is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>
@@ -17,6 +18,7 @@
 			This package includes a T4 template to generate data models for PostgreSQL database and references to the linq2db and Npgsql nugets.
 		</summary>
 		<tags>linq linq2db Npgsql PostgreSQL LinqToDB ORM database DB SQL</tags>
+		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="Npgsql"  version="3.2.5" />
 			<dependency id="linq2db" version="2.6.0" />

--- a/NuGet/linq2db.PostgreSQL.nuspec
+++ b/NuGet/linq2db.PostgreSQL.nuspec
@@ -4,10 +4,6 @@
 		<id>linq2db.PostgreSQL</id>
 		<version>2.6.0</version>
 		<title>LINQ to PostgreSQL</title>
-		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
-		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
-		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
-		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>
 			LINQ to PostgreSQL is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.SQLite.MS.nuspec
+++ b/NuGet/linq2db.SQLite.MS.nuspec
@@ -4,13 +4,10 @@
 		<id>linq2db.SQLite.MS</id>
 		<version>2.6.0</version>
 		<title>LINQ to SQLite</title>
-		<authors>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</authors>
-		<owners>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</owners>
 		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to SQLite is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.SQLite.MS.nuspec
+++ b/NuGet/linq2db.SQLite.MS.nuspec
@@ -4,10 +4,6 @@
 		<id>linq2db.SQLite.MS</id>
 		<version>2.6.0</version>
 		<title>LINQ to SQLite</title>
-		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
-		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
-		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
-		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>
 			LINQ to SQLite is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.SQLite.MS.nuspec
+++ b/NuGet/linq2db.SQLite.MS.nuspec
@@ -15,7 +15,6 @@
 			This package includes a T4 template to generate data models for SQLite database and references to the linq2db and Microsoft.Data.SQLite nugets.
 		</summary>
 		<tags>linq linq2db SQLite LinqToDB ORM database DB SQL</tags>
-		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="linq2db"                version="2.6.0"/>
 			<dependency id="Microsoft.Data.Sqlite"  version="2.1.0"/>

--- a/NuGet/linq2db.SQLite.MS.nuspec
+++ b/NuGet/linq2db.SQLite.MS.nuspec
@@ -2,7 +2,6 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 	<metadata minClientVersion="3.3.0">
 		<id>linq2db.SQLite.MS</id>
-		<version>2.6.0</version>
 		<title>LINQ to SQLite</title>
 		<description>
 			LINQ to SQLite is a data access technology that provides a run-time infrastructure for managing relational data as objects.

--- a/NuGet/linq2db.SQLite.MS.nuspec
+++ b/NuGet/linq2db.SQLite.MS.nuspec
@@ -10,6 +10,7 @@
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to SQLite is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>
@@ -17,6 +18,7 @@
 			This package includes a T4 template to generate data models for SQLite database and references to the linq2db and Microsoft.Data.SQLite nugets.
 		</summary>
 		<tags>linq linq2db SQLite LinqToDB ORM database DB SQL</tags>
+		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="linq2db"                version="2.6.0"/>
 			<dependency id="Microsoft.Data.Sqlite"  version="2.1.0"/>

--- a/NuGet/linq2db.SQLite.nuspec
+++ b/NuGet/linq2db.SQLite.nuspec
@@ -4,10 +4,6 @@
 		<id>linq2db.SQLite</id>
 		<version>2.6.0</version>
 		<title>LINQ to SQLite</title>
-		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
-		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
-		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
-		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>
 			LINQ to SQLite is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.SQLite.nuspec
+++ b/NuGet/linq2db.SQLite.nuspec
@@ -15,7 +15,6 @@
 			This package includes a T4 template to generate data models for SQLite database and references to the linq2db and System.Data.SQLite nugets.
 		</summary>
 		<tags>linq linq2db SQLite LinqToDB ORM database DB SQL</tags>
-		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="linq2db"                  version="2.6.0"/>
 			<dependency id="System.Data.SQLite.Core"  version="1.0.107"/>

--- a/NuGet/linq2db.SQLite.nuspec
+++ b/NuGet/linq2db.SQLite.nuspec
@@ -4,13 +4,10 @@
 		<id>linq2db.SQLite</id>
 		<version>2.6.0</version>
 		<title>LINQ to SQLite</title>
-		<authors>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</authors>
-		<owners>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</owners>
 		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to SQLite is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.SQLite.nuspec
+++ b/NuGet/linq2db.SQLite.nuspec
@@ -2,7 +2,6 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 	<metadata minClientVersion="3.3.0">
 		<id>linq2db.SQLite</id>
-		<version>2.6.0</version>
 		<title>LINQ to SQLite</title>
 		<description>
 			LINQ to SQLite is a data access technology that provides a run-time infrastructure for managing relational data as objects.

--- a/NuGet/linq2db.SQLite.nuspec
+++ b/NuGet/linq2db.SQLite.nuspec
@@ -10,6 +10,7 @@
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to SQLite is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>
@@ -17,6 +18,7 @@
 			This package includes a T4 template to generate data models for SQLite database and references to the linq2db and System.Data.SQLite nugets.
 		</summary>
 		<tags>linq linq2db SQLite LinqToDB ORM database DB SQL</tags>
+		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="linq2db"                  version="2.6.0"/>
 			<dependency id="System.Data.SQLite.Core"  version="1.0.107"/>

--- a/NuGet/linq2db.SapHana.nuspec
+++ b/NuGet/linq2db.SapHana.nuspec
@@ -4,13 +4,10 @@
 		<id>linq2db.SapHana</id>
 		<version>2.6.0</version>
 		<title>LINQ to SAP HANA</title>
-		<authors>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</authors>
-		<owners>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</owners>
 		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to SAP HANA is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.SapHana.nuspec
+++ b/NuGet/linq2db.SapHana.nuspec
@@ -16,7 +16,6 @@
 			SapHana data provider for .NET will still need to be installed on the production or development machine in order to connect to Sybase.
 		</summary>
 		<tags>linq linq2db SapHana LinqToDB ORM database DB SQL</tags>
-		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="linq2db" version="2.6.0"/>
 		</dependencies>

--- a/NuGet/linq2db.SapHana.nuspec
+++ b/NuGet/linq2db.SapHana.nuspec
@@ -2,7 +2,6 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 	<metadata minClientVersion="3.3.0">
 		<id>linq2db.SapHana</id>
-		<version>2.6.0</version>
 		<title>LINQ to SAP HANA</title>
 		<description>
 			LINQ to SAP HANA is a data access technology that provides a run-time infrastructure for managing relational data as objects.

--- a/NuGet/linq2db.SapHana.nuspec
+++ b/NuGet/linq2db.SapHana.nuspec
@@ -10,6 +10,7 @@
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to SAP HANA is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>
@@ -18,6 +19,7 @@
 			SapHana data provider for .NET will still need to be installed on the production or development machine in order to connect to Sybase.
 		</summary>
 		<tags>linq linq2db SapHana LinqToDB ORM database DB SQL</tags>
+		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="linq2db" version="2.6.0"/>
 		</dependencies>

--- a/NuGet/linq2db.SapHana.nuspec
+++ b/NuGet/linq2db.SapHana.nuspec
@@ -4,10 +4,6 @@
 		<id>linq2db.SapHana</id>
 		<version>2.6.0</version>
 		<title>LINQ to SAP HANA</title>
-		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
-		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
-		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
-		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>
 			LINQ to SAP HANA is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.SqlCe.nuspec
+++ b/NuGet/linq2db.SqlCe.nuspec
@@ -2,7 +2,6 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 	<metadata minClientVersion="3.3.0">
 		<id>linq2db.SqlCe</id>
-		<version>2.6.0</version>
 		<title>LINQ to SqlCe</title>
 		<description>
 			LINQ to SqlCe is a data access technology that provides a run-time infrastructure for managing relational data as objects.

--- a/NuGet/linq2db.SqlCe.nuspec
+++ b/NuGet/linq2db.SqlCe.nuspec
@@ -15,7 +15,6 @@
 			This package includes a T4 template to generate data models for SqlCe database and references to the linq2db and Microsoft.SqlServer.Compact nugets.
 		</summary>
 		<tags>linq linq2db SqlCe SqlServerCe SqlServer Compact LinqToDB ORM database DB SQL</tags>
-		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="linq2db" version="2.6.0"/>
 		</dependencies>

--- a/NuGet/linq2db.SqlCe.nuspec
+++ b/NuGet/linq2db.SqlCe.nuspec
@@ -4,13 +4,10 @@
 		<id>linq2db.SqlCe</id>
 		<version>2.6.0</version>
 		<title>LINQ to SqlCe</title>
-		<authors>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</authors>
-		<owners>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</owners>
 		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to SqlCe is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.SqlCe.nuspec
+++ b/NuGet/linq2db.SqlCe.nuspec
@@ -4,10 +4,6 @@
 		<id>linq2db.SqlCe</id>
 		<version>2.6.0</version>
 		<title>LINQ to SqlCe</title>
-		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
-		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
-		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
-		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>
 			LINQ to SqlCe is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.SqlCe.nuspec
+++ b/NuGet/linq2db.SqlCe.nuspec
@@ -10,6 +10,7 @@
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to SqlCe is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>
@@ -17,6 +18,7 @@
 			This package includes a T4 template to generate data models for SqlCe database and references to the linq2db and Microsoft.SqlServer.Compact nugets.
 		</summary>
 		<tags>linq linq2db SqlCe SqlServerCe SqlServer Compact LinqToDB ORM database DB SQL</tags>
+		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="linq2db" version="2.6.0"/>
 		</dependencies>

--- a/NuGet/linq2db.SqlServer.nuspec
+++ b/NuGet/linq2db.SqlServer.nuspec
@@ -4,13 +4,10 @@
 		<id>linq2db.SqlServer</id>
 		<version>2.6.0</version>
 		<title>LINQ to SqlServer</title>
-		<authors>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</authors>
-		<owners>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</owners>
 		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to SqlServer is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.SqlServer.nuspec
+++ b/NuGet/linq2db.SqlServer.nuspec
@@ -4,10 +4,6 @@
 		<id>linq2db.SqlServer</id>
 		<version>2.6.0</version>
 		<title>LINQ to SqlServer</title>
-		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
-		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
-		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
-		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>
 			LINQ to SqlServer is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.SqlServer.nuspec
+++ b/NuGet/linq2db.SqlServer.nuspec
@@ -2,7 +2,6 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 	<metadata minClientVersion="3.3.0">
 		<id>linq2db.SqlServer</id>
-		<version>2.6.0</version>
 		<title>LINQ to SqlServer</title>
 		<description>
 			LINQ to SqlServer is a data access technology that provides a run-time infrastructure for managing relational data as objects.

--- a/NuGet/linq2db.SqlServer.nuspec
+++ b/NuGet/linq2db.SqlServer.nuspec
@@ -15,7 +15,6 @@
 			This package includes a T4 template to generate data models for SqlServer database and references to the linq2db.
 		</summary>
 		<tags>linq linq2db SqlServer LinqToDB ORM database DB SQL</tags>
-		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="linq2db" version="2.6.0"/>
 		</dependencies>

--- a/NuGet/linq2db.SqlServer.nuspec
+++ b/NuGet/linq2db.SqlServer.nuspec
@@ -10,6 +10,7 @@
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to SqlServer is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>
@@ -17,6 +18,7 @@
 			This package includes a T4 template to generate data models for SqlServer database and references to the linq2db.
 		</summary>
 		<tags>linq linq2db SqlServer LinqToDB ORM database DB SQL</tags>
+		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="linq2db" version="2.6.0"/>
 		</dependencies>

--- a/NuGet/linq2db.Sybase.DataAction.nuspec
+++ b/NuGet/linq2db.Sybase.DataAction.nuspec
@@ -2,7 +2,6 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 	<metadata minClientVersion="3.3.0">
 		<id>linq2db.Sybase.DataAction</id>
-		<version>2.6.0</version>
 		<title>LINQ to SAP/Sybase ASE DataAction AdoNetCore.AseClient managed provider</title>
 		<description>
 			LINQ to Sybase ASE is a data access technology that provides a run-time infrastructure for managing relational data as objects.

--- a/NuGet/linq2db.Sybase.DataAction.nuspec
+++ b/NuGet/linq2db.Sybase.DataAction.nuspec
@@ -4,13 +4,10 @@
 		<id>linq2db.Sybase.DataAction</id>
 		<version>2.6.0</version>
 		<title>LINQ to SAP/Sybase ASE DataAction AdoNetCore.AseClient managed provider</title>
-		<authors>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</authors>
-		<owners>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</owners>
 		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to Sybase ASE is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.Sybase.DataAction.nuspec
+++ b/NuGet/linq2db.Sybase.DataAction.nuspec
@@ -15,7 +15,6 @@
 			This package includes a T4 template to generate data models for SAP/Sybase ASE database and a reference to the linq2db and AdoNetCore.AseClient nugets. This is a fully managed provider with .NET Core support.
 		</summary>
 		<tags>linq linq2db SAP Sybase LinqToDB ORM database DB SQL</tags>
-		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="linq2db"              version="2.6.0"  />
 			<dependency id="AdoNetCore.AseClient" version="0.13.0" />

--- a/NuGet/linq2db.Sybase.DataAction.nuspec
+++ b/NuGet/linq2db.Sybase.DataAction.nuspec
@@ -4,10 +4,6 @@
 		<id>linq2db.Sybase.DataAction</id>
 		<version>2.6.0</version>
 		<title>LINQ to SAP/Sybase ASE DataAction AdoNetCore.AseClient managed provider</title>
-		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
-		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
-		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
-		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>
 			LINQ to Sybase ASE is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.Sybase.DataAction.nuspec
+++ b/NuGet/linq2db.Sybase.DataAction.nuspec
@@ -10,6 +10,7 @@
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to Sybase ASE is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>
@@ -17,6 +18,7 @@
 			This package includes a T4 template to generate data models for SAP/Sybase ASE database and a reference to the linq2db and AdoNetCore.AseClient nugets. This is a fully managed provider with .NET Core support.
 		</summary>
 		<tags>linq linq2db SAP Sybase LinqToDB ORM database DB SQL</tags>
+		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="linq2db"              version="2.6.0"  />
 			<dependency id="AdoNetCore.AseClient" version="0.13.0" />

--- a/NuGet/linq2db.Sybase.nuspec
+++ b/NuGet/linq2db.Sybase.nuspec
@@ -10,6 +10,7 @@
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to Sybase ASE is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>
@@ -18,6 +19,7 @@
 			Sybase data provider for .NET will still need to be installed on the production or development machine in order to connect to ASE.
 		</summary>
 		<tags>linq linq2db SAP/Sybase LinqToDB ORM database DB SQL</tags>
+		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="linq2db" version="2.6.0"/>
 		</dependencies>

--- a/NuGet/linq2db.Sybase.nuspec
+++ b/NuGet/linq2db.Sybase.nuspec
@@ -4,13 +4,10 @@
 		<id>linq2db.Sybase</id>
 		<version>2.6.0</version>
 		<title>LINQ to SAP/Sybase ASE</title>
-		<authors>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</authors>
-		<owners>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</owners>
 		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<releaseNotes></releaseNotes>
 		<description>
 			LINQ to Sybase ASE is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.Sybase.nuspec
+++ b/NuGet/linq2db.Sybase.nuspec
@@ -2,7 +2,6 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 	<metadata minClientVersion="3.3.0">
 		<id>linq2db.Sybase</id>
-		<version>2.6.0</version>
 		<title>LINQ to SAP/Sybase ASE</title>
 		<description>
 			LINQ to Sybase ASE is a data access technology that provides a run-time infrastructure for managing relational data as objects.

--- a/NuGet/linq2db.Sybase.nuspec
+++ b/NuGet/linq2db.Sybase.nuspec
@@ -16,7 +16,6 @@
 			Sybase data provider for .NET will still need to be installed on the production or development machine in order to connect to ASE.
 		</summary>
 		<tags>linq linq2db SAP/Sybase LinqToDB ORM database DB SQL</tags>
-		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="linq2db" version="2.6.0"/>
 		</dependencies>

--- a/NuGet/linq2db.Sybase.nuspec
+++ b/NuGet/linq2db.Sybase.nuspec
@@ -4,10 +4,6 @@
 		<id>linq2db.Sybase</id>
 		<version>2.6.0</version>
 		<title>LINQ to SAP/Sybase ASE</title>
-		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
-		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
-		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
-		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>
 			LINQ to Sybase ASE is a data access technology that provides a run-time infrastructure for managing relational data as objects.
 		</description>

--- a/NuGet/linq2db.nuspec
+++ b/NuGet/linq2db.nuspec
@@ -13,7 +13,6 @@
 		<tags>
 			linq linq2db LinqToDB ORM database DB SQL SqlServer Access SqlCe SqlServerCe MySql Firebird SQLite Sybase Oracle ODP PostgreSQL DB2 Informix SapHana
 		</tags>
-		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<group targetFramework=".NETFramework4.5" />
 			<group targetFramework=".NETStandard1.6">

--- a/NuGet/linq2db.nuspec
+++ b/NuGet/linq2db.nuspec
@@ -4,10 +4,6 @@
 		<id>linq2db</id>
 		<version>2.6.0</version>
 		<title>LINQ to DB</title>
-		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
-		<projectUrl>http://linq2db.com</projectUrl>
-		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
-		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>LINQ to DB is a data access technology that provides a run-time infrastructure for managing relational data as objects.</description>
 		<summary />
 		<tags>

--- a/NuGet/linq2db.nuspec
+++ b/NuGet/linq2db.nuspec
@@ -2,7 +2,6 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 	<metadata>
 		<id>linq2db</id>
-		<version>2.6.0</version>
 		<title>LINQ to DB</title>
 		<description>LINQ to DB is a data access technology that provides a run-time infrastructure for managing relational data as objects.</description>
 		<summary />

--- a/NuGet/linq2db.nuspec
+++ b/NuGet/linq2db.nuspec
@@ -4,13 +4,10 @@
 		<id>linq2db</id>
 		<version>2.6.0</version>
 		<title>LINQ to DB</title>
-		<authors>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</authors>
-		<owners>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</owners>
 		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
 		<projectUrl>http://linq2db.com</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<releaseNotes></releaseNotes>
 		<description>LINQ to DB is a data access technology that provides a run-time infrastructure for managing relational data as objects.</description>
 		<summary />
 		<tags>

--- a/NuGet/linq2db.nuspec
+++ b/NuGet/linq2db.nuspec
@@ -10,6 +10,7 @@
 		<projectUrl>http://linq2db.com</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<releaseNotes></releaseNotes>
 		<description>LINQ to DB is a data access technology that provides a run-time infrastructure for managing relational data as objects.</description>
 		<summary />
 		<tags>

--- a/NuGet/linq2db.t4models.nuspec
+++ b/NuGet/linq2db.t4models.nuspec
@@ -4,13 +4,10 @@
 		<id>linq2db.t4models</id>
 		<version>2.6.0</version>
 		<title>LINQ to DB T4 Models</title>
-		<authors>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</authors>
-		<owners>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</owners>
 		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<releaseNotes></releaseNotes>
 		<description>T4 templates to generate data models for LINQ to DB SQL</description>
 		<summary />
 		<tags>

--- a/NuGet/linq2db.t4models.nuspec
+++ b/NuGet/linq2db.t4models.nuspec
@@ -10,12 +10,14 @@
 		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
 		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<releaseNotes></releaseNotes>
 		<description>T4 templates to generate data models for LINQ to DB SQL</description>
 		<summary />
 		<tags>
 			linq linq2db LinqToDB ORM database DB T4 datamodel SqlServer Access SqlCe SqlServerCe MySql Firebird SQLite Sybase
 			Oracle ODP PostgreSQL DB2 Informix SapHana
 		</tags>
+		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="linq2db" version="2.6.0"/>
 		</dependencies>

--- a/NuGet/linq2db.t4models.nuspec
+++ b/NuGet/linq2db.t4models.nuspec
@@ -14,7 +14,6 @@
 			linq linq2db LinqToDB ORM database DB T4 datamodel SqlServer Access SqlCe SqlServerCe MySql Firebird SQLite Sybase
 			Oracle ODP PostgreSQL DB2 Informix SapHana
 		</tags>
-		<repository type="git" url="https://github.com/linq2db/linq2db.git" />
 		<dependencies>
 			<dependency id="linq2db" version="2.6.0"/>
 		</dependencies>

--- a/NuGet/linq2db.t4models.nuspec
+++ b/NuGet/linq2db.t4models.nuspec
@@ -4,10 +4,6 @@
 		<id>linq2db.t4models</id>
 		<version>2.6.0</version>
 		<title>LINQ to DB T4 Models</title>
-		<licenseUrl>https://github.com/linq2db/linq2db/blob/master/MIT-LICENSE.txt</licenseUrl>
-		<projectUrl>https://github.com/linq2db/linq2db</projectUrl>
-		<iconUrl>http://www.gravatar.com/avatar/fc2e509b6ed116b9aa29a7988fdb8990?s=320</iconUrl>
-		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>T4 templates to generate data models for LINQ to DB SQL</description>
 		<summary />
 		<tags>

--- a/NuGet/linq2db.t4models.nuspec
+++ b/NuGet/linq2db.t4models.nuspec
@@ -2,7 +2,6 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 	<metadata minClientVersion="3.3.0">
 		<id>linq2db.t4models</id>
-		<version>2.6.0</version>
 		<title>LINQ to DB T4 Models</title>
 		<description>T4 templates to generate data models for LINQ to DB SQL</description>
 		<summary />


### PR DESCRIPTION
Fix #1414 
- add release notes link to all packages
- add repository link to all packages
- add copyright to all packages
- generate various copy-pasted fields during publish
- update nuget.exe client to recent version
- add PackLocal.cmd to build nugets locally with nuspec update (no more nuspec manual version patching for each release)