### PR TITLE
Added missing conversion points for IQueryable<T> extensions.

### DIFF
--- a/Source/LinqToDB/LinqExtensions.cs
+++ b/Source/LinqToDB/LinqExtensions.cs
@@ -713,11 +713,13 @@ namespace LinqToDB
 		{
 			if (source  == null) throw new ArgumentNullException(nameof(source));
 
-			var query = source.Provider.CreateQuery<T>(
+			var currentSource = ProcessSourceQueryable?.Invoke(source) ?? source;
+
+			var query = currentSource.Provider.CreateQuery<T>(
 				Expression.Call(
 					null,
 					_asUpdatableMethodInfo.MakeGenericMethod(typeof(T)),
-					source.Expression));
+					currentSource.Expression));
 
 			return new Updatable<T> { Query = query };
 		}
@@ -745,11 +747,13 @@ namespace LinqToDB
 			if (extract == null) throw new ArgumentNullException(nameof(extract));
 			if (update  == null) throw new ArgumentNullException(nameof(update));
 
-			var query = source.Provider.CreateQuery<T>(
+			var currentSource = ProcessSourceQueryable?.Invoke(source) ?? source;
+
+			var query = currentSource.Provider.CreateQuery<T>(
 				Expression.Call(
 					null,
 					_setMethodInfo.MakeGenericMethod(typeof(T), typeof(TV)),
-					new[] { source.Expression, Expression.Quote(extract), Expression.Quote(update) }));
+					new[] { currentSource.Expression, Expression.Quote(extract), Expression.Quote(update) }));
 
 			return new Updatable<T> { Query = query };
 		}
@@ -875,11 +879,13 @@ namespace LinqToDB
 			if (source  == null) throw new ArgumentNullException(nameof(source));
 			if (extract == null) throw new ArgumentNullException(nameof(extract));
 
-			var query = source.Provider.CreateQuery<T>(
+			var currentSource = ProcessSourceQueryable?.Invoke(source) ?? source;
+
+			var query = currentSource.Provider.CreateQuery<T>(
 				Expression.Call(
 					null,
 					_setMethodInfo5.MakeGenericMethod(typeof(T), typeof(TV)),
-					new[] { source.Expression, Expression.Quote(extract), Expression.Constant(value, typeof(TV)) }));
+					new[] { currentSource.Expression, Expression.Quote(extract), Expression.Constant(value, typeof(TV)) }));
 
 			return new Updatable<T> { Query = query };
 		}
@@ -1582,8 +1588,10 @@ namespace LinqToDB
 			[NotNull]                ITable<TTarget>                   target,
 			[NotNull, InstantHandle] Expression<Func<TSource,TTarget>> setter)
 		{
-			return ((ExpressionQuery<TSource>)source).DataContext.MappingSchema.ChangeTypeTo<int?>(
-				InsertWithIdentity(source, target, setter));
+			var currentSource = (IQueryable<TSource>)(ProcessSourceQueryable?.Invoke(source) ?? source);
+
+			return ((ExpressionQuery<TSource>)currentSource).DataContext.MappingSchema.ChangeTypeTo<int?>(
+				InsertWithIdentity(currentSource, target, setter));
 		}
 
 		/// <summary>
@@ -1601,8 +1609,10 @@ namespace LinqToDB
 			[NotNull]                ITable<TTarget>                   target,
 			[NotNull, InstantHandle] Expression<Func<TSource,TTarget>> setter)
 		{
-			return ((ExpressionQuery<TSource>)source).DataContext.MappingSchema.ChangeTypeTo<long?>(
-				InsertWithIdentity(source, target, setter));
+			var currentSource = (IQueryable<TSource>)(ProcessSourceQueryable?.Invoke(source) ?? source);
+
+			return ((ExpressionQuery<TSource>)currentSource).DataContext.MappingSchema.ChangeTypeTo<long?>(
+				InsertWithIdentity(currentSource, target, setter));
 		}
 
 		/// <summary>
@@ -1620,8 +1630,10 @@ namespace LinqToDB
 			[NotNull]                ITable<TTarget>                   target,
 			[NotNull, InstantHandle] Expression<Func<TSource,TTarget>> setter)
 		{
-			return ((ExpressionQuery<TSource>)source).DataContext.MappingSchema.ChangeTypeTo<decimal?>(
-				InsertWithIdentity(source, target, setter));
+			var currentSource = (IQueryable<TSource>)(ProcessSourceQueryable?.Invoke(source) ?? source);
+
+			return ((ExpressionQuery<TSource>)currentSource).DataContext.MappingSchema.ChangeTypeTo<decimal?>(
+				InsertWithIdentity(currentSource, target, setter));
 		}
 
 		/// <summary>
@@ -1676,8 +1688,10 @@ namespace LinqToDB
 			[NotNull, InstantHandle] Expression<Func<TSource,TTarget>> setter,
 			CancellationToken                                          token = default)
 		{
-			return ((ExpressionQuery<TSource>)source).DataContext.MappingSchema.ChangeTypeTo<int?>(
-				await InsertWithIdentityAsync(source, target, setter, token));
+			var currentSource = (IQueryable<TSource>)(ProcessSourceQueryable?.Invoke(source) ?? source);
+
+			return ((ExpressionQuery<TSource>)currentSource).DataContext.MappingSchema.ChangeTypeTo<int?>(
+				await InsertWithIdentityAsync(currentSource, target, setter, token));
 		}
 
 		/// <summary>
@@ -1697,8 +1711,10 @@ namespace LinqToDB
 			[NotNull, InstantHandle] Expression<Func<TSource,TTarget>> setter,
 			CancellationToken                                          token = default)
 		{
-			return ((ExpressionQuery<TSource>)source).DataContext.MappingSchema.ChangeTypeTo<long?>(
-				await InsertWithIdentityAsync(source, target, setter, token));
+			var currentSource = (IQueryable<TSource>)(ProcessSourceQueryable?.Invoke(source) ?? source);
+
+			return ((ExpressionQuery<TSource>)currentSource).DataContext.MappingSchema.ChangeTypeTo<long?>(
+				await InsertWithIdentityAsync(currentSource, target, setter, token));
 		}
 
 		/// <summary>
@@ -1718,8 +1734,10 @@ namespace LinqToDB
 			[NotNull, InstantHandle] Expression<Func<TSource,TTarget>> setter,
 			CancellationToken                                          token = default)
 		{
-			return ((ExpressionQuery<TSource>)source).DataContext.MappingSchema.ChangeTypeTo<decimal?>(
-				await InsertWithIdentityAsync(source, target, setter, token));
+			var currentSource = (IQueryable<TSource>)(ProcessSourceQueryable?.Invoke(source) ?? source);
+
+			return ((ExpressionQuery<TSource>)currentSource).DataContext.MappingSchema.ChangeTypeTo<decimal?>(
+				await InsertWithIdentityAsync(currentSource, target, setter, token));
 		}
 
 		class SelectInsertable<T,TT> : ISelectInsertable<T,TT>
@@ -1746,11 +1764,13 @@ namespace LinqToDB
 		{
 			if (target == null) throw new ArgumentNullException(nameof(target));
 
-			var q = source.Provider.CreateQuery<TSource>(
+			var currentSource = ProcessSourceQueryable?.Invoke(source) ?? source;
+
+			var q = currentSource.Provider.CreateQuery<TSource>(
 				Expression.Call(
 					null,
 					_intoMethodInfo2.MakeGenericMethod(typeof(TSource), typeof(TTarget)),
-					new[] { source.Expression, ((IQueryable<TTarget>)target).Expression }));
+					new[] { currentSource.Expression, ((IQueryable<TTarget>)target).Expression }));
 
 			return new SelectInsertable<TSource,TTarget> { Query = q };
 		}
@@ -2387,11 +2407,13 @@ namespace LinqToDB
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (count  == null) throw new ArgumentNullException(nameof(count));
 
-			return source.Provider.CreateQuery<TSource>(
+			var currentSource = ProcessSourceQueryable?.Invoke(source) ?? source;
+
+			return currentSource.Provider.CreateQuery<TSource>(
 				Expression.Call(
 					null,
 					_takeMethodInfo.MakeGenericMethod(typeof(TSource)),
-					new[] { source.Expression, Expression.Quote(count) }));
+					new[] { currentSource.Expression, Expression.Quote(count) }));
 		}
 
 		static readonly MethodInfo _takeMethodInfo2 = MemberHelper.MethodOf(() => Take<int>(null,null,TakeHints.Percent)).GetGenericMethodDefinition();
@@ -2415,11 +2437,13 @@ namespace LinqToDB
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (count  == null) throw new ArgumentNullException(nameof(count));
 
-			return source.Provider.CreateQuery<TSource>(
+			var currentSource = ProcessSourceQueryable?.Invoke(source) ?? source;
+
+			return currentSource.Provider.CreateQuery<TSource>(
 				Expression.Call(
 					null,
 					_takeMethodInfo2.MakeGenericMethod(typeof(TSource)),
-					new[] { source.Expression, Expression.Quote(count), Expression.Constant(hints) }));
+					new[] { currentSource.Expression, Expression.Quote(count), Expression.Constant(hints) }));
 		}
 
 		static readonly MethodInfo _takeMethodInfo3 = MemberHelper.MethodOf(() => Take<int>(null,0,TakeHints.Percent)).GetGenericMethodDefinition();
@@ -2442,11 +2466,13 @@ namespace LinqToDB
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
-			return source.Provider.CreateQuery<TSource>(
+			var currentSource = ProcessSourceQueryable?.Invoke(source) ?? source;
+
+			return currentSource.Provider.CreateQuery<TSource>(
 				Expression.Call(
 					null,
 					_takeMethodInfo3.MakeGenericMethod(typeof(TSource)),
-					new[] { source.Expression, Expression.Constant(count), Expression.Constant(hints) }));
+					new[] { currentSource.Expression, Expression.Constant(count), Expression.Constant(hints) }));
 		}
 
 		static readonly MethodInfo _skipMethodInfo = MemberHelper.MethodOf(() => Skip<int>(null,null)).GetGenericMethodDefinition();
@@ -2467,11 +2493,13 @@ namespace LinqToDB
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (count  == null) throw new ArgumentNullException(nameof(count));
 
-			return source.Provider.CreateQuery<TSource>(
+			var currentSource = ProcessSourceQueryable?.Invoke(source) ?? source;
+
+			return currentSource.Provider.CreateQuery<TSource>(
 				Expression.Call(
 					null,
 					_skipMethodInfo.MakeGenericMethod(typeof(TSource)),
-					new[] { source.Expression, Expression.Quote(count) }));
+					new[] { currentSource.Expression, Expression.Quote(count) }));
 		}
 
 		static readonly MethodInfo _elementAtMethodInfo = MemberHelper.MethodOf(() => ElementAt<int>(null,null)).GetGenericMethodDefinition();
@@ -2618,11 +2646,13 @@ namespace LinqToDB
 			if (source    == null) throw new ArgumentNullException(nameof(source));
 			if (predicate == null) throw new ArgumentNullException(nameof(predicate));
 
-			return source.Provider.CreateQuery<TSource>(
+			var currentSource = ProcessSourceQueryable?.Invoke(source) ?? source;
+
+			return currentSource.Provider.CreateQuery<TSource>(
 				Expression.Call(
 					null,
 					_setMethodInfo7.MakeGenericMethod(typeof(TSource)),
-					new[] { source.Expression, Expression.Quote(predicate) }));
+					new[] { currentSource.Expression, Expression.Quote(predicate) }));
 		}
 
 		#endregion
@@ -2650,11 +2680,13 @@ namespace LinqToDB
 			if (source      == null) throw new ArgumentNullException(nameof(source));
 			if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-			return (IOrderedQueryable<TSource>)source.Provider.CreateQuery<TSource>(
+			var currentSource = ProcessSourceQueryable?.Invoke(source) ?? source;
+
+			return (IOrderedQueryable<TSource>)currentSource.Provider.CreateQuery<TSource>(
 				Expression.Call(
 					null,
 					_thenOrBy.MakeGenericMethod(typeof(TSource), typeof(TKey)),
-					new[] { source.Expression, Expression.Quote(keySelector) }));
+					new[] { currentSource.Expression, Expression.Quote(keySelector) }));
 		}
 
 		static readonly MethodInfo _thenOrByDescending = MemberHelper.MethodOf(() =>
@@ -2678,11 +2710,13 @@ namespace LinqToDB
 			if (source      == null) throw new ArgumentNullException(nameof(source));
 			if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-			return (IOrderedQueryable<TSource>)source.Provider.CreateQuery<TSource>(
+			var currentSource = ProcessSourceQueryable?.Invoke(source) ?? source;
+
+			return (IOrderedQueryable<TSource>)currentSource.Provider.CreateQuery<TSource>(
 				Expression.Call(
 					null,
 					_thenOrByDescending.MakeGenericMethod(typeof(TSource), typeof(TKey)),
-					new[] { source.Expression, Expression.Quote(keySelector) }));
+					new[] { currentSource.Expression, Expression.Quote(keySelector) }));
 		}
 
 		#endregion
@@ -2743,13 +2777,15 @@ namespace LinqToDB
 			if (source    == null) throw new ArgumentNullException(nameof(source));
 			if (predicate == null) throw new ArgumentNullException(nameof(predicate));
 
-			return source.Provider.CreateQuery<TSource>(
+			var currentSource = ProcessSourceQueryable?.Invoke(source) ?? source;
+
+			return currentSource.Provider.CreateQuery<TSource>(
 				Expression.Call(
 					null,
 					MethodHelper.GetMethodInfo(Join, source, joinType, predicate),
 					new[]
 					{
-						source.Expression,
+						currentSource.Expression,
 						Expression.Constant(joinType),
 						Expression.Quote(predicate)
 					}));
@@ -2781,13 +2817,15 @@ namespace LinqToDB
 			if (predicate      == null) throw new ArgumentNullException(nameof(predicate));
 			if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-			return outer.Provider.CreateQuery<TResult>(
+			var currentOuter = ProcessSourceQueryable?.Invoke(outer) ?? outer;
+
+			return currentOuter.Provider.CreateQuery<TResult>(
 				Expression.Call(
 					null,
 					MethodHelper.GetMethodInfo(Join, outer, inner, joinType, predicate, resultSelector),
 					new[]
 					{
-						outer.Expression,
+						currentOuter.Expression,
 						inner.Expression,
 						Expression.Constant(joinType),
 						Expression.Quote(predicate),
@@ -2969,13 +3007,15 @@ namespace LinqToDB
 			if (inner          == null) throw new ArgumentNullException(nameof(inner));
 			if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-			return outer.Provider.CreateQuery<TResult>(
+			var currentOuter = ProcessSourceQueryable?.Invoke(outer) ?? outer;
+
+			return currentOuter.Provider.CreateQuery<TResult>(
 				Expression.Call(
 					null,
 					MethodHelper.GetMethodInfo(CrossJoin, outer, inner, resultSelector),
 					new[]
 					{
-						outer.Expression,
+						currentOuter.Expression,
 						inner.Expression,
 						Expression.Quote(resultSelector)
 					}));
@@ -3002,11 +3042,13 @@ namespace LinqToDB
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
-			return source.Provider.CreateQuery<TSource>(
+			var currentSource = ProcessSourceQueryable?.Invoke(source) ?? source;
+
+			return currentSource.Provider.CreateQuery<TSource>(
 				Expression.Call(
 					null,
 					MethodHelper.GetMethodInfo(AsCte, source),
-					source.Expression));
+					currentSource.Expression));
 		}
 
 		/// <summary>
@@ -3024,11 +3066,13 @@ namespace LinqToDB
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
-			return source.Provider.CreateQuery<TSource>(
+			var currentSource = ProcessSourceQueryable?.Invoke(source) ?? source;
+
+			return currentSource.Provider.CreateQuery<TSource>(
 				Expression.Call(
 					null,
 					MethodHelper.GetMethodInfo(AsCte, source, name),
-					new[] {source.Expression, Expression.Constant(name ?? string.Empty)}));
+					new[] {currentSource.Expression, Expression.Constant(name ?? string.Empty)}));
 		}
 
 		#endregion
@@ -3050,7 +3094,10 @@ namespace LinqToDB
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 
 			if (source is IQueryable<TElement> already)
+			{
+				already = (IQueryable<TElement>)(ProcessSourceQueryable?.Invoke(already) ?? already);
 				return already;
+			}
 
 			var query = new ExpressionQueryImpl<TElement>(dataContext,
 				Expression.Call(


### PR DESCRIPTION
Added missing IQueryable<T> conversion points.

It is needed for `EF Core Integration` because Remotion Linq is trying to analyse expressions even before final parsing.

Related to https://github.com/linq2db/linq2db.EntityFrameworkCore/issues/13