### PR TITLE
Fix postgresql provider "character varying" type bug

### DIFF
--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
@@ -566,8 +566,8 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			if (dbType.StartsWith("numeric(") || dbType.StartsWith("decimal"))
 				dbType = "numeric";
 
-			if (dbType.StartsWith("varchar varying(") || dbType.StartsWith("varchar("))
-				dbType = "varchar varying";
+			if (dbType.StartsWith("varchar varying(") || dbType.StartsWith("varchar(") || dbType.StartsWith("character varying("))
+				dbType = "character varying";
 
 			if (dbType.StartsWith("char(") || dbType.StartsWith("character("))
 				dbType = "character";

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
@@ -566,7 +566,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			if (dbType.StartsWith("numeric(") || dbType.StartsWith("decimal"))
 				dbType = "numeric";
 
-			if (dbType.StartsWith("varchar varying(") || dbType.StartsWith("varchar(") || dbType.StartsWith("character varying("))
+			if (dbType.StartsWith("varchar(") || dbType.StartsWith("character varying("))
 				dbType = "character varying";
 
 			if (dbType.StartsWith("char(") || dbType.StartsWith("character("))


### PR DESCRIPTION
`_npgsqlTypeMap` don't contains `varchar varying` type. 
So I've replace it by `character varying`, that exists [there](https://github.com/linq2db/linq2db/blob/master/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs#L155) (and [in PostgreSQL docs](https://www.postgresql.org/docs/11/datatype-character.html)). Also I've added some additional check (for `character varying` with specified length).