### PR TITLE
[T4] Don't rename Find method

### DIFF
--- a/Source/LinqToDB.Templates/LinqToDB.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.ttinclude
@@ -934,10 +934,10 @@ void GenerateTypesFromMetadata()
 		if (tabfs.Members.Count > 0)
 			DataContextObject.Members.Add(tabfs);
 
-		MakeTypeMembersNamesUnique(DataContextObject);
+		MakeTypeMembersNamesUnique(DataContextObject, "InitDataContext", "InitMappingSchema");
 		MakeMembersNamesUnique(Model.Types, "Table");
 		foreach (var type in Model.Types.OfType<Class>())
-			MakeTypeMembersNamesUnique(type);
+			MakeTypeMembersNamesUnique(type, exceptMethods: new [] { "Find" });
 
 		foreach (var schema in schemas.Values)
 		{
@@ -950,7 +950,7 @@ void GenerateTypesFromMetadata()
 			if (schema.TableFunctions.Members.Count > 0)
 				schema.DataContext.Members.Add(schema.TableFunctions);
 
-			MakeTypeMembersNamesUnique(schema.DataContext);
+			MakeTypeMembersNamesUnique(schema.DataContext, "InitDataContext", "InitMappingSchema");
 			foreach (var type in schema.Type.Members.OfType<Class>())
 				MakeTypeMembersNamesUnique(type);
 		}
@@ -961,7 +961,7 @@ void GenerateTypesFromMetadata()
 		Model.Usings.Add("System.Linq");
 		var tableExtensions = new Class("TableExtensions", defTableExtensions) { IsStatic = true };
 		Model.Types.Add(tableExtensions);
-		MakeTypeMembersNamesUnique(tableExtensions);
+		MakeTypeMembersNamesUnique(tableExtensions, exceptMethods: new [] { "Find" });
 	}
 
 	foreach (var schema in schemas.Values)
@@ -983,9 +983,13 @@ void GenerateTypesFromMetadata()
 	AfterGenerateLinqToDBModel();
 }
 
-void MakeTypeMembersNamesUnique(Class type, string defaultName = "Member")
+void MakeTypeMembersNamesUnique(Class type, string defaultName = "Member", params string[] exceptMethods)
 {
-	MakeMembersNamesUnique(GetAllClassMembers(type.Members), defaultName, type.Name, "InitDataContext", "InitMappingSchema");
+	var reservedNames = new [] { type.Name };
+	if (exceptMethods != null && exceptMethods.Length > 0)
+		reservedNames = reservedNames.Concat(exceptMethods).ToArray();
+
+	MakeMembersNamesUnique(GetAllClassMembers(type.Members, exceptMethods), defaultName, reservedNames);
 }
 
 void MakeMembersNamesUnique(IEnumerable<IClassMember> members, string defaultName, params string[] reservedNames)
@@ -1004,15 +1008,15 @@ void MakeMembersNamesUnique(IEnumerable<IClassMember> members, string defaultNam
 		defaultName);
 }
 
-IEnumerable<IClassMember> GetAllClassMembers(IEnumerable<IClassMember> members)
+IEnumerable<IClassMember> GetAllClassMembers(IEnumerable<IClassMember> members, params string[] exceptMethods)
 {
 	foreach (var member in members)
 	{
 		if (member is MemberGroup mg)
-			foreach (var m in GetAllClassMembers(mg.Members))
+			foreach (var m in GetAllClassMembers(mg.Members, exceptMethods))
 				yield return m;
 		// constructors don't have own type/flag
-		else if (member is Method method && (method.BuildType() == null || method.Name == "InitDataContext" || method.Name == "InitMappingSchema"))
+		else if (member is Method method && (method.BuildType() == null || (exceptMethods != null && exceptMethods.Contains(method.Name))))
 			continue;
 		else
 			yield return member;


### PR DESCRIPTION
Fix #1490

Because right now we don't have enough information in our code-generation model, we just need to ignore those methods during duplicates rename stage.