### PR TITLE
[WIP] Expression-based associations support for multiple queries

### DIFF
--- a/Source/LinqToDB/Linq/Builder/TableBuilder.TableContext.cs
+++ b/Source/LinqToDB/Linq/Builder/TableBuilder.TableContext.cs
@@ -951,10 +951,13 @@ namespace LinqToDB.Linq.Builder
 					if (association.ExpressionPredicate != null)
 					{
 						var l  = association.ExpressionPredicate;
-						var ex = l.Body.Transform(e => e == l.Parameters[0] ? parent : e == l.Parameters[1] ? param : e);
+						var ex = l.GetBody(parent, param);
 
 						expr = expr == null ? ex : Expression.AndAlso(expr, ex);
 					}
+
+					if (expr == null)
+						throw new LinqToDBException("Invalid association for LoadWith");
 
 					var predicate = Expression.Lambda<Func<T,bool>>(expr, param);
 

--- a/Source/LinqToDB/LinqExtensions.cs
+++ b/Source/LinqToDB/LinqExtensions.cs
@@ -2755,6 +2755,11 @@ namespace LinqToDB
 			throw new InvalidOperationException();
 		}
 
+		internal static TOutput AsQueryable<TOutput,TInput>(TInput source)
+		{
+			throw new InvalidOperationException();
+		}
+
 		#endregion
 
 		#region SqlJoin

--- a/Source/LinqToDB/Mapping/EntityMappingBuilder.cs
+++ b/Source/LinqToDB/Mapping/EntityMappingBuilder.cs
@@ -247,6 +247,35 @@ namespace LinqToDB.Mapping
 		}
 
 		/// <summary>
+		/// Adds association mapping to current entity.
+		/// </summary>
+		/// <typeparam name="S">Association member type.</typeparam>
+		/// <typeparam name="ID1">This association side key type.</typeparam>
+		/// <typeparam name="ID2">Other association side key type.</typeparam>
+		/// <param name="prop">Association member getter expression.</param>
+		/// <param name="thisKey">This association key getter expression.</param>
+		/// <param name="otherKey">Other association key getter expression.</param>
+		/// <param name="canBeNull">Defines type of join. True - left join, False - inner join.</param>
+		/// <returns>Returns fluent property mapping builder.</returns>
+		public PropertyMappingBuilder<T> Association<S, ID1, ID2>(
+			[JetBrains.Annotations.NotNull] Expression<Func<T, IEnumerable<S>>> prop,
+			[JetBrains.Annotations.NotNull] Expression<Func<T, ID1>>            thisKey,
+			[JetBrains.Annotations.NotNull] Expression<Func<S, ID2>>            otherKey,
+			                                bool                                canBeNull = true)
+		{
+			if (prop     == null) throw new ArgumentNullException(nameof(prop));
+			if (thisKey  == null) throw new ArgumentNullException(nameof(thisKey));
+			if (otherKey == null) throw new ArgumentNullException(nameof(otherKey));
+
+			var thisKeyName  = MemberHelper.GetMemberInfo(thisKey).Name;
+			var otherKeyName = MemberHelper.GetMemberInfo(otherKey).Name;
+
+			var objProp = Expression.Lambda<Func<T, object>>(Expression.Convert(prop.Body, typeof(object)), prop.Parameters );
+
+			return Property( objProp ).HasAttribute( new AssociationAttribute { ThisKey = thisKeyName, OtherKey = otherKeyName, CanBeNull = canBeNull } );
+		}
+
+		/// <summary>
 		/// Adds one-to-many association mapping to current entity.
 		/// </summary>
 		/// <typeparam name="TOther">Other association side type</typeparam>

--- a/Source/LinqToDB/Mapping/PropertyMappingBuilder.cs
+++ b/Source/LinqToDB/Mapping/PropertyMappingBuilder.cs
@@ -8,6 +8,7 @@ namespace LinqToDB.Mapping
 	using Expressions;
 	using Extensions;
 	using SqlQuery;
+	using System.Collections.Generic;
 
 	/// <summary>
 	/// Column or association fluent mapping builder.
@@ -94,13 +95,99 @@ namespace LinqToDB.Mapping
 		/// <param name="prop">Association member getter expression.</param>
 		/// <param name="thisKey">This association key getter expression.</param>
 		/// <param name="otherKey">Other association key getter expression.</param>
+		/// <param name="canBeNull">Defines type of join. True - left join, False - inner join.</param>
 		/// <returns>Returns association mapping builder.</returns>
 		public PropertyMappingBuilder<T> Association<S, ID1, ID2>(
-			Expression<Func<T, S>> prop,
+			Expression<Func<T, S>>   prop,
 			Expression<Func<T, ID1>> thisKey,
-			Expression<Func<S, ID2>> otherKey)
+			Expression<Func<S, ID2>> otherKey,
+			bool                     canBeNull = true)
 		{
-			return _entity.Association( prop, thisKey, otherKey );
+			return _entity.Association(prop, thisKey, otherKey, canBeNull);
+		}
+
+		/// <summary>
+		/// Adds association mapping to current column's entity.
+		/// </summary>
+		/// <typeparam name="S">Association member type.</typeparam>
+		/// <typeparam name="ID1">This association side key type.</typeparam>
+		/// <typeparam name="ID2">Other association side key type.</typeparam>
+		/// <param name="prop">Association member getter expression.</param>
+		/// <param name="thisKey">This association key getter expression.</param>
+		/// <param name="otherKey">Other association key getter expression.</param>
+		/// <param name="canBeNull">Defines type of join. True - left join, False - inner join.</param>
+		/// <returns>Returns fluent property mapping builder.</returns>
+		public PropertyMappingBuilder<T> Association<S, ID1, ID2>(
+			[JetBrains.Annotations.NotNull] Expression<Func<T, IEnumerable<S>>> prop,
+			[JetBrains.Annotations.NotNull] Expression<Func<T, ID1>>            thisKey,
+			[JetBrains.Annotations.NotNull] Expression<Func<S, ID2>>            otherKey,
+			                                bool                                canBeNull = true)
+		{
+			return _entity.Association(prop, thisKey, otherKey, canBeNull);
+		}
+
+		/// <summary>
+		/// Adds association mapping to current column's entity.
+		/// </summary>
+		/// <typeparam name="TOther">Other association side type</typeparam>
+		/// <param name="prop">Association member getter expression.</param>
+		/// <param name="predicate">Predicate expression.</param>
+		/// <param name="canBeNull">Defines type of join. True - left join, False - inner join.</param>
+		/// <returns>Returns fluent property mapping builder.</returns>
+		public PropertyMappingBuilder<T> Association<TOther>(
+			[JetBrains.Annotations.NotNull] Expression<Func<T, IEnumerable<TOther>>> prop,
+			[JetBrains.Annotations.NotNull] Expression<Func<T, TOther, bool>>        predicate,
+			                                bool                                     canBeNull = true)
+		{
+			return _entity.Association(prop, predicate, canBeNull);
+		}
+
+		/// <summary>
+		/// Adds association mapping to current column's entity.
+		/// </summary>
+		/// <typeparam name="TOther">Other association side type</typeparam>
+		/// <param name="prop">Association member getter expression.</param>
+		/// <param name="predicate">Predicate expression</param>
+		/// <param name="canBeNull">Defines type of join. True - left join, False - inner join.</param>
+		/// <returns>Returns fluent property mapping builder.</returns>
+		public PropertyMappingBuilder<T> Association<TOther>(
+			[JetBrains.Annotations.NotNull] Expression<Func<T, TOther>>       prop,
+			[JetBrains.Annotations.NotNull] Expression<Func<T, TOther, bool>> predicate,
+			                                bool                              canBeNull = true)
+		{
+			return _entity.Association(prop, predicate, canBeNull);
+		}
+
+		/// <summary>
+		/// Adds association mapping to current column's entity.
+		/// </summary>
+		/// <typeparam name="TOther">Other association side type</typeparam>
+		/// <param name="prop">Association member getter expression.</param>
+		/// <param name="queryExpression">Query expression.</param>
+		/// <param name="canBeNull">Defines type of join. True - left join, False - inner join.</param>
+		/// <returns>Returns fluent property mapping builder.</returns>
+		public PropertyMappingBuilder<T> Association<TOther>(
+			[JetBrains.Annotations.NotNull] Expression<Func<T, IEnumerable<TOther>>>              prop,
+			[JetBrains.Annotations.NotNull] Expression<Func<T, IDataContext, IQueryable<TOther>>> queryExpression,
+			                                bool                                     canBeNull = true)
+		{
+			return _entity.Association(prop, queryExpression, canBeNull);
+		}
+
+		/// <summary>
+		/// Adds association mapping to current column's entity.
+		/// </summary>
+		/// <typeparam name="TOther">Other association side type</typeparam>
+		/// <param name="prop">Association member getter expression.</param>
+		/// <param name="queryExpression">Query expression.</param>
+		/// <param name="canBeNull">Defines type of join. True - left join, False - inner join.</param>
+		/// <returns>Returns fluent property mapping builder.</returns>
+		public PropertyMappingBuilder<T> Association<TOther>(
+			[JetBrains.Annotations.NotNull] Expression<Func<T, TOther>>       prop,
+			[JetBrains.Annotations.NotNull] Expression<Func<T, IDataContext, IQueryable<TOther>>> queryExpression,
+			                                bool                              canBeNull = true)
+		{
+			return _entity.Association(prop, queryExpression, canBeNull);
 		}
 
 		/// <summary>

--- a/Tests/Linq/UserTests/Issue1498Tests.cs
+++ b/Tests/Linq/UserTests/Issue1498Tests.cs
@@ -123,8 +123,8 @@ namespace Tests.UserTests
 			{
 				db.MappingSchema.GetFluentMappingBuilder()
 					.Entity<Topic>()
-						.Association(e => e.MessagesF1, (t, m) => t.Id == m.TopicId)
 						.Property(e => e.Id)
+						.Association(e => e.MessagesF1, (t, m) => t.Id == m.TopicId)
 						.Property(e => e.Title)
 						.Property(e => e.Text)
 					.Entity<Message>()
@@ -157,8 +157,8 @@ namespace Tests.UserTests
 			{
 				db.MappingSchema.GetFluentMappingBuilder()
 					.Entity<Topic>()
-						.Association(e => e.MessagesF2, t => t.Id, m => m.TopicId)
 						.Property(e => e.Id)
+						.Association(e => e.MessagesF2, t => t.Id, m => m.TopicId)
 						.Property(e => e.Title)
 						.Property(e => e.Text)
 					.Entity<Message>()
@@ -191,8 +191,8 @@ namespace Tests.UserTests
 			{
 				db.MappingSchema.GetFluentMappingBuilder()
 					.Entity<Topic>()
-						.Association(e => e.MessagesF3, (t, ctx) => ctx.GetTable<Message>().Where(m => m.TopicId == t.Id))
 						.Property(e => e.Id)
+						.Association(e => e.MessagesF3, (t, ctx) => ctx.GetTable<Message>().Where(m => m.TopicId == t.Id))
 						.Property(e => e.Title)
 						.Property(e => e.Text)
 					.Entity<Message>()

--- a/Tests/Linq/UserTests/Issue1498Tests.cs
+++ b/Tests/Linq/UserTests/Issue1498Tests.cs
@@ -31,7 +31,9 @@ namespace Tests.UserTests
 			[Association(QueryExpressionMethod = nameof(Query))]
 			public virtual ICollection<Message> MessagesA3 { get; set; }
 
-			public virtual ICollection<Message> MessagesF { get; set; }
+			public virtual ICollection<Message> MessagesF1 { get; set; }
+			public virtual ICollection<Message> MessagesF2 { get; set; }
+			public virtual ICollection<Message> MessagesF3 { get; set; }
 
 			static Expression<Func<Topic, Message, bool>> Predicate => (t, m) => t.Id == m.TopicId;
 
@@ -121,7 +123,7 @@ namespace Tests.UserTests
 			{
 				db.MappingSchema.GetFluentMappingBuilder()
 					.Entity<Topic>()
-						.Association(e => e.MessagesF, (t, m) => t.Id == m.TopicId)
+						.Association(e => e.MessagesF1, (t, m) => t.Id == m.TopicId)
 						.Property(e => e.Id)
 						.Property(e => e.Title)
 						.Property(e => e.Text)
@@ -141,7 +143,7 @@ namespace Tests.UserTests
 						new
 						{
 							Topic = x,
-							MessagesIds = x.MessagesF.Select(t => t.Id).ToList()
+							MessagesIds = x.MessagesF1.Select(t => t.Id).ToList()
 						}).FirstOrDefault();
 				}
 			}
@@ -155,8 +157,7 @@ namespace Tests.UserTests
 			{
 				db.MappingSchema.GetFluentMappingBuilder()
 					.Entity<Topic>()
-						// TODO: add missing override and uncomment
-						//.Association(e => e.MessagesF, t => t.Id, m => m.TopicId)
+						.Association(e => e.MessagesF2, t => t.Id, m => m.TopicId)
 						.Property(e => e.Id)
 						.Property(e => e.Title)
 						.Property(e => e.Text)
@@ -176,7 +177,7 @@ namespace Tests.UserTests
 						new
 						{
 							Topic = x,
-							MessagesIds = x.MessagesF.Select(t => t.Id).ToList()
+							MessagesIds = x.MessagesF2.Select(t => t.Id).ToList()
 						}).FirstOrDefault();
 				}
 			}
@@ -190,7 +191,7 @@ namespace Tests.UserTests
 			{
 				db.MappingSchema.GetFluentMappingBuilder()
 					.Entity<Topic>()
-						.Association(e => e.MessagesF, (t, ctx) => ctx.GetTable<Message>().Where(m => m.TopicId == t.Id))
+						.Association(e => e.MessagesF3, (t, ctx) => ctx.GetTable<Message>().Where(m => m.TopicId == t.Id))
 						.Property(e => e.Id)
 						.Property(e => e.Title)
 						.Property(e => e.Text)
@@ -210,7 +211,7 @@ namespace Tests.UserTests
 						new
 						{
 							Topic = x,
-							MessagesIds = x.MessagesF.Select(t => t.Id).ToList()
+							MessagesIds = x.MessagesF3.Select(t => t.Id).ToList()
 						}).FirstOrDefault();
 				}
 			}

--- a/Tests/Linq/UserTests/Issue1498Tests.cs
+++ b/Tests/Linq/UserTests/Issue1498Tests.cs
@@ -1,0 +1,219 @@
+﻿using LinqToDB;
+using LinqToDB.Data;
+using LinqToDB.DataProvider.PostgreSQL;
+using LinqToDB.Mapping;
+using Npgsql;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Tests.UserTests
+{
+	[TestFixture]
+	public class Issue1498Tests : TestBase
+	{
+		public class Topic
+		{
+			public int Id { get; set; }
+
+			public string Title { get; set; }
+
+			public string Text { get; set; }
+
+			[Association(ThisKey = "Id", OtherKey = "TopicId")]
+			public virtual ICollection<Message> MessagesA1 { get; set; }
+
+			[Association(ExpressionPredicate = nameof(Predicate))]
+			public virtual ICollection<Message> MessagesA2 { get; set; }
+
+			[Association(QueryExpressionMethod = nameof(Query))]
+			public virtual ICollection<Message> MessagesA3 { get; set; }
+
+			public virtual ICollection<Message> MessagesF { get; set; }
+
+			static Expression<Func<Topic, Message, bool>> Predicate => (t, m) => t.Id == m.TopicId;
+
+			static Expression<Func<Topic, IDataContext, IQueryable<Message>>> Query => (t, ctx) => ctx.GetTable<Message>().Where(m => m.TopicId == t.Id);
+		}
+
+		public class Message
+		{
+			public int Id { get; set; }
+
+			public int TopicId { get; set; }
+
+			[Association(ThisKey = "TopicId", OtherKey = "Id")]
+			public virtual Topic Topic { get; set; }
+
+			public string Text { get; set; }
+		}
+
+		[Test]
+		public void TestAttributesByKey([DataSources] string context)
+		{
+			using (new AllowMultipleQuery())
+			using (var db = GetDataContext(context))
+			using (db.CreateLocalTable<Topic>())
+			using (db.CreateLocalTable<Message>())
+			{
+				db.Insert(new Topic() { Id = 6, Title = "title", Text = "text" });
+
+				db.GetTable<Topic>()
+					.Where(x => x.Id == 6)
+					.Select(x =>
+					new
+					{
+						Topic = x,
+						MessagesIds = x.MessagesA1.Select(t => t.Id).ToList()
+					}).FirstOrDefault();
+			}
+		}
+
+		[Test]
+		public void TestAttributesByExpression([DataSources] string context)
+		{
+			using (new AllowMultipleQuery())
+			using (var db = GetDataContext(context))
+			using (db.CreateLocalTable<Topic>())
+			using (db.CreateLocalTable<Message>())
+			{
+				db.Insert(new Topic() { Id = 6, Title = "title", Text = "text" });
+
+				db.GetTable<Topic>()
+					.Where(x => x.Id == 6)
+					.Select(x =>
+					new
+					{
+						Topic = x,
+						MessagesIds = x.MessagesA2.Select(t => t.Id).ToList()
+					}).FirstOrDefault();
+			}
+		}
+
+		[Test]
+		public void TestAttributesByQuery([DataSources] string context)
+		{
+			using (new AllowMultipleQuery())
+			using (var db = GetDataContext(context))
+			using (db.CreateLocalTable<Topic>())
+			using (db.CreateLocalTable<Message>())
+			{
+				db.Insert(new Topic() { Id = 6, Title = "title", Text = "text" });
+
+				db.GetTable<Topic>()
+					.Where(x => x.Id == 6)
+					.Select(x =>
+					new
+					{
+						Topic = x,
+						MessagesIds = x.MessagesA3.Select(t => t.Id).ToList()
+					}).FirstOrDefault();
+			}
+		}
+
+		[Test]
+		public void TestFluentAssociationByExpression([DataSources] string context)
+		{
+			using (new AllowMultipleQuery())
+			using (var db = GetDataContext(context))
+			{
+				db.MappingSchema.GetFluentMappingBuilder()
+					.Entity<Topic>()
+						.Association(e => e.MessagesF, (t, m) => t.Id == m.TopicId)
+						.Property(e => e.Id)
+						.Property(e => e.Title)
+						.Property(e => e.Text)
+					.Entity<Message>()
+						.Property(e => e.Id)
+						.Property(e => e.TopicId)
+						.Property(e => e.Text);
+
+				using (db.CreateLocalTable<Topic>())
+				using (db.CreateLocalTable<Message>())
+				{
+					db.Insert(new Topic() { Id = 6, Title = "title", Text = "text" });
+
+					db.GetTable<Topic>()
+						.Where(x => x.Id == 6)
+						.Select(x =>
+						new
+						{
+							Topic = x,
+							MessagesIds = x.MessagesF.Select(t => t.Id).ToList()
+						}).FirstOrDefault();
+				}
+			}
+		}
+
+		[Test]
+		public void TestFluentAssociationByKeys([DataSources] string context)
+		{
+			using (new AllowMultipleQuery())
+			using (var db = GetDataContext(context))
+			{
+				db.MappingSchema.GetFluentMappingBuilder()
+					.Entity<Topic>()
+						// TODO: add missing override and uncomment
+						//.Association(e => e.MessagesF, t => t.Id, m => m.TopicId)
+						.Property(e => e.Id)
+						.Property(e => e.Title)
+						.Property(e => e.Text)
+					.Entity<Message>()
+						.Property(e => e.Id)
+						.Property(e => e.TopicId)
+						.Property(e => e.Text);
+
+				using (db.CreateLocalTable<Topic>())
+				using (db.CreateLocalTable<Message>())
+				{
+					db.Insert(new Topic() { Id = 6, Title = "title", Text = "text" });
+
+					db.GetTable<Topic>()
+						.Where(x => x.Id == 6)
+						.Select(x =>
+						new
+						{
+							Topic = x,
+							MessagesIds = x.MessagesF.Select(t => t.Id).ToList()
+						}).FirstOrDefault();
+				}
+			}
+		}
+
+		[Test]
+		public void TestFluentAssociationByQuery([DataSources] string context)
+		{
+			using (new AllowMultipleQuery())
+			using (var db = GetDataContext(context))
+			{
+				db.MappingSchema.GetFluentMappingBuilder()
+					.Entity<Topic>()
+						.Association(e => e.MessagesF, (t, ctx) => ctx.GetTable<Message>().Where(m => m.TopicId == t.Id))
+						.Property(e => e.Id)
+						.Property(e => e.Title)
+						.Property(e => e.Text)
+					.Entity<Message>()
+						.Property(e => e.Id)
+						.Property(e => e.TopicId)
+						.Property(e => e.Text);
+
+				using (db.CreateLocalTable<Topic>())
+				using (db.CreateLocalTable<Message>())
+				{
+					db.Insert(new Topic() { Id = 6, Title = "title", Text = "text" });
+
+					db.GetTable<Topic>()
+						.Where(x => x.Id == 6)
+						.Select(x =>
+						new
+						{
+							Topic = x,
+							MessagesIds = x.MessagesF.Select(t => t.Id).ToList()
+						}).FirstOrDefault();
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fix #1498, fix #1499

- add missing fluent mapping Association method override for IEnumerable<T> property with key selectors
- add missing Association overrides to PropertyMappingBuilder
- add canbeNull parameter to existing Association method of PropertyMappingBuilder