### PR TITLE
Connection factory support by DataConnection and better DataConnection cloning

### DIFF
--- a/Source/LinqToDB/Data/DataConnection.Async.cs
+++ b/Source/LinqToDB/Data/DataConnection.Async.cs
@@ -15,7 +15,10 @@ namespace LinqToDB.Data
 		{
 			if (_connection == null)
 			{
-				_connection = DataProvider.CreateConnection(ConnectionString);
+				if (_connectionFactory != null)
+					_connection = _connectionFactory();
+				else
+					_connection = DataProvider.CreateConnection(ConnectionString);
 
 				if (RetryPolicy != null)
 					_connection = new RetryingDbConnection(this, (DbConnection)_connection, RetryPolicy);

--- a/Tests/Base/TestBase.cs
+++ b/Tests/Base/TestBase.cs
@@ -1068,14 +1068,16 @@ namespace Tests
 
 	public class AllowMultipleQuery : IDisposable
 	{
-		public AllowMultipleQuery()
+		private readonly bool _oldValue = Configuration.Linq.AllowMultipleQuery;
+
+		public AllowMultipleQuery(bool value = true)
 		{
-			Configuration.Linq.AllowMultipleQuery = true;
+			Configuration.Linq.AllowMultipleQuery = value;
 		}
 
 		public void Dispose()
 		{
-			Configuration.Linq.AllowMultipleQuery = false;
+			Configuration.Linq.AllowMultipleQuery = _oldValue;
 		}
 	}
 

--- a/Tests/Linq/UserTests/Issue1486Tests.cs
+++ b/Tests/Linq/UserTests/Issue1486Tests.cs
@@ -1,0 +1,87 @@
+﻿using LinqToDB;
+using LinqToDB.Data;
+using LinqToDB.DataProvider;
+using NUnit.Framework;
+using System.Data;
+using System.Linq;
+using Tests.Model;
+
+namespace Tests.UserTests
+{
+	[TestFixture]
+	public class Issue1486Tests : TestBase
+	{
+		public class IssueDataConnection : DataConnection
+		{
+			public IssueDataConnection(string configuration)
+				: base(GetDataProvider(configuration), GetConnection(configuration), true)
+			{
+			}
+
+			private new static IDataProvider GetDataProvider(string configuration)
+			{
+				return DataConnection.GetDataProvider(configuration);
+			}
+
+			private static IDbConnection GetConnection(string configuration)
+			{
+				string connStr = GetConnectionString(configuration);
+
+				return DataConnection.GetDataProvider(configuration).CreateConnection(connStr);
+			}
+		}
+
+		public class FactoryDataConnection : DataConnection
+		{
+			public FactoryDataConnection(string configuration)
+				: base(GetDataProvider(configuration), () => GetConnection(configuration))
+			{
+			}
+
+			private new static IDataProvider GetDataProvider(string configuration)
+			{
+				return DataConnection.GetDataProvider(configuration);
+			}
+
+			private static IDbConnection GetConnection(string configuration)
+			{
+				string connStr = GetConnectionString(configuration);
+
+				return DataConnection.GetDataProvider(configuration).CreateConnection(connStr);
+			}
+		}
+
+		// excluded providers don't support cloning and remove credentials from connection string
+		[Test]
+		public void TestConnectionStringCopy(
+			[DataSources(
+				false,
+			ProviderName.MySqlConnector,
+			ProviderName.OracleManaged,
+			ProviderName.OracleNative,
+			ProviderName.SapHana)]
+					string context,
+			[Values]
+					bool providerSpecific)
+		{
+			using (new AllowMultipleQuery())
+			using (new AvoidSpecificDataProviderAPI(providerSpecific))
+			using (var db = new IssueDataConnection(context))
+			{
+				db.GetTable<Child>().LoadWith(p => p.Parent.Children).First();
+			}
+		}
+
+		[ActiveIssue("AvoidSpecificDataProviderAPI support missing", Configurations = new[] { ProviderName.OracleManaged, ProviderName.OracleNative })]
+		[Test]
+		public void TestFactory([DataSources(false)] string context, [Values] bool providerSpecific)
+		{
+			using (new AllowMultipleQuery())
+			using (new AvoidSpecificDataProviderAPI(providerSpecific))
+			using (var db = new FactoryDataConnection(context))
+			{
+				db.GetTable<Child>().LoadWith(p => p.Parent.Children).First();
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fix #1486

Improves support for AllowMultipleQuery in conjunction with external connection creation:
- added copy connection string from connection during DataConnection clonning. Fixes AllowMultipleQuery support for SqlCe and Sqlite.ms when parent DataConnection initialized with explicit connection
- added DataConnection constructors that take `Func<IDbConnection>` connection factory method. Fixes AllowMultipleQuery support for MySqlConnector, SAP, Oracle (native and managed) when parent DataConnection initialized with connection factory