### PR TITLE
Asp.net integration

### DIFF
--- a/Source/LinqToDB/Configuration/ServiceConfiguration.cs
+++ b/Source/LinqToDB/Configuration/ServiceConfiguration.cs
@@ -16,6 +16,13 @@ namespace LinqToDB.Configuration
 #if NETSTANDARD2_0
 	public static class ServiceConfiguration
 	{
+		public static IServiceCollection AddLinqToDb(
+			this IServiceCollection serviceCollection,
+			Action<IServiceProvider, LinqToDbConnectionOptions> configure,
+			ServiceLifetime lifetime = ServiceLifetime.Scoped)
+		{
+			return AddLinqToDbContext<DataConnection>(serviceCollection, configure, lifetime);
+		}
 		public static IServiceCollection AddLinqToDbContext<TContext>(
 			this IServiceCollection serviceCollection,
 			Action<IServiceProvider, LinqToDbConnectionOptions> configure,

--- a/Source/LinqToDB/Configuration/ServiceConfiguration.cs
+++ b/Source/LinqToDB/Configuration/ServiceConfiguration.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Data;
+using System.Reflection;
+using LinqToDB.Data;
+using LinqToDB.DataProvider;
+using LinqToDB.Extensions;
+using LinqToDB.Mapping;
+
+#if NETSTANDARD2_0
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+#endif
+
+namespace LinqToDB.Configuration
+{
+#if NETSTANDARD2_0
+	public static class ServiceConfiguration
+	{
+		public static IServiceCollection AddLinqToDbContext<TContext>(
+			this IServiceCollection serviceCollection,
+			Action<IServiceProvider, LinqToDbConnectionOptions> configure,
+			ServiceLifetime lifetime = ServiceLifetime.Scoped) where TContext : IDataContext
+		{
+			return AddLinqToDbContext<TContext, TContext>(serviceCollection, configure, lifetime);
+		}
+
+		public static IServiceCollection AddLinqToDbContext<TContext, TContextImplementation>(
+			this IServiceCollection serviceCollection,
+			Action<IServiceProvider, LinqToDbConnectionOptions> configure,
+			ServiceLifetime lifetime = ServiceLifetime.Scoped) where TContextImplementation : IDataContext
+		{
+			CheckContextConstructor<TContextImplementation>();
+			serviceCollection.TryAdd(new ServiceDescriptor(typeof(TContext), typeof(TContextImplementation), lifetime));
+			serviceCollection.TryAdd(new ServiceDescriptor(typeof(LinqToDbConnectionOptions<TContextImplementation>),
+				provider =>
+				{
+					var options = new LinqToDbConnectionOptions<TContextImplementation>();
+					configure(provider, options);
+					return options;
+				},
+				lifetime));
+			serviceCollection.TryAdd(new ServiceDescriptor(typeof(LinqToDbConnectionOptions),
+				typeof(LinqToDbConnectionOptions<TContextImplementation>)));
+			return serviceCollection;
+		}
+
+		private static void CheckContextConstructor<TContext>()
+		{
+			var constructorInfo = typeof(TContext).GetConstructorEx(new[] {typeof(LinqToDbConnectionOptions)});
+			if (constructorInfo == null)
+			{
+				throw new ArgumentException("Missing constructor accepting 'LinqToDbContextOptions' on type "
+				                            + typeof(TContext).Name);
+			}
+		}
+	}
+#endif
+	public class LinqToDbConnectionOptions
+	{
+		internal MappingSchema _mappingSchema;
+		internal IDataProvider _dataProvider;
+		internal IDbConnection _dbConnection;
+		internal bool _disposeConnection;
+		internal string _configurationString;
+		internal string _providerName;
+		internal string _connectionString;
+		internal Func<IDbConnection> _connectionFactory;
+		internal IDbTransaction _dbTransaction;
+
+		private void CheckAssignSetupType(ConnectionSetupType type)
+		{
+			if (SetupType != ConnectionSetupType.DefaultConfiguration)
+				throw new LinqToDBException(
+					$"LinqToDbConnectionOptions already setup using {SetupType}, use Reset first to overwrite");
+			SetupType = type;
+		}
+
+		internal ConnectionSetupType SetupType { get; set; }
+
+		internal enum ConnectionSetupType
+		{
+			DefaultConfiguration,
+			ConnectionString,
+			ConfigurationString,
+			Connection,
+			ConnectionFactory,
+			Transaction
+		}
+
+		public LinqToDbConnectionOptions UseSqlServer([JetBrains.Annotations.NotNull] string connectionString)
+		{
+			return UseConnectionString(ProviderName.SqlServer, connectionString);
+		}
+		public LinqToDbConnectionOptions UseOracle([JetBrains.Annotations.NotNull] string connectionString)
+		{
+			return UseConnectionString(ProviderName.Oracle, connectionString);
+		}
+		public LinqToDbConnectionOptions UsePostgreSQL([JetBrains.Annotations.NotNull] string connectionString)
+		{
+			return UseConnectionString(ProviderName.PostgreSQL, connectionString);
+		}
+		public LinqToDbConnectionOptions UseMySql([JetBrains.Annotations.NotNull] string connectionString)
+		{
+			return UseConnectionString(ProviderName.MySql, connectionString);
+		}
+		public LinqToDbConnectionOptions UseSQLite([JetBrains.Annotations.NotNull] string connectionString)
+		{
+			return UseConnectionString(ProviderName.SQLite, connectionString);
+		}
+
+		/// <summary>
+		/// Configure the database to use this provider and connection string
+		/// </summary>
+		/// <param name="providerName">See <see cref="ProviderName"/> for Default providers</param>
+		/// <param name="connectionString">Database specific connections string</param>
+		/// <returns></returns>
+		public LinqToDbConnectionOptions UseConnectionString(
+			[JetBrains.Annotations.NotNull] string providerName,
+			[JetBrains.Annotations.NotNull] string connectionString)
+		{
+			CheckAssignSetupType(ConnectionSetupType.ConnectionString);
+			_connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
+			_providerName = providerName ?? throw new ArgumentNullException(nameof(providerName));
+			return this;
+		}
+
+		public LinqToDbConnectionOptions UseConnectionString(
+			[JetBrains.Annotations.NotNull] IDataProvider dataProvider,
+			[JetBrains.Annotations.NotNull] string connectionString)
+		{
+			CheckAssignSetupType(ConnectionSetupType.ConnectionString);
+			_connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
+			_dataProvider = dataProvider ?? throw new ArgumentNullException(nameof(dataProvider));
+			return this;
+		}
+
+		public LinqToDbConnectionOptions UseConfigurationString(
+			[JetBrains.Annotations.NotNull] string configurationString)
+		{
+			CheckAssignSetupType(ConnectionSetupType.ConfigurationString);
+			_configurationString = configurationString ?? throw new ArgumentNullException(nameof(configurationString));
+			return this;
+		}
+
+		public LinqToDbConnectionOptions UseConnectionFactory(
+			[JetBrains.Annotations.NotNull] IDataProvider dataProvider,
+			[JetBrains.Annotations.NotNull] Func<IDbConnection> connectionFactory)
+		{
+			CheckAssignSetupType(ConnectionSetupType.ConnectionFactory);
+			_dataProvider = dataProvider ?? throw new ArgumentNullException(nameof(dataProvider));
+			_connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+			return this;
+		}
+
+		public LinqToDbConnectionOptions UseConnection([JetBrains.Annotations.NotNull] IDataProvider dataProvider,
+			[JetBrains.Annotations.NotNull] IDbConnection connection,
+			bool disposeConnection = false)
+		{
+			CheckAssignSetupType(ConnectionSetupType.Connection);
+			_dataProvider = dataProvider ?? throw new ArgumentNullException(nameof(dataProvider));
+			_dbConnection = connection ?? throw new ArgumentNullException(nameof(connection));
+
+			if (!Common.Configuration.AvoidSpecificDataProviderAPI
+			    && !_dataProvider.IsCompatibleConnection(_dbConnection))
+				throw new LinqToDBException(
+					$"DataProvider '{_dataProvider}' and connection '{_dbConnection}' are not compatible.");
+
+			_disposeConnection = disposeConnection;
+			return this;
+		}
+
+		public LinqToDbConnectionOptions UseTransaction([JetBrains.Annotations.NotNull] IDataProvider dataProvider,
+			[JetBrains.Annotations.NotNull] IDbTransaction transaction)
+		{
+			CheckAssignSetupType(ConnectionSetupType.Transaction);
+			_dataProvider = dataProvider ?? throw new ArgumentNullException(nameof(dataProvider));
+			_dbTransaction = transaction ?? throw new ArgumentNullException(nameof(transaction));
+			return this;
+		}
+
+		public LinqToDbConnectionOptions UseMappingSchema([JetBrains.Annotations.NotNull] MappingSchema mappingSchema)
+		{
+			_mappingSchema = mappingSchema ?? throw new ArgumentNullException(nameof(mappingSchema));
+			return this;
+		}
+
+		public LinqToDbConnectionOptions UseDataProvider([JetBrains.Annotations.NotNull] IDataProvider dataProvider)
+		{
+			_dataProvider = dataProvider ?? throw new ArgumentNullException(nameof(dataProvider));
+			return this;
+		}
+
+		public LinqToDbConnectionOptions Reset()
+		{
+			_mappingSchema = null;
+			_dataProvider = null;
+			_configurationString = null;
+			_connectionString = null;
+			_dbConnection = null;
+			_providerName = null;
+			_dbTransaction = null;
+			_connectionFactory = null;
+			SetupType = ConnectionSetupType.DefaultConfiguration;
+			return this;
+		}
+	}
+
+	//this type is used to discriminate between options for 2 different Contexts
+	public class LinqToDbConnectionOptions<T> : LinqToDbConnectionOptions
+	{
+	}
+}

--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -214,8 +214,19 @@ namespace LinqToDB.Data
 		{
 		}
 
-		public DataConnection(LinqToDbConnectionOptions options)
+		/// <summary>
+		/// Creates database connection object that uses a LinqToDbConnectionOptions to configure the connection.
+		/// </summary>
+		/// <param name="options">Options, setup ahead of time</param>
+		public DataConnection([JetBrains.Annotations.NotNull]LinqToDbConnectionOptions options)
 		{
+			if (options == null)
+				throw new ArgumentNullException(nameof(options));
+			
+			if (!options.IsValidConfigForConnectionType(this))
+				throw new LinqToDBException(
+					$"Improper options type used to create DataConnection {GetType()}, try creating a public constructor calling base and accepting type {nameof(LinqToDbConnectionOptions)}<{GetType().Name}>");
+			
 			InitConfig();
 			
 			switch (options.SetupType)

--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -222,7 +222,7 @@ namespace LinqToDB.Data
 			{
 				case LinqToDbConnectionOptions.ConnectionSetupType.ConfigurationString:
 				case LinqToDbConnectionOptions.ConnectionSetupType.DefaultConfiguration:
-					ConnectionString = options._configurationString ?? DefaultConfiguration;
+					ConfigurationString = options._configurationString ?? DefaultConfiguration;
 					if (ConfigurationString == null)
 						throw new LinqToDBException("Configuration string is not provided.");
 					var ci = GetConfigurationInfo(ConfigurationString);
@@ -237,7 +237,7 @@ namespace LinqToDB.Data
 
 				case LinqToDbConnectionOptions.ConnectionSetupType.ConnectionString:
 					if (options._providerName == null && options._dataProvider == null) 
-						throw new LinqToDBException("DataProvider was not specified ");
+						throw new LinqToDBException("DataProvider was not specified");
 
 					if (options._providerName != null
 					    && !_dataProviders.TryGetValue(options._providerName, out var dataProvider))

--- a/Source/LinqToDB/LinqToDB.csproj
+++ b/Source/LinqToDB/LinqToDB.csproj
@@ -113,6 +113,7 @@
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
 		<PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0" />
 		<PackageReference Include="System.ComponentModel.Annotations" Version="4.4.1" />
 		<PackageReference Include="System.Data.SqlClient" Version="4.5.1" />
 
@@ -135,6 +136,7 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0" />
 		<PackageReference Include="System.ComponentModel.Annotations" Version="4.4.1" />
 		<PackageReference Include="System.Data.SqlClient" Version="4.5.1" />
 

--- a/Tests/Linq/Tests.csproj
+++ b/Tests/Linq/Tests.csproj
@@ -197,6 +197,7 @@
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
 		<PackageReference Include="Microsoft.Data.SQLite" Version="2.1.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
 		<Reference Include="Microsoft.SqlServer.Types">
 			<HintPath>..\..\Redist\dotMorten.Microsoft.SqlServer.Types\Microsoft.SqlServer.Types.dll</HintPath>
 		</Reference>


### PR DESCRIPTION
This should allow users to easily configure linq2db for Asp.NET core

In Setup.cs
```C#
var connectionString; //from json or config
var provider;
services.AddLinqToDbContext<IAppContext, AppContext>((provider, options) => {
    options.UseConnectionString(provider, connectionString)
});
```

Now anywhere in your app you can inject `AppContext`. By Default It's injected with Request scope, but you can adjust that when calling Add

One caveat is that you need to declare a constructor that looks like this if you have more than one context
```C#
public AppContext1(LinqToDbConnectionOptions<AppContext1> options) : base(options) { }
```
Otherwise you might get the wrong options injected

In order to get this to work I had to add a reference to `Microsoft.Extensions.DependencyInjection.Abstractions` the version should be checked for compatibility. 

closes #1514