### PR TITLE
Fix 1515

### DIFF
--- a/Source/LinqToDB.Templates/DataModel.ttinclude
+++ b/Source/LinqToDB.Templates/DataModel.ttinclude
@@ -123,6 +123,7 @@ void LoadServerMetadata(DataConnection dataConnection)
 			table = new Table
 			{
 				TableSchema             = t,
+				IsDefaultSchema         = t.IsDefaultSchema,
 				Schema                  = t.IsDefaultSchema && !IncludeDefaultSchema || string.IsNullOrEmpty(t.SchemaName)? null : t.SchemaName,
 				BaseClass               = BaseEntityClass,
 				TableName               = t.TableName,
@@ -702,6 +703,7 @@ public partial class Table : Class
 	public MemberBase  DataContextProperty     { get; set; }
 	public bool        IsView                  { get; set; }
 	public bool        IsProviderSpecific      { get; set; }
+	public bool        IsDefaultSchema         { get; set; }
 	public string      Description             { get; set; }
 	public string      AliasPropertyName       { get; set; }
 	public string      AliasTypeName           { get; set; }

--- a/Source/LinqToDB.Templates/LinqToDB.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.ttinclude
@@ -26,6 +26,7 @@ bool   GenerateDbTypes                     = false;
 bool   GenerateSchemaAsType                = false;
 bool   GenerateViews                       = true;
 bool   GenerateProcedureResultAsList       = false;
+bool   PrefixTableMappingWithSchema        = true;
 string SchemaNameSuffix                    = "Schema";
 string SchemaDataContextTypeName           = "DataContext";
 
@@ -1006,7 +1007,7 @@ void MakeMembersNamesUnique(IEnumerable<IClassMember> members, string defaultNam
 	LinqToDB.Common.Utils.MakeUniqueNames(
 		members,
 		reservedNames,
-		m => m is Table tbl ? (tbl.Schema != null ? tbl.Schema + "_" : null) + tbl.Name : (m is TypeBase t ? t.Name : ((MemberBase)m).Name),
+		m => m is Table tbl ? (tbl.Schema != null && !tbl.IsDefaultSchema && PrefixTableMappingWithSchema ? tbl.Schema + "_" : null) + tbl.Name : (m is TypeBase t ? t.Name : ((MemberBase)m).Name),
 		(m, newName) =>
 		{
 			if (m is TypeBase t)

--- a/Source/LinqToDB.Templates/README.md
+++ b/Source/LinqToDB.Templates/README.md
@@ -141,6 +141,10 @@ DatabaseName                  = null;
 IncludeDefaultSchema          = true;
 // Enables generation of mappings for views
 GenerateViews                 = true;
+// Enables prefixing mapping classes for tables in non-default schema with schema name
+// E.g. MySchema.MyTable -> MySchema_MyTable
+// Applicable only if GenerateSchemaAsType = false
+PrefixTableMappingWithSchema  = true;
 
 /* Columns comfiguration */
 // Enables compact generation of column properties


### PR DESCRIPTION
Fix #1515 

Fixes side-effects from fixing #1425:
- don't add schema name prefix to mapping classes for default schema
- adds new option `PrefixTableMappingWithSchema` to disable prefixing with schema name for other schemas too