### PR TITLE
test and fix for SelectContext

### DIFF
--- a/Source/LinqToDB/Linq/Builder/SelectContext.cs
+++ b/Source/LinqToDB/Linq/Builder/SelectContext.cs
@@ -491,6 +491,7 @@ namespace LinqToDB.Linq.Builder
 				switch (flags)
 				{
 					case ConvertFlags.Field :
+					case ConvertFlags.Key   :
 					case ConvertFlags.All   :
 						return ProcessScalar(
 							expression,


### PR DESCRIPTION
Adds missing primary key request build to SelectContext

Fixes following exception:
```
The method or operation is not implemented:
at LinqToDB.Linq.Builder.SelectContext.ConvertToIndexInternal(Expression expression, Int32 level, ConvertFlags flags) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\SelectContext.cs:line 593
   at LinqToDB.Linq.Builder.SelectContext.ConvertToIndex(Expression expression, Int32 level, ConvertFlags flags) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\SelectContext.cs:line 433
   at LinqToDB.Linq.Builder.SubQueryContext.ConvertToSql(Expression expression, Int32 level, ConvertFlags flags) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\SubQueryContext.cs:line 39
   at LinqToDB.Linq.Builder.SelectManyBuilder.SelectManyContext.ConvertToSql(Expression expression, Int32 level, ConvertFlags flags) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\SelectManyBuilder.cs:line 304
   at LinqToDB.Linq.Builder.SelectContext.<>c__DisplayClass40_0.<ConvertToSql>b__0(IBuildContext ctx, Expression ex, Int32 l) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\SelectContext.cs:line 303
   at LinqToDB.Linq.Builder.SelectContext.ProcessScalar[T](Expression expression, Int32 level, Func`4 action, Func`1 defaultAction) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\SelectContext.cs:line 903
   at LinqToDB.Linq.Builder.SelectContext.ConvertToSql(Expression expression, Int32 level, ConvertFlags flags) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\SelectContext.cs:line 300
   at LinqToDB.Linq.Builder.SelectContext.<>c__DisplayClass40_0.<ConvertToSql>b__0(IBuildContext ctx, Expression ex, Int32 l) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\SelectContext.cs:line 303
   at LinqToDB.Linq.Builder.SelectContext.ProcessScalar[T](Expression expression, Int32 level, Func`4 action, Func`1 defaultAction) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\SelectContext.cs:line 942
   at LinqToDB.Linq.Builder.SelectContext.ConvertToSql(Expression expression, Int32 level, ConvertFlags flags) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\SelectContext.cs:line 300
   at LinqToDB.Linq.Builder.SelectContext.<>c__DisplayClass40_0.<ConvertToSql>b__0(IBuildContext ctx, Expression ex, Int32 l) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\SelectContext.cs:line 303
   at LinqToDB.Linq.Builder.SelectContext.ProcessScalar[T](Expression expression, Int32 level, Func`4 action, Func`1 defaultAction) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\SelectContext.cs:line 913
   at LinqToDB.Linq.Builder.SelectContext.ConvertToSql(Expression expression, Int32 level, ConvertFlags flags) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\SelectContext.cs:line 300
   at LinqToDB.Linq.Builder.ExpressionBuilder.ConvertExpressions(IBuildContext context, Expression expression, ConvertFlags queryConvertFlag) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\ExpressionBuilder.SqlBuilder.cs:line 660
   at LinqToDB.Linq.Builder.SelectContext.ConvertToSql(Expression expression, Int32 level, ConvertFlags flags) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\SelectContext.cs:line 283
   at LinqToDB.Linq.Builder.ExpressionContext.ConvertToSql(Expression expression, Int32 level, ConvertFlags flags) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\ExpressionContext.cs:line 57
   at LinqToDB.Linq.Builder.ExpressionBuilder.ConvertObjectComparison(ExpressionType nodeType, IBuildContext leftContext, Expression left, IBuildContext rightContext, Expression right) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\ExpressionBuilder.SqlBuilder.cs:line 1958
   at LinqToDB.Linq.Builder.ExpressionBuilder.ConvertCompare(IBuildContext context, ExpressionType nodeType, Expression left, Expression right) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\ExpressionBuilder.SqlBuilder.cs:line 1655
   at LinqToDB.Linq.Builder.ExpressionBuilder.ConvertPredicate(IBuildContext context, Expression expression) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\ExpressionBuilder.SqlBuilder.cs:line 1441
   at LinqToDB.Linq.Builder.ExpressionBuilder.BuildSearchCondition(IBuildContext context, Expression expression, List`1 conditions, Boolean isNotExpression) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\ExpressionBuilder.SqlBuilder.cs:line 2684
   at LinqToDB.Linq.Builder.ExpressionBuilder.BuildWhere(IBuildContext parent, IBuildContext sequence, LambdaExpression condition, Boolean checkForSubQuery, Boolean enforceHaving) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\ExpressionBuilder.SqlBuilder.cs:line 46
   at LinqToDB.Linq.Builder.WhereBuilder.BuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\WhereBuilder.cs:line 25
   at LinqToDB.Linq.Builder.MethodCallBuilder.BuildSequence(ExpressionBuilder builder, BuildInfo buildInfo) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\MethodCallBuilder.cs:line 22
   at LinqToDB.Linq.Builder.ExpressionBuilder.BuildSequence(BuildInfo buildInfo) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\ExpressionBuilder.cs:line 176
   at LinqToDB.Linq.Builder.SelectBuilder.BuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\SelectBuilder.cs:line 36
   at LinqToDB.Linq.Builder.MethodCallBuilder.BuildSequence(ExpressionBuilder builder, BuildInfo buildInfo) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\MethodCallBuilder.cs:line 22
   at LinqToDB.Linq.Builder.ExpressionBuilder.BuildSequence(BuildInfo buildInfo) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\ExpressionBuilder.cs:line 176
   at LinqToDB.Linq.Builder.AllAnyBuilder.BuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\AllAnyBuilder.cs:line 18
   at LinqToDB.Linq.Builder.MethodCallBuilder.BuildSequence(ExpressionBuilder builder, BuildInfo buildInfo) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\MethodCallBuilder.cs:line 22
   at LinqToDB.Linq.Builder.ExpressionBuilder.BuildSequence(BuildInfo buildInfo) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\ExpressionBuilder.cs:line 176
   at LinqToDB.Linq.Builder.ExpressionBuilder.GetSubQuery(IBuildContext context, MethodCallExpression expr) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\ExpressionBuilder.SqlBuilder.cs:line 233
   at LinqToDB.Linq.Builder.ExpressionBuilder.SubQueryToSql(IBuildContext context, MethodCallExpression expression) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\ExpressionBuilder.SqlBuilder.cs:line 247
   at LinqToDB.Linq.Builder.ExpressionBuilder.ConvertToSql(IBuildContext context, Expression expression, Boolean unwrap) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\ExpressionBuilder.SqlBuilder.cs:line 903
   at LinqToDB.Linq.Builder.ExpressionBuilder.ConvertCompare(IBuildContext context, ExpressionType nodeType, Expression left, Expression right) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\ExpressionBuilder.SqlBuilder.cs:line 1698
   at LinqToDB.Linq.Builder.ExpressionBuilder.ConvertPredicate(IBuildContext context, Expression expression) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\ExpressionBuilder.SqlBuilder.cs:line 1441
   at LinqToDB.Linq.Builder.ExpressionBuilder.ConvertPredicate(IBuildContext context, Expression expression) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\ExpressionBuilder.SqlBuilder.cs:line 1514
   at LinqToDB.Linq.Builder.ExpressionBuilder.BuildSearchCondition(IBuildContext context, Expression expression, List`1 conditions, Boolean isNotExpression) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\ExpressionBuilder.SqlBuilder.cs:line 2684
   at LinqToDB.Linq.Builder.ExpressionBuilder.BuildSearchCondition(IBuildContext context, Expression expression, List`1 conditions, Boolean isNotExpression) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\ExpressionBuilder.SqlBuilder.cs:line 2590
   at LinqToDB.Linq.Builder.ExpressionBuilder.BuildWhere(IBuildContext parent, IBuildContext sequence, LambdaExpression condition, Boolean checkForSubQuery, Boolean enforceHaving) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\ExpressionBuilder.SqlBuilder.cs:line 46
   at LinqToDB.Linq.Builder.WhereBuilder.BuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\WhereBuilder.cs:line 25
   at LinqToDB.Linq.Builder.MethodCallBuilder.BuildSequence(ExpressionBuilder builder, BuildInfo buildInfo) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\MethodCallBuilder.cs:line 22
   at LinqToDB.Linq.Builder.ExpressionBuilder.BuildSequence(BuildInfo buildInfo) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\ExpressionBuilder.cs:line 176
   at LinqToDB.Linq.Builder.OrderByBuilder.BuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\OrderByBuilder.cs:line 38
   at LinqToDB.Linq.Builder.MethodCallBuilder.BuildSequence(ExpressionBuilder builder, BuildInfo buildInfo) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\MethodCallBuilder.cs:line 22
   at LinqToDB.Linq.Builder.ExpressionBuilder.BuildSequence(BuildInfo buildInfo) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\ExpressionBuilder.cs:line 176
   at LinqToDB.Linq.Builder.SelectBuilder.BuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\SelectBuilder.cs:line 36
   at LinqToDB.Linq.Builder.MethodCallBuilder.BuildSequence(ExpressionBuilder builder, BuildInfo buildInfo) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\MethodCallBuilder.cs:line 22
   at LinqToDB.Linq.Builder.ExpressionBuilder.BuildSequence(BuildInfo buildInfo) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\ExpressionBuilder.cs:line 176
   at LinqToDB.Linq.Builder.FirstSingleBuilder.BuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\FirstSingleBuilder.cs:line 25
   at LinqToDB.Linq.Builder.MethodCallBuilder.BuildSequence(ExpressionBuilder builder, BuildInfo buildInfo) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\MethodCallBuilder.cs:line 22
   at LinqToDB.Linq.Builder.ExpressionBuilder.BuildSequence(BuildInfo buildInfo) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\ExpressionBuilder.cs:line 176
   at LinqToDB.Linq.Builder.ExpressionBuilder.Build[T]() in c:\GitHub\linq2db\Source\LinqToDB\Linq\Builder\ExpressionBuilder.cs:line 147
   at LinqToDB.Linq.Query`1.CreateQuery(IDataContext dataContext, Expression expr) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Query.cs:line 279
   at LinqToDB.Linq.Query`1.GetQuery(IDataContext dataContext, Expression& expr) in c:\GitHub\linq2db\Source\LinqToDB\Linq\Query.cs:line 232
   at LinqToDB.Linq.ExpressionQuery`1.GetQuery(Expression& expression, Boolean cache) in c:\GitHub\linq2db\Source\LinqToDB\Linq\ExpressionQuery.cs:line 79
   at LinqToDB.Linq.ExpressionQuery`1.System.Linq.IQueryProvider.Execute[TResult](Expression expression) in c:\GitHub\linq2db\Source\LinqToDB\Linq\ExpressionQuery.cs:line 165
   at System.Linq.Queryable.FirstOrDefault[TSource](IQueryable`1 source)
   at Tests.Linq.AssociationTests.ComplexQueryWithManyToMany(String context) in c:\GitHub\linq2db\Tests\Linq\Linq\AssociationTests.cs:line 901
```