### PR TITLE
generate postgres sequencename

### DIFF
--- a/Source/LinqToDB.Templates/DataModel.ttinclude
+++ b/Source/LinqToDB.Templates/DataModel.ttinclude
@@ -151,6 +151,7 @@ void LoadServerMetadata(DataConnection dataConnection)
 						SkipOnInsert    = c.SkipOnInsert,
 						SkipOnUpdate    = c.SkipOnUpdate,
 						Description     = c.Description,
+						SequenceName    = c.SequencyName,
 					})
 			}
 		})
@@ -738,6 +739,7 @@ public partial class Column : Property
 	public bool      IsDuplicateOrEmpty;
 	public bool      IsDiscriminator;
 	public string    AliasName;
+	public string    SequenceName;
 
 	public string MemberName
 	{

--- a/Source/LinqToDB.Templates/LinqToDB.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.ttinclude
@@ -386,6 +386,13 @@ void GenerateTypesFromMetadata()
 				canBeReplaced = false;
 			}
 
+			if(c.SequenceName != null)
+			{				
+				var sequenceNameAttr = new Attribute("SequenceName");
+				sequenceNameAttr.Parameters.Add(ToStringLiteral(c.SequenceName));
+				c.Attributes.Add(sequenceNameAttr);
+			}
+
 			// Nullable.
 			//
 			if (c.IsNullable)

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLSchemaProvider.cs
@@ -155,7 +155,8 @@ namespace LinqToDB.DataProvider.PostgreSQL
 						numeric_scale                                                       as Scale,
 						is_identity = 'YES' OR COALESCE(column_default ~* 'nextval', false) as IsIdentity,
 						is_generated <> 'NEVER'                                             as SkipOnInsert,
-						is_updatable = 'NO'                                                 as SkipOnUpdate
+						is_updatable = 'NO'                                                 as SkipOnUpdate,
+						substring(column_default from 'nextval\(''(.+)''')					as SequenceName
 					FROM
 						information_schema.columns";
 

--- a/Source/LinqToDB/SchemaProvider/ColumnInfo.cs
+++ b/Source/LinqToDB/SchemaProvider/ColumnInfo.cs
@@ -19,5 +19,6 @@ namespace LinqToDB.SchemaProvider
 		public bool   IsIdentity;
 		public bool   SkipOnInsert;
 		public bool   SkipOnUpdate;
+		public string SequenceName;
 	}
 }

--- a/Source/LinqToDB/SchemaProvider/ColumnSchema.cs
+++ b/Source/LinqToDB/SchemaProvider/ColumnSchema.cs
@@ -22,6 +22,10 @@ namespace LinqToDB.SchemaProvider
 		/// <summary>
 		/// Gets flag indicating that it is identity column.
 		/// </summary>
+		public string      SequenceName         { get; set; }
+		/// <summary>
+		/// Gets flag indicating that it is identity column.
+		/// </summary>
 		public bool        IsIdentity           { get; set; }
 		/// <summary>
 		/// Gets flag indicating that column is a part of primary key.

--- a/Source/LinqToDB/SchemaProvider/SchemaProviderBase.cs
+++ b/Source/LinqToDB/SchemaProvider/SchemaProviderBase.cs
@@ -141,6 +141,7 @@ namespace LinqToDB.SchemaProvider
 						Length               = column.c.Length,
 						Precision            = column.c.Precision,
 						Scale                = column.c.Scale,
+						SequenceName         = column.c.SequenceName,
 					});
 				}
 


### PR DESCRIPTION
Hi!
Now sequences are used with standard names. (xxx_seq)

I fixed it for postgres.
1. Added property SequenceName (columnXXX objects)
2. Generating [SequenceName] attribute for postgress from table schema



