### PR TITLE
Parameter size support improvements

### DIFF
--- a/Source/LinqToDB/Common/DbDataType.cs
+++ b/Source/LinqToDB/Common/DbDataType.cs
@@ -16,7 +16,8 @@ namespace LinqToDB.Common
 		{
 			var dataTypeStr = DataType == DataType.Undefined ? string.Empty : $", {DataType}";
 			var dbTypeStr   = string.IsNullOrEmpty(DbType)   ? string.Empty : $", \"{DbType}\"";
-			return $"{SystemType}{dataTypeStr}{dbTypeStr}";
+			var lengthStr   = Length == null                 ? string.Empty : $", \"{Length}\"";
+			return $"{SystemType}{dataTypeStr}{dbTypeStr}{lengthStr}";
 		}
 
 		[DebuggerStepThrough]
@@ -33,6 +34,14 @@ namespace LinqToDB.Common
 		}
 
 		[DebuggerStepThrough]
+		public DbDataType(Type systemType, DataType dataType, string dbType, int? length) : this(systemType)
+		{
+			DataType   = dataType;
+			DbType     = dbType;
+			Length     = length;
+		}
+
+		[DebuggerStepThrough]
 		public DbDataType(Type systemType, string dbType) : this(systemType)
 		{
 			DbType = dbType;
@@ -41,16 +50,18 @@ namespace LinqToDB.Common
 		public Type     SystemType { get; }
 		public DataType DataType   { get; }
 		public string   DbType     { get; }
+		public int?     Length     { get; }
 
-		public DbDataType WithSystemType(Type     systemType) => new DbDataType(systemType, DataType, DbType);
-		public DbDataType WithDataType  (DataType dataType  ) => new DbDataType(SystemType, dataType, DbType);
-		public DbDataType WithDbType    (string   dbName    ) => new DbDataType(SystemType, DataType, dbName);
+		public DbDataType WithSystemType(Type     systemType) => new DbDataType(systemType, DataType, DbType, Length);
+		public DbDataType WithDataType  (DataType dataType  ) => new DbDataType(SystemType, dataType, DbType, Length);
+		public DbDataType WithDbType    (string   dbName    ) => new DbDataType(SystemType, DataType, dbName, Length);
+		public DbDataType WithLength    (int?     length    ) => new DbDataType(SystemType, DataType, DbType, length);
 
 		#region Equality members
 
 		public bool Equals(DbDataType other)
 		{
-			return SystemType == other.SystemType && DataType == other.DataType && string.Equals(DbType, other.DbType);
+			return SystemType == other.SystemType && DataType == other.DataType && string.Equals(DbType, other.DbType) && Length == other.Length;
 		}
 
 		public override bool Equals(object obj)
@@ -65,7 +76,8 @@ namespace LinqToDB.Common
 			{
 				var hashCode = (SystemType != null ? SystemType.GetHashCode() : 0);
 				hashCode = (hashCode * 397) ^ (int) DataType;
-				hashCode = (hashCode * 397) ^ (DbType != null ? DbType.GetHashCode() : 0);
+				hashCode = (hashCode * 397) ^ (DbType != null ? DbType.GetHashCode()       : 0);
+				hashCode = (hashCode * 397) ^ (Length != null ? Length.Value.GetHashCode() : 0);
 				return hashCode;
 			}
 		}

--- a/Source/LinqToDB/Data/CommandInfo.cs
+++ b/Source/LinqToDB/Data/CommandInfo.cs
@@ -834,15 +834,16 @@ namespace LinqToDB.Data
 				var p        = dataConnection.Command.CreateParameter();
 				var dataType = parameter.DataType;
 				var dbType   = parameter.DbType;
+				var size     = parameter.Size;
 				var value    = parameter.Value;
 
 				if (dataType == DataType.Undefined && value != null)
 					dataType = dataConnection.MappingSchema.GetDataType(value.GetType()).DataType;
 
 				if (parameter.Direction != null) p.Direction = parameter.Direction.Value;
-				if (parameter.Size      != null) p.Size      = parameter.Size.     Value;
+				if (size                != null) p.Size      = size.               Value;
 
-				dataConnection.DataProvider.SetParameter(p, parameter.Name, new DbDataType(value != null ? value.GetType() : typeof(object), dataType, dbType), value);
+				dataConnection.DataProvider.SetParameter(p, parameter.Name, new DbDataType(value != null ? value.GetType() : typeof(object), dataType, dbType, size), value);
 				dataConnection.Command.Parameters.Add(p);
 			}
 		}

--- a/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
+++ b/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
@@ -240,6 +240,7 @@ namespace LinqToDB.Data
 				var systemType = parm.SystemType;
 				var dataType   = parm.DataType;
 				var dbType     = parm.DbType;
+				var dbSize     = parm.DbSize;
 				var paramValue = parm.Value;
 
 				if (systemType == null)
@@ -256,8 +257,7 @@ namespace LinqToDB.Data
 							systemType).DataType;
 				}
 
-
-				dataConnection.DataProvider.SetParameter(p, name, new DbDataType(systemType, dataType, dbType), paramValue);
+				dataConnection.DataProvider.SetParameter(p, name, new DbDataType(systemType, dataType, dbType, dbSize), paramValue);
 
 				parms.Add(p);
 			}

--- a/Source/LinqToDB/DataProvider/BasicMerge.cs
+++ b/Source/LinqToDB/DataProvider/BasicMerge.cs
@@ -351,7 +351,7 @@ namespace LinqToDB.DataProvider
 
 						StringBuilder.Append(name);
 						Parameters.Add(new DataParameter(pname == "?" ? pname : "p" + pidx, value,
-							column.DataType, column.DbType));
+							column.DataType, column.DbType) { Size = column.Length });
 					}
 
 					StringBuilder.Append(",");
@@ -437,7 +437,7 @@ namespace LinqToDB.DataProvider
 
 						StringBuilder.Append(name);
 						Parameters.Add(new DataParameter(pname == "?" ? pname : "p" + pidx, value,
-							column.Column.DataType, column.Column.DbType));
+							column.Column.DataType, column.Column.DbType) { Size = column.Column.Length });
 					}
 
 					if (!hasData)

--- a/Source/LinqToDB/DataProvider/BasicMergeBuilder.cs
+++ b/Source/LinqToDB/DataProvider/BasicMergeBuilder.cs
@@ -208,18 +208,18 @@ namespace LinqToDB.DataProvider
 			// avoid parameters in source due to low limits for parameters number in providers
 			if (!valueConverter.TryConvert(Command, columnType, value))
 			{
-				AddSourceValueAsParameter(column.DataType, column.DbType, value);
+				AddSourceValueAsParameter(column.DataType, column.DbType, column.Length, value);
 			}
 		}
 
-		protected void AddSourceValueAsParameter(DataType dataType, string dbType, object value)
+		protected void AddSourceValueAsParameter(DataType dataType, string dbType, int? size, object value)
 		{
 			var name     = GetNextParameterName();
 			var fullName = SqlBuilder.Convert(name, ConvertType.NameToQueryParameter).ToString();
 
 			Command.Append(fullName);
 
-			AddParameter(new DataParameter(name, value, dataType, dbType));
+			AddParameter(new DataParameter(name, value, dataType, dbType) { Size = size });
 		}
 
 		private void BuildAsSourceClause(IEnumerable<string> columnNames)
@@ -1190,7 +1190,7 @@ namespace LinqToDB.DataProvider
 			{
 				param.Name = GetNextParameterName();
 
-				AddParameter(new DataParameter(param.Name, param.Value, param.DataType, param.DbType));
+				AddParameter(new DataParameter(param.Name, param.Value, param.DataType, param.DbType) { Size = param.DbSize });
 			}
 		}
 		#endregion

--- a/Source/LinqToDB/DataProvider/BulkCopyReader.cs
+++ b/Source/LinqToDB/DataProvider/BulkCopyReader.cs
@@ -20,7 +20,7 @@ namespace LinqToDB.DataProvider
 			_enumerator    = collection.GetEnumerator();
 			_mappingSchema = mappingSchema;
 			_columnTypes   = _columns
-				.Select(c => new DbDataType(c.MemberType, c.DataType == DataType.Undefined ? dataProvider.MappingSchema.GetDataType(c.MemberType).DataType : c.DataType, c.DbType))
+				.Select(c => new DbDataType(c.MemberType, c.DataType == DataType.Undefined ? dataProvider.MappingSchema.GetDataType(c.MemberType).DataType : c.DataType, c.DbType, c.Length))
 				.ToArray();
 		}
 

--- a/Source/LinqToDB/DataProvider/Informix/InformixMergeBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixMergeBuilder.cs
@@ -51,7 +51,7 @@ namespace LinqToDB.DataProvider.Informix
 			{
 				if (!valueConverter.TryConvert(Command, columnType, value))
 				{
-					AddSourceValueAsParameter(column.DataType, column.DbType, value);
+					AddSourceValueAsParameter(column.DataType, column.DbType, column.Length, value);
 
 					// even for parameters
 					WriteTypeHint(column, columnType);

--- a/Source/LinqToDB/DataProvider/MultipleRowsHelper.cs
+++ b/Source/LinqToDB/DataProvider/MultipleRowsHelper.cs
@@ -79,7 +79,10 @@ namespace LinqToDB.DataProvider
 						value = dataParameter.Value;
 
 					Parameters.Add(new DataParameter(ParameterName == "?" ? ParameterName : "p" + ParameterIndex, value,
-						column.DataType, column.DbType));
+						column.DataType, column.DbType)
+					{
+						Size = column.Length
+					});
 				}
 
 				StringBuilder.Append(",");

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
@@ -272,8 +272,11 @@ namespace LinqToDB.DataProvider.SqlServer
 						}
 					case SqlDbType.VarChar:
 						{
-							if (value is string strValue && strValue.Length > 8000)
+							var strValue = value as string;
+							if (strValue != null && strValue.Length > 8000)
 								param.Size = -1;
+							else if (dataType.Length != null && dataType.Length <= 8000 && (strValue == null || strValue.Length <= dataType.Length))
+								param.Size = dataType.Length.Value;
 							else
 								param.Size = 8000;
 
@@ -281,10 +284,25 @@ namespace LinqToDB.DataProvider.SqlServer
 						}
 					case SqlDbType.NVarChar:
 						{
-							if (value is string strValue && strValue.Length > 4000)
+							var strValue = value as string;
+							if (strValue != null && strValue.Length > 4000)
 								param.Size = -1;
+							else if (dataType.Length != null && dataType.Length <= 4000 && (strValue == null || strValue.Length <= dataType.Length))
+								param.Size = dataType.Length.Value;
 							else
 								param.Size = 4000;
+
+							break;
+						}
+					case SqlDbType.VarBinary:
+						{
+							var binaryValue = value as byte[];
+							if (binaryValue != null && binaryValue.Length > 8000)
+								param.Size = -1;
+							else if (dataType.Length != null && dataType.Length <= 8000 && (binaryValue == null || binaryValue.Length <= dataType.Length))
+								param.Size = dataType.Length.Value;
+							else
+								param.Size = 8000;
 
 							break;
 						}

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
@@ -273,7 +273,7 @@ namespace LinqToDB.DataProvider.SqlServer
 					case SqlDbType.VarChar:
 						{
 							var strValue = value as string;
-							if (strValue != null && strValue.Length > 8000)
+							if ((strValue != null && strValue.Length > 8000) || (value != null && strValue == null))
 								param.Size = -1;
 							else if (dataType.Length != null && dataType.Length <= 8000 && (strValue == null || strValue.Length <= dataType.Length))
 								param.Size = dataType.Length.Value;
@@ -285,7 +285,7 @@ namespace LinqToDB.DataProvider.SqlServer
 					case SqlDbType.NVarChar:
 						{
 							var strValue = value as string;
-							if (strValue != null && strValue.Length > 4000)
+							if ((strValue != null && strValue.Length > 4000) || (value != null && strValue == null))
 								param.Size = -1;
 							else if (dataType.Length != null && dataType.Length <= 4000 && (strValue == null || strValue.Length <= dataType.Length))
 								param.Size = dataType.Length.Value;
@@ -297,7 +297,7 @@ namespace LinqToDB.DataProvider.SqlServer
 					case SqlDbType.VarBinary:
 						{
 							var binaryValue = value as byte[];
-							if (binaryValue != null && binaryValue.Length > 8000)
+							if ((binaryValue != null && binaryValue.Length > 8000) || (value != null && binaryValue == null))
 								param.Size = -1;
 							else if (dataType.Length != null && dataType.Length <= 8000 && (binaryValue == null || binaryValue.Length <= dataType.Length))
 								param.Size = dataType.Length.Value;

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerMergeBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerMergeBuilder.cs
@@ -68,7 +68,7 @@ namespace LinqToDB.DataProvider.SqlServer
 				if (dataType == DataType.Binary || dataType == DataType.VarBinary)
 				{
 					// don't generate binary literal in source, as it could lead to huge SQL
-					AddSourceValueAsParameter(dataType, column.DbType, value);
+					AddSourceValueAsParameter(dataType, column.DbType, column.Length, value);
 					return;
 				}
 			}

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -205,6 +205,7 @@ namespace LinqToDB.Linq.Builder
 						ep.Accessor,
 						ep.DataTypeAccessor,
 						ep.DbTypeAccessor,
+						ep.SizeAccessor,
 						parm
 					);
 
@@ -1350,11 +1351,12 @@ namespace LinqToDB.Linq.Builder
 						newExpr.ValueExpression    = Expression.PropertyOrField(body, "Value");
 						newExpr.DataTypeExpression = Expression.PropertyOrField(body, "DataType");
 						newExpr.DbTypeExpression   = Expression.PropertyOrField(body, "DbType");
+						newExpr.SizeExpression     = Expression.PropertyOrField(body, "Size");
 					}
 				}
 
 				p = CreateParameterAccessor(
-					DataContext, newExpr.ValueExpression, newExpr.DataTypeExpression, newExpr.DbTypeExpression, expr, ExpressionParam, ParametersParam, name, buildParameterType, expr: convertExpr);
+					DataContext, newExpr.ValueExpression, newExpr.DataTypeExpression, newExpr.DbTypeExpression, newExpr.SizeExpression, expr, ExpressionParam, ParametersParam, name, buildParameterType, expr: convertExpr);
 				CurrentSqlParameters.Add(p);
 			}
 
@@ -1368,6 +1370,7 @@ namespace LinqToDB.Linq.Builder
 			public Expression ValueExpression;
 			public Expression DataTypeExpression;
 			public Expression DbTypeExpression;
+			public Expression SizeExpression;
 
 			public DbDataType DataType;
 		}
@@ -1378,7 +1381,8 @@ namespace LinqToDB.Linq.Builder
 			{
 				DataType           = new DbDataType(expression.Type),
 				DataTypeExpression = Expression.Constant(DataType.Undefined),
-				DbTypeExpression   = Expression.Constant(null, typeof(string))
+				DbTypeExpression   = Expression.Constant(null, typeof(string)),
+				SizeExpression     = Expression.Constant(null, typeof(int?))
 			};
 
 			var unwrapped = expression.Unwrap();
@@ -1408,14 +1412,20 @@ namespace LinqToDB.Linq.Builder
 
 								if (mt.DataType != DataType.Undefined)
 								{
-									result.DataType.WithDataType(mt.DataType);
+									result.DataType           = result.DataType.WithDataType(mt.DataType);
 									result.DataTypeExpression = Expression.Constant(mt.DataType);
 								}
 
 								if (mt.DbType != null)
 								{
-									result.DataType.WithDbType(mt.DbType);
+									result.DataType         = result.DataType.WithDbType(mt.DbType);
 									result.DbTypeExpression = Expression.Constant(mt.DbType);
+								}
+
+								if (mt.Length != null)
+								{
+									result.DataType         = result.DataType.WithLength(mt.Length);
+									result.SizeExpression   = Expression.Constant(mt.Length);
 								}
 
 								setName(ma.Member.Name);
@@ -2064,7 +2074,7 @@ namespace LinqToDB.Linq.Builder
 			var vte  = ReplaceParameter(_expressionAccessors, ex, _ => { });
 			var par  = vte.ValueExpression;
 			var expr = Expression.MakeMemberAccess(par.Type == typeof(object) ? Expression.Convert(par, member.DeclaringType) : par, member);
-			var p    = CreateParameterAccessor(DataContext, expr, vte.DataTypeExpression, vte.DbTypeExpression, expr, ExpressionParam, ParametersParam, member.Name);
+			var p    = CreateParameterAccessor(DataContext, expr, vte.DataTypeExpression, vte.DbTypeExpression, vte.SizeExpression, expr, ExpressionParam, ParametersParam, member.Name);
 
 			_parameters.Add(expr, p);
 			CurrentSqlParameters.Add(p);
@@ -2088,6 +2098,9 @@ namespace LinqToDB.Linq.Builder
 			if (dbType != null)
 				typeResult = typeResult.WithDbType(dbType);
 
+			if (ca != null && ca.HasLength())
+				typeResult = typeResult.WithLength(ca.Length);
+
 			return typeResult;
 		}
 
@@ -2095,7 +2108,8 @@ namespace LinqToDB.Linq.Builder
 		{
 			var systemType = baseType.SystemType;
 			var dataType   = baseType.DataType;
-			string dbType  = baseType.DbType;
+			var dbType     = baseType.DbType;
+			var length     = baseType.Length;
 
 			QueryVisitor.Find(expr, e =>
 			{
@@ -2104,21 +2118,25 @@ namespace LinqToDB.Linq.Builder
 					case QueryElementType.SqlField:
 						dataType   = ((SqlField)e).DataType;
 						dbType     = ((SqlField)e).DbType;
+						length     = ((SqlField)e).Length;
 						//systemType = ((SqlField)e).SystemType;
 						return true;
 					case QueryElementType.SqlParameter:
 						dataType   = ((SqlParameter)e).DataType;
 						dbType     = ((SqlParameter)e).DbType;
+						length     = ((SqlParameter)e).DbSize;
 						//systemType = ((SqlParameter)e).SystemType;
 						return true;
 					case QueryElementType.SqlDataType:
 						dataType   = ((SqlDataType)e).DataType;
 						dbType     = ((SqlDataType)e).DbType;
+						length     = ((SqlDataType)e).Length;
 						//systemType = ((SqlDataType)e).SystemType;
 						return true;
 					case QueryElementType.SqlValue:
 						dataType   = ((SqlValue)e).ValueType.DataType;
 						dbType     = ((SqlValue)e).ValueType.DbType;
+						length     = ((SqlValue)e).ValueType.Length;
 						//systemType = ((SqlValue)e).ValueType.SystemType;
 						return true;
 					default:
@@ -2129,7 +2147,8 @@ namespace LinqToDB.Linq.Builder
 			return new DbDataType(
 				systemType ?? baseType.SystemType,
 				dataType == DataType.Undefined ? baseType.DataType : dataType,
-				string.IsNullOrEmpty(dbType) ? baseType.DbType : dbType
+				string.IsNullOrEmpty(dbType)   ? baseType.DbType   : dbType,
+				length     ?? baseType.Length
 			);
 		}
 
@@ -2138,6 +2157,7 @@ namespace LinqToDB.Linq.Builder
 			Expression          accessorExpression,
 			Expression          dataTypeAccessorExpression,
 			Expression          dbTypeAccessorExpression,
+			Expression          sizeAccessorExpression,
 			Expression          expression,
 			ParameterExpression expressionParam,
 			ParameterExpression parametersParam,
@@ -2154,13 +2174,14 @@ namespace LinqToDB.Linq.Builder
 
 			if (expr != null)
 			{
-				if (accessorExpression == null || dataTypeAccessorExpression == null || dbTypeAccessorExpression == null)
+				if (accessorExpression == null || dataTypeAccessorExpression == null || dbTypeAccessorExpression == null || sizeAccessorExpression == null)
 				{
 					var body = expr.GetBody(accessorExpression);
 
 					accessorExpression         = Expression.PropertyOrField(body, "Value");
 					dataTypeAccessorExpression = Expression.PropertyOrField(body, "DataType");
 					dbTypeAccessorExpression   = Expression.PropertyOrField(body, "DbType");
+					sizeAccessorExpression     = Expression.PropertyOrField(body, "Size");
 				}
 			}
 			else
@@ -2174,6 +2195,7 @@ namespace LinqToDB.Linq.Builder
 					dataTypeAccessorExpression = Expression.PropertyOrField(accessorExpression, "DataType");
 					dbTypeAccessorExpression   = Expression.PropertyOrField(accessorExpression, "DbType");
 					accessorExpression         = Expression.PropertyOrField(accessorExpression, "Value");
+					sizeAccessorExpression     = Expression.PropertyOrField(accessorExpression, "Size");
 				}
 				else
 				{
@@ -2231,13 +2253,21 @@ namespace LinqToDB.Linq.Builder
 				Expression.Convert(dbTypeAccessorExpression, typeof(string)),
 				new [] { expressionParam, parametersParam });
 
+			var sizeAccessor = Expression.Lambda<Func<Expression, object[], int?>>(
+				Expression.Convert(sizeAccessorExpression, typeof(int?)),
+				new[] { expressionParam, parametersParam });
+
 			return new ParameterAccessor
 			(
 				expression,
 				mapper.Compile(),
 				dataTypeAccessor.Compile(),
 				dbTypeAccessor.Compile(),
-				new SqlParameter(accessorExpression.Type, name, null) { IsQueryParameter = !(dataContext.InlineParameters && accessorExpression.Type.IsScalar(false)) }
+				sizeAccessor.Compile(),
+				new SqlParameter(accessorExpression.Type, name, null)
+				{
+					IsQueryParameter = !(dataContext.InlineParameters && accessorExpression.Type.IsScalar(false))
+				}
 			);
 		}
 
@@ -2366,13 +2396,15 @@ namespace LinqToDB.Linq.Builder
 					ep.Accessor,
 					ep.DataTypeAccessor,
 					ep.DbTypeAccessor,
+					ep.SizeAccessor,
 					new SqlParameter(ep.Expression.Type, p.Name, p.Value)
 					{
 						LikeStart        = start,
 						LikeEnd          = end,
 						ReplaceLike      = p.ReplaceLike,
 						IsQueryParameter = !(DataContext.InlineParameters && ep.Expression.Type.IsScalar(false)),
-						DbType           = p.DbType
+						DbType           = p.DbType,
+						DbSize           = p.DbSize
 					}
 				);
 

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -2194,8 +2194,8 @@ namespace LinqToDB.Linq.Builder
 
 					dataTypeAccessorExpression = Expression.PropertyOrField(accessorExpression, "DataType");
 					dbTypeAccessorExpression   = Expression.PropertyOrField(accessorExpression, "DbType");
-					accessorExpression         = Expression.PropertyOrField(accessorExpression, "Value");
 					sizeAccessorExpression     = Expression.PropertyOrField(accessorExpression, "Size");
+					accessorExpression         = Expression.PropertyOrField(accessorExpression, "Value");
 				}
 				else
 				{

--- a/Source/LinqToDB/Linq/Builder/TakeSkipBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/TakeSkipBuilder.cs
@@ -92,7 +92,7 @@ namespace LinqToDB.Linq.Builder
 
 					var ep = (from pm in builder.CurrentSqlParameters where pm.SqlParameter == skip select pm).First();
 
-					ep = new ParameterAccessor(ep.Expression, ep.Accessor, ep.DataTypeAccessor, ep.DbTypeAccessor, parm);
+					ep = new ParameterAccessor(ep.Expression, ep.Accessor, ep.DataTypeAccessor, ep.DbTypeAccessor, ep.SizeAccessor, parm);
 
 					builder.CurrentSqlParameters.Add(ep);
 				}

--- a/Source/LinqToDB/Linq/Query.cs
+++ b/Source/LinqToDB/Linq/Query.cs
@@ -351,12 +351,14 @@ namespace LinqToDB.Linq
 			Func<Expression,object[],object>   accessor,
 			Func<Expression,object[],DataType> dataTypeAccessor,
 			Func<Expression,object[],string>   dbTypeAccessor,
+			Func<Expression,object[],int?>     sizeAccessor,
 			SqlParameter                       sqlParameter)
 		{
 			Expression       = expression;
 			Accessor         = accessor;
 			DataTypeAccessor = dataTypeAccessor;
 			DbTypeAccessor   = dbTypeAccessor;
+			SizeAccessor     = sizeAccessor;
 			SqlParameter     = sqlParameter;
 		}
 
@@ -364,6 +366,7 @@ namespace LinqToDB.Linq
 		public readonly Func<Expression,object[],object>   Accessor;
 		public readonly Func<Expression,object[],DataType> DataTypeAccessor;
 		public readonly Func<Expression,object[],string>   DbTypeAccessor;
+		public readonly Func<Expression,object[],int?>     SizeAccessor;
 		public readonly SqlParameter                       SqlParameter;
 	}
 }

--- a/Source/LinqToDB/Linq/QueryRunner.InsertOrReplace.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.InsertOrReplace.cs
@@ -172,6 +172,7 @@ namespace LinqToDB.Linq
 							p.Accessor,
 							p.DataTypeAccessor,
 							p.DbTypeAccessor,
+							p.SizeAccessor,
 							dic.ContainsKey(p.SqlParameter) ? (SqlParameter)dic[p.SqlParameter] : null
 						))
 					.Where(p => p.SqlParameter != null)

--- a/Source/LinqToDB/Linq/QueryRunner.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.cs
@@ -104,8 +104,9 @@ namespace LinqToDB.Linq
 						(e, o) => p.DataType != DataType.Undefined || p.Value == null
 							? p.DataType
 							: query.MappingSchema.GetDataType(p.Value.GetType()).DataType,
-						(e, o) => p.DbType
-						, p))
+						(e, o) => p.DbType,
+						(e, o) => p.DbSize,
+						p))
 				);
 
 				sql.Parameters = parameters.ToList();
@@ -195,6 +196,11 @@ namespace LinqToDB.Linq
 				if (!string.IsNullOrEmpty(dbType))
 					p.SqlParameter.DbType = dbType;
 
+				var size = p.SizeAccessor(expression, parameters);
+
+				if (size != null)
+					p.SqlParameter.DbSize = size;
+
 			}
 		}
 
@@ -212,9 +218,10 @@ namespace LinqToDB.Linq
 
 			Expression dataTypeExpression = Expression.Constant(DataType.Undefined);
 			Expression dbTypeExpression   = Expression.Constant(null, typeof(string));
+			Expression dbSizeExpression   = Expression.Constant(field.Length, typeof(int?));
 
-			var convertExpression = dataContext.MappingSchema.GetConvertExpression(new DbDataType(field.SystemType, field.DataType, field.DbType),
-				new DbDataType(typeof(DataParameter), field.DataType, field.DbType), createDefault: false);
+			var convertExpression = dataContext.MappingSchema.GetConvertExpression(new DbDataType(field.SystemType, field.DataType, field.DbType, field.Length),
+				new DbDataType(typeof(DataParameter), field.DataType, field.DbType, field.Length), createDefault: false);
 
 			if (convertExpression != null)
 			{
@@ -222,10 +229,11 @@ namespace LinqToDB.Linq
 				getter             = Expression.PropertyOrField(body, "Value");
 				dataTypeExpression = Expression.PropertyOrField(body, "DataType");
 				dbTypeExpression   = Expression.PropertyOrField(body, "DbType");
+				dbSizeExpression   = Expression.PropertyOrField(body, "Size");
 			}
 
 			var param = ExpressionBuilder.CreateParameterAccessor(
-				dataContext, getter, dataTypeExpression, dbTypeExpression, getter, exprParam, Expression.Parameter(typeof(object[]), "ps"), field.Name.Replace('.', '_'), expr: convertExpression);
+				dataContext, getter, dataTypeExpression, dbTypeExpression, dbSizeExpression, getter, exprParam, Expression.Parameter(typeof(object[]), "ps"), field.Name.Replace('.', '_'), expr: convertExpression);
 
 			return param;
 		}

--- a/Source/LinqToDB/Mapping/ColumnDescriptor.cs
+++ b/Source/LinqToDB/Mapping/ColumnDescriptor.cs
@@ -318,8 +318,8 @@ namespace LinqToDB.Mapping
 				var getterExpr = MemberAccessor.GetterExpression.GetBody(Expression.Convert(objParam, MemberAccessor.TypeAccessor.Type));
 
 				var expr = mappingSchema.GetConvertExpression(
-					new DbDataType(MemberType, DataType, DbType), 
-					new DbDataType(typeof(DataParameter), DataType, DbType), createDefault : false);
+					new DbDataType(MemberType, DataType, DbType, Length), 
+					new DbDataType(typeof(DataParameter), DataType, DbType, Length), createDefault : false);
 
 				if (expr != null)
 				{

--- a/Source/LinqToDB/Mapping/MappingSchema.cs
+++ b/Source/LinqToDB/Mapping/MappingSchema.cs
@@ -576,17 +576,18 @@ namespace LinqToDB.Mapping
 		}
 
 		static bool IsSimple (ref DbDataType type) 
-			=> type.DataType == DataType.Undefined && string.IsNullOrEmpty(type.DbType);
+			=> type.DataType == DataType.Undefined && string.IsNullOrEmpty(type.DbType) && type.Length == null;
 
-		static DbDataType Simplify(ref DbDataType type)
+		static void Simplify(ref DbDataType type)
 		{
 			if (!string.IsNullOrEmpty(type.DbType))
-				return type.WithDbType(null);
+				type = type.WithDbType(null);
 
 			if (type.DataType != DataType.Undefined)
-				return type.WithDataType(DataType.Undefined);
+				type = type.WithDataType(DataType.Undefined);
 
-			return type;
+			if (type.Length != null)
+				type = type.WithLength(null);
 		}
 
 		internal ConvertInfo.LambdaInfo GetConverter(DbDataType from, DbDataType to, bool create)
@@ -603,9 +604,9 @@ namespace LinqToDB.Mapping
 				}
 
 				if (!IsSimple(ref from))
-					from = Simplify(ref from);
+					Simplify(ref from);
 				else if (!IsSimple(ref to))
-					to = Simplify(ref to);
+					Simplify(ref to);
 				else break;
 
 			} while (true);

--- a/Source/LinqToDB/ServiceModel/LinqServiceSerializer.cs
+++ b/Source/LinqToDB/ServiceModel/LinqServiceSerializer.cs
@@ -763,6 +763,7 @@ namespace LinqToDB.ServiceModel
 
 							Append((int)elem.ValueType.DataType);
 							Append(elem.ValueType.DbType);
+							Append(elem.ValueType.Length);
 
 							Append(elem.SystemType, elem.Value);
 							break;
@@ -1380,7 +1381,7 @@ namespace LinqToDB.ServiceModel
 							var isQueryParameter = ReadBool();
 							var dataType         = (DataType)ReadInt();
 							var dbType           = ReadString();
-							var dbSize           = ReadInt();
+							var dbSize           = ReadNullableInt();
 							var likeStart        = ReadString();
 							var likeEnd          = ReadString();
 							var replaceLike      = ReadBool();
@@ -1431,11 +1432,12 @@ namespace LinqToDB.ServiceModel
 						{
 							var dataType   = (DataType)ReadInt();
 							var dbType     = ReadString();
+							var length     = ReadNullableInt();
 
 							var systemType = Read<Type>();
 							var value      = ReadValue(systemType);
 
-							obj = new SqlValue(new DbDataType(systemType, dataType, dbType), value);
+							obj = new SqlValue(new DbDataType(systemType, dataType, dbType, length), value);
 
 							break;
 						}

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -3150,18 +3150,18 @@ namespace LinqToDB.SqlProvider
 				{
 					switch (parameter.DbType)
 					{
-						//case DbType.AnsiString           :
-						//case DbType.AnsiStringFixedLength:
-						//case DbType.String               :
-						//case DbType.StringFixedLength    :
-						//	{
-						//		var value = parameter.Value as string;
+						case DbType.AnsiString           :
+						case DbType.AnsiStringFixedLength:
+						case DbType.String               :
+						case DbType.StringFixedLength    :
+							{
+								var value = parameter.Value as string;
 
-						//		if (!string.IsNullOrEmpty(value))
-						//			sb.Append('(').Append(value.Length).Append(')');
+								if (!string.IsNullOrEmpty(value))
+									sb.Append('(').Append(value.Length).Append(')');
 
-						//		break;
-						//	}
+								break;
+							}
 						case DbType.Decimal:
 							{
 								var value = parameter.Value;
@@ -3174,13 +3174,13 @@ namespace LinqToDB.SqlProvider
 
 								break;
 							}
-						//case DbType.Binary:
-						//	{
-						//		if (parameter.Value is byte[] value)
-						//			sb.Append('(').Append(value.Length).Append(')');
+						case DbType.Binary:
+							{
+								if (parameter.Value is byte[] value)
+									sb.Append('(').Append(value.Length).Append(')');
 
-						//		break;
-						//	}
+								break;
+							}
 					}
 				}
 			}

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -3150,18 +3150,18 @@ namespace LinqToDB.SqlProvider
 				{
 					switch (parameter.DbType)
 					{
-						case DbType.AnsiString           :
-						case DbType.AnsiStringFixedLength:
-						case DbType.String               :
-						case DbType.StringFixedLength    :
-							{
-								var value = parameter.Value as string;
+						//case DbType.AnsiString           :
+						//case DbType.AnsiStringFixedLength:
+						//case DbType.String               :
+						//case DbType.StringFixedLength    :
+						//	{
+						//		var value = parameter.Value as string;
 
-								if (!string.IsNullOrEmpty(value))
-									sb.Append('(').Append(value.Length).Append(')');
+						//		if (!string.IsNullOrEmpty(value))
+						//			sb.Append('(').Append(value.Length).Append(')');
 
-								break;
-							}
+						//		break;
+						//	}
 						case DbType.Decimal:
 							{
 								var value = parameter.Value;
@@ -3174,13 +3174,13 @@ namespace LinqToDB.SqlProvider
 
 								break;
 							}
-						case DbType.Binary:
-							{
-								if (parameter.Value is byte[] value)
-									sb.Append('(').Append(value.Length).Append(')');
+						//case DbType.Binary:
+						//	{
+						//		if (parameter.Value is byte[] value)
+						//			sb.Append('(').Append(value.Length).Append(')');
 
-								break;
-							}
+						//		break;
+						//	}
 					}
 				}
 			}

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -2287,7 +2287,7 @@ namespace LinqToDB.SqlProvider
 						}
 						else
 						{
-							BuildValue(new SqlDataType(parm.DataType, parm.SystemType, 0, 0, 0, parm.DbType), parm.Value);
+							BuildValue(new SqlDataType(parm.DataType, parm.SystemType, parm.DbSize, 0, 0, parm.DbType), parm.Value);
 						}
 					}
 

--- a/Source/LinqToDB/SqlProvider/BasicSqlOptimizer.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlOptimizer.cs
@@ -860,6 +860,7 @@ namespace LinqToDB.SqlProvider
 							{
 								parameterExpr2.DataType = field.DataType;
 								parameterExpr2.DbType   = field.DbType;
+								parameterExpr2.DbSize   = field.Length;
 							}
 						}
 
@@ -874,6 +875,7 @@ namespace LinqToDB.SqlProvider
 							{
 								parameterExpr1.DataType = field.DataType;
 								parameterExpr1.DbType   = field.DbType;
+								parameterExpr1.DbSize   = field.Length;
 							}
 						}
 

--- a/Source/LinqToDB/SqlQuery/SqlParameter.cs
+++ b/Source/LinqToDB/SqlQuery/SqlParameter.cs
@@ -26,7 +26,7 @@ namespace LinqToDB.SqlQuery
 		public bool     IsQueryParameter { get; set; }
 		public DataType DataType         { get; set; }
 		public string   DbType           { get; set; }
-		public int      DbSize           { get; set; }
+		public int?     DbSize           { get; set; }
 		public string   LikeStart        { get; set; }
 		public string   LikeEnd          { get; set; }
 		public bool     ReplaceLike      { get; set; }

--- a/Source/LinqToDB/SqlQuery/SqlTable.cs
+++ b/Source/LinqToDB/SqlQuery/SqlTable.cs
@@ -118,7 +118,7 @@ namespace LinqToDB.SqlQuery
 						try
 						{
 							var converter = mappingSchema.GetConverter(
-								new DbDataType(field.SystemType, field.DataType, field.DbType),
+								new DbDataType(field.SystemType, field.DataType, field.DbType, field.Length),
 								new DbDataType(typeof(DataParameter)), true);
 
 							var parameter = converter?.ConvertValueToParameter?.Invoke(DefaultValue.GetValue(field.SystemType, mappingSchema));

--- a/Tests/Base/SqlServerDataSourcesAttribute.cs
+++ b/Tests/Base/SqlServerDataSourcesAttribute.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+using LinqToDB;
+
+namespace Tests
+{
+	public class SqlServerDataSourcesAttribute : IncludeDataSourcesAttribute
+	{
+		public SqlServerDataSourcesAttribute(bool includeLinqService = false)
+			: base(
+				  includeLinqService,
+				  ProviderName.SqlServer2000,
+				  ProviderName.SqlServer2005,
+				  ProviderName.SqlServer2008,
+				  ProviderName.SqlServer2012,
+				  ProviderName.SqlServer2014)
+		{
+		}
+	}
+}

--- a/Tests/Linq/Linq/ParameterTests.SqlServer.cs
+++ b/Tests/Linq/Linq/ParameterTests.SqlServer.cs
@@ -662,7 +662,7 @@ namespace Tests.Linq
 					Assert.AreEqual(1, records.Count);
 					Assert.IsNotNull(records[0].NVarChar);
 					Assert.AreEqual(value, records[0].NVarChar.Value);
-					Assert.That(sql.Contains("NVarChar -- String"));
+					Assert.That(sql.Contains("NVarChar(5000) -- String"));
 				}
 			}
 		}
@@ -688,7 +688,7 @@ namespace Tests.Linq
 					Assert.AreEqual(1, records.Count);
 					Assert.IsNotNull(records[0].VarChar);
 					Assert.AreEqual(value, records[0].VarChar.Value);
-					Assert.That(sql.Contains(" VarChar -- AnsiString"));
+					Assert.That(sql.Contains(" VarChar(10000) -- AnsiString"));
 				}
 			}
 		}
@@ -717,7 +717,7 @@ namespace Tests.Linq
 					Assert.AreEqual(1, records.Count);
 					Assert.IsNotNull(records[0].VarBinary);
 					Assert.AreEqual(value, records[0].VarBinary.Value);
-					Assert.That(sql.Contains("VarBinary -- Binary"));
+					Assert.That(sql.Contains("VarBinary(10000) -- Binary"));
 				}
 			}
 		}

--- a/Tests/Linq/Linq/ParameterTests.SqlServer.cs
+++ b/Tests/Linq/Linq/ParameterTests.SqlServer.cs
@@ -1,0 +1,751 @@
+﻿using System;
+using System.Linq;
+
+using LinqToDB;
+using LinqToDB.Data;
+using LinqToDB.Mapping;
+using NUnit.Framework;
+
+#if !NETSTANDARD1_6 && !NETSTANDARD2_0 && !TRAVIS
+using Tests.FSharp.Models;
+#else
+using Tests.Model;
+#endif
+
+namespace Tests.Linq
+{
+	public partial class ParameterTests
+	{
+		[Table("AllTypes")]
+		class AllTypesWithLength
+		{
+			[Column(                             Length = 1)]  public byte[] VarBinaryDataType;
+			[Column(DataType = DataType.VarChar, Length = 20)] public string VarcharDataType;
+			[Column(                             Length = 20)] public string NVarcharDataType;
+		}
+
+		[Table("AllTypes")]
+		class AllTypesCustom
+		{
+			[Column] public VarBinary VarBinaryDataType;
+			[Column] public VarChar   VarcharDataType;
+			[Column] public NVarChar  NVarcharDataType;
+		}
+
+		[Table("AllTypes")]
+		class AllTypesCustomWithLength
+		{
+			[Column(Length = 1)]  public VarBinary VarBinaryDataType;
+			[Column(Length = 20)] public VarChar   VarcharDataType;
+			[Column(Length = 20)] public NVarChar  NVarcharDataType;
+		}
+
+		class AllTypesCustomMaxLength
+		{
+			public VarBinary VarBinary;
+			public VarChar   VarChar;
+			public NVarChar  NVarChar;
+		}
+
+		class VarChar : CustomBase<string>
+		{
+			public override string ToString(IFormatProvider provider)
+			{
+				return Value;
+			}
+		}
+
+		class NVarChar : CustomBase<string>
+		{
+			public override string ToString(IFormatProvider provider)
+			{
+				return Value;
+			}
+		}
+
+		class VarBinary : CustomBase<byte[]>
+		{
+			public override object ToType(Type conversionType, IFormatProvider provider)
+			{
+				if (conversionType == typeof(byte[]))
+					return Value;
+
+				throw new NotImplementedException();
+			}
+		}
+
+		abstract class CustomBase<TValue> : IConvertible
+		{
+			public TValue Value { get; set; }
+
+			TypeCode IConvertible.GetTypeCode()
+			{
+				throw new NotImplementedException();
+			}
+
+			bool IConvertible.ToBoolean(IFormatProvider provider)
+			{
+				throw new NotImplementedException();
+			}
+
+			byte IConvertible.ToByte(IFormatProvider provider)
+			{
+				throw new NotImplementedException();
+			}
+
+			char IConvertible.ToChar(IFormatProvider provider)
+			{
+				throw new NotImplementedException();
+			}
+
+			DateTime IConvertible.ToDateTime(IFormatProvider provider)
+			{
+				throw new NotImplementedException();
+			}
+
+			decimal IConvertible.ToDecimal(IFormatProvider provider)
+			{
+				throw new NotImplementedException();
+			}
+
+			double IConvertible.ToDouble(IFormatProvider provider)
+			{
+				throw new NotImplementedException();
+			}
+
+			short IConvertible.ToInt16(IFormatProvider provider)
+			{
+				throw new NotImplementedException();
+			}
+
+			int IConvertible.ToInt32(IFormatProvider provider)
+			{
+				throw new NotImplementedException();
+			}
+
+			long IConvertible.ToInt64(IFormatProvider provider)
+			{
+				throw new NotImplementedException();
+			}
+
+			sbyte IConvertible.ToSByte(IFormatProvider provider)
+			{
+				throw new NotImplementedException();
+			}
+
+			float IConvertible.ToSingle(IFormatProvider provider)
+			{
+				throw new NotImplementedException();
+			}
+
+			public virtual string ToString(IFormatProvider provider)
+			{
+				throw new NotImplementedException();
+			}
+
+			public virtual object ToType(Type conversionType, IFormatProvider provider)
+			{
+				throw new NotImplementedException();
+			}
+
+			ushort IConvertible.ToUInt16(IFormatProvider provider)
+			{
+				throw new NotImplementedException();
+			}
+
+			uint IConvertible.ToUInt32(IFormatProvider provider)
+			{
+				throw new NotImplementedException();
+			}
+
+			ulong IConvertible.ToUInt64(IFormatProvider provider)
+			{
+				throw new NotImplementedException();
+			}
+		}
+
+		[Test]
+		public void SqlServerNVarChar4000ParameterSize([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var p = "abc";
+				var sql = db.GetTable<Person>().Where(t => t.FirstName == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring("(4000)"));
+			}
+		}
+
+		[Test]
+		public void SqlServerVarChar8000ParameterSize([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var p = "abc";
+				var sql = db.GetTable<AllTypes>().Where(t => t.VarcharDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring("(8000)"));
+			}
+		}
+
+		[Test]
+		public void SqlServerVarBinary8000ParameterSize([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var p = new byte[] { 1 };
+				var sql = db.GetTable<AllTypes>().Where(t => t.VarBinaryDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring("(8000)"));
+			}
+		}
+
+		[Test]
+		public void SqlServerNVarCharKnownParameterSize([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var p = "abc";
+				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.NVarcharDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring("(20)"));
+			}
+		}
+
+		[Test]
+		public void SqlServerVarCharKnownParameterSize([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var p = "abc";
+				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.VarcharDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring("(20)"));
+			}
+		}
+
+		[Test]
+		public void SqlServerVarBinaryKnownParameterSize([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var p = new byte[] { 1 };
+				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.VarBinaryDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring("(1)"));
+			}
+		}
+
+		[Test]
+		public void SqlServerNVarCharKnownOverflowParameterSize([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var p = "abcdeabcdeabcdeabcde1";
+				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.NVarcharDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring("(4000)"));
+			}
+		}
+
+		[Test]
+		public void SqlServerVarCharKnownOverflowParameterSize([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var p = "abcdeabcdeabcdeabcde1";
+				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.VarcharDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring("(8000)"));
+			}
+		}
+
+		[Test]
+		public void SqlServerVarBinaryKnownOverflowParameterSize([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var p = new byte[] { 1, 2 };
+				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.VarBinaryDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring("(8000)"));
+			}
+		}
+
+		[Test]
+		public void SqlServerCustomNVarChar4000ParameterSize([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context, new MappingSchema()))
+			{
+				SetupCustomTypes(db.MappingSchema);
+				var p = new NVarChar() { Value = "abc" };
+				var sql = db.GetTable<AllTypesCustom>().Where(t => t.NVarcharDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring("NVarChar -- String"));
+			}
+		}
+
+		[Test]
+		public void SqlServerCustomVarChar8000ParameterSize([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context, new MappingSchema()))
+			{
+				SetupCustomTypes(db.MappingSchema);
+				var p = new VarChar() { Value = "abc" };
+				var sql = db.GetTable<AllTypesCustom>().Where(t => t.VarcharDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring(" VarChar -- AnsiString"));
+			}
+		}
+
+		[Test]
+		public void SqlServerCustomVarBinary8000ParameterSize([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context, new MappingSchema()))
+			{
+				SetupCustomTypes(db.MappingSchema);
+				var p = new VarBinary() { Value = new byte[] { 1 } };
+				var sql = db.GetTable<AllTypesCustom>().Where(t => t.VarBinaryDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring("VarBinary -- Binary"));
+			}
+		}
+
+		[Test]
+		public void SqlServerCustomNVarCharKnownParameterSize([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context, new MappingSchema()))
+			{
+				SetupCustomTypes(db.MappingSchema);
+				var p = new NVarChar() { Value = "abc" };
+				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.NVarcharDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring("NVarChar -- String"));
+			}
+		}
+
+		[Test]
+		public void SqlServerCustomVarCharKnownParameterSize([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context, new MappingSchema()))
+			{
+				SetupCustomTypes(db.MappingSchema);
+				var p = new VarChar() { Value = "abc" };
+				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarcharDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring(" VarChar -- AnsiString"));
+			}
+		}
+
+		[Test]
+		public void SqlServerCustomVarBinaryKnownParameterSize([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context, new MappingSchema()))
+			{
+				SetupCustomTypes(db.MappingSchema);
+				var p = new VarBinary() { Value = new byte[] { 1 } };
+				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarBinaryDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring("VarBinary -- Binary"));
+			}
+		}
+
+		[Test]
+		public void SqlServerCustomNVarCharKnownOverflowParameterSize([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context, new MappingSchema()))
+			{
+				SetupCustomTypes(db.MappingSchema);
+				var p = new NVarChar() { Value = "abcdeabcdeabcdeabcde1" };
+				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.NVarcharDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring("NVarChar -- String"));
+			}
+		}
+
+		[Test]
+		public void SqlServerCustomVarCharKnownOverflowParameterSize([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context, new MappingSchema()))
+			{
+				SetupCustomTypes(db.MappingSchema);
+				var p = new VarChar() { Value = "abcdeabcdeabcdeabcde1" };
+				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarcharDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring(" VarChar -- AnsiString"));
+			}
+		}
+
+		[Test]
+		public void SqlServerCustomVarBinaryKnownOverflowParameterSize([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context, new MappingSchema()))
+			{
+				SetupCustomTypes(db.MappingSchema);
+				var p = new VarBinary() { Value = new byte[] { 1, 2 } };
+				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarBinaryDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring("VarBinary -- Binary"));
+			}
+		}
+
+		[Test]
+		public void SqlServerCustomNVarCharMaxOverflowParameterSize([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context, new MappingSchema()))
+			{
+				SetupCustomTypes(db.MappingSchema);
+				using (var table = db.CreateLocalTable<AllTypesCustomMaxLength>())
+				{
+					var value = new string('я', 5000);
+					table.Insert(() => new AllTypesCustomMaxLength()
+					{
+						NVarChar = new NVarChar() { Value = value }
+					});
+
+					var records = table.ToList();
+					var p = new NVarChar() { Value = value };
+					var sql = table.Where(t => t.NVarChar == p).ToString();
+
+					Assert.AreEqual(1, records.Count);
+					Assert.IsNotNull(records[0].NVarChar);
+					Assert.AreEqual(value, records[0].NVarChar.Value);
+					Assert.That(sql.Contains("NVarChar -- String"));
+				}
+			}
+		}
+
+		[Test]
+		public void SqlServerCustomVarCharMaxOverflowParameterSize([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context, new MappingSchema()))
+			{
+				SetupCustomTypes(db.MappingSchema);
+				using (var table = db.CreateLocalTable<AllTypesCustomMaxLength>())
+				{
+					var value = new string('z', 10000);
+					table.Insert(() => new AllTypesCustomMaxLength()
+					{
+						VarChar = new VarChar() { Value = value }
+					});
+
+					var records = table.ToList();
+					var p = new VarChar() { Value = value };
+					var sql = table.Where(t => t.VarChar == p).ToString();
+
+					Assert.AreEqual(1, records.Count);
+					Assert.IsNotNull(records[0].VarChar);
+					Assert.AreEqual(value, records[0].VarChar.Value);
+					Assert.That(sql, Contains.Substring(" VarChar -- AnsiString"));
+				}
+			}
+		}
+
+		[Test]
+		public void SqlServerCustomVarBinaryMaxOverflowParameterSize([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context, new MappingSchema()))
+			{
+				SetupCustomTypes(db.MappingSchema);
+				using (var table = db.CreateLocalTable<AllTypesCustomMaxLength>())
+				{
+					var value = new byte[10000];
+					for (var i = 0; i < value.Length; i++)
+						value[i] = (byte)(i % 256);
+
+					table.Insert(() => new AllTypesCustomMaxLength()
+					{
+						VarBinary = new VarBinary() { Value = value }
+					});
+
+					var records = table.ToList();
+					var p = new VarBinary() { Value = value };
+					var sql = table.Where(t => t.VarBinary == p).ToString();
+
+					Assert.AreEqual(1, records.Count);
+					Assert.IsNotNull(records[0].VarBinary);
+					Assert.AreEqual(value, records[0].VarBinary.Value);
+					Assert.That(sql.Contains("VarBinary -- Binary"));
+				}
+			}
+		}
+
+		[Test]
+		public void SqlServerCustomNVarChar4000ParameterSizeAsDataParameter([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context, new MappingSchema()))
+			{
+				SetupCustomTypes(db.MappingSchema, true);
+				var p = new NVarChar() { Value = "abc" };
+				var sql = db.GetTable<AllTypesCustom>().Where(t => t.NVarcharDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring("(4000)"));
+			}
+		}
+
+		[Test]
+		public void SqlServerCustomVarChar8000ParameterSizeAsDataParameter([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context, new MappingSchema()))
+			{
+				SetupCustomTypes(db.MappingSchema, true);
+				var p = new VarChar() { Value = "abc" };
+				var sql = db.GetTable<AllTypesCustom>().Where(t => t.VarcharDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring("(8000)"));
+			}
+		}
+
+		[Test]
+		public void SqlServerCustomVarBinary8000ParameterSizeAsDataParameter([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context, new MappingSchema()))
+			{
+				SetupCustomTypes(db.MappingSchema, true);
+				var p = new VarBinary() { Value = new byte[] { 1 } };
+				var sql = db.GetTable<AllTypesCustom>().Where(t => t.VarBinaryDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring("(8000)"));
+			}
+		}
+
+		[Test]
+		public void SqlServerCustomNVarCharKnownParameterSizeAsDataParameter([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context, new MappingSchema()))
+			{
+				SetupCustomTypes(db.MappingSchema, true);
+				var p = new NVarChar() { Value = "abc" };
+				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.NVarcharDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring("(20)"));
+			}
+		}
+
+		[Test]
+		public void SqlServerCustomVarCharKnownParameterSizeAsDataParameter([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context, new MappingSchema()))
+			{
+				SetupCustomTypes(db.MappingSchema, true);
+				var p = new VarChar() { Value = "abc" };
+				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarcharDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring("(20)"));
+			}
+		}
+
+		[Test]
+		public void SqlServerCustomVarBinaryKnownParameterSizeAsDataParameter([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context, new MappingSchema()))
+			{
+				SetupCustomTypes(db.MappingSchema, true);
+				var p = new VarBinary() { Value = new byte[] { 1 } };
+				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarBinaryDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring("(1)"));
+			}
+		}
+
+		[Test]
+		public void SqlServerCustomNVarCharKnownOverflowParameterSizeAsDataParameter([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context, new MappingSchema()))
+			{
+				SetupCustomTypes(db.MappingSchema, true);
+				var p = new NVarChar() { Value = "abcdeabcdeabcdeabcde1" };
+				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.NVarcharDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring("(4000)"));
+			}
+		}
+
+		[Test]
+		public void SqlServerCustomVarCharKnownOverflowParameterSizeAsDataParameter([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context, new MappingSchema()))
+			{
+				SetupCustomTypes(db.MappingSchema, true);
+				var p = new VarChar() { Value = "abcdeabcdeabcdeabcde1" };
+				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarcharDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring("(8000)"));
+			}
+		}
+
+		[Test]
+		public void SqlServerCustomVarBinaryKnownOverflowParameterSizeAsDataParameter([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context, new MappingSchema()))
+			{
+				SetupCustomTypes(db.MappingSchema, true);
+				var p = new VarBinary() { Value = new byte[] { 1, 2 } };
+				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarBinaryDataType == p).ToString();
+
+				Console.WriteLine(sql);
+
+				Assert.That(sql, Contains.Substring("(8000)"));
+			}
+		}
+
+		[Test]
+		public void SqlServerCustomNVarCharMaxOverflowParameterSizeAsDataParameter([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context, new MappingSchema()))
+			{
+				SetupCustomTypes(db.MappingSchema, true);
+				using (var table = db.CreateLocalTable<AllTypesCustomMaxLength>())
+				{
+					var value = new string('я', 5000);
+					table.Insert(() => new AllTypesCustomMaxLength()
+					{
+						NVarChar = new NVarChar() { Value = value }
+					});
+
+					var records = table.ToList();
+					var p = new NVarChar() { Value = value };
+					var sql = table.Where(t => t.NVarChar == p).ToString();
+
+					Assert.AreEqual(1, records.Count);
+					Assert.IsNotNull(records[0].NVarChar);
+					Assert.AreEqual(value, records[0].NVarChar.Value);
+					Assert.That(sql.Contains("NVarChar -- String"));
+				}
+			}
+		}
+
+		[Test]
+		public void SqlServerCustomVarCharMaxOverflowParameterSizeAsDataParameter([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context, new MappingSchema()))
+			{
+				SetupCustomTypes(db.MappingSchema, true);
+				using (var table = db.CreateLocalTable<AllTypesCustomMaxLength>())
+				{
+					var value = new string('z', 10000);
+					table.Insert(() => new AllTypesCustomMaxLength()
+					{
+						VarChar = new VarChar() { Value = value }
+					});
+
+					var records = table.ToList();
+					var p = new VarChar() { Value = value };
+					var sql = table.Where(t => t.VarChar == p).ToString();
+
+					Assert.AreEqual(1, records.Count);
+					Assert.IsNotNull(records[0].VarChar);
+					Assert.AreEqual(value, records[0].VarChar.Value);
+					Assert.That(sql.Contains(" VarChar -- AnsiString"));
+				}
+			}
+		}
+
+		[Test]
+		public void SqlServerCustomVarBinaryMaxOverflowParameterSizeAsDataParameter([SqlServerDataSources] string context)
+		{
+			using (var db = new DataConnection(context, new MappingSchema()))
+			{
+				SetupCustomTypes(db.MappingSchema, true);
+				using (var table = db.CreateLocalTable<AllTypesCustomMaxLength>())
+				{
+					var value = new byte[10000];
+					for (var i = 0; i < value.Length; i++)
+						value[i] = (byte)(i % 256);
+
+					table.Insert(() => new AllTypesCustomMaxLength()
+					{
+						VarBinary = new VarBinary() { Value = value }
+					});
+
+					var records = table.ToList();
+					var p = new VarBinary() { Value = value };
+					var sql = table.Where(t => t.VarBinary == p).ToString();
+
+					Assert.AreEqual(1, records.Count);
+					Assert.IsNotNull(records[0].VarBinary);
+					Assert.AreEqual(value, records[0].VarBinary.Value);
+					Assert.That(sql.Contains("VarBinary -- Binary"));
+				}
+			}
+		}
+
+		private void SetupCustomTypes(MappingSchema ms, bool asDataParameter = false)
+		{
+			ms.AddScalarType(typeof(VarBinary), DataType.VarBinary);
+			ms.AddScalarType(typeof(VarChar), DataType.VarChar);
+			ms.AddScalarType(typeof(NVarChar), DataType.NVarChar);
+
+			if (!asDataParameter)
+			{
+				ms.SetConvertExpression<string, VarChar>  (v => new VarChar()   { Value = v });
+				ms.SetConvertExpression<string, NVarChar> (v => new NVarChar()  { Value = v });
+				ms.SetConvertExpression<byte[], VarBinary>(v => new VarBinary() { Value = v });
+				ms.SetConvertExpression<VarChar, string>  (v => v == null ? null : v.Value);
+				ms.SetConvertExpression<NVarChar, string> (v => v == null ? null : v.Value);
+				ms.SetConvertExpression<VarBinary, byte[]>(v => v == null ? null : v.Value);
+			}
+			else
+			{
+				ms.SetConvertExpression<string, VarChar>  (v => new VarChar()   { Value = v });
+				ms.SetConvertExpression<string, NVarChar> (v => new NVarChar()  { Value = v });
+				ms.SetConvertExpression<byte[], VarBinary>(v => new VarBinary() { Value = v });
+				ms.SetConvertExpression<VarChar, DataParameter>  (v => v == null ? null : DataParameter.VarChar(null, v.Value));
+				ms.SetConvertExpression<NVarChar, DataParameter> (v => v == null ? null : DataParameter.NVarChar(null, v.Value));
+				ms.SetConvertExpression<VarBinary, DataParameter>(v => v == null ? null : DataParameter.VarBinary(null, v.Value));
+			}
+		}
+	}
+}

--- a/Tests/Linq/Linq/ParameterTests.cs
+++ b/Tests/Linq/Linq/ParameterTests.cs
@@ -15,7 +15,7 @@ using Tests.Model;
 namespace Tests.Linq
 {
 	[TestFixture]
-	public class ParameterTests : TestBase
+	public partial class ParameterTests : TestBase
 	{
 		[Test]
 		public void InlineParameter([DataSources] string context)
@@ -179,132 +179,6 @@ namespace Tests.Linq
 			}
 		}
 
-		[Test]
-		public void SqlServerNVarChar4000ParameterSize([SqlServerDataSources] string context)
-		{
-			using (var db = new DataConnection(context))
-			{
-				var p = "abc";
-				var sql = db.GetTable<Person>().Where(t => t.FirstName == p).ToString();
-
-				Console.WriteLine(sql);
-
-				Assert.That(sql, Contains.Substring("(4000)"));
-			}
-		}
-
-		[Test]
-		public void SqlServerVarChar8000ParameterSize([SqlServerDataSources] string context)
-		{
-			using (var db = new DataConnection(context))
-			{
-				var p = "abc";
-				var sql = db.GetTable<AllTypes>().Where(t => t.VarcharDataType == p).ToString();
-
-				Console.WriteLine(sql);
-
-				Assert.That(sql, Contains.Substring("(8000)"));
-			}
-		}
-
-		[Test]
-		public void SqlServerVarBinary8000ParameterSize([SqlServerDataSources] string context)
-		{
-			using (var db = new DataConnection(context))
-			{
-				var p = new byte[] { 1 };
-				var sql = db.GetTable<AllTypes>().Where(t => t.VarBinaryDataType == p).ToString();
-
-				Console.WriteLine(sql);
-
-				Assert.That(sql, Contains.Substring("(8000)"));
-			}
-		}
-
-		[Test]
-		public void SqlServerNVarCharKnownParameterSize([SqlServerDataSources] string context)
-		{
-			using (var db = new DataConnection(context))
-			{
-				var p = "abc";
-				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.NVarcharDataType == p).ToString();
-
-				Console.WriteLine(sql);
-
-				Assert.That(sql, Contains.Substring("(20)"));
-			}
-		}
-
-		[Test]
-		public void SqlServerVarCharKnownParameterSize([SqlServerDataSources] string context)
-		{
-			using (var db = new DataConnection(context))
-			{
-				var p = "abc";
-				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.VarcharDataType == p).ToString();
-
-				Console.WriteLine(sql);
-
-				Assert.That(sql, Contains.Substring("(20)"));
-			}
-		}
-
-		[Test]
-		public void SqlServerVarBinaryKnownParameterSize([SqlServerDataSources] string context)
-		{
-			using (var db = new DataConnection(context))
-			{
-				var p = new byte[] { 1 };
-				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.VarBinaryDataType == p).ToString();
-
-				Console.WriteLine(sql);
-
-				Assert.That(sql, Contains.Substring("(1)"));
-			}
-		}
-
-		[Test]
-		public void SqlServerNVarCharKnownOverflowParameterSize([SqlServerDataSources] string context)
-		{
-			using (var db = new DataConnection(context))
-			{
-				var p = "abcdeabcdeabcdeabcde1";
-				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.NVarcharDataType == p).ToString();
-
-				Console.WriteLine(sql);
-
-				Assert.That(sql, Contains.Substring("(4000)"));
-			}
-		}
-
-		[Test]
-		public void SqlServerVarCharKnownOverflowParameterSize([SqlServerDataSources] string context)
-		{
-			using (var db = new DataConnection(context))
-			{
-				var p = "abcdeabcdeabcdeabcde1";
-				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.VarcharDataType == p).ToString();
-
-				Console.WriteLine(sql);
-
-				Assert.That(sql, Contains.Substring("(8000)"));
-			}
-		}
-
-		[Test]
-		public void SqlServerVarBinaryKnownOverflowParameterSize([SqlServerDataSources] string context)
-		{
-			using (var db = new DataConnection(context))
-			{
-				var p = new byte[] { 1, 2 };
-				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.VarBinaryDataType == p).ToString();
-
-				Console.WriteLine(sql);
-
-				Assert.That(sql, Contains.Substring("(8000)"));
-			}
-		}
-
 		class AllTypes
 		{
 			public decimal DecimalDataType;
@@ -312,17 +186,6 @@ namespace Tests.Linq
 			public byte[]  VarBinaryDataType;
 			[Column(DataType = DataType.VarChar)]
 			public string  VarcharDataType;
-		}
-
-		[Table("AllTypes")]
-		class AllTypesWithLength
-		{
-			[Column(Length = 1)]
-			public byte[] VarBinaryDataType;
-			[Column(DataType = DataType.VarChar, Length = 20)]
-			public string VarcharDataType;
-			[Column(Length = 20)]
-			public string NVarcharDataType;
 		}
 
 		// Excluded providers inline such parameter


### PR DESCRIPTION
Fixes #1578 

This pr:
- adds length information to DbDataType object and pass it around
- [MSSQL] fixes varbinary parameter size for query to better hit sql query plan cache on subsequential calls with variable-sized parameters

[MSSQL] varbinary, varchar, nvarchar parameter sizing logic is following with this PR:
- if parameter used against column with length set in mapping and both column length and value length do not exceed max supported length (4000/8000 based on type) - use length from mapping
- otherwise if parameter value length does not exceed max supported length (4000/8000 based on type) - use max supported length
- otherwise use unsized parameter

Some details on how parameter size is important for sql server:
https://blogs.msdn.microsoft.com/psssql/2010/10/05/query-performance-and-plan-cache-issues-when-parameter-length-not-specified-correctly/