### PR TITLE
Add boolean type support for Firebird

### DIFF
--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdConfiguration.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdConfiguration.cs
@@ -22,5 +22,10 @@ namespace LinqToDB.DataProvider.Firebird
 		/// Specifies that Firebird supports literal encoding. Availiable from version 2.5.
 		/// </summary>
 		public static bool IsLiteralEncodingSupported = true;
+
+		/// <summary>
+		/// Specifies that Firebird supports boolean types. Availiable from version 3.0.
+		/// </summary>
+		public static bool SupportBooleanType { get; set; }
 	}
 }

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdDataProvider.cs
@@ -90,8 +90,15 @@ namespace LinqToDB.DataProvider.Firebird
 		{
 			if (value is bool)
 			{
-				value = (bool)value ? "1" : "0";
-				dataType = dataType.WithDataType(DataType.Char);
+				if (FirebirdConfiguration.SupportBooleanType)
+				{
+					dataType = dataType.WithDataType(DataType.Boolean);
+				}
+				else
+				{
+					value = (bool)value ? "1" : "0";
+					dataType = dataType.WithDataType(DataType.Char);
+				}
 			}
 
 			base.SetParameter(parameter, name, dataType, value);

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdSqlBuilder.cs
@@ -19,6 +19,10 @@ namespace LinqToDB.DataProvider.Firebird
 		public FirebirdSqlBuilder(ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags, ValueToSqlConverter valueToSqlConverter)
 			: base(sqlOptimizer, sqlProviderFlags, valueToSqlConverter)
 		{
+			if (FirebirdConfiguration.SupportBooleanType)
+			{
+				valueToSqlConverter.SetConverter(typeof(Boolean), (sb, dt, v) => sb.Append((bool)v ? "true" : "false"));
+			}
 		}
 
 		protected override ISqlBuilder CreateSqlBuilder()
@@ -111,8 +115,14 @@ namespace LinqToDB.DataProvider.Firebird
 					break;
 				case DataType.VarBinary     : StringBuilder.Append("BLOB");            break;
 				// BOOLEAN type available since FB 3.0, but FirebirdDataProvider.SetParameter converts boolean to '1'/'0'
-				// so for now we will use type, compatible with SetParameter by default
-				case DataType.Boolean       : StringBuilder.Append("CHAR");            break;
+				// so for now we will use type, compatible with SetParameter by default.
+				// For Firebird 3.0 you can set the global config FirebirdConfiguration.SupportBooleanType
+				case DataType.Boolean:
+					if (!FirebirdConfiguration.SupportBooleanType)
+					{
+						StringBuilder.Append("CHAR");
+					}
+					break;
 				default: base.BuildDataType(type, createDbType); break;
 			}
 		}


### PR DESCRIPTION
With the global configuration in FirebirdConfiguration.SupportBooleanType you can control the boolean type Firebird will use, so that a column has real boolean values and not 1 or 0.

This is only a global configuration, so that every boolean value is treated like boolean.