### PR TITLE
[WIP] Discuss Support Linq Over WCF On .NETStandard2.0 and .NETCoreApp2.0 (#1678)

### DIFF
--- a/NuGet/linq2db.nuspec
+++ b/NuGet/linq2db.nuspec
@@ -27,6 +27,7 @@
 				<dependency id="Microsoft.CSharp"                     version="4.4.0" />
 				<dependency id="System.ComponentModel.Annotations"    version="4.4.1" />
 				<dependency id="System.Data.SqlClient"                version="4.5.1" />
+				<dependency id="System.ServiceModel.Primitives"				version="4.5.3" />
 			</group>
 			<group targetFramework=".NETCoreApp1.0">
 				<dependency id="Microsoft.CSharp"                     version="4.3.0" />
@@ -43,6 +44,7 @@
 			<group targetFramework=".NETCoreApp2.0">
 				<dependency id="System.ComponentModel.Annotations"    version="4.4.1" />
 				<dependency id="System.Data.SqlClient"                version="4.5.1" />
+				<dependency id="System.ServiceModel.Primitives"				version="4.5.3" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/Source/LinqToDB/LinqToDB.csproj
+++ b/Source/LinqToDB/LinqToDB.csproj
@@ -75,8 +75,11 @@
 		<Compile Remove="Metadata\SystemDataLinqAttributeReader.cs" />
 		<Compile Remove="Metadata\SystemDataSqlServerAttributeReader.cs" />
 		<Compile Remove="Configuration\DataProviderElement.cs;Configuration\DataProviderElementCollection.cs;Configuration\ElementBase.cs;Configuration\ElementCollectionBase.cs;Configuration\LinqToDBSection.cs" />
-		<Compile Remove="ServiceModel\**\*.cs;" />
+		<Compile Remove="ServiceModel\DataService.cs"></Compile>
+		<Compile Remove="ServiceModel\LinqService.cs"></Compile>
 		<Compile Remove="DataProvider\Access\*.cs;DataProvider\SapHana\SapHanaOdbc*.cs" />
 		<Compile Include="Compatibility\System\Data\Linq\Binary.cs" />
+		
+		<PackageReference Include="System.ServiceModel.Primitives" Version="4.5.3" />
 	</ItemGroup>
 </Project>

--- a/Source/LinqToDB/ServiceModel/LinqServiceSerializer.cs
+++ b/Source/LinqToDB/ServiceModel/LinqServiceSerializer.cs
@@ -539,29 +539,34 @@ namespace LinqToDB.ServiceModel
 
 					if (type == null)
 					{
-					type = LinqService.TypeResolver(str);
-					if (type == null)
-					{
-						if (Configuration.LinqService.ThrowUnresolvedTypeException)
-							throw new LinqToDBException(
-								$"Type '{str}' cannot be resolved. Use LinqService.TypeResolver to resolve unknown types.");
+#if !NETSTANDARD2_0
+						type = LinqService.TypeResolver(str);
 
-						UnresolvedTypes.Add(str);
+						if (type == null)
+						{
+	#endif
+							if (Configuration.LinqService.ThrowUnresolvedTypeException)
+								throw new LinqToDBException(
+									$"Type '{str}' cannot be resolved. Use LinqService.TypeResolver to resolve unknown types.");
 
-						Debug.WriteLine(
-							$"Type '{str}' cannot be resolved. Use LinqService.TypeResolver to resolve unknown types.",
-							"LinqServiceSerializer");
+							UnresolvedTypes.Add(str);
+
+							Debug.WriteLine(
+								$"Type '{str}' cannot be resolved. Use LinqService.TypeResolver to resolve unknown types.",
+								"LinqServiceSerializer");
+#if !NETSTANDARD2_0
+						}
+#endif
 					}
-				}
 				}
 
 				return type;
 			}
 		}
 
-		#endregion
+#endregion
 
-		#region QuerySerializer
+#region QuerySerializer
 
 		class QuerySerializer : SerializerBase
 		{
@@ -1256,9 +1261,9 @@ namespace LinqToDB.ServiceModel
 			}
 		}
 
-		#endregion
+#endregion
 
-		#region QueryDeserializer
+#region QueryDeserializer
 
 		public class QueryDeserializer : DeserializerBase
 		{
@@ -1967,9 +1972,9 @@ namespace LinqToDB.ServiceModel
 			}
 		}
 
-		#endregion
+#endregion
 
-		#region ResultSerializer
+#region ResultSerializer
 
 		class ResultSerializer : SerializerBase
 		{
@@ -2021,9 +2026,9 @@ namespace LinqToDB.ServiceModel
 			}
 		}
 
-		#endregion
+#endregion
 
-		#region ResultDeserializer
+#region ResultDeserializer
 
 		class ResultDeserializer : DeserializerBase
 		{
@@ -2082,9 +2087,9 @@ namespace LinqToDB.ServiceModel
 			}
 		}
 
-		#endregion
+#endregion
 
-		#region StringArraySerializer
+#region StringArraySerializer
 
 		class StringArraySerializer : SerializerBase
 		{
@@ -2101,9 +2106,9 @@ namespace LinqToDB.ServiceModel
 			}
 		}
 
-		#endregion
+#endregion
 
-		#region StringArrayDeserializer
+#region StringArrayDeserializer
 
 		class StringArrayDeserializer : DeserializerBase
 		{
@@ -2120,9 +2125,9 @@ namespace LinqToDB.ServiceModel
 			}
 		}
 
-		#endregion
+#endregion
 
-		#region Helpers
+#region Helpers
 
 		interface IArrayHelper
 		{
@@ -2178,6 +2183,6 @@ namespace LinqToDB.ServiceModel
 			return converter(list);
 		}
 
-		#endregion
+#endregion
 	}
 }


### PR DESCRIPTION
I've been trying to add support for Linq Over WCF to .Net Standard 2.0 as described on issue #1678. 

I just removed ServiceModel\LinqService and ServiceModel\DataService. That creates an error on ServiceModel\LinqServiceSerializer but I thought that particular code was just being used on server side, so I introduced a conditional compilation #if !NETSTANDARD2_0.

With that I've been able to run some Linq Over WCF on a Xamarin.Forms project with no problems over an existing LinqService on a production environment.

As a con, it adds a dependency to System.ServiceModel.Primitives. I don't know if that's a bad thing to add between versions.