### PR TITLE
fix issue with mapperexpression nullable columns in SAP HANA

### DIFF
--- a/Data/Create Scripts/SapHana.sql
+++ b/Data/Create Scripts/SapHana.sql
@@ -116,6 +116,7 @@ CREATE COLUMN TABLE "Doctor"
 );;
 ALTER TABLE "Doctor" ADD CONSTRAINT "FK_Doctor_Person" FOREIGN KEY ("PersonID") REFERENCES "Person" ("PersonID") ON UPDATE CASCADE ON DELETE CASCADE;;
 
+INSERT INTO "Doctor" ("PersonID", "Taxonomy") VALUES (1, 'Psychiatry');;
 
 CREATE COLUMN TABLE "Patient"
 (

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaDataProvider.cs
@@ -157,5 +157,11 @@ namespace LinqToDB.DataProvider.SapHana
 		{
 			return new SapHanaMergeBuilder<TTarget, TSource>(connection, merge);
 		}
+
+		public override bool? IsDBNullAllowed(IDataReader reader, int idx)
+		{
+			// provider fails to set AllowDBNull for some results
+			return true;
+		}
 	}
 }

--- a/Tests/Linq/DataProvider/SapHanaTests.cs
+++ b/Tests/Linq/DataProvider/SapHanaTests.cs
@@ -479,7 +479,7 @@ namespace Tests.DataProvider
 			}
 		}
 
-		[ActiveIssue("SAP HANA 1 only?", Configuration = CurrentProvider)]
+		[ActiveIssue("Calculation view missing in database", Configuration = CurrentProvider)]
 		[Test]
 		public void CalculationViewLinqQuery([IncludeDataSources(CurrentProvider)] string context)
 		{

--- a/Tests/Linq/Linq/CalculatedColumnTests.cs
+++ b/Tests/Linq/Linq/CalculatedColumnTests.cs
@@ -116,7 +116,6 @@ namespace Tests.Linq
 			}
 		}
 
-		[ActiveIssue(Configuration = ProviderName.SapHana)]
 		[Test]
 		public void CalculatedColumnTest4([DataSources] string context)
 		{

--- a/Tests/Linq/Linq/CountTests.cs
+++ b/Tests/Linq/Linq/CountTests.cs
@@ -173,7 +173,7 @@ namespace Tests.Linq
 					select g.Count(ch => ch.ChildID > 20));
 		}
 
-		[ActiveIssue("Unsupported by Informix?", Configurations = new[] { ProviderName.Informix, ProviderName.SapHana })]
+		[ActiveIssue(1685, Configurations = new[] { ProviderName.Informix, ProviderName.SapHana })]
 		[Test]
 		public void GroupBy21([DataSources] string context)
 		{
@@ -193,7 +193,7 @@ namespace Tests.Linq
 					select g.Count(p => p.ParentID < 3));
 		}
 
-		[ActiveIssue("Unsupported by Informix?", Configurations = new[] { ProviderName.Informix, ProviderName.SapHana })]
+		[ActiveIssue(1685, Configurations = new[] { ProviderName.Informix, ProviderName.SapHana })]
 		[Test]
 		public void GroupBy22([DataSources] string context)
 		{

--- a/Tests/Linq/Linq/CountTests.cs
+++ b/Tests/Linq/Linq/CountTests.cs
@@ -95,9 +95,8 @@ namespace Tests.Linq
 					from p in db.Parent where p.Children.Count > 2 select p);
 		}
 
-		[ActiveIssue("not supported?", Configuration = ProviderName.SapHana)]
 		[Test]
-		public void SubQueryCount([IncludeDataSources(TestProvName.AllSqlServer2008Plus, ProviderName.SapHana)] string context)
+		public void SubQueryCount([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
 		{
 			using (var db = new TestDataConnection(context))
 			{

--- a/Tests/Linq/Linq/DynamicColumnsTests.cs
+++ b/Tests/Linq/Linq/DynamicColumnsTests.cs
@@ -80,7 +80,6 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[ActiveIssue("HanaException : Data is Null. This method or property cannot be called on Null values.", Configuration = ProviderName.SapHana)]
 		public void SqlPropertyWithNonDynamicAssociationViaObject2([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
@@ -173,7 +172,6 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[ActiveIssue("HanaException : Data is Null. This method or property cannot be called on Null values.", Configuration = ProviderName.SapHana)]
 		public void SqlPropertySelectAssociated([DataSources] string context)
 		{
 			using (var db = GetDataContext(context, ConfigureDynamicClass()))
@@ -264,7 +262,6 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[ActiveIssue("HanaException : Data is Null. This method or property cannot be called on Null values.", Configuration = ProviderName.SapHana)]
 		public void SqlPropertyGroupByAssociated([DataSources] string context)
 		{
 			using (var db = GetDataContext(context, ConfigureDynamicClass()))

--- a/Tests/Linq/Linq/EnumMappingTests.cs
+++ b/Tests/Linq/Linq/EnumMappingTests.cs
@@ -1758,7 +1758,7 @@ namespace Tests.Linq
 		[Test, ActiveIssue(1622)]
 		public void Issue1622Test([DataSources] string context)
 		{
-			using (var db = GetDataContext(context))
+			using (var db = GetDataContext(context, new MappingSchema()))
 			{
 				db.MappingSchema.SetValueToSqlConverter(typeof(Issue1622Enum),
 					(sb, dt, v) =>
@@ -1768,12 +1768,13 @@ namespace Tests.Linq
 
 				using (var table = db.CreateLocalTable<Issue1622Table>())
 				{
-					var item = new Issue1622Table() { Id = 1 };
+					var item = new Issue1622Table() { Id = 1, SomeText = "Value1_suffix" };
 					db.Insert(item);
 
-					//var res = table.Where(e => SomeComparison(e.SomeText, Issue1622Enum.Value1)).ToArray();
-					var res2 = table.Where(e => e.Id == 1).FirstOrDefault();
+					var res = table.Where(e => SomeComparison(e.SomeText, Issue1622Enum.Value1)).Single();
+					var res2 = table.Where(e => e.Id == 1).Single();
 
+					Assert.That(item.Id, Is.EqualTo(res.Id));
 					Assert.That(item.Id, Is.EqualTo(res2.Id));
 				}
 			}

--- a/Tests/Linq/Linq/ExpressionsTests.cs
+++ b/Tests/Linq/Linq/ExpressionsTests.cs
@@ -427,7 +427,6 @@ namespace Tests.Linq
 			}
 		}
 
-		[ActiveIssue(Configuration = ProviderName.SapHana)]
 		[Test]
 		public void ToLowerInvariantTest([DataSources] string context)
 		{

--- a/Tests/Linq/Linq/IssueTests.cs
+++ b/Tests/Linq/Linq/IssueTests.cs
@@ -425,7 +425,6 @@ namespace Tests.Linq
 			};
 		}
 
-		[ActiveIssue(Configuration = ProviderName.SapHana)]
 		[Test]
 		public void Issue376([DataSources] string context)
 		{

--- a/Tests/Linq/Linq/SelectTests.cs
+++ b/Tests/Linq/Linq/SelectTests.cs
@@ -816,7 +816,6 @@ namespace Tests.Linq
 			}
 		}
 
-		[ActiveIssue(1202)]
 		[Test, Parallelizable(ParallelScope.None)]
 		public void SelectReverseNullPropagationTest([DataSources] string context)
 		{
@@ -871,7 +870,6 @@ namespace Tests.Linq
 			}
 		}
 
-		[ActiveIssue(1202)]
 		[Test]
 		public void SelectReverseNullPropagationTest2([DataSources] string context)
 		{

--- a/Tests/Linq/Linq/StringFunctionTests.cs
+++ b/Tests/Linq/Linq/StringFunctionTests.cs
@@ -341,10 +341,10 @@ namespace Tests.Linq
 			}
 		}
 
-		[ActiveIssue(Configuration = ProviderName.SapHana)]
+		[ActiveIssue(1685, Configurations = new[] { ProviderName.Informix, ProviderName.SapHana })]
 		[Test]
 		public void IndexOf3([DataSources(
-			ProviderName.DB2, TestProvName.AllFirebird, ProviderName.Informix,
+			ProviderName.DB2, TestProvName.AllFirebird,
 			ProviderName.SqlCe, ProviderName.Access, ProviderName.SQLiteMS)]
 			string context)
 		{

--- a/Tests/Linq/Update/TruncateTableTests.cs
+++ b/Tests/Linq/Update/TruncateTableTests.cs
@@ -41,9 +41,9 @@ namespace Tests.xUpdate
 		}
 
 		// SAP hana not related to oracle this issue, we just cannot use two ActiveIssue attributes
-		[ActiveIssue(":NEW as parameter", Configurations = new[] { ProviderName.OracleNative, ProviderName.SapHana })]
+		[ActiveIssue(":NEW as parameter", Configurations = new[] { ProviderName.OracleNative })]
 		[Test]
-		public void TruncateIdentityTest([DataSources(ProviderName.Informix)]
+		public void TruncateIdentityTest([DataSources(ProviderName.Informix, ProviderName.SapHana)]
 			string context)
 		{
 			using (var db = GetDataContext(context))

--- a/Tests/Linq/Update/TruncateTableTests.cs
+++ b/Tests/Linq/Update/TruncateTableTests.cs
@@ -40,7 +40,6 @@ namespace Tests.xUpdate
 			[Column]                       public decimal Field1;
 		}
 
-		// SAP hana not related to oracle this issue, we just cannot use two ActiveIssue attributes
 		[ActiveIssue(":NEW as parameter", Configurations = new[] { ProviderName.OracleNative })]
 		[Test]
 		public void TruncateIdentityTest([DataSources(ProviderName.Informix, ProviderName.SapHana)]

--- a/Tests/Linq/UserTests/Issue569Tests.cs
+++ b/Tests/Linq/UserTests/Issue569Tests.cs
@@ -75,7 +75,6 @@
 			}
 		}
 
-		[ActiveIssue(Configuration = ProviderName.SapHana)]
 		[Test]
 		public void Test3([DataSources] string context)
 		{


### PR DESCRIPTION
SAP HANA fails to report proper value for column AllowDBNull property for some queries and linq2db fails with `HanaException : Data is Null. This method or property cannot be called on Null values.`

Also removed couple of fixed ActiveIssue attributes