### PR TITLE
Add DateDiff implementation and fix AddDate for SQLite

### DIFF
--- a/Source/LinqToDB/Sql/Sql.DateTime.cs
+++ b/Source/LinqToDB/Sql/Sql.DateTime.cs
@@ -469,7 +469,8 @@ namespace LinqToDB
 					case Sql.DateParts.Hour        : builder.ResultExpression = builder.Add<DateTime>(date, builder.Div(number,                  24)); break;
 					case Sql.DateParts.Minute      : builder.ResultExpression = builder.Add<DateTime>(date, builder.Div(number,             60 * 24)); break;
 					case Sql.DateParts.Second      : builder.ResultExpression = builder.Add<DateTime>(date, builder.Div(number,        60 * 60 * 24)); break;
-					case Sql.DateParts.Millisecond : builder.ResultExpression = builder.Add<DateTime>(date, builder.Div(number, 1000 * 60 * 60 * 24)); break;	
+						// adding number to timestamp instead of adding interval leads to wrong result type and loose of precision
+					case Sql.DateParts.Millisecond : builder.ResultExpression = builder.Add<DateTime>(date, builder.Mul(new SqlExpression("interval '0.001' second", Precedence.Primary), number, typeof(int))); break;	
 					default:
 						throw new ArgumentOutOfRangeException();
 				}

--- a/Source/LinqToDB/Sql/Sql.DateTime.cs
+++ b/Source/LinqToDB/Sql/Sql.DateTime.cs
@@ -606,32 +606,25 @@ namespace LinqToDB
 				var date    = builder.GetExpression("date");
 				var number  = builder.GetExpression("number");
 
-				string expStr;
+				string expStr = "strftime('%Y-%m-%d %H:%M:%f', {0},";
 				switch (part)
 				{
-					case Sql.DateParts.Year        : expStr = "{0} || ' Year'"; break;
-					case Sql.DateParts.Quarter     : 
-						expStr = "({0}) || ' Month'"; 
-						number = builder.Mul(number, 3);
-						break;
-					case Sql.DateParts.Month       : expStr = "{0} || ' Month'"; break;
+					case Sql.DateParts.Year        : expStr +=            "{1} || ' Year')"; break;
+					case Sql.DateParts.Quarter     : expStr +=       "({1}*3) || ' Month')"; break;
+					case Sql.DateParts.Month       : expStr +=           "{1} || ' Month')"; break;
 					case Sql.DateParts.DayOfYear   : 
 					case Sql.DateParts.WeekDay     : 
-					case Sql.DateParts.Day         : expStr = "{0} || ' Day'";          break;
-					case Sql.DateParts.Week        : 
-						expStr = "({0}) || ' Day'"; 
-						number = builder.Mul(number, 7);
-						break;
-					case Sql.DateParts.Hour        : expStr = "{0} || ' Hour'"; break;
-					case Sql.DateParts.Minute      : expStr = "{0} || ' Minute'"; break;
-					case Sql.DateParts.Second      : expStr = "{0} || ' Second'"; break;
-					case Sql.DateParts.Millisecond : expStr = "{0} || ' Millisecond'"; break;
+					case Sql.DateParts.Day         : expStr +=             "{1} || ' Day')"; break;
+					case Sql.DateParts.Week        : expStr +=         "({1}*7) || ' Day')"; break;
+					case Sql.DateParts.Hour        : expStr +=            "{1} || ' Hour')"; break;
+					case Sql.DateParts.Minute      : expStr +=          "{1} || ' Minute')"; break;
+					case Sql.DateParts.Second      : expStr +=          "{1} || ' Second')"; break;
+					case Sql.DateParts.Millisecond : expStr += "({1}/1000.0) || ' Second')"; break;
 					default:
 						throw new ArgumentOutOfRangeException();
 				}
 
-				builder.ResultExpression = new SqlFunction(typeof(DateTime?), "DateTime", date,
-					new SqlExpression(expStr, Precedence.Additive, number));
+				builder.ResultExpression = new SqlExpression(typeof(DateTime?), expStr, date, number);
 			}
 		}
 
@@ -860,11 +853,36 @@ namespace LinqToDB
 			}
 		}
 
+		class DateDiffBuilderSQLite : IExtensionCallBuilder
+		{
+			public void Build(ISqExtensionBuilder builder)
+			{
+				var part = builder.GetValue<Sql.DateParts>(0);
+				var startDate = builder.GetExpression(1);
+				var endDate = builder.GetExpression(2);
+
+				var expStr = "round((julianday({1}) - julianday({0}))";
+				switch (part)
+				{
+					case DateParts.Day:         expStr += ")";          break;
+					case DateParts.Hour:        expStr += " * 24)";       break;
+					case DateParts.Minute:      expStr += " * 1440)";     break;
+					case DateParts.Second:      expStr += " * 86400)";    break;
+					case DateParts.Millisecond: expStr += " * 86400000)"; break;
+					default:
+						throw new ArgumentOutOfRangeException();
+				}
+
+				builder.ResultExpression = new SqlExpression(typeof(int), expStr, startDate, endDate );
+			}
+		}
+
 		[CLSCompliant(false)]
 		[Sql.Extension(            "DateDiff",      BuilderType = typeof(DateDiffBuilder))]
 		[Sql.Extension(PN.MySql,   "TIMESTAMPDIFF", BuilderType = typeof(DateDiffBuilder))]
 		[Sql.Extension(PN.DB2,     "",              BuilderType = typeof(DateDiffBuilderDB2))]
 		[Sql.Extension(PN.SapHana, "",              BuilderType = typeof(DateDiffBuilderSapHana))]
+		[Sql.Extension(PN.SQLite,  "",              BuilderType = typeof(DateDiffBuilderSQLite))]
 		public static int? DateDiff(DateParts part, DateTime? startDate, DateTime? endDate)
 		{
 			if (startDate == null || endDate == null)

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -1117,7 +1117,7 @@ namespace Tests.Linq
 			}
 		}
 
-		[Test, ActiveIssue(1615)]
+		[Test]
 		public void Issue1615Test([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -598,8 +598,8 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 			{
-				var res1 = (from t in db.Types select           Sql.DateAdd(Sql.DateParts.Millisecond, 41, t.DateTimeValue)) .ToList();
-				var res2 = (from t in db.Types select Sql.AsSql(Sql.DateAdd(Sql.DateParts.Millisecond, 41, t.DateTimeValue))).ToList();
+				var res1 = (from t in db.Types select           Sql.DateAdd(Sql.DateParts.Millisecond, 226, t.DateTimeValue)) .ToList();
+				var res2 = (from t in db.Types select Sql.AsSql(Sql.DateAdd(Sql.DateParts.Millisecond, 226, t.DateTimeValue))).ToList();
 
 				for (int i =0; i < res1.Count; i++)
 				{
@@ -669,14 +669,15 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 			{
-				var res1 = (from t in db.Types select          (t.DateTimeValue.AddMilliseconds(221))).ToList();
-				var res2 = (from t in db.Types select Sql.AsSql(t.DateTimeValue.AddMilliseconds(221))).ToList();
+				var res1 = (from t in db.Types select          (t.DateTimeValue.AddMilliseconds(226))).ToList();
+				var res2 = (from t in db.Types select Sql.AsSql(t.DateTimeValue.AddMilliseconds(226))).ToList();
 
 				for (int i = 0; i < res1.Count; i++)
 				{
 					var delta = res1[i] - res2[i];
 					Assert.IsTrue(delta.Between(TimeSpan.FromMilliseconds(-1), TimeSpan.FromMilliseconds(1)));
 				}
+
 			}
 		}
 
@@ -929,15 +930,9 @@ namespace Tests.Linq
 			string context)
 		{
 			using (var db = GetDataContext(context))
-			{
-				var res1 = (from t in Types select (int)(t.DateTimeValue.AddMilliseconds(100) - t.DateTimeValue).TotalMilliseconds).ToList();
-				var res2 = (from t in db.Types select (int)Sql.AsSql((t.DateTimeValue.AddMilliseconds(100) - t.DateTimeValue).TotalMilliseconds)).ToList();
-				for (int i = 0; i < res1.Count; i++)
-				{
-					var delta = res1[i] - res2[i];
-					Assert.AreEqual(delta, 0, 1);
-				}
-			}
+			AreEqual(
+					from t in Types select (int)(t.DateTimeValue.AddSeconds(100) - t.DateTimeValue).TotalMilliseconds,
+					from t in db.Types select (int)Sql.AsSql((t.DateTimeValue.AddSeconds(100) - t.DateTimeValue).TotalMilliseconds));
 		}
 
 		[Test]
@@ -951,16 +946,9 @@ namespace Tests.Linq
 			string context)
 		{
 			using (var db = GetDataContext(context))
-			{
-				var res1 = (from t in Types    select Sql.DateDiff(Sql.DateParts.Millisecond, t.DateTimeValue, t.DateTimeValue.AddMilliseconds(42))).ToList();
-				var res2 = (from t in db.Types select Sql.AsSql(Sql.DateDiff(Sql.DateParts.Millisecond, t.DateTimeValue, t.DateTimeValue.AddMilliseconds(42)))).ToList();
-
-				for (int i = 0; i < res1.Count; i++)
-				{
-					var delta = res1[i] - res2[i];
-					Assert.AreEqual(delta.Value, 0, 1);
-				}
-			}
+				AreEqual(
+						from t in Types    select           Sql.DateDiff(Sql.DateParts.Millisecond, t.DateTimeValue, t.DateTimeValue.AddSeconds(42)),
+						from t in db.Types select Sql.AsSql(Sql.DateDiff(Sql.DateParts.Millisecond, t.DateTimeValue, t.DateTimeValue.AddSeconds(42))));
 		}
 
 		#endregion

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -943,8 +943,8 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
-						from t in Types    select           Sql.DateDiff(Sql.DateParts.Millisecond, t.DateTimeValue, t.DateTimeValue.AddSeconds(42)),
-						from t in db.Types select Sql.AsSql(Sql.DateDiff(Sql.DateParts.Millisecond, t.DateTimeValue, t.DateTimeValue.AddSeconds(42))));
+					from t in    Types select           Sql.DateDiff(Sql.DateParts.Millisecond, t.DateTimeValue, t.DateTimeValue.AddSeconds(1)),
+					from t in db.Types select Sql.AsSql(Sql.DateDiff(Sql.DateParts.Millisecond, t.DateTimeValue, t.DateTimeValue.AddSeconds(1))));
 		}
 
 		#endregion

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -926,9 +926,9 @@ namespace Tests.Linq
 			string context)
 		{
 			using (var db = GetDataContext(context))
-			AreEqual(
-					from t in    Types select           (int)(t.DateTimeValue.AddSeconds(100) - t.DateTimeValue).TotalMilliseconds,
-					from t in db.Types select (int)Sql.AsSql((t.DateTimeValue.AddSeconds(100) - t.DateTimeValue).TotalMilliseconds));
+				AreEqual(
+					from t in    Types select           (int)(t.DateTimeValue.AddSeconds(1) - t.DateTimeValue).TotalMilliseconds,
+					from t in db.Types select (int)Sql.AsSql((t.DateTimeValue.AddSeconds(1) - t.DateTimeValue).TotalMilliseconds));
 		}
 
 		[Test]

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -15,14 +15,14 @@ namespace Tests.Linq
 	public class DateTimeFunctionsTests : TestBase
 	{
 		//This custom comparers allows for an error of 1 millisecond.  
-		public class CustomMillisecondsComparer : IEqualityComparer<int>
+		public class CustomIntComparer : IEqualityComparer<int>
 		{
 			public bool Equals(int x, int y) => (x >= (y - 1) && x <= (y + 1));
 
 			public int GetHashCode(int x) => 0;
 		}
 
-		public class CustomNullableMillisecondsComparer : IEqualityComparer<int?>
+		public class CustomNullableIntComparer : IEqualityComparer<int?>
 		{
 			public bool Equals(int? x, int? y)
 			{
@@ -974,7 +974,7 @@ namespace Tests.Linq
 					AreEqual(
 						from t in Types select (int)(t.DateTimeValue.AddSeconds(1) - t.DateTimeValue).TotalMilliseconds,
 						from t in db.Types select (int)Sql.AsSql((t.DateTimeValue.AddSeconds(1) - t.DateTimeValue).TotalMilliseconds),
-						new CustomMillisecondsComparer());
+						new CustomIntComparer());
 				}
 				else
 				{
@@ -1003,7 +1003,7 @@ namespace Tests.Linq
 					AreEqual(
 						from t in Types select Sql.DateDiff(Sql.DateParts.Millisecond, t.DateTimeValue, t.DateTimeValue.AddSeconds(1)),
 						from t in db.Types select Sql.AsSql(Sql.DateDiff(Sql.DateParts.Millisecond, t.DateTimeValue, t.DateTimeValue.AddSeconds(1))),
-						new CustomNullableMillisecondsComparer());
+						new CustomNullableIntComparer());
 				}
 				else
 				{

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -801,7 +801,6 @@ namespace Tests.Linq
 				ProviderName.Informix,
 				TestProvName.AllOracle,
 				TestProvName.AllPostgreSQL,
-				TestProvName.AllSQLite,
 				ProviderName.Access)]
 			string context)
 		{
@@ -832,7 +831,6 @@ namespace Tests.Linq
 				ProviderName.Informix,
 				TestProvName.AllOracle,
 				TestProvName.AllPostgreSQL,
-				TestProvName.AllSQLite,
 				ProviderName.Access)]
 			string context)
 		{
@@ -863,7 +861,6 @@ namespace Tests.Linq
 				ProviderName.Informix,
 				TestProvName.AllOracle,
 				TestProvName.AllPostgreSQL,
-				TestProvName.AllSQLite,
 				ProviderName.Access)]
 			string context)
 		{
@@ -894,7 +891,6 @@ namespace Tests.Linq
 				ProviderName.Informix,
 				TestProvName.AllOracle,
 				TestProvName.AllPostgreSQL,
-				TestProvName.AllSQLite,
 				ProviderName.Access)]
 			string context)
 		{

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -927,7 +927,7 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 			AreEqual(
-					from t in Types    select (int)          (t.DateTimeValue.AddSeconds(100) - t.DateTimeValue).TotalMilliseconds,
+					from t in    Types select           (int)(t.DateTimeValue.AddSeconds(100) - t.DateTimeValue).TotalMilliseconds,
 					from t in db.Types select (int)Sql.AsSql((t.DateTimeValue.AddSeconds(100) - t.DateTimeValue).TotalMilliseconds));
 		}
 

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -931,7 +931,7 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 			AreEqual(
-					from t in Types select (int)(t.DateTimeValue.AddSeconds(100) - t.DateTimeValue).TotalMilliseconds,
+					from t in Types    select (int)          (t.DateTimeValue.AddSeconds(100) - t.DateTimeValue).TotalMilliseconds,
 					from t in db.Types select (int)Sql.AsSql((t.DateTimeValue.AddSeconds(100) - t.DateTimeValue).TotalMilliseconds));
 		}
 

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -597,7 +597,16 @@ namespace Tests.Linq
 		public void DateAddMillisecond([DataSources(ProviderName.Informix, ProviderName.Access, ProviderName.SapHana, TestProvName.AllMySql)] string context)
 		{
 			using (var db = GetDataContext(context))
-				(from t in db.Types select Sql.AsSql(Sql.DateAdd(Sql.DateParts.Millisecond, 41, t.DateTimeValue))).ToList();
+			{
+				var res1 = (from t in db.Types select           Sql.DateAdd(Sql.DateParts.Millisecond, 41, t.DateTimeValue)) .ToList();
+				var res2 = (from t in db.Types select Sql.AsSql(Sql.DateAdd(Sql.DateParts.Millisecond, 41, t.DateTimeValue))).ToList();
+
+				for (int i =0; i < res1.Count; i++)
+				{
+					var delta = res1[i] - res2[i];
+					Assert.IsTrue(delta.Between(TimeSpan.FromMilliseconds(-1), TimeSpan.FromMilliseconds(1)));
+				}
+			}
 		}
 
 		[Test]
@@ -659,7 +668,16 @@ namespace Tests.Linq
 			string context)
 		{
 			using (var db = GetDataContext(context))
-				(from t in db.Types select Sql.AsSql(t.DateTimeValue.AddMilliseconds(221))).ToList();
+			{
+				var res1 = (from t in db.Types select          (t.DateTimeValue.AddMilliseconds(221))).ToList();
+				var res2 = (from t in db.Types select Sql.AsSql(t.DateTimeValue.AddMilliseconds(221))).ToList();
+
+				for (int i = 0; i < res1.Count; i++)
+				{
+					var delta = res1[i] - res2[i];
+					Assert.IsTrue(delta.Between(TimeSpan.FromMilliseconds(-1), TimeSpan.FromMilliseconds(1)));
+				}
+			}
 		}
 
 		[Test]
@@ -798,7 +816,6 @@ namespace Tests.Linq
 				ProviderName.Informix,
 				TestProvName.AllOracle,
 				TestProvName.AllPostgreSQL,
-				TestProvName.AllSQLite,
 				ProviderName.Access)]
 			string context)
 		{
@@ -830,7 +847,6 @@ namespace Tests.Linq
 				ProviderName.Informix,
 				TestProvName.AllOracle,
 				TestProvName.AllPostgreSQL,
-				TestProvName.AllSQLite,
 				ProviderName.Access)]
 			string context)
 		{
@@ -862,7 +878,6 @@ namespace Tests.Linq
 				ProviderName.Informix,
 				TestProvName.AllOracle,
 				TestProvName.AllPostgreSQL,
-				TestProvName.AllSQLite,
 				ProviderName.Access)]
 			string context)
 		{
@@ -894,7 +909,6 @@ namespace Tests.Linq
 				ProviderName.Informix,
 				TestProvName.AllOracle,
 				TestProvName.AllPostgreSQL,
-				TestProvName.AllSQLite,
 				ProviderName.Access)]
 			string context)
 		{
@@ -910,15 +924,20 @@ namespace Tests.Linq
 				ProviderName.Informix,
 				TestProvName.AllOracle,
 				TestProvName.AllPostgreSQL,
-				TestProvName.AllSQLite,
 				TestProvName.AllMySql,
 				ProviderName.Access)]
 			string context)
 		{
 			using (var db = GetDataContext(context))
-				AreEqual(
-					from t in    Types select           (int)(t.DateTimeValue.AddSeconds(1) - t.DateTimeValue).TotalMilliseconds,
-					from t in db.Types select (int)Sql.AsSql((t.DateTimeValue.AddSeconds(1) - t.DateTimeValue).TotalMilliseconds));
+			{
+				var res1 = (from t in Types select (int)(t.DateTimeValue.AddMilliseconds(100) - t.DateTimeValue).TotalMilliseconds).ToList();
+				var res2 = (from t in db.Types select (int)Sql.AsSql((t.DateTimeValue.AddMilliseconds(100) - t.DateTimeValue).TotalMilliseconds)).ToList();
+				for (int i = 0; i < res1.Count; i++)
+				{
+					var delta = res1[i] - res2[i];
+					Assert.AreEqual(delta, 0, 1);
+				}
+			}
 		}
 
 		[Test]
@@ -927,15 +946,21 @@ namespace Tests.Linq
 				ProviderName.Informix,
 				TestProvName.AllOracle,
 				TestProvName.AllPostgreSQL,
-				TestProvName.AllSQLite,
 				TestProvName.AllMySql,
 				ProviderName.Access)]
 			string context)
 		{
 			using (var db = GetDataContext(context))
-				AreEqual(
-					from t in    Types select           Sql.DateDiff(Sql.DateParts.Millisecond, t.DateTimeValue, t.DateTimeValue.AddSeconds(1)),
-					from t in db.Types select Sql.AsSql(Sql.DateDiff(Sql.DateParts.Millisecond, t.DateTimeValue, t.DateTimeValue.AddSeconds(1))));
+			{
+				var res1 = (from t in Types    select Sql.DateDiff(Sql.DateParts.Millisecond, t.DateTimeValue, t.DateTimeValue.AddMilliseconds(42))).ToList();
+				var res2 = (from t in db.Types select Sql.AsSql(Sql.DateDiff(Sql.DateParts.Millisecond, t.DateTimeValue, t.DateTimeValue.AddMilliseconds(42)))).ToList();
+
+				for (int i = 0; i < res1.Count; i++)
+				{
+					var delta = res1[i] - res2[i];
+					Assert.AreEqual(delta.Value, 0, 1);
+				}
+			}
 		}
 
 		#endregion


### PR DESCRIPTION
fix #1688

for SQLite:
DateTime(...)  equivalent  strftime('%Y-%m-%d %H:%M:%S', ...) but we need use %f format to get milliseconds.