### PR TITLE
Get rid of static provider parameter setters

### DIFF
--- a/Source/LinqToDB/DataProvider/DB2/DB2DataProvider.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2DataProvider.cs
@@ -179,7 +179,7 @@ namespace LinqToDB.DataProvider.DB2
 			base.InitCommand(dataConnection, commandType, commandText, parameters);
 		}
 
-		static Action<IDbDataParameter> _setBlob;
+		Action<IDbDataParameter> _setBlob;
 
 		public override void SetParameter(IDbDataParameter parameter, string name, DbDataType dataType, object value)
 		{

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdDataProvider.cs
@@ -50,7 +50,7 @@ namespace LinqToDB.DataProvider.Firebird
 			return value;
 		}
 
-		static Action<IDbDataParameter> _setTimeStamp;
+		Action<IDbDataParameter> _setTimeStamp;
 
 		public    override string ConnectionNamespace => "FirebirdSql.Data.FirebirdClient";
 		protected override string ConnectionTypeName  => $"{ConnectionNamespace}.FbConnection, {ConnectionNamespace}";

--- a/Source/LinqToDB/DataProvider/Informix/InformixDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixDataProvider.cs
@@ -180,7 +180,7 @@ namespace LinqToDB.DataProvider.Informix
 			base.SetParameter(parameter, name, dataType, value);
 		}
 
-		static Action<IDbDataParameter> _setText;
+		Action<IDbDataParameter> _setText;
 
 		protected override void SetParameterType(IDbDataParameter parameter, DbDataType dataType)
 		{

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
@@ -437,17 +437,17 @@ namespace LinqToDB.DataProvider.PostgreSQL
 		}
 #endif
 
-		static Action<IDbDataParameter> _setMoney;
-		static Action<IDbDataParameter> _setVarBinary;
-		static Action<IDbDataParameter> _setBoolean;
-		static Action<IDbDataParameter> _setXml;
-		static Action<IDbDataParameter> _setText;
-		static Action<IDbDataParameter> _setBit;
-		static Action<IDbDataParameter> _setHstore;
-		static Action<IDbDataParameter> _setJsonb;
-		static Action<IDbDataParameter> _setJson;
+		Action<IDbDataParameter> _setMoney;
+		Action<IDbDataParameter> _setVarBinary;
+		Action<IDbDataParameter> _setBoolean;
+		Action<IDbDataParameter> _setXml;
+		Action<IDbDataParameter> _setText;
+		Action<IDbDataParameter> _setBit;
+		Action<IDbDataParameter> _setHstore;
+		Action<IDbDataParameter> _setJsonb;
+		Action<IDbDataParameter> _setJson;
 
-		static Action<IDbDataParameter, object> _setNativeParameterType;
+		Action<IDbDataParameter, object> _setNativeParameterType;
 
 		public override void SetParameter(IDbDataParameter parameter, string name, DbDataType dataType, object value)
 		{

--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteDataProvider.cs
@@ -128,7 +128,7 @@ namespace LinqToDB.DataProvider.SQLite
 			base.SetParameterType(parameter, dataType);
 		}
 
-		static Action<string> _createDatabase;
+		Action<string> _createDatabase;
 
 		public void CreateDatabase([JetBrains.Annotations.NotNull] string databaseName, bool deleteIfExists = false)
 		{

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaDataProvider.cs
@@ -53,10 +53,10 @@ namespace LinqToDB.DataProvider.SapHana
 		public override string DbFactoryProviderName => "Sap.Data.Hana";
 #endif
 
-		static Action<IDbDataParameter> _setText;
-		static Action<IDbDataParameter> _setNText;
-		static Action<IDbDataParameter> _setBlob;
-		static Action<IDbDataParameter> _setVarBinary;
+		Action<IDbDataParameter> _setText;
+		Action<IDbDataParameter> _setNText;
+		Action<IDbDataParameter> _setBlob;
+		Action<IDbDataParameter> _setVarBinary;
 
 		protected override void OnConnectionTypeCreated(Type connectionType)
 		{

--- a/Source/LinqToDB/DataProvider/SqlCe/SqlCeDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlCe/SqlCeDataProvider.cs
@@ -62,16 +62,16 @@ namespace LinqToDB.DataProvider.SqlCe
 			_setBoolean   = GetSetParameter(connectionType, SqlDbType.Bit);
 		}
 
-		static Action<IDbDataParameter> _setNText;
-		static Action<IDbDataParameter> _setNChar;
-		static Action<IDbDataParameter> _setNVarChar;
-		static Action<IDbDataParameter> _setTimestamp;
-		static Action<IDbDataParameter> _setBinary;
-		static Action<IDbDataParameter> _setVarBinary;
-		static Action<IDbDataParameter> _setImage;
-		static Action<IDbDataParameter> _setDateTime;
-		static Action<IDbDataParameter> _setMoney;
-		static Action<IDbDataParameter> _setBoolean;
+		Action<IDbDataParameter> _setNText;
+		Action<IDbDataParameter> _setNChar;
+		Action<IDbDataParameter> _setNVarChar;
+		Action<IDbDataParameter> _setTimestamp;
+		Action<IDbDataParameter> _setBinary;
+		Action<IDbDataParameter> _setVarBinary;
+		Action<IDbDataParameter> _setImage;
+		Action<IDbDataParameter> _setDateTime;
+		Action<IDbDataParameter> _setMoney;
+		Action<IDbDataParameter> _setBoolean;
 
 		static Action<IDbDataParameter> GetSetParameter(Type connectionType, SqlDbType value)
 		{

--- a/Tests/Linq/TestProviders/Npgsql4PostgreSQLDataProvider.cs
+++ b/Tests/Linq/TestProviders/Npgsql4PostgreSQLDataProvider.cs
@@ -48,7 +48,7 @@ namespace Tests
 #endif
 		}
 
-		private Type _dataReaderType;
+		private  Type _dataReaderType;
 		volatile Type _connectionType;
 
 		private readonly Assembly _assembly;
@@ -110,15 +110,15 @@ namespace Tests
 			SetConverterToV3(baseProvider.NpgsqlLineType          , NpgsqlLineType);
 			SetConverterToV3NpgsqlInet(baseProvider.NpgsqlInetType, NpgsqlInetType);
 
-			_setMoney     = GetSetParameter(connectionType    , "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Money");
+			_setMoney     = GetSetParameter(connectionType, "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Money");
 			_setVarBinary = GetSetParameter(connectionType, "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Bytea");
-			_setBoolean   = GetSetParameter(connectionType  , "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Boolean");
-			_setXml       = GetSetParameter(connectionType      , "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Xml");
-			_setText      = GetSetParameter(connectionType     , "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Text");
-			_setBit       = GetSetParameter(connectionType      , "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Bit");
-			_setHstore    = GetSetParameter(connectionType   , "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Hstore");
-			_setJson      = GetSetParameter(connectionType     , "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Json");
-			_setJsonb     = GetSetParameter(connectionType    , "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Jsonb");
+			_setBoolean   = GetSetParameter(connectionType, "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Boolean");
+			_setXml       = GetSetParameter(connectionType, "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Xml");
+			_setText      = GetSetParameter(connectionType, "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Text");
+			_setBit       = GetSetParameter(connectionType, "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Bit");
+			_setHstore    = GetSetParameter(connectionType, "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Hstore");
+			_setJson      = GetSetParameter(connectionType, "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Json");
+			_setJsonb     = GetSetParameter(connectionType, "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Jsonb");
 
 			_setNativeParameterType = GetSetParameter<object>(connectionType, "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType);
 		}

--- a/Tests/Linq/TestProviders/Npgsql4PostgreSQLDataProvider.cs
+++ b/Tests/Linq/TestProviders/Npgsql4PostgreSQLDataProvider.cs
@@ -110,30 +110,30 @@ namespace Tests
 			SetConverterToV3(baseProvider.NpgsqlLineType          , NpgsqlLineType);
 			SetConverterToV3NpgsqlInet(baseProvider.NpgsqlInetType, NpgsqlInetType);
 
-			_setMoney = GetSetParameter(connectionType    , "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Money");
+			_setMoney     = GetSetParameter(connectionType    , "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Money");
 			_setVarBinary = GetSetParameter(connectionType, "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Bytea");
-			_setBoolean = GetSetParameter(connectionType  , "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Boolean");
-			_setXml = GetSetParameter(connectionType      , "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Xml");
-			_setText = GetSetParameter(connectionType     , "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Text");
-			_setBit = GetSetParameter(connectionType      , "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Bit");
-			_setHstore = GetSetParameter(connectionType   , "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Hstore");
-			_setJson = GetSetParameter(connectionType     , "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Json");
-			_setJsonb = GetSetParameter(connectionType    , "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Jsonb");
+			_setBoolean   = GetSetParameter(connectionType  , "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Boolean");
+			_setXml       = GetSetParameter(connectionType      , "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Xml");
+			_setText      = GetSetParameter(connectionType     , "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Text");
+			_setBit       = GetSetParameter(connectionType      , "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Bit");
+			_setHstore    = GetSetParameter(connectionType   , "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Hstore");
+			_setJson      = GetSetParameter(connectionType     , "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Json");
+			_setJsonb     = GetSetParameter(connectionType    , "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType, "Jsonb");
 
 			_setNativeParameterType = GetSetParameter<object>(connectionType, "NpgsqlParameter", "NpgsqlDbType", NpgsqlDbType);
 		}
 
-		static Action<IDbDataParameter> _setMoney;
-		static Action<IDbDataParameter> _setVarBinary;
-		static Action<IDbDataParameter> _setBoolean;
-		static Action<IDbDataParameter> _setXml;
-		static Action<IDbDataParameter> _setText;
-		static Action<IDbDataParameter> _setBit;
-		static Action<IDbDataParameter> _setHstore;
-		static Action<IDbDataParameter> _setJsonb;
-		static Action<IDbDataParameter> _setJson;
+		Action<IDbDataParameter> _setMoney;
+		Action<IDbDataParameter> _setVarBinary;
+		Action<IDbDataParameter> _setBoolean;
+		Action<IDbDataParameter> _setXml;
+		Action<IDbDataParameter> _setText;
+		Action<IDbDataParameter> _setBit;
+		Action<IDbDataParameter> _setHstore;
+		Action<IDbDataParameter> _setJsonb;
+		Action<IDbDataParameter> _setJson;
 
-		static Action<IDbDataParameter, object> _setNativeParameterType;
+		Action<IDbDataParameter, object> _setNativeParameterType;
 
 		private void SetConverterToV3NpgsqlInet(Type from, Type to)
 		{


### PR DESCRIPTION
We store custom parameter setters in static variable,

Having them as static doesn't give us anything, because each new instance of provider instance always overrides them.

From other side having them static leads to issues when different providers used for same database. E.g. we already removed statics for this reason from sybase provider. Now it gives issues when we run tests with both npgsql3/npgsql4 providers.
