### PR TITLE
Fix creation of table with identity trigger for oracle native provider

### DIFF
--- a/Source/LinqToDB/Data/CommandInfo.cs
+++ b/Source/LinqToDB/Data/CommandInfo.cs
@@ -137,9 +137,11 @@ namespace LinqToDB.Data
 		/// <returns>Returns collection of query result records.</returns>
 		public IEnumerable<T> Query<T>(Func<IDataReader,T> objectReader)
 		{
-			DataConnection.InitCommand(CommandType, CommandText, Parameters, null);
+			var hasParameters = Parameters?.Length > 0;
 
-			if (Parameters != null && Parameters.Length > 0)
+			DataConnection.InitCommand(CommandType, CommandText, Parameters, null, hasParameters);
+
+			if (hasParameters)
 				SetParameters(DataConnection, Parameters);
 
 			return ReadEnumerator(DataConnection.ExecuteReader(GetCommandBehavior()), objectReader);
@@ -232,9 +234,11 @@ namespace LinqToDB.Data
 		{
 			await DataConnection.EnsureConnectionAsync(cancellationToken);
 
-			DataConnection.InitCommand(CommandType, CommandText, Parameters, null);
+			var hasParameters = Parameters?.Length > 0;
 
-			if (Parameters != null && Parameters.Length > 0)
+			DataConnection.InitCommand(CommandType, CommandText, Parameters, null, hasParameters);
+
+			if (hasParameters)
 				SetParameters(DataConnection, Parameters);
 
 			using (var rd = await DataConnection.ExecuteReaderAsync(GetCommandBehavior(), cancellationToken))
@@ -264,9 +268,11 @@ namespace LinqToDB.Data
 		/// <returns>Returns collection of query result records.</returns>
 		public IEnumerable<T> Query<T>()
 		{
-			DataConnection.InitCommand(CommandType, CommandText, Parameters, null);
+			var hasParameters = Parameters?.Length > 0;
 
-			if (Parameters != null && Parameters.Length > 0)
+			DataConnection.InitCommand(CommandType, CommandText, Parameters, null, hasParameters);
+
+			if (hasParameters)
 				SetParameters(DataConnection, Parameters);
 
 			return ReadEnumerator<T>(DataConnection.ExecuteReader(GetCommandBehavior()));
@@ -379,9 +385,11 @@ namespace LinqToDB.Data
 		{
 			await DataConnection.EnsureConnectionAsync(cancellationToken);
 
-			DataConnection.InitCommand(CommandType, CommandText, Parameters, null);
+			var hasParameters = Parameters?.Length > 0;
 
-			if (Parameters != null && Parameters.Length > 0)
+			DataConnection.InitCommand(CommandType, CommandText, Parameters, null, hasParameters);
+
+			if (hasParameters)
 				SetParameters(DataConnection, Parameters);
 
 			using (var rd = await DataConnection.ExecuteReaderAsync(GetCommandBehavior(), cancellationToken))
@@ -461,9 +469,9 @@ namespace LinqToDB.Data
 		/// <returns>Number of records, affected by command execution.</returns>
 		public int Execute()
 		{
-			DataConnection.InitCommand(CommandType, CommandText, Parameters, null);
+			var hasParameters = Parameters?.Length > 0;
 
-			var hasParameters = Parameters != null && Parameters.Length > 0;
+			DataConnection.InitCommand(CommandType, CommandText, Parameters, null, hasParameters);
 
 			if (hasParameters)
 				SetParameters(DataConnection, Parameters);
@@ -519,9 +527,9 @@ namespace LinqToDB.Data
 		{
 			await DataConnection.EnsureConnectionAsync(cancellationToken);
 
-			DataConnection.InitCommand(CommandType, CommandText, Parameters, null);
+			var hasParameters = Parameters?.Length > 0;
 
-			var hasParameters = Parameters != null && Parameters.Length > 0;
+			DataConnection.InitCommand(CommandType, CommandText, Parameters, null, hasParameters);
 
 			if (hasParameters)
 				SetParameters(DataConnection, Parameters);
@@ -556,9 +564,11 @@ namespace LinqToDB.Data
 		/// <returns>Resulting value.</returns>
 		public T Execute<T>()
 		{
-			DataConnection.InitCommand(CommandType, CommandText, Parameters, null);
+			var hasParameters = Parameters?.Length > 0;
 
-			if (Parameters != null && Parameters.Length > 0)
+			DataConnection.InitCommand(CommandType, CommandText, Parameters, null, hasParameters);
+
+			if (hasParameters)
 				SetParameters(DataConnection, Parameters);
 
 			using (var rd = DataConnection.ExecuteReader(GetCommandBehavior()))
@@ -638,9 +648,11 @@ namespace LinqToDB.Data
 		{
 			await DataConnection.EnsureConnectionAsync(cancellationToken);
 
-			DataConnection.InitCommand(CommandType, CommandText, Parameters, null);
+			var hasParameters = Parameters?.Length > 0;
 
-			if (Parameters != null && Parameters.Length > 0)
+			DataConnection.InitCommand(CommandType, CommandText, Parameters, null, hasParameters);
+
+			if (hasParameters)
 				SetParameters(DataConnection, Parameters);
 
 			using (var rd = await DataConnection.ExecuteReaderAsync(GetCommandBehavior(), cancellationToken))
@@ -682,9 +694,11 @@ namespace LinqToDB.Data
 		/// <returns>Data reader object.</returns>
 		public DataReader ExecuteReader()
 		{
-			DataConnection.InitCommand(CommandType, CommandText, Parameters, null);
+			var hasParameters = Parameters?.Length > 0;
 
-			if (Parameters != null && Parameters.Length > 0)
+			DataConnection.InitCommand(CommandType, CommandText, Parameters, null, hasParameters);
+
+			if (hasParameters)
 				SetParameters(DataConnection, Parameters);
 
 			return new DataReader { CommandInfo = this, Reader = DataConnection.ExecuteReader(GetCommandBehavior()) };
@@ -762,9 +776,11 @@ namespace LinqToDB.Data
 		{
 			await DataConnection.EnsureConnectionAsync(cancellationToken);
 
-			DataConnection.InitCommand(CommandType, CommandText, Parameters, null);
+			var hasParameters = Parameters?.Length > 0;
 
-			if (Parameters != null && Parameters.Length > 0)
+			DataConnection.InitCommand(CommandType, CommandText, Parameters, null, hasParameters);
+
+			if (hasParameters)
 				SetParameters(DataConnection, Parameters);
 
 			return new DataReaderAsync { CommandInfo = this, Reader = await DataConnection.ExecuteReaderAsync(GetCommandBehavior(), cancellationToken) };

--- a/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
+++ b/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
@@ -280,9 +280,11 @@ namespace LinqToDB.Data
 			{
 				SetCommand(true);
 
-				_dataConnection.InitCommand(CommandType.Text, _preparedQuery.Commands[0], null, QueryHints);
+				var hasParameters = _preparedQuery.Parameters?.Length > 0;
 
-				if (_preparedQuery.Parameters != null)
+				_dataConnection.InitCommand(CommandType.Text, _preparedQuery.Commands[0], null, QueryHints, hasParameters);
+
+				if (hasParameters)
 					foreach (var p in _preparedQuery.Parameters)
 						_dataConnection.Command.Parameters.Add(p);
 			}
@@ -293,9 +295,11 @@ namespace LinqToDB.Data
 			{
 				if (preparedQuery.Commands.Length == 1)
 				{
-					dataConnection.InitCommand(CommandType.Text, preparedQuery.Commands[0], null, preparedQuery.QueryHints);
+					var hasParameters = preparedQuery.Parameters?.Length > 0;
 
-					if (preparedQuery.Parameters != null)
+					dataConnection.InitCommand(CommandType.Text, preparedQuery.Commands[0], null, preparedQuery.QueryHints, hasParameters);
+
+					if (hasParameters)
 						foreach (var p in preparedQuery.Parameters)
 							dataConnection.Command.Parameters.Add(p);
 
@@ -306,9 +310,11 @@ namespace LinqToDB.Data
 
 				for (var i = 0; i < preparedQuery.Commands.Length; i++)
 				{
-					dataConnection.InitCommand(CommandType.Text, preparedQuery.Commands[i], null, i == 0 ? preparedQuery.QueryHints : null);
+					var hasParameters = i == 0 && preparedQuery.Parameters?.Length > 0;
 
-					if (i == 0 && preparedQuery.Parameters != null)
+					dataConnection.InitCommand(CommandType.Text, preparedQuery.Commands[i], null, i == 0 ? preparedQuery.QueryHints : null, hasParameters);
+
+					if (hasParameters)
 						foreach (var p in preparedQuery.Parameters)
 							dataConnection.Command.Parameters.Add(p);
 
@@ -387,7 +393,7 @@ namespace LinqToDB.Data
 
 				dataConnection.ExecuteNonQuery();
 
-				dataConnection.InitCommand(CommandType.Text, preparedQuery.Commands[1], null, null);
+				dataConnection.InitCommand(CommandType.Text, preparedQuery.Commands[1], null, null, false);
 
 				return dataConnection.ExecuteScalar();
 			}
@@ -398,9 +404,11 @@ namespace LinqToDB.Data
 
 				GetParameters(dataConnection, context, preparedQuery);
 
-				dataConnection.InitCommand(CommandType.Text, preparedQuery.Commands[0], null, preparedQuery.QueryHints);
+				var hasParameters = preparedQuery.Parameters?.Length > 0;
 
-				if (preparedQuery.Parameters != null)
+				dataConnection.InitCommand(CommandType.Text, preparedQuery.Commands[0], null, preparedQuery.QueryHints, hasParameters);
+
+				if (hasParameters)
 					foreach (var p in preparedQuery.Parameters)
 						dataConnection.Command.Parameters.Add(p);
 
@@ -423,9 +431,11 @@ namespace LinqToDB.Data
 
 				GetParameters(dataConnection, context, preparedQuery);
 
-				dataConnection.InitCommand(CommandType.Text, preparedQuery.Commands[0], null, preparedQuery.QueryHints);
+				var hasParameters = preparedQuery.Parameters?.Length > 0;
 
-				if (preparedQuery.Parameters != null)
+				dataConnection.InitCommand(CommandType.Text, preparedQuery.Commands[0], null, preparedQuery.QueryHints, hasParameters);
+
+				if (hasParameters)
 					foreach (var p in preparedQuery.Parameters)
 						dataConnection.Command.Parameters.Add(p);
 
@@ -436,9 +446,11 @@ namespace LinqToDB.Data
 			{
 				SetCommand(true);
 
-				_dataConnection.InitCommand(CommandType.Text, _preparedQuery.Commands[0], null, QueryHints);
+				var hasParameters = _preparedQuery.Parameters?.Length > 0;
 
-				if (_preparedQuery.Parameters != null)
+				_dataConnection.InitCommand(CommandType.Text, _preparedQuery.Commands[0], null, QueryHints, hasParameters);
+
+				if (hasParameters)
 					foreach (var p in _preparedQuery.Parameters)
 						_dataConnection.Command.Parameters.Add(p);
 
@@ -479,9 +491,11 @@ namespace LinqToDB.Data
 
 				base.SetCommand(true);
 
-				_dataConnection.InitCommand(CommandType.Text, _preparedQuery.Commands[0], null, QueryHints);
+				var hasParameters = _preparedQuery.Parameters?.Length > 0;
 
-				if (_preparedQuery.Parameters != null)
+				_dataConnection.InitCommand(CommandType.Text, _preparedQuery.Commands[0], null, QueryHints, hasParameters);
+
+				if (hasParameters)
 					foreach (var p in _preparedQuery.Parameters)
 						_dataConnection.Command.Parameters.Add(p);
 
@@ -500,10 +514,12 @@ namespace LinqToDB.Data
 
 				if (_preparedQuery.Commands.Length == 1)
 				{
-					_dataConnection.InitCommand(
-						CommandType.Text, _preparedQuery.Commands[0], null, _preparedQuery.QueryHints);
+					var hasParameters = _preparedQuery.Parameters?.Length > 0;
 
-					if (_preparedQuery.Parameters != null)
+					_dataConnection.InitCommand(
+						CommandType.Text, _preparedQuery.Commands[0], null, _preparedQuery.QueryHints, hasParameters);
+
+					if (hasParameters)
 						foreach (var p in _preparedQuery.Parameters)
 							_dataConnection.Command.Parameters.Add(p);
 
@@ -512,10 +528,12 @@ namespace LinqToDB.Data
 
 				for (var i = 0; i < _preparedQuery.Commands.Length; i++)
 				{
-					_dataConnection.InitCommand(
-						CommandType.Text, _preparedQuery.Commands[i], null, i == 0 ? _preparedQuery.QueryHints : null);
+					var hasParameters = i == 0 && _preparedQuery.Parameters?.Length > 0;
 
-					if (i == 0 && _preparedQuery.Parameters != null)
+					_dataConnection.InitCommand(
+						CommandType.Text, _preparedQuery.Commands[i], null, i == 0 ? _preparedQuery.QueryHints : null, hasParameters);
+
+					if (hasParameters)
 						foreach (var p in _preparedQuery.Parameters)
 							_dataConnection.Command.Parameters.Add(p);
 
@@ -578,7 +596,7 @@ namespace LinqToDB.Data
 
 				await _dataConnection.ExecuteNonQueryAsync(cancellationToken);
 
-				_dataConnection.InitCommand(CommandType.Text, _preparedQuery.Commands[1], null, null);
+				_dataConnection.InitCommand(CommandType.Text, _preparedQuery.Commands[1], null, null, false);
 
 				return await _dataConnection.ExecuteScalarAsync(cancellationToken);
 			}

--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -1053,7 +1053,7 @@ namespace LinqToDB.Data
 		/// </summary>
 		public string LastQuery;
 
-		internal void InitCommand(CommandType commandType, string sql, DataParameter[] parameters, List<string> queryHints)
+		internal void InitCommand(CommandType commandType, string sql, DataParameter[] parameters, List<string> queryHints, bool withParameters)
 		{
 			if (queryHints?.Count > 0)
 			{
@@ -1062,7 +1062,7 @@ namespace LinqToDB.Data
 				queryHints.Clear();
 			}
 
-			DataProvider.InitCommand(this, commandType, sql, parameters);
+			DataProvider.InitCommand(this, commandType, sql, parameters, withParameters);
 			LastQuery = Command.CommandText;
 		}
 

--- a/Source/LinqToDB/DataProvider/DB2/DB2DataProvider.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2DataProvider.cs
@@ -173,10 +173,10 @@ namespace LinqToDB.DataProvider.DB2
 			return _sqlOptimizer;
 		}
 
-		public override void InitCommand(DataConnection dataConnection, CommandType commandType, string commandText, DataParameter[] parameters)
+		public override void InitCommand(DataConnection dataConnection, CommandType commandType, string commandText, DataParameter[] parameters, bool withParameters)
 		{
 			dataConnection.DisposeCommand();
-			base.InitCommand(dataConnection, commandType, commandText, parameters);
+			base.InitCommand(dataConnection, commandType, commandText, parameters, withParameters);
 		}
 
 		static Action<IDbDataParameter> _setBlob;

--- a/Source/LinqToDB/DataProvider/DataProviderBase.cs
+++ b/Source/LinqToDB/DataProvider/DataProviderBase.cs
@@ -102,7 +102,7 @@ namespace LinqToDB.DataProvider
 		public    abstract ISqlBuilder   CreateSqlBuilder();
 		public    abstract ISqlOptimizer GetSqlOptimizer ();
 
-		public virtual void InitCommand(DataConnection dataConnection, CommandType commandType, string commandText, DataParameter[] parameters)
+		public virtual void InitCommand(DataConnection dataConnection, CommandType commandType, string commandText, DataParameter[] parameters, bool withParameters)
 		{
 			dataConnection.Command.CommandType = commandType;
 

--- a/Source/LinqToDB/DataProvider/IDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/IDataProvider.cs
@@ -23,7 +23,15 @@ namespace LinqToDB.DataProvider
 		IDbConnection      CreateConnection      (string connectionString);
 		ISqlBuilder        CreateSqlBuilder      ();
 		ISqlOptimizer      GetSqlOptimizer       ();
-		void               InitCommand           (DataConnection dataConnection, CommandType commandType, string commandText, DataParameter[] parameters);
+		/// <summary>
+		/// Initializes <see cref="DataConnection.Command"/> object.
+		/// </summary>
+		/// <param name="dataConnection">Data connection instance to initialize with new command.</param>
+		/// <param name="commandType">Type of command.</param>
+		/// <param name="commandText">Command SQL.</param>
+		/// <param name="parameters">Optional list of parameters to add to initialized command.</param>
+		/// <param name="withParameters">Flag to indicate that command has parameters. Used to configure parameters support when method called without parameters and parameters added later to command.</param>
+		void InitCommand           (DataConnection dataConnection, CommandType commandType, string commandText, DataParameter[] parameters, bool withParameters);
 		void               DisposeCommand        (DataConnection dataConnection);
 		object             GetConnectionInfo     (DataConnection dataConnection, string parameterName);
 		Expression         GetReaderExpression   (MappingSchema mappingSchema, IDataReader reader, int idx, Expression readerExpression, Type toType);

--- a/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
@@ -285,10 +285,11 @@ namespace LinqToDB.DataProvider.Oracle
 			{
 				// ((OracleCommand)dataConnection.Command).BindByName = true;
 
-				var p = Expression.Parameter(typeof(DataConnection), "dataConnection");
+				var p     = Expression.Parameter(typeof(DataConnection), "dataConnection");
+				var pbind = Expression.Parameter(typeof(bool), "value");
 
 				_setBindByName =
-					Expression.Lambda<Action<DataConnection>>(
+					Expression.Lambda<Action<DataConnection, bool>>(
 						Expression.Assign(
 							Expression.PropertyOrField(
 								Expression.Convert(
@@ -297,8 +298,9 @@ namespace LinqToDB.DataProvider.Oracle
 										Expression.Convert(Expression.PropertyOrField(p, "Command"), typeof(DbCommand))),
 									connectionType.AssemblyEx().GetType(AssemblyName + ".Client.OracleCommand", true)),
 								"BindByName"),
-							Expression.Constant(true)),
-							p
+							pbind),
+							p,
+							pbind
 					).Compile();
 			}
 
@@ -437,25 +439,23 @@ namespace LinqToDB.DataProvider.Oracle
 		}
 #endif
 
-		Action<DataConnection> _setBindByName;
+		Action<DataConnection, bool> _setBindByName;
 
-		public override void InitCommand(DataConnection dataConnection, CommandType commandType, string commandText, DataParameter[] parameters)
+		public override void InitCommand(DataConnection dataConnection, CommandType commandType, string commandText, DataParameter[] parameters, bool withParameters)
 		{
 			dataConnection.DisposeCommand();
 
 			if (_setBindByName == null)
 				EnsureConnection();
 
-			//if (Name == ProviderName.OracleNative)
-				_setBindByName(dataConnection);
+			// binding disabled for native provider without parameters to reduce changes to fail when SQL contains
+			// parameter-like token.
+			// This is mostly issue with triggers creation, because they can have record tokens like :NEW
+			// incorectly identified by native provider as parameter
+			var bind = Name != ProviderName.OracleNative || parameters?.Length > 0 || withParameters;
+			_setBindByName(dataConnection, bind);
 
-//			if (Name == ProviderName.OracleNative)
-//			{
-//				dynamic cmd = Proxy.GetUnderlyingObject((DbCommand)dataConnection.Command);
-//				cmd.BindByName = true;
-//			}
-
-			base.InitCommand(dataConnection, commandType, commandText, parameters);
+			base.InitCommand(dataConnection, commandType, commandText, parameters, withParameters);
 
 			if (parameters != null)
 				foreach (var parameter in parameters)

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaOdbcDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaOdbcDataProvider.cs
@@ -62,7 +62,7 @@ namespace LinqToDB.DataProvider.SapHana
 			return new SapHanaOdbcSchemaProvider();
 		}
 
-		public override void InitCommand(DataConnection dataConnection, CommandType commandType, string commandText, DataParameter[] parameters)
+		public override void InitCommand(DataConnection dataConnection, CommandType commandType, string commandText, DataParameter[] parameters, bool withParameters)
 		{
 			if (commandType == CommandType.StoredProcedure)
 			{
@@ -70,7 +70,7 @@ namespace LinqToDB.DataProvider.SapHana
 				commandType = CommandType.Text;
 			}
 
-			base.InitCommand(dataConnection, commandType, commandText, parameters);
+			base.InitCommand(dataConnection, commandType, commandText, parameters, withParameters);
 		}
 
 		public override ISqlBuilder CreateSqlBuilder()

--- a/Tests/Linq/DataProvider/ExpressionTests.cs
+++ b/Tests/Linq/DataProvider/ExpressionTests.cs
@@ -26,7 +26,7 @@ namespace Tests.DataProvider
 
 			using (var conn = new DataConnection(dataProvider, connectionString))
 			{
-				conn.InitCommand(CommandType.Text, "SELECT 1", null, null);
+				conn.InitCommand(CommandType.Text, "SELECT 1", null, null, false);
 
 				var rd = conn.Command.ExecuteReader();
 

--- a/Tests/Linq/DataProvider/OracleTests.cs
+++ b/Tests/Linq/DataProvider/OracleTests.cs
@@ -2024,7 +2024,6 @@ namespace Tests.DataProvider
 		}
 
 		[Test]
-		[ActiveIssue(":NEW as parameter", Configuration = ProviderName.OracleNative)]
 		public void Issue723Test1([IncludeDataSources(TestProvName.AllOracle)] string context)
 		{
 			var ms = new MappingSchema();
@@ -2076,7 +2075,6 @@ namespace Tests.DataProvider
 		}
 
 		[Test]
-		[ActiveIssue(":NEW as parameter", Configuration = ProviderName.OracleNative)]
 		public void Issue723Test2([IncludeDataSources(TestProvName.AllOracle)] string context)
 		{
 			using (var db = GetDataContext(context))

--- a/Tests/Linq/Linq/DynamicColumnsTests.cs
+++ b/Tests/Linq/Linq/DynamicColumnsTests.cs
@@ -373,7 +373,6 @@ namespace Tests.Linq
 			db.CreateTable<T>(tableName);
 		}
 
-		[ActiveIssue(":NEW as parameter", Configuration = ProviderName.OracleNative)]
 		[Test]
 		public void SqlPropertyNoStoreNonIdentifier([DataSources] string context)
 		{
@@ -403,7 +402,6 @@ namespace Tests.Linq
 			}
 		}
 
-		[ActiveIssue(":NEW as parameter", Configuration = ProviderName.OracleNative)]
 		[Test]
 		public void SqlPropertyNoStoreNonIdentifierGrouping([DataSources] string context)
 		{

--- a/Tests/Linq/Update/CreateTableTests.cs
+++ b/Tests/Linq/Update/CreateTableTests.cs
@@ -23,7 +23,6 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		[ActiveIssue(":NEW as parameter", Configuration = ProviderName.OracleNative)]
 		public void CreateTable1([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
@@ -46,7 +45,6 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		[ActiveIssue(":NEW as parameter", Configuration = ProviderName.OracleNative)]
 		public async Task CreateTable1Async([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))

--- a/Tests/Linq/Update/DeleteTests.cs
+++ b/Tests/Linq/Update/DeleteTests.cs
@@ -396,7 +396,6 @@ namespace Tests.xUpdate
 			}
 		}
 
-		[ActiveIssue(":NEW as parameter", Configuration = ProviderName.OracleNative)]
 		[Test]
 		public void DeleteByTableName([DataSources] string context)
 		{
@@ -429,7 +428,6 @@ namespace Tests.xUpdate
 			}
 		}
 
-		[ActiveIssue(":NEW as parameter", Configuration = ProviderName.OracleNative)]
 		[Test]
 		public async Task DeleteByTableNameAsync([DataSources] string context)
 		{

--- a/Tests/Linq/Update/DropTableTests.cs
+++ b/Tests/Linq/Update/DropTableTests.cs
@@ -51,7 +51,6 @@ namespace Tests.xUpdate
 			public int ID1 { get; set; }
 		}
 
-		[ActiveIssue(":NEW as parameter", Configuration = ProviderName.OracleNative)]
 		[Test]
 		public void DropCurrentDatabaseTableWIthIdentityTest([DataSources] string context)
 		{

--- a/Tests/Linq/Update/InsertTests.cs
+++ b/Tests/Linq/Update/InsertTests.cs
@@ -1589,7 +1589,6 @@ namespace Tests.xUpdate
 			return tableName;
 		}
 
-		[ActiveIssue(":NEW as parameter", Configuration = ProviderName.OracleNative)]
 		[Test]
 		public void InsertByTableName([DataSources] string context)
 		{
@@ -1636,7 +1635,6 @@ namespace Tests.xUpdate
 			}
 		}
 
-		[ActiveIssue(":NEW as parameter", Configuration = ProviderName.OracleNative)]
 		[Test]
 		public async Task InsertByTableNameAsync([DataSources] string context)
 		{

--- a/Tests/Linq/Update/MergeTests.CommandValidation.cs
+++ b/Tests/Linq/Update/MergeTests.CommandValidation.cs
@@ -190,7 +190,7 @@ namespace Tests.xUpdate
 
 				ISqlOptimizer IDataProvider.GetSqlOptimizer() => throw new NotImplementedException();
 
-				void IDataProvider.InitCommand(DataConnection dataConnection, CommandType commandType, string commandText, DataParameter[] parameters) => throw new NotImplementedException();
+				void IDataProvider.InitCommand(DataConnection dataConnection, CommandType commandType, string commandText, DataParameter[] parameters, bool withParameters) => throw new NotImplementedException();
 
 				bool IDataProvider.IsCompatibleConnection(IDbConnection connection) => throw new NotImplementedException();
 

--- a/Tests/Linq/Update/TruncateTableTests.cs
+++ b/Tests/Linq/Update/TruncateTableTests.cs
@@ -40,7 +40,6 @@ namespace Tests.xUpdate
 			[Column]                       public decimal Field1;
 		}
 
-		[ActiveIssue(":NEW as parameter", Configurations = new[] { ProviderName.OracleNative })]
 		[Test]
 		public void TruncateIdentityTest([DataSources(ProviderName.Informix, ProviderName.SapHana)]
 			string context)
@@ -72,7 +71,6 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		[ActiveIssue(":NEW as parameter", Configuration = ProviderName.OracleNative)]
 		public void TruncateIdentityNoResetTest([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))

--- a/Tests/Linq/Update/UpdateTests.cs
+++ b/Tests/Linq/Update/UpdateTests.cs
@@ -1206,9 +1206,6 @@ namespace Tests.xUpdate
 			}
 		}
 
-		[ActiveIssue(
-			Configuration = ProviderName.OracleNative,
-			Details       = "ORA-00955: name is already used by an existing object")]
 		[Test]
 		public void UpdateByTableName([DataSources] string context)
 		{
@@ -1252,9 +1249,6 @@ namespace Tests.xUpdate
 			}
 		}
 
-		[ActiveIssue(
-			Configuration = ProviderName.OracleNative,
-			Details       = "ORA-00955: name is already used by an existing object")]
 		[Test]
 		public async Task UpdateByTableNameAsync([DataSources] string context)
 		{

--- a/Tests/Linq/UserTests/Issue1222Tests.cs
+++ b/Tests/Linq/UserTests/Issue1222Tests.cs
@@ -46,7 +46,6 @@ namespace Tests.UserTests
 			[Column("inIdMain"), NotNull]          public int InIdMain { get; set; } // int
 		}
 
-		[ActiveIssue(":NEW as parameter", Configuration = ProviderName.OracleNative)]
 		[Test]
 		public void Test([DataSources] string context)
 		{

--- a/Tests/Linq/UserTests/Issue1279Tests.cs
+++ b/Tests/Linq/UserTests/Issue1279Tests.cs
@@ -16,7 +16,6 @@ namespace Tests.UserTests
 			public char CharFld { get; set; }
 		}
 
-		[ActiveIssue(":NEW as parameter", Configuration = ProviderName.OracleNative)]
 		[Test]
 		public void Test([DataSources] string context)
 		{

--- a/Tests/Linq/UserTests/Issue1438Tests.cs
+++ b/Tests/Linq/UserTests/Issue1438Tests.cs
@@ -18,7 +18,6 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		[ActiveIssue(":NEW as parameter", Configuration = ProviderName.OracleNative)]
 		public void GeneralTest([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))

--- a/Tests/Linq/UserTests/Issue564Tests.cs
+++ b/Tests/Linq/UserTests/Issue564Tests.cs
@@ -47,7 +47,6 @@ namespace Tests.UserTests
 			public int IntValue { get; set; }
 		}
 
-		[ActiveIssue(":NEW as parameter", Configuration = ProviderName.OracleNative)]
 		[Test]
 		public void Test([DataSources(false)] string context)
 		{


### PR DESCRIPTION
Set BindByName property only for commands with parameters for native provider to workaround issue when :NEW token treated by provider as parameter