### PR TITLE
Dynamic store configuration improvements

### DIFF
--- a/Source/LinqToDB/Expressions/Extensions.cs
+++ b/Source/LinqToDB/Expressions/Extensions.cs
@@ -944,6 +944,18 @@ namespace LinqToDB.Expressions
 				e == lambda.Parameters[1] ? exprToReplaceParameter2 : e);
 		}
 
+		/// <summary>
+		/// Returns the body of <paramref name="lambda"/> but replaces the first three parameters of
+		/// that lambda expression with the given replace expressions.
+		/// </summary>
+		public static Expression GetBody(this LambdaExpression lambda, Expression exprToReplaceParameter1, Expression exprToReplaceParameter2, Expression exprToReplaceParameter3)
+		{
+			return Transform(lambda.Body, e =>
+				e == lambda.Parameters[0] ? exprToReplaceParameter1 :
+				e == lambda.Parameters[1] ? exprToReplaceParameter2 :
+				e == lambda.Parameters[2] ? exprToReplaceParameter3 : e);
+		}
+
 		static IEnumerable<T> Transform<T>(ICollection<T> source, Func<T,T> func)
 			where T : class
 		{

--- a/Source/LinqToDB/Expressions/MappingExpressionsExtensions.cs
+++ b/Source/LinqToDB/Expressions/MappingExpressionsExtensions.cs
@@ -18,36 +18,37 @@ namespace LinqToDB.Extensions
 			if (members.Length > 1)
 				throw new LinqToDBException($"Ambiguous members '{memberName}' for type '{type.Name}' has been found");
 
-			if (members[0] is PropertyInfo propInfo)
+			switch (members[0])
 			{
-				var value = propInfo.GetValue(null, null);
-				if (value == null)
-					return null;
+				case PropertyInfo propInfo:
+					{
+						var value = propInfo.GetValue(null, null);
+						if (value == null)
+							return null;
 
-				if (value is TExpression expression)
-					return expression;
+						if (value is TExpression expression)
+							return expression;
 
-				throw new LinqToDBException($"Property '{memberName}' for type '{type.Name}' should return expression");
+						throw new LinqToDBException($"Property '{memberName}' for type '{type.Name}' should return expression");
+					}
+				case MethodInfo method:
+					{
+						if (method.GetParameters().Length > 0)
+							throw new LinqToDBException($"Method '{memberName}' for type '{type.Name}' should have no parameters");
+
+						var value = method.Invoke(null, Array<object>.Empty);
+						if (value == null)
+							return null;
+
+						if (value is TExpression expression)
+							return expression;
+
+						throw new LinqToDBException($"Method '{memberName}' for type '{type.Name}' should return expression");
+					}
+				default:
+					throw new LinqToDBException(
+						$"Member '{memberName}' for type '{type.Name}' should be static property or method");
 			}
-			else
-			{
-				if (members[0] is MethodInfo method)
-				{
-					if (method.GetParameters().Length > 0)
-						throw new LinqToDBException($"Method '{memberName}' for type '{type.Name}' should have no parameters");
-					var value = method.Invoke(null, Array<object>.Empty);
-					if (value == null)
-						return null;
-
-					if (value is TExpression expression)
-						return expression;
-
-					throw new LinqToDBException($"Method '{memberName}' for type '{type.Name}' should return expression");
-				}
-			}
-
-			throw new LinqToDBException(
-				$"Member '{memberName}' for type '{type.Name}' should be static property or method");
 		}
 	}
 }

--- a/Source/LinqToDB/Expressions/MappingExpressionsExtensions.cs
+++ b/Source/LinqToDB/Expressions/MappingExpressionsExtensions.cs
@@ -22,11 +22,7 @@ namespace LinqToDB.Extensions
 			{
 				case PropertyInfo propInfo:
 					{
-						var value = propInfo.GetValue(null, null);
-						if (value == null)
-							return null;
-
-						if (value is TExpression expression)
+						if (propInfo.GetValue(null, null) is TExpression expression)
 							return expression;
 
 						throw new LinqToDBException($"Property '{memberName}' for type '{type.Name}' should return expression");
@@ -36,11 +32,7 @@ namespace LinqToDB.Extensions
 						if (method.GetParameters().Length > 0)
 							throw new LinqToDBException($"Method '{memberName}' for type '{type.Name}' should have no parameters");
 
-						var value = method.Invoke(null, Array<object>.Empty);
-						if (value == null)
-							return null;
-
-						if (value is TExpression expression)
+						if (method.Invoke(null, Array<object>.Empty) is TExpression expression)
 							return expression;
 
 						throw new LinqToDBException($"Method '{memberName}' for type '{type.Name}' should return expression");

--- a/Source/LinqToDB/Expressions/MappingExpressionsExtensions.cs
+++ b/Source/LinqToDB/Expressions/MappingExpressionsExtensions.cs
@@ -1,0 +1,56 @@
+﻿using LinqToDB.Common;
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace LinqToDB.Extensions
+{
+	static class MappingExpressionsExtensions
+	{
+		public static TExpression GetExpressionFromExpressionMember<TExpression>(this Type type, string memberName)
+			where TExpression : Expression
+		{
+			var members = type.GetStaticMembersEx(memberName);
+
+			if (members.Length == 0)
+				throw new LinqToDBException($"Static member '{memberName}' for type '{type.Name}' not found");
+
+			if (members.Length > 1)
+				throw new LinqToDBException($"Ambiguous members '{memberName}' for type '{type.Name}' has been found");
+
+			var propInfo = members[0] as PropertyInfo;
+
+			if (propInfo != null)
+			{
+				var value = propInfo.GetValue(null, null);
+				if (value == null)
+					return null;
+
+				if (value is TExpression expression)
+					return expression;
+
+				throw new LinqToDBException($"Property '{memberName}' for type '{type.Name}' should return expression");
+			}
+			else
+			{
+				var method = members[0] as MethodInfo;
+				if (method != null)
+				{
+					if (method.GetParameters().Length > 0)
+						throw new LinqToDBException($"Method '{memberName}' for type '{type.Name}' should have no parameters");
+					var value = method.Invoke(null, Array<object>.Empty);
+					if (value == null)
+						return null;
+
+					if (value is TExpression expression)
+						return expression;
+
+					throw new LinqToDBException($"Method '{memberName}' for type '{type.Name}' should return expression");
+				}
+			}
+
+			throw new LinqToDBException(
+				$"Member '{memberName}' for type '{type.Name}' should be static property or method");
+		}
+	}
+}

--- a/Source/LinqToDB/Expressions/MappingExpressionsExtensions.cs
+++ b/Source/LinqToDB/Expressions/MappingExpressionsExtensions.cs
@@ -18,9 +18,7 @@ namespace LinqToDB.Extensions
 			if (members.Length > 1)
 				throw new LinqToDBException($"Ambiguous members '{memberName}' for type '{type.Name}' has been found");
 
-			var propInfo = members[0] as PropertyInfo;
-
-			if (propInfo != null)
+			if (members[0] is PropertyInfo propInfo)
 			{
 				var value = propInfo.GetValue(null, null);
 				if (value == null)
@@ -33,8 +31,7 @@ namespace LinqToDB.Extensions
 			}
 			else
 			{
-				var method = members[0] as MethodInfo;
-				if (method != null)
+				if (members[0] is MethodInfo method)
 				{
 					if (method.GetParameters().Length > 0)
 						throw new LinqToDBException($"Method '{memberName}' for type '{type.Name}' should have no parameters");

--- a/Source/LinqToDB/Linq/Builder/TableBuilder.TableContext.cs
+++ b/Source/LinqToDB/Linq/Builder/TableBuilder.TableContext.cs
@@ -179,7 +179,7 @@ namespace LinqToDB.Linq.Builder
 						if (member.MemberInfo.IsDynamicColumnPropertyEx())
 						{
 							var typeAcc = TypeAccessor.GetAccessor(member.MemberInfo.ReflectedTypeEx());
-							var setter  = new MemberAccessor(typeAcc, member.MemberInfo).SetterExpression;
+							var setter  = new MemberAccessor(typeAcc, member.MemberInfo, EntityDescriptor).SetterExpression;
 
 							exprs.Add(Expression.Invoke(setter, parentObject, ex));
 						}
@@ -1248,7 +1248,7 @@ namespace LinqToDB.Linq.Builder
 												Name             = fieldName,
 												PhysicalName     = fieldName,
 												ColumnDescriptor = new ColumnDescriptor(Builder.MappingSchema, new ColumnAttribute(fieldName),
-													new MemberAccessor(EntityDescriptor.TypeAccessor, memberExpression.Member))
+													new MemberAccessor(EntityDescriptor.TypeAccessor, memberExpression.Member, EntityDescriptor))
 											};
 
 											SqlTable.Add(newField);

--- a/Source/LinqToDB/Mapping/AssociationDescriptor.cs
+++ b/Source/LinqToDB/Mapping/AssociationDescriptor.cs
@@ -224,47 +224,7 @@ namespace LinqToDB.Mapping
 				throw new ArgumentException($"Member '{MemberInfo.Name}' has no declaring type");
 
 			if (!string.IsNullOrEmpty(ExpressionQueryMethod))
-			{
-				var members = type.GetStaticMembersEx(ExpressionQueryMethod);
-
-				if (members.Length == 0)
-					throw new LinqToDBException($"Static member '{ExpressionQueryMethod}' for type '{type.Name}' not found");
-
-				if (members.Length > 1)
-					throw new LinqToDBException($"Ambiguous members '{ExpressionQueryMethod}' for type '{type.Name}' has been found");
-
-				var propInfo = members[0] as PropertyInfo;
-
-				if (propInfo != null)
-				{
-					var value = propInfo.GetValue(null, null);
-					if (value == null)
-						return null;
-
-					queryExpression = value as Expression;
-					if (queryExpression == null)
-						throw new LinqToDBException($"Property '{ExpressionQueryMethod}' for type '{type.Name}' should return expression");
-				}
-				else
-				{
-					var method = members[0] as MethodInfo;
-					if (method != null)
-					{
-						if (method.GetParameters().Length > 0)
-							throw new LinqToDBException($"Method '{ExpressionQueryMethod}' for type '{type.Name}' should have no parameters");
-						var value = method.Invoke(null, Array<object>.Empty);
-						if (value == null)
-							return null;
-
-						queryExpression = value as Expression;
-						if (queryExpression == null)
-							throw new LinqToDBException($"Method '{ExpressionQueryMethod}' for type '{type.Name}' should return expression");
-					}
-				}
-				if (queryExpression == null)
-					throw new LinqToDBException(
-						$"Member '{ExpressionQueryMethod}' for type '{type.Name}' should be static property or method");
-			}
+				queryExpression = type.GetExpressionFromExpressionMember<Expression>(ExpressionQueryMethod);
 			else
 				queryExpression = ExpressionQuery;
 

--- a/Source/LinqToDB/Mapping/DynamicColumnAccessorAttribute.cs
+++ b/Source/LinqToDB/Mapping/DynamicColumnAccessorAttribute.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Linq.Expressions;
+
+namespace LinqToDB.Mapping
+{
+	/// <summary>
+	/// Configure setter and getter methods for dynamic columns.
+	/// </summary>
+	/// <remarks>
+	/// Expected signatures for getter and setter:
+	/// <code>
+	/// // should return true and value of property, if property value found in storage
+	/// // should return false if property value not found in storage
+	/// static object Getter(Entity object, string propertyName, object defaultValue);
+	/// // or
+	/// object this.Getter(string propertyName, object defaultValue);
+	/// // where defaultValue is default value for property type for current MappingSchema
+	/// 
+	/// static void Setter(Entity object, string propertyName, object value)
+	/// or
+	/// void this.Setter(string propertyName, object value)
+	/// </code>
+	/// </remarks>
+	/// <seealso cref="Attribute" />
+	[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+	public class DynamicColumnAccessorAttribute : Attribute
+	{
+		/// <summary>
+		/// Gets or sets mapping schema configuration name, for which this attribute should be taken into account.
+		/// <see cref="ProviderName"/> for standard names.
+		/// Attributes with <c>null</c> or empty string <see cref="Configuration"/> value applied to all configurations (if no attribute found for current configuration).
+		/// </summary>
+		public string Configuration          { get; set; }
+
+		/// <summary>
+		/// Gets or sets name of dynamic properties property setter method.
+		/// </summary>
+		public string SetterMethod           { get; set; }
+
+		/// <summary>
+		/// Gets or sets name of dynamic properties property getter method.
+		/// </summary>
+		public string GetterMethod           { get; set; }
+
+		/// <summary>
+		/// Gets or sets name of dynamic properties property setter expression method.
+		/// </summary>
+		public string SetterExpressionMethod { get; set; }
+
+		/// <summary>
+		/// Gets or sets name of dynamic properties property getter expression method.
+		/// </summary>
+		public string GetterExpressionMethod { get; set; }
+
+		/// <summary>
+		/// Gets or sets name of dynamic properties property set expression.
+		/// </summary>
+		public Expression SetterExpression   { get; set; }
+
+		/// <summary>
+		/// Gets or sets name of dynamic properties property get expression.
+		/// </summary>
+		public Expression GetterExpression   { get; set; }
+
+		protected internal void Validate()
+		{
+			var setters = 0;
+			var getters = 0;
+			if (SetterMethod           != null) setters++;
+			if (SetterExpressionMethod != null) setters++;
+			if (SetterExpression       != null) setters++;
+			if (GetterMethod           != null) getters++;
+			if (GetterExpressionMethod != null) getters++;
+			if (GetterExpression       != null) getters++;
+
+			if (setters != 1 || getters != 1)
+				throw new LinqToDBException($"{nameof(DynamicColumnAccessorAttribute)} should have exactly one setter and getter configured.");
+		}
+	}
+}

--- a/Source/LinqToDB/Mapping/DynamicColumnAccessorAttribute.cs
+++ b/Source/LinqToDB/Mapping/DynamicColumnAccessorAttribute.cs
@@ -23,44 +23,46 @@ namespace LinqToDB.Mapping
 	/// </remarks>
 	/// <seealso cref="Attribute" />
 	[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-	public class DynamicColumnAccessorAttribute : Attribute
+	public class DynamicColumnAccessorAttribute : Attribute, IConfigurationProvider
 	{
 		/// <summary>
 		/// Gets or sets mapping schema configuration name, for which this attribute should be taken into account.
 		/// <see cref="ProviderName"/> for standard names.
 		/// Attributes with <c>null</c> or empty string <see cref="Configuration"/> value applied to all configurations (if no attribute found for current configuration).
 		/// </summary>
-		public string Configuration          { get; set; }
+		public string Configuration              { get; set; }
 
 		/// <summary>
 		/// Gets or sets name of dynamic properties property setter method.
 		/// </summary>
-		public string SetterMethod           { get; set; }
+		public string SetterMethod               { get; set; }
 
 		/// <summary>
 		/// Gets or sets name of dynamic properties property getter method.
 		/// </summary>
-		public string GetterMethod           { get; set; }
+		public string GetterMethod               { get; set; }
 
 		/// <summary>
-		/// Gets or sets name of dynamic properties property setter expression method.
+		/// Gets or sets name of dynamic properties property setter expression method or property. Method or property
+		/// must be static.
 		/// </summary>
-		public string SetterExpressionMethod { get; set; }
+		public string SetterExpressionMethod     { get; set; }
 
 		/// <summary>
-		/// Gets or sets name of dynamic properties property getter expression method.
+		/// Gets or sets name of dynamic properties property getter expression method or property. Method or property
+		/// must be static.
 		/// </summary>
-		public string GetterExpressionMethod { get; set; }
+		public string GetterExpressionMethod     { get; set; }
 
 		/// <summary>
 		/// Gets or sets name of dynamic properties property set expression.
 		/// </summary>
-		public Expression SetterExpression   { get; set; }
+		public LambdaExpression SetterExpression { get; set; }
 
 		/// <summary>
 		/// Gets or sets name of dynamic properties property get expression.
 		/// </summary>
-		public Expression GetterExpression   { get; set; }
+		public LambdaExpression GetterExpression { get; set; }
 
 		protected internal void Validate()
 		{

--- a/Source/LinqToDB/Mapping/DynamicColumnsStoreAttribute.cs
+++ b/Source/LinqToDB/Mapping/DynamicColumnsStoreAttribute.cs
@@ -7,7 +7,7 @@ namespace LinqToDB.Mapping
 	/// </summary>
 	/// <seealso cref="System.Attribute" />
 	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-	public class DynamicColumnsStoreAttribute : Attribute
+	public class DynamicColumnsStoreAttribute : Attribute, IConfigurationProvider
 	{
 		/// <summary>
 		/// Gets or sets mapping schema configuration name, for which this attribute should be taken into account.

--- a/Source/LinqToDB/Mapping/EntityDescriptor.cs
+++ b/Source/LinqToDB/Mapping/EntityDescriptor.cs
@@ -8,6 +8,8 @@ namespace LinqToDB.Mapping
 	using Extensions;
 	using Linq;
 	using Reflection;
+	using System.Linq.Expressions;
+	using System.Reflection;
 
 	/// <summary>
 	/// Stores mapping entity descriptor.
@@ -21,13 +23,16 @@ namespace LinqToDB.Mapping
 		/// <param name="type">Mapping class type.</param>
 		public EntityDescriptor(MappingSchema mappingSchema, Type type)
 		{
-			TypeAccessor = TypeAccessor.GetAccessor(type);
-			Associations = new List<AssociationDescriptor>();
-			Columns = new List<ColumnDescriptor>();
+			MappingSchema = mappingSchema;
+			TypeAccessor  = TypeAccessor.GetAccessor(type);
+			Associations  = new List<AssociationDescriptor>();
+			Columns       = new List<ColumnDescriptor>();
 
-			Init(mappingSchema);
-			InitInheritanceMapping(mappingSchema);
+			Init();
+			InitInheritanceMapping();
 		}
+
+		internal MappingSchema MappingSchema { get; }
 
 		/// <summary>
 		/// Gets or sets mapping type accessor.
@@ -88,11 +93,6 @@ namespace LinqToDB.Mapping
 		public SkipModification SkipModificationFlags { get; private set; }
 
 		/// <summary>
-		/// Gets the dynamic columns store descriptor.
-		/// </summary>
-		public ColumnDescriptor DynamicColumnsStore { get; private set; }
-
-		/// <summary>
 		/// Gets list of column descriptors for current entity.
 		/// </summary>
 		public List<ColumnDescriptor> Columns { get; private set; }
@@ -136,9 +136,9 @@ namespace LinqToDB.Mapping
 		/// </summary>
 		internal bool HasComplexColumns { get; private set; }
 
-		void Init(MappingSchema mappingSchema)
+		void Init()
 		{
-			var ta = mappingSchema.GetAttribute<TableAttribute>(TypeAccessor.Type, a => a.Configuration);
+			var ta = MappingSchema.GetAttribute<TableAttribute>(TypeAccessor.Type, a => a.Configuration);
 
 			if (ta != null)
 			{
@@ -156,13 +156,15 @@ namespace LinqToDB.Mapping
 					TableName = TableName.Substring(1);
 			}
 
+			InitializeDynamicColumnsAccessors();
+
 			var attrs = new List<ColumnAttribute>();
 			var members = TypeAccessor.Members.Concat(
-				mappingSchema.GetDynamicColumns(ObjectType).Select(dc => new MemberAccessor(TypeAccessor, dc)));
+				MappingSchema.GetDynamicColumns(ObjectType).Select(dc => new MemberAccessor(TypeAccessor, dc, this)));
 
 			foreach (var member in members)
 			{
-				var aa = mappingSchema.GetAttribute<AssociationAttribute>(TypeAccessor.Type, member.MemberInfo, attr => attr.Configuration);
+				var aa = MappingSchema.GetAttribute<AssociationAttribute>(TypeAccessor.Type, member.MemberInfo, attr => attr.Configuration);
 
 				if (aa != null)
 				{
@@ -173,7 +175,7 @@ namespace LinqToDB.Mapping
 					continue;
 				}
 
-				var ca = mappingSchema.GetAttribute<ColumnAttribute>(TypeAccessor.Type, member.MemberInfo, attr => attr.Configuration);
+				var ca = MappingSchema.GetAttribute<ColumnAttribute>(TypeAccessor.Type, member.MemberInfo, attr => attr.Configuration);
 
 				if (ca != null)
 				{
@@ -185,23 +187,23 @@ namespace LinqToDB.Mapping
 						}
 						else
 						{
-							var cd = new ColumnDescriptor(mappingSchema, ca, member);
+							var cd = new ColumnDescriptor(MappingSchema, ca, member);
 							AddColumn(cd);
 							_columnNames.Add(member.Name, cd);
 						}
 					}
 				}
 				else if (
-					!IsColumnAttributeRequired && mappingSchema.IsScalarType(member.Type) ||
-					mappingSchema.GetAttribute<IdentityAttribute>(TypeAccessor.Type, member.MemberInfo, attr => attr.Configuration) != null ||
-					mappingSchema.GetAttribute<PrimaryKeyAttribute>(TypeAccessor.Type, member.MemberInfo, attr => attr.Configuration) != null)
+					!IsColumnAttributeRequired && MappingSchema.IsScalarType(member.Type) ||
+					MappingSchema.GetAttribute<IdentityAttribute>(TypeAccessor.Type, member.MemberInfo, attr => attr.Configuration) != null ||
+					MappingSchema.GetAttribute<PrimaryKeyAttribute>(TypeAccessor.Type, member.MemberInfo, attr => attr.Configuration) != null)
 				{
-					var cd = new ColumnDescriptor(mappingSchema, new ColumnAttribute(), member);
+					var cd = new ColumnDescriptor(MappingSchema, new ColumnAttribute(), member);
 					AddColumn(cd);
 					_columnNames.Add(member.Name, cd);
 				}
 
-				var caa = mappingSchema.GetAttribute<ColumnAliasAttribute>(TypeAccessor.Type, member.MemberInfo, attr => attr.Configuration);
+				var caa = MappingSchema.GetAttribute<ColumnAliasAttribute>(TypeAccessor.Type, member.MemberInfo, attr => attr.Configuration);
 
 				if (caa != null)
 				{
@@ -211,31 +213,25 @@ namespace LinqToDB.Mapping
 					Aliases.Add(member.Name, caa.MemberName);
 				}
 
-				var ma = mappingSchema.GetAttribute<ExpressionMethodAttribute>(TypeAccessor.Type, member.MemberInfo, attr => attr.Configuration);
+				var ma = MappingSchema.GetAttribute<ExpressionMethodAttribute>(TypeAccessor.Type, member.MemberInfo, attr => attr.Configuration);
 				if (ma != null && ma.IsColumn)
 				{
 					if (CalculatedMembers == null)
 						CalculatedMembers = new List<MemberAccessor>();
 					CalculatedMembers.Add(member);
 				}
-
-				// dynamic columns store property
-				var dcsProp = mappingSchema.GetAttribute<DynamicColumnsStoreAttribute>(TypeAccessor.Type, member.MemberInfo, attr => attr.Configuration);
-
-				if (dcsProp != null)
-					DynamicColumnsStore = new ColumnDescriptor(mappingSchema, new ColumnAttribute(member.Name), member);
 			}
 
-			var typeColumnAttrs = mappingSchema.GetAttributes<ColumnAttribute>(TypeAccessor.Type, a => a.Configuration);
+			var typeColumnAttrs = MappingSchema.GetAttributes<ColumnAttribute>(TypeAccessor.Type, a => a.Configuration);
 
 			foreach (var attr in typeColumnAttrs.Concat(attrs))
 				if (attr.IsColumn)
-					SetColumn(attr, mappingSchema);
+					SetColumn(attr);
 
 			SkipModificationFlags = Columns.Aggregate(SkipModification.None, (s, c) => s | c.SkipModificationFlags);
 		}
 
-		void SetColumn(ColumnAttribute attr, MappingSchema mappingSchema)
+		void SetColumn(ColumnAttribute attr)
 		{
 			if (attr.MemberName == null)
 				throw new LinqToDBException($"The Column attribute of the '{TypeAccessor.Type}' type must have MemberName.");
@@ -243,7 +239,7 @@ namespace LinqToDB.Mapping
 			if (attr.MemberName.IndexOf('.') < 0)
 			{
 				var ex = TypeAccessor[attr.MemberName];
-				var cd = new ColumnDescriptor(mappingSchema, attr, ex);
+				var cd = new ColumnDescriptor(MappingSchema, attr, ex);
 
 				if (_columnNames.Remove(attr.MemberName))
 					Columns.RemoveAll(c => c.MemberName == attr.MemberName);
@@ -253,7 +249,7 @@ namespace LinqToDB.Mapping
 			}
 			else
 			{
-				var cd = new ColumnDescriptor(mappingSchema, attr, new MemberAccessor(TypeAccessor, attr.MemberName));
+				var cd = new ColumnDescriptor(MappingSchema, attr, new MemberAccessor(TypeAccessor, attr.MemberName, this));
 
 				if (!string.IsNullOrWhiteSpace(attr.MemberName))
 				{
@@ -285,9 +281,9 @@ namespace LinqToDB.Mapping
 			}
 		}
 
-		internal void InitInheritanceMapping(MappingSchema mappingSchema)
+		internal void InitInheritanceMapping()
 		{
-			var mappingAttrs = mappingSchema.GetAttributes<InheritanceMappingAttribute>(ObjectType, a => a.Configuration, false);
+			var mappingAttrs = MappingSchema.GetAttributes<InheritanceMappingAttribute>(ObjectType, a => a.Configuration, false);
 			var result = new List<InheritanceMapping>(mappingAttrs.Length);
 
 			if (mappingAttrs.Length > 0)
@@ -303,7 +299,7 @@ namespace LinqToDB.Mapping
 
 					var ed = mapping.Type.Equals(ObjectType)
 						? this
-						: mappingSchema.GetEntityDescriptor(mapping.Type);
+						: MappingSchema.GetEntityDescriptor(mapping.Type);
 
 					//foreach (var column in this.Columns)
 					//{
@@ -345,5 +341,198 @@ namespace LinqToDB.Mapping
 			if (columnDescriptor.MemberAccessor.IsComplex)
 				HasComplexColumns = true;
 		}
+
+		#region Dynamic Columns
+		/// <summary>
+		/// Gets the dynamic columns store descriptor.
+		/// </summary>
+		public ColumnDescriptor   DynamicColumnsStore { get; private set; }
+
+		/// <summary>
+		/// Gets or sets optional dynamic column value getter expression with following signature:
+		/// <code>
+		/// object Getter(TEntity entity, string propertyName, object defaultValue);
+		/// </code>
+		/// </summary>
+		internal LambdaExpression DynamicColumnGetter { get; private set; }
+
+		/// <summary>
+		/// Gets or sets optional dynamic column value setter expression with following signature:
+		/// <code>
+		/// void Setter(TEntity entity, string propertyName, object value);
+		/// </code>
+		/// </summary>
+		internal LambdaExpression DynamicColumnSetter { get; private set; }
+
+		private void InitializeDynamicColumnsAccessors()
+		{
+			// initialize dynamic columns store accessors
+			var dynamicStoreAttributes = new List<IConfigurationProvider>();
+			var accessors = MappingSchema.GetAttribute<DynamicColumnAccessorAttribute>(TypeAccessor.Type, attr => attr.Configuration);
+			if (accessors != null)
+			{
+				dynamicStoreAttributes.Add(accessors);
+			}
+			var storeMembers = new Dictionary<DynamicColumnsStoreAttribute, MemberAccessor>();
+
+			foreach (var member in TypeAccessor.Members)
+			{
+				// dynamic columns store property
+				var dcsProp = MappingSchema.GetAttribute<DynamicColumnsStoreAttribute>(TypeAccessor.Type, member.MemberInfo, attr => attr.Configuration);
+
+				if (dcsProp != null)
+				{
+					dynamicStoreAttributes.Add(dcsProp);
+					storeMembers.Add(dcsProp, member);
+				}
+			}
+
+			if (dynamicStoreAttributes.Count > 0)
+			{
+				IConfigurationProvider dynamicStoreAttribute;
+				if (dynamicStoreAttributes.Count > 1)
+				{
+					var orderedAttributes = MappingSchema.SortByConfiguration(attr => attr.Configuration, dynamicStoreAttributes).ToArray();
+
+					if (orderedAttributes[1].Configuration == orderedAttributes[0].Configuration)
+						throw new LinqToDBException($"Multiple dynamic store configuration attributes with same configuration found for {TypeAccessor.Type}");
+
+					dynamicStoreAttribute = orderedAttributes[0];
+				}
+				else
+					dynamicStoreAttribute = dynamicStoreAttributes[0];
+
+				var objParam          = Expression.Parameter(TypeAccessor.Type, "obj");
+				var propNameParam     = Expression.Parameter(typeof(string), "propertyName");
+				var defaultValueParam = Expression.Parameter(typeof(object), "defaultValue");
+				var valueParam        = Expression.Parameter(typeof(object), "value");
+
+				if (dynamicStoreAttribute is DynamicColumnsStoreAttribute storeAttribute)
+				{
+					var member          = storeMembers[storeAttribute];
+					DynamicColumnsStore = new ColumnDescriptor(MappingSchema, new ColumnAttribute(member.Name), member);
+
+					// getter expression
+					var storageType = member.MemberInfo.GetMemberType();
+					var storedType  = storageType.GetGenericArguments()[1];
+					var outVar      = Expression.Variable(storedType);
+
+					var tryGetValueMethodInfo = storageType.GetMethod("TryGetValue");
+
+					if (tryGetValueMethodInfo == null)
+						throw new LinqToDBException("Storage property do not have method 'TryGetValue'");
+
+					// get value via "Item" accessor; we're not null-checking
+					DynamicColumnGetter =
+						Expression.Lambda(
+							Expression.Block(
+								new[] { outVar },
+								Expression.IfThen(
+									Expression.Not(
+										Expression.Call(
+											Expression.MakeMemberAccess(
+												objParam,
+												member.MemberInfo),
+											tryGetValueMethodInfo,
+											propNameParam,
+											outVar)),
+									Expression.Assign(outVar, defaultValueParam)),
+								outVar),
+							objParam,
+							propNameParam,
+							defaultValueParam);
+
+					// if null, create new dictionary; then assign value
+					DynamicColumnSetter =
+						Expression.Lambda(
+							Expression.Block(
+								Expression.IfThen(
+									Expression.ReferenceEqual(
+										Expression.MakeMemberAccess(objParam, member.MemberInfo),
+										Expression.Constant(null)),
+									Expression.Assign(
+										Expression.MakeMemberAccess(objParam, member.MemberInfo),
+										Expression.New(typeof(Dictionary<string, object>)))),
+								Expression.Assign(
+									Expression.Property(
+										Expression.MakeMemberAccess(objParam, member.MemberInfo),
+										"Item",
+										propNameParam),
+									Expression.Convert(valueParam, typeof(object)))),
+							objParam,
+							propNameParam,
+							valueParam);
+				}
+				else
+				{
+					var accessorsAttribute = (DynamicColumnAccessorAttribute)dynamicStoreAttribute;
+
+					if (accessorsAttribute.GetterMethod != null)
+					{
+						var mi = TypeAccessor.Type.GetMethod(accessorsAttribute.GetterMethod, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+
+						if (mi.IsStatic)
+							DynamicColumnGetter =
+								Expression.Lambda(
+									Expression.Call(
+										mi,
+										objParam,
+										propNameParam,
+										defaultValueParam),
+									objParam,
+									propNameParam,
+									defaultValueParam);
+						else
+							DynamicColumnGetter =
+								Expression.Lambda(
+									Expression.Call(
+										objParam,
+										mi,
+										propNameParam,
+										defaultValueParam),
+									objParam,
+									propNameParam,
+									defaultValueParam);
+					}
+					else if (accessorsAttribute.GetterExpressionMethod != null)
+						DynamicColumnGetter = TypeAccessor.Type.GetExpressionFromExpressionMember<LambdaExpression>(accessorsAttribute.GetterExpressionMethod);
+					else
+						DynamicColumnGetter = accessorsAttribute.GetterExpression;
+
+					if (accessorsAttribute.SetterMethod != null)
+					{
+						var mi = TypeAccessor.Type.GetMethod(accessorsAttribute.SetterMethod, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+
+						if (mi.IsStatic)
+							DynamicColumnSetter =
+								Expression.Lambda(
+									Expression.Call(
+										mi,
+										objParam,
+										propNameParam,
+										valueParam),
+									objParam,
+									propNameParam,
+									valueParam);
+						else
+							DynamicColumnSetter =
+								Expression.Lambda(
+									Expression.Call(
+										objParam,
+										mi,
+										propNameParam,
+										valueParam),
+									objParam,
+									propNameParam,
+									valueParam);
+					}
+					else if (accessorsAttribute.SetterExpressionMethod != null)
+						DynamicColumnSetter = TypeAccessor.Type.GetExpressionFromExpressionMember<LambdaExpression>(accessorsAttribute.SetterExpressionMethod);
+					else
+						DynamicColumnSetter = accessorsAttribute.SetterExpression;
+				}
+			}
+		}
+		#endregion
 	}
 }

--- a/Source/LinqToDB/Mapping/EntityMappingBuilder.cs
+++ b/Source/LinqToDB/Mapping/EntityMappingBuilder.cs
@@ -533,10 +533,12 @@ namespace LinqToDB.Mapping
 		/// </summary>
 		/// <param name="func">Column mapping property or field getter expression.</param>
 		/// <returns>Returns fluent property mapping builder.</returns>
-		public PropertyMappingBuilder<T> DynamicColumnsStore(Expression<Func<T, object>> func)
+		public EntityMappingBuilder<T> DynamicColumnsStore(Expression<Func<T, object>> func)
 		{
-			return new PropertyMappingBuilder<T>(this, func)
+			Member(func)
 				.HasAttribute(new DynamicColumnsStoreAttribute() { Configuration = Configuration });
+
+			return this;
 		}
 
 		public EntityMappingBuilder<T> DynamicPropertyAccessors(

--- a/Source/LinqToDB/Mapping/EntityMappingBuilder.cs
+++ b/Source/LinqToDB/Mapping/EntityMappingBuilder.cs
@@ -527,6 +527,36 @@ namespace LinqToDB.Mapping
 			return this;
 		}
 
+		#region Dynamic Properties
+		/// <summary>
+		/// Adds dynamic columns store dictionary member mapping to current entity.
+		/// </summary>
+		/// <param name="func">Column mapping property or field getter expression.</param>
+		/// <returns>Returns fluent property mapping builder.</returns>
+		public PropertyMappingBuilder<T> DynamicColumnsStore(Expression<Func<T, object>> func)
+		{
+			return new PropertyMappingBuilder<T>(this, func)
+				.HasAttribute(new DynamicColumnsStoreAttribute() { Configuration = Configuration });
+		}
+
+		public EntityMappingBuilder<T> DynamicPropertyAccessors(
+			Expression<Func<T, string, object, object>> getter,
+			Expression<Action<T, string, object>> setter)
+		{
+			_builder.HasAttribute(
+				typeof(T),
+				new DynamicColumnAccessorAttribute()
+				{
+					GetterExpression = getter,
+					SetterExpression = setter,
+					Configuration = Configuration
+				});
+
+			return this;
+		}
+
+		#endregion
+
 		EntityMappingBuilder<T> SetTable(Action<TableAttribute> setColumn)
 		{
 			return SetAttribute(

--- a/Source/LinqToDB/Mapping/IConfigurationProvider.cs
+++ b/Source/LinqToDB/Mapping/IConfigurationProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace LinqToDB.Mapping
+{
+	internal interface IConfigurationProvider
+	{
+		string Configuration { get; set; }
+	}
+}

--- a/Source/LinqToDB/Mapping/MappingSchema.cs
+++ b/Source/LinqToDB/Mapping/MappingSchema.cs
@@ -1559,5 +1559,17 @@ namespace LinqToDB.Mapping
 		}
 
 		#endregion
+
+		internal IEnumerable<T> SortByConfiguration<T>(Func<T, string> configGetter, IEnumerable<T> values)
+		{
+			return values
+				.Select(val => new
+				{
+					Value = val,
+					Order = Array.IndexOf(ConfigurationList, configGetter(val)) == -1 ? ConfigurationList.Length : Array.IndexOf(ConfigurationList, configGetter(val))
+				})
+				.OrderBy(_ => _.Order)
+				.Select(_ => _.Value);
+		}
 	}
 }

--- a/Source/LinqToDB/Reflection/MemberAccessor.cs
+++ b/Source/LinqToDB/Reflection/MemberAccessor.cs
@@ -306,7 +306,7 @@ namespace LinqToDB.Reflection
 			}
 		}
 
-		static MethodInfo _throwOnDynamicStoreMissingMethod = typeof(MemberAccessor).GetMethod(nameof(ThrowOnDynamicStoreMissing), BindingFlags.Static | BindingFlags.NonPublic);
+		static MethodInfo _throwOnDynamicStoreMissingMethod = MemberHelper.MethodOf(() => ThrowOnDynamicStoreMissing<int>()).GetGenericMethodDefinition();
 		static T ThrowOnDynamicStoreMissing<T>()
 		{
 			throw new ArgumentException("Tried getting dynamic column value, without setting dynamic column store on type.");

--- a/Source/LinqToDB/Reflection/MemberAccessor.cs
+++ b/Source/LinqToDB/Reflection/MemberAccessor.cs
@@ -217,7 +217,7 @@ namespace LinqToDB.Reflection
 							ed.DynamicColumnGetter.GetBody(
 								objParam,
 								Expression.Constant(memberInfo.Name),
-								new DefaultValueExpression(ed.MappingSchema, Type)),
+								Expression.Convert(new DefaultValueExpression(ed.MappingSchema, Type), typeof(object))),
 							Type),
 						objParam);
 				}

--- a/Source/LinqToDB/Reflection/MemberAccessor.cs
+++ b/Source/LinqToDB/Reflection/MemberAccessor.cs
@@ -17,13 +17,13 @@ namespace LinqToDB.Reflection
 			typeof(ArgumentException).GetConstructor(new[] {typeof(string)}) ??
 				throw new Exception($"Can not retrieve information about constructor for {nameof(ArgumentException)}");
 
-		internal MemberAccessor(TypeAccessor typeAccessor, string memberName)
+		internal MemberAccessor(TypeAccessor typeAccessor, string memberName, EntityDescriptor ed)
 		{
 			TypeAccessor = typeAccessor;
 
 			if (memberName.IndexOf('.') < 0)
 			{
-				SetSimple(Expression.PropertyOrField(Expression.Constant(null, typeAccessor.Type), memberName).Member);
+				SetSimple(Expression.PropertyOrField(Expression.Constant(null, typeAccessor.Type), memberName).Member, ed);
 			}
 			else
 			{
@@ -83,7 +83,7 @@ namespace LinqToDB.Reflection
 
 						expr = Expression.Block(
 							new[] { ret },
-							Expression.Assign(ret, new DefaultValueExpression(MappingSchema.Default, Type)),
+							Expression.Assign(ret, new DefaultValueExpression(ed?.MappingSchema ?? MappingSchema.Default, Type)),
 							MakeGetter(objParam, 0),
 							ret);
 					}
@@ -176,15 +176,15 @@ namespace LinqToDB.Reflection
 			SetExpressions();
 		}
 
-		public MemberAccessor(TypeAccessor typeAccessor, MemberInfo memberInfo)
+		public MemberAccessor(TypeAccessor typeAccessor, MemberInfo memberInfo, EntityDescriptor ed)
 		{
 			TypeAccessor = typeAccessor;
 
-			SetSimple(memberInfo);
+			SetSimple(memberInfo, ed);
 			SetExpressions();
 		}
 
-		void SetSimple(MemberInfo memberInfo)
+		void SetSimple(MemberInfo memberInfo, EntityDescriptor ed)
 		{
 			MemberInfo = memberInfo;
 			Type       = MemberInfo is PropertyInfo propertyInfo ? propertyInfo.PropertyType : ((FieldInfo)MemberInfo).FieldType;
@@ -202,88 +202,58 @@ namespace LinqToDB.Reflection
 
 			var objParam   = Expression.Parameter(TypeAccessor.Type, "obj");
 			var valueParam = Expression.Parameter(Type, "value");
+			var getterType = typeof(Func<,>).MakeGenericType(TypeAccessor.Type, Type);
+			var setterType = typeof(Action<,>).MakeGenericType(TypeAccessor.Type, Type);
 
 			if (HasGetter && memberInfo.IsDynamicColumnPropertyEx())
 			{
 				IsComplex = true;
 
-				if (TypeAccessor.DynamicColumnsStoreAccessor != null)
+				if (ed?.DynamicColumnGetter != null)
 				{
-					// get value via "Item" accessor; we're not null-checking
-
-					var storageType = TypeAccessor.DynamicColumnsStoreAccessor.MemberInfo.GetMemberType();
-					var storedType  = storageType.GetGenericArguments()[1];
-					var outVar      = Expression.Variable(storedType);
-					var resultVar   = Expression.Variable(Type);
-
-					MethodInfo tryGetValueMethodInfo = storageType.GetMethod("TryGetValue");
-
-					if (tryGetValueMethodInfo == null)
-						throw new LinqToDBException("Storage property do not have method 'TryGetValue'");
-
-					GetterExpression =
-						Expression.Lambda(
-							Expression.Block(
-								new[] { outVar, resultVar },
-								Expression.IfThenElse(
-									Expression.Call(
-										Expression.MakeMemberAccess(objParam,
-											TypeAccessor.DynamicColumnsStoreAccessor.MemberInfo),
-										tryGetValueMethodInfo,
-										Expression.Constant(memberInfo.Name), outVar),
-									Expression.Assign(resultVar, Expression.Convert(outVar, Type)),
-									Expression.Assign(resultVar,
-										new DefaultValueExpression(MappingSchema.Default, Type))
-								),
-								resultVar
-							),
-							objParam);
+					GetterExpression = Expression.Lambda(
+						getterType,
+						Expression.Convert(
+							ed.DynamicColumnGetter.GetBody(
+								objParam,
+								Expression.Constant(memberInfo.Name),
+								new DefaultValueExpression(ed.MappingSchema, Type)),
+							Type),
+						objParam);
 				}
 				else
 					// dynamic columns store was not provided, throw exception when accessed
+					// @mace_windu: why not throw it immediately? Fail fast
 					GetterExpression = Expression.Lambda(
-						Expression.Throw(
-							Expression.New(
-								ArgumentExceptionConstructorInfo,
-								Expression.Constant("Tried getting dynamic column value, without setting dynamic column store on type."))),
+						getterType,
+						Expression.Call(_throwOnDynamicStoreMissingMethod.MakeGenericMethod(Type)),
 						objParam);
 			}
 			else if (HasGetter)
-			{
-				GetterExpression = Expression.Lambda(Expression.MakeMemberAccess(objParam, memberInfo), objParam);
-			}
+				GetterExpression = Expression.Lambda(getterType, Expression.MakeMemberAccess(objParam, memberInfo), objParam);
 			else
-			{
-				GetterExpression = Expression.Lambda(new DefaultValueExpression(MappingSchema.Default, Type), objParam);
-			}
+				GetterExpression = Expression.Lambda(getterType, new DefaultValueExpression(ed?.MappingSchema ?? MappingSchema.Default, Type), objParam);
 
 			if (HasSetter && memberInfo.IsDynamicColumnPropertyEx())
 			{
 				IsComplex = true;
 
-				if (TypeAccessor.DynamicColumnsStoreAccessor != null)
-					// if null, create new dictionary; then assign value
-					SetterExpression =
-						Expression.Lambda(
-							Expression.Block(
-								Expression.IfThen(
-									Expression.ReferenceEqual(
-										Expression.MakeMemberAccess(objParam, TypeAccessor.DynamicColumnsStoreAccessor.MemberInfo),
-										Expression.Constant(null)),
-									Expression.Assign(
-										Expression.MakeMemberAccess(objParam, TypeAccessor.DynamicColumnsStoreAccessor.MemberInfo),
-										Expression.New(typeof(Dictionary<string, object>)))),
-								Expression.Assign(
-									Expression.Property(
-										Expression.MakeMemberAccess(objParam, TypeAccessor.DynamicColumnsStoreAccessor.MemberInfo),
-										"Item",
-										Expression.Constant(memberInfo.Name)),
-									Expression.Convert(valueParam, typeof(object)))),
+				if (ed?.DynamicColumnSetter != null)
+				{
+					SetterExpression = Expression.Lambda(
+						setterType,
+						ed.DynamicColumnSetter.GetBody(
 							objParam,
-							valueParam);
+							Expression.Constant(memberInfo.Name),
+							valueParam),
+						objParam,
+						valueParam);
+				}
 				else
 					// dynamic columns store was not provided, throw exception when accessed
-					GetterExpression = Expression.Lambda(
+					// @mace_windu: why not throw it immediately? Fail fast
+					SetterExpression = Expression.Lambda(
+						setterType,
 						Expression.Block(
 							Expression.Throw(
 								Expression.New(
@@ -296,17 +266,17 @@ namespace LinqToDB.Reflection
 
 			}
 			else if (HasSetter)
-			{
 				SetterExpression = Expression.Lambda(
+					setterType,
 					Expression.Assign(Expression.MakeMemberAccess(objParam, memberInfo), valueParam),
 					objParam,
 					valueParam);
-			}
 			else
 			{
 				var fakeParam = Expression.Parameter(typeof(int));
 
 				SetterExpression = Expression.Lambda(
+					setterType,
 					Expression.Block(
 						new[] { fakeParam },
 						new Expression[] { Expression.Assign(fakeParam, Expression.Constant(0)) }),
@@ -334,6 +304,13 @@ namespace LinqToDB.Reflection
 
 				Setter = setter.Compile();
 			}
+		}
+
+		static MethodInfo _throwOnDynamicStoreMissingMethod = typeof(MemberAccessor).GetMethod(nameof(ThrowOnDynamicStoreMissing), BindingFlags.Static | BindingFlags.NonPublic);
+		static T ThrowOnDynamicStoreMissing<T>()
+		{
+			throw new ArgumentException("Tried getting dynamic column value, without setting dynamic column store on type.");
+
 		}
 
 		#region Public Properties

--- a/Source/LinqToDB/Reflection/TypeAccessor.cs
+++ b/Source/LinqToDB/Reflection/TypeAccessor.cs
@@ -16,7 +16,7 @@ namespace LinqToDB.Reflection
 		{
 			if (member == null) throw new ArgumentNullException("member");
 
-			_members.Add(member);
+			Members.Add(member);
 			_membersByName[member.MemberInfo.Name] = member;
 		}
 
@@ -40,20 +40,14 @@ namespace LinqToDB.Reflection
 
 		#region Public Members
 
-		public IObjectFactory          ObjectFactory               { get; set; }
-		public abstract Type           Type                        { get; }
-
-		/// <summary>
-		/// Gets the dynamic columns store accessor.
-		/// </summary>
-		public abstract MemberAccessor DynamicColumnsStoreAccessor { get; }
+		public IObjectFactory          ObjectFactory { get; set; }
+		public abstract Type           Type          { get; }
 
 		#endregion
 
 		#region Items
 
-		readonly List<MemberAccessor> _members = new List<MemberAccessor>();
-		public   List<MemberAccessor>  Members => _members;
+		public List<MemberAccessor>    Members       { get; } = new List<MemberAccessor>();
 
 		readonly ConcurrentDictionary<string,MemberAccessor> _membersByName = new ConcurrentDictionary<string,MemberAccessor>();
 
@@ -63,14 +57,14 @@ namespace LinqToDB.Reflection
 			{
 				return _membersByName.GetOrAdd(memberName, name =>
 				{
-					var ma = new MemberAccessor(this, name);
+					var ma = new MemberAccessor(this, name, null);
 					Members.Add(ma);
 					return ma;
 				});
 			}
 		}
 
-		public MemberAccessor this[int index] => _members[index];
+		public MemberAccessor this[int index] => Members[index];
 
 		#endregion
 

--- a/Source/LinqToDB/Reflection/TypeAccessorT.cs
+++ b/Source/LinqToDB/Reflection/TypeAccessorT.cs
@@ -94,15 +94,9 @@ namespace LinqToDB.Reflection
 
 		internal TypeAccessor()
 		{
-			// set DynamicColumnStoreAccessor
-			var columnStoreProperty = typeof(T).GetMembers().FirstOrDefault(m => m.GetCustomAttributes<DynamicColumnsStoreAttribute>().Any());
-
-			if (columnStoreProperty != null)
-				DynamicColumnsStoreAccessor = new MemberAccessor(this, columnStoreProperty);
-
 			// init members
 			foreach (var member in _members)
-				AddMember(new MemberAccessor(this, member));
+				AddMember(new MemberAccessor(this, member, null));
 
 			ObjectFactory = _objectFactory;
 		}
@@ -119,8 +113,5 @@ namespace LinqToDB.Reflection
 		}
 
 		public override Type Type { get { return typeof(T); } }
-
-		/// <inheritdoc cref="TypeAccessor.DynamicColumnsStoreAccessor"/>
-		public override MemberAccessor DynamicColumnsStoreAccessor { get; }
 	}
 }

--- a/Tests/Linq/Mapping/DynamicStoreTests.cs
+++ b/Tests/Linq/Mapping/DynamicStoreTests.cs
@@ -1,0 +1,736 @@
+﻿using LinqToDB;
+using LinqToDB.Mapping;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Tests.Mapping
+{
+	[TestFixture]
+	public class DynamicStoreTests : TestBase
+	{
+		[Table("DynamicColumnsTestTable")]
+		class DynamicColumnsTestFullTable
+		{
+			[Column]
+			public int Id { get; set; }
+
+			[Column]
+			public string Name { get; set; }
+		}
+
+		[Table("DynamicColumnsTestTable")]
+		class FluentMetadataBasedStore
+		{
+			public int Id { get; set; }
+
+			public Dictionary<string, object> Values { get; set; } = new Dictionary<string, object>();
+
+			public Dictionary<string, object> SQLiteValues { get; set; } = new Dictionary<string, object>();
+		}
+
+		[Table("DynamicColumnsTestTable")]
+		class AttributeMetadataBasedStore
+		{
+			[Column]
+			public int Id { get; set; }
+
+			[DynamicColumnsStore]
+			public Dictionary<string, object> Values { get; set; } = new Dictionary<string, object>();
+
+			[DynamicColumnsStore(Configuration = ProviderName.SQLite)]
+			public Dictionary<string, object> SQLiteValues { get; set; } = new Dictionary<string, object>();
+		}
+
+		[Table("DynamicColumnsTestTable")]
+		class CustomSetterGetterBase
+		{
+			[Column]
+			public int Id { get; set; }
+
+			public Dictionary<string, object> Values { get; set; } = new Dictionary<string, object>();
+
+			public Dictionary<string, object> SQLiteValues { get; set; } = new Dictionary<string, object>();
+		}
+
+		[DynamicColumnAccessor(GetterMethod = nameof(GetProperty), SetterMethod = nameof(SetProperty))]
+		class InstanceGetterSetterMethods : CustomSetterGetterBase
+		{
+			public object GetProperty(string name, object defaultValue)
+			{
+				if (!Values.TryGetValue(name, out object value))
+					value = defaultValue;
+
+				return value;
+			}
+
+			public void SetProperty(string name, object value)
+			{
+				Values[name] = value;
+			}
+		}
+
+		[DynamicColumnAccessor(GetterMethod = nameof(GetProperty), SetterMethod = nameof(SetProperty))]
+		class StaticGetterSetterMethods : CustomSetterGetterBase
+		{
+			public static Dictionary<int, Dictionary<string, object>> InstanceValues { get; set; } = new Dictionary<int, Dictionary<string, object>>();
+
+			public static object GetProperty(StaticGetterSetterMethods instance, string name, object defaultValue)
+			{
+				if (!InstanceValues.ContainsKey(instance.Id))
+					return defaultValue;
+
+				if (!InstanceValues[instance.Id].TryGetValue(name, out var value))
+					value = defaultValue;
+
+				return value;
+			}
+
+			public static void SetProperty(StaticGetterSetterMethods instance, string name, object value)
+			{
+				if (!InstanceValues.ContainsKey(instance.Id))
+				{
+					InstanceValues.Add(instance.Id, new Dictionary<string, object>());
+				}
+
+				InstanceValues[instance.Id][name] = value;
+			}
+		}
+
+		[DynamicColumnAccessor(GetterExpressionMethod = nameof(GetPropertyExpression), SetterExpressionMethod =nameof(SetPropertyExpression))]
+		class InstanceGetterSetterExpressionMethods : CustomSetterGetterBase
+		{
+			public static Expression<Func<InstanceGetterSetterExpressionMethods, string, object, object>> GetPropertyExpression()
+			{
+				return (instance, name, defaultValue) => instance.GetProperty(name, defaultValue);
+			}
+
+			public static Expression<Action<InstanceGetterSetterMethods, string, object>> SetPropertyExpression()
+			{
+				return (instance, name, value) => instance.SetProperty(name, value);
+			}
+
+			public object GetProperty(string name, object defaultValue)
+			{
+				if (!Values.TryGetValue(name, out var value))
+					value = defaultValue;
+
+				return value;
+			}
+
+			public void SetProperty(string name, object value)
+			{
+				Values[name] = value;
+			}
+		}
+
+		[DynamicColumnAccessor(GetterExpressionMethod = nameof(GetPropertyExpression), SetterExpressionMethod = nameof(SetPropertyExpression))]
+		class StaticGetterSetterExpressionMethods : CustomSetterGetterBase
+		{
+			public static Dictionary<int, Dictionary<string, object>> InstanceValues { get; set; } = new Dictionary<int, Dictionary<string, object>>();
+
+			public static Expression<Func<StaticGetterSetterExpressionMethods, string, object, object>> GetPropertyExpression()
+			{
+				return (instance, name, defaultValue) => GetProperty(instance, name, defaultValue);
+			}
+
+			public static Expression<Action<StaticGetterSetterExpressionMethods, string, object>> SetPropertyExpression()
+			{
+				return (instance, name, value) => SetProperty(instance, name, value);
+			}
+
+			public static object GetProperty(StaticGetterSetterExpressionMethods instance, string name, object defaultValue)
+			{
+				if (!InstanceValues.ContainsKey(instance.Id))
+					return defaultValue;
+
+				if (!InstanceValues[instance.Id].TryGetValue(name, out var value))
+					value = defaultValue;
+
+				return value;
+			}
+
+			public static void SetProperty(StaticGetterSetterExpressionMethods instance, string name, object value)
+			{
+				if (!InstanceValues.ContainsKey(instance.Id))
+				{
+					InstanceValues.Add(instance.Id, new Dictionary<string, object>());
+				}
+
+				InstanceValues[instance.Id][name] = value;
+			}
+		}
+
+		[DynamicColumnAccessor(GetterMethod = nameof(GetProperty), SetterMethod = nameof(SetProperty))]
+		[DynamicColumnAccessor(GetterMethod = nameof(GetSQLiteProperty), SetterMethod = nameof(SetSQLiteProperty), Configuration = ProviderName.SQLite)]
+		class SQLiteInstanceGetterSetterMethods : CustomSetterGetterBase
+		{
+			public object GetSQLiteProperty(string name, object defaultValue)
+			{
+				if (!SQLiteValues.TryGetValue(name, out object value))
+					value = defaultValue;
+
+				return value;
+			}
+
+			public void SetSQLiteProperty(string name, object value)
+			{
+				SQLiteValues[name] = value;
+			}
+
+			public object GetProperty(string name, object defaultValue)
+			{
+				if (!Values.TryGetValue(name, out object value))
+					value = defaultValue;
+
+				return value;
+			}
+
+			public void SetProperty(string name, object value)
+			{
+				Values[name] = value;
+			}
+		}
+
+		[Table("DynamicColumnsTestTable")]
+		[DynamicColumnAccessor(GetterMethod = nameof(GetSQLiteProperty), SetterMethod = nameof(SetSQLiteProperty), Configuration = ProviderName.SQLite)]
+		class GetterSetterVsStorageMethods1
+		{
+			[Column]
+			public int Id { get; set; }
+
+			[DynamicColumnsStore]
+			public Dictionary<string, object> Values { get; set; } = new Dictionary<string, object>();
+
+			public Dictionary<string, object> SQLiteValues { get; set; } = new Dictionary<string, object>();
+
+			public object GetSQLiteProperty(string name, object defaultValue)
+			{
+				if (!SQLiteValues.TryGetValue(name, out object value))
+					value = defaultValue;
+
+				return value;
+			}
+
+			public void SetSQLiteProperty(string name, object value)
+			{
+				SQLiteValues[name] = value;
+			}
+		}
+
+		[Table("DynamicColumnsTestTable")]
+		[DynamicColumnAccessor(GetterMethod = nameof(GetProperty), SetterMethod = nameof(SetProperty))]
+		class GetterSetterVsStorageMethods2
+		{
+			[Column]
+			public int Id { get; set; }
+
+			[DynamicColumnsStore(Configuration = "Unknown")]
+			public Dictionary<string, object> Values { get; set; } = new Dictionary<string, object>();
+
+			[DynamicColumnsStore(Configuration = ProviderName.SQLite)]
+			public Dictionary<string, object> SQLiteValues { get; set; } = new Dictionary<string, object>();
+
+			public object GetProperty(string name, object defaultValue)
+			{
+				if (!Values.TryGetValue(name, out object value))
+					value = defaultValue;
+
+				return value;
+			}
+
+			public void SetProperty(string name, object value)
+			{
+				Values[name] = value;
+			}
+		}
+
+		[Table("DynamicColumnsTestTable")]
+		[DynamicColumnAccessor(GetterMethod = nameof(GetProperty), SetterMethod = nameof(SetProperty))]
+		class GetterSetterVsStorageMethodsConflict
+		{
+			[Column]
+			public int Id { get; set; }
+
+			[DynamicColumnsStore]
+			public Dictionary<string, object> Values { get; set; } = new Dictionary<string, object>();
+
+			public object GetProperty(string name, object defaultValue)
+			{
+				if (!Values.TryGetValue(name, out object value))
+					value = defaultValue;
+
+				return value;
+			}
+
+			public void SetProperty(string name, object value)
+			{
+				Values[name] = value;
+			}
+		}
+
+		[Test]
+		public void TestDynamicColumnStoreFromMetadataReader([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			var ms = new MappingSchema();
+
+			var builder = ms.GetFluentMappingBuilder();
+			builder.Entity<FluentMetadataBasedStore>()
+				.HasColumn(e => e.Id)
+				.Property(x => Sql.Property<string>(x, "Name"))
+				.Member(e => e.Values).HasAttribute(new DynamicColumnsStoreAttribute());
+
+			using (var db = GetDataContext(context, ms))
+			using (db.CreateLocalTable<DynamicColumnsTestFullTable>())
+			{
+				var obj = new FluentMetadataBasedStore { Id = 5 };
+				obj.Values.Add("Name", "test_name");
+				db.Insert(obj);
+
+
+				var data = db.GetTable<FluentMetadataBasedStore>().ToList();
+				Assert.AreEqual(1, data.Count);
+				Assert.AreEqual(5, data[0].Id);
+				Assert.AreEqual(1, data[0].Values.Count);
+				Assert.AreEqual("Name", data[0].Values.Keys.Single());
+				Assert.AreEqual("test_name", data[0].Values["Name"]);
+			}
+		}
+
+		[Test]
+		public void TestDynamicColumnStoreFluentExtension([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			var ms = new MappingSchema();
+
+			var builder = ms.GetFluentMappingBuilder();
+			builder.Entity<FluentMetadataBasedStore>()
+				.HasColumn(e => e.Id)
+				.DynamicColumnsStore(e => e.Values)
+				.Property(x => Sql.Property<string>(x, "Name"));
+
+			using (var db = GetDataContext(context, ms))
+			using (db.CreateLocalTable<DynamicColumnsTestFullTable>())
+			{
+				var obj = new FluentMetadataBasedStore { Id = 5 };
+				obj.Values.Add("Name", "test_name");
+				db.Insert(obj);
+
+
+				var data = db.GetTable<FluentMetadataBasedStore>().ToList();
+				Assert.AreEqual(1, data.Count);
+				Assert.AreEqual(5, data[0].Id);
+				Assert.AreEqual(1, data[0].Values.Count);
+				Assert.AreEqual("Name", data[0].Values.Keys.Single());
+				Assert.AreEqual("test_name", data[0].Values["Name"]);
+			}
+		}
+
+		[Test]
+		public void TestDynamicColumnStoreFluentWithConfiguration([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			var ms = new MappingSchema();
+
+			var builder = ms.GetFluentMappingBuilder();
+			builder.Entity<FluentMetadataBasedStore>()
+				.HasColumn(e => e.Id)
+				.DynamicColumnsStore(e => e.Values)
+				.Property(x => Sql.Property<string>(x, "Name"))
+				.Entity<FluentMetadataBasedStore>(ProviderName.SQLite)
+				.DynamicColumnsStore(e => e.SQLiteValues);
+
+			using (var db = GetDataContext(context, ms))
+			using (db.CreateLocalTable<DynamicColumnsTestFullTable>())
+			{
+				var obj = new FluentMetadataBasedStore { Id = 5 };
+				obj.SQLiteValues.Add("Name", "test_name");
+				db.Insert(obj);
+
+
+				var data = db.GetTable<FluentMetadataBasedStore>().ToList();
+				Assert.AreEqual(1, data.Count);
+				Assert.AreEqual(5, data[0].Id);
+				Assert.AreEqual(0, data[0].Values.Count);
+				Assert.AreEqual(1, data[0].SQLiteValues.Count);
+				Assert.AreEqual("Name", data[0].SQLiteValues.Keys.Single());
+				Assert.AreEqual("test_name", data[0].SQLiteValues["Name"]);
+			}
+		}
+
+		[Test]
+		public void TestDynamicColumnStoreAttributeWithConfiguration([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			var ms = new MappingSchema();
+
+			ms.GetFluentMappingBuilder()
+				.Entity<AttributeMetadataBasedStore>()
+				.Property(x => Sql.Property<string>(x, "Name"));
+
+			using (var db = GetDataContext(context, ms))
+			using (db.CreateLocalTable<DynamicColumnsTestFullTable>())
+			{
+				var obj = new AttributeMetadataBasedStore { Id = 5 };
+				obj.SQLiteValues.Add("Name", "test_name");
+				db.Insert(obj);
+
+				var data = db.GetTable<AttributeMetadataBasedStore>().ToList();
+				Assert.AreEqual(1, data.Count);
+				Assert.AreEqual(5, data[0].Id);
+				Assert.AreEqual(0, data[0].Values.Count);
+				Assert.AreEqual(1, data[0].SQLiteValues.Count);
+				Assert.AreEqual("Name", data[0].SQLiteValues.Keys.Single());
+				Assert.AreEqual("test_name", data[0].SQLiteValues["Name"]);
+			}
+		}
+
+		[Test]
+		public void DynamicColumnStoreIssue1521([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			var ms = new MappingSchema();
+
+			var builder = ms.GetFluentMappingBuilder();
+			builder.Entity<FluentMetadataBasedStore>()
+				.HasColumn(e => e.Id)
+				.Property(x => Sql.Property<string>(x, "Name"))
+				.Member(e => e.Values);
+
+			using (var db = GetDataContext(context, ms))
+			using (db.CreateLocalTable<DynamicColumnsTestFullTable>())
+			{
+				var obj = new FluentMetadataBasedStore { Id = 5 };
+				obj.Values.Add("Name", "test_name");
+				db.Insert(obj);
+
+				var data = db.GetTable<FluentMetadataBasedStore>().ToList();
+				Assert.AreEqual(1, data.Count);
+				Assert.AreEqual(5, data[0].Id);
+				Assert.AreEqual(1, data[0].Values.Count);
+				Assert.AreEqual("Name", data[0].Values.Keys.Single());
+				Assert.AreEqual("test_name", data[0].Values["Name"]);
+			}
+		}
+
+		[Test]
+		public void TestDynamicColumnStoreInstanceAccessors([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			var ms = new MappingSchema();
+
+			ms.GetFluentMappingBuilder()
+				.Entity<InstanceGetterSetterMethods>()
+				.Property(x => Sql.Property<string>(x, "Name"));
+
+			using (var db = GetDataContext(context, ms))
+			using (db.CreateLocalTable<DynamicColumnsTestFullTable>())
+			{
+				var obj = new InstanceGetterSetterMethods { Id = 5 };
+				obj.Values.Add("Name", "test_name");
+				db.Insert(obj);
+
+				var data = db.GetTable<InstanceGetterSetterMethods>().ToList();
+				Assert.AreEqual(1, data.Count);
+				Assert.AreEqual(5, data[0].Id);
+				Assert.AreEqual(0, data[0].SQLiteValues.Count);
+				Assert.AreEqual(1, data[0].Values.Count);
+				Assert.AreEqual("Name", data[0].Values.Keys.Single());
+				Assert.AreEqual("test_name", data[0].Values["Name"]);
+			}
+		}
+
+		[Test]
+		public void TestDynamicColumnStoreStaticAccessors([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			StaticGetterSetterMethods.InstanceValues.Clear();
+			var ms = new MappingSchema();
+
+			ms.GetFluentMappingBuilder()
+				.Entity<StaticGetterSetterMethods>()
+				.Property(x => Sql.Property<string>(x, "Name"));
+
+			using (var db = GetDataContext(context, ms))
+			using (db.CreateLocalTable<DynamicColumnsTestFullTable>())
+			{
+				var obj = new StaticGetterSetterMethods { Id = 5 };
+				StaticGetterSetterMethods.InstanceValues.Add(5, new Dictionary<string, object>());
+				StaticGetterSetterMethods.InstanceValues[5].Add("Name", "test_name");
+				db.Insert(obj);
+
+				StaticGetterSetterMethods.InstanceValues.Clear();
+
+				var data = db.GetTable<StaticGetterSetterMethods>().ToList();
+				Assert.AreEqual(1, data.Count);
+				Assert.AreEqual(5, data[0].Id);
+				Assert.AreEqual(0, data[0].SQLiteValues.Count);
+				Assert.AreEqual(0, data[0].Values.Count);
+				Assert.AreEqual(1, StaticGetterSetterMethods.InstanceValues.Count);
+				Assert.AreEqual(5, StaticGetterSetterMethods.InstanceValues.Keys.Single());
+				Assert.AreEqual(1, StaticGetterSetterMethods.InstanceValues[5].Count);
+				Assert.AreEqual("Name", StaticGetterSetterMethods.InstanceValues[5].Keys.Single());
+				Assert.AreEqual("test_name", StaticGetterSetterMethods.InstanceValues[5]["Name"]);
+			}
+		}
+
+		[Test]
+		public void TestDynamicColumnStoreInstanceExpressionAccessors([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			var ms = new MappingSchema();
+
+			ms.GetFluentMappingBuilder()
+				.Entity<InstanceGetterSetterExpressionMethods>()
+				.Property(x => Sql.Property<string>(x, "Name"));
+
+			using (var db = GetDataContext(context, ms))
+			using (db.CreateLocalTable<DynamicColumnsTestFullTable>())
+			{
+				var obj = new InstanceGetterSetterExpressionMethods { Id = 5 };
+				obj.Values.Add("Name", "test_name");
+				db.Insert(obj);
+
+				var data = db.GetTable<InstanceGetterSetterExpressionMethods>().ToList();
+				Assert.AreEqual(1, data.Count);
+				Assert.AreEqual(5, data[0].Id);
+				Assert.AreEqual(0, data[0].SQLiteValues.Count);
+				Assert.AreEqual(1, data[0].Values.Count);
+				Assert.AreEqual("Name", data[0].Values.Keys.Single());
+				Assert.AreEqual("test_name", data[0].Values["Name"]);
+			}
+		}
+
+		[Test]
+		public void TestDynamicColumnStoreStaticExpressionAccessors([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			StaticGetterSetterExpressionMethods.InstanceValues.Clear();
+
+			var ms = new MappingSchema();
+
+			ms.GetFluentMappingBuilder()
+				.Entity<StaticGetterSetterExpressionMethods>()
+				.Property(x => Sql.Property<string>(x, "Name"));
+
+			using (var db = GetDataContext(context, ms))
+			using (db.CreateLocalTable<DynamicColumnsTestFullTable>())
+			{
+				var obj = new StaticGetterSetterExpressionMethods { Id = 5 };
+				StaticGetterSetterExpressionMethods.InstanceValues.Add(5, new Dictionary<string, object>());
+				StaticGetterSetterExpressionMethods.InstanceValues[5].Add("Name", "test_name");
+				db.Insert(obj);
+
+				StaticGetterSetterExpressionMethods.InstanceValues.Clear();
+
+				var data = db.GetTable<StaticGetterSetterExpressionMethods>().ToList();
+				Assert.AreEqual(1, data.Count);
+				Assert.AreEqual(5, data[0].Id);
+				Assert.AreEqual(0, data[0].SQLiteValues.Count);
+				Assert.AreEqual(0, data[0].Values.Count);
+				Assert.AreEqual(1, StaticGetterSetterExpressionMethods.InstanceValues.Count);
+				Assert.AreEqual(5, StaticGetterSetterExpressionMethods.InstanceValues.Keys.Single());
+				Assert.AreEqual(1, StaticGetterSetterExpressionMethods.InstanceValues[5].Count);
+				Assert.AreEqual("Name", StaticGetterSetterExpressionMethods.InstanceValues[5].Keys.Single());
+				Assert.AreEqual("test_name", StaticGetterSetterExpressionMethods.InstanceValues[5]["Name"]);
+			}
+		}
+
+		[Test]
+		public void TestDynamicColumnStoreInstanceConfigurationAccessors([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			var ms = new MappingSchema();
+
+			ms.GetFluentMappingBuilder()
+				.Entity<SQLiteInstanceGetterSetterMethods>()
+				.Property(x => Sql.Property<string>(x, "Name"));
+
+			using (var db = GetDataContext(context, ms))
+			using (db.CreateLocalTable<DynamicColumnsTestFullTable>())
+			{
+				var obj = new SQLiteInstanceGetterSetterMethods { Id = 5 };
+				obj.SQLiteValues.Add("Name", "test_name");
+				db.Insert(obj);
+
+				var data = db.GetTable<SQLiteInstanceGetterSetterMethods>().ToList();
+				Assert.AreEqual(1, data.Count);
+				Assert.AreEqual(5, data[0].Id);
+				Assert.AreEqual(0, data[0].Values.Count);
+				Assert.AreEqual(1, data[0].SQLiteValues.Count);
+				Assert.AreEqual("Name", data[0].SQLiteValues.Keys.Single());
+				Assert.AreEqual("test_name", data[0].SQLiteValues["Name"]);
+			}
+		}
+
+		[Test]
+		public void TestDynamicColumnStoreGetterSetterVsStorageMethods1([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			var ms = new MappingSchema();
+
+			ms.GetFluentMappingBuilder()
+				.Entity<GetterSetterVsStorageMethods1>()
+				.Property(x => Sql.Property<string>(x, "Name"));
+
+			using (var db = GetDataContext(context, ms))
+			using (db.CreateLocalTable<DynamicColumnsTestFullTable>())
+			{
+				var obj = new GetterSetterVsStorageMethods1 { Id = 5 };
+				obj.SQLiteValues.Add("Name", "test_name");
+				db.Insert(obj);
+
+				var data = db.GetTable<GetterSetterVsStorageMethods1>().ToList();
+				Assert.AreEqual(1, data.Count);
+				Assert.AreEqual(5, data[0].Id);
+				Assert.AreEqual(0, data[0].Values.Count);
+				Assert.AreEqual(1, data[0].SQLiteValues.Count);
+				Assert.AreEqual("Name", data[0].SQLiteValues.Keys.Single());
+				Assert.AreEqual("test_name", data[0].SQLiteValues["Name"]);
+			}
+		}
+
+		[Test]
+		public void TestDynamicColumnStoreGetterSetterVsStorageMethods2([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			var ms = new MappingSchema();
+
+			ms.GetFluentMappingBuilder()
+				.Entity<GetterSetterVsStorageMethods2>()
+				.Property(x => Sql.Property<string>(x, "Name"));
+
+			using (var db = GetDataContext(context, ms))
+			using (db.CreateLocalTable<DynamicColumnsTestFullTable>())
+			{
+				var obj = new GetterSetterVsStorageMethods2 { Id = 5 };
+				obj.SQLiteValues.Add("Name", "test_name");
+				db.Insert(obj);
+
+				var data = db.GetTable<GetterSetterVsStorageMethods2>().ToList();
+				Assert.AreEqual(1, data.Count);
+				Assert.AreEqual(5, data[0].Id);
+				Assert.AreEqual(0, data[0].Values.Count);
+				Assert.AreEqual(1, data[0].SQLiteValues.Count);
+				Assert.AreEqual("Name", data[0].SQLiteValues.Keys.Single());
+				Assert.AreEqual("test_name", data[0].SQLiteValues["Name"]);
+			}
+		}
+
+		[Test]
+		public void TestDynamicColumnStoreGetterSetterVsStorageMethodsConflict([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			var ms = new MappingSchema();
+			ms.GetFluentMappingBuilder()
+				.Entity<GetterSetterVsStorageMethodsConflict>()
+				.Property(x => Sql.Property<string>(x, "Name"));
+
+			using (var db = GetDataContext(context, ms))
+			using (db.CreateLocalTable<DynamicColumnsTestFullTable>())
+			{
+				var obj = new GetterSetterVsStorageMethodsConflict { Id = 5 };
+				obj.Values.Add("Name", "test_name");
+
+				Assert.Throws<LinqToDBException>(() => db.Insert(obj));
+				Assert.Throws<LinqToDBException>(() => db.GetTable<GetterSetterVsStorageMethodsConflict>().ToList());
+			}
+		}
+
+		[Test]
+		public void TestDynamicColumnStoreExpressions([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			var storage = new Dictionary<int, Dictionary<string, object>>();
+
+			var ms = new MappingSchema();
+			var builder = ms.GetFluentMappingBuilder();
+
+			builder.Entity<CustomSetterGetterBase>()
+				.DynamicPropertyAccessors(
+					(instance, property, defaultValue) => Getter(storage, instance, property, defaultValue),
+					(instance, property, value) => Setter(storage, instance, property, value))
+				.HasColumn(e => e.Id)
+				.Property(x => Sql.Property<string>(x, "Name"));
+
+			using (var db = GetDataContext(context, ms))
+			using (db.CreateLocalTable<DynamicColumnsTestFullTable>())
+			{
+				var obj = new CustomSetterGetterBase { Id = 5 };
+				obj.Values.Add("Name", "test_name");
+				db.Insert(obj);
+
+				var data = db.GetTable<CustomSetterGetterBase>().ToList();
+				Assert.AreEqual(1, data.Count);
+				Assert.AreEqual(5, data[0].Id);
+				Assert.AreEqual(0, data[0].SQLiteValues.Count);
+				Assert.AreEqual(0, data[0].Values.Count);
+				Assert.AreEqual(1, storage.Count);
+				Assert.AreEqual(5, storage.Keys.Single());
+				Assert.AreEqual(1, storage[5].Count);
+				Assert.AreEqual("Name", storage[5].Keys.Single());
+				Assert.AreEqual("test_name", storage[5]["Name"]);
+			}
+		}
+
+		static object Getter(IDictionary<int, Dictionary<string, object>> storage, CustomSetterGetterBase instance, string property, object defaultValue)
+		{
+			if (!storage.ContainsKey(instance.Id))
+				return defaultValue;
+
+			if (!storage[instance.Id].TryGetValue(property, out var value))
+				value = defaultValue;
+
+			return value;
+		}
+
+		static void Setter(IDictionary<int, Dictionary<string, object>> storage, CustomSetterGetterBase instance, string property, object value)
+		{
+			if (!storage.ContainsKey(instance.Id))
+				storage.Add(instance.Id, new Dictionary<string, object>());
+
+			storage[instance.Id][property] = value;
+		}
+
+		[Test]
+		public void TestDynamicColumnStoreAttributeDefaultValue([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			var ms = new MappingSchema();
+			ms.SetDefaultValue(typeof(string), "me_default");
+
+			ms.GetFluentMappingBuilder()
+				.Entity<AttributeMetadataBasedStore>()
+				.Property(x => Sql.Property<string>(x, "Name"));
+
+			using (var db = GetDataContext(context, ms))
+			using (db.CreateLocalTable<DynamicColumnsTestFullTable>())
+			{
+				var obj = new AttributeMetadataBasedStore { Id = 5 };
+				db.Insert(obj);
+
+				var data = db.GetTable<AttributeMetadataBasedStore>().ToList();
+				Assert.AreEqual(1, data.Count);
+				Assert.AreEqual(5, data[0].Id);
+				Assert.AreEqual(0, data[0].Values.Count);
+				Assert.AreEqual(1, data[0].SQLiteValues.Count);
+				Assert.AreEqual("Name", data[0].SQLiteValues.Keys.Single());
+				Assert.AreEqual("me_default", data[0].SQLiteValues["Name"]);
+			}
+		}
+
+		[Test]
+		public void TestDynamicColumnStoreAccessorsDefaultValue([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			var ms = new MappingSchema();
+			ms.SetDefaultValue(typeof(string), "accessor_def");
+
+			ms.GetFluentMappingBuilder()
+				.Entity<InstanceGetterSetterMethods>()
+				.Property(x => Sql.Property<string>(x, "Name"));
+
+			using (var db = GetDataContext(context, ms))
+			using (db.CreateLocalTable<DynamicColumnsTestFullTable>())
+			{
+				var obj = new InstanceGetterSetterMethods { Id = 5 };
+				db.Insert(obj);
+
+				var data = db.GetTable<InstanceGetterSetterMethods>().ToList();
+				Assert.AreEqual(1, data.Count);
+				Assert.AreEqual(5, data[0].Id);
+				Assert.AreEqual(0, data[0].SQLiteValues.Count);
+				Assert.AreEqual(1, data[0].Values.Count);
+				Assert.AreEqual("Name", data[0].Values.Keys.Single());
+				Assert.AreEqual("accessor_def", data[0].Values["Name"]);
+			}
+		}
+	}
+}

--- a/Tests/Linq/Mapping/FluentDynamicMappingTests.cs
+++ b/Tests/Linq/Mapping/FluentDynamicMappingTests.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using System.Linq.Expressions;
+using System.Reflection;
 using LinqToDB;
 using LinqToDB.Mapping;
 
@@ -26,6 +27,9 @@ namespace Tests.Mapping
 
 			[DynamicColumnsStore]
 			public IDictionary<string, object> ExtendedColumns { get; set; }
+
+			[DynamicColumnsStore(Configuration = ProviderName.SQLite)]
+			public IDictionary<string, object> ExtendedSQLiteColumns { get; set; }
 		}
 
 		[Table]
@@ -222,8 +226,21 @@ namespace Tests.Mapping
 
 			var ed = ms.GetEntityDescriptor(typeof(MyClass));
 
-			Assert.AreEqual(ed.DynamicColumnsStore.MemberName, "ExtendedColumns");
-			Assert.IsFalse(ed.Columns.Any(c => c.MemberName == "ExtendedColumns"));
+			Assert.AreEqual(ed.DynamicColumnsStore.MemberName, nameof(MyClass.ExtendedColumns));
+			Assert.IsFalse(ed.Columns.Any(c => c.MemberName == nameof(MyClass.ExtendedColumns)));
+			Assert.IsFalse(ed.Columns.Any(c => c.MemberName == nameof(MyClass.ExtendedSQLiteColumns)));
+		}
+
+		[Test]
+		public void HasDynamicColumnStoreWithConfiguration()
+		{
+			var ms = new MappingSchema(ProviderName.SQLite);
+
+			var ed = ms.GetEntityDescriptor(typeof(MyClass));
+
+			Assert.AreEqual(ed.DynamicColumnsStore.MemberName, nameof(MyClass.ExtendedSQLiteColumns));
+			Assert.IsFalse(ed.Columns.Any(c => c.MemberName == nameof(MyClass.ExtendedColumns)));
+			Assert.IsFalse(ed.Columns.Any(c => c.MemberName == nameof(MyClass.ExtendedSQLiteColumns)));
 		}
 
 		[Test]

--- a/Tests/Linq/Tests.csproj
+++ b/Tests/Linq/Tests.csproj
@@ -68,6 +68,7 @@
 		<Compile Remove="DataProvider\OracleTests.cs" />
 		<Compile Remove="Linq\DynamicColumnsTests.cs" />
 		<Compile Remove="Mapping\FluentDynamicMappingTests.cs" />
+		<Compile Remove="Mapping\DynamicStoreTests.cs" />
 		<Compile Remove="Update\DynamicColumnsTests.cs" />
 		<Compile Remove="UserTests\Issue1268Tests.cs" />
 	</ItemGroup>


### PR DESCRIPTION
Fix #1521, fix #1477

- respect `DynamicColumnsStoreAttribute.Configuration` property (before it was using first dictionary with such attribute)
- allow custom storage setter/getter methods using `DynamicColumnAccessorAttribute` mapping entity attribute instead of dictionary
- fluent mapper: new method `DynamicColumnsStore` to configure store dictionary
- fluent mapper: new method `DynamicPropertyAccessors` to configure store getters/setters
- fix type accessor to use current mapping schema instead of default for default values