### PR TITLE
Extension point adds possibility to change implementation of DbCommand methods ExecuteScalar, ExecuteNonQuery, ExecureReader

### DIFF
--- a/Source/LinqToDB/Data/DataConnection.Async.cs
+++ b/Source/LinqToDB/Data/DataConnection.Async.cs
@@ -4,6 +4,7 @@ using System.Data.Common;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using LinqToDB.Data.DbCommandProcessor;
 
 namespace LinqToDB.Data
 {
@@ -213,7 +214,7 @@ namespace LinqToDB.Data
 		internal async Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
 		{
 			if (TraceSwitch.Level == TraceLevel.Off || OnTraceConnection == null)
-				return await ((DbCommand)Command).ExecuteNonQueryAsync(cancellationToken);
+				return await ((DbCommand)Command).ExecuteNonQueryExtAsync(cancellationToken);
 
 			var now = DateTime.UtcNow;
 			var sw  = Stopwatch.StartNew();
@@ -232,7 +233,7 @@ namespace LinqToDB.Data
 
 			try
 			{
-				var ret = await ((DbCommand)Command).ExecuteNonQueryAsync(cancellationToken);
+				var ret = await ((DbCommand)Command).ExecuteNonQueryExtAsync(cancellationToken);
 
 				if (TraceSwitch.TraceInfo)
 				{
@@ -273,7 +274,7 @@ namespace LinqToDB.Data
 		internal async Task<object> ExecuteScalarAsync(CancellationToken cancellationToken)
 		{
 			if (TraceSwitch.Level == TraceLevel.Off || OnTraceConnection == null)
-				return await ((DbCommand)Command).ExecuteScalarAsync(cancellationToken);
+				return await ((DbCommand)Command).ExecuteScalarExtAsync(cancellationToken);
 
 			var now = DateTime.UtcNow;
 			var sw  = Stopwatch.StartNew();
@@ -292,7 +293,7 @@ namespace LinqToDB.Data
 
 			try
 			{
-				var ret = await ((DbCommand)Command).ExecuteScalarAsync(cancellationToken);
+				var ret = await ((DbCommand)Command).ExecuteScalarExtAsync(cancellationToken);
 
 				if (TraceSwitch.TraceInfo)
 				{
@@ -334,7 +335,7 @@ namespace LinqToDB.Data
 			CancellationToken cancellationToken)
 		{
 			if (TraceSwitch.Level == TraceLevel.Off || OnTraceConnection == null)
-				return await ((DbCommand)Command).ExecuteReaderAsync(commandBehavior, cancellationToken);
+				return await ((DbCommand)Command).ExecuteReaderExtAsync(commandBehavior, cancellationToken);
 
 			var now = DateTime.UtcNow;
 			var sw  = Stopwatch.StartNew();
@@ -353,7 +354,7 @@ namespace LinqToDB.Data
 
 			try
 			{
-				var ret = await ((DbCommand)Command).ExecuteReaderAsync(commandBehavior, cancellationToken);
+				var ret = await ((DbCommand)Command).ExecuteReaderExtAsync(commandBehavior, cancellationToken);
 
 				if (TraceSwitch.TraceInfo)
 				{

--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -19,6 +19,7 @@ namespace LinqToDB.Data
 	using DataProvider;
 	using Expressions;
 	using LinqToDB.Async;
+	using LinqToDB.Data.DbCommandProcessor;
 	using Mapping;
 	using RetryPolicy;
 
@@ -1134,7 +1135,7 @@ namespace LinqToDB.Data
 		{
 			if (TraceSwitch.Level == TraceLevel.Off || OnTraceConnection == null)
 				using (DataProvider.ExecuteScope())
-					return Command.ExecuteNonQuery();
+					return Command.ExecuteNonQueryExt();
 
 			var now = DateTime.UtcNow;
 			var sw  = Stopwatch.StartNew();
@@ -1155,7 +1156,7 @@ namespace LinqToDB.Data
 			{
 				int ret;
 				using (DataProvider.ExecuteScope())
-					ret = Command.ExecuteNonQuery();
+					ret = Command.ExecuteNonQueryExt();
 
 				if (TraceSwitch.TraceInfo)
 				{
@@ -1194,7 +1195,7 @@ namespace LinqToDB.Data
 		object ExecuteScalar()
 		{
 			if (TraceSwitch.Level == TraceLevel.Off || OnTraceConnection == null)
-				return Command.ExecuteScalar();
+				return Command.ExecuteScalarExt();
 
 			var now = DateTime.UtcNow;
 			var sw  = Stopwatch.StartNew();
@@ -1212,7 +1213,7 @@ namespace LinqToDB.Data
 
 			try
 			{
-				var ret = Command.ExecuteScalar();
+				var ret = Command.ExecuteScalarExt();
 
 				if (TraceSwitch.TraceInfo)
 				{
@@ -1256,7 +1257,7 @@ namespace LinqToDB.Data
 		{
 			if (TraceSwitch.Level == TraceLevel.Off || OnTraceConnection == null)
 				using (DataProvider.ExecuteScope())
-					return Command.ExecuteReader(GetCommandBehavior(commandBehavior));
+					return Command.ExecuteReaderExt(GetCommandBehavior(commandBehavior));
 
 			var now = DateTime.UtcNow;
 			var sw  = Stopwatch.StartNew();
@@ -1277,7 +1278,7 @@ namespace LinqToDB.Data
 				IDataReader ret;
 
 				using (DataProvider.ExecuteScope())
-					ret = Command.ExecuteReader(GetCommandBehavior(commandBehavior));
+					ret = Command.ExecuteReaderExt(GetCommandBehavior(commandBehavior));
 
 				if (TraceSwitch.TraceInfo)
 				{

--- a/Source/LinqToDB/Data/DbCommandProcessor/DbCommandDefaultProcessor.cs
+++ b/Source/LinqToDB/Data/DbCommandProcessor/DbCommandDefaultProcessor.cs
@@ -1,0 +1,30 @@
+﻿using JetBrains.Annotations;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LinqToDB.Data.DbCommandProcessor
+{
+	[PublicAPI]
+	public class DbCommandDefaultProcessor : IDbCommandProcessor
+	{
+		public int ExecuteNonQuery(DbCommand cmd)
+			=> cmd.ExecuteNonQuery();
+
+		public Task<int> ExecuteNonQueryAsync(DbCommand cmd, CancellationToken ct)
+			=> cmd.ExecuteNonQueryAsync(ct);
+
+		public DbDataReader ExecuteReader(DbCommand cmd, CommandBehavior commandBehavior)
+			=> cmd.ExecuteReader(commandBehavior);
+
+		public Task<DbDataReader> ExecuteReaderAsync(DbCommand cmd, CommandBehavior commandBehavior, CancellationToken ct)
+			=> cmd.ExecuteReaderAsync(commandBehavior, ct);
+
+		public object ExecuteScalar(DbCommand cmd)
+			=> cmd.ExecuteScalar();
+
+		public Task<object> ExecuteScalarAsync(DbCommand cmd, CancellationToken ct)
+			=> cmd.ExecuteScalarAsync(ct);
+	}
+}

--- a/Source/LinqToDB/Data/DbCommandProcessor/DbCommandProcessorExtensions.cs
+++ b/Source/LinqToDB/Data/DbCommandProcessor/DbCommandProcessorExtensions.cs
@@ -1,0 +1,39 @@
+﻿using JetBrains.Annotations;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LinqToDB.Data.DbCommandProcessor
+{
+	/// <summary>
+	/// Extension point adds possibility to change implementation of DbCommand methods ExecuteScalar, ExecuteNonQuery, ExecureReader and their Async equivalents.
+	/// One of possible use cases: put commands into queue and initiate them in special separate thread, to overcome lock contention in TimerQueue.Timer
+	/// </summary>
+	[PublicAPI]
+	public static class DbCommandProcessorExtensions
+	{
+		/// <summary>
+		/// Single instance. Change of it is not thread safe.
+		/// </summary>
+		public static IDbCommandProcessor Instance { get; set; } = new DbCommandDefaultProcessor();
+
+		public static object ExecuteScalarExt(this IDbCommand cmd) =>
+			Instance.ExecuteScalar((DbCommand)cmd);
+
+		public static Task<object> ExecuteScalarExtAsync(this DbCommand cmd, CancellationToken ct) =>
+			Instance.ExecuteScalarAsync(cmd, ct);
+
+		public static int ExecuteNonQueryExt(this IDbCommand cmd) =>
+			Instance.ExecuteNonQuery((DbCommand)cmd);
+
+		public static Task<int> ExecuteNonQueryExtAsync(this DbCommand cmd, CancellationToken ct) =>
+			Instance.ExecuteNonQueryAsync(cmd, ct);
+
+		public static DbDataReader ExecuteReaderExt(this IDbCommand cmd, CommandBehavior commandBehavior) =>
+			Instance.ExecuteReader((DbCommand)cmd, commandBehavior);
+
+		public static Task<DbDataReader> ExecuteReaderExtAsync(this DbCommand cmd, CommandBehavior commandBehavior, CancellationToken ct) =>
+			Instance.ExecuteReaderAsync(cmd, commandBehavior, ct);
+	}
+}

--- a/Source/LinqToDB/Data/DbCommandProcessor/IDbCommandProcessor.cs
+++ b/Source/LinqToDB/Data/DbCommandProcessor/IDbCommandProcessor.cs
@@ -1,0 +1,19 @@
+﻿using JetBrains.Annotations;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LinqToDB.Data.DbCommandProcessor
+{
+	[PublicAPI]
+	public interface IDbCommandProcessor
+	{
+		object ExecuteScalar(DbCommand cmd);
+		Task<object> ExecuteScalarAsync(DbCommand cmd, CancellationToken ct);
+		int ExecuteNonQuery(DbCommand cmd);
+		Task<int> ExecuteNonQueryAsync(DbCommand cmd, CancellationToken ct);
+		DbDataReader ExecuteReader(DbCommand cmd, CommandBehavior commandBehavior);
+		Task<DbDataReader> ExecuteReaderAsync(DbCommand cmd, CommandBehavior commandBehavior, CancellationToken ct);
+	}
+}

--- a/Source/LinqToDB/Data/RetryPolicy/RetryingDbCommand.cs
+++ b/Source/LinqToDB/Data/RetryPolicy/RetryingDbCommand.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 namespace LinqToDB.Data.RetryPolicy
 {
 	using Configuration;
+	using LinqToDB.Data.DbCommandProcessor;
 
 	class RetryingDbCommand : DbCommand, IProxy<DbCommand>
 	{
@@ -79,34 +80,34 @@ namespace LinqToDB.Data.RetryPolicy
 
 		protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
 		{
-			return _policy.Execute(() => _command.ExecuteReader(behavior));
+			return _policy.Execute(() => _command.ExecuteReaderExt(behavior));
 		}
 
 		public override int ExecuteNonQuery()
 		{
-			return _policy.Execute(() => _command.ExecuteNonQuery());
+			return _policy.Execute(() => _command.ExecuteNonQueryExt());
 		}
 
 		public override object ExecuteScalar()
 		{
-			return _policy.Execute(() => _command.ExecuteScalar());
+			return _policy.Execute(() => _command.ExecuteScalarExt());
 		}
 
 #if !NET40
 
 		protected override Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
 		{
-			return _policy.ExecuteAsync(ct => _command.ExecuteReaderAsync(behavior, ct), cancellationToken);
+			return _policy.ExecuteAsync(ct => _command.ExecuteReaderExtAsync(behavior, ct), cancellationToken);
 		}
 
 		public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
 		{
-			return _policy.ExecuteAsync(ct => _command.ExecuteNonQueryAsync(ct), cancellationToken);
+			return _policy.ExecuteAsync(ct => _command.ExecuteNonQueryExtAsync(ct), cancellationToken);
 		}
 
 		public override Task<object> ExecuteScalarAsync(CancellationToken cancellationToken)
 		{
-			return _policy.ExecuteAsync(ct => _command.ExecuteScalarAsync(ct), cancellationToken);
+			return _policy.ExecuteAsync(ct => _command.ExecuteScalarExtAsync(ct), cancellationToken);
 		}
 
 #endif


### PR DESCRIPTION
Extension point adds possibility to change implementation of `DbCommand` methods `ExecuteScalar`, `ExecuteNonQuery`, `ExecureReader` and their Async equivalents.

One of possible use cases: put commands into queue and initiate them in special separate thread, to overcome lock contention in `TimerQueue.Timer`

See: https://github.com/avtc/timer.noLock
