### PR TITLE
Fix #1721 - CreateTable generation for DateTime2 with Precision.

### DIFF
--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2008SqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2008SqlBuilder.cs
@@ -33,20 +33,5 @@ namespace LinqToDB.DataProvider.SqlServer
 		{
 			get { return ProviderName.SqlServer2008; }
 		}
-
-		protected override void BuildDataType(SqlDataType type, bool createDbType)
-		{
-			switch (type.DataType)
-			{
-				case DataType.DateTime2:
-					if (type.Precision > 0)
-					{
-						StringBuilder.Append(type.DataType).Append('(').Append(type.Precision).Append(')');
-						return;
-					}
-					break;
-			}
-			base.BuildDataType(type, createDbType);
-		}
 	}
 }

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2008SqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2008SqlBuilder.cs
@@ -42,7 +42,7 @@ namespace LinqToDB.DataProvider.SqlServer
 					if (type.Precision > 0)
 					{
 						StringBuilder.Append(type.DataType).Append('(').Append(type.Precision).Append(')');
-						return;;
+						return;
 					}
 					break;
 			}

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2008SqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2008SqlBuilder.cs
@@ -33,5 +33,20 @@ namespace LinqToDB.DataProvider.SqlServer
 		{
 			get { return ProviderName.SqlServer2008; }
 		}
+
+		protected override void BuildDataType(SqlDataType type, bool createDbType)
+		{
+			switch (type.DataType)
+			{
+				case DataType.DateTime2:
+					if (type.Precision > 0)
+					{
+						StringBuilder.Append(type.DataType).Append('(').Append(type.Precision).Append(')');
+						return;;
+					}
+					break;
+			}
+			base.BuildDataType(type, createDbType);
+		}
 	}
 }

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlBuilder.cs
@@ -319,6 +319,17 @@ namespace LinqToDB.DataProvider.SqlServer
 					}
 
 					break;
+
+				case DataType.DateTime2 :
+					if (type.Precision > 0)
+					{
+						StringBuilder
+							.Append(type.DataType)
+							.Append('(').Append(type.Precision).Append(')');
+						return;
+					}
+
+					break;
 			}
 
 			base.BuildDataType(type, createDbType);

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlBuilder.cs
@@ -323,7 +323,9 @@ namespace LinqToDB.DataProvider.SqlServer
 				case DataType.DateTime2:
 				case DataType.DateTimeOffset:
 				case DataType.Time:
-					if (type.Precision > 0)
+					// Default precision for all three types is 7.
+					// For all other non-null values (including 0) precision must be specified.
+					if (type.Precision != null && type.Precision != 7)
 					{
 						StringBuilder
 							.Append(type.DataType)

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlBuilder.cs
@@ -323,17 +323,14 @@ namespace LinqToDB.DataProvider.SqlServer
 				case DataType.DateTime2:
 				case DataType.DateTimeOffset:
 				case DataType.Time:
+					StringBuilder.Append(type.DataType);
 					// Default precision for all three types is 7.
 					// For all other non-null values (including 0) precision must be specified.
 					if (type.Precision != null && type.Precision != 7)
 					{
-						StringBuilder
-							.Append(type.DataType)
-							.Append('(').Append(type.Precision).Append(')');
-						return;
+						StringBuilder.Append('(').Append(type.Precision).Append(')');
 					}
-
-					break;
+					return;
 			}
 
 			base.BuildDataType(type, createDbType);

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlBuilder.cs
@@ -320,7 +320,9 @@ namespace LinqToDB.DataProvider.SqlServer
 
 					break;
 
-				case DataType.DateTime2 :
+				case DataType.DateTime2:
+				case DataType.DateTimeOffset:
+				case DataType.Time:
 					if (type.Precision > 0)
 					{
 						StringBuilder

--- a/Tests/Linq/UserTests/Issue1721Tests.cs
+++ b/Tests/Linq/UserTests/Issue1721Tests.cs
@@ -1,0 +1,32 @@
+﻿using LinqToDB;
+using LinqToDB.Mapping;
+using NUnit.Framework;
+using System;
+
+namespace Tests.UserTests
+{
+	[TestFixture]
+	public class Issue1721Tests : TestBase
+	{
+		public class I1721Model
+		{
+			[Column(DataType = DataType.DateTime2, Precision = 7), NotNull]
+			public DateTime BadField { get; set; }
+		}
+
+		[ActiveIssue(1721, Configuration = ProviderName.SqlServer2008)]
+		[Test]
+		public void Issue1721Test([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				Assert.DoesNotThrow(() =>
+				{
+					using (var temp = db.CreateTempTable<I1721Model>("Issue1721"))
+					{ }
+				}, 
+				"CreateTempTable with `DateTime2(7)` field.");
+			}
+		}
+	}
+}

--- a/Tests/Linq/UserTests/Issue1721Tests.cs
+++ b/Tests/Linq/UserTests/Issue1721Tests.cs
@@ -14,7 +14,6 @@ namespace Tests.UserTests
 			public DateTime BadField { get; set; }
 		}
 
-		[ActiveIssue(1721, Configuration = ProviderName.SqlServer2008)]
 		[Test]
 		public void Issue1721Test([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
 		{

--- a/Tests/Linq/UserTests/Issue1721Tests.cs
+++ b/Tests/Linq/UserTests/Issue1721Tests.cs
@@ -11,7 +11,13 @@ namespace Tests.UserTests
 		public class I1721Model
 		{
 			[Column(DataType = DataType.DateTime2, Precision = 7), NotNull]
-			public DateTime BadField { get; set; }
+			public DateTime TestDateTime2 { get; set; }
+
+			[Column(DataType = DataType.DateTimeOffset, Precision = 7), NotNull]
+			public DateTimeOffset TestDateTimeOffset { get; set; }
+
+			[Column(DataType = DataType.Time, Precision = 7), NotNull]
+			public TimeSpan TestTime { get; set; }
 		}
 
 		[Test]


### PR DESCRIPTION
DateTime2 type first available in MS SQL 2008.  Added override to `SqlServer2008SqlBuilder` to correctly generate type string for DateTime2 with Precision.

Test add but not tested, fix confirmed in external program.  Please check this test.