### PR TITLE
Fix nuget dependencies

### DIFF
--- a/Build/linq2db.Source.props
+++ b/Build/linq2db.Source.props
@@ -57,24 +57,5 @@
 		<DefineConstants>$(DefineConstants);NETSTANDARD2_0</DefineConstants>
 	</PropertyGroup>
 
-	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' OR '$(TargetFramework)' == 'netcoreapp1.0' ">
-		<PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-		<PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
-		<PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
-		<PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-		<PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
-		<PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-		<PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
-		<PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
-		<PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp2.0' ">
-		<PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-		<PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
-		<PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
-		<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0"/>
-		<PackageReference Include="System.Data.Common" Version="4.3.0" />
-	</ItemGroup>
+	
 </Project>

--- a/NuGet/linq2db.Tools.nuspec
+++ b/NuGet/linq2db.Tools.nuspec
@@ -10,47 +10,22 @@
 		</tags>
 		<dependencies>
 			<group targetFramework=".NETFramework4.5" >
-				<dependency id="linq2db"                              version="2.6.4"/>
+				<dependency id="linq2db" version="2.6.4"/>
 			</group>
 			<group targetFramework=".NETFramework4.6" >
-				<dependency id="linq2db"                              version="2.6.4"/>
+				<dependency id="linq2db" version="2.6.4"/>
 			</group>
 			<group targetFramework=".NETStandard1.6">
-				<dependency id="linq2db"                              version="2.6.4"/>
-				<dependency id="Microsoft.CSharp"                     version="4.3.0" />
-				<dependency id="System.Diagnostics.TraceSource"       version="4.3.0" />
-				<dependency id="Microsoft.Extensions.DependencyModel" version="1.1.0" />
-				<dependency id="System.ComponentModel.Annotations"    version="4.4.1" />
-				<dependency id="System.ComponentModel.TypeConverter"  version="4.3.0" />
-				<dependency id="System.Linq.Queryable"                version="4.3.0" />
-				<dependency id="System.Runtime.Loader"                version="4.3.0" />
-				<dependency id="System.Xml.XmlDocument"               version="4.3.0" />
-				<dependency id="System.Data.SqlClient"                version="4.6.0" />
-				<dependency id="System.Net.NetworkInformation"        version="4.3.0" />
+				<dependency id="linq2db" version="2.6.4"/>
 			</group>
 			<group targetFramework=".NETStandard2.0">
 				<dependency id="linq2db" version="2.6.4"/>
-				<dependency id="Microsoft.CSharp"                     version="4.4.0" />
-				<dependency id="System.ComponentModel.Annotations"    version="4.4.1" />
-				<dependency id="System.Data.SqlClient"                version="4.6.0" />
 			</group>
 			<group targetFramework=".NETCoreApp1.0">
 				<dependency id="linq2db" version="2.6.4"/>
-				<dependency id="Microsoft.CSharp"                     version="4.3.0" />
-				<dependency id="System.Diagnostics.TraceSource"       version="4.3.0" />
-				<dependency id="Microsoft.Extensions.DependencyModel" version="1.1.0" />
-				<dependency id="System.ComponentModel.Annotations"    version="4.4.1" />
-				<dependency id="System.ComponentModel.TypeConverter"  version="4.3.0" />
-				<dependency id="System.Linq.Queryable"                version="4.3.0" />
-				<dependency id="System.Runtime.Loader"                version="4.3.0" />
-				<dependency id="System.Xml.XmlDocument"               version="4.3.0" />
-				<dependency id="System.Data.SqlClient"                version="4.6.0" />
-				<dependency id="System.Net.NetworkInformation"        version="4.3.0" />
 			</group>
 			<group targetFramework=".NETCoreApp2.0">
-				<dependency id="linq2db"                              version="2.6.4"/>
-				<dependency id="System.ComponentModel.Annotations"    version="4.4.1" />
-				<dependency id="System.Data.SqlClient"                version="4.6.0" />
+				<dependency id="linq2db" version="2.6.4"/>
 			</group>
 		</dependencies>
 	</metadata>

--- a/NuGet/linq2db.Tools.nuspec
+++ b/NuGet/linq2db.Tools.nuspec
@@ -25,14 +25,14 @@
 				<dependency id="System.Linq.Queryable"                version="4.3.0" />
 				<dependency id="System.Runtime.Loader"                version="4.3.0" />
 				<dependency id="System.Xml.XmlDocument"               version="4.3.0" />
-				<dependency id="System.Data.SqlClient"                version="4.5.1" />
+				<dependency id="System.Data.SqlClient"                version="4.6.0" />
 				<dependency id="System.Net.NetworkInformation"        version="4.3.0" />
 			</group>
 			<group targetFramework=".NETStandard2.0">
 				<dependency id="linq2db" version="2.6.4"/>
 				<dependency id="Microsoft.CSharp"                     version="4.4.0" />
 				<dependency id="System.ComponentModel.Annotations"    version="4.4.1" />
-				<dependency id="System.Data.SqlClient"                version="4.5.1" />
+				<dependency id="System.Data.SqlClient"                version="4.6.0" />
 			</group>
 			<group targetFramework=".NETCoreApp1.0">
 				<dependency id="linq2db" version="2.6.4"/>
@@ -44,13 +44,13 @@
 				<dependency id="System.Linq.Queryable"                version="4.3.0" />
 				<dependency id="System.Runtime.Loader"                version="4.3.0" />
 				<dependency id="System.Xml.XmlDocument"               version="4.3.0" />
-				<dependency id="System.Data.SqlClient"                version="4.5.1" />
+				<dependency id="System.Data.SqlClient"                version="4.6.0" />
 				<dependency id="System.Net.NetworkInformation"        version="4.3.0" />
 			</group>
 			<group targetFramework=".NETCoreApp2.0">
 				<dependency id="linq2db"                              version="2.6.4"/>
 				<dependency id="System.ComponentModel.Annotations"    version="4.4.1" />
-				<dependency id="System.Data.SqlClient"                version="4.5.1" />
+				<dependency id="System.Data.SqlClient"                version="4.6.0" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/NuGet/linq2db.nuspec
+++ b/NuGet/linq2db.nuspec
@@ -12,10 +12,10 @@
 			<group targetFramework=".NETFramework4.5" />
 			<group targetFramework=".NETFramework4.6" />
 			<group targetFramework=".NETStandard1.6">
-				<dependency id="Microsoft.CSharp"                     version="4.3.0" />
+				<dependency id="Microsoft.CSharp"                     version="4.5.0" />
 				<dependency id="System.Diagnostics.TraceSource"       version="4.3.0" />
-				<dependency id="Microsoft.Extensions.DependencyModel" version="1.1.0" />
-				<dependency id="System.ComponentModel.Annotations"    version="4.4.1" />
+				<dependency id="Microsoft.Extensions.DependencyModel" version="2.1.0" />
+				<dependency id="System.ComponentModel.Annotations"    version="4.5.0" />
 				<dependency id="System.ComponentModel.TypeConverter"  version="4.3.0" />
 				<dependency id="System.Linq.Queryable"                version="4.3.0" />
 				<dependency id="System.Runtime.Loader"                version="4.3.0" />
@@ -24,16 +24,16 @@
 				<dependency id="System.Net.NetworkInformation"        version="4.3.0" />
 			</group>
 			<group targetFramework=".NETStandard2.0">
-				<dependency id="Microsoft.CSharp"                     version="4.4.0" />
-				<dependency id="System.ComponentModel.Annotations"    version="4.4.1" />
+				<dependency id="Microsoft.CSharp"                     version="4.5.0" />
+				<dependency id="System.ComponentModel.Annotations"    version="4.5.0" />
 				<dependency id="System.Data.SqlClient"                version="4.6.0" />
 				<dependency id="System.Data.DataSetExtensions"        version="4.5.0" />
 			</group>
 			<group targetFramework=".NETCoreApp1.0">
-				<dependency id="Microsoft.CSharp"                     version="4.3.0" />
+				<dependency id="Microsoft.CSharp"                     version="4.5.0" />
 				<dependency id="System.Diagnostics.TraceSource"       version="4.3.0" />
-				<dependency id="Microsoft.Extensions.DependencyModel" version="1.1.0" />
-				<dependency id="System.ComponentModel.Annotations"    version="4.4.1" />
+				<dependency id="Microsoft.Extensions.DependencyModel" version="2.1.0" />
+				<dependency id="System.ComponentModel.Annotations"    version="4.5.0" />
 				<dependency id="System.ComponentModel.TypeConverter"  version="4.3.0" />
 				<dependency id="System.Linq.Queryable"                version="4.3.0" />
 				<dependency id="System.Runtime.Loader"                version="4.3.0" />
@@ -42,7 +42,7 @@
 				<dependency id="System.Net.NetworkInformation"        version="4.3.0" />
 			</group>
 			<group targetFramework=".NETCoreApp2.0">
-				<dependency id="System.ComponentModel.Annotations"    version="4.4.1" />
+				<dependency id="System.ComponentModel.Annotations"    version="4.5.0" />
 				<dependency id="System.Data.SqlClient"                version="4.6.0" />
 				<dependency id="System.Data.DataSetExtensions"        version="4.5.0" />
 			</group>

--- a/NuGet/linq2db.nuspec
+++ b/NuGet/linq2db.nuspec
@@ -20,13 +20,13 @@
 				<dependency id="System.Linq.Queryable"                version="4.3.0" />
 				<dependency id="System.Runtime.Loader"                version="4.3.0" />
 				<dependency id="System.Xml.XmlDocument"               version="4.3.0" />
-				<dependency id="System.Data.SqlClient"                version="4.5.1" />
+				<dependency id="System.Data.SqlClient"                version="4.6.0" />
 				<dependency id="System.Net.NetworkInformation"        version="4.3.0" />
 			</group>
 			<group targetFramework=".NETStandard2.0">
 				<dependency id="Microsoft.CSharp"                     version="4.4.0" />
 				<dependency id="System.ComponentModel.Annotations"    version="4.4.1" />
-				<dependency id="System.Data.SqlClient"                version="4.5.1" />
+				<dependency id="System.Data.SqlClient"                version="4.6.0" />
 				<dependency id="System.Data.DataSetExtensions"        version="4.5.0" />
 			</group>
 			<group targetFramework=".NETCoreApp1.0">
@@ -38,12 +38,12 @@
 				<dependency id="System.Linq.Queryable"                version="4.3.0" />
 				<dependency id="System.Runtime.Loader"                version="4.3.0" />
 				<dependency id="System.Xml.XmlDocument"               version="4.3.0" />
-				<dependency id="System.Data.SqlClient"                version="4.5.1" />
+				<dependency id="System.Data.SqlClient"                version="4.6.0" />
 				<dependency id="System.Net.NetworkInformation"        version="4.3.0" />
 			</group>
 			<group targetFramework=".NETCoreApp2.0">
 				<dependency id="System.ComponentModel.Annotations"    version="4.4.1" />
-				<dependency id="System.Data.SqlClient"                version="4.5.1" />
+				<dependency id="System.Data.SqlClient"                version="4.6.0" />
 				<dependency id="System.Data.DataSetExtensions"        version="4.5.0" />
 			</group>
 		</dependencies>

--- a/Source/LinqToDB/LinqToDB.csproj
+++ b/Source/LinqToDB/LinqToDB.csproj
@@ -76,4 +76,24 @@
 		<Compile Remove="DataProvider\Access\*.cs;DataProvider\SapHana\SapHanaOdbc*.cs" />
 		<Compile Include="Compatibility\System\Data\Linq\Binary.cs" />
 	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' OR '$(TargetFramework)' == 'netcoreapp1.0' ">
+		<PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+		<PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
+		<PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
+		<PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+		<PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
+		<PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+		<PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
+		<PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
+		<PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp2.0' ">
+		<PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+		<PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
+		<PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
+		<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0"/>
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
Fix #1704

- move nuget dependencies back to linq2db project (linq2db.tools will get them as transient dependencies from linq2db)
- remove `System.Data.Common` dependency
- update multiple outdated nuspec dependencies (including system.data.sqlclient)

Incident summary: we shouldn't forget to update nuspec files when we bump dependencies for released products