### PR TITLE
Add option to configure await in linq2db using ConfigureAwait()

### DIFF
--- a/Source/LinqToDB/Async/AsyncFactory.cs
+++ b/Source/LinqToDB/Async/AsyncFactory.cs
@@ -92,7 +92,7 @@ namespace LinqToDB.Async
 		private static async Task<IAsyncDbTransaction> Wrap<TTransaction>(Task<TTransaction> transaction)
 			where TTransaction: IDbTransaction
 		{
-			return Create(await transaction);
+			return Create(await transaction.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext));
 		}
 
 		private static Func<IDbTransaction, IAsyncDbTransaction> TransactionFactory(Type type)

--- a/Source/LinqToDB/AsyncExtensions.cs
+++ b/Source/LinqToDB/AsyncExtensions.cs
@@ -145,14 +145,14 @@ namespace LinqToDB
 			if (source is ExpressionQuery<TSource> query)
 			{
 				var list = new List<TSource>();
-				await query.GetForEachAsync(list.Add, token);
+				await query.GetForEachAsync(list.Add, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 				return list;
 			}
 
 			if (LinqExtensions.ExtensionsAdapter != null)
-				return await LinqExtensions.ExtensionsAdapter.ToListAsync(source, token);
+				return await LinqExtensions.ExtensionsAdapter.ToListAsync(source, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await GetTask(() => source.AsEnumerable().TakeWhile(_ => !token.IsCancellationRequested).ToList(), token);
+			return await GetTask(() => source.AsEnumerable().TakeWhile(_ => !token.IsCancellationRequested).ToList(), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		#endregion
@@ -173,22 +173,22 @@ namespace LinqToDB
 			if (source is ExpressionQuery<TSource> query)
 			{
 				var list = new List<TSource>();
-				await query.GetForEachAsync(list.Add, token);
+				await query.GetForEachAsync(list.Add, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 				return list.ToArray();
 
-//				var list = new List<TSource>();
-//
-//				using (var enumerator = query.GetAsyncEnumerable().GetEnumerator())
-//					while (await enumerator.MoveNext(token))
-//						list.Add(enumerator.Current);
-//
-//				return list.ToArray();
+				//				var list = new List<TSource>();
+				//
+				//				using (var enumerator = query.GetAsyncEnumerable().GetEnumerator())
+				//					while (await enumerator.MoveNext(token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
+				//						list.Add(enumerator.Current);
+				//
+				//				return list.ToArray();
 			}
 
 			if (LinqExtensions.ExtensionsAdapter != null)
-				return await LinqExtensions.ExtensionsAdapter.ToArrayAsync(source, token);
+				return await LinqExtensions.ExtensionsAdapter.ToArrayAsync(source, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await GetTask(() => source.AsEnumerable().TakeWhile(_ => !token.IsCancellationRequested).ToArray(), token);
+			return await GetTask(() => source.AsEnumerable().TakeWhile(_ => !token.IsCancellationRequested).ToArray(), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		#endregion
@@ -212,14 +212,14 @@ namespace LinqToDB
 			if (source is ExpressionQuery<TSource> query)
 			{
 				var dic = new Dictionary<TKey,TSource>();
-				await query.GetForEachAsync(item => dic.Add(keySelector(item), item), token);
+				await query.GetForEachAsync(item => dic.Add(keySelector(item), item), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 				return dic;
 			}
 
 			if (LinqExtensions.ExtensionsAdapter != null)
-				return await LinqExtensions.ExtensionsAdapter.ToDictionaryAsync(source, keySelector, token);
+				return await LinqExtensions.ExtensionsAdapter.ToDictionaryAsync(source, keySelector, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await GetTask(() => source.AsEnumerable().TakeWhile(_ => !token.IsCancellationRequested).ToDictionary(keySelector), token);
+			return await GetTask(() => source.AsEnumerable().TakeWhile(_ => !token.IsCancellationRequested).ToDictionary(keySelector), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		/// <summary>
@@ -241,14 +241,14 @@ namespace LinqToDB
 			if (source is ExpressionQuery<TSource> query)
 			{
 				var dic = new Dictionary<TKey,TSource>(comparer);
-				await query.GetForEachAsync(item => dic.Add(keySelector(item), item), token);
+				await query.GetForEachAsync(item => dic.Add(keySelector(item), item), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 				return dic;
 			}
 
 			if (LinqExtensions.ExtensionsAdapter != null)
-				return await LinqExtensions.ExtensionsAdapter.ToDictionaryAsync(source, keySelector, comparer, token);
+				return await LinqExtensions.ExtensionsAdapter.ToDictionaryAsync(source, keySelector, comparer, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await GetTask(() => source.AsEnumerable().TakeWhile(_ => !token.IsCancellationRequested).ToDictionary(keySelector, comparer), token);
+			return await GetTask(() => source.AsEnumerable().TakeWhile(_ => !token.IsCancellationRequested).ToDictionary(keySelector, comparer), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		/// <summary>
@@ -271,14 +271,14 @@ namespace LinqToDB
 			if (source is ExpressionQuery<TSource> query)
 			{
 				var dic = new Dictionary<TKey,TElement>();
-				await query.GetForEachAsync(item => dic.Add(keySelector(item), elementSelector(item)), token);
+				await query.GetForEachAsync(item => dic.Add(keySelector(item), elementSelector(item)), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 				return dic;
 			}
 
 			if (LinqExtensions.ExtensionsAdapter != null)
-				return await LinqExtensions.ExtensionsAdapter.ToDictionaryAsync(source, keySelector, elementSelector, token);
+				return await LinqExtensions.ExtensionsAdapter.ToDictionaryAsync(source, keySelector, elementSelector, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await GetTask(() => source.AsEnumerable().TakeWhile(_ => !token.IsCancellationRequested).ToDictionary(keySelector, elementSelector), token);
+			return await GetTask(() => source.AsEnumerable().TakeWhile(_ => !token.IsCancellationRequested).ToDictionary(keySelector, elementSelector), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		/// <summary>
@@ -303,14 +303,14 @@ namespace LinqToDB
 			if (source is ExpressionQuery<TSource> query)
 			{
 				var dic = new Dictionary<TKey,TElement>();
-				await query.GetForEachAsync(item => dic.Add(keySelector(item), elementSelector(item)), token);
+				await query.GetForEachAsync(item => dic.Add(keySelector(item), elementSelector(item)), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 				return dic;
 			}
 
 			if (LinqExtensions.ExtensionsAdapter != null)
-				return await LinqExtensions.ExtensionsAdapter.ToDictionaryAsync(source, keySelector, elementSelector, comparer, token);
+				return await LinqExtensions.ExtensionsAdapter.ToDictionaryAsync(source, keySelector, elementSelector, comparer, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await GetTask(() => source.AsEnumerable().TakeWhile(_ => !token.IsCancellationRequested).ToDictionary(keySelector, elementSelector, comparer), token);
+			return await GetTask(() => source.AsEnumerable().TakeWhile(_ => !token.IsCancellationRequested).ToDictionary(keySelector, elementSelector, comparer), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		#endregion

--- a/Source/LinqToDB/Common/Configuration.cs
+++ b/Source/LinqToDB/Common/Configuration.cs
@@ -6,6 +6,7 @@ namespace LinqToDB.Common
 {
 	using Data;
 	using Data.RetryPolicy;
+	using System.Threading.Tasks;
 
 	/// <summary>
 	/// Contains global linq2db settings.
@@ -33,6 +34,12 @@ namespace LinqToDB.Common
 		/// Default value: <c>false</c>.
 		/// </summary>
 		public static bool AvoidSpecificDataProviderAPI;
+
+		/// <summary>
+		/// Defines value to pass to <see cref="Task.ConfigureAwait(bool)"/> method for all linq2db internal await operations.
+		/// Default value: <c>true</c>.
+		/// </summary>
+		public static bool ContinueOnCapturedContext = true;
 
 		public static class Data
 		{

--- a/Source/LinqToDB/Common/Internal/Cache/MemoryCacheExtensions.cs
+++ b/Source/LinqToDB/Common/Internal/Cache/MemoryCacheExtensions.cs
@@ -109,7 +109,7 @@ namespace LinqToDB.Common.Internal.Cache
             if (!cache.TryGetValue(key, out object result))
             {
                 var entry = cache.CreateEntry(key);
-                result = await factory(entry);
+                result = await factory(entry).ConfigureAwait(Configuration.ContinueOnCapturedContext);
                 entry.SetValue(result);
                 // need to manually call dispose instead of having a using
                 // in case the factory passed in throws, in which case we

--- a/Source/LinqToDB/Data/CommandInfo.cs
+++ b/Source/LinqToDB/Data/CommandInfo.cs
@@ -181,7 +181,7 @@ namespace LinqToDB.Data
 		public async Task<List<T>> QueryToListAsync<T>(Func<IDataReader,T> objectReader, CancellationToken cancellationToken)
 		{
 			var list = new List<T>();
-			await QueryForEachAsync(objectReader, list.Add, cancellationToken);
+			await QueryForEachAsync(objectReader, list.Add, cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 			return list;
 		}
 
@@ -206,7 +206,7 @@ namespace LinqToDB.Data
 		public async Task<T[]> QueryToArrayAsync<T>(Func<IDataReader,T> objectReader, CancellationToken cancellationToken)
 		{
 			var list = new List<T>();
-			await QueryForEachAsync(objectReader, list.Add, cancellationToken);
+			await QueryForEachAsync(objectReader, list.Add, cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 			return list.ToArray();
 		}
 
@@ -232,7 +232,7 @@ namespace LinqToDB.Data
 		/// <returns>Returns task.</returns>
 		public async Task QueryForEachAsync<T>(Func<IDataReader,T> objectReader, Action<T> action, CancellationToken cancellationToken)
 		{
-			await DataConnection.EnsureConnectionAsync(cancellationToken);
+			await DataConnection.EnsureConnectionAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 			var hasParameters = Parameters?.Length > 0;
 
@@ -241,8 +241,8 @@ namespace LinqToDB.Data
 			if (hasParameters)
 				SetParameters(DataConnection, Parameters);
 
-			using (var rd = await DataConnection.ExecuteReaderAsync(GetCommandBehavior(), cancellationToken))
-				while (await rd.ReadAsync(cancellationToken))
+			using (var rd = await DataConnection.ExecuteReaderAsync(GetCommandBehavior(), cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
+				while (await rd.ReadAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 					action(objectReader(rd));
 		}
 
@@ -336,7 +336,7 @@ namespace LinqToDB.Data
 		public async Task<List<T>> QueryToListAsync<T>(CancellationToken cancellationToken)
 		{
 			var list = new List<T>();
-			await QueryForEachAsync<T>(list.Add, cancellationToken);
+			await QueryForEachAsync<T>(list.Add, cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 			return list;
 		}
 
@@ -359,7 +359,7 @@ namespace LinqToDB.Data
 		public async Task<T[]> QueryToArrayAsync<T>(CancellationToken cancellationToken)
 		{
 			var list = new List<T>();
-			await QueryForEachAsync<T>(list.Add, cancellationToken);
+			await QueryForEachAsync<T>(list.Add, cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 			return list.ToArray();
 		}
 
@@ -383,7 +383,7 @@ namespace LinqToDB.Data
 		/// <returns>Returns task.</returns>
 		public async Task QueryForEachAsync<T>(Action<T> action, CancellationToken cancellationToken)
 		{
-			await DataConnection.EnsureConnectionAsync(cancellationToken);
+			await DataConnection.EnsureConnectionAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 			var hasParameters = Parameters?.Length > 0;
 
@@ -392,9 +392,9 @@ namespace LinqToDB.Data
 			if (hasParameters)
 				SetParameters(DataConnection, Parameters);
 
-			using (var rd = await DataConnection.ExecuteReaderAsync(GetCommandBehavior(), cancellationToken))
+			using (var rd = await DataConnection.ExecuteReaderAsync(GetCommandBehavior(), cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 			{
-				if (await rd.ReadAsync(cancellationToken))
+				if (await rd.ReadAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 				{
 					var additionalKey = GetCommandAdditionalKey(rd);
 					var objectReader  = GetObjectReader<T>(DataConnection, rd, DataConnection.Command.CommandText, additionalKey);
@@ -420,7 +420,7 @@ namespace LinqToDB.Data
 
 						action(result);
 
-					} while (await rd.ReadAsync(cancellationToken));
+					} while (await rd.ReadAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext));
 				}
 			}
 		}
@@ -525,7 +525,7 @@ namespace LinqToDB.Data
 		/// <returns>Task with number of records, affected by command execution.</returns>
 		public async Task<int> ExecuteAsync(CancellationToken cancellationToken)
 		{
-			await DataConnection.EnsureConnectionAsync(cancellationToken);
+			await DataConnection.EnsureConnectionAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 			var hasParameters = Parameters?.Length > 0;
 
@@ -534,7 +534,7 @@ namespace LinqToDB.Data
 			if (hasParameters)
 				SetParameters(DataConnection, Parameters);
 
-			var commandResult = await DataConnection.ExecuteNonQueryAsync(cancellationToken);
+			var commandResult = await DataConnection.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 			if (hasParameters)
 				RebindParameters(DataConnection, Parameters);
@@ -646,7 +646,7 @@ namespace LinqToDB.Data
 		/// <returns>Task with resulting value.</returns>
 		public async Task<T> ExecuteAsync<T>(CancellationToken cancellationToken)
 		{
-			await DataConnection.EnsureConnectionAsync(cancellationToken);
+			await DataConnection.EnsureConnectionAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 			var hasParameters = Parameters?.Length > 0;
 
@@ -655,9 +655,9 @@ namespace LinqToDB.Data
 			if (hasParameters)
 				SetParameters(DataConnection, Parameters);
 
-			using (var rd = await DataConnection.ExecuteReaderAsync(GetCommandBehavior(), cancellationToken))
+			using (var rd = await DataConnection.ExecuteReaderAsync(GetCommandBehavior(), cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 			{
-				if (await rd.ReadAsync(cancellationToken))
+				if (await rd.ReadAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 				{
 					var additionalKey = GetCommandAdditionalKey(rd);
 					try
@@ -774,7 +774,7 @@ namespace LinqToDB.Data
 		/// <returns>Task with data reader object.</returns>
 		public async Task<DataReaderAsync> ExecuteReaderAsync(CancellationToken cancellationToken)
 		{
-			await DataConnection.EnsureConnectionAsync(cancellationToken);
+			await DataConnection.EnsureConnectionAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 			var hasParameters = Parameters?.Length > 0;
 
@@ -783,12 +783,12 @@ namespace LinqToDB.Data
 			if (hasParameters)
 				SetParameters(DataConnection, Parameters);
 
-			return new DataReaderAsync { CommandInfo = this, Reader = await DataConnection.ExecuteReaderAsync(GetCommandBehavior(), cancellationToken) };
+			return new DataReaderAsync { CommandInfo = this, Reader = await DataConnection.ExecuteReaderAsync(GetCommandBehavior(), cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext) };
 		}
 
 		internal async Task ExecuteQueryAsync<T>(DbDataReader rd, string sql, Action<T> action, CancellationToken cancellationToken)
 		{
-			if (await rd.ReadAsync(cancellationToken))
+			if (await rd.ReadAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 			{
 				var additionalKey = GetCommandAdditionalKey(rd);
 				var objectReader  = GetObjectReader<T>(DataConnection, rd, sql, additionalKey);
@@ -814,13 +814,13 @@ namespace LinqToDB.Data
 
 					action(result);
 
-				} while (await rd.ReadAsync(cancellationToken));
+				} while (await rd.ReadAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext));
 			}
 		}
 
 		internal async Task<T> ExecuteScalarAsync<T>(DbDataReader rd, string sql, CancellationToken cancellationToken)
 		{
-			if (await rd.ReadAsync(cancellationToken))
+			if (await rd.ReadAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 			{
 				var additionalKey = GetCommandAdditionalKey(rd);
 				try

--- a/Source/LinqToDB/Data/DataConnection.Async.cs
+++ b/Source/LinqToDB/Data/DataConnection.Async.cs
@@ -20,7 +20,7 @@ namespace LinqToDB.Data
 		/// <returns>Database transaction object.</returns>
 		public virtual async Task<DataConnectionTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
 		{
-			await EnsureConnectionAsync(cancellationToken);
+			await EnsureConnectionAsync(cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 			// If transaction is open, we dispose it, it will rollback all changes.
 			//
@@ -28,7 +28,7 @@ namespace LinqToDB.Data
 
 			// Create new transaction object.
 			//
-			TransactionAsync = await _connection.BeginTransactionAsync(cancellationToken);
+			TransactionAsync = await _connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 			_closeTransaction = true;
 
@@ -48,7 +48,7 @@ namespace LinqToDB.Data
 		/// <returns>Database transaction object.</returns>
 		public virtual async Task<DataConnectionTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
 		{
-			await EnsureConnectionAsync(cancellationToken);
+			await EnsureConnectionAsync(cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 			// If transaction is open, we dispose it, it will rollback all changes.
 			//
@@ -56,7 +56,7 @@ namespace LinqToDB.Data
 
 			// Create new transaction object.
 			//
-			TransactionAsync = await _connection.BeginTransactionAsync(isolationLevel, cancellationToken);
+			TransactionAsync = await _connection.BeginTransactionAsync(isolationLevel, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 			_closeTransaction = true;
 
@@ -95,15 +95,15 @@ namespace LinqToDB.Data
 				{
 					var task = OnBeforeConnectionOpenAsync?.Invoke(this, _connection.Connection, cancellationToken);
 					if (task != null)
-						await task;
+						await task.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-					await _connection.OpenAsync(cancellationToken);
+					await _connection.OpenAsync(cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 					_closeConnection = true;
 
 					task = OnConnectionOpenedAsync?.Invoke(this, _connection.Connection, cancellationToken);
 					if (task != null)
-						await task;
+						await task.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 				}
 				catch (Exception ex)
 				{
@@ -134,7 +134,7 @@ namespace LinqToDB.Data
 		{
 			if (TransactionAsync != null)
 			{
-				await TransactionAsync.CommitAsync(cancellationToken);
+				await TransactionAsync.CommitAsync(cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 				if (_closeTransaction)
 				{
@@ -157,7 +157,7 @@ namespace LinqToDB.Data
 		{
 			if (TransactionAsync != null)
 			{
-				await TransactionAsync.RollbackAsync(cancellationToken);
+				await TransactionAsync.RollbackAsync(cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 				if (_closeTransaction)
 				{
@@ -195,7 +195,7 @@ namespace LinqToDB.Data
 					_connection = null;
 				}
 				else if (_closeConnection)
-					await _connection.CloseAsync();
+					await _connection.CloseAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			}
 
 			OnClosed?.Invoke(this, EventArgs.Empty);
@@ -208,13 +208,13 @@ namespace LinqToDB.Data
 		public async Task DisposeAsync(CancellationToken cancellationToken = default)
 		{
 			Disposed = true;
-			await CloseAsync(cancellationToken);
+			await CloseAsync(cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		internal async Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
 		{
 			if (TraceSwitch.Level == TraceLevel.Off || OnTraceConnection == null)
-				return await ((DbCommand)Command).ExecuteNonQueryExtAsync(cancellationToken);
+				return await ((DbCommand)Command).ExecuteNonQueryExtAsync(cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 			var now = DateTime.UtcNow;
 			var sw  = Stopwatch.StartNew();
@@ -233,7 +233,7 @@ namespace LinqToDB.Data
 
 			try
 			{
-				var ret = await ((DbCommand)Command).ExecuteNonQueryExtAsync(cancellationToken);
+				var ret = await ((DbCommand)Command).ExecuteNonQueryExtAsync(cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 				if (TraceSwitch.TraceInfo)
 				{
@@ -274,7 +274,7 @@ namespace LinqToDB.Data
 		internal async Task<object> ExecuteScalarAsync(CancellationToken cancellationToken)
 		{
 			if (TraceSwitch.Level == TraceLevel.Off || OnTraceConnection == null)
-				return await ((DbCommand)Command).ExecuteScalarExtAsync(cancellationToken);
+				return await ((DbCommand)Command).ExecuteScalarExtAsync(cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 			var now = DateTime.UtcNow;
 			var sw  = Stopwatch.StartNew();
@@ -293,7 +293,7 @@ namespace LinqToDB.Data
 
 			try
 			{
-				var ret = await ((DbCommand)Command).ExecuteScalarExtAsync(cancellationToken);
+				var ret = await ((DbCommand)Command).ExecuteScalarExtAsync(cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 				if (TraceSwitch.TraceInfo)
 				{
@@ -335,7 +335,7 @@ namespace LinqToDB.Data
 			CancellationToken cancellationToken)
 		{
 			if (TraceSwitch.Level == TraceLevel.Off || OnTraceConnection == null)
-				return await ((DbCommand)Command).ExecuteReaderExtAsync(commandBehavior, cancellationToken);
+				return await ((DbCommand)Command).ExecuteReaderExtAsync(commandBehavior, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 			var now = DateTime.UtcNow;
 			var sw  = Stopwatch.StartNew();
@@ -354,7 +354,7 @@ namespace LinqToDB.Data
 
 			try
 			{
-				var ret = await ((DbCommand)Command).ExecuteReaderExtAsync(commandBehavior, cancellationToken);
+				var ret = await ((DbCommand)Command).ExecuteReaderExtAsync(commandBehavior, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 				if (TraceSwitch.TraceInfo)
 				{

--- a/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
+++ b/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
@@ -492,7 +492,7 @@ namespace LinqToDB.Data
 			{
 				_isAsync = true;
 
-				await _dataConnection.EnsureConnectionAsync(cancellationToken);
+				await _dataConnection.EnsureConnectionAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 				base.SetCommand(true);
 
@@ -504,7 +504,7 @@ namespace LinqToDB.Data
 					foreach (var p in _preparedQuery.Parameters)
 						_dataConnection.Command.Parameters.Add(p);
 
-				var dataReader = await _dataConnection.ExecuteReaderAsync(_dataConnection.GetCommandBehavior(CommandBehavior.Default), cancellationToken);
+				var dataReader = await _dataConnection.ExecuteReaderAsync(_dataConnection.GetCommandBehavior(CommandBehavior.Default), cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 				return new DataReaderAsync(dataReader);
 			}
@@ -513,7 +513,7 @@ namespace LinqToDB.Data
 			{
 				_isAsync = true;
 
-				await _dataConnection.EnsureConnectionAsync(cancellationToken);
+				await _dataConnection.EnsureConnectionAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 				base.SetCommand(true);
 
@@ -528,7 +528,7 @@ namespace LinqToDB.Data
 						foreach (var p in _preparedQuery.Parameters)
 							_dataConnection.Command.Parameters.Add(p);
 
-					return await _dataConnection.ExecuteNonQueryAsync(cancellationToken);
+					return await _dataConnection.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 				}
 
 				for (var i = 0; i < _preparedQuery.Commands.Length; i++)
@@ -546,7 +546,7 @@ namespace LinqToDB.Data
 					{
 						try
 						{
-							await _dataConnection.ExecuteNonQueryAsync(cancellationToken);
+							await _dataConnection.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 						}
 						catch
 						{
@@ -554,7 +554,7 @@ namespace LinqToDB.Data
 					}
 					else
 					{
-						await _dataConnection.ExecuteNonQueryAsync(cancellationToken);
+						await _dataConnection.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 					}
 				}
 
@@ -565,7 +565,7 @@ namespace LinqToDB.Data
 			{
 				_isAsync = true;
 
-				await _dataConnection.EnsureConnectionAsync(cancellationToken);
+				await _dataConnection.EnsureConnectionAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 				SetCommand();
 
@@ -591,19 +591,19 @@ namespace LinqToDB.Data
 					{
 						// так сделано потому, что фаерберд провайдер не возвращает никаких параметров через ExecuteReader
 						// остальные провайдеры должны поддерживать такой режим
-						await _dataConnection.ExecuteNonQueryAsync(cancellationToken);
+						await _dataConnection.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 						return idparam.Value;
 					}
 
-					return await _dataConnection.ExecuteScalarAsync(cancellationToken);
+					return await _dataConnection.ExecuteScalarAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 				}
 
-				await _dataConnection.ExecuteNonQueryAsync(cancellationToken);
+				await _dataConnection.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 				_dataConnection.InitCommand(CommandType.Text, _preparedQuery.Commands[1], null, null, false);
 
-				return await _dataConnection.ExecuteScalarAsync(cancellationToken);
+				return await _dataConnection.ExecuteScalarAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 			}
 		}
 	}

--- a/Source/LinqToDB/Data/DataConnectionTransaction.cs
+++ b/Source/LinqToDB/Data/DataConnectionTransaction.cs
@@ -52,7 +52,7 @@ namespace LinqToDB.Data
 		/// <returns>Asynchronous operation completion task.</returns>
 		public async Task CommitAsync(CancellationToken cancellationToken = default)
 		{
-			await DataConnection.CommitTransactionAsync(cancellationToken);
+			await DataConnection.CommitTransactionAsync(cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			_disposeTransaction = false;
 		}
 
@@ -64,7 +64,7 @@ namespace LinqToDB.Data
 		/// <returns>Asynchronous operation completion task.</returns>
 		public async Task RollbackAsync(CancellationToken cancellationToken = default)
 		{
-			await DataConnection.RollbackTransactionAsync(cancellationToken);
+			await DataConnection.RollbackTransactionAsync(cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			_disposeTransaction = false;
 		}
 

--- a/Source/LinqToDB/Data/DataReaderAsync.cs
+++ b/Source/LinqToDB/Data/DataReaderAsync.cs
@@ -50,7 +50,7 @@ namespace LinqToDB.Data
 		public async Task<List<T>> QueryToListAsync<T>(Func<IDataReader,T> objectReader, CancellationToken cancellationToken)
 		{
 			var list = new List<T>();
-			await QueryForEachAsync(objectReader, list.Add, cancellationToken);
+			await QueryForEachAsync(objectReader, list.Add, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			return list;
 		}
 
@@ -62,7 +62,7 @@ namespace LinqToDB.Data
 		public async Task<T[]> QueryToArrayAsync<T>(Func<IDataReader,T> objectReader, CancellationToken cancellationToken)
 		{
 			var list = new List<T>();
-			await QueryForEachAsync(objectReader, list.Add, cancellationToken);
+			await QueryForEachAsync(objectReader, list.Add, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			return list.ToArray();
 		}
 
@@ -73,7 +73,7 @@ namespace LinqToDB.Data
 
 		public async Task QueryForEachAsync<T>(Func<IDataReader,T> objectReader, Action<T> action, CancellationToken cancellationToken)
 		{
-			while (await Reader.ReadAsync(cancellationToken))
+			while (await Reader.ReadAsync(cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
 				action(objectReader(Reader));
 		}
 
@@ -89,7 +89,7 @@ namespace LinqToDB.Data
 		public async Task<List<T>> QueryToListAsync<T>(CancellationToken cancellationToken)
 		{
 			var list = new List<T>();
-			await QueryForEachAsync<T>(list.Add, cancellationToken);
+			await QueryForEachAsync<T>(list.Add, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			return list;
 		}
 
@@ -101,7 +101,7 @@ namespace LinqToDB.Data
 		public async Task<T[]> QueryToArrayAsync<T>(CancellationToken cancellationToken)
 		{
 			var list = new List<T>();
-			await QueryForEachAsync<T>(list.Add, cancellationToken);
+			await QueryForEachAsync<T>(list.Add, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			return list.ToArray();
 		}
 
@@ -113,12 +113,12 @@ namespace LinqToDB.Data
 		public async Task QueryForEachAsync<T>(Action<T> action, CancellationToken cancellationToken)
 		{
 			if (ReadNumber != 0)
-				if (!await Reader.NextResultAsync(cancellationToken))
+				if (!await Reader.NextResultAsync(cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
 					return;
 
 			ReadNumber++;
 
-			await CommandInfo.ExecuteQueryAsync(Reader, CommandInfo.DataConnection.Command.CommandText + "$$$" + ReadNumber, action, cancellationToken);
+			await CommandInfo.ExecuteQueryAsync(Reader, CommandInfo.DataConnection.Command.CommandText + "$$$" + ReadNumber, action, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		#endregion
@@ -133,7 +133,7 @@ namespace LinqToDB.Data
 		public async Task<List<T>> QueryToListAsync<T>(T template, CancellationToken cancellationToken)
 		{
 			var list = new List<T>();
-			await QueryForEachAsync(template, list.Add, cancellationToken);
+			await QueryForEachAsync(template, list.Add, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			return list;
 		}
 
@@ -145,7 +145,7 @@ namespace LinqToDB.Data
 		public async Task<T[]> QueryToArrayAsync<T>(T template, CancellationToken cancellationToken)
 		{
 			var list = new List<T>();
-			await QueryForEachAsync(template, list.Add, cancellationToken);
+			await QueryForEachAsync(template, list.Add, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			return list.ToArray();
 		}
 
@@ -171,14 +171,14 @@ namespace LinqToDB.Data
 		public async Task<T> ExecuteForEachAsync<T>(CancellationToken cancellationToken)
 		{
 			if (ReadNumber != 0)
-				if (!await Reader.NextResultAsync(cancellationToken))
+				if (!await Reader.NextResultAsync(cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
 					return default(T);
 
 			ReadNumber++;
 
 			var sql = CommandInfo.DataConnection.Command.CommandText + "$$$" + ReadNumber;
 
-			return await CommandInfo.ExecuteScalarAsync<T>(Reader, sql, cancellationToken);
+			return await CommandInfo.ExecuteScalarAsync<T>(Reader, sql, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		#endregion

--- a/Source/LinqToDB/Data/RetryPolicy/RetryPolicyBase.cs
+++ b/Source/LinqToDB/Data/RetryPolicy/RetryPolicyBase.cs
@@ -162,12 +162,12 @@ namespace LinqToDB.Data.RetryPolicy
 		{
 			if (Suspended)
 			{
-				await operation(cancellationToken);
+				await operation(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 				return;
 			}
 
 			OnFirstExecution();
-			await ExecuteImplementationAsync(async ct => { await operation(ct); return 0; }, cancellationToken);
+			await ExecuteImplementationAsync(async ct => { await operation(ct).ConfigureAwait(Configuration.ContinueOnCapturedContext); return 0; }, cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 		}
 
 		async Task<TResult> ExecuteImplementationAsync<TResult>(
@@ -184,7 +184,7 @@ namespace LinqToDB.Data.RetryPolicy
 				try
 				{
 					Suspended = true;
-					var result = await operation(cancellationToken);
+					var result = await operation(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 					Suspended = false;
 					return result;
 				}
@@ -204,7 +204,7 @@ namespace LinqToDB.Data.RetryPolicy
 					OnRetry();
 				}
 
-				await TaskEx.Delay(delay.Value, cancellationToken);
+				await TaskEx.Delay(delay.Value, cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 			}
 		}
 

--- a/Source/LinqToDB/Data/RetryPolicy/RetryingDbConnection.cs
+++ b/Source/LinqToDB/Data/RetryPolicy/RetryingDbConnection.cs
@@ -68,7 +68,7 @@ namespace LinqToDB.Data.RetryPolicy
 #endif
 			async Task OpenAsync(CancellationToken cancellationToken)
 		{
-			await _policy.ExecuteAsync(async ct => await _connection.OpenAsync(ct), cancellationToken);
+			await _policy.ExecuteAsync(async ct => await _connection.OpenAsync(ct).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext), cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		void IDisposable.Dispose()

--- a/Source/LinqToDB/DataContext.cs
+++ b/Source/LinqToDB/DataContext.cs
@@ -368,7 +368,7 @@ namespace LinqToDB
 		{
 			var dct = new DataContextTransaction(this);
 
-			await dct.BeginTransactionAsync(level);
+			await dct.BeginTransactionAsync(level).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 			return dct;
 		}
@@ -384,7 +384,7 @@ namespace LinqToDB
 		{
 			var dct = new DataContextTransaction(this);
 
-			await dct.BeginTransactionAsync();
+			await dct.BeginTransactionAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 			return dct;
 		}

--- a/Source/LinqToDB/DataContextTransaction.cs
+++ b/Source/LinqToDB/DataContextTransaction.cs
@@ -70,7 +70,7 @@ namespace LinqToDB
 		{
 			var db = DataContext.GetDataConnection();
 
-			await db.BeginTransactionAsync();
+			await db.BeginTransactionAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 			if (_transactionCounter == 0)
 				DataContext.LockDbManagerCounter++;
@@ -88,7 +88,7 @@ namespace LinqToDB
 		{
 			var db = DataContext.GetDataConnection();
 
-			await db.BeginTransactionAsync(level);
+			await db.BeginTransactionAsync(level).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 			if (_transactionCounter == 0)
 				DataContext.LockDbManagerCounter++;
@@ -150,7 +150,7 @@ namespace LinqToDB
 			{
 				var db = DataContext.GetDataConnection();
 
-				await db.CommitTransactionAsync(cancellationToken);
+				await db.CommitTransactionAsync(cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 				_transactionCounter--;
 
@@ -174,7 +174,7 @@ namespace LinqToDB
 			{
 				var db = DataContext.GetDataConnection();
 
-				await db.RollbackTransactionAsync(cancellationToken);
+				await db.RollbackTransactionAsync(cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 				_transactionCounter--;
 

--- a/Source/LinqToDB/DataExtensions.cs
+++ b/Source/LinqToDB/DataExtensions.cs
@@ -357,7 +357,7 @@ namespace LinqToDB
 		{
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 
-			var ret = await QueryRunner.InsertWithIdentity<T>.QueryAsync(dataContext, obj, tableName, databaseName, schemaName, token);
+			var ret = await QueryRunner.InsertWithIdentity<T>.QueryAsync(dataContext, obj, tableName, databaseName, schemaName, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			return dataContext.MappingSchema.ChangeTypeTo<int>(ret);
 		}
 
@@ -378,7 +378,7 @@ namespace LinqToDB
 		{
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 
-			var ret = await QueryRunner.InsertWithIdentity<T>.QueryAsync(dataContext, obj, tableName, databaseName, schemaName, token);
+			var ret = await QueryRunner.InsertWithIdentity<T>.QueryAsync(dataContext, obj, tableName, databaseName, schemaName, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			return dataContext.MappingSchema.ChangeTypeTo<long>(ret);
 		}
 
@@ -399,7 +399,7 @@ namespace LinqToDB
 		{
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 
-			var ret = await QueryRunner.InsertWithIdentity<T>.QueryAsync(dataContext, obj, tableName, databaseName, schemaName, token);
+			var ret = await QueryRunner.InsertWithIdentity<T>.QueryAsync(dataContext, obj, tableName, databaseName, schemaName, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			return dataContext.MappingSchema.ChangeTypeTo<decimal>(ret);
 		}
 
@@ -659,11 +659,11 @@ namespace LinqToDB
 
 			if (throwExceptionIfNotExists)
 			{
-				await QueryRunner.DropTable<T>.QueryAsync(dataContext, tableName, databaseName, schemaName, !throwExceptionIfNotExists, token);
+				await QueryRunner.DropTable<T>.QueryAsync(dataContext, tableName, databaseName, schemaName, !throwExceptionIfNotExists, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			}
 			else try
 			{
-				await QueryRunner.DropTable<T>.QueryAsync(dataContext, tableName, databaseName, schemaName, !throwExceptionIfNotExists, token);
+				await QueryRunner.DropTable<T>.QueryAsync(dataContext, tableName, databaseName, schemaName, !throwExceptionIfNotExists, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			}
 			catch
 			{
@@ -702,7 +702,7 @@ namespace LinqToDB
 					databaseName ?? table.DatabaseName,
 					schemaName   ?? table.SchemaName,
 					!throwExceptionIfNotExists,
-					token);
+					token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			}
 			else try
 			{
@@ -712,7 +712,7 @@ namespace LinqToDB
 					databaseName ?? table.DatabaseName,
 					schemaName   ?? table.SchemaName,
 					!throwExceptionIfNotExists,
-					token);
+					token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			}
 			catch
 			{

--- a/Source/LinqToDB/DataProvider/BasicMerge.cs
+++ b/Source/LinqToDB/DataProvider/BasicMerge.cs
@@ -52,7 +52,7 @@ namespace LinqToDB.DataProvider
 			if (!BuildCommand(dataConnection, predicate, delete, source, tableName, databaseName, schemaName))
 				return 0;
 
-			return await ExecuteAsync(dataConnection, token);
+			return await ExecuteAsync(dataConnection, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		/// <summary>

--- a/Source/LinqToDB/DataProvider/DataProviderBase.cs
+++ b/Source/LinqToDB/DataProvider/DataProviderBase.cs
@@ -505,7 +505,7 @@ namespace LinqToDB.DataProvider
 			if (builder.NoopCommand)
 				return 0;
 
-			return await dataConnection.ExecuteAsync(cmd, token, builder.Parameters);
+			return await dataConnection.ExecuteAsync(cmd, token, builder.Parameters).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 		}
 
 		protected virtual BasicMergeBuilder<TTarget, TSource> GetMergeBuilder<TTarget, TSource>(

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerMerge.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerMerge.cs
@@ -68,7 +68,7 @@ namespace LinqToDB.DataProvider.SqlServer
 					schemaName   ?? table.SchemaName,
 					tableName    ?? table.TableName).ToString();
 
-				await dataConnection.ExecuteAsync($"SET IDENTITY_INSERT {tblName} ON", token);
+				await dataConnection.ExecuteAsync($"SET IDENTITY_INSERT {tblName} ON", token).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 			}
 
 			Exception ex = null;
@@ -76,7 +76,7 @@ namespace LinqToDB.DataProvider.SqlServer
 
 			try
 			{
-				ret = await base.MergeAsync(dataConnection, predicate, delete, source, tableName, databaseName, schemaName, token);
+				ret = await base.MergeAsync(dataConnection, predicate, delete, source, tableName, databaseName, schemaName, token).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 			}
 			catch (Exception e)
 			{
@@ -84,7 +84,7 @@ namespace LinqToDB.DataProvider.SqlServer
 			}
 
 			if (hasIdentity)
-				await dataConnection.ExecuteAsync($"SET IDENTITY_INSERT {tblName} OFF", token);
+				await dataConnection.ExecuteAsync($"SET IDENTITY_INSERT {tblName} OFF", token).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 			if (ex != null)
 				throw ex;

--- a/Source/LinqToDB/Linq/Builder/FirstSingleBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/FirstSingleBuilder.cs
@@ -121,7 +121,7 @@ namespace LinqToDB.Linq.Builder
 					var obj   = default(T);
 
 					await query.GetForEachAsync(db, expr, ps,
-						r => { obj = r; count++; return false; }, token);
+						r => { obj = r; count++; return false; }, token).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 					return count > 0 ? obj : Array<T>.Empty.First();
 				};
@@ -136,7 +136,7 @@ namespace LinqToDB.Linq.Builder
 					var count = 0;
 					var obj   = default(T);
 
-					await query.GetForEachAsync(db, expr, ps, r => { obj = r; count++; return false; }, token);
+					await query.GetForEachAsync(db, expr, ps, r => { obj = r; count++; return false; }, token).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 					return count > 0 ? obj : Array<T>.Empty.FirstOrDefault();
 				};
@@ -158,7 +158,7 @@ namespace LinqToDB.Linq.Builder
 								obj = r;
 							count++;
 							return count == 1;
-						}, token);
+						}, token).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 					return count == 1 ? obj : new T[count].Single();
 				};
@@ -180,7 +180,7 @@ namespace LinqToDB.Linq.Builder
 								obj = r;
 							count++;
 							return count == 1;
-						}, token);
+						}, token).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 					return count == 1 ? obj : new T[count].SingleOrDefault();
 				};

--- a/Source/LinqToDB/Linq/CompiledTableT.cs
+++ b/Source/LinqToDB/Linq/CompiledTableT.cs
@@ -103,7 +103,7 @@ namespace LinqToDB.Linq
 			var db    = (IDataContext)parameters[0];
 			var query = GetInfo(db);
 
-			return (T)(await query.GetElementAsync(db, _expression, parameters, default));
+			return (T)await query.GetElementAsync(db, _expression, parameters, default).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 	}
 }

--- a/Source/LinqToDB/Linq/ExpressionQuery.cs
+++ b/Source/LinqToDB/Linq/ExpressionQuery.cs
@@ -87,7 +87,7 @@ namespace LinqToDB.Linq
 		async Task<TResult> IQueryProviderAsync.ExecuteAsync<TResult>(Expression expression, CancellationToken token)
 		{
 			var value = await GetQuery(ref expression, false).GetElementAsync(
-				DataContext, expression, Parameters, token);
+				DataContext, expression, Parameters, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 			return (TResult)value;
 		}

--- a/Source/LinqToDB/Linq/QueryRunner.CreateTable.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.CreateTable.cs
@@ -70,7 +70,7 @@ namespace LinqToDB.Linq
 
 				SetNonQueryQuery(query);
 
-				await query.GetElementAsync(dataContext, Expression.Constant(null), null, token);
+				await query.GetElementAsync(dataContext, Expression.Constant(null), null, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 				ITable<T> table = new Table<T>(dataContext);
 

--- a/Source/LinqToDB/Linq/QueryRunner.Delete.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.Delete.cs
@@ -88,7 +88,7 @@ namespace LinqToDB.Linq
 							return CreateQuery(dataContext, tableName, databaseName, schemaName, type);
 						});
 
-				var result = ei == null ? 0 : await ei.GetElementAsync(dataContext, Expression.Constant(obj), null, token);
+				var result = ei == null ? 0 : await ei.GetElementAsync(dataContext, Expression.Constant(obj), null, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 				return (int)result;
 			}

--- a/Source/LinqToDB/Linq/QueryRunner.DropTable.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.DropTable.cs
@@ -54,7 +54,7 @@ namespace LinqToDB.Linq
 
 				SetNonQueryQuery(query);
 
-				await query.GetElementAsync(dataContext, Expression.Constant(null), null, token);
+				await query.GetElementAsync(dataContext, Expression.Constant(null), null, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			}
 		}
 	}

--- a/Source/LinqToDB/Linq/QueryRunner.Insert.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.Insert.cs
@@ -90,7 +90,7 @@ namespace LinqToDB.Linq
 							return CreateQuery(dataContext, entityDescriptor, obj, tableName, databaseName, schemaName, type);
 						});
 
-				var result = await ei.GetElementAsync(dataContext, Expression.Constant(obj), null, token);
+				var result = await ei.GetElementAsync(dataContext, Expression.Constant(obj), null, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 				return (int)result;
 			}

--- a/Source/LinqToDB/Linq/QueryRunner.InsertOrReplace.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.InsertOrReplace.cs
@@ -157,7 +157,7 @@ namespace LinqToDB.Linq
 						return CreateQuery(dataContext, entityDescriptor, obj, tableName, schema, databaseName, type);
 					});
 
-				var result = ei == null ? 0 : await ei.GetElementAsync(dataContext, Expression.Constant(obj), null, token);
+				var result = ei == null ? 0 : await ei.GetElementAsync(dataContext, Expression.Constant(obj), null, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 				return (int)result;
 			}

--- a/Source/LinqToDB/Linq/QueryRunner.InsertWithIdentity.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.InsertWithIdentity.cs
@@ -94,7 +94,7 @@ namespace LinqToDB.Linq
 							return CreateQuery(dataContext, entityDescriptor, obj, tableName, databaseName, schemaName, type);
 						});
 
-				return await ei.GetElementAsync(dataContext, Expression.Constant(obj), null, token);
+				return await ei.GetElementAsync(dataContext, Expression.Constant(obj), null, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			}
 		}
 	}

--- a/Source/LinqToDB/Linq/QueryRunner.Update.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.Update.cs
@@ -111,7 +111,7 @@ namespace LinqToDB.Linq
 							return CreateQuery(dataContext, entityDescriptor, obj, tableName, databaseName, schemaName, type);
 						});
 
-				var result = ei == null ? 0 : await ei.GetElementAsync(dataContext, Expression.Constant(obj), null, token);
+				var result = ei == null ? 0 : await ei.GetElementAsync(dataContext, Expression.Constant(obj), null, token).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 				return (int)result;
 			}

--- a/Source/LinqToDB/Linq/QueryRunner.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.cs
@@ -375,16 +375,16 @@ namespace LinqToDB.Linq
 				{
 					mapper.QueryRunner = runner;
 
-					using (var dr = await runner.ExecuteReaderAsync(cancellationToken))
+					using (var dr = await runner.ExecuteReaderAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 					{
 						var skip = skipAction?.Invoke(expression, ps) ?? 0;
 
-						while (skip-- > 0 && await dr.ReadAsync(cancellationToken))
+						while (skip-- > 0 && await dr.ReadAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 							{}
 
 						var take = takeAction?.Invoke(expression, ps) ?? int.MaxValue;
 
-						while (take-- > 0 && await dr.ReadAsync(cancellationToken))
+						while (take-- > 0 && await dr.ReadAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 						{
 							runner.RowsCount++;
 							if (!func(mapper.Map(runner, dr.DataReader)))
@@ -444,20 +444,20 @@ namespace LinqToDB.Linq
 
 					_mapper.QueryRunner = _queryRunner;
 
-					_dataReader = await _queryRunner.ExecuteReaderAsync(cancellationToken);
+					_dataReader = await _queryRunner.ExecuteReaderAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 					var skip = _skipAction?.Invoke(_expression, _ps) ?? 0;
 
 					while (skip-- > 0)
 					{
-						if (!await _dataReader.ReadAsync(cancellationToken))
+						if (!await _dataReader.ReadAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 							return false;
 					}
 
 					_take = _takeAction?.Invoke(_expression, _ps) ?? int.MaxValue;
 				}
 
-				if (_take-- > 0 && await _dataReader.ReadAsync(cancellationToken))
+				if (_take-- > 0 && await _dataReader.ReadAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 				{
 					_queryRunner.RowsCount++;
 
@@ -687,9 +687,9 @@ namespace LinqToDB.Linq
 				{
 					mapper.QueryRunner = runner;
 
-					using (var dr = await runner.ExecuteReaderAsync(cancellationToken))
+					using (var dr = await runner.ExecuteReaderAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 					{
-						if (await dr.ReadAsync(cancellationToken))
+						if (await dr.ReadAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 						{
 							runner.RowsCount++;
 
@@ -739,7 +739,7 @@ namespace LinqToDB.Linq
 			CancellationToken cancellationToken)
 		{
 			using (var runner = dataContext.GetQueryRunner(query, 0, expression, ps))
-				return await runner.ExecuteScalarAsync(cancellationToken);
+				return await runner.ExecuteScalarAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 		}
 
 		#endregion
@@ -773,7 +773,7 @@ namespace LinqToDB.Linq
 			CancellationToken cancellationToken)
 		{
 			using (var runner = dataContext.GetQueryRunner(query, 0, expression, ps))
-				return await runner.ExecuteNonQueryAsync(cancellationToken);
+				return await runner.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 		}
 
 		#endregion
@@ -817,14 +817,14 @@ namespace LinqToDB.Linq
 		{
 			using (var runner = dataContext.GetQueryRunner(query, 0, expr, parameters))
 			{
-				var n = await runner.ExecuteNonQueryAsync(cancellationToken);
+				var n = await runner.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 				if (n != 0)
 					return n;
 
 				runner.QueryNumber = 1;
 
-				return await runner.ExecuteNonQueryAsync(cancellationToken);
+				return await runner.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 			}
 		}
 
@@ -869,14 +869,14 @@ namespace LinqToDB.Linq
 		{
 			using (var runner = dataContext.GetQueryRunner(query, 0, expr, parameters))
 			{
-				var n = await runner.ExecuteScalarAsync(cancellationToken);
+				var n = await runner.ExecuteScalarAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 				if (n != null)
 					return 0;
 
 				runner.QueryNumber = 1;
 
-				return await runner.ExecuteNonQueryAsync(cancellationToken);
+				return await runner.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 			}
 		}
 

--- a/Source/LinqToDB/LinqExtensions.cs
+++ b/Source/LinqToDB/LinqExtensions.cs
@@ -266,7 +266,7 @@ namespace LinqToDB
 				read = true;
 				item = r;
 				return false;
-			});
+			}).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 			if (read)
 				return item;
@@ -318,9 +318,9 @@ namespace LinqToDB
 				currentSource.Expression);
 
 			if (currentSource is IQueryProviderAsync query)
-				return await query.ExecuteAsync<int>(expr, token);
+				return await query.ExecuteAsync<int>(expr, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token);
+			return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		static readonly MethodInfo _deleteMethodInfo2 = MemberHelper.MethodOf(() => Delete<int>(null, null)).GetGenericMethodDefinition();
@@ -372,9 +372,9 @@ namespace LinqToDB
 				new[] { currentSource.Expression, Expression.Quote(predicate) });
 
 			if (currentSource is IQueryProviderAsync query)
-				return await query.ExecuteAsync<int>(expr, token);
+				return await query.ExecuteAsync<int>(expr, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token);
+			return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		#endregion
@@ -439,9 +439,9 @@ namespace LinqToDB
 				new[] { currentSource.Expression, ((IQueryable<TTarget>)target).Expression, Expression.Quote(setter) });
 
 			if (currentSource is IQueryProviderAsync query)
-				return await query.ExecuteAsync<int>(expr, token);
+				return await query.ExecuteAsync<int>(expr, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token);
+			return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		internal static readonly MethodInfo UpdateMethodInfo2 = MemberHelper.MethodOf(() => Update<int>(null, null)).GetGenericMethodDefinition();
@@ -491,9 +491,9 @@ namespace LinqToDB
 				new[] { currentSource.Expression, Expression.Quote(setter) });
 
 			if (currentSource is IQueryProviderAsync query)
-				return await query.ExecuteAsync<int>(expr, token);
+				return await query.ExecuteAsync<int>(expr, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token);
+			return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		static readonly MethodInfo _updateMethodInfo3 = MemberHelper.MethodOf(() => Update<int>(null, null, null)).GetGenericMethodDefinition();
@@ -551,9 +551,9 @@ namespace LinqToDB
 				new[] { currentSource.Expression, Expression.Quote(predicate), Expression.Quote(setter) });
 
 			if (currentSource is IQueryProviderAsync query)
-				return await query.ExecuteAsync<int>(expr, token);
+				return await query.ExecuteAsync<int>(expr, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token);
+			return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		static readonly MethodInfo _updateMethodInfo4 = MemberHelper.MethodOf(() => Update<int>(null)).GetGenericMethodDefinition();
@@ -600,9 +600,9 @@ namespace LinqToDB
 				currentQuery.Expression);
 
 			if (currentQuery is IQueryProviderAsync query)
-				return await query.ExecuteAsync<int>(expr, token);
+				return await query.ExecuteAsync<int>(expr, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await TaskEx.Run(() => currentQuery.Provider.Execute<int>(expr), token);
+			return await TaskEx.Run(() => currentQuery.Provider.Execute<int>(expr), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		static readonly MethodInfo _updateMethodInfo5 = MemberHelper.MethodOf(()
@@ -665,9 +665,9 @@ namespace LinqToDB
 				new[] { currentSource.Expression, Expression.Quote(target), Expression.Quote(setter) });
 
 			if (currentSource is IQueryProviderAsync query)
-				return await query.ExecuteAsync<int>(expr, token);
+				return await query.ExecuteAsync<int>(expr, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token);
+			return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		class Updatable<T> : IUpdatable<T>
@@ -955,9 +955,9 @@ namespace LinqToDB
 				new[] { currentSource.Expression, Expression.Quote(setter) });
 
 			if (currentSource is IQueryProviderAsync query)
-				return await query.ExecuteAsync<int>(expr, token);
+				return await query.ExecuteAsync<int>(expr, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token);
+			return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		static readonly MethodInfo _insertWithIdentityMethodInfo = MemberHelper.MethodOf(() => InsertWithIdentity<int>(null,null)).GetGenericMethodDefinition();
@@ -1055,9 +1055,9 @@ namespace LinqToDB
 				new[] { currentSource.Expression, Expression.Quote(setter) });
 
 			if (currentSource is IQueryProviderAsync query)
-				return await query.ExecuteAsync<object>(expr, token);
+				return await query.ExecuteAsync<object>(expr, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await TaskEx.Run(() => currentSource.Provider.Execute<object>(expr), token);
+			return await TaskEx.Run(() => currentSource.Provider.Execute<object>(expr), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		/// <summary>
@@ -1073,7 +1073,7 @@ namespace LinqToDB
 			[NotNull, InstantHandle] Expression<Func<T>> setter,
 			CancellationToken                            token = default)
 		{
-			return target.DataContext.MappingSchema.ChangeTypeTo<int>(await InsertWithIdentityAsync(target, setter, token));
+			return target.DataContext.MappingSchema.ChangeTypeTo<int>(await InsertWithIdentityAsync(target, setter, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext));
 		}
 
 		/// <summary>
@@ -1089,7 +1089,7 @@ namespace LinqToDB
 			[NotNull, InstantHandle] Expression<Func<T>> setter,
 			CancellationToken                            token = default)
 		{
-			return target.DataContext.MappingSchema.ChangeTypeTo<long>(await InsertWithIdentityAsync(target, setter, token));
+			return target.DataContext.MappingSchema.ChangeTypeTo<long>(await InsertWithIdentityAsync(target, setter, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext));
 		}
 
 		/// <summary>
@@ -1105,7 +1105,7 @@ namespace LinqToDB
 			[NotNull, InstantHandle] Expression<Func<T>> setter,
 			CancellationToken                            token = default)
 		{
-			return target.DataContext.MappingSchema.ChangeTypeTo<decimal>(await InsertWithIdentityAsync(target, setter, token));
+			return target.DataContext.MappingSchema.ChangeTypeTo<decimal>(await InsertWithIdentityAsync(target, setter, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext));
 		}
 
 		#region ValueInsertable
@@ -1318,9 +1318,9 @@ namespace LinqToDB
 				_insertMethodInfo2.MakeGenericMethod(typeof(T)), currentQueryable.Expression);
 
 			if (currentQueryable is IQueryProviderAsync query)
-				return await query.ExecuteAsync<int>(expr, token);
+				return await query.ExecuteAsync<int>(expr, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await TaskEx.Run(() => currentQueryable.Provider.Execute<int>(expr), token);
+			return await TaskEx.Run(() => currentQueryable.Provider.Execute<int>(expr), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		static readonly MethodInfo _insertWithIdentityMethodInfo2 = MemberHelper.MethodOf(() => InsertWithIdentity<int>(null)).GetGenericMethodDefinition();
@@ -1402,9 +1402,9 @@ namespace LinqToDB
 				currentQueryable.Expression);
 
 			if (currentQueryable is IQueryProviderAsync query)
-				return await query.ExecuteAsync<object>(expr, token);
+				return await query.ExecuteAsync<object>(expr, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await TaskEx.Run(() => currentQueryable.Provider.Execute<object>(expr), token);
+			return await TaskEx.Run(() => currentQueryable.Provider.Execute<object>(expr), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		/// <summary>
@@ -1418,7 +1418,7 @@ namespace LinqToDB
 			[NotNull] this IValueInsertable<T> source, CancellationToken token = default)
 		{
 			return ((ExpressionQuery<T>)((ValueInsertable<T>)source).Query).DataContext.MappingSchema.ChangeTypeTo<int?>(
-				await InsertWithIdentityAsync(source, token));
+				await InsertWithIdentityAsync(source, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext));
 		}
 
 		/// <summary>
@@ -1432,7 +1432,7 @@ namespace LinqToDB
 			[NotNull] this IValueInsertable<T> source, CancellationToken token = default)
 		{
 			return ((ExpressionQuery<T>)((ValueInsertable<T>)source).Query).DataContext.MappingSchema.ChangeTypeTo<long?>(
-				await InsertWithIdentityAsync(source, token));
+				await InsertWithIdentityAsync(source, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext));
 		}
 
 		/// <summary>
@@ -1446,7 +1446,7 @@ namespace LinqToDB
 			[NotNull] this IValueInsertable<T> source, CancellationToken token = default)
 		{
 			return ((ExpressionQuery<T>)((ValueInsertable<T>)source).Query).DataContext.MappingSchema.ChangeTypeTo<decimal?>(
-				await InsertWithIdentityAsync(source, token));
+				await InsertWithIdentityAsync(source, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext));
 		}
 
 		#endregion
@@ -1513,9 +1513,9 @@ namespace LinqToDB
 				new[] { currentSource.Expression, ((IQueryable<TTarget>)target).Expression, Expression.Quote(setter) });
 
 			if (currentSource is IQueryProviderAsync query)
-				return await query.ExecuteAsync<int>(expr, token);
+				return await query.ExecuteAsync<int>(expr, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token);
+			return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		static readonly MethodInfo _insertWithIdentityMethodInfo3 =
@@ -1642,9 +1642,9 @@ namespace LinqToDB
 					new[] { currentSource.Expression, ((IQueryable<TTarget>)target).Expression, Expression.Quote(setter) });
 
 			if (currentSource is IQueryProviderAsync query)
-				return await query.ExecuteAsync<object>(expr, token);
+				return await query.ExecuteAsync<object>(expr, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await TaskEx.Run(() => currentSource.Provider.Execute<object>(expr), token);
+			return await TaskEx.Run(() => currentSource.Provider.Execute<object>(expr), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		/// <summary>
@@ -1667,7 +1667,7 @@ namespace LinqToDB
 			var currentSource = (IQueryable<TSource>)(ProcessSourceQueryable?.Invoke(source) ?? source);
 
 			return ((ExpressionQuery<TSource>)currentSource).DataContext.MappingSchema.ChangeTypeTo<int?>(
-				await InsertWithIdentityAsync(currentSource, target, setter, token));
+				await InsertWithIdentityAsync(currentSource, target, setter, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext));
 		}
 
 		/// <summary>
@@ -1690,7 +1690,7 @@ namespace LinqToDB
 			var currentSource = (IQueryable<TSource>)(ProcessSourceQueryable?.Invoke(source) ?? source);
 
 			return ((ExpressionQuery<TSource>)currentSource).DataContext.MappingSchema.ChangeTypeTo<long?>(
-				await InsertWithIdentityAsync(currentSource, target, setter, token));
+				await InsertWithIdentityAsync(currentSource, target, setter, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext));
 		}
 
 		/// <summary>
@@ -1713,7 +1713,7 @@ namespace LinqToDB
 			var currentSource = (IQueryable<TSource>)(ProcessSourceQueryable?.Invoke(source) ?? source);
 
 			return ((ExpressionQuery<TSource>)currentSource).DataContext.MappingSchema.ChangeTypeTo<decimal?>(
-				await InsertWithIdentityAsync(currentSource, target, setter, token));
+				await InsertWithIdentityAsync(currentSource, target, setter, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext));
 		}
 
 		class SelectInsertable<T,TT> : ISelectInsertable<T,TT>
@@ -1902,9 +1902,9 @@ namespace LinqToDB
 				_insertMethodInfo4.MakeGenericMethod(typeof(TSource), typeof(TTarget)), currentQueryable.Expression);
 
 			if (currentQueryable is IQueryProviderAsync query)
-				return await query.ExecuteAsync<int>(expr, token);
+				return await query.ExecuteAsync<int>(expr, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await TaskEx.Run(() => currentQueryable.Provider.Execute<int>(expr), token);
+			return await TaskEx.Run(() => currentQueryable.Provider.Execute<int>(expr), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		static readonly MethodInfo _insertWithIdentityMethodInfo4 =
@@ -1994,9 +1994,9 @@ namespace LinqToDB
 				currentQueryable.Expression);
 
 			if (currentQueryable is IQueryProviderAsync query)
-				return await query.ExecuteAsync<object>(expr, token);
+				return await query.ExecuteAsync<object>(expr, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await TaskEx.Run(() => currentQueryable.Provider.Execute<object>(expr), token);
+			return await TaskEx.Run(() => currentQueryable.Provider.Execute<object>(expr), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		/// <summary>
@@ -2011,7 +2011,7 @@ namespace LinqToDB
 			[NotNull] this ISelectInsertable<TSource,TTarget> source, CancellationToken token = default)
 		{
 			return ((ExpressionQuery<TSource>)((SelectInsertable<TSource,TTarget>)source).Query).DataContext.MappingSchema.ChangeTypeTo<int?>(
-				await InsertWithIdentityAsync(source, token));
+				await InsertWithIdentityAsync(source, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext));
 		}
 
 		/// <summary>
@@ -2026,7 +2026,7 @@ namespace LinqToDB
 			[NotNull] this ISelectInsertable<TSource,TTarget> source, CancellationToken token = default)
 		{
 			return ((ExpressionQuery<TSource>)((SelectInsertable<TSource,TTarget>)source).Query).DataContext.MappingSchema.ChangeTypeTo<long?>(
-				await InsertWithIdentityAsync(source, token));
+				await InsertWithIdentityAsync(source, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext));
 		}
 
 		/// <summary>
@@ -2041,7 +2041,7 @@ namespace LinqToDB
 			[NotNull] this ISelectInsertable<TSource,TTarget> source, CancellationToken token = default)
 		{
 			return ((ExpressionQuery<TSource>)((SelectInsertable<TSource,TTarget>)source).Query).DataContext.MappingSchema.ChangeTypeTo<decimal?>(
-				await InsertWithIdentityAsync(source, token));
+				await InsertWithIdentityAsync(source, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext));
 		}
 
 		#endregion
@@ -2116,9 +2116,9 @@ namespace LinqToDB
 				new[] { currentSource.Expression, Expression.Quote(insertSetter), Expression.Quote(onDuplicateKeyUpdateSetter) });
 
 			if (currentSource is IQueryProviderAsync query)
-				return await query.ExecuteAsync<int>(expr, token);
+				return await query.ExecuteAsync<int>(expr, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token);
+			return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		static readonly MethodInfo _insertOrUpdateMethodInfo2 =
@@ -2201,9 +2201,9 @@ namespace LinqToDB
 				Expression.Quote(keySelector));
 
 			if (currentSource is IQueryProviderAsync query)
-				return await query.ExecuteAsync<int>(expr, token);
+				return await query.ExecuteAsync<int>(expr, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token);
+			return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		#endregion
@@ -2283,17 +2283,17 @@ namespace LinqToDB
 			if (throwExceptionIfNotExists)
 			{
 				if (query != null)
-					return await query.ExecuteAsync<int>(expr, token);
+					return await query.ExecuteAsync<int>(expr, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-				return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token);
+				return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			}
 
 			try
 			{
 				if (query != null)
-					return await query.ExecuteAsync<int>(expr, token);
+					return await query.ExecuteAsync<int>(expr, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-				return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token);
+				return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			}
 			catch
 			{
@@ -2356,9 +2356,9 @@ namespace LinqToDB
 				new[] { currentSource.Expression, Expression.Constant(resetIdentity) });
 
 			if (currentSource is IQueryProviderAsync query)
-				return await query.ExecuteAsync<int>(expr, token);
+				return await query.ExecuteAsync<int>(expr, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token);
+			return await TaskEx.Run(() => currentSource.Provider.Execute<int>(expr), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		#endregion
@@ -2534,9 +2534,9 @@ namespace LinqToDB
 					new[] { currentSource.Expression, Expression.Quote(index) });
 
 			if (currentSource is IQueryProviderAsync query)
-				return await query.ExecuteAsync<TSource>(expr, token);
+				return await query.ExecuteAsync<TSource>(expr, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await TaskEx.Run(() => currentSource.Provider.Execute<TSource>(expr), token);
+			return await TaskEx.Run(() => currentSource.Provider.Execute<TSource>(expr), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		static readonly MethodInfo _elementAtOrDefaultMethodInfo = MemberHelper.MethodOf(() => ElementAtOrDefault<int>(null,null)).GetGenericMethodDefinition();
@@ -2591,9 +2591,9 @@ namespace LinqToDB
 					new[] { currentSource.Expression, Expression.Quote(index) });
 
 			if (currentSource is IQueryProviderAsync query)
-				return await query.ExecuteAsync<TSource>(expr, token);
+				return await query.ExecuteAsync<TSource>(expr, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			return await TaskEx.Run(() => currentSource.Provider.Execute<TSource>(expr), token);
+			return await TaskEx.Run(() => currentSource.Provider.Execute<TSource>(expr), token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
 		#endregion

--- a/Source/LinqToDB/Merge.cs
+++ b/Source/LinqToDB/Merge.cs
@@ -694,7 +694,7 @@ namespace LinqToDB
 		/// <param name="merge">Merge command definition.</param>
 		/// <param name="token">Asynchronous operation cancellation token.</param>
 		/// <returns>Returns number of target table records, affected by merge comand.</returns>
-		public static async Task<int> MergeAsync<TTarget, TSource>(
+		public static Task<int> MergeAsync<TTarget, TSource>(
 			this IMergeable<TTarget, TSource> merge,
 			CancellationToken                 token = default)
 				where TTarget : class
@@ -714,7 +714,7 @@ namespace LinqToDB
 					throw new ArgumentException("DataContext must be of DataConnection or DataContext type.");
 			}
 
-			return await dataConnection.DataProvider.MergeAsync(dataConnection, definition, token);
+			return dataConnection.DataProvider.MergeAsync(dataConnection, definition, token);
 		}
 		#endregion
 	}

--- a/Source/LinqToDB/ServiceModel/RemoteDataContextBase.QueryRunner.cs
+++ b/Source/LinqToDB/ServiceModel/RemoteDataContextBase.QueryRunner.cs
@@ -248,7 +248,7 @@ namespace LinqToDB.ServiceModel
 					LinqServiceSerializer.Serialize(
 						q,
 						q.IsParameterDependent ? q.Parameters.ToArray() : queryContext.GetParameters(),
-						QueryHints));
+						QueryHints)).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 				var result = LinqServiceSerializer.DeserializeResult(ret);
 				var reader = new ServiceModelDataReader(_dataContext.MappingSchema, result);
@@ -273,7 +273,7 @@ namespace LinqToDB.ServiceModel
 					_dataContext.Configuration,
 					LinqServiceSerializer.Serialize(
 						q,
-						q.IsParameterDependent ? q.Parameters.ToArray() : queryContext.GetParameters(), QueryHints));
+						q.IsParameterDependent ? q.Parameters.ToArray() : queryContext.GetParameters(), QueryHints)).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			}
 
 			public override async Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
@@ -296,7 +296,7 @@ namespace LinqToDB.ServiceModel
 
 				_client = _dataContext.GetClient();
 
-				return await _client.ExecuteNonQueryAsync(_dataContext.Configuration, data);
+				return await _client.ExecuteNonQueryAsync(_dataContext.Configuration, data).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			}
 		}
 	}

--- a/Source/LinqToDB/ServiceModel/RemoteDataContextBase.cs
+++ b/Source/LinqToDB/ServiceModel/RemoteDataContextBase.cs
@@ -301,7 +301,7 @@ namespace LinqToDB.ServiceModel
 				try
 				{
 					var data = LinqServiceSerializer.Serialize(_queryBatch.ToArray());
-					await client.ExecuteBatchAsync(Configuration, data);
+					await client.ExecuteBatchAsync(Configuration, data).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 				}
 				finally
 				{


### PR DESCRIPTION
Fix #1366
Fix #1754 
- adds new option `Configuration.ContinueOnCapturedContext = true`
- adds ConfigureAwait() calls to all awaits in linq2db code
- removes unnecessary await in MergeAsync

PS: not my favorite PR