### PR TITLE
Fix left/right/full outer join() null record mapping

### DIFF
--- a/Source/LinqToDB/Linq/Builder/AllJoinsBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/AllJoinsBuilder.cs
@@ -10,9 +10,15 @@ namespace LinqToDB.Linq.Builder
 	{
 		protected override bool CanBuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo)
 		{
+			return IsMatchingMethod(methodCall, false);
+		}
+
+		internal static bool IsMatchingMethod(MethodCallExpression methodCall, bool rightNullableOnly)
+		{
 			return
-				methodCall.IsQueryable("Join") && methodCall.Arguments.Count == 3 ||
-				methodCall.IsQueryable("InnerJoin", "LeftJoin", "RightJoin", "FullJoin") && methodCall.Arguments.Count == 2;
+				methodCall.IsQueryable("Join") && methodCall.Arguments.Count == 3
+				|| !rightNullableOnly && methodCall.IsQueryable("InnerJoin", "LeftJoin", "RightJoin", "FullJoin") && methodCall.Arguments.Count == 2
+				|| rightNullableOnly && methodCall.IsQueryable("RightJoin", "FullJoin") && methodCall.Arguments.Count == 2;
 		}
 
 		protected override IBuildContext BuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo)

--- a/Source/LinqToDB/Linq/Builder/AllJoinsBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/AllJoinsBuilder.cs
@@ -19,8 +19,6 @@ namespace LinqToDB.Linq.Builder
 		{
 			var sequence = builder.BuildSequence(new BuildInfo(buildInfo, methodCall.Arguments[0]));
 
-			sequence = new SubQueryContext(sequence);
-
 			JoinType joinType;
 			var conditionIndex = 1;
 
@@ -48,6 +46,10 @@ namespace LinqToDB.Linq.Builder
 			}
 
 			buildInfo.JoinType = joinType;
+
+			sequence = joinType == JoinType.Left
+				? new DefaultIfEmptyBuilder.DefaultIfEmptyContext(buildInfo.Parent, sequence, null)
+				: (IBuildContext)new SubQueryContext(sequence);
 
 			if (methodCall.Arguments[conditionIndex] != null)
 			{

--- a/Source/LinqToDB/Linq/Builder/AllJoinsBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/AllJoinsBuilder.cs
@@ -53,7 +53,7 @@ namespace LinqToDB.Linq.Builder
 
 			buildInfo.JoinType = joinType;
 
-			sequence = joinType == JoinType.Left
+			sequence = joinType == JoinType.Left || joinType == JoinType.Full
 				? new DefaultIfEmptyBuilder.DefaultIfEmptyContext(buildInfo.Parent, sequence, null)
 				: (IBuildContext)new SubQueryContext(sequence);
 

--- a/Source/LinqToDB/Linq/Builder/AllJoinsBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/AllJoinsBuilder.cs
@@ -53,9 +53,9 @@ namespace LinqToDB.Linq.Builder
 
 			buildInfo.JoinType = joinType;
 
-			sequence = joinType == JoinType.Left || joinType == JoinType.Full
-				? new DefaultIfEmptyBuilder.DefaultIfEmptyContext(buildInfo.Parent, sequence, null)
-				: (IBuildContext)new SubQueryContext(sequence);
+			if (joinType == JoinType.Left || joinType == JoinType.Full)
+				sequence = new DefaultIfEmptyBuilder.DefaultIfEmptyContext(buildInfo.Parent, sequence, null);
+			sequence = new SubQueryContext(sequence);
 
 			if (methodCall.Arguments[conditionIndex] != null)
 			{

--- a/Source/LinqToDB/Linq/Builder/AllJoinsLinqBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/AllJoinsLinqBuilder.cs
@@ -56,9 +56,10 @@ namespace LinqToDB.Linq.Builder
 				outerContext = new DefaultIfEmptyBuilder.DefaultIfEmptyContext(buildInfo.Parent, outerContext, null);
 			outerContext = new SubQueryContext(outerContext);
 
-			innerContext = joinType == JoinType.Left || joinType == JoinType.Full
-				? new DefaultIfEmptyBuilder.DefaultIfEmptyContext(buildInfo.Parent, innerContext, null)
-				: (IBuildContext)new SubQueryContext(innerContext);
+
+			if (joinType == JoinType.Left || joinType == JoinType.Full)
+				innerContext = new DefaultIfEmptyBuilder.DefaultIfEmptyContext(buildInfo.Parent, innerContext, null);
+			innerContext = new SubQueryContext(innerContext);
 
 			var selector = (LambdaExpression)methodCall.Arguments[methodCall.Arguments.Count - 1].Unwrap();
 

--- a/Source/LinqToDB/Linq/Builder/AllJoinsLinqBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/AllJoinsLinqBuilder.cs
@@ -52,11 +52,11 @@ namespace LinqToDB.Linq.Builder
 					break;
 			}
 
-			if (joinType == JoinType.Right)
+			if (joinType == JoinType.Right || joinType == JoinType.Full)
 				outerContext = new DefaultIfEmptyBuilder.DefaultIfEmptyContext(buildInfo.Parent, outerContext, null);
 			outerContext = new SubQueryContext(outerContext);
 
-			innerContext = joinType == JoinType.Left
+			innerContext = joinType == JoinType.Left || joinType == JoinType.Full
 				? new DefaultIfEmptyBuilder.DefaultIfEmptyContext(buildInfo.Parent, innerContext, null)
 				: (IBuildContext)new SubQueryContext(innerContext);
 

--- a/Source/LinqToDB/Linq/Builder/AllJoinsLinqBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/AllJoinsLinqBuilder.cs
@@ -22,7 +22,7 @@ namespace LinqToDB.Linq.Builder
 
 		protected override IBuildContext BuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo)
 		{
-			var outerContext = builder.BuildSequence(new BuildInfo(buildInfo, methodCall.Arguments[0], buildInfo.SelectQuery));
+			var outerContext = builder.BuildSequence(new BuildInfo(buildInfo, methodCall.Arguments[0]));
 			var innerContext = builder.BuildSequence(new BuildInfo(buildInfo, methodCall.Arguments[1], new SelectQuery()));
 
 			JoinType joinType;
@@ -52,7 +52,10 @@ namespace LinqToDB.Linq.Builder
 					break;
 			}
 
+			if (joinType == JoinType.Right)
+				outerContext = new DefaultIfEmptyBuilder.DefaultIfEmptyContext(buildInfo.Parent, outerContext, null);
 			outerContext = new SubQueryContext(outerContext);
+
 			innerContext = joinType == JoinType.Left
 				? new DefaultIfEmptyBuilder.DefaultIfEmptyContext(buildInfo.Parent, innerContext, null)
 				: (IBuildContext)new SubQueryContext(innerContext);

--- a/Source/LinqToDB/Linq/Builder/DefaultIfEmptyBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/DefaultIfEmptyBuilder.cs
@@ -49,11 +49,13 @@ namespace LinqToDB.Linq.Builder
 
 			private readonly Expression _defaultValue;
 
+			public bool Disabled { get; set; }
+
 			public override Expression BuildExpression(Expression expression, int level, bool enforceServerSide)
 			{
 				var expr = Sequence.BuildExpression(expression, level, enforceServerSide);
 
-				if (expression == null)
+				if (!Disabled && expression == null)
 				{
 					var q =
 						from col in SelectQuery.Select.Columns

--- a/Source/LinqToDB/Linq/Builder/SelectManyBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/SelectManyBuilder.cs
@@ -32,8 +32,8 @@ namespace LinqToDB.Linq.Builder
 			if (expr is MethodCallExpression mc && AllJoinsBuilder.IsMatchingMethod(mc, true))
 			{
 				defaultIfEmpty = new DefaultIfEmptyBuilder.DefaultIfEmptyContext(buildInfo.Parent, sequence, null);
-				sequence = new SubQueryContext(defaultIfEmpty);
 				defaultIfEmpty.Disabled = true;
+				sequence = new SubQueryContext(defaultIfEmpty);
 			}
 
 			var context        = new SelectManyContext(buildInfo.Parent, collectionSelector, sequence);

--- a/Source/LinqToDB/Linq/Builder/SelectManyBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/SelectManyBuilder.cs
@@ -44,7 +44,7 @@ namespace LinqToDB.Linq.Builder
 			if (resultSelector.Parameters.Count > 1)
 				collection.SetAlias(resultSelector.Parameters[1].Name);
 
-			if (defaultIfEmpty != null && collectionInfo.JoinType == JoinType.Right)
+			if (defaultIfEmpty != null && (collectionInfo.JoinType == JoinType.Right || collectionInfo.JoinType == JoinType.Full))
 				defaultIfEmpty.Disabled = false;
 
 			var leftJoin       = collection is DefaultIfEmptyBuilder.DefaultIfEmptyContext || collectionInfo.JoinType == JoinType.Left;

--- a/Source/LinqToDB/SqlQuery/SelectQueryOptimizer.cs
+++ b/Source/LinqToDB/SqlQuery/SelectQueryOptimizer.cs
@@ -734,8 +734,7 @@ namespace LinqToDB.SqlQuery
 					{
 						// We can not remove subquery that is left side for FULL and RIGHT joins and there is filter
 						var join = source.Joins[0];
-						if (join.JoinType == JoinType.Full ||
-						    join.JoinType == JoinType.Right
+						if ((join.JoinType == JoinType.Full || join.JoinType == JoinType.Right)
 							&& !select.Where.IsEmpty)
 						canRemove = false;
 					}

--- a/Tests/Linq/Linq/JoinTests.cs
+++ b/Tests/Linq/Linq/JoinTests.cs
@@ -1830,7 +1830,12 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void FullJoinWithRecordSelection1([DataSources(TestProvName.AllSQLite)] string context)
+		public void FullJoinWithRecordSelection1([DataSources(
+			TestProvName.AllSQLite,
+			ProviderName.Access,
+			ProviderName.SqlCe,
+			TestProvName.AllMySql,
+			TestProvName.AllSybase)] string context)
 		{
 			using (var db = GetDataContext(context))
 			using (var factTable = db.CreateLocalTable(Fact.Data))
@@ -1852,7 +1857,12 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void FullJoinWithRecordSelection2([DataSources(TestProvName.AllSQLite)] string context)
+		public void FullJoinWithRecordSelection2([DataSources(
+			TestProvName.AllSQLite,
+			ProviderName.Access,
+			ProviderName.SqlCe,
+			TestProvName.AllMySql,
+			TestProvName.AllSybase)] string context)
 		{
 			using (var db = GetDataContext(context))
 			using (var factTable = db.CreateLocalTable(Fact.Data))
@@ -1874,7 +1884,12 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void FullJoinWithRecordSelection3([DataSources(TestProvName.AllSQLite)] string context)
+		public void FullJoinWithRecordSelection3([DataSources(
+			TestProvName.AllSQLite,
+			ProviderName.Access,
+			ProviderName.SqlCe,
+			TestProvName.AllMySql,
+			TestProvName.AllSybase)] string context)
 		{
 			using (var db = GetDataContext(context))
 			using (var factTable = db.CreateLocalTable(Fact.Data))
@@ -1895,7 +1910,12 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void FullJoinWithRecordSelection4([DataSources(TestProvName.AllSQLite)] string context)
+		public void FullJoinWithRecordSelection4([DataSources(
+			TestProvName.AllSQLite,
+			ProviderName.Access,
+			ProviderName.SqlCe,
+			TestProvName.AllMySql,
+			TestProvName.AllSybase)] string context)
 		{
 			using (var db = GetDataContext(context))
 			using (var factTable = db.CreateLocalTable(Fact.Data))

--- a/Tests/Linq/Linq/JoinTests.cs
+++ b/Tests/Linq/Linq/JoinTests.cs
@@ -1663,5 +1663,72 @@ namespace Tests.Linq
 				Assert.IsNull(results[1].leftTag);
 			}
 		}
+
+		[Test]
+		public void LeftJoinWithRecordSelection5([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var factTable = db.CreateLocalTable(Fact.Data))
+			using (var tagTable = db.CreateLocalTable(Tag.Data))
+			{
+				var q =
+					from ft in factTable.LeftJoin(tagTable, (f, t) => t.FactId == f.Id, (f, t) => new { fact = f, leftTag = t })
+					where ft.fact.Id > 3
+					select ft;
+
+				var results = q.ToArray();
+
+				Assert.AreEqual(2, results.Length);
+				Assert.AreEqual(4, results[0].fact.Id);
+				Assert.AreEqual("Tag4", results[0].leftTag.Name);
+				Assert.AreEqual(5, results[1].fact.Id);
+				Assert.IsNull(results[1].leftTag);
+			}
+		}
+
+		[Test]
+		public void LeftJoinWithRecordSelection6([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var factTable = db.CreateLocalTable(Fact.Data))
+			using (var tagTable = db.CreateLocalTable(Tag.Data))
+			{
+				var q =
+					from ft in factTable.Join(tagTable, SqlJoinType.Left, (f, t) => t.FactId == f.Id, (f, t) => new { fact = f, leftTag = t })
+					where ft.fact.Id > 3
+					select ft;
+
+				var results = q.ToArray();
+
+				Assert.AreEqual(2, results.Length);
+				Assert.AreEqual(4, results[0].fact.Id);
+				Assert.AreEqual("Tag4", results[0].leftTag.Name);
+				Assert.AreEqual(5, results[1].fact.Id);
+				Assert.IsNull(results[1].leftTag);
+			}
+		}
+
+		[Test]
+		public void LeftJoinWithRecordSelection7([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var factTable = db.CreateLocalTable(Fact.Data))
+			using (var tagTable = db.CreateLocalTable(Tag.Data))
+			{
+				var t =
+					from fact in factTable
+					from leftTag in tagTable.Join(SqlJoinType.Left, tag => tag.FactId == fact.Id)
+					where fact.Id > 3
+					select new { fact, leftTag };
+
+				var results = t.ToArray();
+
+				Assert.AreEqual(2, results.Length);
+				Assert.AreEqual(4, results[0].fact.Id);
+				Assert.AreEqual("Tag4", results[0].leftTag.Name);
+				Assert.AreEqual(5, results[1].fact.Id);
+				Assert.IsNull(results[1].leftTag);
+			}
+		}
 	}
 }

--- a/Tests/Linq/Linq/JoinTests.cs
+++ b/Tests/Linq/Linq/JoinTests.cs
@@ -1596,7 +1596,6 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[ActiveIssue(1773)]
 		public void LeftJoinWithRecordSelection2([DataSources] string context)
 		{
 			using (var db        = GetDataContext(context))

--- a/Tests/Linq/Linq/JoinTests.cs
+++ b/Tests/Linq/Linq/JoinTests.cs
@@ -1393,7 +1393,12 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SqlFullJoinWithCount1([AllJoinsSource] string context)
+		public void SqlFullJoinWithCount1([DataSources(
+			TestProvName.AllSQLite,
+			ProviderName.Access,
+			ProviderName.SqlCe,
+			TestProvName.AllMySql,
+			TestProvName.AllSybase)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -1409,7 +1414,12 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SqlFullJoinWithCount2([AllJoinsSource] string context)
+		public void SqlFullJoinWithCount2([DataSources(
+			TestProvName.AllSQLite,
+			ProviderName.Access,
+			ProviderName.SqlCe,
+			TestProvName.AllMySql,
+			TestProvName.AllSybase)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -1427,7 +1437,12 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SqlFullJoinWithCount3([AllJoinsSource] string context)
+		public void SqlFullJoinWithCount3([DataSources(
+			TestProvName.AllSQLite,
+			ProviderName.Access,
+			ProviderName.SqlCe,
+			TestProvName.AllMySql,
+			TestProvName.AllSybase)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -1445,7 +1460,12 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SqlFullJoinWithCount4([AllJoinsSource] string context)
+		public void SqlFullJoinWithCount4([DataSources(
+			TestProvName.AllSQLite,
+			ProviderName.Access,
+			ProviderName.SqlCe,
+			TestProvName.AllMySql,
+			TestProvName.AllSybase)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -1464,7 +1484,12 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SqlFullJoinWithCount5([AllJoinsSource] string context)
+		public void SqlFullJoinWithCount5([DataSources(
+			TestProvName.AllSQLite,
+			ProviderName.Access,
+			ProviderName.SqlCe,
+			TestProvName.AllMySql,
+			TestProvName.AllSybase)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -1482,7 +1507,12 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SqlFullJoinWithBothFilters([AllJoinsSource] string context)
+		public void SqlFullJoinWithBothFilters([DataSources(
+			TestProvName.AllSQLite,
+			ProviderName.Access,
+			ProviderName.SqlCe,
+			TestProvName.AllMySql,
+			TestProvName.AllSybase)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -1512,7 +1542,12 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SqlFullJoinWithBothFiltersAlternative([AllJoinsSource] string context)
+		public void SqlFullJoinWithBothFiltersAlternative([DataSources(
+			TestProvName.AllSQLite,
+			ProviderName.Access,
+			ProviderName.SqlCe,
+			TestProvName.AllMySql,
+			TestProvName.AllSybase)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -1542,7 +1577,12 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SqlFullJoinWithInnerJoinOnLeftWithConditions([AllJoinsSource] string context)
+		public void SqlFullJoinWithInnerJoinOnLeftWithConditions([DataSources(
+			TestProvName.AllSQLite,
+			ProviderName.Access,
+			ProviderName.SqlCe,
+			TestProvName.AllMySql,
+			TestProvName.AllSybase)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -1584,7 +1624,12 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SqlFullJoinWithInnerJoinOnLeftWithoutConditions([AllJoinsSource] string context)
+		public void SqlFullJoinWithInnerJoinOnLeftWithoutConditions([DataSources(
+			TestProvName.AllSQLite,
+			ProviderName.Access,
+			ProviderName.SqlCe,
+			TestProvName.AllMySql,
+			TestProvName.AllSybase)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -1625,7 +1670,12 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SqlFullJoinWithInnerJoinOnLeftWithoutAllConditions([AllJoinsSource] string context)
+		public void SqlFullJoinWithInnerJoinOnLeftWithoutAllConditions([DataSources(
+			TestProvName.AllSQLite,
+			ProviderName.Access,
+			ProviderName.SqlCe,
+			TestProvName.AllMySql,
+			TestProvName.AllSybase)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -1664,7 +1714,12 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SqlFullJoinWithInnerJoinOnRightWithConditions([AllJoinsSource] string context)
+		public void SqlFullJoinWithInnerJoinOnRightWithConditions([DataSources(
+			TestProvName.AllSQLite,
+			ProviderName.Access,
+			ProviderName.SqlCe,
+			TestProvName.AllMySql,
+			TestProvName.AllSybase)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -1706,7 +1761,12 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SqlFullJoinWithInnerJoinOnRightWithoutConditions([AllJoinsSource] string context)
+		public void SqlFullJoinWithInnerJoinOnRightWithoutConditions([DataSources(
+			TestProvName.AllSQLite,
+			ProviderName.Access,
+			ProviderName.SqlCe,
+			TestProvName.AllMySql,
+			TestProvName.AllSybase)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -1747,7 +1807,12 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SqlFullJoinWithInnerJoinOnRightWithoutAllConditions([AllJoinsSource] string context)
+		public void SqlFullJoinWithInnerJoinOnRightWithoutAllConditions([DataSources(
+			TestProvName.AllSQLite,
+			ProviderName.Access,
+			ProviderName.SqlCe,
+			TestProvName.AllMySql,
+			TestProvName.AllSybase)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -1786,7 +1851,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SqlRightJoinWithInnerJoinOnLeftWithConditions([AllJoinsSource] string context)
+		public void SqlRightJoinWithInnerJoinOnLeftWithConditions([DataSources(TestProvName.AllSQLite)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -1828,7 +1893,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SqlRightJoinWithInnerJoinOnLeftWithoutConditions([AllJoinsSource] string context)
+		public void SqlRightJoinWithInnerJoinOnLeftWithoutConditions([DataSources(TestProvName.AllSQLite)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -1869,7 +1934,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SqlRightJoinWithInnerJoinOnLeftWithoutAllConditions([AllJoinsSource] string context)
+		public void SqlRightJoinWithInnerJoinOnLeftWithoutAllConditions([DataSources(TestProvName.AllSQLite)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -1908,7 +1973,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SqlRightJoinWithInnerJoinOnRightWithConditions([AllJoinsSource] string context)
+		public void SqlRightJoinWithInnerJoinOnRightWithConditions([DataSources(TestProvName.AllSQLite, ProviderName.Access)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -1950,7 +2015,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SqlRightJoinWithInnerJoinOnRightWithoutConditions([AllJoinsSource] string context)
+		public void SqlRightJoinWithInnerJoinOnRightWithoutConditions([DataSources(TestProvName.AllSQLite, ProviderName.Access)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -1991,7 +2056,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SqlRightJoinWithInnerJoinOnRightWithoutAllConditions([AllJoinsSource] string context)
+		public void SqlRightJoinWithInnerJoinOnRightWithoutAllConditions([DataSources(TestProvName.AllSQLite, ProviderName.Access)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{

--- a/Tests/Linq/Linq/JoinTests.cs
+++ b/Tests/Linq/Linq/JoinTests.cs
@@ -1730,5 +1730,96 @@ namespace Tests.Linq
 				Assert.IsNull(results[1].leftTag);
 			}
 		}
+
+		[Test]
+		public void RightJoinWithRecordSelection1([DataSources(TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var factTable = db.CreateLocalTable(Fact.Data))
+			using (var tagTable = db.CreateLocalTable(Tag.Data))
+			{
+				var t =
+					from leftTag in tagTable
+					from fact in factTable.RightJoin(fact => leftTag.FactId == fact.Id)
+					where fact.Id > 3
+					select new { fact, leftTag };
+
+				var results = t.ToArray();
+
+				Assert.AreEqual(2, results.Length);
+				Assert.AreEqual(4, results[0].fact.Id);
+				Assert.AreEqual("Tag4", results[0].leftTag.Name);
+				Assert.AreEqual(5, results[1].fact.Id);
+				Assert.IsNull(results[1].leftTag);
+			}
+		}
+
+		[Test]
+		public void RightJoinWithRecordSelection2([DataSources(TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var factTable = db.CreateLocalTable(Fact.Data))
+			using (var tagTable = db.CreateLocalTable(Tag.Data))
+			{
+				var t =
+					from leftTag in tagTable
+					from fact in factTable.Join(SqlJoinType.Right, fact => leftTag.FactId == fact.Id)
+					where fact.Id > 3
+					select new { fact, leftTag };
+
+				var results = t.ToArray();
+
+				Assert.AreEqual(2, results.Length);
+				Assert.AreEqual(4, results[0].fact.Id);
+				Assert.AreEqual("Tag4", results[0].leftTag.Name);
+				Assert.AreEqual(5, results[1].fact.Id);
+				Assert.IsNull(results[1].leftTag);
+			}
+		}
+
+		[Test]
+		public void RightJoinWithRecordSelection3([DataSources(TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var factTable = db.CreateLocalTable(Fact.Data))
+			using (var tagTable = db.CreateLocalTable(Tag.Data))
+			{
+				var q =
+					from ft in tagTable.RightJoin(factTable, (t, f) => t.FactId == f.Id, (t, f) => new { fact = f, leftTag = t })
+					where ft.fact.Id > 3
+					select ft;
+
+				var results = q.ToArray();
+
+				Assert.AreEqual(2, results.Length);
+				Assert.AreEqual(4, results[0].fact.Id);
+				Assert.AreEqual("Tag4", results[0].leftTag.Name);
+				Assert.AreEqual(5, results[1].fact.Id);
+				Assert.IsNull(results[1].leftTag);
+			}
+		}
+
+		[Test]
+		public void RightJoinWithRecordSelection4([DataSources(TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var factTable = db.CreateLocalTable(Fact.Data))
+			using (var tagTable = db.CreateLocalTable(Tag.Data))
+			{
+				var q =
+					from ft in tagTable.Join(factTable, SqlJoinType.Right, (t, f) => t.FactId == f.Id, (t, f) => new { fact = f, leftTag = t })
+					where ft.fact.Id > 3
+					select ft;
+
+				var results = q.ToArray();
+
+				Assert.AreEqual(2, results.Length);
+				Assert.AreEqual(4, results[0].fact.Id);
+				Assert.AreEqual("Tag4", results[0].leftTag.Name);
+				Assert.AreEqual(5, results[1].fact.Id);
+				Assert.IsNull(results[1].leftTag);
+			}
+		}
+
 	}
 }

--- a/Tests/Linq/Linq/SelectTests.cs
+++ b/Tests/Linq/Linq/SelectTests.cs
@@ -1041,7 +1041,7 @@ namespace Tests.Linq
 				var result = query.ToArray();
 
 				Assert.NotNull(result[0].Child1);
-				Assert.NotNull(result[1].Child1);
+				Assert.IsNull (result[1].Child1);
 
 				Assert.NotNull(result[0].Child2);
 				Assert.AreEqual(1,         result[0].Child2.Id);
@@ -1054,9 +1054,7 @@ namespace Tests.Linq
 				Assert.AreEqual("Generated", result[1].Child3.Value);
 
 				Assert.Null(result[0].Child4);
-				Assert.NotNull(result[1].Child4);
-				Assert.AreEqual(0,    result[1].Child4.Id);
-				Assert.AreEqual(null, result[1].Child4.Value);
+				Assert.IsNull(result[1].Child4);
 			}
 		}
 

--- a/Tests/Linq/UserTests/Issue820Tests.cs
+++ b/Tests/Linq/UserTests/Issue820Tests.cs
@@ -42,6 +42,7 @@ namespace Tests.UserTests
 			}
 		}
 
+		[ActiveIssue(1685, Configuration = ProviderName.SapHana)]
 		[Test]
 		public void TestAndWithCastAndFunction([DataSources] string context)
 		{


### PR DESCRIPTION
Fix #1773

Fixes:
- selection of null record as null for left/right/full join nullable side for all Join*() API
- full join left side subquery optimization