### PR TITLE
Fix Sybase time datetime and type handling issues

### DIFF
--- a/Source/LinqToDB/DataProvider/Sybase/SybaseDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseDataProvider.cs
@@ -40,7 +40,7 @@ namespace LinqToDB.DataProvider.Sybase
 			SetCharFieldToType<char>("nchar", (r, i) => DataTools.GetChar(r, i));
 
 			SetProviderField<IDataReader,TimeSpan,DateTime>((r,i) => r.GetDateTime(i) - new DateTime(1900, 1, 1));
-			SetProviderField<IDataReader,DateTime,DateTime>((r,i) => GetDateTime(r, i));
+			SetField<IDataReader,DateTime>("time", (r,i) => GetDateTimeAsTime(r, i));
 
 			_sqlOptimizer = new SybaseSqlOptimizer(SqlProviderFlags);
 		}
@@ -54,7 +54,7 @@ namespace LinqToDB.DataProvider.Sybase
 		public override string DbFactoryProviderName => "Sybase.Data.AseClient";
 #endif
 
-		static DateTime GetDateTime(IDataReader dr, int idx)
+		static DateTime GetDateTimeAsTime(IDataReader dr, int idx)
 		{
 			var value = dr.GetDateTime(idx);
 
@@ -141,7 +141,7 @@ namespace LinqToDB.DataProvider.Sybase
 					break;
 
 				case DataType.Time       :
-					if (value is TimeSpan) value = new DateTime(1900, 1, 1) + (TimeSpan)value;
+					if (value is TimeSpan ts) value = new DateTime(1900, 1, 1) + ts;
 					break;
 
 				case DataType.Xml        :

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseMappingSchema.cs
@@ -41,6 +41,10 @@ namespace LinqToDB.DataProvider.Sybase
 			}
 			else
 			{
+				// to match logic for values as parameters
+				if (value < TimeSpan.Zero)
+					value = TimeSpan.FromDays(1 - value.Days) + value;
+
 				var format = "hh\\:mm\\:ss\\.fff";
 
 				stringBuilder


### PR DESCRIPTION
Fix #1707

- apply date part adjustment on data read only to DateTime values of db type 'time'
- update 'time' literal generation for negative TimeSpan to match behavior for parameters. From now negative interval literal will generate value, corresponding to `1 day - interval time part`. E.g. `-1 hour` interval with result in 23:00 time value (same for `-x days 1 hour`, as day part is ignored)