### PR TITLE
Fix issue #1622

### DIFF
--- a/Source/LinqToDB.Templates/DataModel.ttinclude
+++ b/Source/LinqToDB.Templates/DataModel.ttinclude
@@ -99,7 +99,7 @@ HashSet<string> KeyWords = new HashSet<string>
 
 void LoadServerMetadata(DataConnection dataConnection)
 {
-	SqlBuilder = dataConnection.DataProvider.CreateSqlBuilder();
+	SqlBuilder = dataConnection.DataProvider.CreateSqlBuilder(dataConnection.MappingSchema);
 
 	var sp = dataConnection.DataProvider.GetSchemaProvider();
 	var db = sp.GetSchema(dataConnection, GetSchemaOptions);

--- a/Source/LinqToDB/Data/DataConnection.Linq.cs
+++ b/Source/LinqToDB/Data/DataConnection.Linq.cs
@@ -79,12 +79,7 @@ namespace LinqToDB.Data
 
 		string IDataContext.ContextID => DataProvider.Name;
 
-		static Func<ISqlBuilder> GetCreateSqlProvider(IDataProvider dp)
-		{
-			return dp.CreateSqlBuilder;
-		}
-
-		Func<ISqlBuilder> IDataContext.CreateSqlProvider => GetCreateSqlProvider(DataProvider);
+		Func<ISqlBuilder> IDataContext.CreateSqlProvider => () => DataProvider.CreateSqlBuilder(MappingSchema);
 
 		static Func<ISqlOptimizer> GetGetSqlOptimizer(IDataProvider dp)
 		{

--- a/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
+++ b/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
@@ -66,7 +66,7 @@ namespace LinqToDB.Data
 			{
 				SetCommand(false);
 
-				var sqlProvider = _preparedQuery.SqlProvider ?? _dataConnection.DataProvider.CreateSqlBuilder();
+				var sqlProvider = _preparedQuery.SqlProvider ?? _dataConnection.DataProvider.CreateSqlBuilder(_dataConnection.MappingSchema);
 
 				var sb = new StringBuilder();
 
@@ -99,7 +99,7 @@ namespace LinqToDB.Data
 
 						var sql = sb.ToString();
 
-						var sqlBuilder = _dataConnection.DataProvider.CreateSqlBuilder();
+						var sqlBuilder = _dataConnection.DataProvider.CreateSqlBuilder(_dataConnection.MappingSchema);
 						sql = sqlBuilder.ApplyQueryHints(sql, _preparedQuery.QueryHints);
 
 						sb = new StringBuilder(sql);
@@ -171,7 +171,7 @@ namespace LinqToDB.Data
 					sql.IsParameterDependent = true;
 				}
 
-				var sqlProvider = dataConnection.DataProvider.CreateSqlBuilder();
+				var sqlProvider = dataConnection.DataProvider.CreateSqlBuilder(dataConnection.MappingSchema);
 
 				sql = dataConnection.DataProvider.GetSqlOptimizer().OptimizeStatement(sql, dataConnection.MappingSchema);
 

--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -1058,7 +1058,7 @@ namespace LinqToDB.Data
 		{
 			if (queryHints?.Count > 0)
 			{
-				var sqlProvider = DataProvider.CreateSqlBuilder();
+				var sqlProvider = DataProvider.CreateSqlBuilder(MappingSchema);
 				sql = sqlProvider.ApplyQueryHints(sql, queryHints);
 				queryHints.Clear();
 			}

--- a/Source/LinqToDB/Data/TraceInfo.cs
+++ b/Source/LinqToDB/Data/TraceInfo.cs
@@ -102,7 +102,7 @@ namespace LinqToDB.Data
 					if (_sqlText != null)
 						return _sqlText;
 
-					var sqlProvider = DataConnection.DataProvider.CreateSqlBuilder();
+					var sqlProvider = DataConnection.DataProvider.CreateSqlBuilder(DataConnection.MappingSchema);
 					var sb          = new StringBuilder();
 
 					sb.Append("-- ").Append(DataConnection.ConfigurationString);

--- a/Source/LinqToDB/DataContext.cs
+++ b/Source/LinqToDB/DataContext.cs
@@ -246,7 +246,7 @@ namespace LinqToDB
 			}
 		}
 
-		Func<ISqlBuilder>   IDataContext.CreateSqlProvider => DataProvider.CreateSqlBuilder;
+		Func<ISqlBuilder>   IDataContext.CreateSqlProvider => () => DataProvider.CreateSqlBuilder(MappingSchema);
 		Func<ISqlOptimizer> IDataContext.GetSqlOptimizer   => DataProvider.GetSqlOptimizer;
 		Type                IDataContext.DataReaderType    => DataProvider.DataReaderType;
 		SqlProviderFlags    IDataContext.SqlProviderFlags  => DataProvider.SqlProviderFlags;

--- a/Source/LinqToDB/DataProvider/Access/AccessDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessDataProvider.cs
@@ -66,9 +66,9 @@ namespace LinqToDB.DataProvider.Access
 			return new OleDbConnection(connectionString);
 		}
 
-		public override ISqlBuilder CreateSqlBuilder()
+		public override ISqlBuilder CreateSqlBuilder(MappingSchema mappingSchema)
 		{
-			return new AccessSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, MappingSchema.ValueToSqlConverter);
+			return new AccessSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, mappingSchema.ValueToSqlConverter);
 		}
 
 		readonly ISqlOptimizer _sqlOptimizer;

--- a/Source/LinqToDB/DataProvider/BasicMerge.cs
+++ b/Source/LinqToDB/DataProvider/BasicMerge.cs
@@ -78,7 +78,7 @@ namespace LinqToDB.DataProvider
 			where T : class
 		{
 			var table      = dataConnection.MappingSchema.GetEntityDescriptor(typeof(T));
-			var sqlBuilder = dataConnection.DataProvider.CreateSqlBuilder();
+			var sqlBuilder = dataConnection.DataProvider.CreateSqlBuilder(dataConnection.MappingSchema);
 
 			Columns = table.Columns
 				.Select(c => new ColumnInfo
@@ -317,7 +317,7 @@ namespace LinqToDB.DataProvider
 		protected virtual bool BuildUsing<T>(DataConnection dataConnection, IEnumerable<T> source)
 		{
 			var table          = dataConnection.MappingSchema.GetEntityDescriptor(typeof(T));
-			var sqlBuilder     = dataConnection.DataProvider.CreateSqlBuilder();
+			var sqlBuilder     = dataConnection.DataProvider.CreateSqlBuilder(dataConnection.MappingSchema);
 			var pname          = sqlBuilder.Convert("p", ConvertType.NameToQueryParameter).ToString();
 			var valueConverter = dataConnection.MappingSchema.ValueToSqlConverter;
 
@@ -400,7 +400,7 @@ namespace LinqToDB.DataProvider
 		protected bool BuildUsing2<T>(DataConnection dataConnection, IEnumerable<T> source, string top, string fromDummyTable)
 		{
 			var table          = dataConnection.MappingSchema.GetEntityDescriptor(typeof(T));
-			var sqlBuilder     = dataConnection.DataProvider.CreateSqlBuilder();
+			var sqlBuilder     = dataConnection.DataProvider.CreateSqlBuilder(dataConnection.MappingSchema);
 			var pname          = sqlBuilder.Convert("p", ConvertType.NameToQueryParameter).ToString();
 			var valueConverter = dataConnection.MappingSchema.ValueToSqlConverter;
 

--- a/Source/LinqToDB/DataProvider/DB2/DB2BulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2BulkCopy.cs
@@ -33,7 +33,7 @@ namespace LinqToDB.DataProvider.DB2
 
 			if (dataConnection.Transaction == null)
 			{
-				var sqlBuilder = dataConnection.DataProvider.CreateSqlBuilder();
+				var sqlBuilder = dataConnection.DataProvider.CreateSqlBuilder(dataConnection.MappingSchema);
 				var descriptor = dataConnection.MappingSchema.GetEntityDescriptor(typeof(T));
 				var tableName  = GetTableName(sqlBuilder, options, table);
 

--- a/Source/LinqToDB/DataProvider/DB2/DB2DataProvider.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2DataProvider.cs
@@ -159,11 +159,11 @@ namespace LinqToDB.DataProvider.DB2
 		}
 #endif
 
-		public override ISqlBuilder CreateSqlBuilder()
+		public override ISqlBuilder CreateSqlBuilder(MappingSchema mappingSchema)
 		{
 			return Version == DB2Version.zOS ?
-				new DB2zOSSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, MappingSchema.ValueToSqlConverter) as ISqlBuilder:
-				new DB2LUWSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, MappingSchema.ValueToSqlConverter);
+				new DB2zOSSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, mappingSchema.ValueToSqlConverter) as ISqlBuilder:
+				new DB2LUWSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, mappingSchema.ValueToSqlConverter);
 		}
 
 		readonly DB2SqlOptimizer _sqlOptimizer;

--- a/Source/LinqToDB/DataProvider/DataProviderBase.cs
+++ b/Source/LinqToDB/DataProvider/DataProviderBase.cs
@@ -99,7 +99,7 @@ namespace LinqToDB.DataProvider
 		}
 
 		protected abstract IDbConnection CreateConnectionInternal (string connectionString);
-		public    abstract ISqlBuilder   CreateSqlBuilder();
+		public    abstract ISqlBuilder   CreateSqlBuilder(MappingSchema mappingSchema);
 		public    abstract ISqlOptimizer GetSqlOptimizer ();
 
 		public virtual void InitCommand(DataConnection dataConnection, CommandType commandType, string commandText, DataParameter[] parameters, bool withParameters)

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdDataProvider.cs
@@ -62,9 +62,9 @@ namespace LinqToDB.DataProvider.Firebird
 			_setTimeStamp = GetSetParameter(connectionType, "FbParameter",         "FbDbType", "FbDbType", "TimeStamp");
 		}
 
-		public override ISqlBuilder CreateSqlBuilder()
+		public override ISqlBuilder CreateSqlBuilder(MappingSchema mappingSchema)
 		{
-			return new FirebirdSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, MappingSchema.ValueToSqlConverter);
+			return new FirebirdSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, mappingSchema.ValueToSqlConverter);
 		}
 
 		readonly ISqlOptimizer _sqlOptimizer;

--- a/Source/LinqToDB/DataProvider/IDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/IDataProvider.cs
@@ -21,7 +21,7 @@ namespace LinqToDB.DataProvider
 		MappingSchema      MappingSchema         { get; }
 		SqlProviderFlags   SqlProviderFlags      { get; }
 		IDbConnection      CreateConnection      (string connectionString);
-		ISqlBuilder        CreateSqlBuilder      ();
+		ISqlBuilder        CreateSqlBuilder      (MappingSchema mappingSchema);
 		ISqlOptimizer      GetSqlOptimizer       ();
 		/// <summary>
 		/// Initializes <see cref="DataConnection.Command"/> object.

--- a/Source/LinqToDB/DataProvider/Informix/InformixDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixDataProvider.cs
@@ -138,9 +138,9 @@ namespace LinqToDB.DataProvider.Informix
 		public override string DbFactoryProviderName => "IBM.Data.Informix";
 #endif
 
-		public override ISqlBuilder CreateSqlBuilder()
+		public override ISqlBuilder CreateSqlBuilder(MappingSchema mappingSchema)
 		{
-			return new InformixSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, MappingSchema.ValueToSqlConverter);
+			return new InformixSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, mappingSchema.ValueToSqlConverter);
 		}
 
 		readonly ISqlOptimizer _sqlOptimizer;

--- a/Source/LinqToDB/DataProvider/MultipleRowsHelper.cs
+++ b/Source/LinqToDB/DataProvider/MultipleRowsHelper.cs
@@ -25,7 +25,7 @@ namespace LinqToDB.DataProvider
 		{
 			DataConnection = dataConnection;
 			Options        = options;
-			SqlBuilder     = dataConnection.DataProvider.CreateSqlBuilder();
+			SqlBuilder     = dataConnection.DataProvider.CreateSqlBuilder(dataConnection.MappingSchema);
 			ValueConverter = dataConnection.MappingSchema.ValueToSqlConverter;
 			Descriptor     = dataConnection.MappingSchema.GetEntityDescriptor(entityType);
 			Columns        = Descriptor.Columns

--- a/Source/LinqToDB/DataProvider/MySql/MySqlDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlDataProvider.cs
@@ -79,9 +79,9 @@ namespace LinqToDB.DataProvider.MySql
 		}
 #endif
 
-		public override ISqlBuilder CreateSqlBuilder()
+		public override ISqlBuilder CreateSqlBuilder(MappingSchema mappingSchema)
 		{
-			return new MySqlSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, MappingSchema.ValueToSqlConverter);
+			return new MySqlSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, mappingSchema.ValueToSqlConverter);
 		}
 
 		static class MappingSchemaInstance

--- a/Source/LinqToDB/DataProvider/Oracle/OracleBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleBulkCopy.cs
@@ -36,7 +36,7 @@ namespace LinqToDB.DataProvider.Oracle
 
 			if (dataConnection == null) throw new ArgumentNullException(nameof(dataConnection));
 
-			var sqlBuilder = dataConnection.DataProvider.CreateSqlBuilder();
+			var sqlBuilder = dataConnection.DataProvider.CreateSqlBuilder(dataConnection.MappingSchema);
 			var descriptor = dataConnection.MappingSchema.GetEntityDescriptor(typeof(T));
 			var tableName  = GetTableName(sqlBuilder, options, table);
 

--- a/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
@@ -410,9 +410,9 @@ namespace LinqToDB.DataProvider.Oracle
 
 		public             bool   IsXmlTypeSupported  => _oracleXmlType != null;
 
-		public override ISqlBuilder CreateSqlBuilder()
+		public override ISqlBuilder CreateSqlBuilder(MappingSchema mappingSchema)
 		{
-			return new OracleSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, MappingSchema.ValueToSqlConverter);
+			return new OracleSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, mappingSchema.ValueToSqlConverter);
 		}
 
 		static class MappingSchemaInstance

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
@@ -46,7 +46,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			if (!(connection.GetType() == _connectionType || connection.GetType().IsSubclassOfEx(_connectionType)))
 				return MultipleRowsCopy(table, options, source);
 
-			var sqlBuilder   = _dataProvider.CreateSqlBuilder();
+			var sqlBuilder   = _dataProvider.CreateSqlBuilder(dataConnection.MappingSchema);
 			var ed           = dataConnection.MappingSchema.GetEntityDescriptor(typeof(T));
 			var tableName    = GetTableName(sqlBuilder, options, table);
 			var columns      = ed.Columns.Where(c => !c.SkipOnInsert || options.KeepIdentity == true && c.IsIdentity).ToArray();
@@ -137,7 +137,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 				Expression.Call(writerVar, "StartRow", Array<Type>.Empty)
 			};
 
-			var builder = (BasicSqlBuilder)_dataProvider.CreateSqlBuilder();
+			var builder = (BasicSqlBuilder)_dataProvider.CreateSqlBuilder(mappingSchema);
 
 			for (var i = 0; i < columns.Length; i++)
 			{

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
@@ -420,9 +420,9 @@ namespace LinqToDB.DataProvider.PostgreSQL
 		protected override string ConnectionTypeName  { get { return "Npgsql.NpgsqlConnection, Npgsql"; } }
 		protected override string DataReaderTypeName  { get { return "Npgsql.NpgsqlDataReader, Npgsql"; } }
 
-		public override ISqlBuilder CreateSqlBuilder()
+		public override ISqlBuilder CreateSqlBuilder(MappingSchema mappingSchema)
 		{
-			return new PostgreSQLSqlBuilder(this, GetSqlOptimizer(), SqlProviderFlags, MappingSchema.ValueToSqlConverter);
+			return new PostgreSQLSqlBuilder(this, GetSqlOptimizer(), SqlProviderFlags, mappingSchema.ValueToSqlConverter);
 		}
 
 		readonly ISqlOptimizer _sqlOptimizer;

--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteDataProvider.cs
@@ -72,9 +72,9 @@ namespace LinqToDB.DataProvider.SQLite
 		{
 		}
 
-		public override ISqlBuilder CreateSqlBuilder()
+		public override ISqlBuilder CreateSqlBuilder(MappingSchema mappingSchema)
 		{
-			return new SQLiteSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, MappingSchema.ValueToSqlConverter);
+			return new SQLiteSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, mappingSchema.ValueToSqlConverter);
 		}
 
 		static class MappingSchemaInstance

--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteExtensions.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteExtensions.cs
@@ -536,7 +536,7 @@ namespace LinqToDB.DataProvider.SQLite
 			var parameterTokens = new string[ed.Columns.Count];
 			var parameters = new DataParameter[ed.Columns.Count];
 
-			var sqlBuilder = dc.DataProvider.CreateSqlBuilder();
+			var sqlBuilder = dc.DataProvider.CreateSqlBuilder(dc.MappingSchema);
 
 			for (var i = 0; i < ed.Columns.Count; i++)
 			{

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaBulkCopy.cs
@@ -105,7 +105,7 @@ namespace LinqToDB.DataProvider.SapHana
 				if (options.MaxBatchSize.HasValue)    dbc.BatchSize = options.MaxBatchSize.Value;
 				if (options.BulkCopyTimeout.HasValue) dbc.BulkCopyTimeout = options.BulkCopyTimeout.Value;
 
-				var sqlBuilder = _dataProvider.CreateSqlBuilder();
+				var sqlBuilder = _dataProvider.CreateSqlBuilder(dataConnection.MappingSchema);
 				var tableName  = GetTableName(sqlBuilder, options, table);
 
 				dbc.DestinationTableName = tableName;

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaDataProvider.cs
@@ -76,9 +76,9 @@ namespace LinqToDB.DataProvider.SapHana
 		}
 #endif
 
-		public override ISqlBuilder CreateSqlBuilder()
+		public override ISqlBuilder CreateSqlBuilder(MappingSchema mappingSchema)
 		{
-			return new SapHanaSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, MappingSchema.ValueToSqlConverter);
+			return new SapHanaSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, mappingSchema.ValueToSqlConverter);
 		}
 
 		readonly ISqlOptimizer _sqlOptimizer;

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaOdbcDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaOdbcDataProvider.cs
@@ -73,9 +73,9 @@ namespace LinqToDB.DataProvider.SapHana
 			base.InitCommand(dataConnection, commandType, commandText, parameters, withParameters);
 		}
 
-		public override ISqlBuilder CreateSqlBuilder()
+		public override ISqlBuilder CreateSqlBuilder(MappingSchema mappingSchema)
 		{
-			return new SapHanaOdbcSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, MappingSchema.ValueToSqlConverter);
+			return new SapHanaOdbcSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, mappingSchema.ValueToSqlConverter);
 		}
 
 		readonly ISqlOptimizer _sqlOptimizer;

--- a/Source/LinqToDB/DataProvider/SqlCe/SqlCeDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlCe/SqlCeDataProvider.cs
@@ -91,9 +91,9 @@ namespace LinqToDB.DataProvider.SqlCe
 
 		#region Overrides
 
-		public override ISqlBuilder CreateSqlBuilder()
+		public override ISqlBuilder CreateSqlBuilder(MappingSchema mappingSchema)
 		{
-			return new SqlCeSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, MappingSchema.ValueToSqlConverter);
+			return new SqlCeSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, mappingSchema.ValueToSqlConverter);
 		}
 
 		readonly ISqlOptimizer _sqlOptimizer;

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerBulkCopy.cs
@@ -34,7 +34,7 @@ namespace LinqToDB.DataProvider.SqlServer
 				{
 					var ed      = dataConnection.MappingSchema.GetEntityDescriptor(typeof(T));
 					var columns = ed.Columns.Where(c => !c.SkipOnInsert || options.KeepIdentity == true && c.IsIdentity).ToList();
-					var sb      = _dataProvider.CreateSqlBuilder();
+					var sb      = _dataProvider.CreateSqlBuilder(dataConnection.MappingSchema);
 					var rd      = new BulkCopyReader(_dataProvider, dataConnection.MappingSchema, columns, source);
 					var sqlopt  = SqlBulkCopyOptions.Default;
 					var rc      = new BulkCopyRowsCopied();
@@ -64,7 +64,7 @@ namespace LinqToDB.DataProvider.SqlServer
 						if (options.MaxBatchSize.   HasValue) bc.BatchSize       = options.MaxBatchSize.   Value;
 						if (options.BulkCopyTimeout.HasValue) bc.BulkCopyTimeout = options.BulkCopyTimeout.Value;
 
-						var sqlBuilder = _dataProvider.CreateSqlBuilder();
+						var sqlBuilder = _dataProvider.CreateSqlBuilder(dataConnection.MappingSchema);
 						var tableName  = GetTableName(sqlBuilder, options, table);
 
 						bc.DestinationTableName = tableName;

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
@@ -133,15 +133,15 @@ namespace LinqToDB.DataProvider.SqlServer
 			return new SqlConnection(connectionString);
 		}
 
-		public override ISqlBuilder CreateSqlBuilder()
+		public override ISqlBuilder CreateSqlBuilder(MappingSchema mappingSchema)
 		{
 			switch (Version)
 			{
-				case SqlServerVersion.v2000 : return new SqlServer2000SqlBuilder(GetSqlOptimizer(), SqlProviderFlags, MappingSchema.ValueToSqlConverter);
-				case SqlServerVersion.v2005 : return new SqlServer2005SqlBuilder(GetSqlOptimizer(), SqlProviderFlags, MappingSchema.ValueToSqlConverter);
-				case SqlServerVersion.v2008 : return new SqlServer2008SqlBuilder(GetSqlOptimizer(), SqlProviderFlags, MappingSchema.ValueToSqlConverter);
-				case SqlServerVersion.v2012 : return new SqlServer2012SqlBuilder(GetSqlOptimizer(), SqlProviderFlags, MappingSchema.ValueToSqlConverter);
-				case SqlServerVersion.v2017 : return new SqlServer2017SqlBuilder(GetSqlOptimizer(), SqlProviderFlags, MappingSchema.ValueToSqlConverter);
+				case SqlServerVersion.v2000 : return new SqlServer2000SqlBuilder(GetSqlOptimizer(), SqlProviderFlags, mappingSchema.ValueToSqlConverter);
+				case SqlServerVersion.v2005 : return new SqlServer2005SqlBuilder(GetSqlOptimizer(), SqlProviderFlags, mappingSchema.ValueToSqlConverter);
+				case SqlServerVersion.v2008 : return new SqlServer2008SqlBuilder(GetSqlOptimizer(), SqlProviderFlags, mappingSchema.ValueToSqlConverter);
+				case SqlServerVersion.v2012 : return new SqlServer2012SqlBuilder(GetSqlOptimizer(), SqlProviderFlags, mappingSchema.ValueToSqlConverter);
+				case SqlServerVersion.v2017 : return new SqlServer2017SqlBuilder(GetSqlOptimizer(), SqlProviderFlags, mappingSchema.ValueToSqlConverter);
 			}
 
 			throw new InvalidOperationException();

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerMerge.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerMerge.cs
@@ -30,7 +30,7 @@ namespace LinqToDB.DataProvider.SqlServer
 
 			if (hasIdentity)
 			{
-				var sqlBuilder = dataConnection.DataProvider.CreateSqlBuilder();
+				var sqlBuilder = dataConnection.DataProvider.CreateSqlBuilder(dataConnection.MappingSchema);
 
 				tblName = sqlBuilder.ConvertTableName(new StringBuilder(),
 					databaseName ?? table.DatabaseName,
@@ -61,7 +61,7 @@ namespace LinqToDB.DataProvider.SqlServer
 
 			if (hasIdentity)
 			{
-				var sqlBuilder = dataConnection.DataProvider.CreateSqlBuilder();
+				var sqlBuilder = dataConnection.DataProvider.CreateSqlBuilder(dataConnection.MappingSchema);
 
 				tblName = sqlBuilder.ConvertTableName(new StringBuilder(),
 					databaseName ?? table.DatabaseName,

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseDataProvider.cs
@@ -101,9 +101,9 @@ namespace LinqToDB.DataProvider.Sybase
 
 		#region Overrides
 
-		public override ISqlBuilder CreateSqlBuilder()
+		public override ISqlBuilder CreateSqlBuilder(MappingSchema mappingSchema)
 		{
-			return new SybaseSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, MappingSchema.ValueToSqlConverter);
+			return new SybaseSqlBuilder(GetSqlOptimizer(), SqlProviderFlags, mappingSchema.ValueToSqlConverter);
 		}
 
 		static class MappingSchemaInstance

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -1371,15 +1371,20 @@ namespace LinqToDB.Linq.Builder
 			var lambda = Expression.Lambda<Func<object>>(Expression.Convert(expr, typeof(object)));
 			var v      = lambda.Compile()();
 
-			if (v != null && v.GetType().IsEnumEx())
+			if (v != null && MappingSchema.ValueToSqlConverter.CanConvert(v.GetType()))
+				value = new SqlValue(v);
+			else
 			{
-				var attrs = v.GetType().GetCustomAttributesEx(typeof(Sql.EnumAttribute), true);
+				if (v != null && v.GetType().IsEnumEx())
+				{
+					var attrs = v.GetType().GetCustomAttributesEx(typeof(Sql.EnumAttribute), true);
 
-				if (attrs.Length == 0)
-					v = MappingSchema.EnumToValue((Enum)v);
+					if (attrs.Length == 0)
+						v = MappingSchema.EnumToValue((Enum)v);
+				}
+
+				value = MappingSchema.GetSqlValue(expr.Type, v);
 			}
-
-			value = MappingSchema.GetSqlValue(expr.Type, v);
 
 			_constants.Add(expr, value);
 

--- a/Source/LinqToDB/Linq/Expressions.cs
+++ b/Source/LinqToDB/Linq/Expressions.cs
@@ -1707,7 +1707,21 @@ namespace LinqToDB.Linq
 
 		// SqlServer
 		//
-		[Sql.Function]
+		class DateAddBuilder : Sql.IExtensionCallBuilder
+		{
+			public void Build(Sql.ISqExtensionBuilder builder)
+			{
+				var part    = builder.GetValue<Sql.DateParts>("part");
+				var partStr = Sql.DatePartBuilder.DatePartToStr(part);
+				var number  = builder.GetExpression("number");
+				var days    = builder.GetExpression("days");
+
+				builder.ResultExpression = new SqlQuery.SqlFunction(typeof(DateTime?), builder.Expression,
+					new SqlQuery.SqlExpression(partStr, SqlQuery.Precedence.Primary), number, days);
+			}
+		}
+
+		[Sql.Extension("DateAdd", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilder))]
 		public static DateTime? DateAdd(Sql.DateParts part, int? number, int? days)
 		{
 			return days == null ? null : Sql.DateAdd(part, number, new DateTime(1900, 1, days.Value + 1));

--- a/Source/LinqToDB/SchemaProvider/SchemaProviderBase.cs
+++ b/Source/LinqToDB/SchemaProvider/SchemaProviderBase.cs
@@ -207,7 +207,7 @@ namespace LinqToDB.SchemaProvider
 			{
 				#region Procedures
 
-				var sqlProvider = dataConnection.DataProvider.CreateSqlBuilder();
+				var sqlProvider = dataConnection.DataProvider.CreateSqlBuilder(dataConnection.MappingSchema);
 				var procs       = GetProcedures(dataConnection);
 				var procPparams = GetProcedureParameters(dataConnection);
 				var n           = 0;

--- a/Source/LinqToDB/ServiceModel/LinqService.cs
+++ b/Source/LinqToDB/ServiceModel/LinqService.cs
@@ -47,7 +47,7 @@ namespace LinqToDB.ServiceModel
 				return new LinqServiceInfo
 				{
 					MappingSchemaType = ctx.DataProvider.MappingSchema.     GetType().AssemblyQualifiedName,
-					SqlBuilderType    = ctx.DataProvider.CreateSqlBuilder().GetType().AssemblyQualifiedName,
+					SqlBuilderType    = ctx.DataProvider.CreateSqlBuilder(ctx.MappingSchema).GetType().AssemblyQualifiedName,
 					SqlOptimizerType  = ctx.DataProvider.GetSqlOptimizer(). GetType().AssemblyQualifiedName,
 					SqlProviderFlags  = ctx.DataProvider.SqlProviderFlags,
 					ConfigurationList = ctx.MappingSchema.ConfigurationList,

--- a/Source/LinqToDB/Sql/Sql.DateTime.cs
+++ b/Source/LinqToDB/Sql/Sql.DateTime.cs
@@ -42,7 +42,7 @@ namespace LinqToDB
 
 		#region DatePart
 
-		class DatePartBuilder : Sql.IExtensionCallBuilder
+		internal class DatePartBuilder : Sql.IExtensionCallBuilder
 		{
 			public void Build(Sql.ISqExtensionBuilder builder)
 			{
@@ -708,24 +708,23 @@ namespace LinqToDB
 				var date    = builder.GetExpression("date");
 				var number  = builder.GetExpression("number");
 
-				ISqlExpression partSql = null;
 				switch (part)
 				{
 					case Sql.DateParts.Quarter   :
-						partSql = new SqlValue(Sql.DateParts.Month);
-						number  = builder.Mul(number, 3);
+						part   = DateParts.Month;
+						number = builder.Mul(number, 3);
 						break;
 					case Sql.DateParts.DayOfYear :
 					case Sql.DateParts.WeekDay   :
-						partSql = new SqlValue(Sql.DateParts.Day);
+						part   = DateParts.Day;
 						break;
 					case Sql.DateParts.Week      :
-						partSql = new SqlValue(Sql.DateParts.Day);
+						part   = DateParts.Day;
 						number = builder.Mul(number, 7);
 						break;
 				}
 
-				partSql = partSql ?? new SqlValue(part);
+				var partSql = new SqlExpression(part.ToString());
 
 				builder.ResultExpression = new SqlFunction(typeof(DateTime?), "DateAdd", partSql, number, date);
 			}

--- a/Source/LinqToDB/SqlProvider/ValueToSqlConverter.cs
+++ b/Source/LinqToDB/SqlProvider/ValueToSqlConverter.cs
@@ -19,6 +19,18 @@ namespace LinqToDB.SqlProvider
 			BaseConverters = converters ?? Array<ValueToSqlConverter>.Empty;
 		}
 
+		public bool CanConvert(Type type)
+		{
+			if (_converters.ContainsKey(type))
+				return true;
+
+			for (var i = 0; i < BaseConverters.Length; i++)
+				if (BaseConverters[i].CanConvert(type))
+					return true;
+
+			return false;
+		}
+
 		internal void SetDefaults()
 		{
 			SetConverter(typeof(Boolean),    (sb,dt,v) => sb.Append((bool)v       ? "1" : "0"));
@@ -162,31 +174,33 @@ namespace LinqToDB.SqlProvider
 
 			ConverterType converter = null;
 
-			if (_converters.Count > 0 && !type.IsEnumEx())
+			if (_converters.Count > 0)
 			{
-				switch (type.GetTypeCodeEx())
+				if (!_converters.TryGetValue(type, out converter))
 				{
+					switch (type.GetTypeCodeEx())
+					{
 #if NETSTANDARD1_6
-					case (TypeCode)2       : stringBuilder.Append("NULL"); return true;
+					case (TypeCode)2          : stringBuilder.Append("NULL")  ; return true;
 #else
-					case TypeCode.DBNull   : stringBuilder.Append("NULL"); return true;
+						case TypeCode.DBNull  : stringBuilder.Append("NULL")  ; return true;
 #endif
-					case TypeCode.Boolean  : converter = _booleanConverter;  break;
-					case TypeCode.Char     : converter = _charConverter;     break;
-					case TypeCode.SByte    : converter = _sByteConverter;    break;
-					case TypeCode.Byte     : converter = _byteConverter;     break;
-					case TypeCode.Int16    : converter = _int16Converter;    break;
-					case TypeCode.UInt16   : converter = _uInt16Converter;   break;
-					case TypeCode.Int32    : converter = _int32Converter;    break;
-					case TypeCode.UInt32   : converter = _uInt32Converter;   break;
-					case TypeCode.Int64    : converter = _int64Converter;    break;
-					case TypeCode.UInt64   : converter = _uInt64Converter;   break;
-					case TypeCode.Single   : converter = _singleConverter;   break;
-					case TypeCode.Double   : converter = _doubleConverter;   break;
-					case TypeCode.Decimal  : converter = _decimalConverter;  break;
-					case TypeCode.DateTime : converter = _dateTimeConverter; break;
-					case TypeCode.String   : converter = _stringConverter;   break;
-					default                : _converters.TryGetValue(type, out converter); break;
+						case TypeCode.Boolean : converter = _booleanConverter ; break;
+						case TypeCode.Char    : converter = _charConverter    ; break;
+						case TypeCode.SByte   : converter = _sByteConverter   ; break;
+						case TypeCode.Byte    : converter = _byteConverter    ; break;
+						case TypeCode.Int16   : converter = _int16Converter   ; break;
+						case TypeCode.UInt16  : converter = _uInt16Converter  ; break;
+						case TypeCode.Int32   : converter = _int32Converter   ; break;
+						case TypeCode.UInt32  : converter = _uInt32Converter  ; break;
+						case TypeCode.Int64   : converter = _int64Converter   ; break;
+						case TypeCode.UInt64  : converter = _uInt64Converter  ; break;
+						case TypeCode.Single  : converter = _singleConverter  ; break;
+						case TypeCode.Double  : converter = _doubleConverter  ; break;
+						case TypeCode.Decimal : converter = _decimalConverter ; break;
+						case TypeCode.DateTime: converter = _dateTimeConverter; break;
+						case TypeCode.String  : converter = _stringConverter  ; break;
+					}
 				}
 			}
 
@@ -240,23 +254,26 @@ namespace LinqToDB.SqlProvider
 			{
 				_converters[type] = converter;
 
-				switch (type.GetTypeCodeEx())
+				if (!type.IsEnumEx())
 				{
-					case TypeCode.Boolean  : _booleanConverter  = converter; return;
-					case TypeCode.Char     : _charConverter     = converter; return;
-					case TypeCode.SByte    : _sByteConverter    = converter; return;
-					case TypeCode.Byte     : _byteConverter     = converter; return;
-					case TypeCode.Int16    : _int16Converter    = converter; return;
-					case TypeCode.UInt16   : _uInt16Converter   = converter; return;
-					case TypeCode.Int32    : _int32Converter    = converter; return;
-					case TypeCode.UInt32   : _uInt32Converter   = converter; return;
-					case TypeCode.Int64    : _int64Converter    = converter; return;
-					case TypeCode.UInt64   : _uInt64Converter   = converter; return;
-					case TypeCode.Single   : _singleConverter   = converter; return;
-					case TypeCode.Double   : _doubleConverter   = converter; return;
-					case TypeCode.Decimal  : _decimalConverter  = converter; return;
-					case TypeCode.DateTime : _dateTimeConverter = converter; return;
-					case TypeCode.String   : _stringConverter   = converter; return;
+					switch (type.GetTypeCodeEx())
+					{
+						case TypeCode.Boolean : _booleanConverter  = converter; return;
+						case TypeCode.Char    : _charConverter     = converter; return;
+						case TypeCode.SByte   : _sByteConverter    = converter; return;
+						case TypeCode.Byte    : _byteConverter     = converter; return;
+						case TypeCode.Int16   : _int16Converter    = converter; return;
+						case TypeCode.UInt16  : _uInt16Converter   = converter; return;
+						case TypeCode.Int32   : _int32Converter    = converter; return;
+						case TypeCode.UInt32  : _uInt32Converter   = converter; return;
+						case TypeCode.Int64   : _int64Converter    = converter; return;
+						case TypeCode.UInt64  : _uInt64Converter   = converter; return;
+						case TypeCode.Single  : _singleConverter   = converter; return;
+						case TypeCode.Double  : _doubleConverter   = converter; return;
+						case TypeCode.Decimal : _decimalConverter  = converter; return;
+						case TypeCode.DateTime: _dateTimeConverter = converter; return;
+						case TypeCode.String  : _stringConverter   = converter; return;
+					}
 				}
 			}
 		}

--- a/Source/LinqToDB/Tools/DataExtensions.cs
+++ b/Source/LinqToDB/Tools/DataExtensions.cs
@@ -36,7 +36,7 @@ namespace LinqToDB.Tools
 
 					if (sequenceName != null)
 					{
-						var sql       = context.DataProvider.CreateSqlBuilder().GetReserveSequenceValuesSql(sourceList.Count, sequenceName);
+						var sql       = context.DataProvider.CreateSqlBuilder(context.MappingSchema).GetReserveSequenceValuesSql(sourceList.Count, sequenceName);
 						var sequences = context.Query<object>(sql).ToList();
 
 						for (var i = 0; i < sourceList.Count; i++)
@@ -48,7 +48,7 @@ namespace LinqToDB.Tools
 					}
 					else
 					{
-						var sql      = context.DataProvider.CreateSqlBuilder().GetMaxValueSql(entityDescriptor, column);
+						var sql      = context.DataProvider.CreateSqlBuilder(context.MappingSchema).GetMaxValueSql(entityDescriptor, column);
 						var maxValue = context.Execute<object>(sql);
 
 						if (maxValue == null || maxValue == DBNull.Value)

--- a/Tests/Linq/Linq/EnumMappingTests.cs
+++ b/Tests/Linq/Linq/EnumMappingTests.cs
@@ -1755,7 +1755,8 @@ namespace Tests.Linq
 		[Sql.Expression("{0} = {1}", InlineParameters = true, ServerSideOnly = true, IsPredicate = true)]
 		public static bool SomeComparison(string column, Issue1622Enum value) => throw new InvalidOperationException();
 
-		[Test, ActiveIssue(1622)]
+		[ActiveIssue(SkipForNonLinqService = true, Details = "Fails due to default mapping schema on remote server. Fixed in 3.0")]
+		[Test]
 		public void Issue1622Test([DataSources] string context)
 		{
 			using (var db = GetDataContext(context, new MappingSchema()))
@@ -1775,7 +1776,9 @@ namespace Tests.Linq
 					var res2 = table.Where(e => e.Id == 1).Single();
 
 					Assert.That(item.Id, Is.EqualTo(res.Id));
+					Assert.That(item.SomeText, Is.EqualTo(res.SomeText));
 					Assert.That(item.Id, Is.EqualTo(res2.Id));
+					Assert.That(item.SomeText, Is.EqualTo(res2.SomeText));
 				}
 			}
 		}

--- a/Tests/Linq/Linq/QueryInheritanceTests.cs
+++ b/Tests/Linq/Linq/QueryInheritanceTests.cs
@@ -26,7 +26,7 @@ namespace Tests.Linq
 
 			var connection = (DataConnection) dataContext;
 
-			var sqlBuilder = connection.DataProvider.CreateSqlBuilder();
+			var sqlBuilder = connection.DataProvider.CreateSqlBuilder(connection.MappingSchema);
 			var sb = new StringBuilder();
 			sqlBuilder.BuildSql(0, query, sb);
 

--- a/Tests/Linq/TestProviders/Npgsql4PostgreSQLDataProvider.cs
+++ b/Tests/Linq/TestProviders/Npgsql4PostgreSQLDataProvider.cs
@@ -323,9 +323,9 @@ namespace Tests
 		}
 #endif
 
-		public override ISqlBuilder CreateSqlBuilder()
+		public override ISqlBuilder CreateSqlBuilder(MappingSchema mappingSchema)
 		{
-			return new Npgsql4PostgreSQLSqlBuilder(this, GetSqlOptimizer(), SqlProviderFlags, MappingSchema.ValueToSqlConverter);
+			return new Npgsql4PostgreSQLSqlBuilder(this, GetSqlOptimizer(), SqlProviderFlags, mappingSchema.ValueToSqlConverter);
 		}
 
 		protected override void SetParameterType(IDbDataParameter parameter, DbDataType dataType)

--- a/Tests/Linq/TestProviders/TestNoopProvider.cs
+++ b/Tests/Linq/TestProviders/TestNoopProvider.cs
@@ -823,7 +823,7 @@ namespace Tests
 			// Just for triggering of static constructor
 		}
 
-		public override ISqlBuilder CreateSqlBuilder()
+		public override ISqlBuilder CreateSqlBuilder(MappingSchema mappingSchema)
 		{
 			return new TestNoopSqlBuilder();
 		}

--- a/Tests/Linq/Update/MergeTests.CommandValidation.cs
+++ b/Tests/Linq/Update/MergeTests.CommandValidation.cs
@@ -172,7 +172,7 @@ namespace Tests.xUpdate
 
 				IDbConnection IDataProvider.CreateConnection(string connectionString) => throw new NotImplementedException();
 
-				ISqlBuilder IDataProvider.CreateSqlBuilder() => throw new NotImplementedException();
+				ISqlBuilder IDataProvider.CreateSqlBuilder(MappingSchema mappingSchema) => throw new NotImplementedException();
 
 				void IDataProvider.DisposeCommand(DataConnection dataConnection) => throw new NotImplementedException();
 


### PR DESCRIPTION
Fixes #1622
- fix enums support in ValueToSqlConverter
- adds support for custom ValueToSql conversions on sql builder level
- backport Sql.DateParts enum fixes from 3.0 branch

Known issues:
- fix doesn't work for remote context due to lack of custom mapping schema support on server-side. Already fixed in 3.0 branch