### PR TITLE
Add PrefixTableMappingForDefaultSchema T4 option

### DIFF
--- a/Source/LinqToDB.Templates/DataModel.ttinclude
+++ b/Source/LinqToDB.Templates/DataModel.ttinclude
@@ -129,7 +129,7 @@ void LoadServerMetadata(DataConnection dataConnection)
 			{
 				TableSchema             = t,
 				IsDefaultSchema         = t.IsDefaultSchema,
-				Schema                  = t.IsDefaultSchema && !IncludeDefaultSchema || string.IsNullOrEmpty(t.SchemaName)? null : t.SchemaName,
+				Schema                  = t.IsDefaultSchema && !IncludeDefaultSchema || string.IsNullOrEmpty(t.SchemaName) ? null : t.SchemaName,
 				BaseClass               = BaseEntityClass,
 				TableName               = t.TableName,
 				TypeName                = t.TypeName,

--- a/Source/LinqToDB.Templates/LinqToDB.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.ttinclude
@@ -27,6 +27,7 @@ bool   GenerateSchemaAsType                = false;
 bool   GenerateViews                       = true;
 bool   GenerateProcedureResultAsList       = false;
 bool   PrefixTableMappingWithSchema        = true;
+bool   PrefixTableMappingForDefaultSchema  = false;
 string SchemaNameSuffix                    = "Schema";
 string SchemaDataContextTypeName           = "DataContext";
 
@@ -1013,7 +1014,7 @@ void MakeMembersNamesUnique(IEnumerable<IClassMember> members, string defaultNam
 	LinqToDB.Common.Utils.MakeUniqueNames(
 		members,
 		reservedNames,
-		m => m is Table tbl ? (tbl.Schema != null && !tbl.IsDefaultSchema && PrefixTableMappingWithSchema ? tbl.Schema + "_" : null) + tbl.Name : (m is TypeBase t ? t.Name : ((MemberBase)m).Name),
+		m => m is Table tbl ? (tbl.Schema != null && (PrefixTableMappingForDefaultSchema || !tbl.IsDefaultSchema) && PrefixTableMappingWithSchema ? tbl.Schema + "_" : null) + tbl.Name : (m is TypeBase t ? t.Name : ((MemberBase)m).Name),
 		(m, newName) =>
 		{
 			if (m is TypeBase t)

--- a/Source/LinqToDB.Templates/README.md
+++ b/Source/LinqToDB.Templates/README.md
@@ -150,20 +150,24 @@ SchemaDataContextTypeName       = "DataContext"
 
 /* Table mappings configuration */
 // (string) Specify base class (or comma-separated list of class and/or interfaces) for table mappings
-BaseEntityClass               = null;
+BaseEntityClass                    = null;
 // Enables generation of TableAttribute.Database property using database name, returned by schema loader
-GenerateDatabaseName          = false;
+GenerateDatabaseName               = false;
 // Enables generation of TableAttribute.Database property with provided name value.
 // (string) If set, overrides GenerateDatabaseName behavior
-DatabaseName                  = null;
+DatabaseName                       = null;
 // Enables generation of TableAttribute.Schema property for default schema
-IncludeDefaultSchema          = true;
+IncludeDefaultSchema               = true;
 // Enables generation of mappings for views
-GenerateViews                 = true;
+GenerateViews                      = true;
 // Enables prefixing mapping classes for tables in non-default schema with schema name
 // E.g. MySchema.MyTable -> MySchema_MyTable
 // Applicable only if GenerateSchemaAsType = false
-PrefixTableMappingWithSchema  = true;
+PrefixTableMappingWithSchema       = true;
+// Enables prefixing mapping classes for tables in default schema with schema name
+// E.g. dbo.MyTable -> dbo_MyTable
+// Applicable only if IncludeDefaultSchema = true && GenerateSchemaAsType = false && PrefixTableMappingWithSchema = true
+PrefixTableMappingForDefaultSchema = false;
 
 /* Columns comfiguration */
 // Enables compact generation of column properties

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdSchemaProvider.cs
@@ -33,7 +33,7 @@ namespace LinqToDB.DataProvider.Firebird
 				{
 					TableID         = catalog + '.' + t.Field<string>("TABLE_SCHEMA") + '.' + name,
 					CatalogName     = catalog,
-					SchemaName      = null, //schema,
+					SchemaName      = schema,
 					TableName       = name,
 					IsDefaultSchema = schema == "SYSDBA",
 					IsView          = t.Field<string>("TABLE_TYPE") == "VIEW",
@@ -118,7 +118,7 @@ namespace LinqToDB.DataProvider.Firebird
 				{
 					ProcedureID         = catalog + "." + schema + "." + name,
 					CatalogName         = catalog,
-					SchemaName          = null, //schema,
+					SchemaName          = schema, //schema,
 					ProcedureName       = name,
 					IsDefaultSchema     = schema.IsNullOrEmpty(),
 					ProcedureDefinition = p.Field<string>("SOURCE")

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaSchemaProvider.cs
@@ -82,13 +82,13 @@ namespace LinqToDB.DataProvider.SapHana
 
 				return new TableInfo
 				{
-					CatalogName = null,
-					Description = comments,
+					CatalogName     = null,
+					Description     = comments,
 					IsDefaultSchema = schemaName == DefaultSchema,
-					IsView = !isTable,
-					SchemaName = schemaName,
-					TableID = schemaName + '.' + tableName,
-					TableName = tableName
+					IsView          = !isTable,
+					SchemaName      = schemaName,
+					TableID         = schemaName + '.' + tableName,
+					TableName       = tableName
 				};
 			}, GetTablesQuery());
 
@@ -271,15 +271,15 @@ namespace LinqToDB.DataProvider.SapHana
 				var definition = rd.IsDBNull(4) ? null : rd.GetString(4);
 				return new ProcedureInfo
 				{
-					ProcedureID = String.Concat(schema, '.', procedure),
-					CatalogName = null,
+					ProcedureID         = string.Concat(schema, '.', procedure),
+					CatalogName         = null,
 					IsAggregateFunction = false,
-					IsDefaultSchema = schema == DefaultSchema,
-					IsFunction = isFunction,
-					IsTableFunction = isTableFunction,
+					IsDefaultSchema     = schema == DefaultSchema,
+					IsFunction          = isFunction,
+					IsTableFunction     = isTableFunction,
 					ProcedureDefinition = definition,
-					ProcedureName = procedure,
-					SchemaName = schema
+					ProcedureName       = procedure,
+					SchemaName          = schema
 				};
 			}, @"
 				SELECT
@@ -570,13 +570,13 @@ namespace LinqToDB.DataProvider.SapHana
 				var tableName = x.GetString(1);
 				return new TableInfo
 				{
-					CatalogName = null,
-					Description = x.IsDBNull(2) ? null : x.GetString(2),
+					CatalogName     = null,
+					Description     = x.IsDBNull(2) ? null : x.GetString(2),
 					IsDefaultSchema = schemaName == DefaultSchema,
-					IsView = true,
-					SchemaName = schemaName,
-					TableID = schemaName + '.' + tableName,
-					TableName = tableName
+					IsView          = true,
+					SchemaName      = schemaName,
+					TableID         = schemaName + '.' + tableName,
+					TableName       = tableName
 				};
 			}, @"
 				SELECT 

--- a/Tests/T4.Linq/Firebird.generated.cs
+++ b/Tests/T4.Linq/Firebird.generated.cs
@@ -202,9 +202,9 @@ namespace FirebirdDataContext
 		#region Associations
 
 		/// <summary>
-		/// INTEG_7030
+		/// INTEG_15177
 		/// </summary>
-		[Association(ThisKey="PERSONID", OtherKey="PERSONID", CanBeNull=false, Relationship=Relationship.OneToOne, KeyName="INTEG_7030", BackReferenceName="INTEG")]
+		[Association(ThisKey="PERSONID", OtherKey="PERSONID", CanBeNull=false, Relationship=Relationship.OneToOne, KeyName="INTEG_15177", BackReferenceName="INTEG")]
 		public PERSON PERSON { get; set; }
 
 		#endregion
@@ -228,7 +228,7 @@ namespace FirebirdDataContext
 		public DOCTOR DOCTOR { get; set; }
 
 		/// <summary>
-		/// INTEG_7030_BackReference
+		/// INTEG_15177_BackReference
 		/// </summary>
 		[Association(ThisKey="PERSONID", OtherKey="PERSONID", CanBeNull=true, Relationship=Relationship.OneToOne, IsBackReference=true)]
 		public PATIENT INTEG { get; set; }

--- a/Tests/T4.Linq/Firebird.tt
+++ b/Tests/T4.Linq/Firebird.tt
@@ -6,6 +6,7 @@
 <#
 	NamespaceName = "FirebirdDataContext";
 
+	IncludeDefaultSchema = false;
 	GenerateDataTypes = true;
 	GenerateDbTypes   = true;
 

--- a/Tests/T4.Linq/Firebird3.generated.cs
+++ b/Tests/T4.Linq/Firebird3.generated.cs
@@ -77,6 +77,7 @@ namespace Firebird3DataContext
 		public ITable<XXPATIENT709>      XXPATIENT709       { get { return this.GetTable<XXPATIENT709>(); } }
 		public ITable<XXPATIENT72>       XXPATIENT72        { get { return this.GetTable<XXPATIENT72>(); } }
 		public ITable<XXPATIENT740>      XXPATIENT740       { get { return this.GetTable<XXPATIENT740>(); } }
+		public ITable<XxpersonF330>      XxpersonF330       { get { return this.GetTable<XxpersonF330>(); } }
 
 		public TESTDB30DB()
 		{
@@ -490,9 +491,9 @@ namespace Firebird3DataContext
 		#region Associations
 
 		/// <summary>
-		/// INTEG_6852
+		/// INTEG_14797
 		/// </summary>
-		[Association(ThisKey="PERSONID", OtherKey="PERSONID", CanBeNull=false, Relationship=Relationship.OneToOne, KeyName="INTEG_6852", BackReferenceName="INTEG")]
+		[Association(ThisKey="PERSONID", OtherKey="PERSONID", CanBeNull=false, Relationship=Relationship.OneToOne, KeyName="INTEG_14797", BackReferenceName="INTEG")]
 		public PERSON PERSON { get; set; }
 
 		#endregion
@@ -516,7 +517,7 @@ namespace Firebird3DataContext
 		public DOCTOR DOCTOR { get; set; }
 
 		/// <summary>
-		/// INTEG_6852_BackReference
+		/// INTEG_14797_BackReference
 		/// </summary>
 		[Association(ThisKey="PERSONID", OtherKey="PERSONID", CanBeNull=true, Relationship=Relationship.OneToOne, IsBackReference=true)]
 		public PATIENT INTEG { get; set; }
@@ -711,6 +712,16 @@ namespace Firebird3DataContext
 	{
 		[Column(DbType="integer",      DataType=DataType.Int32,    Length=4, Precision=0, Scale=0),   PrimaryKey,  NotNull] public int    PERSONID  { get; set; } // integer
 		[Column(DbType="varchar(255)", DataType=DataType.NVarChar, Length=255, Precision=0, Scale=0),    Nullable         ] public string DIAGNOSIS { get; set; } // varchar(255)
+	}
+
+	[Table("XXPERSON_F3_30")]
+	public partial class XxpersonF330
+	{
+		[Column(DbType="varchar(255)", DataType=DataType.NVarChar, Length=255, Precision=0, Scale=0),              NotNull] public string FIRSTNAME  { get; set; } // varchar(255)
+		[Column(DbType="integer",      DataType=DataType.Int32,    Length=4, Precision=0, Scale=0),   PrimaryKey,  NotNull] public int    PERSONID   { get; set; } // integer
+		[Column(DbType="varchar(255)", DataType=DataType.NVarChar, Length=255, Precision=0, Scale=0),              NotNull] public string LASTNAME   { get; set; } // varchar(255)
+		[Column(DbType="varchar(255)", DataType=DataType.NVarChar, Length=255, Precision=0, Scale=0),    Nullable         ] public string MIDDLENAME { get; set; } // varchar(255)
+		[Column(DbType="char(1)",      DataType=DataType.NChar,    Length=1, Precision=0, Scale=0),                NotNull] public char   GENDER     { get; set; } // char(1)
 	}
 
 	public static partial class TESTDB30DBStoredProcedures
@@ -1371,6 +1382,12 @@ namespace Firebird3DataContext
 		}
 
 		public static XXPATIENT740 Find(this ITable<XXPATIENT740> table, int PERSONID)
+		{
+			return table.FirstOrDefault(t =>
+				t.PERSONID == PERSONID);
+		}
+
+		public static XxpersonF330 Find(this ITable<XxpersonF330> table, int PERSONID)
 		{
 			return table.FirstOrDefault(t =>
 				t.PERSONID == PERSONID);

--- a/Tests/T4.Linq/Firebird3.tt
+++ b/Tests/T4.Linq/Firebird3.tt
@@ -6,6 +6,7 @@
 <#
 	NamespaceName = "Firebird3DataContext";
 
+	IncludeDefaultSchema = false;
 	GenerateDataTypes = true;
 	GenerateDbTypes   = true;
 

--- a/Tests/T4.Linq/SapHana.generated.cs
+++ b/Tests/T4.Linq/SapHana.generated.cs
@@ -13473,40 +13473,6 @@ namespace SapHanaDataContext
 
 		#endregion
 
-		#region PrdGlobalEccCvMARAproc
-
-		public static IEnumerable<PrdGlobalEccCvMARAprocResult> PrdGlobalEccCvMARAproc(this DataConnection dataConnection)
-		{
-			var ms = dataConnection.MappingSchema;
-
-			return dataConnection.QueryProc(dataReader =>
-				new PrdGlobalEccCvMARAprocResult
-				{
-					id      = Converter.ChangeTypeTo<int?>  (dataReader.GetValue(0), ms),
-					Column2 = Converter.ChangeTypeTo<string>(dataReader.GetValue(1), ms),
-				},
-				"\"TESTHANA\".\"prd.global.ecc/CV_MARAproc\"");
-		}
-
-		public partial class PrdGlobalEccCvMARAprocResult
-		{
-			               public int?   id      { get; set; }
-			[Column("id")] public string Column2 { get; set; }
-		}
-
-		#endregion
-
-		#region DROPEXISTINGVIEW
-
-		public static int DROPEXISTINGVIEW0(this DataConnection dataConnection, string VIEWNAME, string SCHEMANAME)
-		{
-			return dataConnection.ExecuteProc("\"TESTHANA\".\"DROPEXISTINGVIEW\"",
-				new DataParameter("VIEWNAME",   VIEWNAME,   DataType.VarChar),
-				new DataParameter("SCHEMANAME", SCHEMANAME, DataType.VarChar));
-		}
-
-		#endregion
-
 		#region PersonSelectByKey
 
 		public static IEnumerable<PersonSelectByKeyResult> PersonSelectByKey(this DataConnection dataConnection, int? ID)
@@ -13691,6 +13657,40 @@ namespace SapHanaDataContext
 		public static int AddIssue792Record(this DataConnection dataConnection)
 		{
 			return dataConnection.ExecuteProc("\"TESTHANA\".\"AddIssue792Record\"");
+		}
+
+		#endregion
+
+		#region PrdGlobalEccCvMARAproc
+
+		public static IEnumerable<PrdGlobalEccCvMARAprocResult> PrdGlobalEccCvMARAproc(this DataConnection dataConnection)
+		{
+			var ms = dataConnection.MappingSchema;
+
+			return dataConnection.QueryProc(dataReader =>
+				new PrdGlobalEccCvMARAprocResult
+				{
+					id      = Converter.ChangeTypeTo<int?>  (dataReader.GetValue(0), ms),
+					Column2 = Converter.ChangeTypeTo<string>(dataReader.GetValue(1), ms),
+				},
+				"\"TESTHANA\".\"prd.global.ecc/CV_MARAproc\"");
+		}
+
+		public partial class PrdGlobalEccCvMARAprocResult
+		{
+			               public int?   id      { get; set; }
+			[Column("id")] public string Column2 { get; set; }
+		}
+
+		#endregion
+
+		#region DROPEXISTINGVIEW
+
+		public static int DROPEXISTINGVIEW0(this DataConnection dataConnection, string VIEWNAME, string SCHEMANAME)
+		{
+			return dataConnection.ExecuteProc("\"TESTHANA\".\"DROPEXISTINGVIEW\"",
+				new DataParameter("VIEWNAME",   VIEWNAME,   DataType.VarChar),
+				new DataParameter("SCHEMANAME", SCHEMANAME, DataType.VarChar));
 		}
 
 		#endregion
@@ -15367,17 +15367,6 @@ namespace SapHanaDataContext
 
 		#endregion
 
-		#region AfllangWrapperProcedureDrop
-
-		public static int AfllangWrapperProcedureDrop(this DataConnection dataConnection, string SCHEMA_NAME, string PROCEDURE_NAME)
-		{
-			return dataConnection.ExecuteProc("\"SYS\".\"AFLLANG_WRAPPER_PROCEDURE_DROP\"",
-				new DataParameter("SCHEMA_NAME",    SCHEMA_NAME,    DataType.NVarChar),
-				new DataParameter("PROCEDURE_NAME", PROCEDURE_NAME, DataType.NVarChar));
-		}
-
-		#endregion
-
 		#region AflpmOnlineRegistrationCleanup
 
 		public static int AflpmOnlineRegistrationCleanup(this DataConnection dataConnection)
@@ -15393,6 +15382,17 @@ namespace SapHanaDataContext
 		{
 			return dataConnection.ExecuteProc("\"SYSTEM\".\"AFLPM_ERASER\"",
 				new DataParameter("PROC", PROC, DataType.VarChar));
+		}
+
+		#endregion
+
+		#region AfllangWrapperProcedureDrop
+
+		public static int AfllangWrapperProcedureDrop(this DataConnection dataConnection, string SCHEMA_NAME, string PROCEDURE_NAME)
+		{
+			return dataConnection.ExecuteProc("\"SYS\".\"AFLLANG_WRAPPER_PROCEDURE_DROP\"",
+				new DataParameter("SCHEMA_NAME",    SCHEMA_NAME,    DataType.NVarChar),
+				new DataParameter("PROCEDURE_NAME", PROCEDURE_NAME, DataType.NVarChar));
 		}
 
 		#endregion


### PR DESCRIPTION
Fix #1656

- adds new T4 option `bool PrefixTableMappingForDefaultSchema = false` to enable table mapping class prefixing with schema name for default schema too. Works only if following options also set to specified values:  `IncludeDefaultSchema = true && GenerateSchemaAsType = false && PrefixTableMappingWithSchema = true`
- fixed SchemaName field population for Firebird. Set `IncludeDefaultSchema = false`, if you don't want it to start generate `Schema` mapping properties.