### PR TITLE
improve RESPECT NULLS window function token support across databases

### DIFF
--- a/Source/LinqToDB/Sql/Sql.Analytic.cs
+++ b/Source/LinqToDB/Sql/Sql.Analytic.cs
@@ -107,16 +107,15 @@ namespace LinqToDB
 		{
 			switch (nulls)
 			{
-				case Sql.Nulls.None :
-				case Sql.Nulls.Respect :
+				case Sql.Nulls.None   :
+				case Sql.Nulls.Respect:
 					// no need to add RESPECT NULLS, as it is default behavior and token itself supported only by Oracle and Informix
-					break;
+					return string.Empty;
 				case Sql.Nulls.Ignore :
 					return "IGNORE NULLS";
 				default :
 					throw new ArgumentOutOfRangeException();
 			}
-			return string.Empty;
 		}
 
 		static string GetFromStr(Sql.From from)

--- a/Source/LinqToDB/Sql/Sql.Analytic.cs
+++ b/Source/LinqToDB/Sql/Sql.Analytic.cs
@@ -108,9 +108,9 @@ namespace LinqToDB
 			switch (nulls)
 			{
 				case Sql.Nulls.None :
-					break;
 				case Sql.Nulls.Respect :
-					return "RESPECT NULLS";
+					// no need to add RESPECT NULLS, as it is default behavior and token itself supported only by Oracle and Informix
+					break;
 				case Sql.Nulls.Ignore :
 					return "IGNORE NULLS";
 				default :

--- a/Tests/Base/TestProvName.cs
+++ b/Tests/Base/TestProvName.cs
@@ -24,26 +24,27 @@ namespace Tests
 		/// </summary>
 		public const string NoopProvider  = "TestNoopProvider";
 
-		public const string AllMySql             = "MySql,MySqlConnector,MySql57,MariaDB";
+		public const string AllMySql              = "MySql,MySqlConnector,MySql57,MariaDB";
 		// MySql excluded because v5.5 has inadequate FTS behavior
-		public const string AllMySqlFullText     = "MySqlConnector,MySql57,MariaDB";
-		public const string AllMySqlData         = "MySql,MySql57,MariaDB";
-		public const string AllPostgreSQL        = "PostgreSQL,PostgreSQL.9.2,PostgreSQL.9.3,PostgreSQL.9.5,PostgreSQL.10,PostgreSQL.11,PostgreSQL.EDGE";
-		public const string AllPostgreSQLv3      = "PostgreSQL,PostgreSQL.9.2,PostgreSQL.9.3,PostgreSQL.9.5,PostgreSQL.10,PostgreSQL.11";
-		public const string AllPostgreSQLLess10  = "PostgreSQL,PostgreSQL.9.2,PostgreSQL.9.3,PostgreSQL.9.5";
-		public const string AllPostgreSQL93Plus  = "PostgreSQL,PostgreSQL.9.3,PostgreSQL.9.5,PostgreSQL.10,PostgreSQL.11,PostgreSQL.EDGE";
-		public const string AllPostgreSQL95Plus  = "PostgreSQL,PostgreSQL.9.5,PostgreSQL.10,PostgreSQL.11,PostgreSQL.EDGE";
-		public const string AllPostgreSQL10Plus  = "PostgreSQL.10,PostgreSQL.11,PostgreSQL.EDGE";
-		public const string AllOracle            = "Oracle.Native,Oracle.Managed";
-		public const string AllFirebird          = "Firebird,Firebird3";
-		public const string AllSQLite            = "SQLite.Classic,SQLite.MS";
-		public const string AllSybase            = "Sybase,Sybase.Managed";
-		public const string AllSqlServer         = "SqlServer.2000,SqlServer.2005,SqlServer.2008,SqlServer.2012,SqlServer.2014,SqlServer.2017,SqlAzure.2012";
-		public const string AllSqlServer2005Plus = "SqlServer.2005,SqlServer.2008,SqlServer.2012,SqlServer.2014,SqlServer.2017,SqlAzure.2012";
-		public const string AllSqlServer2008Plus = "SqlServer.2008,SqlServer.2012,SqlServer.2014,SqlServer.2017,SqlAzure.2012";
-		public const string AllSqlServer2012Plus = "SqlServer.2012,SqlServer.2014,SqlServer.2017,SqlAzure.2012";
-		public const string AllSqlServer2016Plus = "SqlServer.2017,SqlAzure.2012";
-		public const string AllSqlServer2017Plus = "SqlServer.2017";
-		public const string AllSQLiteNorthwind   = "Northwind.SQLite,Northwind.SQLite.MS";
+		public const string AllMySqlFullText      = "MySqlConnector,MySql57,MariaDB";
+		public const string AllMySqlData          = "MySql,MySql57,MariaDB";
+		public const string AllPostgreSQL         = "PostgreSQL,PostgreSQL.9.2,PostgreSQL.9.3,PostgreSQL.9.5,PostgreSQL.10,PostgreSQL.11,PostgreSQL.EDGE";
+		public const string AllPostgreSQLv3       = "PostgreSQL,PostgreSQL.9.2,PostgreSQL.9.3,PostgreSQL.9.5,PostgreSQL.10,PostgreSQL.11";
+		public const string AllPostgreSQLLess10   = "PostgreSQL,PostgreSQL.9.2,PostgreSQL.9.3,PostgreSQL.9.5";
+		public const string AllPostgreSQL93Plus   = "PostgreSQL,PostgreSQL.9.3,PostgreSQL.9.5,PostgreSQL.10,PostgreSQL.11,PostgreSQL.EDGE";
+		public const string AllPostgreSQL95Plus   = "PostgreSQL,PostgreSQL.9.5,PostgreSQL.10,PostgreSQL.11,PostgreSQL.EDGE";
+		public const string AllPostgreSQL10Plus   = "PostgreSQL.10,PostgreSQL.11,PostgreSQL.EDGE";
+		public const string AllOracle             = "Oracle.Native,Oracle.Managed";
+		public const string AllFirebird           = "Firebird,Firebird3";
+		public const string AllSQLite             = "SQLite.Classic,SQLite.MS";
+		public const string AllSybase             = "Sybase,Sybase.Managed";
+		public const string AllSqlServer          = "SqlServer.2000,SqlServer.2005,SqlServer.2008,SqlServer.2012,SqlServer.2014,SqlServer.2017,SqlAzure.2012";
+		public const string AllSqlServer2008Minus = "SqlServer.2000,SqlServer.2005,SqlServer.2008";
+		public const string AllSqlServer2005Plus  = "SqlServer.2005,SqlServer.2008,SqlServer.2012,SqlServer.2014,SqlServer.2017,SqlAzure.2012";
+		public const string AllSqlServer2008Plus  = "SqlServer.2008,SqlServer.2012,SqlServer.2014,SqlServer.2017,SqlAzure.2012";
+		public const string AllSqlServer2012Plus  = "SqlServer.2012,SqlServer.2014,SqlServer.2017,SqlAzure.2012";
+		public const string AllSqlServer2016Plus  = "SqlServer.2017,SqlAzure.2012";
+		public const string AllSqlServer2017Plus  = "SqlServer.2017";
+		public const string AllSQLiteNorthwind    = "Northwind.SQLite,Northwind.SQLite.MS";
 	}
 }


### PR DESCRIPTION
Fix #1732 
- [x] don't generate RESPECT NULLS as it is default option
- [x] test that it doesn't break other functions, that use this option: LEAD, FIRST_VALUE, LAST_VALUE, NTH_VALUE