### PR TITLE
Implemented support of Single custom record in query - SelectQuery

### DIFF
--- a/Source/LinqToDB/DataExtensions.cs
+++ b/Source/LinqToDB/DataExtensions.cs
@@ -885,7 +885,7 @@ namespace LinqToDB
 		/// <summary>
 		///     <para>
 		///         Creates a LINQ query based on expression. Returned <see cref="IQueryable{T}" /> represents single record.
-		///			Could be useful for function calls, querying of database variables or properties, subqueries.
+		///         Could be useful for function calls, querying of database variables or properties, subqueries.
 		///     </para>
 		/// </summary>
 		/// <typeparam name="TEntity">Type of result.</typeparam>

--- a/Source/LinqToDB/DataExtensions.cs
+++ b/Source/LinqToDB/DataExtensions.cs
@@ -877,5 +877,40 @@ namespace LinqToDB
 
 		#endregion
 
+		#region SelectQuery
+
+		public static MethodInfo SelectQueryMethodInfo =
+			MemberHelper.MethodOf(() => SelectQuery<int>(null, null)).GetGenericMethodDefinition();
+
+		/// <summary>
+		///     <para>
+		///         Creates a LINQ query based on expression. Returned <see cref="IQueryable{T}" /> represents single record.
+		///			Could be useful for function calls, querying of database variables or properties, subqueries.
+		///     </para>
+		/// </summary>
+		/// <typeparam name="TEntity">Type of result.</typeparam>
+		/// <param name="dataContext">Database connection context.</param>
+		/// <param name="selector">Value selection expression.</param>
+		/// <returns> An <see cref="IQueryable{T}" /> representing single record. </returns>
+		[Pure]
+		public static IQueryable<TEntity> SelectQuery<TEntity>(
+			[NotNull]                this IDataContext         dataContext,
+			[NotNull, InstantHandle] Expression<Func<TEntity>> selector)
+		{
+			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
+			if (selector    == null) throw new ArgumentNullException(nameof(selector));
+
+			var table = new Table<TEntity>(dataContext);
+
+			return ((IQueryable<TEntity>)table).Provider.CreateQuery<TEntity>(
+				Expression.Call(
+					null,
+					MethodHelper.GetMethodInfo(SelectQuery, dataContext, selector),
+					new Expression[] { Expression.Constant(dataContext), Expression.Quote(selector) }));
+		}
+
+
+		#endregion
+
 	}
 }

--- a/Source/LinqToDB/DataExtensions.cs
+++ b/Source/LinqToDB/DataExtensions.cs
@@ -884,14 +884,28 @@ namespace LinqToDB
 
 		/// <summary>
 		///     <para>
-		///         Creates a LINQ query based on expression. Returned <see cref="IQueryable{T}" /> represents single record.
-		///         Could be useful for function calls, querying of database variables or properties, subqueries.
+		///         Creates a LINQ query based on expression. Returned <see cref="IQueryable{T}" /> represents single record.<para />
+		///         Could be useful for function calls, querying of database variables, properties or subqueries.
 		///     </para>
 		/// </summary>
 		/// <typeparam name="TEntity">Type of result.</typeparam>
 		/// <param name="dataContext">Database connection context.</param>
 		/// <param name="selector">Value selection expression.</param>
 		/// <returns> An <see cref="IQueryable{T}" /> representing single record. </returns>
+		/// <remarks>
+		///     Method works for most supported database engines, except databases which do not support <code>SELECT Value</code> without FROM statement.<para />
+		///     For Oracle it will be translated to <code>SELECT Value FROM SYS.DUAL</code>
+		/// </remarks>
+		/// <example>
+		/// Complex record:
+		/// <code>
+		/// db.SelectQuery(() => new { Version = 1, CurrentTimeStamp = Sql.CurrentTimeStamp });
+		/// </code>
+		/// Scalar value:
+		/// <code>
+		/// db.SelectQuery(() => Sql.CurrentTimeStamp);
+		/// </code>
+		/// </example>
 		[Pure]
 		public static IQueryable<TEntity> SelectQuery<TEntity>(
 			[NotNull]                this IDataContext         dataContext,

--- a/Source/LinqToDB/Expressions/InternalExtensions.cs
+++ b/Source/LinqToDB/Expressions/InternalExtensions.cs
@@ -1028,6 +1028,13 @@ namespace LinqToDB.Expressions
 			return false;
 		}
 
+		public static bool IsSameGenericMethod(this MethodCallExpression method, MethodInfo genericMethodInfo)
+		{
+			if (!method.Method.IsGenericMethod)
+				return false;
+			return method.Method.GetGenericMethodDefinition() == genericMethodInfo;
+		}
+
 		public static bool IsAssociation(this MethodCallExpression method, MappingSchema mappingSchema)
 		{
 			return mappingSchema.GetAttribute<AssociationAttribute>(method.Method.DeclaringType, method.Method) != null;

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -233,11 +233,12 @@ namespace LinqToDB.Linq.Builder
 			var info = new BuildInfo(context, expr, new SelectQuery { ParentSelect = context.SelectQuery });
 			var ctx  = BuildSequence(info);
 
-			if (ctx.SelectQuery.Select.Columns.Count == 0 &&
-				(ctx.IsExpression(null, 0, RequestFor.Expression).Result ||
-				 ctx.IsExpression(null, 0, RequestFor.Field).     Result))
+			if (ctx.SelectQuery.Select.Columns.Count == 0) 
 			{
-				ctx.ConvertToIndex(null, 0, ConvertFlags.Field);
+				if (ctx.IsExpression(null, 0, RequestFor.Field).Result)
+					ctx.ConvertToIndex(null, 0, ConvertFlags.Field);
+				if (ctx.IsExpression(null, 0, RequestFor.Expression).Result)
+					ctx.ConvertToIndex(null, 0, ConvertFlags.All);
 			}
 
 			return ctx;

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
@@ -41,6 +41,7 @@ namespace LinqToDB.Linq.Builder
 			new AggregationBuilder         (),
 			new MethodChainBuilder         (),
 			new ScalarSelectBuilder        (),
+			new SelectQueryBuilder         (),
 			new CountBuilder               (),
 			new PassThroughBuilder         (),
 			new TableAttributeBuilder      (),

--- a/Source/LinqToDB/Linq/Builder/SelectContext.cs
+++ b/Source/LinqToDB/Linq/Builder/SelectContext.cs
@@ -40,6 +40,23 @@ namespace LinqToDB.Linq.Builder
 
 		public readonly Dictionary<MemberInfo,Expression> Members = new Dictionary<MemberInfo,Expression>(new MemberInfoComparer());
 
+		public SelectContext(IBuildContext parent, ExpressionBuilder builder, LambdaExpression lambda, SelectQuery selectQuery)
+		{
+			Parent      = parent;
+			Sequence    = Array<IBuildContext>.Empty;
+			Builder     = builder;
+			Lambda      = lambda;
+			Body        = lambda.Body;
+			SelectQuery = selectQuery;
+
+			foreach (var context in Sequence)
+				context.Parent = this;
+
+			IsScalar = !Builder.ProcessProjection(Members, Body);
+
+			Builder.Contexts.Add(this);
+		}
+
 		public SelectContext(IBuildContext parent, LambdaExpression lambda, params IBuildContext[] sequences)
 		{
 			Parent      = parent;

--- a/Source/LinqToDB/Linq/Builder/SelectContext.cs
+++ b/Source/LinqToDB/Linq/Builder/SelectContext.cs
@@ -49,9 +49,6 @@ namespace LinqToDB.Linq.Builder
 			Body        = lambda.Body;
 			SelectQuery = selectQuery;
 
-			foreach (var context in Sequence)
-				context.Parent = this;
-
 			IsScalar = !Builder.ProcessProjection(Members, Body);
 
 			Builder.Contexts.Add(this);

--- a/Source/LinqToDB/Linq/Builder/SelectQueryBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/SelectQueryBuilder.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq.Expressions;
 using LinqToDB.Expressions;
-using LinqToDB.SqlQuery;
 
 namespace LinqToDB.Linq.Builder
 {

--- a/Source/LinqToDB/Linq/Builder/SelectQueryBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/SelectQueryBuilder.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Linq.Expressions;
+using LinqToDB.Expressions;
+using LinqToDB.SqlQuery;
+
+namespace LinqToDB.Linq.Builder
+{
+	class SelectQueryBuilder : MethodCallBuilder
+	{
+		protected override bool CanBuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo)
+		{
+			return methodCall.IsSameGenericMethod(DataExtensions.SelectQueryMethodInfo);
+		}
+
+		protected override IBuildContext BuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo)
+		{
+			var sequence = new SelectContext(buildInfo.Parent, builder,
+				(LambdaExpression)methodCall.Arguments[1].Unwrap(),
+				buildInfo.SelectQuery);
+
+			return sequence;
+		}
+
+		protected override SequenceConvertInfo Convert(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo,
+			ParameterExpression param)
+		{
+			return null;
+		}
+
+	}
+}

--- a/Tests/Linq/Linq/SelectQueryTests.cs
+++ b/Tests/Linq/Linq/SelectQueryTests.cs
@@ -1,0 +1,166 @@
+﻿using System.Linq;
+using LinqToDB;
+using LinqToDB.Mapping;
+using NUnit.Framework;
+
+namespace Tests.Linq
+{
+	[TestFixture]
+	public class SelectQueryTests : TestBase
+	{
+		[Table]
+		class SampleClass
+		{
+			[Column] public int Id    { get; set; }
+			[Column] public int Value { get; set; }
+		}
+
+		[Test]
+		public void UnionTest([DataSources(ProviderName.Access)] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var table = db.CreateLocalTable<SampleClass>())
+			{
+				var values1 = from t in db.GetTable<SampleClass>()
+					where t.Value == 1
+					select new
+					{
+						Value1 = Sql.DateAdd(Sql.DateParts.Day, t.Value, Sql.CurrentTimestamp),
+						Value2 = Sql.DateAdd(Sql.DateParts.Day, 2, Sql.CurrentTimestamp)
+					};
+
+				var values2 = db.SelectQuery(() => new
+				{
+					Value1 = Sql.DateAdd(Sql.DateParts.Day, 3, Sql.CurrentTimestamp),
+					Value2 = Sql.DateAdd(Sql.DateParts.Day, 4, Sql.CurrentTimestamp)
+				});
+
+				var query = values1.Union(values2);
+				var result = query.ToArray();
+
+				var result2 = query.Select(v => v.Value2).ToArray();
+			}
+		}
+
+		[Test]
+		public void SubQueryTest([DataSources(ProviderName.Access)] string context)
+		{
+			var data = GenerateData();
+			using (var db = GetDataContext(context))
+			using (new AllowMultipleQuery())
+			using (db.CreateLocalTable(data))
+			{
+				var values1 = from t in db.GetTable<SampleClass>()
+					where t.Value == 1
+					select new
+					{
+						Value1 = Sql.DateAdd(Sql.DateParts.Day, t.Value, Sql.CurrentTimestamp),
+						Value2 = Sql.DateAdd(Sql.DateParts.Day, 2, Sql.CurrentTimestamp)
+					};
+
+				var values2 = db.SelectQuery(() => new
+				{
+					Value1 = Sql.DateAdd(Sql.DateParts.Day, 3, Sql.CurrentTimestamp),
+					Value2 = Sql.DateAdd(Sql.DateParts.Day, 4, Sql.CurrentTimestamp)
+				});
+
+				var queryUnion = values1.Union(values2);
+
+				var query = from t in db.GetTable<SampleClass>()
+					select new
+					{
+						t,
+						subQuery = queryUnion.FirstOrDefault()
+					};
+
+				var result = query.ToArray();
+			}
+		}
+
+		[Test]
+		public void JoinTest([DataSources(ProviderName.Access)] string context)
+		{
+			var data = GenerateData();
+			using (var db = GetDataContext(context))
+			using (new AllowMultipleQuery())
+			using (db.CreateLocalTable(data))
+			{
+				var query = from t in db.GetTable<SampleClass>()
+                    from s in db.SelectQuery(() => new { Key = Sql.AsSql(1), SecondValue = Sql.AsSql(3)}).InnerJoin(s => s.Key == t.Id)
+					select new
+					{
+						t,
+                        s
+					};
+
+				var actual = query.ToArray();
+
+                var expectedQuery = from t in data
+	                from s in new []{ new { Key = 1, SecondValue = 3}}.Where(s => s.Key == t.Id)
+	                select new
+	                {
+		                t,
+		                s
+	                };
+
+                var expected = expectedQuery.ToArray();
+
+                //TODO: Enable when merging new CompareBuilder
+                //AreEqual(expected, actual);
+			}
+		}
+
+		[Test]
+		public void JoinScalarTest([DataSources(ProviderName.Access)] string context)
+		{
+			var data = GenerateData();
+			using (var db = GetDataContext(context))
+			using (new AllowMultipleQuery())
+			using (db.CreateLocalTable(data))
+			{
+				var query = from t in db.GetTable<SampleClass>()
+					from s in db.SelectQuery(() => Sql.AsSql(1)).InnerJoin(s => s == t.Id)
+					select new
+					{
+						t,
+						s
+					};
+
+				var actual = query.ToArray();
+
+				var expectedQuery = from t in data
+					from s in new[] { 1 }.Where(s => s == t.Id)
+					select new
+					{
+						t,
+						s
+					};
+
+				var expected = expectedQuery.ToArray();
+
+				//TODO: Enable when merging new CompareBuilder
+				//AreEqual(expected, actual);
+			}
+		}
+
+
+		private static SampleClass[] GenerateData()
+		{
+			return Enumerable.Range(1, 1).Select(i => new SampleClass() { Id = i, Value = i * 100 }).ToArray();
+		}
+
+		[Test]
+		public void FirstTest([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var table = db.CreateLocalTable<SampleClass>())
+			{
+				var values = db.SelectQuery(() => new
+				{
+					Value1 = Sql.DateAdd(Sql.DateParts.Day, 1, Sql.CurrentTimestamp),
+					Value2 = Sql.DateAdd(Sql.DateParts.Day, 2, Sql.CurrentTimestamp)
+				}).First();
+			}
+		}
+	}
+}

--- a/Tests/Linq/Linq/SelectQueryTests.cs
+++ b/Tests/Linq/Linq/SelectQueryTests.cs
@@ -86,27 +86,27 @@ namespace Tests.Linq
 			using (db.CreateLocalTable(data))
 			{
 				var query = from t in db.GetTable<SampleClass>()
-                    from s in db.SelectQuery(() => new { Key = Sql.AsSql(1), SecondValue = Sql.AsSql(3)}).InnerJoin(s => s.Key == t.Id)
+					from s in db.SelectQuery(() => new { Key = Sql.AsSql(1), SecondValue = Sql.AsSql(3)}).InnerJoin(s => s.Key == t.Id)
 					select new
 					{
 						t,
-                        s
+						s
 					};
 
 				var actual = query.ToArray();
 
-                var expectedQuery = from t in data
-	                from s in new []{ new { Key = 1, SecondValue = 3}}.Where(s => s.Key == t.Id)
-	                select new
-	                {
-		                t,
-		                s
-	                };
+				var expectedQuery = from t in data
+					from s in new []{ new { Key = 1, SecondValue = 3}}.Where(s => s.Key == t.Id)
+					select new
+					{
+						t,
+						s
+					};
 
-                var expected = expectedQuery.ToArray();
+				var expected = expectedQuery.ToArray();
 
-                //TODO: Enable when merging new CompareBuilder
-                //AreEqual(expected, actual);
+				//TODO: Enable when merging new CompareBuilder
+				//AreEqual(expected, actual);
 			}
 		}
 

--- a/Tests/Tests.Playground/Tests.Playground.csproj
+++ b/Tests/Tests.Playground/Tests.Playground.csproj
@@ -9,8 +9,6 @@
 
 	<ItemGroup>
 		<Compile Include="..\Linq\Create\CreateData.cs" Link="CreateData.cs" />
-		<Compile Include="..\Linq\Linq\FromSqlTests.cs" Link="FromSqlTests.cs" />
-		<Compile Include="..\Linq\Linq\SelectQueryTests.cs" Link="SelectQueryTests.cs" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tests/Tests.Playground/Tests.Playground.csproj
+++ b/Tests/Tests.Playground/Tests.Playground.csproj
@@ -9,6 +9,8 @@
 
 	<ItemGroup>
 		<Compile Include="..\Linq\Create\CreateData.cs" Link="CreateData.cs" />
+		<Compile Include="..\Linq\Linq\FromSqlTests.cs" Link="FromSqlTests.cs" />
+		<Compile Include="..\Linq\Linq\SelectQueryTests.cs" Link="SelectQueryTests.cs" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
It is possible now to inject into LINQ query single custom recordset via
```cs
db.SelectQuery(() => new { value1 = 1, Value2 = 2 })
```