### PR TITLE
Fix dateadd SQL precedence issues for some providers

### DIFF
--- a/Source/LinqToDB/Sql/Sql.DateTime.cs
+++ b/Source/LinqToDB/Sql/Sql.DateTime.cs
@@ -455,22 +455,25 @@ namespace LinqToDB
 				string expStr;
 				switch (part)
 				{
-					case Sql.DateParts.Year        : expStr = "{0} + {1} * INTERVAL '1' YEAR"      ; break;
-					case Sql.DateParts.Quarter     : expStr = "{0} + {1} * INTERVAL '3' MONTH"     ; break;
-					case Sql.DateParts.Month       : expStr = "{0} + {1} * INTERVAL '1' MONTH"     ; break;
+					case Sql.DateParts.Year        : expStr = "{0} * INTERVAL '1' YEAR"      ; break;
+					case Sql.DateParts.Quarter     : expStr = "{0} * INTERVAL '3' MONTH"     ; break;
+					case Sql.DateParts.Month       : expStr = "{0} * INTERVAL '1' MONTH"     ; break;
 					case Sql.DateParts.DayOfYear   :
 					case Sql.DateParts.WeekDay     :
-					case Sql.DateParts.Day         : expStr = "{0} + {1} * INTERVAL '1' DAY"       ; break;
-					case Sql.DateParts.Week        : expStr = "{0} + {1} * INTERVAL '7' DAY"       ; break;
-					case Sql.DateParts.Hour        : expStr = "{0} + {1} * INTERVAL '1' HOUR"      ; break;
-					case Sql.DateParts.Minute      : expStr = "{0} + {1} * INTERVAL '1' MINUTE"    ; break;
-					case Sql.DateParts.Second      : expStr = "{0} + {1} * INTERVAL '1' SECOND"    ; break;
-					case Sql.DateParts.Millisecond : expStr = "{0} + {1} * INTERVAL '0.001' SECOND"; break;
+					case Sql.DateParts.Day         : expStr = "{0} * INTERVAL '1' DAY"       ; break;
+					case Sql.DateParts.Week        : expStr = "{0} * INTERVAL '7' DAY"       ; break;
+					case Sql.DateParts.Hour        : expStr = "{0} * INTERVAL '1' HOUR"      ; break;
+					case Sql.DateParts.Minute      : expStr = "{0} * INTERVAL '1' MINUTE"    ; break;
+					case Sql.DateParts.Second      : expStr = "{0} * INTERVAL '1' SECOND"    ; break;
+					case Sql.DateParts.Millisecond : expStr = "{0} * INTERVAL '0.001' SECOND"; break;
 					default:
 						throw new ArgumentOutOfRangeException();
 				}
 
-				builder.ResultExpression = new SqlExpression(typeof(DateTime?), expStr, Precedence.Additive, date, number);
+				builder.ResultExpression = builder.Add(
+					date,
+					new SqlExpression(typeof(TimeSpan?), expStr, Precedence.Multiplicative, number),
+					typeof(DateTime?));
 			}
 		}
 
@@ -486,22 +489,25 @@ namespace LinqToDB
 
 				switch (part)
 				{
-					case Sql.DateParts.Year        : expStr = "{0} + {1} Year";                 break;
-					case Sql.DateParts.Quarter     : expStr = "{0} + ({1} * 3) Month";          break;
-					case Sql.DateParts.Month       : expStr = "{0} + {1} Month";                break;
+					case Sql.DateParts.Year        : expStr = "{0} Year";                 break;
+					case Sql.DateParts.Quarter     : expStr = "({0} * 3) Month";          break;
+					case Sql.DateParts.Month       : expStr = "{0} Month";                break;
 					case Sql.DateParts.DayOfYear   : 
 					case Sql.DateParts.WeekDay     : 
-					case Sql.DateParts.Day         : expStr = "{0} + {1} Day";                  break;
-					case Sql.DateParts.Week        : expStr = "{0} + ({1} * 7) Day";            break;
-					case Sql.DateParts.Hour        : expStr = "{0} + {1} Hour";                 break;
-					case Sql.DateParts.Minute      : expStr = "{0} + {1} Minute";               break;
-					case Sql.DateParts.Second      : expStr = "{0} + {1} Second";               break;
-					case Sql.DateParts.Millisecond : expStr = "{0} + ({1} * 1000) Microsecond"; break;
+					case Sql.DateParts.Day         : expStr = "{0} Day";                  break;
+					case Sql.DateParts.Week        : expStr = "({0} * 7) Day";            break;
+					case Sql.DateParts.Hour        : expStr = "{0} Hour";                 break;
+					case Sql.DateParts.Minute      : expStr = "{0} Minute";               break;
+					case Sql.DateParts.Second      : expStr = "{0} Second";               break;
+					case Sql.DateParts.Millisecond : expStr = "({0} * 1000) Microsecond"; break;
 					default:
 						throw new ArgumentOutOfRangeException();
 				}
 
-				builder.ResultExpression = new SqlExpression(typeof(DateTime?), expStr, Precedence.Additive, date, number);
+				builder.ResultExpression = builder.Add(
+					date,
+					new SqlExpression(typeof(TimeSpan?), expStr, Precedence.Primary, number),
+					typeof(DateTime?));
 			}
 		}
 
@@ -546,22 +552,25 @@ namespace LinqToDB
 				string expStr;
 				switch (part)
 				{
-					case Sql.DateParts.Year        : expStr = "{0} + {1} * Interval '1 Year'";         break;
-					case Sql.DateParts.Quarter     : expStr = "{0} + {1} * Interval '1 Month' * 3";    break;
-					case Sql.DateParts.Month       : expStr = "{0} + {1} * Interval '1 Month'";        break;
+					case Sql.DateParts.Year        : expStr = "{0} * Interval '1 Year'";         break;
+					case Sql.DateParts.Quarter     : expStr = "{0} * Interval '1 Month' * 3";    break;
+					case Sql.DateParts.Month       : expStr = "{0} * Interval '1 Month'";        break;
 					case Sql.DateParts.DayOfYear   : 
 					case Sql.DateParts.WeekDay     : 
-					case Sql.DateParts.Day         : expStr = "{0} + {1} * Interval '1 Day'";          break;
-					case Sql.DateParts.Week        : expStr = "{0} + {1} * Interval '1 Day' * 7";      break;
-					case Sql.DateParts.Hour        : expStr = "{0} + {1} * Interval '1 Hour'";         break;
-					case Sql.DateParts.Minute      : expStr = "{0} + {1} * Interval '1 Minute'";       break;
-					case Sql.DateParts.Second      : expStr = "{0} + {1} * Interval '1 Second'";       break;
-					case Sql.DateParts.Millisecond : expStr = "{0} + {1} * Interval '1 Millisecond'";  break;
+					case Sql.DateParts.Day         : expStr = "{0} * Interval '1 Day'";          break;
+					case Sql.DateParts.Week        : expStr = "{0} * Interval '1 Day' * 7";      break;
+					case Sql.DateParts.Hour        : expStr = "{0} * Interval '1 Hour'";         break;
+					case Sql.DateParts.Minute      : expStr = "{0} * Interval '1 Minute'";       break;
+					case Sql.DateParts.Second      : expStr = "{0} * Interval '1 Second'";       break;
+					case Sql.DateParts.Millisecond : expStr = "{0} * Interval '1 Millisecond'";  break;
 					default:
 						throw new ArgumentOutOfRangeException();
 				}
 
-				builder.ResultExpression = new SqlExpression(typeof(DateTime?), expStr, Precedence.Additive, date, number);
+				builder.ResultExpression = builder.Add(
+					date,
+					new SqlExpression(typeof(TimeSpan?), expStr, Precedence.Multiplicative, number),
+					typeof(DateTime?));
 			}
 		}
 
@@ -622,7 +631,7 @@ namespace LinqToDB
 						throw new ArgumentOutOfRangeException();
 				}
 
-				builder.ResultExpression = new SqlExpression(typeof(DateTime?), expStr, date, number);
+				builder.ResultExpression = new SqlExpression(typeof(DateTime?), expStr, Precedence.Concatenate, date, number);
 			}
 		}
 

--- a/Source/LinqToDB/SqlQuery/Precedence.cs
+++ b/Source/LinqToDB/SqlQuery/Precedence.cs
@@ -6,6 +6,10 @@ namespace LinqToDB.SqlQuery
 	{
 		public const int Primary            = 100; // (x) x.y f(x) a[x] x++ x-- new typeof sizeof checked unchecked
 		public const int Unary              =  90; // + - ! ++x --x (T)x
+		/// <summary>
+		/// This precedence is only for SQLite's || concatenate operator: https://www.sqlite.org/lang_expr.html
+		/// </summary>
+		public const int Concatenate        =  85; // SQLite's ||
 		public const int Multiplicative     =  80; // * / %
 		public const int Subtraction        =  70; // -
 		public const int Additive           =  60; // +

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -827,6 +827,360 @@ namespace Tests.Linq
 
 		#endregion
 
+		#region DateAdd Expression
+
+		[Test]
+		public void DateAddYearExpression([DataSources] string context)
+		{
+			var part1 = 6;
+			var part2 = 5;
+
+			using (var db = GetDataContext(context))
+				AreEqual(
+					from t in Types select Sql.DateAdd(Sql.DateParts.Year, 11, t.DateTimeValue).Value.Date,
+					from t in db.Types select Sql.AsSql(Sql.DateAdd(Sql.DateParts.Year, part1 + part2, t.DateTimeValue)).Value.Date);
+		}
+
+		[Test]
+		public void DateAddQuarterExpression([DataSources] string context)
+		{
+			var part1 = 6;
+			var part2 = 5;
+
+			using (var db = GetDataContext(context))
+				AreEqual(
+					from t in Types select Sql.DateAdd(Sql.DateParts.Quarter, -1, t.DateTimeValue).Value.Date,
+					from t in db.Types select Sql.AsSql(Sql.DateAdd(Sql.DateParts.Quarter, part2 - part1, t.DateTimeValue)).Value.Date);
+		}
+
+		[Test]
+		public void DateAddMonthExpression([DataSources] string context)
+		{
+			var part1 = 5;
+			var part2 = 3;
+
+			using (var db = GetDataContext(context))
+				AreEqual(
+					from t in Types select Sql.DateAdd(Sql.DateParts.Month, 2, t.DateTimeValue).Value.Date,
+					from t in db.Types select Sql.AsSql(Sql.DateAdd(Sql.DateParts.Month, part1 - part2, t.DateTimeValue)).Value.Date);
+		}
+
+		[Test]
+		public void DateAddDayOfYearExpression([DataSources] string context)
+		{
+			var part1 = 6;
+			var part2 = 3;
+
+			using (var db = GetDataContext(context))
+				AreEqual(
+					from t in Types select Sql.DateAdd(Sql.DateParts.DayOfYear, 3, t.DateTimeValue).Value.Date,
+					from t in db.Types select Sql.AsSql(Sql.DateAdd(Sql.DateParts.DayOfYear, part1 - part2, t.DateTimeValue)).Value.Date);
+		}
+
+		[Test]
+		public void DateAddDayExpression([DataSources] string context)
+		{
+			var part1 = 2;
+			var part2 = 3;
+
+			using (var db = GetDataContext(context))
+				AreEqual(
+					from t in Types select Sql.DateAdd(Sql.DateParts.Day, 5, t.DateTimeValue).Value.Date,
+					from t in db.Types select Sql.AsSql(Sql.DateAdd(Sql.DateParts.Day, part1 + part2, t.DateTimeValue)).Value.Date);
+		}
+
+		[Test]
+		public void DateAddWeekExpression([DataSources] string context)
+		{
+			var part1 = 2;
+			var part2 = 3;
+
+			using (var db = GetDataContext(context))
+				AreEqual(
+					from t in Types select Sql.DateAdd(Sql.DateParts.Week, -1, t.DateTimeValue).Value.Date,
+					from t in db.Types select Sql.AsSql(Sql.DateAdd(Sql.DateParts.Week, part1 - part2, t.DateTimeValue)).Value.Date);
+		}
+
+		[Test]
+		public void DateAddWeekDayExpression([DataSources] string context)
+		{
+			var part1 = 2;
+			var part2 = 3;
+
+			using (var db = GetDataContext(context))
+				AreEqual(
+					from t in Types select Sql.DateAdd(Sql.DateParts.WeekDay, 1, t.DateTimeValue).Value.Date,
+					from t in db.Types select Sql.AsSql(Sql.DateAdd(Sql.DateParts.WeekDay, part2 - part1, t.DateTimeValue)).Value.Date);
+		}
+
+		[Test]
+		public void DateAddHourExpression([DataSources] string context)
+		{
+			var part1 = 2;
+			var part2 = 3;
+
+			using (var db = GetDataContext(context))
+				AreEqual(
+					from t in Types select Sql.DateAdd(Sql.DateParts.Hour, 1, t.DateTimeValue).Value.Hour,
+					from t in db.Types select Sql.AsSql(Sql.DateAdd(Sql.DateParts.Hour, part2 - part1, t.DateTimeValue)).Value.Hour);
+		}
+
+		[Test]
+		public void DateAddMinuteExpression([DataSources] string context)
+		{
+			var part1 = 2;
+			var part2 = 3;
+
+			using (var db = GetDataContext(context))
+				AreEqual(
+					from t in Types select Sql.DateAdd(Sql.DateParts.Minute, 5, t.DateTimeValue).Value.Minute,
+					from t in db.Types select Sql.AsSql(Sql.DateAdd(Sql.DateParts.Minute, part1 + part2, t.DateTimeValue)).Value.Minute);
+		}
+
+		[Test]
+		public void DateAddSecondExpression([DataSources] string context)
+		{
+			var part1 = 20;
+			var part2 = 21;
+
+			using (var db = GetDataContext(context))
+				AreEqual(
+					from t in Types select Sql.DateAdd(Sql.DateParts.Second, 41, t.DateTimeValue).Value.Second,
+					from t in db.Types select Sql.AsSql(Sql.DateAdd(Sql.DateParts.Second, part1 + part2, t.DateTimeValue)).Value.Second);
+		}
+
+		[Test]
+		public void DateAddMillisecondExpression([DataSources(ProviderName.Informix, ProviderName.Access, ProviderName.SapHana, TestProvName.AllMySql)] string context)
+		{
+			var part1 = 200;
+			var part2 = 26;
+
+			using (var db = GetDataContext(context))
+				AreEqual(
+						from t in db.Types select Sql.DateAdd(Sql.DateParts.Millisecond, 226, t.DateTimeValue),
+						from t in db.Types select Sql.AsSql(Sql.DateAdd(Sql.DateParts.Millisecond, part1 + part2, t.DateTimeValue)),
+						new CustomNullableDateTimeComparer());
+		}
+
+		[Test]
+		public void AddYearsExpression([DataSources] string context)
+		{
+			var part1 = 5;
+			var part2 = 4;
+
+			using (var db = GetDataContext(context))
+				AreEqual(
+					from t in Types select t.DateTimeValue.AddYears(1).Date,
+					from t in db.Types select Sql.AsSql(t.DateTimeValue.AddYears(part1 - part2)).Date);
+		}
+
+		[Test]
+		public void AddMonthsExpression([DataSources] string context)
+		{
+			var part1 = 2;
+			var part2 = 4;
+
+			using (var db = GetDataContext(context))
+				AreEqual(
+					from t in Types select t.DateTimeValue.AddMonths(-2).Date,
+					from t in db.Types select Sql.AsSql(t.DateTimeValue.AddMonths(part1 - part2)).Date);
+		}
+
+		[Test]
+		public void AddDaysExpression([DataSources] string context)
+		{
+			var part1 = 2;
+			var part2 = 3;
+
+			using (var db = GetDataContext(context))
+				AreEqual(
+					from t in Types select t.DateTimeValue.AddDays(5).Date,
+					from t in db.Types select Sql.AsSql(t.DateTimeValue.AddDays(part1 + part2)).Date);
+		}
+
+		[Test]
+		public void AddHoursExpression([DataSources] string context)
+		{
+			var part1 = 11;
+			var part2 = 11;
+
+			using (var db = GetDataContext(context))
+				AreEqual(
+					from t in Types select t.DateTimeValue.AddHours(22).Hour,
+					from t in db.Types select Sql.AsSql(t.DateTimeValue.AddHours(part1 + part2)).Hour);
+		}
+
+		[Test]
+		public void AddMinutesExpression([DataSources] string context)
+		{
+			var part1 = 1;
+			var part2 = 9;
+
+			using (var db = GetDataContext(context))
+				AreEqual(
+					from t in Types select t.DateTimeValue.AddMinutes(-8).Minute,
+					from t in db.Types select Sql.AsSql(t.DateTimeValue.AddMinutes(part1 - part2)).Minute);
+		}
+
+		[Test]
+		public void AddSecondsExpression([DataSources] string context)
+		{
+			var part1 = 5;
+			var part2 = 40;
+
+			using (var db = GetDataContext(context))
+				AreEqual(
+					from t in Types select t.DateTimeValue.AddSeconds(-35).Second,
+					from t in db.Types select Sql.AsSql(t.DateTimeValue.AddSeconds(part1 - part2)).Second);
+		}
+
+		[Test]
+		public void AddMillisecondsExpression([DataSources(ProviderName.Informix, ProviderName.Access, ProviderName.SapHana, TestProvName.AllMySql)]
+			string context)
+		{
+			var part1 = 150;
+			var part2 = 76;
+
+			using (var db = GetDataContext(context))
+				AreEqual(
+					from t in db.Types select (t.DateTimeValue.AddMilliseconds(226)),
+					from t in db.Types select Sql.AsSql(t.DateTimeValue.AddMilliseconds(part1 + part2)),
+					new CustomDateTimeComparer());
+		}
+
+		[Test]
+		public void AddDaysFromColumnPositiveExpression([DataSources(ProviderName.Informix)] string context)
+		{
+			var part1 = 4;
+			var part2 = 4;
+
+			using (var db = GetDataContext(context))
+			{
+				db.Insert(new LinqDataTypes { ID = 5000, SmallIntValue = 2, DateTimeValue = new DateTime(2018, 01, 03) });
+				try
+				{
+					var result = db.Types
+						.Count(t => t.ID == 5000 && t.DateTimeValue.AddDays(t.SmallIntValue + part1 - part2) > new DateTime(2018, 01, 02));
+					Assert.AreEqual(1, result);
+				}
+				finally
+				{
+					db.Types.Delete(t => t.ID == 5000);
+				}
+			}
+		}
+
+		[Test]
+		public void AddDaysFromColumnNegativeExpression([DataSources(ProviderName.Informix)] string context)
+		{
+			var part1 = 4;
+			var part2 = 4;
+
+			using (var db = GetDataContext(context))
+			{
+				db.Insert(new LinqDataTypes { ID = 5000, SmallIntValue = -2, DateTimeValue = new DateTime(2018, 01, 03) });
+
+				try
+				{
+					var result = db.Types
+						.Count(t => t.ID == 5000 && Sql.AsSql(t.DateTimeValue.AddDays(t.SmallIntValue + part1 - part2)) < new DateTime(2018, 01, 02));
+
+					Assert.AreEqual(1, result);
+				}
+				finally
+				{
+					db.Types.Delete(t => t.ID == 5000);
+				}
+			}
+		}
+
+		[Test]
+		public void AddDaysFromColumnExpression([DataSources(ProviderName.Informix)] string context)
+		{
+			var part1 = 4;
+			var part2 = 4;
+
+			using (var db = GetDataContext(context))
+			{
+				var needsFix = db.ProviderNeedsTimeFix(context);
+
+				AreEqual(Types.Select(t => TestUtils.FixTime(t.DateTimeValue.AddDays(t.SmallIntValue + part1 - part2), needsFix)),
+					db.Types.Select(t => t.DateTimeValue.AddDays(t.SmallIntValue)));
+			}
+		}
+
+		[Test]
+		public void AddWeekFromColumnExpression([DataSources(ProviderName.Informix)] string context)
+		{
+			var part1 = 4;
+			var part2 = 4;
+
+			using (var db = GetDataContext(context))
+			{
+				AreEqual(
+					from t in Types select Sql.DateAdd(Sql.DateParts.Week, t.SmallIntValue, t.DateTimeValue).Value.Date,
+					from t in db.Types select Sql.AsSql(Sql.DateAdd(Sql.DateParts.Week, t.SmallIntValue + part1 - part2, t.DateTimeValue)).Value.Date);
+			}
+		}
+
+		[Test]
+		public void AddQuarterFromColumnExpression([DataSources(ProviderName.Informix)] string context)
+		{
+			var part1 = 4;
+			var part2 = 4;
+
+			using (var db = GetDataContext(context))
+			{
+				AreEqual(
+					from t in Types select Sql.DateAdd(Sql.DateParts.Quarter, t.SmallIntValue, t.DateTimeValue).Value.Date,
+					from t in db.Types select Sql.AsSql(Sql.DateAdd(Sql.DateParts.Quarter, t.SmallIntValue + part1 - part2, t.DateTimeValue)).Value.Date);
+			}
+		}
+
+		[Test]
+		public void AddYearFromColumnExpression([DataSources(ProviderName.Informix)] string context)
+		{
+			var part1 = 4;
+			var part2 = 4;
+
+			using (var db = GetDataContext(context))
+			{
+				AreEqual(
+					from t in Types select Sql.DateAdd(Sql.DateParts.Year, t.SmallIntValue, t.DateTimeValue).Value.Date,
+					from t in db.Types select Sql.AsSql(Sql.DateAdd(Sql.DateParts.Year, t.SmallIntValue + part1 - part2, t.DateTimeValue)).Value.Date);
+			}
+		}
+
+		[Test]
+		public void AddDynamicFromColumnExpression(
+			[DataSources(ProviderName.Informix)] string context,
+			[Values(
+				Sql.DateParts.Day,
+				Sql.DateParts.Hour,
+				Sql.DateParts.Minute,
+				Sql.DateParts.Month,
+				Sql.DateParts.Year,
+				Sql.DateParts.Second
+				)] Sql.DateParts datepart)
+		{
+			var part1 = 4;
+			var part2 = 4;
+
+			using (var db = GetDataContext(context))
+			{
+				var expected =
+					(from t in Types select Sql.DateAdd(datepart, t.SmallIntValue, t.DateTimeValue)).Select(d =>
+						Truncate(d.Value, TimeSpan.TicksPerSecond));
+				var result =
+					(from t in db.Types select Sql.AsSql(Sql.DateAdd(datepart, t.SmallIntValue + part1 - part2, t.DateTimeValue)))
+					.ToList().Select(d => Truncate(d.Value, TimeSpan.TicksPerSecond));
+
+				AreEqual(expected, result);
+			}
+		}
+
+		#endregion
+
 		#region DateDiff
 
 		[Test]


### PR DESCRIPTION
Fixed incorrect precedence applied to dateadd expressions if interval is also expression.
Fixes DB2, Oracle, SQLite and PostgreSQL