### PR TITLE
Added ability to apply TableExpression to the query.

### DIFF
--- a/Source/LinqToDB/Expressions/Extensions.cs
+++ b/Source/LinqToDB/Expressions/Extensions.cs
@@ -1362,9 +1362,15 @@ namespace LinqToDB.Expressions
 			TransformInfo ti;
 
 			{
-				ti = func(expr);
-				if (ti.Stop || ti.Expression != expr)
-					return ti.Expression;
+				do
+				{
+					ti = func(expr);
+					if (ti.Stop || !ti.Continue && ti.Expression != expr)
+						return ti.Expression;
+					if (expr == ti.Expression)
+						break;
+					expr = ti.Expression;
+				} while (true);
 			}
 
 			switch (expr.NodeType)

--- a/Source/LinqToDB/Expressions/TransformInfo.cs
+++ b/Source/LinqToDB/Expressions/TransformInfo.cs
@@ -5,19 +5,29 @@ namespace LinqToDB.Expressions
 {
 	public struct TransformInfo
 	{
-		public TransformInfo(Expression expression, bool stop)
-		{
-			Expression = expression;
-			Stop       = stop;
-		}
-
 		public TransformInfo(Expression expression)
 		{
 			Expression = expression;
 			Stop       = false;
+			Continue   = false;
+		}
+
+		public TransformInfo(Expression expression, bool stop)
+		{
+			Expression = expression;
+			Stop       = stop;
+			Continue   = false;
+		}
+
+		public TransformInfo(Expression expression, bool stop, bool @continue)
+		{
+			Expression = expression;
+			Stop       = stop;
+			Continue   = @continue;
 		}
 
 		public Expression Expression;
 		public bool       Stop;
+		public bool		  Continue;
 	}
 }

--- a/Source/LinqToDB/ITableMutable.cs
+++ b/Source/LinqToDB/ITableMutable.cs
@@ -1,4 +1,6 @@
-﻿namespace LinqToDB
+﻿using System.Linq.Expressions;
+
+namespace LinqToDB
 {
 	/// <summary>
 	/// This is internal API and is not intended for use by Linq To DB applications.
@@ -23,5 +25,12 @@
 		/// It may change or be removed without further notice.
 		/// </summary>
 		ITable<T> ChangeTableName   (string tableName);
+
+		/// <summary>
+		/// This is internal API and is not intended for use by Linq To DB applications.
+		/// It may change or be removed without further notice.
+		/// </summary>
+		ITable<T> ChangeExpression   (Expression expression);
+
 	}
 }

--- a/Source/LinqToDB/Linq/Builder/ApplyTableExpressionBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ApplyTableExpressionBuilder.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using LinqToDB.Expressions;
+
+namespace LinqToDB.Linq.Builder
+{
+	class ApplyTableExpressionBuilder : MethodCallBuilder
+	{
+		protected override bool CanBuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo)
+		{
+			return methodCall.IsSameGenericMethod(
+				LinqExtensions.ApplyTableExpressionMethodInfo1,
+				LinqExtensions.ApplyTableExpressionMethodInfo2, 
+				LinqExtensions.ApplyTableExpressionExceptMethodInfo);
+		}
+
+		protected override IBuildContext BuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo)
+		{
+			var context = builder.BuildSequence(new BuildInfo(buildInfo, methodCall.Arguments[0]));
+
+			var groups = Enumerable.Empty<string>();
+			if (methodCall.Arguments.Count > 2)
+			{
+				var groupsStr = (string)methodCall.Arguments[2].EvaluateExpression();
+				groups = groupsStr.Split(',', ';');
+			}
+
+			var isExcept      = methodCall.IsSameGenericMethod(LinqExtensions.ApplyTableExpressionExceptMethodInfo);
+			var expressionStr = (string)methodCall.Arguments[1].EvaluateExpression();
+
+			context.SelectQuery.AddApplyTableExpression(isExcept, expressionStr, groups);
+
+			return context;
+		}
+
+		protected override SequenceConvertInfo Convert(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo,
+			ParameterExpression param)
+		{
+			return null;
+		}
+	}
+}

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.QueryBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.QueryBuilder.cs
@@ -826,6 +826,7 @@ namespace LinqToDB.Linq.Builder
 											var dcConst = Expression.Constant(context.Builder.DataContext.Clone(true));
 
 											expr = queryMethod.GetBody(me.Expression, dcConst);
+											expr = context.Builder.ConvertExpressionTree(expr);
 										}
 										else
 										{

--- a/Source/LinqToDB/Linq/Builder/TableBuilder.AssociatedTableContext.cs
+++ b/Source/LinqToDB/Linq/Builder/TableBuilder.AssociatedTableContext.cs
@@ -73,6 +73,7 @@ namespace LinqToDB.Linq.Builder
 				{
 					var selectManyMethod = GetAssociationQueryExpression(Expression.Constant(builder.DataContext),
 						queryMethod.Parameters[0], parent.ObjectType, parent.Expression, queryMethod);
+					selectManyMethod = builder.ConvertExpressionTree(selectManyMethod);
 
 					var ownerTableSource = SelectQuery.From.Tables[0];
 
@@ -359,6 +360,8 @@ namespace LinqToDB.Linq.Builder
 
 						expression = queryMethod.Body.Transform(e =>
 							e == ownerParam ? ownerExpr : (e == dcParam ? lContext : e));
+
+						expression = builder.ConvertExpressionTree(expression);
 					}
 					else
 					{

--- a/Source/LinqToDB/Linq/Builder/TableBuilder.TableContext.cs
+++ b/Source/LinqToDB/Linq/Builder/TableBuilder.TableContext.cs
@@ -918,6 +918,7 @@ namespace LinqToDB.Linq.Builder
 					if (queryMethod != null)
 					{
 						expr = queryMethod.GetBody(parent, Expression.Constant(association.Builder.DataContext));
+						expr = association.Builder.ConvertExpressionTree(expr);
 						return expr;
 					}
 

--- a/Source/LinqToDB/Linq/Builder/TableGroupBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/TableGroupBuilder.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+using LinqToDB.Expressions;
+using LinqToDB.SqlQuery;
+
+namespace LinqToDB.Linq.Builder
+{
+	class TableGroupBuilder : MethodCallBuilder
+	{
+		protected override bool CanBuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo)
+		{
+			return methodCall.IsSameGenericMethod(LinqExtensions.TableGroupMethodInfo);
+		}
+
+		protected override IBuildContext BuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo)
+		{
+			var context = builder.BuildSequence(new BuildInfo(buildInfo, methodCall.Arguments[0]));
+			if (context is TableBuilder.TableContext tableContext)
+			{
+				var sqlTable = tableContext.SqlTable;
+				if (sqlTable.Groups == null)
+				{
+					sqlTable.Groups = new HashSet<string>();
+				}
+
+				var groups = (string)methodCall.Arguments[1].EvaluateExpression();
+				foreach (var group in groups.Split(',', ';'))
+				{
+					sqlTable.Groups.Add(group);
+				}
+			}
+
+			return context;
+		}
+
+		protected override SequenceConvertInfo Convert(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo,
+			ParameterExpression param)
+		{
+			return null;
+		}
+	}
+}

--- a/Source/LinqToDB/Linq/Builder/WithTableExpressionBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/WithTableExpressionBuilder.cs
@@ -11,7 +11,7 @@ namespace LinqToDB.Linq.Builder
 	{
 		protected override bool CanBuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo)
 		{
-			return methodCall.IsQueryable("With", "WithTableExpression");
+			return methodCall.IsSameGenericMethod(LinqExtensions.WithTableExpressionMethodInfo);
 		}
 
 		protected override IBuildContext BuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo)
@@ -22,12 +22,7 @@ namespace LinqToDB.Linq.Builder
 
 			table.SqlTable.SqlTableType   = SqlTableType.Expression;
 			table.SqlTable.TableArguments = new ISqlExpression[0];
-
-			switch (methodCall.Method.Name)
-			{
-				case "With"                : table.SqlTable.Name = $"{{0}} {{1}} WITH ({value})"; break;
-				case "WithTableExpression" : table.SqlTable.Name = value;                         break;
-			}
+			table.SqlTable.Name           = value;
 
 			return sequence;
 		}

--- a/Source/LinqToDB/Linq/TableT.cs
+++ b/Source/LinqToDB/Linq/TableT.cs
@@ -123,6 +123,16 @@ namespace LinqToDB.Linq
 			return table;
 		}
 
+		public ITable<T> ChangeExpression(Expression expression)
+		{
+			var table          = new Table<T>(DataContext);
+			table.SchemaName   = SchemaName;
+			table.DatabaseName = DatabaseName;
+			table.Expression   = expression;
+			table.TableName    = TableName;
+			return table;
+		}
+
 		#region Overrides
 
 		public override string ToString()

--- a/Source/LinqToDB/SqlQuery/SelectQuery.cs
+++ b/Source/LinqToDB/SqlQuery/SelectQuery.cs
@@ -95,6 +95,25 @@ namespace LinqToDB.SqlQuery
 		public  bool                    HasUniqueKeys => _uniqueKeys != null && _uniqueKeys.Count > 0;
 
 
+		private List<SqlApplyTableExpression> _applyTableExpressions;
+
+		public void AddApplyTableExpression(bool isExcept, string expressionStr, IEnumerable<string> groups)
+		{
+			var apply = new SqlApplyTableExpression(isExcept, expressionStr, groups);
+			if (_applyTableExpressions == null)
+				_applyTableExpressions = new List<SqlApplyTableExpression>();
+			_applyTableExpressions.Add(apply);
+		}
+
+		public IEnumerable<SqlApplyTableExpression> GetApplyTableExpressions()
+		{
+			if (_applyTableExpressions == null)
+				return Enumerable.Empty<SqlApplyTableExpression>();
+			return _applyTableExpressions;
+		}
+
+		public bool HasApplyTableExpressions => _applyTableExpressions?.Count > 0;
+
 		#endregion
 
 		#region Union

--- a/Source/LinqToDB/SqlQuery/SqlApplyTableExpression.cs
+++ b/Source/LinqToDB/SqlQuery/SqlApplyTableExpression.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace LinqToDB.SqlQuery
+{
+	public class SqlApplyTableExpression
+	{
+		public SqlApplyTableExpression(bool isExcept, string expressionStr, IEnumerable<string> groups)
+		{
+			IsExcept = isExcept;
+			ExpressionStr = expressionStr;
+			Groups = new HashSet<string>(groups);
+		}
+
+		public bool IsExcept { get; }
+		public string ExpressionStr { get; }
+		public HashSet<string> Groups { get; }
+	}
+}

--- a/Source/LinqToDB/SqlQuery/SqlTable.cs
+++ b/Source/LinqToDB/SqlQuery/SqlTable.cs
@@ -207,6 +207,9 @@ namespace LinqToDB.SqlQuery
 		public virtual SqlTableType     SqlTableType   { get; set; }
 		public         ISqlExpression[] TableArguments { get; set; }
 
+		public HashSet<string>          Groups         { get; set; }
+
+
 		public Dictionary<string,SqlField> Fields { get; }
 
 		public SequenceNameAttribute[] SequenceAttributes { get; protected set; }

--- a/Source/LinqToDB/TempTable.cs
+++ b/Source/LinqToDB/TempTable.cs
@@ -236,6 +236,11 @@ namespace LinqToDB
 			return ((ITableMutable<T>)_table).ChangeTableName(tableName);
 		}
 
+		ITable<T> ITableMutable<T>.ChangeExpression(Expression expression)
+		{
+			return ((ITableMutable<T>)_table).ChangeExpression(expression);
+		}
+
 		#endregion
 
 		#region IQueryProvider

--- a/Tests/Linq/Linq/TableExpressionTests.cs
+++ b/Tests/Linq/Linq/TableExpressionTests.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using LinqToDB;
+using LinqToDB.Mapping;
+using NUnit.Framework;
+
+namespace Tests.Linq
+{
+	[TestFixture]
+	public class TableExpressionTests : TestBase
+	{
+		[Table]
+		class TestClass
+		{
+			[Column] public int Id    { get; set; }
+			[Column] public int Value { get; set; }
+
+
+			[Association(QueryExpressionMethod = nameof(OthersImpl))]
+			public List<TestClass> Others { get; }
+
+			[Association(QueryExpressionMethod = nameof(Others2Impl))]
+			public List<TestClass> Others2 { get; }
+
+			static Expression<Func<TestClass, IDataContext, IQueryable<TestClass>>> OthersImpl()
+			{
+				return (t, dc) => dc.GetTable<TestClass>().TableName("TestClassChild").TableGroup("A").Where(z => z.Id == t.Id).Take(10);
+			}
+
+			static Expression<Func<TestClass, IDataContext, IQueryable<TestClass>>> Others2Impl()
+			{
+				return (t, dc) => ChildTable(dc).Where(o2 => o2.Id == t.Id).Take(10);
+			}
+
+			private static ITable<TestClass> ChildTable(IDataContext dc)
+			{
+				return dc.GetTable<TestClass>().TableName("TestClassChild2").TableGroup("A").TableGroup("A2");
+			}
+
+		}
+
+		[Test]
+		public void TestGroups([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var query = from c1 in db.GetTable<TestClass>().TableGroup("G1")
+					from c2 in db.GetTable<TestClass>().TableGroup("G2").LeftJoin(c2 => c2.Id != c1.Id)
+					from c3 in db.GetTable<TestClass>().LeftJoin(c3 => c3.Id != c1.Id)
+					select new { c1, c2, c3 };
+
+				var query1 = query.ApplyWith("NOLOCK", "G1");
+				var str1  = query1.ToString();
+				Console.WriteLine(str1);
+				Assert.That(str1, Does.Contain("[c1] WITH (NOLOCK)").And.Not.Contain("[c2] WITH (NOLOCK)").And.Not.Contain("[c3] WITH (NOLOCK)"));
+
+				var query2 = query.ApplyWithExcept("NOLOCK", "G1");
+				var str2   = query2.ToString();
+				Console.WriteLine(str2);
+				Assert.That(str2, Does.Contain("[c2] WITH (NOLOCK)").And.Contain("[c3] WITH (NOLOCK)").And.Not.Contain("[c1] WITH (NOLOCK)"));
+
+				var query3 = query.ApplyWithExcept("NOLOCK", "G1,G2");
+				var str3   = query3.ToString();
+				Console.WriteLine(str3);
+				Assert.That(str3, Does.Contain("[c3] WITH (NOLOCK)").And.Not.Contain("[c1] WITH (NOLOCK)").And.Not.Contain("[c2] WITH (NOLOCK)"));
+			}
+		}
+
+		[Test]
+		public void TestQueryableAssociation([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var query = from c1 in db.GetTable<TestClass>().TableGroup("G1")
+					from a1 in c1.Others 
+					from a2 in c1.Others2 
+					select new
+					{
+						c1,
+						a1,
+						a2
+					};
+
+				var query1 = query.ApplyWith("NOLOCK", "A");
+				var str1  = query1.ToString();
+				Console.WriteLine(str1);
+
+				Assert.That(str1, Does.Contain("[TestClassChild] [z] WITH (NOLOCK)").And.Not.Contain("[TestClass] [c1] WITH (NOLOCK)"));
+
+				var query2 = query.ApplyWithExcept("NOLOCK", "A");
+				var str2   = query2.ToString();
+				Console.WriteLine(str2);
+
+				Assert.That(str2, Does.Contain("[TestClass] [c1] WITH (NOLOCK)").And.Not.Contain("[TestClassChild] [z] WITH (NOLOCK)"));
+
+				var query3 = query.ApplyWithExcept("NOLOCK", "G1");
+				var str3   = query3.ToString();
+				Console.WriteLine(str3);
+
+				Assert.That(str3, Does.Contain("[TestClassChild] [z] WITH (NOLOCK)").And.Not.Contain("[TestClass] [c1] WITH (NOLOCK)"));
+
+				var query4 = query.ApplyWith("NOLOCK");
+				var str4  = query4.ToString();
+				Console.WriteLine(str4);
+
+				Assert.That(str4, Does.Contain("[TestClassChild] [z] WITH (NOLOCK)").And.Contain("[TestClass] [c1] WITH (NOLOCK)"));
+
+				var query5 = query;
+				var str5  = query5.ToString();
+				Console.WriteLine(str5);
+
+				Assert.That(str5, Does.Not.Contain("[TestClassChild] [z] WITH (NOLOCK)").And.Not.Contain("[TestClass] [c1] WITH (NOLOCK)"));
+
+				var query6 = query.ApplyWithExcept("NOLOCK", "A2,G1");
+				var str6   = query6.ToString();
+				Console.WriteLine(str6);
+
+				Assert.That(str6, Does.Not.Contain("[TestClassChild2] [o2] WITH (NOLOCK)").And.Contain("[TestClassChild] [z] WITH (NOLOCK)").And.Not.Contain("[TestClass] [c1] WITH (NOLOCK)"));
+
+				var cteQuery = query.AsCte();
+				var query7 = (from t2 in db.GetTable<TestClass>().TableGroup("G2")
+					from cte in cteQuery 
+					select new { t2, cte }).ApplyWith("NOLOCK");
+				var str7   = query7.ToString();
+				Console.WriteLine(str7);
+
+				Assert.That(str7, Does.Contain("[TestClass] [t2] WITH (NOLOCK)").And.Not.Contain("[TestClassChild] [z] WITH (NOLOCK)").And.Not.Contain("[TestClassChild2] [o2] WITH (NOLOCK)"));
+
+			}
+		}
+
+	}
+}

--- a/Tests/Linq/Linq/TableFunctionTests.cs
+++ b/Tests/Linq/Linq/TableFunctionTests.cs
@@ -137,11 +137,22 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 			{
-				var q =
+				var q1 =
 					from p in db.Parent.SchemaName("dbo").With("TABLOCK,UPDLOCK")
 					select p;
 
-				q.ToList();
+				var q2 = 
+					(from p in db.Parent.SchemaName("dbo")
+					select p).ApplyWith("TABLOCK,UPDLOCK");
+
+				var str1 = q1.ToString();
+				var str2 = q2.ToString();
+
+				Console.WriteLine(str2);
+
+				Assert.That(str1, Is.EqualTo(str2));
+
+				Assert.That(str1, Does.Contain("WITH (TABLOCK,UPDLOCK)"));
 			}
 		}
 


### PR DESCRIPTION
- Added ability to apply Table Expression to the query.
- Expression conversion improvements.
- Added ability for `Transform` function to continue processing when, for example, removing transparent methods. Reduces recursions during transformation.
- Fixed several found bugs with Queryable associations.
- Help in #1545

It also helps in situation when it is needed to add `AS OF SCN` to the tables when processing Oracle's tables in history.