### PR TITLE
[schema] add option to disable FK schema information load

### DIFF
--- a/Source/LinqToDB.Templates/README.md
+++ b/Source/LinqToDB.Templates/README.md
@@ -46,6 +46,8 @@ All loaded schema information is used for mappings generation, so if you want to
 ```cs
 // Enables loading of tables and views information
 GetSchemaOptions.GetTables             = true;
+// Enables loading of foreign key relations for associations
+GetSchemaOptions.GetForeignKeys        = true;
 // Enables loading of functions and procedures information
 GetSchemaOptions.GetProcedures         = true;
 // Enables use of System.Char type in generated model for text types

--- a/Source/LinqToDB/DataProvider/Access/AccessSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessSchemaProvider.cs
@@ -137,8 +137,10 @@ namespace LinqToDB.DataProvider.Access
 
 		protected override List<ForeignKeyInfo> GetForeignKeys(DataConnection dataConnection)
 		{
+			// this line (GetOleDbSchemaTable) could crash application hard with AV:
+			// https://github.com/linq2db/linq2db.LINQPad/issues/23
 			var data = ((OleDbConnection)Proxy.GetUnderlyingObject((DbConnection)dataConnection.Connection))
-				.GetOleDbSchemaTable(OleDbSchemaGuid.Foreign_Keys, new object[] { null, null });
+				.GetOleDbSchemaTable(OleDbSchemaGuid.Foreign_Keys, null);
 
 			var q = from fk in data.AsEnumerable()
 					select new ForeignKeyInfo

--- a/Source/LinqToDB/SchemaProvider/GetSchemaOptions.cs
+++ b/Source/LinqToDB/SchemaProvider/GetSchemaOptions.cs
@@ -12,6 +12,11 @@ namespace LinqToDB.SchemaProvider
 		/// </summary>
 		public bool     GetTables             = true;
 		/// <summary>
+		/// Enable or disable read of foreign keys. Default - enabled (<c>true</c>).
+		/// Disabe could be useful at least for Access, as it could <a href="https://github.com/linq2db/linq2db.LINQPad/issues/23">crash</a> on some database files.
+		/// </summary>
+		public bool     GetForeignKeys        = true;
+		/// <summary>
 		/// Enable or disable read of procedures and functions metadata. Default - enabled (<c>true</c>).
 		/// </summary>
 		public bool     GetProcedures         = true;

--- a/Source/LinqToDB/SchemaProvider/SchemaProviderBase.cs
+++ b/Source/LinqToDB/SchemaProvider/SchemaProviderBase.cs
@@ -149,7 +149,7 @@ namespace LinqToDB.SchemaProvider
 
 				#region FK
 
-				var fks = GetForeignKeys(dataConnection);
+				var fks = options.GetForeignKeys ? GetForeignKeys(dataConnection) : new List<ForeignKeyInfo>();
 
 				foreach (var fk in fks.OrderBy(f => f.Ordinal))
 				{


### PR DESCRIPTION
This change required to implement workaround for https://github.com/linq2db/linq2db.LINQPad/issues/23 where JET engine crashes with AV when we try to load foreign key information