### PR TITLE
Added missed MappingSchema initialization for DataContext's DataConnection.

### DIFF
--- a/Source/LinqToDB/DataContext.cs
+++ b/Source/LinqToDB/DataContext.cs
@@ -219,6 +219,9 @@ namespace LinqToDB
 
 				if (OnTraceConnection != null)
 					_dataConnection.OnTraceConnection = OnTraceConnection;
+
+				if (MappingSchema != null && MappingSchema != _dataConnection.MappingSchema)
+					_dataConnection.AddMappingSchema(MappingSchema);
 			}
 
 			return _dataConnection;


### PR DESCRIPTION
Found during EF Core integration update.