### PR TITLE
add support for Microsoft.Data.SqlClient

### DIFF
--- a/Build/Azure/README.md
+++ b/Build/Azure/README.md
@@ -51,7 +51,7 @@ Legend:
 |SQLite [3.26.0](https://www.sqlite.org/releaselog/3_26_0.html)<br>[Microsoft.Data.SQLite](https://www.nuget.org/packages/Microsoft.Data.SQLite/) 2.2.6<br>with NorthwindDB Tests|:heavy_minus_sign:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |SQLite [3.28.0](https://www.sqlite.org/releaselog/3_28_0.html)<br>[System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite.Core/) 1.0.111<br>with NorthwindDB Tests|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |Access<sup>[3](#notes)</sup><br>Jet 4.0 OLE DB|:heavy_check_mark:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
-|Access<sup>[3](#notes)</sup><br>ACE 12 OLE DB|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
+|Access<sup>[3](#notes)</sup><br>ACE 12 OLE DB|:heavy_check_mark:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL CE<sup>[4](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL Server 2000<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.7.0|:x:|:x:|:x:|:x:|
 |MS SQL Server 2005<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.7.0|:x:|:x:|:x:|:x:|
@@ -73,17 +73,17 @@ Legend:
 |PostgreSQL 10<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.0.10|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |PostgreSQL 11<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.0.10|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |PostgreSQL 12<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.0.10|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|DB2 LUW 11.5.0.0a<br>[IBM.Data.DB2](https://www.nuget.org/packages/IBM.Data.DB.Provider/) 11.1.4040.4 (netfx)<br>[IBM.Data.DB2.Core](https://www.nuget.org/packages/IBM.Data.DB2.Core/) ([osx](https://www.nuget.org/packages/IBM.Data.DB2.Core-osx/), [lin](https://www.nuget.org/packages/IBM.Data.DB2.Core-lnx/)) 1.3.0.100 (netcore)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|Informix 12.10.FC12W1DE<br>IBM.Data.Informix ? (netfx)<br>[IBM.Data.DB2.Core](https://www.nuget.org/packages/IBM.Data.DB2.Core/) ([osx](https://www.nuget.org/packages/IBM.Data.DB2.Core-osx/), [lin](https://www.nuget.org/packages/IBM.Data.DB2.Core-lnx/)) 1.3.0.100 (netcore)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|Informix 14.10.FC1DE<br>IBM.Data.Informix ? (netfx)<br>[IBM.Data.DB2.Core](https://www.nuget.org/packages/IBM.Data.DB2.Core/) ([osx](https://www.nuget.org/packages/IBM.Data.DB2.Core-osx/), [lin](https://www.nuget.org/packages/IBM.Data.DB2.Core-lnx/)) 1.3.0.100 (netcore)|:x:|:x:|:x:|:x:|
+|DB2 LUW 11.5.0.0a<br>[IBM.Data.DB2](https://www.nuget.org/packages/IBM.Data.DB.Provider/) 11.1.4040.4 (netfx)<br>[IBM.Data.DB2.Core](https://www.nuget.org/packages/IBM.Data.DB2.Core/) ([osx](https://www.nuget.org/packages/IBM.Data.DB2.Core-osx/), [lin](https://www.nuget.org/packages/IBM.Data.DB2.Core-lnx/)) 1.3.0.100 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|Informix 12.10.FC12W1DE<br>IBM.Data.Informix ? (netfx)<br>[IBM.Data.DB2.Core](https://www.nuget.org/packages/IBM.Data.DB2.Core/) ([osx](https://www.nuget.org/packages/IBM.Data.DB2.Core-osx/), [lin](https://www.nuget.org/packages/IBM.Data.DB2.Core-lnx/)) 1.3.0.100 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|Informix 14.10.FC1DE<br>IBM.Data.Informix ? (netfx)<br>[IBM.Data.DB2.Core](https://www.nuget.org/packages/IBM.Data.DB2.Core/) ([osx](https://www.nuget.org/packages/IBM.Data.DB2.Core-osx/), [lin](https://www.nuget.org/packages/IBM.Data.DB2.Core-lnx/)) 1.3.0.100 (core)|:x:|:x:|:x:|:x:|
 |SAP HANA 2.0 SPS 04r40<br>Native Provider|:x:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
 |SAP HANA 2.0 SPS 04r40<br>ODBC Provider|:x:|:x:|:x:|:x:|
 |SAP/Sybase ASE 16.2<br>[AdoNetCore.AseClient](https://www.nuget.org/packages/AdoNetCore.AseClient/) 0.14.0|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |SAP/Sybase ASE 16.2<br>Native Client|:x:|:x:|:x:|:x:|
 |Oracle 11g XE<br>Native Client|:x:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
-|Oracle 11g XE<br>[Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) 19.3.1 (netfx)<br>[Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core/) 2.19.31 (netcore)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|Oracle 11g XE<br>[Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) 19.3.1 (netfx)<br>[Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core/) 2.19.31 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |Oracle 18c XE<br>Native Client|:x:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
-|Oracle 18c XE<br>[Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) 19.3.1 (netfx)<br>[Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core/) 2.19.31 (netcore)|:x:|:x:|:x:|:x:|
+|Oracle 18c XE<br>[Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) 19.3.1 (netfx)<br>[Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core/) 2.19.31 (core)|:x:|:x:|:x:|:x:|
 |Firebird 2.1<br>[FirebirdSql.Data.FirebirdClient](https://www.nuget.org/packages/FirebirdSql.Data.FirebirdClient/) 7.1.1|:x:|:x:|:x:|:x:|
 |Firebird 2.5<br>[FirebirdSql.Data.FirebirdClient](https://www.nuget.org/packages/FirebirdSql.Data.FirebirdClient/) 7.1.1|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |Firebird 3.0<br>[FirebirdSql.Data.FirebirdClient](https://www.nuget.org/packages/FirebirdSql.Data.FirebirdClient/) 7.1.1|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|

--- a/Build/Azure/README.md
+++ b/Build/Azure/README.md
@@ -50,9 +50,9 @@ Legend:
 |SQLite [3.13.0](https://www.sqlite.org/releaselog/3_13_0.html)<sup>[2](#notes)</sup><br>[Microsoft.Data.SQLite](https://www.nuget.org/packages/Microsoft.Data.SQLite/) 1.1.1<br>with NorthwindDB Tests|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
 |SQLite [3.26.0](https://www.sqlite.org/releaselog/3_26_0.html)<br>[Microsoft.Data.SQLite](https://www.nuget.org/packages/Microsoft.Data.SQLite/) 2.2.6<br>with NorthwindDB Tests|:heavy_minus_sign:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |SQLite [3.28.0](https://www.sqlite.org/releaselog/3_28_0.html)<br>[System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite.Core/) 1.0.111<br>with NorthwindDB Tests|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-|Access<sup>[3](#notes)</sup><br>Jet 4.0 OLE DB|:heavy_check_mark:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
-|Access<sup>[3](#notes)</sup><br>ACE 12 OLE DB|:heavy_check_mark:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
-|MS SQL CE<sup>[4](#notes)</sup>|:heavy_check_mark:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
+|Access<sup>[3](#notes)</sup><br>Jet 4.0 OLE DB|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
+|Access<sup>[3](#notes)</sup><br>ACE 12 OLE DB|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
+|MS SQL CE<sup>[4](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL Server 2000<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.7.0|:x:|:x:|:x:|:x:|
 |MS SQL Server 2005<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.7.0|:x:|:x:|:x:|:x:|
 |MS SQL Server 2008<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.7.0|:x:|:x:|:x:|:x:|
@@ -61,6 +61,7 @@ Legend:
 |MS SQL Server 2016<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.7.0|:x:|:x:|:x:|:x:|
 |MS SQL Server 2017<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.7.0<br>with NorthwindDB<sup>[5](#notes)</sup> Tests|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |MS SQL Server 2019<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.7.0|:x:|:x:|:x:|:x:|
+|MS SQL Server 2017<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 1.0.19269.1<br>with NorthwindDB<sup>[5](#notes)</sup> Tests|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |Azure SQL<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.7.0|:x:|:x:|:x:|:x:|
 |MySQL 5.6<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.17|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |MySQL 8<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.17|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|

--- a/Build/Azure/README.md
+++ b/Build/Azure/README.md
@@ -50,7 +50,7 @@ Legend:
 |SQLite [3.13.0](https://www.sqlite.org/releaselog/3_13_0.html)<sup>[2](#notes)</sup><br>[Microsoft.Data.SQLite](https://www.nuget.org/packages/Microsoft.Data.SQLite/) 1.1.1<br>with NorthwindDB Tests|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
 |SQLite [3.26.0](https://www.sqlite.org/releaselog/3_26_0.html)<br>[Microsoft.Data.SQLite](https://www.nuget.org/packages/Microsoft.Data.SQLite/) 2.2.6<br>with NorthwindDB Tests|:heavy_minus_sign:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |SQLite [3.28.0](https://www.sqlite.org/releaselog/3_28_0.html)<br>[System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite.Core/) 1.0.111<br>with NorthwindDB Tests|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-|Access<sup>[3](#notes)</sup><br>Jet 4.0 OLE DB|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
+|Access<sup>[3](#notes)</sup><br>Jet 4.0 OLE DB|:heavy_check_mark:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
 |Access<sup>[3](#notes)</sup><br>ACE 12 OLE DB|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL CE<sup>[4](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL Server 2000<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.7.0|:x:|:x:|:x:|:x:|
@@ -73,22 +73,17 @@ Legend:
 |PostgreSQL 10<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.0.10|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |PostgreSQL 11<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.0.10|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |PostgreSQL 12<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.0.10|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|DB2 LUW 11.5.0.0a<br>[IBM.Data.DB2](https://www.nuget.org/packages/IBM.Data.DB.Provider/) 11.1.4040.4|:x:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
-|DB2 LUW 11.5.0.0a<br>[IBM.Data.DB2.Core](https://www.nuget.org/packages/IBM.Data.DB2.Core/) ([osx](https://www.nuget.org/packages/IBM.Data.DB2.Core-osx/), [lin](https://www.nuget.org/packages/IBM.Data.DB2.Core-lnx/)) 1.3.0.100|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|Informix 12.10.FC12W1DE<br>IBM.Data.Informix ?|:x:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
-|Informix 14.10.FC1DE<br>IBM.Data.Informix ?|:x:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
-|Informix 12.10.FC12W1DE<br>[IBM.Data.DB2.Core](https://www.nuget.org/packages/IBM.Data.DB2.Core/) ([osx](https://www.nuget.org/packages/IBM.Data.DB2.Core-osx/), [lin](https://www.nuget.org/packages/IBM.Data.DB2.Core-lnx/)) 1.3.0.100|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|Informix 14.10.FC1DE<br>[IBM.Data.DB2.Core](https://www.nuget.org/packages/IBM.Data.DB2.Core/) ([osx](https://www.nuget.org/packages/IBM.Data.DB2.Core-osx/), [lin](https://www.nuget.org/packages/IBM.Data.DB2.Core-lnx/)) 1.3.0.100|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|DB2 LUW 11.5.0.0a<br>[IBM.Data.DB2](https://www.nuget.org/packages/IBM.Data.DB.Provider/) 11.1.4040.4 (netfx)<br>[IBM.Data.DB2.Core](https://www.nuget.org/packages/IBM.Data.DB2.Core/) ([osx](https://www.nuget.org/packages/IBM.Data.DB2.Core-osx/), [lin](https://www.nuget.org/packages/IBM.Data.DB2.Core-lnx/)) 1.3.0.100 (netcore)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|Informix 12.10.FC12W1DE<br>IBM.Data.Informix ? (netfx)<br>[IBM.Data.DB2.Core](https://www.nuget.org/packages/IBM.Data.DB2.Core/) ([osx](https://www.nuget.org/packages/IBM.Data.DB2.Core-osx/), [lin](https://www.nuget.org/packages/IBM.Data.DB2.Core-lnx/)) 1.3.0.100 (netcore)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|Informix 14.10.FC1DE<br>IBM.Data.Informix ? (netfx)<br>[IBM.Data.DB2.Core](https://www.nuget.org/packages/IBM.Data.DB2.Core/) ([osx](https://www.nuget.org/packages/IBM.Data.DB2.Core-osx/), [lin](https://www.nuget.org/packages/IBM.Data.DB2.Core-lnx/)) 1.3.0.100 (netcore)|:x:|:x:|:x:|:x:|
 |SAP HANA 2.0 SPS 04r40<br>Native Provider|:x:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
 |SAP HANA 2.0 SPS 04r40<br>ODBC Provider|:x:|:x:|:x:|:x:|
 |SAP/Sybase ASE 16.2<br>[AdoNetCore.AseClient](https://www.nuget.org/packages/AdoNetCore.AseClient/) 0.14.0|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |SAP/Sybase ASE 16.2<br>Native Client|:x:|:x:|:x:|:x:|
-|Oracle 11c XE<br>Native Client|:x:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
-|Oracle 11c XE<br>[Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) 19.3.1|:x:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
-|Oracle 11g XE<br>[Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core/) 2.19.31|:heavy_minus_sign:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|Oracle 11g XE<br>Native Client|:x:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
+|Oracle 11g XE<br>[Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) 19.3.1 (netfx)<br>[Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core/) 2.19.31 (netcore)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |Oracle 18c XE<br>Native Client|:x:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
-|Oracle 18c XE<br>[Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) 19.3.1|:x:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
-|Oracle 18c XE<br>[Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core/) 2.19.31|:heavy_minus_sign:|:x:|:x:|:x:|
+|Oracle 18c XE<br>[Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) 19.3.1 (netfx)<br>[Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core/) 2.19.31 (netcore)|:x:|:x:|:x:|:x:|
 |Firebird 2.1<br>[FirebirdSql.Data.FirebirdClient](https://www.nuget.org/packages/FirebirdSql.Data.FirebirdClient/) 7.1.1|:x:|:x:|:x:|:x:|
 |Firebird 2.5<br>[FirebirdSql.Data.FirebirdClient](https://www.nuget.org/packages/FirebirdSql.Data.FirebirdClient/) 7.1.1|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |Firebird 3.0<br>[FirebirdSql.Data.FirebirdClient](https://www.nuget.org/packages/FirebirdSql.Data.FirebirdClient/) 7.1.1|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
@@ -142,5 +137,6 @@ Legend:
 |`TestProvName.NorthwindSQLiteMS`|Microsoft.Data.Sqlite FTS||
 |`ProviderName.Sybase`|Sybase ASE using official provider||
 |`ProviderName.SybaseManaged`|Sybase ASE using DataAction provider||
-|`ProviderName.SapHana`|SAP HANA 2||
+|`ProviderName.SapHanaNative`|SAP HANA 2 using native provider||
+|`ProviderName.SapHanaOdbc`|SAP HANA 2 using ODBC provider||
 |`TestProvName.NoopProvider`|fake test provider to perform tests without database dependencies|

--- a/Build/Azure/net46/access.ace.json
+++ b/Build/Azure/net46/access.ace.json
@@ -7,6 +7,9 @@
 		"Connections": {
 			"Access": {
 				"ConnectionString": "Provider=Microsoft.ACE.OLEDB.12.0;Data Source=Database\\TestData.mdb;Locale Identifier=1033;Persist Security Info=True"
+			},
+			"Access.Data": {
+				"ConnectionString": "Provider=Microsoft.ACE.OLEDB.12.0;Data Source=Database\\Data\\TestData.mdb;Locale Identifier=1033;Persist Security Info=True"
 			}
 		}
 	}

--- a/Build/Azure/net46/sqlserver.2017.ms.json
+++ b/Build/Azure/net46/sqlserver.2017.ms.json
@@ -1,0 +1,20 @@
+﻿{
+	"NET46.Azure": {
+		"Providers": [
+			// SQL Server 2017 + generic sqlserver tests + northwind db tests
+			"SqlServer.2017",
+			//"Northwind", FTS not awailable in default images, need to use custom one
+			"SqlServer"
+		],
+		"Connections": {
+			"SqlServer": {
+				"Provider": "Microsoft.Data.SqlClient",
+				"ConnectionString": "Server=localhost;Database=TestData;User Id=sa;Password=Password12!;"
+			},
+			"SqlServer.2017": {
+				"Provider": "Microsoft.Data.SqlClient",
+				"ConnectionString": "Server=localhost;Database=TestData2017;User Id=sa;Password=Password12!;"
+			}
+		}
+	}
+}

--- a/Build/Azure/netcoreapp21/access.ace.json
+++ b/Build/Azure/netcoreapp21/access.ace.json
@@ -7,6 +7,9 @@
 		"Connections": {
 			"Access": {
 				"ConnectionString": "Provider=Microsoft.ACE.OLEDB.12.0;Data Source=Database\\TestData.mdb;Locale Identifier=1033;Persist Security Info=True"
+			},
+			"Access.Data": {
+				"ConnectionString": "Provider=Microsoft.ACE.OLEDB.12.0;Data Source=Database\\Data\\TestData.mdb;Locale Identifier=1033;Persist Security Info=True"
 			}
 		}
 	}

--- a/Build/Azure/netcoreapp21/access.ace.json
+++ b/Build/Azure/netcoreapp21/access.ace.json
@@ -1,0 +1,13 @@
+﻿{
+	"NET46.Azure": {
+		"Providers": [
+			// Access with ACE OLE DB provider
+			"Access"
+		],
+		"Connections": {
+			"Access": {
+				"ConnectionString": "Provider=Microsoft.ACE.OLEDB.12.0;Data Source=Database\\TestData.mdb;Locale Identifier=1033;Persist Security Info=True"
+			}
+		}
+	}
+}

--- a/Build/Azure/netcoreapp21/access.ace.json
+++ b/Build/Azure/netcoreapp21/access.ace.json
@@ -1,5 +1,5 @@
 ﻿{
-	"NET46.Azure": {
+	"CORE21.Azure": {
 		"Providers": [
 			// Access with ACE OLE DB provider
 			"Access"

--- a/Build/Azure/netcoreapp21/access.json
+++ b/Build/Azure/netcoreapp21/access.json
@@ -1,0 +1,8 @@
+﻿{
+	"NET46.Azure": {
+		"Providers": [
+			// Access with Jet OLE DB provider
+			"Access"
+		]
+	}
+}

--- a/Build/Azure/netcoreapp21/access.json
+++ b/Build/Azure/netcoreapp21/access.json
@@ -1,5 +1,5 @@
 ﻿{
-	"NET46.Azure": {
+	"CORE21.Azure": {
 		"Providers": [
 			// Access with Jet OLE DB provider
 			"Access"

--- a/Build/Azure/netcoreapp21/access.json
+++ b/Build/Azure/netcoreapp21/access.json
@@ -1,8 +1,0 @@
-﻿{
-	"CORE21.Azure": {
-		"Providers": [
-			// Access with Jet OLE DB provider
-			"Access"
-		]
-	}
-}

--- a/Build/Azure/netcoreapp21/sqlce.json
+++ b/Build/Azure/netcoreapp21/sqlce.json
@@ -1,0 +1,8 @@
+﻿{
+	"NET46.Azure": {
+		"Providers": [
+			// SQL CE
+			"SqlCe"
+		]
+	}
+}

--- a/Build/Azure/netcoreapp21/sqlce.json
+++ b/Build/Azure/netcoreapp21/sqlce.json
@@ -1,5 +1,5 @@
 ﻿{
-	"NET46.Azure": {
+	"CORE21.Azure": {
 		"Providers": [
 			// SQL CE
 			"SqlCe"

--- a/Build/Azure/netcoreapp21/sqlserver.2017.ms.json
+++ b/Build/Azure/netcoreapp21/sqlserver.2017.ms.json
@@ -1,0 +1,20 @@
+﻿{
+	"CORE21.Azure": {
+		"Providers": [
+			// SQL Server 2017 + generic sqlserver tests + northwind db tests
+			"SqlServer.2017",
+			//"Northwind", FTS not awailable in default images, need to use custom one
+			"SqlServer"
+		],
+		"Connections": {
+			"SqlServer": {
+				"Provider": "Microsoft.Data.SqlClient",
+				"ConnectionString": "Server=localhost;Database=TestData;User Id=sa;Password=Password12!;"
+			},
+			"SqlServer.2017": {
+				"Provider": "Microsoft.Data.SqlClient",
+				"ConnectionString": "Server=localhost;Database=TestData2017;User Id=sa;Password=Password12!;"
+			}
+		}
+	}
+}

--- a/Build/Azure/pipelines/default.yml
+++ b/Build/Azure/pipelines/default.yml
@@ -382,6 +382,10 @@ stages:
         SQLite_MS:
           title: 'SQLite.MS'
           config: 'sqlite.ms'
+        SqlCE:
+          title: 'SQL CE'
+          config: 'sqlce'
+          psscript: 'sqlce.ps1'
         SqlServer2017_MS:
           title: 'SQL Server 2017 (Microsoft.Data.SqlClient)'
           config: 'sqlserver.2017.ms'

--- a/Build/Azure/pipelines/default.yml
+++ b/Build/Azure/pipelines/default.yml
@@ -54,7 +54,7 @@ stages:
     - task: UseDotNet@2
       displayName: Install .NET Core 3.0
       inputs:
-        version: 3.0.100
+        version: 3.0.x
 
     - task: DotNetCoreCLI@2
       inputs:
@@ -301,8 +301,12 @@ stages:
 
     strategy:
       matrix:
+        SqlServer2017_MS:
+          title: 'SQL Server 2017 (Microsoft.Data.SqlClient)'
+          config: 'sqlserver.2017.ms'
+          script: 'sqlserver.2017.cmd'
         SqlServer2017:
-          title: 'SQL Server 2017'
+          title: 'SQL Server 2017 (System.Data.SqlClient)'
           config: 'sqlserver.2017'
           script: 'sqlserver.2017.cmd'
         PostgreSQL10:
@@ -378,8 +382,12 @@ stages:
         SQLite_MS:
           title: 'SQLite.MS'
           config: 'sqlite.ms'
+        SqlServer2017_MS:
+          title: 'SQL Server 2017 (Microsoft.Data.SqlClient)'
+          config: 'sqlserver.2017.ms'
+          script: 'sqlserver.2017.cmd'
         SqlServer2017:
-          title: 'SQL Server 2017'
+          title: 'SQL Server 2017 (System.Data.SqlClient)'
           config: 'sqlserver.2017'
           script: 'sqlserver.2017.cmd'
         PostgreSQL10:
@@ -405,6 +413,13 @@ stages:
         script: '$(System.DefaultWorkingDirectory)\scripts\$(script)'
         workingDirectory: '$(System.DefaultWorkingDirectory)'
       condition: variables['script']
+      displayName: Setup tests
+
+    - task: PowerShell@2
+      inputs:
+        filePath: '$(System.DefaultWorkingDirectory)\scripts\$(psscript)'
+        workingDirectory: '$(System.DefaultWorkingDirectory)'
+      condition: variables['psscript']
       displayName: Setup tests
 
     - task: VSTest@2
@@ -495,8 +510,12 @@ stages:
         SQLite_MS:
           title: 'SQLite.MS'
           config: 'sqlite.ms'
+        SqlServer2017_MS:
+          title: 'SQL Server 2017 (Microsoft.Data.SqlClient)'
+          config: 'sqlserver.2017.ms'
+          script: 'sqlserver.2017.sh'
         SqlServer2017:
-          title: 'SQL Server 2017'
+          title: 'SQL Server 2017 (System.Data.SqlClient)'
           config: 'sqlserver.2017'
           script: 'sqlserver.2017.sh'
         MySQL:
@@ -628,8 +647,13 @@ stages:
         SQLite_MS:
           title: 'SQLite.MS'
           config: 'sqlite.ms'
+        SqlServer2017_MS:
+          title: 'SQL Server 2017 (Microsoft.Data.SqlClient)'
+          config: 'sqlserver.2017.ms'
+          script: 'mac.sqlserver.2017.sh'
+          docker: 'true'
         SqlServer2017:
-          title: 'SQL Server 2017'
+          title: 'SQL Server 2017 (System.Data.SqlClient)'
           config: 'sqlserver.2017'
           script: 'mac.sqlserver.2017.sh'
           docker: 'true'

--- a/Build/Azure/pipelines/experimental.yml
+++ b/Build/Azure/pipelines/experimental.yml
@@ -305,12 +305,12 @@ stages:
         Access_JET:
           title: 'Access Jet'
           config: 'access'
-          buildPlatform: 'x86'
+          platform: 'x86'
         Access_ACE:
           title: 'Access ACE'
           config: 'access.ace'
           script: 'access.ace.cmd'
-          buildPlatform: 'x86'
+          platform: 'x86'
     steps:
     - checkout: none
 
@@ -342,7 +342,7 @@ stages:
     - task: VSTest@2
       inputs:
         testAssemblyVer2: linq2db.Tests.dll
-        platform: '$(buildPlatform)'
+        platform: '$(platform)'
         configuration: '$(buildConfiguration)'
         testFilterCriteria: 'TestCategory != SkipCI'
         otherConsoleOptions: '/Framework:.NETCoreApp,Version=v2.1'

--- a/Build/Azure/pipelines/experimental.yml
+++ b/Build/Azure/pipelines/experimental.yml
@@ -305,17 +305,8 @@ stages:
 
     strategy:
       matrix:
-        Access_JET:
-          title: 'Access Jet'
-          config: 'access'
-          extraParams: '/Platform:x86'
-        Access_ACE_x86:
-          title: 'Access ACE (32)'
-          config: 'access.ace'
-          script: 'access.ace.x64.cmd'
-          extraParams: '/Platform:x86'
-        Access_ACE_x64:
-          title: 'Access ACE (64)'
+        Access_ACE:
+          title: 'Access ACE (x64)'
           config: 'access.ace'
           script: 'access.ace.x64.cmd'
     steps:
@@ -352,7 +343,7 @@ stages:
         platform: '$(buildPlatform)'
         configuration: '$(buildConfiguration)'
         testFilterCriteria: 'TestCategory != SkipCI'
-        otherConsoleOptions: '/Framework:.NETCoreApp,Version=v2.1 $(extraParams)'
+        otherConsoleOptions: '/Framework:.NETCoreApp,Version=v2.1'
       displayName: '$(title)'
 
     - task: PublishTestResults@2

--- a/Build/Azure/pipelines/experimental.yml
+++ b/Build/Azure/pipelines/experimental.yml
@@ -130,6 +130,7 @@ stages:
     displayName: 'Tests: Lin / NETCOREAPP2.1 / '
     dependsOn: build_job
     condition: ne(variables['Build.SourceBranchName'], 'release')
+    condition: eq(variables['Build.SourceBranchName'], 'fake')
 
     strategy:
       matrix:
@@ -204,7 +205,8 @@ stages:
       vmImage: 'macOS-10.14'
     displayName: 'Tests: Mac / NETCOREAPP2.1 / '
     dependsOn: build_job
-    condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'release'))
+#    condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'release'))
+    condition: eq(variables['Build.SourceBranchName'], 'fake')
 
     strategy:
       matrix:
@@ -299,18 +301,19 @@ stages:
     displayName: 'Tests: Win / NETCOREAPP2.1 / '
     dependsOn: build_job
     condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'release'))
+#    condition: eq(variables['Build.SourceBranchName'], 'fake')
 
     strategy:
       matrix:
         Access_JET:
           title: 'Access Jet'
           config: 'access'
-          platform: 'x86'
+          extraParams: '/Platform:x86'
         Access_ACE:
           title: 'Access ACE'
           config: 'access.ace'
           script: 'access.ace.cmd'
-          platform: 'x86'
+          extraParams: '/Platform:x86'
     steps:
     - checkout: none
 
@@ -342,10 +345,10 @@ stages:
     - task: VSTest@2
       inputs:
         testAssemblyVer2: linq2db.Tests.dll
-        platform: '$(platform)'
+        platform: '$(buildPlatform)'
         configuration: '$(buildConfiguration)'
         testFilterCriteria: 'TestCategory != SkipCI'
-        otherConsoleOptions: '/Framework:.NETCoreApp,Version=v2.1'
+        otherConsoleOptions: '/Framework:.NETCoreApp,Version=v2.1 $(extraParams)'
       displayName: '$(title)'
 
     - task: PublishTestResults@2

--- a/Build/Azure/pipelines/experimental.yml
+++ b/Build/Azure/pipelines/experimental.yml
@@ -42,7 +42,7 @@ stages:
     - task: UseDotNet@2
       displayName: Install .NET Core 3.0
       inputs:
-        version: 3.0.100
+        version: 3.0.x
 
     - task: DotNetCoreCLI@2
       inputs:
@@ -133,21 +133,17 @@ stages:
 
     strategy:
       matrix:
-        SqlServer2017:
-          title: 'SQL Server 2017 (Microsoft.Data.SqlClient)'
-          config: 'sqlserver.2017.ms'
-          script: 'sqlserver.2017.sh'
 #        Informix12:
 #          title: 'Informix 12.10'
 #          config: 'informix'
 #          script: 'informix12.sh'
 #          nuget: 'IBM.Data.DB2.Core-lnx'
-#        SAPHANA2:
-#          title: 'SAP HANA 2 SPS 04r40'
-#          config: 'hana2'
-#          script: 'mac.hana2.sh'
-#          docker: 'true'
-#          docker_login: 'true'
+        SAPHANA2:
+          title: 'SAP HANA 2 SPS 04r40'
+          config: 'hana2'
+          script: 'mac.hana2.sh'
+          docker: 'true'
+          docker_login: 'true'
     steps:
     - checkout: none
 
@@ -212,23 +208,18 @@ stages:
 
     strategy:
       matrix:
-        SqlServer2017:
-          title: 'SQL Server 2017 (Microsoft.Data.SqlClient)'
-          config: 'sqlserver.2017.ms'
-          script: 'mac.sqlserver.2017.sh'
-          docker: 'true'
 #        Informix12:
 #          title: 'Informix 12.10'
 #          config: 'informix'
 #          script: 'mac.informix12.sh'
 #          docker: 'true'
 #          nuget: 'IBM.Data.DB2.Core-osx'
-#        SAPHANA2:
-#          title: 'SAP HANA 2 SPS 04r40'
-#          config: 'hana2'
-#          script: 'mac.hana2.sh'
-#          docker: 'true'
-#          docker_login: 'true'
+        SAPHANA2:
+          title: 'SAP HANA 2 SPS 04r40'
+          config: 'hana2'
+          script: 'mac.hana2.sh'
+          docker: 'true'
+          docker_login: 'true'
 
     steps:
     - checkout: none
@@ -298,31 +289,36 @@ stages:
         testResultsFiles: '**/*.trx'
         testRunTitle: 'Mac / NETCOREAPP2.1 / $(title)'
 
-  - job: test_win_netfx46_job_2016
+###################################
+#  Tests: Windows (NETCOREAPP2_1) #
+#  Windows 2016                   #
+###################################
+  - job: test_win2016_netcoreapp21_job
     pool:
       vmImage: 'vs2017-win2016'
-    displayName: 'Tests: Win / NETFX 4.6 / '
+    displayName: 'Tests: Win / NETCOREAPP2.1 / '
     dependsOn: build_job
     condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'release'))
 
     strategy:
       matrix:
-        SqlServer2017:
-          title: 'SQL Server 2017 (Microsoft.Data.SqlClient)'
-          config: 'sqlserver.2017.ms'
-          script: 'sqlserver.2017.cmd'
-
+        Access_JET:
+          title: 'Access Jet'
+          config: 'access'
+        Access_ACE:
+          title: 'Access ACE'
+          config: 'access.ace'
+          script: 'access.ace.cmd'
+        SqlCE:
+          title: 'SQL CE'
+          config: 'sqlce'
+          psscript: 'sqlce.ps1'
     steps:
     - checkout: none
 
     - task: DownloadPipelineArtifact@2
       inputs:
-        artifactName: '$(netfx46_tests)'
-        targetPath: '$(System.DefaultWorkingDirectory)'
-
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        artifactName: '$(netfx46_tests)'
+        artifactName: '$(netcore21_tests)'
         targetPath: '$(System.DefaultWorkingDirectory)'
 
     - task: CmdLine@2
@@ -343,60 +339,6 @@ stages:
         filePath: '$(System.DefaultWorkingDirectory)\scripts\$(psscript)'
         workingDirectory: '$(System.DefaultWorkingDirectory)'
       condition: variables['psscript']
-      displayName: Setup tests
-
-    - task: VSTest@2
-      inputs:
-        testAssemblyVer2: linq2db.Tests.dll
-        platform: '$(buildPlatform)'
-        configuration: '$(buildConfiguration)'
-        testFiltercriteria: 'TestCategory != SkipCI'
-        otherConsoleOptions: '/Framework:.NETFramework,Version=v4.6'
-      displayName: '$(title)'
-
-    - task: PublishTestResults@2
-      condition: succeededOrFailed()
-      inputs:
-        testRunner: VsTest
-        testResultsFiles: '**/*.trx'
-        testRunTitle: 'Windows / NET46 / $(title)'
-
-###################################
-#  Tests: Windows (NETCOREAPP2_1) #
-#  Windows 2016                   #
-###################################
-  - job: test_win2016_netcoreapp21_job
-    pool:
-      vmImage: 'vs2017-win2016'
-    displayName: 'Tests: Win / NETCOREAPP2.1 / '
-    dependsOn: build_job
-    condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'release'))
-
-    strategy:
-      matrix:
-        SqlServer2017:
-          title: 'SQL Server 2017 (Microsoft.Data.SqlClient)'
-          config: 'sqlserver.2017.ms'
-          script: 'sqlserver.2017.cmd'
-    steps:
-    - checkout: none
-
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        artifactName: '$(netcore21_tests)'
-        targetPath: '$(System.DefaultWorkingDirectory)'
-
-    - task: CmdLine@2
-      inputs:
-        script: 'copy $(System.DefaultWorkingDirectory)\configs\$(config).json UserDataProviders.json'
-        workingDirectory: '$(System.DefaultWorkingDirectory)'
-      displayName: Copy test config
-
-    - task: CmdLine@2
-      inputs:
-        script: '$(System.DefaultWorkingDirectory)\scripts\$(script)'
-        workingDirectory: '$(System.DefaultWorkingDirectory)'
-      condition: variables['script']
       displayName: Setup tests
 
     - task: VSTest@2

--- a/Build/Azure/pipelines/experimental.yml
+++ b/Build/Azure/pipelines/experimental.yml
@@ -133,17 +133,21 @@ stages:
 
     strategy:
       matrix:
-        Informix12:
-          title: 'Informix 12.10'
-          config: 'informix'
-          script: 'informix12.sh'
-          nuget: 'IBM.Data.DB2.Core-lnx'
-        SAPHANA2:
-          title: 'SAP HANA 2 SPS 04r40'
-          config: 'hana2'
-          script: 'mac.hana2.sh'
-          docker: 'true'
-          docker_login: 'true'
+        SqlServer2017:
+          title: 'SQL Server 2017 (Microsoft.Data.SqlClient)'
+          config: 'sqlserver.2017.ms'
+          script: 'sqlserver.2017.sh'
+#        Informix12:
+#          title: 'Informix 12.10'
+#          config: 'informix'
+#          script: 'informix12.sh'
+#          nuget: 'IBM.Data.DB2.Core-lnx'
+#        SAPHANA2:
+#          title: 'SAP HANA 2 SPS 04r40'
+#          config: 'hana2'
+#          script: 'mac.hana2.sh'
+#          docker: 'true'
+#          docker_login: 'true'
     steps:
     - checkout: none
 
@@ -208,18 +212,23 @@ stages:
 
     strategy:
       matrix:
-        Informix12:
-          title: 'Informix 12.10'
-          config: 'informix'
-          script: 'mac.informix12.sh'
+        SqlServer2017:
+          title: 'SQL Server 2017 (Microsoft.Data.SqlClient)'
+          config: 'sqlserver.2017.ms'
+          script: 'mac.sqlserver.2017.sh'
           docker: 'true'
-          nuget: 'IBM.Data.DB2.Core-osx'
-        SAPHANA2:
-          title: 'SAP HANA 2 SPS 04r40'
-          config: 'hana2'
-          script: 'mac.hana2.sh'
-          docker: 'true'
-          docker_login: 'true'
+#        Informix12:
+#          title: 'Informix 12.10'
+#          config: 'informix'
+#          script: 'mac.informix12.sh'
+#          docker: 'true'
+#          nuget: 'IBM.Data.DB2.Core-osx'
+#        SAPHANA2:
+#          title: 'SAP HANA 2 SPS 04r40'
+#          config: 'hana2'
+#          script: 'mac.hana2.sh'
+#          docker: 'true'
+#          docker_login: 'true'
 
     steps:
     - checkout: none
@@ -288,3 +297,120 @@ stages:
         testRunner: VsTest
         testResultsFiles: '**/*.trx'
         testRunTitle: 'Mac / NETCOREAPP2.1 / $(title)'
+
+  - job: test_win_netfx46_job_2016
+    pool:
+      vmImage: 'vs2017-win2016'
+    displayName: 'Tests: Win / NETFX 4.6 / '
+    dependsOn: build_job
+    condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'release'))
+
+    strategy:
+      matrix:
+        SqlServer2017:
+          title: 'SQL Server 2017 (Microsoft.Data.SqlClient)'
+          config: 'sqlserver.2017.ms'
+          script: 'sqlserver.2017.cmd'
+
+    steps:
+    - checkout: none
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: '$(netfx46_tests)'
+        targetPath: '$(System.DefaultWorkingDirectory)'
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: '$(netfx46_tests)'
+        targetPath: '$(System.DefaultWorkingDirectory)'
+
+    - task: CmdLine@2
+      inputs:
+        script: 'copy $(System.DefaultWorkingDirectory)\configs\$(config).json UserDataProviders.json'
+        workingDirectory: '$(System.DefaultWorkingDirectory)'
+      displayName: Copy test config
+
+    - task: CmdLine@2
+      inputs:
+        script: '$(System.DefaultWorkingDirectory)\scripts\$(script)'
+        workingDirectory: '$(System.DefaultWorkingDirectory)'
+      condition: variables['script']
+      displayName: Setup tests
+
+    - task: PowerShell@2
+      inputs:
+        filePath: '$(System.DefaultWorkingDirectory)\scripts\$(psscript)'
+        workingDirectory: '$(System.DefaultWorkingDirectory)'
+      condition: variables['psscript']
+      displayName: Setup tests
+
+    - task: VSTest@2
+      inputs:
+        testAssemblyVer2: linq2db.Tests.dll
+        platform: '$(buildPlatform)'
+        configuration: '$(buildConfiguration)'
+        testFiltercriteria: 'TestCategory != SkipCI'
+        otherConsoleOptions: '/Framework:.NETFramework,Version=v4.6'
+      displayName: '$(title)'
+
+    - task: PublishTestResults@2
+      condition: succeededOrFailed()
+      inputs:
+        testRunner: VsTest
+        testResultsFiles: '**/*.trx'
+        testRunTitle: 'Windows / NET46 / $(title)'
+
+###################################
+#  Tests: Windows (NETCOREAPP2_1) #
+#  Windows 2016                   #
+###################################
+  - job: test_win2016_netcoreapp21_job
+    pool:
+      vmImage: 'vs2017-win2016'
+    displayName: 'Tests: Win / NETCOREAPP2.1 / '
+    dependsOn: build_job
+    condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'release'))
+
+    strategy:
+      matrix:
+        SqlServer2017:
+          title: 'SQL Server 2017 (Microsoft.Data.SqlClient)'
+          config: 'sqlserver.2017.ms'
+          script: 'sqlserver.2017.cmd'
+    steps:
+    - checkout: none
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: '$(netcore21_tests)'
+        targetPath: '$(System.DefaultWorkingDirectory)'
+
+    - task: CmdLine@2
+      inputs:
+        script: 'copy $(System.DefaultWorkingDirectory)\configs\$(config).json UserDataProviders.json'
+        workingDirectory: '$(System.DefaultWorkingDirectory)'
+      displayName: Copy test config
+
+    - task: CmdLine@2
+      inputs:
+        script: '$(System.DefaultWorkingDirectory)\scripts\$(script)'
+        workingDirectory: '$(System.DefaultWorkingDirectory)'
+      condition: variables['script']
+      displayName: Setup tests
+
+    - task: VSTest@2
+      inputs:
+        testAssemblyVer2: linq2db.Tests.dll
+        platform: '$(buildPlatform)'
+        configuration: '$(buildConfiguration)'
+        testFilterCriteria: 'TestCategory != SkipCI'
+        otherConsoleOptions: '/Framework:.NETCoreApp,Version=v2.1'
+      displayName: '$(title)'
+
+    - task: PublishTestResults@2
+      condition: succeededOrFailed()
+      inputs:
+        testRunner: VsTest
+        testResultsFiles: '**/*.trx'
+        testRunTitle: 'Windows / NETCOREAPP2.1 / $(title)'

--- a/Build/Azure/pipelines/experimental.yml
+++ b/Build/Azure/pipelines/experimental.yml
@@ -129,7 +129,7 @@ stages:
       vmImage: 'ubuntu-16.04'
     displayName: 'Tests: Lin / NETCOREAPP2.1 / '
     dependsOn: build_job
-    condition: ne(variables['Build.SourceBranchName'], 'release')
+#    condition: ne(variables['Build.SourceBranchName'], 'release')
     condition: eq(variables['Build.SourceBranchName'], 'fake')
 
     strategy:

--- a/Build/Azure/pipelines/experimental.yml
+++ b/Build/Azure/pipelines/experimental.yml
@@ -305,14 +305,12 @@ stages:
         Access_JET:
           title: 'Access Jet'
           config: 'access'
+          buildPlatform: 'x86'
         Access_ACE:
           title: 'Access ACE'
           config: 'access.ace'
           script: 'access.ace.cmd'
-        SqlCE:
-          title: 'SQL CE'
-          config: 'sqlce'
-          psscript: 'sqlce.ps1'
+          buildPlatform: 'x86'
     steps:
     - checkout: none
 

--- a/Build/Azure/pipelines/experimental.yml
+++ b/Build/Azure/pipelines/experimental.yml
@@ -309,11 +309,15 @@ stages:
           title: 'Access Jet'
           config: 'access'
           extraParams: '/Platform:x86'
-        Access_ACE:
-          title: 'Access ACE'
+        Access_ACE_x86:
+          title: 'Access ACE (32)'
           config: 'access.ace'
-          script: 'access.ace.cmd'
+          script: 'access.ace.x64.cmd'
           extraParams: '/Platform:x86'
+        Access_ACE_x64:
+          title: 'Access ACE (64)'
+          config: 'access.ace'
+          script: 'access.ace.x64.cmd'
     steps:
     - checkout: none
 

--- a/Build/Azure/pipelines/test-all.yml
+++ b/Build/Azure/pipelines/test-all.yml
@@ -302,6 +302,10 @@ stages:
         SQLite_MS:
           title: 'SQLite.MS'
           config: 'sqlite.ms'
+        SqlCE:
+          title: 'SQL CE'
+          config: 'sqlce'
+          psscript: 'sqlce.ps1'
         SqlServer2017_MS:
           title: 'SQL Server 2017 (Microsoft.Data.SqlClient)'
           config: 'sqlserver.2017.ms'

--- a/Build/Azure/pipelines/test-all.yml
+++ b/Build/Azure/pipelines/test-all.yml
@@ -45,7 +45,7 @@ stages:
     - task: UseDotNet@2
       displayName: Install .NET Core 3.0
       inputs:
-        version: 3.0.100
+        version: 3.0.x
 
     - task: DotNetCoreCLI@2
       inputs:
@@ -221,8 +221,12 @@ stages:
 
     strategy:
       matrix:
+        SqlServer2017_MS:
+          title: 'SQL Server 2017 (Microsoft.Data.SqlClient)'
+          config: 'sqlserver.2017.ms'
+          script: 'sqlserver.2017.cmd'
         SqlServer2017:
-          title: 'SQL Server 2017'
+          title: 'SQL Server 2017 (System.Data.SqlClient)'
           config: 'sqlserver.2017'
           script: 'sqlserver.2017.cmd'
         PostgreSQL10:
@@ -298,8 +302,12 @@ stages:
         SQLite_MS:
           title: 'SQLite.MS'
           config: 'sqlite.ms'
+        SqlServer2017_MS:
+          title: 'SQL Server 2017 (Microsoft.Data.SqlClient)'
+          config: 'sqlserver.2017.ms'
+          script: 'sqlserver.2017.cmd'
         SqlServer2017:
-          title: 'SQL Server 2017'
+          title: 'SQL Server 2017 (System.Data.SqlClient)'
           config: 'sqlserver.2017'
           script: 'sqlserver.2017.cmd'
         PostgreSQL10:
@@ -325,6 +333,13 @@ stages:
         script: '$(System.DefaultWorkingDirectory)\scripts\$(script)'
         workingDirectory: '$(System.DefaultWorkingDirectory)'
       condition: variables['script']
+      displayName: Setup tests
+
+    - task: PowerShell@2
+      inputs:
+        filePath: '$(System.DefaultWorkingDirectory)\scripts\$(psscript)'
+        workingDirectory: '$(System.DefaultWorkingDirectory)'
+      condition: variables['psscript']
       displayName: Setup tests
 
     - task: VSTest@2
@@ -415,8 +430,12 @@ stages:
         SQLite_MS:
           title: 'SQLite.MS'
           config: 'sqlite.ms'
+        SqlServer2017_MS:
+          title: 'SQL Server 2017 (Microsoft.Data.SqlClient)'
+          config: 'sqlserver.2017.ms'
+          script: 'sqlserver.2017.sh'
         SqlServer2017:
-          title: 'SQL Server 2017'
+          title: 'SQL Server 2017 (System.Data.SqlClient)'
           config: 'sqlserver.2017'
           script: 'sqlserver.2017.sh'
         MySQL:
@@ -548,8 +567,13 @@ stages:
         SQLite_MS:
           title: 'SQLite.MS'
           config: 'sqlite.ms'
+        SqlServer2017_MS:
+          title: 'SQL Server 2017 (Microsoft.Data.SqlClient)'
+          config: 'sqlserver.2017.ms'
+          script: 'mac.sqlserver.2017.sh'
+          docker: 'true'
         SqlServer2017:
-          title: 'SQL Server 2017'
+          title: 'SQL Server 2017 (System.Data.SqlClient)'
           config: 'sqlserver.2017'
           script: 'mac.sqlserver.2017.sh'
           docker: 'true'

--- a/Build/Azure/scripts/access.ace.x64.cmd
+++ b/Build/Azure/scripts/access.ace.x64.cmd
@@ -1,0 +1,1 @@
+choco install msaccess2010-redist-x64

--- a/Build/linq2db.Tests.Providers.props
+++ b/Build/linq2db.Tests.Providers.props
@@ -19,6 +19,8 @@
 
 		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+		<PackageReference Include="System.Data.SqlClient" Version="4.7.0" />
+		<PackageReference Include="Microsoft.Data.SqlClient" Version="1.0.19269.1" />
 
 		<ProjectReference Include="..\Base\Tests.Base.csproj" />
 

--- a/NuGet/Access/CopyMe.Access.tt.txt
+++ b/NuGet/Access/CopyMe.Access.tt.txt
@@ -39,8 +39,12 @@
 
 	NamespaceName = "DataModels";
 
+	// to configure GetSchemaOptions properties, add them here, before load metadata call
+
 	LoadAccessMetadata(@"C:\Data", "MyDatabase.mdb");
 //	LoadAccessMetadata(string connectionString);
+
+	// to adjust loaded database model before generation, add your code here, after load metadata, but before GenerateModel() call
 
 	GenerateModel();
 #>

--- a/NuGet/DB2.Core/CopyMe.DB2.tt.txt
+++ b/NuGet/DB2.Core/CopyMe.DB2.tt.txt
@@ -43,8 +43,12 @@
 
 	NamespaceName = "DataModels";
 
+	// to configure GetSchemaOptions properties, add them here, before load metadata call
+
 	LoadDB2Metadata("MyServer", "50000", "MyDatabase", "MyUser", "TestPassword");
 //	LoadDB2Metadata(string connectionString);
+
+	// to adjust loaded database model before generation, add your code here, after load metadata, but before GenerateModel() call
 
 	GenerateModel();
 #>

--- a/NuGet/DB2/CopyMe.DB2.tt.txt
+++ b/NuGet/DB2/CopyMe.DB2.tt.txt
@@ -43,8 +43,12 @@
 
 	NamespaceName = "DataModels";
 
+	// to configure GetSchemaOptions properties, add them here, before load metadata call
+
 	LoadDB2Metadata("MyServer", "50000", "MyDatabase", "MyUser", "TestPassword");
 //	LoadDB2Metadata(string connectionString);
+
+	// to adjust loaded database model before generation, add your code here, after load metadata, but before GenerateModel() call
 
 	GenerateModel();
 #>

--- a/NuGet/Firebird/CopyMe.Firebird.tt.txt
+++ b/NuGet/Firebird/CopyMe.Firebird.tt.txt
@@ -38,9 +38,13 @@
 
 	NamespaceName = "DataModels";
 
+	// to configure GetSchemaOptions properties, add them here, before load metadata call
+
 	LoadFirebirdMetadata("MyServer", @"C:\Data\MyDatabase.fdb");
 //	LoadFirebirdMetadata(string server, string database, string uid, string password);
 //	LoadFirebirdMetadata(string connectionString);
+
+	// to adjust loaded database model before generation, add your code here, after load metadata, but before GenerateModel() call
 
 	GenerateModel();
 #>

--- a/NuGet/Informix.Core/CopyMe.Informix.tt.txt
+++ b/NuGet/Informix.Core/CopyMe.Informix.tt.txt
@@ -44,8 +44,12 @@
 
 	NamespaceName = "DataModels";
 
+	// to configure GetSchemaOptions properties, add them here, before load metadata call
+
 	LoadInformixMetadata("MyServer", "9088", "ol_informix1170", "MyDatabase", "informix", "TestPassword");
 //	LoadInformixMetadata(string connectionString);
+
+	// to adjust loaded database model before generation, add your code here, after load metadata, but before GenerateModel() call
 
 	GenerateModel();
 #>

--- a/NuGet/Informix/CopyMe.Informix.tt.txt
+++ b/NuGet/Informix/CopyMe.Informix.tt.txt
@@ -44,8 +44,12 @@
 
 	NamespaceName = "DataModels";
 
+	// to configure GetSchemaOptions properties, add them here, before load metadata call
+
 	LoadInformixMetadata("MyServer", "9088", "ol_informix1170", "MyDatabase", "informix", "TestPassword");
 //	LoadInformixMetadata(string connectionString);
+
+	// to adjust loaded database model before generation, add your code here, after load metadata, but before GenerateModel() call
 
 	GenerateModel();
 #>

--- a/NuGet/MySql/CopyMe.MySql.tt.txt
+++ b/NuGet/MySql/CopyMe.MySql.tt.txt
@@ -38,8 +38,12 @@
 
 	NamespaceName = "DataModels";
 
+	// to configure GetSchemaOptions properties, add them here, before load metadata call
+
 	LoadMySqlMetadata("MyServer", "MyDatabase", "root", "TestPassword");
 //	LoadMySqlMetadata(string connectionString);
+
+	// to adjust loaded database model before generation, add your code here, after load metadata, but before GenerateModel() call
 
 	GenerateModel();
 #>

--- a/NuGet/MySqlConnector/CopyMe.MySqlConnector.tt.txt
+++ b/NuGet/MySqlConnector/CopyMe.MySqlConnector.tt.txt
@@ -38,8 +38,12 @@
 
 	NamespaceName = "DataModels";
 
+	// to configure GetSchemaOptions properties, add them here, before load metadata call
+
 	LoadMySqlMetadata("MyServer", "MyDatabase", "root", "TestPassword");
 //	LoadMySqlMetadata(string connectionString);
+
+	// to adjust loaded database model before generation, add your code here, after load metadata, but before GenerateModel() call
 
 	GenerateModel();
 #>

--- a/NuGet/Oracle/CopyMe.Oracle.tt.txt
+++ b/NuGet/Oracle/CopyMe.Oracle.tt.txt
@@ -38,8 +38,12 @@
 
 	NamespaceName = "DataModels";
 
+	// to configure GetSchemaOptions properties, add them here, before load metadata call
+
 	LoadOracleMetadata("MyServer", "1521", "MyDatabase", "MyUser", "MyPassword");
 //	LoadOracleMetadata(string connectionString);
+
+	// to adjust loaded database model before generation, add your code here, after load metadata, but before GenerateModel() call
 
 	GenerateModel();
 #>

--- a/NuGet/Pack.bat
+++ b/NuGet/Pack.bat
@@ -23,6 +23,7 @@ del *.nupkg
 ..\Redist\NuGet Pack linq2db.SQLite.nuspec
 ..\Redist\NuGet Pack linq2db.SQLite.MS.nuspec
 ..\Redist\NuGet Pack linq2db.SqlServer.nuspec
+..\Redist\NuGet Pack linq2db.SqlServer.MS.nuspec
 ..\Redist\NuGet Pack linq2db.Sybase.nuspec
 ..\Redist\NuGet Pack linq2db.Sybase.DataAction.nuspec
 ..\Redist\NuGet Pack linq2db.t4models.nuspec

--- a/NuGet/PackCI.bat
+++ b/NuGet/PackCI.bat
@@ -21,6 +21,7 @@ md built
 ..\Redist\NuGet Pack linq2db.SQLite.nuspec -OutputDirectory built
 ..\Redist\NuGet Pack linq2db.SQLite.MS.nuspec -OutputDirectory built
 ..\Redist\NuGet Pack linq2db.SqlServer.nuspec -OutputDirectory built
+..\Redist\NuGet Pack linq2db.SqlServer.MS.nuspec -OutputDirectory built
 ..\Redist\NuGet Pack linq2db.Sybase.nuspec -OutputDirectory built
 ..\Redist\NuGet Pack linq2db.Sybase.DataAction.nuspec -OutputDirectory built
 ..\Redist\NuGet Pack linq2db.t4models.nuspec -OutputDirectory built

--- a/NuGet/PostgreSQL/CopyMe.PostgreSQL.tt.txt
+++ b/NuGet/PostgreSQL/CopyMe.PostgreSQL.tt.txt
@@ -38,8 +38,12 @@
 
 	NamespaceName = "DataModels";
 
+	// to configure GetSchemaOptions properties, add them here, before load metadata call
+
 	LoadPostgreSQLMetadata("MyServer", "5432", "MyDatabase", "postgres", "TestPassword");
 //	LoadPostgreSQLMetadata(string connectionString);
+
+	// to adjust loaded database model before generation, add your code here, after load metadata, but before GenerateModel() call
 
 	GenerateModel();
 #>

--- a/NuGet/SQLite/CopyMe.SQLite.tt.txt
+++ b/NuGet/SQLite/CopyMe.SQLite.tt.txt
@@ -38,8 +38,12 @@
 
 	NamespaceName = "DataModels";
 
+	// to configure GetSchemaOptions properties, add them here, before load metadata call
+
 	LoadSQLiteMetadata(@"C:\Data", "MyDatabase.sqlite");
 //	LoadSQLiteMetadata(string connectionString);
+
+	// to adjust loaded database model before generation, add your code here, after load metadata, but before GenerateModel() call
 
 	GenerateModel();
 #>

--- a/NuGet/SapHana/CopyMe.SapHana.tt.txt
+++ b/NuGet/SapHana/CopyMe.SapHana.tt.txt
@@ -42,8 +42,12 @@
 
 	NamespaceName = "DataModels";
 
+	// to configure GetSchemaOptions properties, add them here, before load metadata call
+
 	LoadSapHanaMetadata("MyServer", "MyDatabase", "TestUser", "TestPassword");
 //	LoadSapHanaMetadata(string connectionString);
+
+	// to adjust loaded database model before generation, add your code here, after load metadata, but before GenerateModel() call
 
 	GenerateModel();
 #>

--- a/NuGet/SqlCe/CopyMe.SqlCe.tt.txt
+++ b/NuGet/SqlCe/CopyMe.SqlCe.tt.txt
@@ -38,8 +38,12 @@
 
 	NamespaceName = "DataModels";
 
+	// to configure GetSchemaOptions properties, add them here, before load metadata call
+
 	LoadSqlCeMetadata(@"C:\Data", "MyDatabase.sdf");
 //	LoadSqlCeMetadata(string connectionString);
+
+	// to adjust loaded database model before generation, add your code here, after load metadata, but before GenerateModel() call
 
 	GenerateModel();
 #>

--- a/NuGet/SqlServer/CopyMe.SqlServer.tt.txt
+++ b/NuGet/SqlServer/CopyMe.SqlServer.tt.txt
@@ -48,9 +48,13 @@
 
 	NamespaceName = "DataModels";
 
+	// to configure GetSchemaOptions properties, add them here, before load metadata call
+
 	LoadSqlServerMetadata("MyServer", "MyDatabase", "User", "Password");
 //	LoadSqlServerMetadata(".", "MyDatabase"); // Integrated Security
 //	LoadSqlServerMetadata(string connectionString);
+
+	// to adjust loaded database model before generation, add your code here, after load metadata, but before GenerateModel() call
 
 	GenerateModel();
 #>

--- a/NuGet/Sybase.DataAction/CopyMe.Sybase.DataAction.tt.txt
+++ b/NuGet/Sybase.DataAction/CopyMe.Sybase.DataAction.tt.txt
@@ -38,8 +38,12 @@
 
 	NamespaceName = "DataModels";
 
+	// to configure GetSchemaOptions properties, add them here, before load metadata call
+
 	LoadSybaseMetadata("MyServer", "5000", "MyDatabase", "sa", "TestPassword");
 //	LoadSybaseMetadata(string connectionString);
+
+	// to adjust loaded database model before generation, add your code here, after load metadata, but before GenerateModel() call
 
 	GenerateModel();
 #>

--- a/NuGet/Sybase/CopyMe.Sybase.tt.txt
+++ b/NuGet/Sybase/CopyMe.Sybase.tt.txt
@@ -42,8 +42,12 @@
 
 	NamespaceName = "DataModels";
 
+	// to configure GetSchemaOptions properties, add them here, before load metadata call
+
 	LoadSybaseMetadata("MyServer", "5000", "MyDatabase", "sa", "TestPassword");
 //	LoadSybaseMetadata(string connectionString);
+
+	// to adjust loaded database model before generation, add your code here, after load metadata, but before GenerateModel() call
 
 	GenerateModel();
 #>

--- a/NuGet/linq2db.Access.nuspec
+++ b/NuGet/linq2db.Access.nuspec
@@ -32,7 +32,12 @@
 	</metadata>
 	<files>
 		<file src="..\Source\LinqToDB\bin\Release\net46\linq2db.dll"          target="tools" />
-		
+
+		<file src="_._"                                                       target="lib\net45" />
+		<file src="_._"                                                       target="lib\net46" />
+		<file src="_._"                                                       target="lib\netstandard2.0" />
+		<file src="_._"                                                       target="lib\netcoreapp2.1" />
+
 		<file src="Access\linq2db.Access.props"                               target="build" />
 		
 		<file src="Access\*.*"                                                target="contentFiles\any\any\LinqToDB.Templates" exclude="**\*.props" />

--- a/NuGet/linq2db.SqlServer.MS.nuspec
+++ b/NuGet/linq2db.SqlServer.MS.nuspec
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+	<metadata minClientVersion="3.3.0">
+		<id>linq2db.SqlServer.MS</id>
+		<title>LINQ to SqlServer</title>
+		<description>
+			LINQ to SqlServer is a data access technology that provides a run-time infrastructure for managing relational data as objects.
+		</description>
+		<summary>
+			This package includes a T4 template to generate data models for SqlServer database and references to the linq2db and Microsoft.Data.SqlClient provider.
+		</summary>
+		<tags>linq linq2db SqlServer LinqToDB ORM database DB SQL</tags>
+		<dependencies>
+			<dependency id="linq2db"                   version="3.0.0"       />
+			<dependency id="Microsoft.Data.SqlClient"  version="1.0.19269.1" />
+		</dependencies>
+		<contentFiles>
+			<files include="**\*" buildAction="None"/>
+		</contentFiles>
+	</metadata>
+	<files>
+		<file src="..\Tests\Linq\bin\Azure\net46\Microsoft.SqlServer.Types.dll"     target="tools" />
+		<file src="..\Source\LinqToDB\bin\Release\net46\linq2db.dll"                target="tools" />
+		
+		<file src="SqlServer\linq2db.SqlServer.props"                               target="build" />
+		
+		<file src="SqlServer\*.*"                                                   target="contentFiles\any\any\LinqToDB.Templates" exclude="**\*.props" />
+		<file src="t4models\*.ttinclude"                                            target="contentFiles\any\any\LinqToDB.Templates"/>
+		<file src="..\Source\LinqToDB.Templates\*.ttinclude"                        target="contentFiles\any\any\LinqToDB.Templates" exclude="**\LinqToDB.*.ttinclude"/>
+		<file src="..\Source\LinqToDB.Templates\*.SqlServer.ttinclude"              target="contentFiles\any\any\LinqToDB.Templates" />
+		
+		<file src="SqlServer\*.*"                                                   target="content\LinqToDB.Templates" exclude="**\*.props" />
+		<file src="t4models\*.ttinclude"                                            target="content\LinqToDB.Templates"/>
+		<file src="..\Source\LinqToDB.Templates\*.ttinclude"                        target="content\LinqToDB.Templates" exclude="**\LinqToDB.*.ttinclude"/>
+		<file src="..\Source\LinqToDB.Templates\*.SqlServer.ttinclude"              target="content\LinqToDB.Templates" />
+	</files>
+</package>

--- a/NuGet/linq2db.SqlServer.MS.nuspec
+++ b/NuGet/linq2db.SqlServer.MS.nuspec
@@ -22,7 +22,7 @@
 		<file src="..\Tests\Linq\bin\Azure\net46\Microsoft.SqlServer.Types.dll"     target="tools" />
 		<file src="..\Source\LinqToDB\bin\Release\net46\linq2db.dll"                target="tools" />
 		
-		<file src="SqlServer\linq2db.SqlServer.props"                               target="build" />
+		<file src="SqlServer\linq2db.SqlServer.props"                               target="build\linq2db.SqlServer.MS.props" />
 		
 		<file src="SqlServer\*.*"                                                   target="contentFiles\any\any\LinqToDB.Templates" exclude="**\*.props" />
 		<file src="t4models\*.ttinclude"                                            target="contentFiles\any\any\LinqToDB.Templates"/>

--- a/NuGet/linq2db.nuspec
+++ b/NuGet/linq2db.nuspec
@@ -16,14 +16,12 @@
 				<dependency id="System.ComponentModel.Annotations"    version="4.6.0" />
 				<dependency id="System.Data.Odbc"                     version="4.6.0" />
 				<dependency id="System.Data.OleDb"                    version="4.6.0" />
-				<dependency id="System.Data.SqlClient"                version="4.7.0" />
 				<dependency id="System.Data.DataSetExtensions"        version="4.5.0" />
 			</group>
 			<group targetFramework=".NETCoreApp2.1">
 				<dependency id="System.ComponentModel.Annotations"    version="4.6.0" />
 				<dependency id="System.Data.Odbc"                     version="4.6.0" />
 				<dependency id="System.Data.OleDb"                    version="4.6.0" />
-				<dependency id="System.Data.SqlClient"                version="4.7.0" />
 				<dependency id="System.Data.DataSetExtensions"        version="4.5.0" />
 			</group>
 		</dependencies>

--- a/Source/LinqToDB.Templates/LinqToDB.SqlServer.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.SqlServer.ttinclude
@@ -1,4 +1,5 @@
-<#@ include file="LinqToDB.ttinclude" #>
+<#@ include file="LinqToDB.ttinclude"                  #>
+<#@ import namespace="LinqToDB.DataProvider.SqlServer" #>
 <#
 	{
 		GenerateProcedureDbType = p => p.DataType == "Structured" && p.SchemaType != null;
@@ -110,36 +111,51 @@ void DoGenerateSqlServerFreeText()
 	);
 }
 
-LinqToDB.Data.DataConnection GetSqlServerConnection(string connectionString)
+LinqToDB.Data.DataConnection GetSqlServerConnection(
+	string connectionString,
+	SqlServerVersion  version  = SqlServerVersion.v2008,
+	SqlServerProvider provider = SqlServerProvider.SystemDataSqlClient)
 {
-	return LinqToDB.DataProvider.SqlServer.SqlServerTools.CreateDataConnection(connectionString);
+	return LinqToDB.DataProvider.SqlServer.SqlServerTools.CreateDataConnection(connectionString, version, provider);
 }
 
-LinqToDB.Data.DataConnection GetSqlServerConnection(string server, string database)
+LinqToDB.Data.DataConnection GetSqlServerConnection(
+	string server,
+	string database,
+	SqlServerVersion  version  = SqlServerVersion.v2008,
+	SqlServerProvider provider = SqlServerProvider.SystemDataSqlClient)
 {
-	return GetSqlServerConnection(string.Format("Data Source={0};Database={1};Integrated Security=SSPI", server, database));
+	return GetSqlServerConnection(string.Format("Data Source={0};Database={1};Integrated Security=SSPI", server, database, version, provider));
 }
 
-LinqToDB.Data.DataConnection GetSqlServerConnection(string server, string database, string user, string password)
+LinqToDB.Data.DataConnection GetSqlServerConnection(string server, string database, string user, string password,
+	SqlServerVersion  version  = SqlServerVersion.v2008,
+	SqlServerProvider provider = SqlServerProvider.SystemDataSqlClient)
 {
-	return GetSqlServerConnection(string.Format("Server={0};Database={1};User Id={2};Password={3};", server, database, user, password));
+	return GetSqlServerConnection(string.Format("Server={0};Database={1};User Id={2};Password={3};", server, database, user, password), version, provider);
 }
 
-void LoadSqlServerMetadata(string connectionString)
+void LoadSqlServerMetadata(string connectionString,
+	SqlServerVersion  version  = SqlServerVersion.v2008,
+	SqlServerProvider provider = SqlServerProvider.SystemDataSqlClient)
 {
-	using (var dataConnection = GetSqlServerConnection(connectionString))
+	using (var dataConnection = GetSqlServerConnection(connectionString, version, provider))
 		LoadMetadata(dataConnection);
 }
 
-void LoadSqlServerMetadata(string server, string database)
+void LoadSqlServerMetadata(string server, string database,
+	SqlServerVersion  version  = SqlServerVersion.v2008,
+	SqlServerProvider provider = SqlServerProvider.SystemDataSqlClient)
 {
-	using (var dataConnection = GetSqlServerConnection(server, database))
+	using (var dataConnection = GetSqlServerConnection(server, database, version, provider))
 		LoadMetadata(dataConnection);
 }
 
-void LoadSqlServerMetadata(string server, string database, string user, string password)
+void LoadSqlServerMetadata(string server, string database, string user, string password,
+	SqlServerVersion  version  = SqlServerVersion.v2008,
+	SqlServerProvider provider = SqlServerProvider.SystemDataSqlClient)
 {
-	using (var dataConnection = GetSqlServerConnection(server, database, user, password))
+	using (var dataConnection = GetSqlServerConnection(server, database, user, password, version, provider))
 		LoadMetadata(dataConnection);
 }
 #>

--- a/Source/LinqToDB/Configuration/IDataProviderSettings.cs
+++ b/Source/LinqToDB/Configuration/IDataProviderSettings.cs
@@ -40,8 +40,14 @@ namespace LinqToDB.Configuration
 		/// </para>
 		/// <para>
 		/// SQL Server:
-		/// <list><item>version - T-SQL support level, recognized values:
-		/// <c>"2000"</c>, <c>"2005"</c>, <c>"2012"</c>, <c>"2014"</c>. Default: <c>"2008"</c>.</item></list>
+		/// <list>
+		/// <item>assemblyName - provider assembly name. Recognized values:
+		/// <c>"System.Data"</c>, <c>"System.Data.SqlClient"</c>, <c>"Microsoft.Data.SqlClient"</c>.
+		/// </item>
+		/// <item>version - T-SQL support level, recognized values:
+		/// <c>"2000"</c>, <c>"2005"</c>, <c>"2012"</c>, <c>"2014"</c>. Default: <c>"2008"</c>.
+		/// </item>
+		/// </list>
 		/// </para>
 		/// <para>
 		/// DB2:

--- a/Source/LinqToDB/DataProvider/Informix/InformixDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixDataProvider.cs
@@ -92,7 +92,7 @@ namespace LinqToDB.DataProvider.Informix
 			{
 				SetField(typeof(Int64), "BIGINT", "GetBigInt", false);
 
-				SetProviderField(_ifxDecimal , typeof(decimal) , InformixTools.IsCore ? "GetDB2Decimal" : "GetIfxDecimal");
+				SetProviderField(_ifxDecimal , typeof(decimal) , InformixTools.IsCore ? "GetDB2Decimal"  : "GetIfxDecimal");
 				SetProviderField(_ifxDateTime, typeof(DateTime), InformixTools.IsCore ? "GetDB2DateTime" : "GetIfxDateTime");
 				if (_ifxTimeSpan != null)
 					SetProviderField(_ifxTimeSpan, typeof(TimeSpan), InformixTools.IsCore ? "GetDB2TimeSpan" : "GetIfxTimeSpan", false);

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaBulkCopy.cs
@@ -37,7 +37,7 @@ namespace LinqToDB.DataProvider.SapHana
 
 			var connection = dataConnection.Connection;
 
-			if (connection == null )
+			if (connection == null)
 				return MultipleRowsCopy(table, options, source);
 
 			if (!(connection.GetType() == _connectionType || connection.GetType().IsSubclassOf(_connectionType)))

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerBulkCopy.cs
@@ -2,24 +2,29 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
-using System.Data.SqlClient;
 using System.Linq;
 
 using LinqToDB.Configuration;
 
 namespace LinqToDB.DataProvider.SqlServer
 {
+	using System.Data;
+	using System.Linq.Expressions;
 	using Data;
 	using SqlProvider;
 
 	class SqlServerBulkCopy : BasicBulkCopy
 	{
-		public SqlServerBulkCopy(SqlServerDataProvider dataProvider)
+		public SqlServerBulkCopy(SqlServerDataProvider dataProvider, Type connectionType)
 		{
 			_dataProvider = dataProvider;
 		}
 
-		readonly SqlServerDataProvider _dataProvider;
+		readonly SqlServerDataProvider                                       _dataProvider;
+		readonly Type                                                        _connectionType;
+		Func<IDbConnection, SqlBulkCopyOptions, IDbTransaction, IDisposable> _bulkCopyFactory;
+		Func<int, string, object>                                            _columnMappingFactory;
+		Action<object, Action<object>>                                       _bulkCopySubscriber;
 
 		protected override BulkCopyRowsCopied ProviderSpecificCopy<T>(
 			[JetBrains.Annotations.NotNull] ITable<T> table,
@@ -29,9 +34,10 @@ namespace LinqToDB.DataProvider.SqlServer
 			if (!(table?.DataContext is DataConnection dataConnection))
 				throw new ArgumentNullException(nameof(dataConnection));
 
-			if (dataConnection.Connection is DbConnection dbConnection)
+			var connection = dataConnection.Connection;
+			if (connection is DbConnection dbConnection)
 			{
-				if (Proxy.GetUnderlyingObject(dbConnection) is SqlConnection connection)
+				if (Proxy.GetUnderlyingObject(dbConnection).GetType() == _connectionType)
 				{
 					var ed      = dataConnection.MappingSchema.GetEntityDescriptor(typeof(T));
 					var columns = ed.Columns.Where(c => !c.SkipOnInsert || options.KeepIdentity == true && c.IsIdentity).ToList();
@@ -40,6 +46,18 @@ namespace LinqToDB.DataProvider.SqlServer
 					var sqlopt  = SqlBulkCopyOptions.Default;
 					var rc      = new BulkCopyRowsCopied();
 
+					if (_bulkCopyFactory == null)
+					{
+						var clientNamespace    = _dataProvider.ConnectionNamespace;
+						var bulkCopyType       = _connectionType.Assembly.GetType(clientNamespace + ".SqlBulkCopy",              true);
+						var bulkCopyOptionType = _connectionType.Assembly.GetType(clientNamespace + ".SqlBulkCopyOptions",       true);
+						var transactionType    = _connectionType.Assembly.GetType(clientNamespace + ".SqlTransaction",           true);
+						var columnMappingType  = _connectionType.Assembly.GetType(clientNamespace + ".SqlBulkCopyColumnMapping", true);
+
+						_bulkCopyFactory      = CreateBulkCopyFactory(_connectionType, bulkCopyType, bulkCopyOptionType, transactionType);
+						_columnMappingFactory = CreateColumnMappingCreator(columnMappingType);
+					}
+
 					if (options.CheckConstraints       == true) sqlopt |= SqlBulkCopyOptions.CheckConstraints;
 					if (options.KeepIdentity           == true) sqlopt |= SqlBulkCopyOptions.KeepIdentity;
 					if (options.TableLock              == true) sqlopt |= SqlBulkCopyOptions.TableLock;
@@ -47,38 +65,43 @@ namespace LinqToDB.DataProvider.SqlServer
 					if (options.FireTriggers           == true) sqlopt |= SqlBulkCopyOptions.FireTriggers;
 					if (options.UseInternalTransaction == true) sqlopt |= SqlBulkCopyOptions.UseInternalTransaction;
 
-					using (var bc = new SqlBulkCopy(connection, sqlopt, (SqlTransaction)dataConnection.Transaction))
+					using (var bc = _bulkCopyFactory(connection, sqlopt, dataConnection.Transaction))
 					{
-						if (options.NotifyAfter != 0 && options.RowsCopiedCallback != null)
+						if (_bulkCopySubscriber == null)
 						{
-							bc.NotifyAfter = options.NotifyAfter;
-
-							bc.SqlRowsCopied += (sender,e) =>
-							{
-								rc.RowsCopied = e.RowsCopied;
-								options.RowsCopiedCallback(rc);
-								if (rc.Abort)
-									e.Abort = true;
-							};
+							_bulkCopySubscriber = CreateBulkCopySubscriber(bc, "SqlRowsCopied");
 						}
 
-						if (options.MaxBatchSize.   HasValue) bc.BatchSize       = options.MaxBatchSize.   Value;
-						if (options.BulkCopyTimeout.HasValue) bc.BulkCopyTimeout = options.BulkCopyTimeout.Value;
+						dynamic dbc = bc;
+						if (options.NotifyAfter != 0 && options.RowsCopiedCallback != null)
+						{
+							dbc.NotifyAfter = options.NotifyAfter;
+
+							_bulkCopySubscriber(bc, arg =>
+							{
+								dynamic darg = arg;
+								rc.RowsCopied = darg.RowsCopied;
+								options.RowsCopiedCallback(rc);
+								if (rc.Abort)
+									darg.Abort = true;
+							});
+						}
+
+						if (options.MaxBatchSize.   HasValue) dbc.BatchSize       = options.MaxBatchSize.   Value;
+						if (options.BulkCopyTimeout.HasValue) dbc.BulkCopyTimeout = options.BulkCopyTimeout.Value;
 
 						var sqlBuilder = _dataProvider.CreateSqlBuilder(dataConnection.MappingSchema);
 						var tableName  = GetTableName(sqlBuilder, options, table);
 
-						bc.DestinationTableName = tableName;
+						dbc.DestinationTableName = tableName;
 
 						for (var i = 0; i < columns.Count; i++)
-							bc.ColumnMappings.Add(new SqlBulkCopyColumnMapping(
-								i,
-								sb.Convert(columns[i].ColumnName, ConvertType.NameToQueryField).ToString()));
+							dbc.ColumnMappings.Add((dynamic)_columnMappingFactory(i, sb.Convert(columns[i].ColumnName, ConvertType.NameToQueryField).ToString()));
 
 						TraceAction(
 							dataConnection,
-							() => "INSERT BULK " + tableName + "("+ string.Join(", ", bc.ColumnMappings.Cast<SqlBulkCopyColumnMapping>().Select(x=>x.DestinationColumn)) + Environment.NewLine,
-							() => { bc.WriteToServer(rd); return rd.Count; });
+							() => "INSERT BULK " + tableName + "("+ string.Join(", ", ((IEnumerable<dynamic>)dbc.ColumnMappings).Select(x => x.DestinationColumn)) + Environment.NewLine,
+							() => { dbc.WriteToServer(rd); return rd.Count; });
 					}
 
 					if (rc.RowsCopied != rd.Count)
@@ -117,6 +140,44 @@ namespace LinqToDB.DataProvider.SqlServer
 				helper.DataConnection.Execute("SET IDENTITY_INSERT " + helper.TableName + " OFF");
 
 			return ret;
+		}
+
+		[Flags]
+		private enum SqlBulkCopyOptions
+		{
+			AllowEncryptedValueModifications = 64,
+			CheckConstraints = 2,
+			Default = 0,
+			FireTriggers = 16,
+			KeepIdentity = 1,
+			KeepNulls = 8,
+			TableLock = 4,
+			UseInternalTransaction = 32
+		}
+
+		static Func<IDbConnection, SqlBulkCopyOptions, IDbTransaction, IDisposable> CreateBulkCopyFactory(
+			Type connectionType, Type bulkCopyType, Type bulkCopyOptionType, Type externalTransactionConnection)
+		{
+			var p1   = Expression.Parameter(typeof(IDbConnection),      "pc");
+			var p2   = Expression.Parameter(typeof(SqlBulkCopyOptions), "po");
+			var p3   = Expression.Parameter(typeof(IDbTransaction),     "pt");
+			var ctor = bulkCopyType.GetConstructor(new[]
+			{
+				connectionType,
+				bulkCopyOptionType,
+				externalTransactionConnection
+			});
+
+			var l = Expression.Lambda<Func<IDbConnection, SqlBulkCopyOptions, IDbTransaction, IDisposable>>(
+				Expression.Convert(
+					Expression.New(ctor,
+						Expression.Convert(p1, connectionType),
+						Expression.Convert(p2, bulkCopyOptionType),
+						Expression.Convert(p3, externalTransactionConnection)),
+					typeof(IDisposable)),
+				p1, p2, p3);
+
+			return l.Compile();
 		}
 	}
 }

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerBulkCopy.cs
@@ -17,7 +17,8 @@ namespace LinqToDB.DataProvider.SqlServer
 	{
 		public SqlServerBulkCopy(SqlServerDataProvider dataProvider, Type connectionType)
 		{
-			_dataProvider = dataProvider;
+			_dataProvider   = dataProvider;
+			_connectionType = connectionType;
 		}
 
 		readonly SqlServerDataProvider                                       _dataProvider;

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerBulkCopy.cs
@@ -101,7 +101,7 @@ namespace LinqToDB.DataProvider.SqlServer
 
 						TraceAction(
 							dataConnection,
-							() => "INSERT BULK " + tableName + "("+ string.Join(", ", ((IEnumerable<dynamic>)dbc.ColumnMappings).Select(x => x.DestinationColumn)) + Environment.NewLine,
+							() => "INSERT BULK " + tableName + "("+ string.Join(", ", columns.Select(x => x.ColumnName)) + Environment.NewLine,
 							() => { dbc.WriteToServer(rd); return rd.Count; });
 					}
 

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
@@ -21,12 +21,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		#region Init
 
 		public SqlServerDataProvider(string name, SqlServerVersion version)
-			: this(name, version,
-#if NET45 || NET46
-			SqlServerProvider.SystemData)
-#else
-			SqlServerProvider.SystemDataSqlClient)
-#endif
+			: this(name, version, SqlServerProvider.SystemDataSqlClient)
 		{
 		}
 
@@ -124,7 +119,7 @@ namespace LinqToDB.DataProvider.SqlServer
 				if (_dataReaderType != null)
 					return _dataReaderType;
 
-				if (Provider == SqlServerProvider.SystemData)
+				if (Provider == SqlServerProvider.SystemDataSqlClient)
 				{
 					_dataReaderType = typeof(System.Data.SqlClient.SqlDataReader);
 					return _dataReaderType;
@@ -140,7 +135,7 @@ namespace LinqToDB.DataProvider.SqlServer
 			if (_connectionType != null)
 				return _connectionType;
 
-			if (Provider == SqlServerProvider.SystemData)
+			if (Provider == SqlServerProvider.SystemDataSqlClient)
 			{
 				_connectionType = typeof(System.Data.SqlClient.SqlConnection);
 				OnConnectionTypeCreated(_connectionType);
@@ -155,12 +150,7 @@ namespace LinqToDB.DataProvider.SqlServer
 
 		#region Public Properties
 
-		public string AssemblyName          => Provider == SqlServerProvider.SystemDataSqlClient
-			? "System.Data.SqlClient"
-#if NET45 || NET46
-			: Provider == SqlServerProvider.SystemData ? "System.Data"
-#endif
-			: "Microsoft.Data.SqlClient";
+		public             string AssemblyName          => Provider == SqlServerProvider.SystemDataSqlClient    ? "System.Data.SqlClient" : "Microsoft.Data.SqlClient";
 		public    override string ConnectionNamespace   => Provider == SqlServerProvider.MicrosoftDataSqlClient ? "Microsoft.Data.SqlClient" : "System.Data.SqlClient";
 		protected override string ConnectionTypeName    => $"{ConnectionNamespace}.SqlConnection, {AssemblyName}";
 		protected override string DataReaderTypeName    => $"{ConnectionNamespace}.SqlDataReader, {AssemblyName}";

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
@@ -4,30 +4,37 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
-using System.Data.SqlClient;
 using System.Data.SqlTypes;
 using System.Linq;
 
-using Microsoft.SqlServer.Server;
-
 namespace LinqToDB.DataProvider.SqlServer
 {
-	using Configuration;
 	using Common;
 	using Data;
-	using Extensions;
+	using LinqToDB.Extensions;
 	using Mapping;
 	using SchemaProvider;
 	using SqlProvider;
 
-	public class SqlServerDataProvider : DataProviderBase
+	public class SqlServerDataProvider : DynamicDataProviderBase
 	{
 		#region Init
 
 		public SqlServerDataProvider(string name, SqlServerVersion version)
-			: base(name, (MappingSchema)null)
+			: this(name, version,
+#if NET45 || NET46
+			SqlServerProvider.SystemData)
+#else
+			SqlServerProvider.SystemDataSqlClient)
+#endif
 		{
-			Version = version;
+		}
+
+		public SqlServerDataProvider(string name, SqlServerVersion version, SqlServerProvider provider)
+			: base(name, null)
+		{
+			Version  = version;
+			Provider = provider;
 
 			SqlProviderFlags.IsDistinctOrderBySupported       = false;
 			SqlProviderFlags.IsSubQueryOrderBySupported       = false;
@@ -51,31 +58,6 @@ namespace LinqToDB.DataProvider.SqlServer
 			SetCharFieldToType<char>("char",  (r, i) => DataTools.GetChar(r, i));
 			SetCharFieldToType<char>("nchar", (r, i) => DataTools.GetChar(r, i));
 
-			if (!Configuration.AvoidSpecificDataProviderAPI)
-			{
-				SetProviderField<SqlDataReader,SqlBinary  ,SqlBinary  >((r,i) => r.GetSqlBinary  (i));
-				SetProviderField<SqlDataReader,SqlBoolean ,SqlBoolean >((r,i) => r.GetSqlBoolean (i));
-				SetProviderField<SqlDataReader,SqlByte    ,SqlByte    >((r,i) => r.GetSqlByte    (i));
-				SetProviderField<SqlDataReader,SqlDateTime,SqlDateTime>((r,i) => r.GetSqlDateTime(i));
-				SetProviderField<SqlDataReader,SqlDecimal ,SqlDecimal >((r,i) => r.GetSqlDecimal (i));
-				SetProviderField<SqlDataReader,SqlDouble  ,SqlDouble  >((r,i) => r.GetSqlDouble  (i));
-				SetProviderField<SqlDataReader,SqlGuid    ,SqlGuid    >((r,i) => r.GetSqlGuid    (i));
-				SetProviderField<SqlDataReader,SqlInt16   ,SqlInt16   >((r,i) => r.GetSqlInt16   (i));
-				SetProviderField<SqlDataReader,SqlInt32   ,SqlInt32   >((r,i) => r.GetSqlInt32   (i));
-				SetProviderField<SqlDataReader,SqlInt64   ,SqlInt64   >((r,i) => r.GetSqlInt64   (i));
-				SetProviderField<SqlDataReader,SqlMoney   ,SqlMoney   >((r,i) => r.GetSqlMoney   (i));
-				SetProviderField<SqlDataReader,SqlSingle  ,SqlSingle  >((r,i) => r.GetSqlSingle  (i));
-				SetProviderField<SqlDataReader,SqlString  ,SqlString  >((r,i) => r.GetSqlString  (i));
-				SetProviderField<SqlDataReader,SqlXml     ,SqlXml     >((r,i) => r.GetSqlXml     (i));
-
-				SetProviderField<SqlDataReader,DateTimeOffset>((r,i) => r.GetDateTimeOffset(i));
-				SetProviderField<SqlDataReader,TimeSpan>      ((r,i) => r.GetTimeSpan      (i));
-			}
-			else
-			{
-				SetProviderField<IDataReader,SqlString  ,SqlString  >((r,i) => r.GetString  (i));
-			}
-
 			_sqlServer2000SqlOptimizer = new SqlServer2000SqlOptimizer(SqlProviderFlags);
 			_sqlServer2005SqlOptimizer = new SqlServer2005SqlOptimizer(SqlProviderFlags);
 			_sqlServer2008SqlOptimizer = new SqlServerSqlOptimizer    (SqlProviderFlags);
@@ -88,14 +70,110 @@ namespace LinqToDB.DataProvider.SqlServer
 			SetField<IDataReader,decimal>("decimal",    (r,i) => SqlServerTools.DataReaderGetDecimal(r, i));
 		}
 
+		private Type                                _parameterType;
+		private Type                                _sqlDataRecordType;
+
+		private Action<IDbDataParameter, string>    _setUdtTypeName;
+		private Action<IDbDataParameter, string>    _setTypeName;
+		private Action<IDbDataParameter, SqlDbType> _setSqlDbType;
+
+		private Func<IDbDataParameter, SqlDbType>   _getSqlDbType;
+
+		protected override void OnConnectionTypeCreated(Type connectionType)
+		{
+			if (!Configuration.AvoidSpecificDataProviderAPI)
+			{
+				SetProviderField<SqlBinary  , SqlBinary  >("GetSqlBinary"  );
+				SetProviderField<SqlBoolean , SqlBoolean > ("GetSqlBoolean");
+				SetProviderField<SqlByte    , SqlByte    > ("GetSqlByte"   );
+				SetProviderField<SqlDateTime, SqlDateTime>("GetSqlDateTime");
+				SetProviderField<SqlDecimal , SqlDecimal >("GetSqlDecimal" );
+				SetProviderField<SqlDouble  , SqlDouble  >("GetSqlDouble"  );
+				SetProviderField<SqlGuid    , SqlGuid    >("GetSqlGuid"    );
+				SetProviderField<SqlInt16   , SqlInt16   >("GetSqlInt16"   );
+				SetProviderField<SqlInt32   , SqlInt32   >("GetSqlInt32"   );
+				SetProviderField<SqlInt64   , SqlInt64   >("GetSqlInt64"   );
+				SetProviderField<SqlMoney   , SqlMoney   >("GetSqlMoney"   );
+				SetProviderField<SqlSingle  , SqlSingle  >("GetSqlSingle"  );
+				SetProviderField<SqlString  , SqlString  >("GetSqlString"  );
+				SetProviderField<SqlXml     , SqlXml     >("GetSqlXml"     );
+
+				SetProviderField<DateTimeOffset>("GetDateTimeOffset");
+				SetProviderField<TimeSpan>      ("GetTimeSpan");
+			}
+			else
+			{
+				SetProviderField<IDataReader,SqlString  ,SqlString  >((r,i) => r.GetString(i));
+			}
+
+			_parameterType     = connectionType.Assembly.GetType(ParameterTypeName,     true);
+			_sqlDataRecordType = connectionType.Assembly.GetType(SqlDataRecordTypeName, true);
+
+			_setUdtTypeName = GetSetParameter<string>   (_parameterType, "UdtTypeName", typeof(string));
+			_setTypeName    = GetSetParameter<string>   (_parameterType, "TypeName",    typeof(string));
+			_setSqlDbType   = GetSetParameter<SqlDbType>(_parameterType, "SqlDbType",   typeof(SqlDbType));
+			_getSqlDbType   = GetGetParameter<SqlDbType>(_parameterType, "SqlDbType");
+		}
+
+#if NET45 || NET46
+		Type _dataReaderType;
+		public override Type DataReaderType
+		{
+			get
+			{
+				if (_dataReaderType != null)
+					return _dataReaderType;
+
+				if (Provider == SqlServerProvider.SystemData)
+				{
+					_dataReaderType = typeof(System.Data.SqlClient.SqlDataReader);
+					return _dataReaderType;
+				}
+
+				return base.DataReaderType;
+			}
+		}
+
+		Type _connectionType;
+		protected internal override Type GetConnectionType()
+		{
+			if (_connectionType != null)
+				return _connectionType;
+
+			if (Provider == SqlServerProvider.SystemData)
+			{
+				_connectionType = typeof(System.Data.SqlClient.SqlConnection);
+				OnConnectionTypeCreated(_connectionType);
+				return _connectionType;
+			}
+
+			return base.GetConnectionType();
+		}
+#endif
+
 		#endregion
 
 		#region Public Properties
 
-		public override string ConnectionNamespace => typeof(SqlConnection).Namespace;
-		public override Type   DataReaderType      => typeof(SqlDataReader);
+		public string AssemblyName          => Provider == SqlServerProvider.SystemDataSqlClient
+			? "System.Data.SqlClient"
+#if NET45 || NET46
+			: Provider == SqlServerProvider.SystemData ? "System.Data"
+#endif
+			: "Microsoft.Data.SqlClient";
+		public    override string ConnectionNamespace   => Provider == SqlServerProvider.MicrosoftDataSqlClient ? "Microsoft.Data.SqlClient" : "System.Data.SqlClient";
+		protected override string ConnectionTypeName    => $"{ConnectionNamespace}.SqlConnection, {AssemblyName}";
+		protected override string DataReaderTypeName    => $"{ConnectionNamespace}.SqlDataReader, {AssemblyName}";
+		protected          string ParameterTypeName     => $"{ConnectionNamespace}.SqlParameter";
+		protected          string SqlDataRecordTypeName => Provider == SqlServerProvider.MicrosoftDataSqlClient ? "Microsoft.Data.SqlClient.Server.SqlDataRecord" : "Microsoft.SqlServer.Server.SqlDataRecord";
 
-		public SqlServerVersion Version { get; }
+#if !NETSTANDARD2_0
+		public override string DbFactoryProviderName => Provider == SqlServerProvider.MicrosoftDataSqlClient ? "Microsoft.Data.SqlClient" : "System.Data.SqlClient";
+#endif
+
+		public SqlServerVersion Version   { get; }
+
+		public SqlServerProvider Provider { get; }
 
 		#endregion
 
@@ -125,11 +203,6 @@ namespace LinqToDB.DataProvider.SqlServer
 
 				return base.MappingSchema;
 			}
-		}
-
-		protected override IDbConnection CreateConnectionInternal(string connectionString)
-		{
-			return new SqlConnection(connectionString);
 		}
 
 		public override ISqlBuilder CreateSqlBuilder(MappingSchema mappingSchema)
@@ -164,11 +237,6 @@ namespace LinqToDB.DataProvider.SqlServer
 			}
 
 			return _sqlServer2008SqlOptimizer;
-		}
-
-		public override bool IsCompatibleConnection(IDbConnection connection)
-		{
-			return typeof(SqlConnection).IsSameOrParentOf(Proxy.GetUnderlyingObject((DbConnection)connection).GetType());
 		}
 
 		public override ISchemaProvider GetSchemaProvider()
@@ -212,8 +280,7 @@ namespace LinqToDB.DataProvider.SqlServer
 				case DataType.Udt        :
 					{
 						if (value != null && _udtTypes.TryGetValue(value.GetType(), out var s))
-							if (parameter is SqlParameter)
-								((SqlParameter)parameter).UdtTypeName = s;
+							_setUdtTypeName(parameter, s);
 					}
 
 					break;
@@ -240,10 +307,11 @@ namespace LinqToDB.DataProvider.SqlServer
 					break;
 
 				case DataType.Undefined:
-					if (value is DataTable
-						|| value is DbDataReader
-						|| value is IEnumerable<SqlDataRecord>
-						|| value is IEnumerable<DbDataRecord>)
+					if (value != null
+						&& (value is DataTable
+							|| value is DbDataReader
+							|| value is IEnumerable<DbDataRecord>
+							|| value.GetType().IsEnumerableTType(_sqlDataRecordType)))
 					{
 						dataType = dataType.WithDataType(DataType.Structured);
 					}
@@ -253,19 +321,19 @@ namespace LinqToDB.DataProvider.SqlServer
 
 			base.SetParameter(parameter, name, dataType, value);
 
-			if (parameter is SqlParameter param)
+			if (parameter.GetType() == _parameterType)
 			{
 				// Setting for NVarChar and VarChar constant size. It reduces count of cached plans.
-				switch (param.SqlDbType)
+				switch (_getSqlDbType(parameter))
 				{
 					case SqlDbType.Structured:
 						{
 							if (!dataType.DbType.IsNullOrEmpty())
-								param.TypeName = dataType.DbType;
+								_setTypeName(parameter, dataType.DbType);
 
 							// TVP doesn't support DBNull
-							if (param.Value is DBNull)
-								param.Value = null;
+							if (parameter.Value is DBNull)
+								parameter.Value = null;
 
 							break;
 						}
@@ -273,11 +341,11 @@ namespace LinqToDB.DataProvider.SqlServer
 						{
 							var strValue = value as string;
 							if ((strValue != null && strValue.Length > 8000) || (value != null && strValue == null))
-								param.Size = -1;
+								parameter.Size = -1;
 							else if (dataType.Length != null && dataType.Length <= 8000 && (strValue == null || strValue.Length <= dataType.Length))
-								param.Size = dataType.Length.Value;
+								parameter.Size = dataType.Length.Value;
 							else
-								param.Size = 8000;
+								parameter.Size = 8000;
 
 							break;
 						}
@@ -285,11 +353,11 @@ namespace LinqToDB.DataProvider.SqlServer
 						{
 							var strValue = value as string;
 							if ((strValue != null && strValue.Length > 4000) || (value != null && strValue == null))
-								param.Size = -1;
+								parameter.Size = -1;
 							else if (dataType.Length != null && dataType.Length <= 4000 && (strValue == null || strValue.Length <= dataType.Length))
-								param.Size = dataType.Length.Value;
+								parameter.Size = dataType.Length.Value;
 							else
-								param.Size = 4000;
+								parameter.Size = 4000;
 
 							break;
 						}
@@ -297,11 +365,11 @@ namespace LinqToDB.DataProvider.SqlServer
 						{
 							var binaryValue = value as byte[];
 							if ((binaryValue != null && binaryValue.Length > 8000) || (value != null && binaryValue == null))
-								param.Size = -1;
+								parameter.Size = -1;
 							else if (dataType.Length != null && dataType.Length <= 8000 && (binaryValue == null || binaryValue.Length <= dataType.Length))
-								param.Size = dataType.Length.Value;
+								parameter.Size = dataType.Length.Value;
 							else
-								param.Size = 8000;
+								parameter.Size = 8000;
 
 							break;
 						}
@@ -328,21 +396,21 @@ namespace LinqToDB.DataProvider.SqlServer
 							DbType.DateTime :
 							DbType.DateTime2;
 					break;
-				case DataType.Text          : ((SqlParameter)parameter).SqlDbType = SqlDbType.Text;          break;
-				case DataType.NText         : ((SqlParameter)parameter).SqlDbType = SqlDbType.NText;         break;
-				case DataType.Binary        : ((SqlParameter)parameter).SqlDbType = SqlDbType.Binary;        break;
+				case DataType.Text          : _setSqlDbType(parameter, SqlDbType.Text);          break;
+				case DataType.NText         : _setSqlDbType(parameter, SqlDbType.NText);         break;
+				case DataType.Binary        : _setSqlDbType(parameter, SqlDbType.Binary);        break;
 				case DataType.Blob          :
-				case DataType.VarBinary     : ((SqlParameter)parameter).SqlDbType = SqlDbType.VarBinary;     break;
-				case DataType.Image         : ((SqlParameter)parameter).SqlDbType = SqlDbType.Image;         break;
-				case DataType.Money         : ((SqlParameter)parameter).SqlDbType = SqlDbType.Money;         break;
-				case DataType.SmallMoney    : ((SqlParameter)parameter).SqlDbType = SqlDbType.SmallMoney;    break;
-				case DataType.Date          : ((SqlParameter)parameter).SqlDbType = SqlDbType.Date;          break;
-				case DataType.Time          : ((SqlParameter)parameter).SqlDbType = SqlDbType.Time;          break;
-				case DataType.SmallDateTime : ((SqlParameter)parameter).SqlDbType = SqlDbType.SmallDateTime; break;
-				case DataType.Timestamp     : ((SqlParameter)parameter).SqlDbType = SqlDbType.Timestamp;     break;
-				case DataType.Xml           : ((SqlParameter)parameter).SqlDbType = SqlDbType.Xml;           break;
-				case DataType.Structured    : ((SqlParameter)parameter).SqlDbType = SqlDbType.Structured;    break;
-				default                     : base.SetParameterType(parameter, dataType);                    break;
+				case DataType.VarBinary     : _setSqlDbType(parameter, SqlDbType.VarBinary);     break;
+				case DataType.Image         : _setSqlDbType(parameter, SqlDbType.Image);         break;
+				case DataType.Money         : _setSqlDbType(parameter, SqlDbType.Money);         break;
+				case DataType.SmallMoney    : _setSqlDbType(parameter, SqlDbType.SmallMoney);    break;
+				case DataType.Date          : _setSqlDbType(parameter, SqlDbType.Date);          break;
+				case DataType.Time          : _setSqlDbType(parameter, SqlDbType.Time);          break;
+				case DataType.SmallDateTime : _setSqlDbType(parameter, SqlDbType.SmallDateTime); break;
+				case DataType.Timestamp     : _setSqlDbType(parameter, SqlDbType.Timestamp);     break;
+				case DataType.Xml           : _setSqlDbType(parameter, SqlDbType.Xml);           break;
+				case DataType.Structured    : _setSqlDbType(parameter, SqlDbType.Structured);    break;
+				default                     : base.SetParameterType(parameter, dataType);        break;
 			}
 		}
 
@@ -389,7 +457,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		public override BulkCopyRowsCopied BulkCopy<T>(ITable<T> table, BulkCopyOptions options, IEnumerable<T> source)
 		{
 			if (_bulkCopy == null)
-				_bulkCopy = new SqlServerBulkCopy(this);
+				_bulkCopy = new SqlServerBulkCopy(this, GetConnectionType());
 
 			return _bulkCopy.BulkCopy(
 				options.BulkCopyType == BulkCopyType.Default ? SqlServerTools.DefaultBulkCopyType : options.BulkCopyType,

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
@@ -269,7 +269,9 @@ namespace LinqToDB.DataProvider.SqlServer
 			{
 				case DataType.Udt        :
 					{
-						if (value != null && _udtTypes.TryGetValue(value.GetType(), out var s))
+						if (parameter.GetType() == _parameterType
+							&& value != null
+							&& _udtTypes.TryGetValue(value.GetType(), out var s))
 							_setUdtTypeName(parameter, s);
 					}
 

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerFactory.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerFactory.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Specialized;
-
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
 
 namespace LinqToDB.DataProvider.SqlServer
 {
@@ -17,22 +14,45 @@ namespace LinqToDB.DataProvider.SqlServer
 
 		IDataProvider IDataProviderFactory.GetDataProvider(IEnumerable<NamedValue> attributes)
 		{
-			var version = attributes.FirstOrDefault(_ => _.Name == "version");
+#if NET45 || NET46
+			var provider = SqlServerProvider.SystemData;
+#else
+			var provider     = SqlServerProvider.SystemDataSqlClient;
+#endif
+
+			var version      = attributes.FirstOrDefault(_ => _.Name == "version");
+			var assemblyName = attributes.FirstOrDefault(_ => _.Name == "assemblyName")?.Value;
+
+			if (assemblyName != null)
+			{
+				switch (assemblyName)
+				{
+					case "System.Data.SqlClient":
+						provider = SqlServerProvider.SystemDataSqlClient;
+						break;
+					case "Microsoft.Data.SqlClient":
+						provider = SqlServerProvider.MicrosoftDataSqlClient;
+						break;
+				}
+			}
+
+			SqlServerTools.Provider = provider;
+
 			if (version != null)
 			{
 				switch (version.Value)
 				{
-					case "2000" : return new SqlServerDataProvider(ProviderName.SqlServer2000, SqlServerVersion.v2000);
-					case "2005" : return new SqlServerDataProvider(ProviderName.SqlServer2005, SqlServerVersion.v2005);
-					case "2012" : return new SqlServerDataProvider(ProviderName.SqlServer2012, SqlServerVersion.v2012);
-					case "2014" : return new SqlServerDataProvider(ProviderName.SqlServer2014, SqlServerVersion.v2012);
-					case "2017" : return new SqlServerDataProvider(ProviderName.SqlServer2017, SqlServerVersion.v2017);
+					case "2000" : return new SqlServerDataProvider(ProviderName.SqlServer2000, SqlServerVersion.v2000, provider);
+					case "2005" : return new SqlServerDataProvider(ProviderName.SqlServer2005, SqlServerVersion.v2005, provider);
+					case "2012" : return new SqlServerDataProvider(ProviderName.SqlServer2012, SqlServerVersion.v2012, provider);
+					case "2014" : return new SqlServerDataProvider(ProviderName.SqlServer2014, SqlServerVersion.v2012, provider);
+					case "2017" : return new SqlServerDataProvider(ProviderName.SqlServer2017, SqlServerVersion.v2017, provider);
 				}
 			}
 
-			return new SqlServerDataProvider(ProviderName.SqlServer2008, SqlServerVersion.v2008);
+			return new SqlServerDataProvider(ProviderName.SqlServer2008, SqlServerVersion.v2008, provider);
 		}
 
-		#endregion
+#endregion
 	}
 }

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerFactory.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerFactory.cs
@@ -10,30 +10,15 @@ namespace LinqToDB.DataProvider.SqlServer
 	[UsedImplicitly]
 	class SqlServerFactory : IDataProviderFactory
 	{
-		#region IDataProviderFactory Implementation
-
 		IDataProvider IDataProviderFactory.GetDataProvider(IEnumerable<NamedValue> attributes)
 		{
-#if NET45 || NET46
-			var provider = SqlServerProvider.SystemData;
-#else
 			var provider     = SqlServerProvider.SystemDataSqlClient;
-#endif
-
 			var version      = attributes.FirstOrDefault(_ => _.Name == "version");
 			var assemblyName = attributes.FirstOrDefault(_ => _.Name == "assemblyName")?.Value;
 
-			if (assemblyName != null)
+			if (assemblyName == "Microsoft.Data.SqlClient")
 			{
-				switch (assemblyName)
-				{
-					case "System.Data.SqlClient":
-						provider = SqlServerProvider.SystemDataSqlClient;
-						break;
-					case "Microsoft.Data.SqlClient":
-						provider = SqlServerProvider.MicrosoftDataSqlClient;
-						break;
-				}
+				provider = SqlServerProvider.MicrosoftDataSqlClient;
 			}
 
 			SqlServerTools.Provider = provider;
@@ -52,7 +37,5 @@ namespace LinqToDB.DataProvider.SqlServer
 
 			return new SqlServerDataProvider(ProviderName.SqlServer2008, SqlServerVersion.v2008, provider);
 		}
-
-#endregion
 	}
 }

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerMappingSchema.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq.Expressions;
 using System.Text;
 using System.Xml;
-using LinqToDB.Extensions;
 
 namespace LinqToDB.DataProvider.SqlServer
 {

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerProvider.cs
@@ -1,0 +1,14 @@
+﻿namespace LinqToDB.DataProvider.SqlServer
+{
+	public enum SqlServerProvider
+	{
+#if NET45 || NET46
+		Default = SystemData,
+		SystemData = 0,
+#else
+		Default = SystemDataSqlClient,
+#endif
+		SystemDataSqlClient = 1,
+		MicrosoftDataSqlClient = 2
+	}
+}

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerProvider.cs
@@ -2,13 +2,7 @@
 {
 	public enum SqlServerProvider
 	{
-#if NET45 || NET46
-		Default = SystemData,
-		SystemData = 0,
-#else
-		Default = SystemDataSqlClient,
-#endif
-		SystemDataSqlClient = 1,
-		MicrosoftDataSqlClient = 2
+		SystemDataSqlClient,
+		MicrosoftDataSqlClient
 	}
 }

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerRetryPolicy.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerRetryPolicy.cs
@@ -6,12 +6,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 
 using JetBrains.Annotations;
 
 namespace LinqToDB.DataProvider.SqlServer
 {
+	using System.Linq;
 	using Common;
 	using Data.RetryPolicy;
 
@@ -56,10 +56,8 @@ namespace LinqToDB.DataProvider.SqlServer
 		{
 			if (_additionalErrorNumbers != null)
 			{
-				var sqlException = exception as SqlException;
-
-				if (sqlException != null)
-					foreach (SqlError err in sqlException.Errors)
+				if (SqlServerTransientExceptionDetector.ExceptionTypes.Any(e => e == exception.GetType()))
+					foreach (dynamic err in ((dynamic)exception).Errors)
 						if (_additionalErrorNumbers.Contains(err.Number))
 							return true;
 			}
@@ -82,10 +80,8 @@ namespace LinqToDB.DataProvider.SqlServer
 
 		static bool IsMemoryOptimizedError(Exception exception)
 		{
-			var sqlException = exception as SqlException;
-
-			if (sqlException != null)
-				foreach (SqlError err in sqlException.Errors)
+			if (SqlServerTransientExceptionDetector.ExceptionTypes.Any(e => e == exception.GetType()))
+				foreach (dynamic err in ((dynamic)exception).Errors)
 					switch (err.Number)
 					{
 						case 41301:

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlBuilder.cs
@@ -370,17 +370,17 @@ namespace LinqToDB.DataProvider.SqlServer
 
 		protected override string GetTypeName(IDbDataParameter parameter)
 		{
-			return ((System.Data.SqlClient.SqlParameter)parameter).TypeName;
+			return ((dynamic)parameter).TypeName;
 		}
 
 		protected override string GetUdtTypeName(IDbDataParameter parameter)
 		{
-			return ((System.Data.SqlClient.SqlParameter)parameter).UdtTypeName;
+			return ((dynamic)parameter).UdtTypeName;
 		}
 
 		protected override string GetProviderTypeName(IDbDataParameter parameter)
 		{
-			return ((System.Data.SqlClient.SqlParameter)parameter).SqlDbType.ToString();
+			return ((dynamic)parameter).SqlDbType.ToString();
 		}
 
 		protected override void BuildTruncateTable(SqlTruncateTableStatement truncateTable)

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerTools.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerTools.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Reflection;
 
@@ -18,13 +17,32 @@ namespace LinqToDB.DataProvider.SqlServer
 	{
 		#region Init
 
+		public static SqlServerProvider Provider = SqlServerProvider.Default;
+
 		private static readonly Func<string, string> _quoteIdentifier;
 
-		static readonly SqlServerDataProvider _sqlServerDataProvider2000 = new SqlServerDataProvider(ProviderName.SqlServer2000, SqlServerVersion.v2000);
-		static readonly SqlServerDataProvider _sqlServerDataProvider2005 = new SqlServerDataProvider(ProviderName.SqlServer2005, SqlServerVersion.v2005);
-		static readonly SqlServerDataProvider _sqlServerDataProvider2008 = new SqlServerDataProvider(ProviderName.SqlServer2008, SqlServerVersion.v2008);
-		static readonly SqlServerDataProvider _sqlServerDataProvider2012 = new SqlServerDataProvider(ProviderName.SqlServer2012, SqlServerVersion.v2012);
-		static readonly SqlServerDataProvider _sqlServerDataProvider2017 = new SqlServerDataProvider(ProviderName.SqlServer2017, SqlServerVersion.v2017);
+#if NET45 || NET46
+		// System.Data
+		static readonly SqlServerDataProvider _sqlServerDataProvider2000sd = new SqlServerDataProvider(ProviderName.SqlServer2000, SqlServerVersion.v2000, SqlServerProvider.SystemData);
+		static readonly SqlServerDataProvider _sqlServerDataProvider2005sd = new SqlServerDataProvider(ProviderName.SqlServer2005, SqlServerVersion.v2005, SqlServerProvider.SystemData);
+		static readonly SqlServerDataProvider _sqlServerDataProvider2008sd = new SqlServerDataProvider(ProviderName.SqlServer2008, SqlServerVersion.v2008, SqlServerProvider.SystemData);
+		static readonly SqlServerDataProvider _sqlServerDataProvider2012sd = new SqlServerDataProvider(ProviderName.SqlServer2012, SqlServerVersion.v2012, SqlServerProvider.SystemData);
+		static readonly SqlServerDataProvider _sqlServerDataProvider2017sd = new SqlServerDataProvider(ProviderName.SqlServer2017, SqlServerVersion.v2017, SqlServerProvider.SystemData);
+#endif
+
+		// System.Data.SqlClient
+		static readonly SqlServerDataProvider _sqlServerDataProvider2000sdc = new SqlServerDataProvider(ProviderName.SqlServer2000, SqlServerVersion.v2000, SqlServerProvider.SystemDataSqlClient);
+		static readonly SqlServerDataProvider _sqlServerDataProvider2005sdc = new SqlServerDataProvider(ProviderName.SqlServer2005, SqlServerVersion.v2005, SqlServerProvider.SystemDataSqlClient);
+		static readonly SqlServerDataProvider _sqlServerDataProvider2008sdc = new SqlServerDataProvider(ProviderName.SqlServer2008, SqlServerVersion.v2008, SqlServerProvider.SystemDataSqlClient);
+		static readonly SqlServerDataProvider _sqlServerDataProvider2012sdc = new SqlServerDataProvider(ProviderName.SqlServer2012, SqlServerVersion.v2012, SqlServerProvider.SystemDataSqlClient);
+		static readonly SqlServerDataProvider _sqlServerDataProvider2017sdc = new SqlServerDataProvider(ProviderName.SqlServer2017, SqlServerVersion.v2017, SqlServerProvider.SystemDataSqlClient);
+
+		// Microsoft.Data.SqlClient
+		static readonly SqlServerDataProvider _sqlServerDataProvider2000mdc = new SqlServerDataProvider(ProviderName.SqlServer2000, SqlServerVersion.v2000, SqlServerProvider.MicrosoftDataSqlClient);
+		static readonly SqlServerDataProvider _sqlServerDataProvider2005mdc = new SqlServerDataProvider(ProviderName.SqlServer2005, SqlServerVersion.v2005, SqlServerProvider.MicrosoftDataSqlClient);
+		static readonly SqlServerDataProvider _sqlServerDataProvider2008mdc = new SqlServerDataProvider(ProviderName.SqlServer2008, SqlServerVersion.v2008, SqlServerProvider.MicrosoftDataSqlClient);
+		static readonly SqlServerDataProvider _sqlServerDataProvider2012mdc = new SqlServerDataProvider(ProviderName.SqlServer2012, SqlServerVersion.v2012, SqlServerProvider.MicrosoftDataSqlClient);
+		static readonly SqlServerDataProvider _sqlServerDataProvider2017mdc = new SqlServerDataProvider(ProviderName.SqlServer2017, SqlServerVersion.v2017, SqlServerProvider.MicrosoftDataSqlClient);
 
 		public static bool AutoDetectProvider { get; set; }
 
@@ -32,13 +50,38 @@ namespace LinqToDB.DataProvider.SqlServer
 		{
 			AutoDetectProvider = true;
 
-			DataConnection.AddDataProvider(ProviderName.SqlServer,     _sqlServerDataProvider2008);
-			DataConnection.AddDataProvider(ProviderName.SqlServer2014, _sqlServerDataProvider2012);
-			DataConnection.AddDataProvider(_sqlServerDataProvider2017);
-			DataConnection.AddDataProvider(_sqlServerDataProvider2012);
-			DataConnection.AddDataProvider(_sqlServerDataProvider2008);
-			DataConnection.AddDataProvider(_sqlServerDataProvider2005);
-			DataConnection.AddDataProvider(_sqlServerDataProvider2000);
+			switch (Provider)
+			{
+#if NET45 || NET46
+				case SqlServerProvider.SystemData:
+					DataConnection.AddDataProvider(ProviderName.SqlServer, _sqlServerDataProvider2008sd);
+					DataConnection.AddDataProvider(ProviderName.SqlServer2014, _sqlServerDataProvider2012sd);
+					DataConnection.AddDataProvider(_sqlServerDataProvider2017sd);
+					DataConnection.AddDataProvider(_sqlServerDataProvider2012sd);
+					DataConnection.AddDataProvider(_sqlServerDataProvider2008sd);
+					DataConnection.AddDataProvider(_sqlServerDataProvider2005sd);
+					DataConnection.AddDataProvider(_sqlServerDataProvider2000sd);
+					break;
+#endif
+				case SqlServerProvider.SystemDataSqlClient:
+					DataConnection.AddDataProvider(ProviderName.SqlServer, _sqlServerDataProvider2008sdc);
+					DataConnection.AddDataProvider(ProviderName.SqlServer2014, _sqlServerDataProvider2012sdc);
+					DataConnection.AddDataProvider(_sqlServerDataProvider2017sdc);
+					DataConnection.AddDataProvider(_sqlServerDataProvider2012sdc);
+					DataConnection.AddDataProvider(_sqlServerDataProvider2008sdc);
+					DataConnection.AddDataProvider(_sqlServerDataProvider2005sdc);
+					DataConnection.AddDataProvider(_sqlServerDataProvider2000sdc);
+					break;
+				case SqlServerProvider.MicrosoftDataSqlClient:
+					DataConnection.AddDataProvider(ProviderName.SqlServer, _sqlServerDataProvider2008mdc);
+					DataConnection.AddDataProvider(ProviderName.SqlServer2014, _sqlServerDataProvider2012mdc);
+					DataConnection.AddDataProvider(_sqlServerDataProvider2017mdc);
+					DataConnection.AddDataProvider(_sqlServerDataProvider2012mdc);
+					DataConnection.AddDataProvider(_sqlServerDataProvider2008mdc);
+					DataConnection.AddDataProvider(_sqlServerDataProvider2005mdc);
+					DataConnection.AddDataProvider(_sqlServerDataProvider2000mdc);
+					break;
+			}
 
 			DataConnection.AddProviderDetector(ProviderDetector);
 
@@ -48,7 +91,6 @@ namespace LinqToDB.DataProvider.SqlServer
 			}
 			catch
 			{
-				// see https://github.com/linq2db/linq2db/issues/1487
 			}
 
 			if (_quoteIdentifier == null)
@@ -56,16 +98,15 @@ namespace LinqToDB.DataProvider.SqlServer
 
 		}
 
-#if !NETSTANDARD2_0
-		private static Func<string, string> TryToUseCommandBuilder()
-		{
-			return new SqlCommandBuilder().QuoteIdentifier;
-		}
-#else
-		// this sad code needed for mono linker https://github.com/linq2db/linq2db/issues/1487
+		// also check https://github.com/linq2db/linq2db/issues/1487
 		private static Func<string, string> TryToUseCommandBuilder()
 		{
 			var type = Type.GetType("System.Data.SqlClient.SqlCommandBuilder, System.Data.SqlClient", false);
+			type = type ?? Type.GetType("System.Data.SqlClient.SqlCommandBuilder, Microsoft.Data.SqlClient", false);
+#if NET45 || NET46
+			type = type ?? Type.GetType("System.Data.SqlClient.SqlCommandBuilder, System.Data", false);
+#endif
+
 			if (type != null)
 			{
 				var mi = type.GetMethod("QuoteIdentifier", BindingFlags.Public | BindingFlags.Instance);
@@ -75,7 +116,6 @@ namespace LinqToDB.DataProvider.SqlServer
 
 			return null;
 		}
-#endif
 
 		internal static string QuoteIdentifier(string identifier)
 		{
@@ -84,8 +124,18 @@ namespace LinqToDB.DataProvider.SqlServer
 
 		static IDataProvider ProviderDetector(IConnectionStringSettings css, string connectionString)
 		{
-			//if (css.IsGlobal /* DataConnection.IsMachineConfig(css)*/)
-			//	return null;
+			var provider = Provider;
+
+			if (css.ProviderName == "Microsoft.Data.SqlClient")
+			{
+				provider = SqlServerProvider.MicrosoftDataSqlClient;
+			}
+			else if (css.ProviderName == "System.Data.SqlClient")
+			{
+				// not sure about it, netfx applications will start failing if they were using sql client from System.Data
+				// with this provider name
+				provider = SqlServerProvider.SystemDataSqlClient;
+			}
 
 			switch (css.ProviderName)
 			{
@@ -96,34 +146,34 @@ namespace LinqToDB.DataProvider.SqlServer
 						goto case "SqlServer";
 					break;
 
-				case "SqlServer2000"         :
-				case "SqlServer.2000"        : return _sqlServerDataProvider2000;
-				case "SqlServer2005"         :
-				case "SqlServer.2005"        : return _sqlServerDataProvider2005;
-				case "SqlServer2008"         :
-				case "SqlServer.2008"        : return _sqlServerDataProvider2008;
-				case "SqlServer2012"         :
-				case "SqlServer.2012"        : return _sqlServerDataProvider2012;
-				case "SqlServer2014"         :
-				case "SqlServer.2014"        :
-				case "SqlServer2016"         :
-				case "SqlServer.2016"        : return _sqlServerDataProvider2012;
-				case "SqlServer2017"         :
-				case "SqlServer.2017"        :
-				case "SqlServer2019"         :
-				case "SqlServer.2019"        : return _sqlServerDataProvider2017;
+				case "SqlServer2000"            :
+				case "SqlServer.2000"           : return GetDataProvider(SqlServerVersion.v2000, provider);
+				case "SqlServer2005"            :
+				case "SqlServer.2005"           : return GetDataProvider(SqlServerVersion.v2005, provider);
+				case "SqlServer2008"            :
+				case "SqlServer.2008"           : return GetDataProvider(SqlServerVersion.v2008, provider);
+				case "SqlServer2012"            :
+				case "SqlServer.2012"           :
+				case "SqlServer2014"            :
+				case "SqlServer.2014"           :
+				case "SqlServer2016"            :
+				case "SqlServer.2016"           : return GetDataProvider(SqlServerVersion.v2012, provider);
+				case "SqlServer2017"            :
+				case "SqlServer.2017"           :
+				case "SqlServer2019"            :
+				case "SqlServer.2019"           : return GetDataProvider(SqlServerVersion.v2017, provider);
 
-				case "SqlServer"             :
-				case "System.Data.SqlClient" :
+				case "SqlServer"                :
+				case "System.Data.SqlClient"    :
+				case "Microsoft.Data.SqlClient" :
 
-					if (css.Name.Contains("2000")) return _sqlServerDataProvider2000;
-					if (css.Name.Contains("2005")) return _sqlServerDataProvider2005;
-					if (css.Name.Contains("2008")) return _sqlServerDataProvider2008;
-					if (css.Name.Contains("2012")) return _sqlServerDataProvider2012;
-					if (css.Name.Contains("2014")) return _sqlServerDataProvider2012;
-					if (css.Name.Contains("2016")) return _sqlServerDataProvider2012;
-					if (css.Name.Contains("2017")) return _sqlServerDataProvider2017;
-					if (css.Name.Contains("2019")) return _sqlServerDataProvider2017;
+					if (css.Name.Contains("2000"))	return GetDataProvider(SqlServerVersion.v2000, provider);
+					if (css.Name.Contains("2005"))	return GetDataProvider(SqlServerVersion.v2005, provider);
+					if (css.Name.Contains("2008"))	return GetDataProvider(SqlServerVersion.v2008, provider);
+					if (css.Name.Contains("2012") || css.Name.Contains("2014") || css.Name.Contains("2016"))
+													return GetDataProvider(SqlServerVersion.v2012, provider);
+					if (css.Name.Contains("2017") || css.Name.Contains("2019"))
+													return GetDataProvider(SqlServerVersion.v2017, provider);
 
 					if (AutoDetectProvider)
 					{
@@ -131,14 +181,15 @@ namespace LinqToDB.DataProvider.SqlServer
 						{
 							var cs = string.IsNullOrWhiteSpace(connectionString) ? css.ConnectionString : connectionString;
 
-							using (var conn = new SqlConnection(cs))
+							using (var conn = CreateConnection(provider, cs))
 							{
 								conn.Open();
+								dynamic dconn = conn;
 
-								if (int.TryParse(conn.ServerVersion.Split('.')[0], out var version))
+								if (int.TryParse(((string)dconn.ServerVersion).Split('.')[0], out var version))
 								{
 									if (version <= 8)
-										return _sqlServerDataProvider2000;
+										return GetDataProvider(SqlServerVersion.v2000, provider);
 
 									using (var cmd = conn.CreateCommand())
 									{
@@ -146,34 +197,34 @@ namespace LinqToDB.DataProvider.SqlServer
 										var level = Converter.ChangeTypeTo<int>(cmd.ExecuteScalar());
 
 										if (level >= 140)
-											return _sqlServerDataProvider2017;
+											return GetDataProvider(SqlServerVersion.v2017, provider);
 										if (level >= 110)
-											return _sqlServerDataProvider2012;
+											return GetDataProvider(SqlServerVersion.v2012, provider);
 										if (level >= 100)
-											return _sqlServerDataProvider2008;
+											return GetDataProvider(SqlServerVersion.v2008, provider);
 										if (level >= 90)
-											return _sqlServerDataProvider2005;
+											return GetDataProvider(SqlServerVersion.v2005, provider);
 										if (level >= 80)
-											return _sqlServerDataProvider2000;
+											return GetDataProvider(SqlServerVersion.v2000, provider);
 
 										switch (version)
 										{
-											case  8 : return _sqlServerDataProvider2000;
-											case  9 : return _sqlServerDataProvider2005;
-											case 10 : return _sqlServerDataProvider2008;
-											case 11 : return _sqlServerDataProvider2012;
-											case 12 : return _sqlServerDataProvider2012;
-											case 14 : return _sqlServerDataProvider2017;
+											case  8 : return GetDataProvider(SqlServerVersion.v2000, provider);
+											case  9 : return GetDataProvider(SqlServerVersion.v2005, provider);
+											case 10 : return GetDataProvider(SqlServerVersion.v2008, provider);
+											case 11 :
+											case 12 : return GetDataProvider(SqlServerVersion.v2012, provider);
+											case 14 : return GetDataProvider(SqlServerVersion.v2017, provider);
 											default :
 												if (version > 14)
-													return _sqlServerDataProvider2017;
-												return _sqlServerDataProvider2008;
+													return GetDataProvider(SqlServerVersion.v2017, provider);
+												return GetDataProvider(SqlServerVersion.v2008, provider);
 										}
 									}
 								}
 							}
 						}
-						catch (Exception)
+						catch
 						{
 						}
 					}
@@ -184,39 +235,113 @@ namespace LinqToDB.DataProvider.SqlServer
 			return null;
 		}
 
-#endregion
-
-		#region Public Members
-
-		public static IDataProvider GetDataProvider(SqlServerVersion version = SqlServerVersion.v2008)
+		private static IDbConnection CreateConnection(SqlServerProvider provider, string connectionString)
 		{
-			switch (version)
+			Type type;
+			switch (provider)
 			{
-				case SqlServerVersion.v2000 : return _sqlServerDataProvider2000;
-				case SqlServerVersion.v2005 : return _sqlServerDataProvider2005;
-				case SqlServerVersion.v2012 : return _sqlServerDataProvider2012;
-				case SqlServerVersion.v2017 : return _sqlServerDataProvider2017;
+#if NET45 || NET46
+				case SqlServerProvider.SystemData:
+					type = typeof(System.Data.SqlClient.SqlConnection);
+					break;
+#endif
+				case SqlServerProvider.SystemDataSqlClient:
+					type = Type.GetType("System.Data.SqlClient.SqlConnection, System.Data.SqlClient");
+					break;
+				case SqlServerProvider.MicrosoftDataSqlClient:
+					type = Type.GetType("Microsoft.Data.SqlClient.SqlConnection, Microsoft.Data.SqlClient");
+					break;
+				default:
+					throw new InvalidOperationException();
 			}
 
-			return _sqlServerDataProvider2008;
+			return (IDbConnection)Activator.CreateInstance(type, connectionString);
+		}
+
+#endregion
+
+#region Public Members
+
+		public static IDataProvider GetDataProvider(
+			SqlServerVersion version   = SqlServerVersion.v2008,
+			SqlServerProvider provider = SqlServerProvider.Default)
+		{
+			switch (provider)
+			{
+#if NET45 || NET46
+				case SqlServerProvider.SystemData:
+					switch (version)
+					{
+						case SqlServerVersion.v2000: return _sqlServerDataProvider2000sd;
+						case SqlServerVersion.v2005: return _sqlServerDataProvider2005sd;
+						case SqlServerVersion.v2012: return _sqlServerDataProvider2012sd;
+						case SqlServerVersion.v2017: return _sqlServerDataProvider2017sd;
+						default: return _sqlServerDataProvider2008sd;
+					}
+#endif
+				case SqlServerProvider.SystemDataSqlClient:
+					switch (version)
+					{
+						case SqlServerVersion.v2000: return _sqlServerDataProvider2000sdc;
+						case SqlServerVersion.v2005: return _sqlServerDataProvider2005sdc;
+						case SqlServerVersion.v2012: return _sqlServerDataProvider2012sdc;
+						case SqlServerVersion.v2017: return _sqlServerDataProvider2017sdc;
+						default: return _sqlServerDataProvider2008sdc;
+					}
+				case SqlServerProvider.MicrosoftDataSqlClient:
+					switch (version)
+					{
+						case SqlServerVersion.v2000: return _sqlServerDataProvider2000mdc;
+						case SqlServerVersion.v2005: return _sqlServerDataProvider2005mdc;
+						case SqlServerVersion.v2012: return _sqlServerDataProvider2012mdc;
+						case SqlServerVersion.v2017: return _sqlServerDataProvider2017mdc;
+						default: return _sqlServerDataProvider2008mdc;
+					}
+				default:
+#if NET45 || NET46
+					return _sqlServerDataProvider2008sd;
+#else
+					return _sqlServerDataProvider2008sdc;
+#endif
+			}
+		}
+
+		private static IEnumerable<SqlServerDataProvider> Providers
+		{
+			get
+			{
+#if NET45 || NET46
+				yield return _sqlServerDataProvider2000sd;
+				yield return _sqlServerDataProvider2005sd;
+				yield return _sqlServerDataProvider2008sd;
+				yield return _sqlServerDataProvider2012sd;
+				yield return _sqlServerDataProvider2017sd;
+#endif
+
+				yield return _sqlServerDataProvider2000sdc;
+				yield return _sqlServerDataProvider2005sdc;
+				yield return _sqlServerDataProvider2008sdc;
+				yield return _sqlServerDataProvider2012sdc;
+				yield return _sqlServerDataProvider2017sdc;
+
+				yield return _sqlServerDataProvider2000mdc;
+				yield return _sqlServerDataProvider2005mdc;
+				yield return _sqlServerDataProvider2008mdc;
+				yield return _sqlServerDataProvider2012mdc;
+				yield return _sqlServerDataProvider2017mdc;
+			}
 		}
 
 		public static void AddUdtType(Type type, string udtName)
 		{
-			_sqlServerDataProvider2000.AddUdtType(type, udtName);
-			_sqlServerDataProvider2005.AddUdtType(type, udtName);
-			_sqlServerDataProvider2008.AddUdtType(type, udtName);
-			_sqlServerDataProvider2012.AddUdtType(type, udtName);
-			_sqlServerDataProvider2017.AddUdtType(type, udtName);
+			foreach (var provider in Providers)
+				provider.AddUdtType(type, udtName);
 		}
 
 		public static void AddUdtType<T>(string udtName, T nullValue, DataType dataType = DataType.Undefined)
 		{
-			_sqlServerDataProvider2000.AddUdtType(udtName, nullValue, dataType);
-			_sqlServerDataProvider2005.AddUdtType(udtName, nullValue, dataType);
-			_sqlServerDataProvider2008.AddUdtType(udtName, nullValue, dataType);
-			_sqlServerDataProvider2012.AddUdtType(udtName, nullValue, dataType);
-			_sqlServerDataProvider2017.AddUdtType(udtName, nullValue, dataType);
+			foreach (var provider in Providers)
+				provider.AddUdtType(udtName, nullValue, dataType);
 		}
 
 		/// <summary>
@@ -255,52 +380,37 @@ namespace LinqToDB.DataProvider.SqlServer
 			SqlGeometryType    = sqlGeometryType;
 		}
 
-		#endregion
+#endregion
 
-		#region CreateDataConnection
+#region CreateDataConnection
 
-		public static DataConnection CreateDataConnection(string connectionString, SqlServerVersion version = SqlServerVersion.v2008)
+		public static DataConnection CreateDataConnection(
+			string            connectionString,
+			SqlServerVersion  version  = SqlServerVersion.v2008,
+			SqlServerProvider provider = SqlServerProvider.Default)
 		{
-			switch (version)
-			{
-				case SqlServerVersion.v2000 : return new DataConnection(_sqlServerDataProvider2000, connectionString);
-				case SqlServerVersion.v2005 : return new DataConnection(_sqlServerDataProvider2005, connectionString);
-				case SqlServerVersion.v2012 : return new DataConnection(_sqlServerDataProvider2012, connectionString);
-				case SqlServerVersion.v2017 : return new DataConnection(_sqlServerDataProvider2017, connectionString);
-			}
-
-			return new DataConnection(_sqlServerDataProvider2008, connectionString);
+			return new DataConnection(GetDataProvider(version, provider), connectionString);
 		}
 
-		public static DataConnection CreateDataConnection(IDbConnection connection, SqlServerVersion version = SqlServerVersion.v2008)
+		public static DataConnection CreateDataConnection(
+			IDbConnection     connection,
+			SqlServerVersion  version  = SqlServerVersion.v2008,
+			SqlServerProvider provider = SqlServerProvider.Default)
 		{
-			switch (version)
-			{
-				case SqlServerVersion.v2000 : return new DataConnection(_sqlServerDataProvider2000, connection);
-				case SqlServerVersion.v2005 : return new DataConnection(_sqlServerDataProvider2005, connection);
-				case SqlServerVersion.v2012 : return new DataConnection(_sqlServerDataProvider2012, connection);
-				case SqlServerVersion.v2017 : return new DataConnection(_sqlServerDataProvider2017, connection);
-			}
-
-			return new DataConnection(_sqlServerDataProvider2008, connection);
+			return new DataConnection(GetDataProvider(version, provider), connection);
 		}
 
-		public static DataConnection CreateDataConnection(IDbTransaction transaction, SqlServerVersion version = SqlServerVersion.v2008)
+		public static DataConnection CreateDataConnection(
+			IDbTransaction    transaction,
+			SqlServerVersion  version  = SqlServerVersion.v2008,
+			SqlServerProvider provider = SqlServerProvider.Default)
 		{
-			switch (version)
-			{
-				case SqlServerVersion.v2000 : return new DataConnection(_sqlServerDataProvider2000, transaction);
-				case SqlServerVersion.v2005 : return new DataConnection(_sqlServerDataProvider2005, transaction);
-				case SqlServerVersion.v2012 : return new DataConnection(_sqlServerDataProvider2012, transaction);
-				case SqlServerVersion.v2017 : return new DataConnection(_sqlServerDataProvider2017, transaction);
-			}
-
-			return new DataConnection(_sqlServerDataProvider2008, transaction);
+			return new DataConnection(GetDataProvider(version, provider), transaction);
 		}
 
-		#endregion
+#endregion
 
-		#region BulkCopy
+#region BulkCopy
 
 		public  static BulkCopyType  DefaultBulkCopyType { get; set; } = BulkCopyType.ProviderSpecific;
 
@@ -328,7 +438,7 @@ namespace LinqToDB.DataProvider.SqlServer
 				}, source);
 		}
 
-		#endregion
+#endregion
 
 		public static class Sql
 		{

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseDataProvider.cs
@@ -8,7 +8,6 @@ using System.Xml.Linq;
 namespace LinqToDB.DataProvider.Sybase
 {
 	using Data;
-	using LinqToDB.Linq;
 	using Mapping;
 	using Common;
 	using SchemaProvider;

--- a/Source/LinqToDB/Extensions/ReflectionExtensions.cs
+++ b/Source/LinqToDB/Extensions/ReflectionExtensions.cs
@@ -574,6 +574,19 @@ namespace LinqToDB.Extensions
 			return typeof(object);
 		}
 
+		public static bool IsEnumerableTType(this Type type, Type elementType)
+		{
+			foreach (var interfaceType in type.GetInterfaces())
+			{
+				if (interfaceType.IsGenericType
+						&& interfaceType.GetGenericTypeDefinition() == typeof(IEnumerable<>)
+						&& interfaceType.GetGenericArguments()[0] == elementType)
+					return true;
+			}
+
+			return false;
+		}
+
 		public static bool IsGenericEnumerableType(this Type type)
 		{
 			if (type.IsGenericType)

--- a/Source/LinqToDB/LinqToDB.csproj
+++ b/Source/LinqToDB/LinqToDB.csproj
@@ -70,7 +70,6 @@
 		<Compile Include="Compatibility\System\Diagnostics\CodeAnalysis\NullableAttributes.cs" />
 
 		<PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
-		<PackageReference Include="System.Data.SqlClient" Version="4.7.0" />
 		<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
 		<PackageReference Include="System.ComponentModel.Annotations" Version="4.6.0" />
 		<PackageReference Include="System.Data.Odbc" Version="4.6.0" />

--- a/Source/LinqToDB/Mapping/MappingSchema.cs
+++ b/Source/LinqToDB/Mapping/MappingSchema.cs
@@ -844,7 +844,7 @@ namespace LinqToDB.Mapping
 		/// - <see cref="LinqToDB.Metadata.MetadataReader"/> - aggregation metadata provider over collection of other providers;
 		/// - <see cref="AttributeReader"/> - .NET attributes provider;
 		/// - <see cref="FluentMetadataReader"/> - fluent mappings metadata provider;
-		/// - <see cref="SystemDataSqlServerAttributeReader"/> - metadata provider that converts <see cref="Microsoft.SqlServer.Server"/> attributes to LINQ to DB mapping attributes;
+		/// - <see cref="SystemDataSqlServerAttributeReader"/> - metadata provider that converts Microsoft.SqlServer.Server attributes to LINQ to DB mapping attributes;
 		/// - <see cref="XmlAttributeReader"/> - XML-based mappings metadata provider.
 		/// </summary>
 #endif

--- a/Tests/Linq/DataProvider/SqlServerTests.cs
+++ b/Tests/Linq/DataProvider/SqlServerTests.cs
@@ -1153,7 +1153,7 @@ namespace Tests.DataProvider
 		{
 			try
 			{
-				var value = ((SqlDataReader)rd).GetSqlDecimal(idx);
+				SqlDecimal value = ((dynamic)rd).GetSqlDecimal(idx);
 
 				if (value.Precision > ClrPrecision)
 				{

--- a/Tests/Linq/DataProvider/SqlServerTests.cs
+++ b/Tests/Linq/DataProvider/SqlServerTests.cs
@@ -107,9 +107,12 @@ namespace Tests.DataProvider
 				Assert.That(TestType<DateTime?>      (conn, "datetime2DataType",      DataType.DateTime2,      "AllTypes2"), Is.EqualTo(new DateTime(2012, 12, 12, 12, 12, 12, 12)));
 				Assert.That(TestType<TimeSpan?>      (conn, "timeDataType",           DataType.Time,           "AllTypes2"), Is.EqualTo(new TimeSpan(0, 12, 12, 12, 12)));
 
-				Assert.That(TestType<SqlHierarchyId?>(conn, "hierarchyidDataType",              tableName:"AllTypes2"),            Is.EqualTo(SqlHierarchyId.Parse("/1/3/")));
-				Assert.That(TestType<SqlGeography>   (conn, "geographyDataType", skipPass:true, tableName:"AllTypes2").ToString(), Is.EqualTo("LINESTRING (-122.36 47.656, -122.343 47.656)"));
-				Assert.That(TestType<SqlGeometry>    (conn, "geometryDataType",  skipPass:true, tableName:"AllTypes2").ToString(), Is.EqualTo("LINESTRING (100 100, 20 180, 180 180)"));
+				if (!IsMsProvider(context))
+				{
+					Assert.That(TestType<SqlHierarchyId?>(conn, "hierarchyidDataType",              tableName:"AllTypes2"),            Is.EqualTo(SqlHierarchyId.Parse("/1/3/")));
+					Assert.That(TestType<SqlGeography>   (conn, "geographyDataType", skipPass:true, tableName:"AllTypes2").ToString(), Is.EqualTo("LINESTRING (-122.36 47.656, -122.343 47.656)"));
+					Assert.That(TestType<SqlGeometry>    (conn, "geometryDataType",  skipPass:true, tableName:"AllTypes2").ToString(), Is.EqualTo("LINESTRING (100 100, 20 180, 180 180)"));
+				}
 			}
 		}
 
@@ -584,6 +587,9 @@ namespace Tests.DataProvider
 		[Test]
 		public void TestHierarchyID([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
 		{
+			if (IsMsProvider(context))
+				Assert.Inconclusive("Spatial types test disabled for Microsoft.Data.SqlClient");
+
 			using (var conn = new DataConnection(context))
 			{
 				var id = SqlHierarchyId.Parse("/1/3/");
@@ -600,6 +606,9 @@ namespace Tests.DataProvider
 		[Test]
 		public void TestGeometry([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
 		{
+			if (IsMsProvider(context))
+				Assert.Inconclusive("Spatial types test disabled for Microsoft.Data.SqlClient");
+
 			using (var conn = new DataConnection(context))
 			{
 				var id = SqlGeometry.Parse("LINESTRING (100 100, 20 180, 180 180)");
@@ -619,6 +628,9 @@ namespace Tests.DataProvider
 		[Test]
 		public void TestGeography([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
 		{
+			if (IsMsProvider(context))
+				Assert.Inconclusive("Spatial types test disabled for Microsoft.Data.SqlClient");
+
 			using (var conn = new DataConnection(context))
 			{
 				var id = SqlGeography.Parse("LINESTRING (-122.36 47.656, -122.343 47.656)");
@@ -998,6 +1010,9 @@ namespace Tests.DataProvider
 
 		void BulkCopyAllTypes2(string context, BulkCopyType bulkCopyType)
 		{
+			if (IsMsProvider(context))
+				Assert.Inconclusive("Spatial types test disabled for Microsoft.Data.SqlClient");
+
 			using (var db = new DataConnection(context))
 			{
 				db.CommandTimeout = 60;
@@ -1026,6 +1041,9 @@ namespace Tests.DataProvider
 		[Test]
 		public void BulkCopyAllTypes2MultipleRows([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
 		{
+			if (IsMsProvider(context))
+				Assert.Inconclusive("Spatial types test disabled for Microsoft.Data.SqlClient");
+
 			BulkCopyAllTypes2(context, BulkCopyType.MultipleRows);
 		}
 
@@ -1391,6 +1409,11 @@ namespace Tests.DataProvider
 				Assert.AreEqual(-1, rows);
 				Assert.AreEqual(4, result);
 			}
+		}
+
+		private bool IsMsProvider(string context)
+		{
+			return ((SqlServerDataProvider)DataConnection.GetDataProvider(GetProviderName(context, out var _))).Provider == SqlServerProvider.MicrosoftDataSqlClient;
 		}
 	}
 }

--- a/Tests/Linq/DataProvider/SqlServerTypesTests.TVP.cs
+++ b/Tests/Linq/DataProvider/SqlServerTypesTests.TVP.cs
@@ -12,6 +12,9 @@ using Microsoft.SqlServer.Server;
 
 using NUnit.Framework;
 
+using SqlDataRecordMS = Microsoft.Data.SqlClient.Server.SqlDataRecord;
+using SqlMetaDataMS = Microsoft.Data.SqlClient.Server.SqlMetaData;
+
 namespace Tests.DataProvider
 {
 	public partial class SqlServerTypesTests
@@ -61,14 +64,32 @@ namespace Tests.DataProvider
 			}
 		}
 
+		public static IEnumerable<SqlDataRecordMS> GetSqlDataRecordsMS()
+		{
+			var sqlRecord = new SqlDataRecordMS(
+				new SqlMetaDataMS("Id", SqlDbType.Int),
+				new SqlMetaDataMS("Name", SqlDbType.NVarChar, 10));
+
+			foreach (var record in TestData)
+			{
+				sqlRecord.SetValue(0, record.Id);
+				sqlRecord.SetValue(1, record.Name);
+
+				yield return sqlRecord;
+			}
+		}
+
 		public static IEnumerable<Func<DataConnection, object>> ParameterFactories
 		{
 			get
 			{
 				// as DataTable
 				yield return _ => GetDataTable();
+
 				// as IEnumerable<SqlDataRecord>
-				yield return _ => GetSqlDataRecords();
+				yield return _ => _.Connection is Microsoft.Data.SqlClient.SqlConnection
+				? (object)GetSqlDataRecordsMS()
+				: GetSqlDataRecords();
 
 				// TODO: doesn't work now as DbDataReader converted to Lst<object> of DbDataRecordInternal somewhere in linq2db
 				// before we can pass it to provider

--- a/Tests/Linq/DataProvider/SqlServerTypesTests.cs
+++ b/Tests/Linq/DataProvider/SqlServerTypesTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using LinqToDB;
 using LinqToDB.Common;
 using LinqToDB.Data;
+using LinqToDB.DataProvider.SqlServer;
 using LinqToDB.Mapping;
 
 using Microsoft.SqlServer.Types;
@@ -45,6 +46,11 @@ namespace Tests.DataProvider
 		[Test]
 		public void TestHierarchyId([IncludeDataSources(true, TestProvName.AllSqlServer2008Plus)] string context)
 		{
+#if NETCOREAPP2_1
+			if (IsMsProvider(context))
+				Assert.Inconclusive("Spatial types test disabled for Microsoft.Data.SqlClient");
+#endif
+
 			using (var conn = GetDataContext(context))
 			{
 				conn.GetTable<AllTypes2>()
@@ -82,6 +88,10 @@ namespace Tests.DataProvider
 		[Test]
 		public void TestGeography([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
 		{
+#if NETCOREAPP2_1
+			if (IsMsProvider(context))
+				Assert.Inconclusive("Spatial types test disabled for Microsoft.Data.SqlClient");
+#endif
 			using (var conn = GetDataContext(context))
 			{
 				conn.InlineParameters = true;
@@ -141,6 +151,9 @@ namespace Tests.DataProvider
 		[Test]
 		public void Where1([IncludeDataSources(true, TestProvName.AllSqlServer2008Plus)] string context)
 		{
+			if (IsMsProvider(context))
+				Assert.Inconclusive("Spatial types test disabled for Microsoft.Data.SqlClient");
+
 			using (var db = GetDataContext(context))
 			{
 				var hid = SqlHierarchyId.Parse("/1/");
@@ -156,6 +169,9 @@ namespace Tests.DataProvider
 		[Test]
 		public void Where2([IncludeDataSources(true, TestProvName.AllSqlServer2008Plus)] string context)
 		{
+			if (IsMsProvider(context))
+				Assert.Inconclusive("Spatial types test disabled for Microsoft.Data.SqlClient");
+
 			using (var db = GetDataContext(context))
 			{
 				var hid = SqlHierarchyId.Parse("/1/");
@@ -171,6 +187,9 @@ namespace Tests.DataProvider
 		[Test]
 		public void Where3([IncludeDataSources(true, TestProvName.AllSqlServer2008Plus)] string context)
 		{
+			if (IsMsProvider(context))
+				Assert.Inconclusive("Spatial types test disabled for Microsoft.Data.SqlClient");
+
 			using (var db = GetDataContext(context))
 			{
 				var hid = SqlHierarchyId.Parse("/1/");
@@ -186,6 +205,9 @@ namespace Tests.DataProvider
 		[Test]
 		public void Where4([IncludeDataSources(true, TestProvName.AllSqlServer2008Plus)] string context)
 		{
+			if (IsMsProvider(context))
+				Assert.Inconclusive("Spatial types test disabled for Microsoft.Data.SqlClient");
+
 			using (var db = GetDataContext(context))
 			{
 				var hid = SqlHierarchyId.Parse("/1/");
@@ -201,6 +223,9 @@ namespace Tests.DataProvider
 		[Test]
 		public void Where5([IncludeDataSources(true, TestProvName.AllSqlServer2008Plus)] string context)
 		{
+			if (IsMsProvider(context))
+				Assert.Inconclusive("Spatial types test disabled for Microsoft.Data.SqlClient");
+
 			using (var db = GetDataContext(context))
 			{
 				var hid = SqlHierarchyId.Parse("/1/");
@@ -216,6 +241,9 @@ namespace Tests.DataProvider
 		[Test]
 		public void Where6([IncludeDataSources(true, TestProvName.AllSqlServer2008Plus)] string context)
 		{
+			if (IsMsProvider(context))
+				Assert.Inconclusive("Spatial types test disabled for Microsoft.Data.SqlClient");
+
 			using (var db = GetDataContext(context))
 			{
 				var hid = SqlHierarchyId.Parse("/1/");
@@ -239,6 +267,9 @@ namespace Tests.DataProvider
 		[Test]
 		public void Where7([IncludeDataSources(true, TestProvName.AllSqlServer2008Plus)] string context)
 		{
+			if (IsMsProvider(context))
+				Assert.Inconclusive("Spatial types test disabled for Microsoft.Data.SqlClient");
+
 			using (var db = GetDataContext(context))
 			{
 				var hid = SqlHierarchyId.Parse("/1/");
@@ -254,6 +285,9 @@ namespace Tests.DataProvider
 		[Test]
 		public void Where8([IncludeDataSources(true, TestProvName.AllSqlServer2008Plus)] string context)
 		{
+			if (IsMsProvider(context))
+				Assert.Inconclusive("Spatial types test disabled for Microsoft.Data.SqlClient");
+
 			using (var db = GetDataContext(context))
 			{
 				var hid = SqlHierarchyId.Parse("/1/");
@@ -282,10 +316,18 @@ namespace Tests.DataProvider
 			};
 		}
 
+		private bool IsMsProvider(string context)
+		{
+			return ((SqlServerDataProvider)DataConnection.GetDataProvider(GetProviderName(context, out var _))).Provider == SqlServerProvider.MicrosoftDataSqlClient;
+		}
+
 		// https://github.com/linq2db/linq2db/issues/1836
 		[Test]
 		public void SelectSqlGeography([IncludeDataSources(true, TestProvName.AllSqlServer2008Plus)] string context)
 		{
+			if (IsMsProvider(context))
+				Assert.Inconclusive("Spatial types test disabled for Microsoft.Data.SqlClient");
+
 			using (var db = GetDataContext(context))
 			using (var t  = db.CreateLocalTable(Issue1836.Data))
 			{

--- a/Tests/Linq/Exceptions/CommonTests.cs
+++ b/Tests/Linq/Exceptions/CommonTests.cs
@@ -85,8 +85,8 @@ namespace Tests.Exceptions
 
 				var n = 555;
 
-				Assert.Throws(
-					typeof(System.Data.SqlClient.SqlException),
+				var ex = Assert.Throws(
+					Is.AssignableTo<Exception>(),
 					() =>
 						db.Parent.Insert(() => new Parent
 						{
@@ -94,9 +94,10 @@ namespace Tests.Exceptions
 							Value1   = n
 						}),
 					"Invalid object name 'Parent1'.");
+				Assert.True(ex.GetType().Name == "SqlException");
 
-				Assert.Throws(
-					typeof(System.Data.SqlClient.SqlException),
+				ex = Assert.Throws(
+					Is.AssignableTo<Exception>(),
 					() =>
 						db.Parent.Insert(() => new Parent
 						{
@@ -104,6 +105,7 @@ namespace Tests.Exceptions
 							Value1   = n
 						}),
 					"Invalid object name 'Parent1'.");
+				Assert.True(ex.GetType().Name == "SqlException");
 
 				db.Parent.Delete(p => p.ParentID == n);
 			}

--- a/Tests/Tests.T4/Databases/SqlServer.MS.generated.cs
+++ b/Tests/Tests.T4/Databases/SqlServer.MS.generated.cs
@@ -21,7 +21,7 @@ using LinqToDB.Mapping;
 
 using Microsoft.SqlServer.Types;
 
-namespace DataModel
+namespace DataContextMS
 {
 	public partial class NorthwindDB : LinqToDB.Data.DataConnection
 	{

--- a/Tests/Tests.T4/Databases/SqlServer.MS.tt
+++ b/Tests/Tests.T4/Databases/SqlServer.MS.tt
@@ -1,0 +1,63 @@
+﻿<#@ template language="C#" debug="True" hostSpecific="True"                                #>
+<#@ output extension=".generated.cs"                                                       #>
+<#@ include file="..\Shared.ttinclude"                                                     #>
+<#@ include file="SqlServer.ttinclude"                                                     #>
+<#@ include file="..\..\..\Source\LinqToDB.Templates\LinqToDB.SqlServer.ttinclude"         #>
+<#@ include file="..\..\..\Source\LinqToDB.Templates\ObsoleteAttributes.ttinclude"         #>
+<#@ assembly name="$(SolutionDir)Tests\Linq\bin\Debug\net46\Microsoft.SqlServer.Types.dll" #>
+<#
+	NamespaceName   = "DataContextMS";
+//	DataContextName = "NorthwindDB";
+	DatabaseName    = null;//"Northwind";
+	GenerateDatabaseName = false;
+	OneToManyAssociationType = "List<{0}>";
+	GenerateSchemaAsType = true;
+	GenerateAssociationExtensions = true;
+//	BaseEntityClass = "object";
+//GenerateSqlServerFreeText = true;
+
+//	GenerateBackReferences = false;
+//	GenerateAssociations = true;
+
+//	GetSchemaOptions.GetProcedures = false;
+
+	IncludeDefaultSchema = false;
+	GenerateObsoleteAttributeForAliases = true;
+	GenerateDataTypes = true;
+	GenerateDbTypes   = true;
+
+	//GenerateSchemaAsType = true;
+
+	SchemaNameMapping.Add("TestSchema", "MySchema");
+
+	GenerateProcedureResultAsList = true;
+
+	GetSchemaOptions.LoadTable = t => t.Name != "Products" && t.Name != "Person";
+	
+	LoadSqlServerMetadata(GetConnectionString("Northwind"), SqlServerVersion.v2012, LinqToDB.DataProvider.SqlServer.SqlServerProvider.MicrosoftDataSqlClient);
+
+	Tables["Order Details"].Columns["OrderID"]. MemberName = "ID";
+
+	GetTable("Categories").   AliasPropertyName = "CATEG";
+	GetTable("Categories").   AliasTypeName     = "CATEG";
+	GetTable("Order Details").AliasPropertyName = "Order_Details";
+	GetTable("Order Details").AliasTypeName     = "ORD_DET";
+
+	var member = GetColumn("Categories", "CategoryID");
+	member.Attributes.Add(new Attribute("SequenceName", "\"https://github.com/linq2db/linq2db/issues/1866\""));
+
+	GenerateTypesFromMetadata();
+
+	DataContextName   = null;
+	DataContextObject = null;
+
+	DatabaseName = null;//"TestData";
+
+	//GenerateConstructors = false;
+
+	LoadSqlServerMetadata(GetConnectionString("SqlServer.2014"), SqlServerVersion.v2012, LinqToDB.DataProvider.SqlServer.SqlServerProvider.MicrosoftDataSqlClient);
+
+	AddReturnParameter("Issue1897");
+
+	GenerateModel();
+#>

--- a/Tests/Tests.T4/Tests.T4.csproj
+++ b/Tests/Tests.T4/Tests.T4.csproj
@@ -70,6 +70,10 @@
 			<Generator>TextTemplatingFileGenerator</Generator>
 			<LastGenOutput>SQLite.generated.cs</LastGenOutput>
 		</None>
+		<None Update="Databases\SqlServer.MS.tt">
+		  <LastGenOutput>SqlServer.MS.generated.cs</LastGenOutput>
+		  <Generator>TextTemplatingFileGenerator</Generator>
+		</None>
 		<None Update="Databases\SqlServerAzure.tt">
 			<LastGenOutput>SqlServerAzure.generated.cs</LastGenOutput>
 			<Generator>TextTemplatingFileGenerator</Generator>
@@ -217,6 +221,11 @@
 			<DesignTime>True</DesignTime>
 			<AutoGen>True</AutoGen>
 			<DependentUpon>SqlServer.tt</DependentUpon>
+		</Compile>
+		<Compile Update="Databases\SqlServer.MS.generated.cs">
+		  <DesignTime>True</DesignTime>
+		  <AutoGen>True</AutoGen>
+		  <DependentUpon>SqlServer.MS.tt</DependentUpon>
 		</Compile>
 		<Compile Update="Databases\SqlServerAzure.generated.cs">
 			<DesignTime>True</DesignTime>

--- a/linq2db.sln
+++ b/linq2db.sln
@@ -289,7 +289,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "netcoreapp21", "netcoreapp21", "{9C01FF5E-F85A-4561-A05B-8F32A4E11C6D}"
 	ProjectSection(SolutionItems) = preProject
 		Build\Azure\netcoreapp21\access.ace.json = Build\Azure\netcoreapp21\access.ace.json
-		Build\Azure\netcoreapp21\access.json = Build\Azure\netcoreapp21\access.json
 		Build\Azure\netcoreapp21\db2.json = Build\Azure\netcoreapp21\db2.json
 		Build\Azure\netcoreapp21\firebird25.json = Build\Azure\netcoreapp21\firebird25.json
 		Build\Azure\netcoreapp21\firebird3.json = Build\Azure\netcoreapp21\firebird3.json

--- a/linq2db.sln
+++ b/linq2db.sln
@@ -288,6 +288,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "net46", "net46", "{B7AADC73
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "netcoreapp21", "netcoreapp21", "{9C01FF5E-F85A-4561-A05B-8F32A4E11C6D}"
 	ProjectSection(SolutionItems) = preProject
+		Build\Azure\netcoreapp21\access.ace.json = Build\Azure\netcoreapp21\access.ace.json
+		Build\Azure\netcoreapp21\access.json = Build\Azure\netcoreapp21\access.json
 		Build\Azure\netcoreapp21\db2.json = Build\Azure\netcoreapp21\db2.json
 		Build\Azure\netcoreapp21\firebird25.json = Build\Azure\netcoreapp21\firebird25.json
 		Build\Azure\netcoreapp21\firebird3.json = Build\Azure\netcoreapp21\firebird3.json
@@ -305,6 +307,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "netcoreapp21", "netcoreapp2
 		Build\Azure\netcoreapp21\pgsql92.json = Build\Azure\netcoreapp21\pgsql92.json
 		Build\Azure\netcoreapp21\pgsql93.json = Build\Azure\netcoreapp21\pgsql93.json
 		Build\Azure\netcoreapp21\pgsql95.json = Build\Azure\netcoreapp21\pgsql95.json
+		Build\Azure\netcoreapp21\sqlce.json = Build\Azure\netcoreapp21\sqlce.json
 		Build\Azure\netcoreapp21\sqlite.json = Build\Azure\netcoreapp21\sqlite.json
 		Build\Azure\netcoreapp21\sqlite.ms.json = Build\Azure\netcoreapp21\sqlite.ms.json
 		Build\Azure\netcoreapp21\sqlserver.2017.json = Build\Azure\netcoreapp21\sqlserver.2017.json

--- a/linq2db.sln
+++ b/linq2db.sln
@@ -199,6 +199,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SqlServer", "SqlServer", "{949EA01F-64E8-4AB4-8120-699D79A51F6E}"
 	ProjectSection(SolutionItems) = preProject
 		NuGet\SqlServer\CopyMe.SqlServer.tt.txt = NuGet\SqlServer\CopyMe.SqlServer.tt.txt
+		NuGet\linq2db.SqlServer.MS.nuspec = NuGet\linq2db.SqlServer.MS.nuspec
 		NuGet\linq2db.SqlServer.nuspec = NuGet\linq2db.SqlServer.nuspec
 		NuGet\SqlServer\linq2db.SqlServer.props = NuGet\SqlServer\linq2db.SqlServer.props
 		NuGet\SqlServer\LinqToDB.SqlServer.SqlTypes.Tools.ttinclude = NuGet\SqlServer\LinqToDB.SqlServer.SqlTypes.Tools.ttinclude

--- a/linq2db.sln
+++ b/linq2db.sln
@@ -318,6 +318,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{49A37E5A-A8A3-4C89-B11C-D700A9F52BAA}"
 	ProjectSection(SolutionItems) = preProject
 		Build\Azure\scripts\access.ace.cmd = Build\Azure\scripts\access.ace.cmd
+		Build\Azure\scripts\access.ace.x64.cmd = Build\Azure\scripts\access.ace.x64.cmd
 		Build\Azure\scripts\db2.sh = Build\Azure\scripts\db2.sh
 		Build\Azure\scripts\firebird25.sh = Build\Azure\scripts\firebird25.sh
 		Build\Azure\scripts\firebird3.sh = Build\Azure\scripts\firebird3.sh

--- a/linq2db.sln
+++ b/linq2db.sln
@@ -283,6 +283,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "net46", "net46", "{B7AADC73
 		Build\Azure\net46\sqlite.json = Build\Azure\net46\sqlite.json
 		Build\Azure\net46\sqlite.ms.json = Build\Azure\net46\sqlite.ms.json
 		Build\Azure\net46\sqlserver.2017.json = Build\Azure\net46\sqlserver.2017.json
+		Build\Azure\net46\sqlserver.2017.ms.json = Build\Azure\net46\sqlserver.2017.ms.json
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "netcoreapp21", "netcoreapp21", "{9C01FF5E-F85A-4561-A05B-8F32A4E11C6D}"
@@ -307,6 +308,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "netcoreapp21", "netcoreapp2
 		Build\Azure\netcoreapp21\sqlite.json = Build\Azure\netcoreapp21\sqlite.json
 		Build\Azure\netcoreapp21\sqlite.ms.json = Build\Azure\netcoreapp21\sqlite.ms.json
 		Build\Azure\netcoreapp21\sqlserver.2017.json = Build\Azure\netcoreapp21\sqlserver.2017.json
+		Build\Azure\netcoreapp21\sqlserver.2017.ms.json = Build\Azure\netcoreapp21\sqlserver.2017.ms.json
 		Build\Azure\netcoreapp21\sybase.json = Build\Azure\netcoreapp21\sybase.json
 	EndProjectSection
 EndProject

--- a/linq2db.sln
+++ b/linq2db.sln
@@ -100,6 +100,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NuGet", "NuGet", "{3A081B6E
 		NuGet\linq2db.SqlCe.nuspec = NuGet\linq2db.SqlCe.nuspec
 		NuGet\linq2db.SQLite.MS.nuspec = NuGet\linq2db.SQLite.MS.nuspec
 		NuGet\linq2db.SQLite.nuspec = NuGet\linq2db.SQLite.nuspec
+		NuGet\linq2db.SqlServer.MS.nuspec = NuGet\linq2db.SqlServer.MS.nuspec
 		NuGet\linq2db.SqlServer.nuspec = NuGet\linq2db.SqlServer.nuspec
 		NuGet\linq2db.Sybase.DataAction.nuspec = NuGet\linq2db.Sybase.DataAction.nuspec
 		NuGet\linq2db.Sybase.nuspec = NuGet\linq2db.Sybase.nuspec


### PR DESCRIPTION
- adds support for Microsoft.Data.SqlClient
- fix #1715
- fix #1895
- also added t4 template put_your_code_here comments to fix #1919
- added `Microsoft.Data.SqlClient` provider to azure tests
- added `SQL CE` provider to azure tests for .net core (win)

Remaining tasks:
- ~add sqlce and access azure test runs for .net core while I'm here~ nope, x64 bit oledb providers cannot handle transactions. Will research it later
