### PR TITLE
Trimming ColumnInfo.DataType & ColumnType

### DIFF
--- a/Source/LinqToDB/SchemaProvider/ColumnInfo.cs
+++ b/Source/LinqToDB/SchemaProvider/ColumnInfo.cs
@@ -6,12 +6,15 @@ namespace LinqToDB.SchemaProvider
 	[DebuggerDisplay("TableID = {TableID}, Name = {Name}, DataType = {DataType}, Length = {Length}, Precision = {Precision}, Scale = {Scale}")]
 	public class ColumnInfo
 	{
+		private string _dataType;
+		private string _columnType;
+
 		public string TableID;
 		public string Name;
 		public bool   IsNullable;
 		public int    Ordinal;
-		public string DataType;
-		public string ColumnType;
+		public string DataType      { get => _dataType;   set => _dataType   = value.Trim(); }
+		public string ColumnType    { get => _columnType; set => _columnType = value.Trim(); }
 		public long?  Length;
 		public int?   Precision;
 		public int?   Scale;


### PR DESCRIPTION
Schema provider can read type with spaces

Ex: SQLite can return "varchar " (this depends on database...) and corresponding model property is generated with `object` system type, instead of `string`.