### PR TITLE
Fix for #1927. Implemented support of LONG and LONG RAW datatypes in Oracle.

### DIFF
--- a/Data/Create Scripts/Oracle.sql
+++ b/Data/Create Scripts/Oracle.sql
@@ -748,6 +748,7 @@ CREATE TABLE AllTypes
 	binaryDataType           blob                           NULL,
 	bfileDataType            bfile                          NULL,
 	guidDataType             raw(16)                        NULL,
+	longDataType             long                           NULL,
 
 	uriDataType              UriType                        NULL,
 	xmlDataType              XmlType                        NULL
@@ -800,6 +801,7 @@ INSERT INTO AllTypes
 	binaryDataType,
 	bfileDataType,
 	guidDataType,
+	longDataType,
 
 	uriDataType,
 	xmlDataType
@@ -832,6 +834,7 @@ SELECT
 	NULL binaryDataType,
 	NULL bfileDataType,
 	NULL guidDataType,
+	NULL longDataType,
 
 	NULL uriDataType,
 	NULL xmlDataType
@@ -865,6 +868,7 @@ SELECT
 	to_blob('00AA'),
 	bfilename('DATA_DIR', 'bfile.txt'),
 	sys_guid(),
+	'LONG',
 
 	SYS.URIFACTORY.GETURI('http://www.linq2db.com'),
 	XMLTYPE('<root><element strattr="strvalue" intattr="12345"/></root>')
@@ -877,6 +881,21 @@ create table t_entity
 	time      date,
 	duration  interval day(3) to second(2)
 )
+/
+
+DROP TABLE LongRawTable
+/
+
+CREATE TABLE LongRawTable
+(
+	ID              NUMBER        NOT NULL PRIMARY KEY,
+	longRawDataType long raw      NULL
+)
+/
+
+INSERT INTO LongRawTable
+SELECT 1, NULL                        FROM dual UNION ALL
+SELECT 2, to_blob('4c4f4e4720524157') FROM dual -- "LONG RAW"
 /
 
 DROP TABLE DecimalOverflow

--- a/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
@@ -247,20 +247,6 @@ namespace LinqToDB.DataProvider.Oracle
 				ReaderExpressions[new ReaderInfo { ToType = typeof(int),     FieldType = typeof(decimal)}        ] = GetDecimal(typeof(int),     true);
 				ReaderExpressions[new ReaderInfo { ToType = typeof(long),    FieldType = typeof(decimal)}        ] = GetDecimal(typeof(long),    true);
 				ReaderExpressions[new ReaderInfo {                           FieldType = typeof(decimal)}        ] = GetDecimal(typeof(decimal), false);
-
-				ReaderExpressions[new ReaderInfo { ToType = typeof(string), FieldType  = typeof(byte[]), DataTypeName = "LongRaw" }] =
-					Expression.Lambda(
-						Expression.Call(Expression.Constant(Encoding.UTF8),
-							MemberHelper.MethodOf(() => Encoding.UTF8.GetString(null)),
-							Expression.Convert(
-								Expression.Call(
-									dataReaderParameter,
-									"GetValue",
-									null,
-									indexParameter), 
-								typeof(byte[]))),
-						dataReaderParameter,
-						indexParameter);
 			}
 
 			{
@@ -539,13 +525,6 @@ namespace LinqToDB.DataProvider.Oracle
 					if (value is TimeSpan)
 						dataType = dataType.WithDataType(DataType.Undefined);
 					break;
-				case DataType.LongRaw:
-					{
-						//LONG RAW accepts only arrays and Guid
-						if (value is string str) 
-							value = Encoding.UTF8.GetBytes(str);
-						break;
-					}
 			}
 
 			if (dataType.DataType == DataType.Undefined && value is string && ((string)value).Length >= 4000)

--- a/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
@@ -464,6 +464,8 @@ namespace LinqToDB.DataProvider.Oracle
 
 			// For LONG data type fetching initialization
 			command.InitialLONGFetchSize = -1;
+			// For LOB data type fetching initialization
+			command.InitialLOBFetchSize  = -1;
 
 			if (parameters != null)
 				foreach (var parameter in parameters)

--- a/Source/LinqToDB/DataType.cs
+++ b/Source/LinqToDB/DataType.cs
@@ -257,5 +257,15 @@ namespace LinqToDB
 		/// SQL Server 2008+ table-valued parameter type (TVP).
 		/// </summary>
 		Structured,
+
+		/// <summary>
+		/// Oracle data type for storing character data of variable length up to 2 Gigabytes in length (bigger version of the VARCHAR2 datatype).
+		/// </summary>
+		Long,
+
+		/// <summary>
+		/// Oracle data type for storing binary data of variable length up to 2 Gigabytes in length.
+		/// </summary>
+		LongRaw
 	}
 }

--- a/Tests/Linq/DataProvider/OracleTests.cs
+++ b/Tests/Linq/DataProvider/OracleTests.cs
@@ -8,7 +8,7 @@ using System.Xml.Linq;
 using System.Globalization;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-
+using System.Text;
 using LinqToDB;
 using LinqToDB.Common;
 using LinqToDB.Data;
@@ -618,6 +618,7 @@ namespace Tests.DataProvider
 			[Column(DataType=DataType.Blob,           Length=4000),                         Nullable         ] public byte[]          BINARYDATATYPE         { get; set; } // BLOB
 			[Column(DataType=DataType.VarBinary,      Length=530),                          Nullable         ] public byte[]          BFILEDATATYPE          { get; set; } // BFILE
 			[Column(DataType=DataType.Binary,         Length=16),                           Nullable         ] public byte[]          GUIDDATATYPE           { get; set; } // RAW(16)
+			[Column(DataType=DataType.Long),                                                Nullable         ] public string          LONGDATATYPE           { get; set; } // LONG
 			[Column(DataType=DataType.Undefined,      Length=256),                          Nullable         ] public object          URIDATATYPE            { get; set; } // URITYPE
 			[Column(DataType=DataType.Xml,            Length=2000),                         Nullable         ] public string          XMLDATATYPE            { get; set; } // XMLTYPE
 		}
@@ -2359,5 +2360,116 @@ namespace Tests.DataProvider
 				_ = db.Person.ToList();
 			}
 		}
+
+
+		[Test]
+		public void LongDataTypeTest([IncludeDataSources(false, TestProvName.AllOracle)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				db.GetTable<ALLTYPE>()
+					.Where(t => t.ID > 2)
+					.Delete();
+
+				try
+				{
+					var items = db.GetTable<ALLTYPE>()
+						.Select(t => new { t.LONGDATATYPE })
+						.ToArray();
+
+					Assert.That(items.Length, Is.GreaterThanOrEqualTo(2));
+					Assert.That(items[0].LONGDATATYPE, Is.Null);
+					Assert.That(items[1].LONGDATATYPE, Is.EqualTo("LONG"));
+
+					var str = new string('A', 10000);
+
+					var id = db.GetTable<ALLTYPE>().InsertWithDecimalIdentity(() => new ALLTYPE
+					{
+						LONGDATATYPE = str, 
+					});
+
+					var insertedItems = db.GetTable<ALLTYPE>()
+						.Where(t => t.ID == id)
+						.Select(t => new { t.LONGDATATYPE })
+						.ToArray();
+
+					Assert.That(insertedItems[0].LONGDATATYPE, Is.EqualTo(str));
+
+					var str2 = new string('B', 4000);
+
+					var id2 = db.GetTable<ALLTYPE>().InsertWithDecimalIdentity(() => new ALLTYPE
+					{
+						LONGDATATYPE = Sql.ToSql(str2), 
+					});
+
+					var insertedItems2 = db.GetTable<ALLTYPE>()
+						.Where(t => t.ID == id2)
+						.Select(t => new { t.LONGDATATYPE })
+						.ToArray();
+
+					Assert.That(insertedItems2[0].LONGDATATYPE, Is.EqualTo(str2));
+				}
+				finally
+				{
+					db.GetTable<ALLTYPE>()
+						.Where(t => t.ID > 2)
+						.Delete();
+				}
+			}
+		}
+
+		class LongRawTable
+		{
+			[Column(Name =  "ID")] public int Id { get; set; }
+			[Column(Name = "longRawDataType", DataType=DataType.LongRaw), Nullable] public byte[] LONGRAWDATATYPEByte { get; set; } // LONG RAW
+			[Column(Name = "longRawDataType", DataType=DataType.LongRaw), Nullable] public string LONGRAWDATATYPEString { get; set; } // LONG RAW
+		}
+
+		[Test]
+		public void LongRawDataTypeTest([IncludeDataSources(false, TestProvName.AllOracle)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				db.GetTable<LongRawTable>()
+					.Where(t => t.Id > 2)
+					.Delete();
+
+				var items = db.GetTable<LongRawTable>()
+					.Select(t => new { t.Id, t.LONGRAWDATATYPEByte, t.LONGRAWDATATYPEString })
+					.ToArray();
+
+				Assert.That(items.Length, Is.EqualTo(2));
+				Assert.That(items[0].LONGRAWDATATYPEByte, Is.Null);
+				Assert.That(items[0].LONGRAWDATATYPEString, Is.Null);
+				Assert.That(items[1].LONGRAWDATATYPEByte, Is.Not.Null);
+				Assert.That(items[1].LONGRAWDATATYPEString, Is.EqualTo("LONG RAW"));
+					
+				var str1 = new string('A', 10000);
+
+				db.GetTable<LongRawTable>().Insert(() => new LongRawTable
+				{
+					Id = 3,
+					LONGRAWDATATYPEString = str1, 
+				});
+
+				var str2 = new string('B', 10000);
+
+				db.GetTable<LongRawTable>().Insert(() => new LongRawTable
+				{
+					Id = 4,
+					LONGRAWDATATYPEString = str2, 
+				});
+
+				var insertedItems = db.GetTable<LongRawTable>()
+					.Where(t => t.Id.In(3, 4))
+					.Select(t => new { t.LONGRAWDATATYPEString })
+					.ToArray();
+
+				Assert.That(insertedItems.Length, Is.EqualTo(2));
+				Assert.That(insertedItems[0].LONGRAWDATATYPEString, Is.EqualTo(str1));
+				Assert.That(insertedItems[1].LONGRAWDATATYPEString, Is.EqualTo(str2));
+			}
+		}
+
 	}
 }

--- a/Tests/Linq/DataProvider/OracleTests.cs
+++ b/Tests/Linq/DataProvider/OracleTests.cs
@@ -2421,8 +2421,7 @@ namespace Tests.DataProvider
 		class LongRawTable
 		{
 			[Column(Name =  "ID")] public int Id { get; set; }
-			[Column(Name = "longRawDataType", DataType=DataType.LongRaw), Nullable] public byte[] LONGRAWDATATYPEByte { get; set; } // LONG RAW
-			[Column(Name = "longRawDataType", DataType=DataType.LongRaw), Nullable] public string LONGRAWDATATYPEString { get; set; } // LONG RAW
+			[Column(Name = "longRawDataType", DataType=DataType.LongRaw), Nullable] public byte[] LONGRAWDATATYPE { get; set; } // LONG RAW
 		}
 
 		[Test]
@@ -2435,39 +2434,37 @@ namespace Tests.DataProvider
 					.Delete();
 
 				var items = db.GetTable<LongRawTable>()
-					.Select(t => new { t.Id, t.LONGRAWDATATYPEByte, t.LONGRAWDATATYPEString })
+					.Select(t => new { t.LONGRAWDATATYPE })
 					.ToArray();
 
 				Assert.That(items.Length, Is.EqualTo(2));
-				Assert.That(items[0].LONGRAWDATATYPEByte, Is.Null);
-				Assert.That(items[0].LONGRAWDATATYPEString, Is.Null);
-				Assert.That(items[1].LONGRAWDATATYPEByte, Is.Not.Null);
-				Assert.That(items[1].LONGRAWDATATYPEString, Is.EqualTo("LONG RAW"));
+				Assert.That(items[0].LONGRAWDATATYPE, Is.Null);
+				Assert.That(items[1].LONGRAWDATATYPE, Is.Not.Null);
 					
-				var str1 = new string('A', 10000);
+				var bytes1 = Encoding.UTF8.GetBytes(new string('A', 10000));
 
 				db.GetTable<LongRawTable>().Insert(() => new LongRawTable
 				{
 					Id = 3,
-					LONGRAWDATATYPEString = str1, 
+					LONGRAWDATATYPE = bytes1, 
 				});
 
-				var str2 = new string('B', 10000);
+				var bytes2 = Encoding.UTF8.GetBytes(new string('B', 10000));
 
 				db.GetTable<LongRawTable>().Insert(() => new LongRawTable
 				{
 					Id = 4,
-					LONGRAWDATATYPEString = str2, 
+					LONGRAWDATATYPE = bytes2, 
 				});
 
 				var insertedItems = db.GetTable<LongRawTable>()
 					.Where(t => t.Id.In(3, 4))
-					.Select(t => new { t.LONGRAWDATATYPEString })
+					.Select(t => new { t.LONGRAWDATATYPE })
 					.ToArray();
 
 				Assert.That(insertedItems.Length, Is.EqualTo(2));
-				Assert.That(insertedItems[0].LONGRAWDATATYPEString, Is.EqualTo(str1));
-				Assert.That(insertedItems[1].LONGRAWDATATYPEString, Is.EqualTo(str2));
+				Assert.That(insertedItems[0].LONGRAWDATATYPE, Is.EqualTo(bytes1));
+				Assert.That(insertedItems[1].LONGRAWDATATYPE, Is.EqualTo(bytes2));
 			}
 		}
 


### PR DESCRIPTION
Fixes #1927 and #1899