### PR TITLE
Fix for #1928. Fixed wrong algorithm for handling SqlQueryDependentAttribute.

### DIFF
--- a/Source/LinqToDB/DataExtensions.cs
+++ b/Source/LinqToDB/DataExtensions.cs
@@ -793,6 +793,20 @@ namespace LinqToDB
 
 				return base.ExpressionsEqual(expr1, expr2, comparer);
 			}
+
+			public override Expression PrepareForCache(Expression expression)
+			{
+				if (expression.NodeType != ExpressionType.Call)
+					return base.PrepareForCache(expression);
+
+				var mc = (MethodCallExpression)expression;
+				var newArguments = new List<Expression>();
+				newArguments.Add(Expression.Constant(mc.Arguments[0].EvaluateExpression()));
+				newArguments.AddRange(mc.Arguments.Skip(1));
+
+				mc = mc.Update(mc.Object, newArguments);
+				return mc;
+			}
 		}
 
 		/// <summary>

--- a/Source/LinqToDB/Expressions/InternalExtensions.cs
+++ b/Source/LinqToDB/Expressions/InternalExtensions.cs
@@ -64,11 +64,13 @@ namespace LinqToDB.Expressions
 
 		internal static bool EqualsTo(this Expression expr1, Expression expr2,
 			Dictionary<Expression,QueryableAccessor> queryableAccessorDic,
+			Dictionary<Expression,object>            queryDependedObjects,
 			bool compareConstantValues = false)
 		{
 			return EqualsTo(expr1, expr2, new EqualsToInfo
 			{
 				QueryableAccessorDic  = queryableAccessorDic,
+				QueryDependedObjects  = queryDependedObjects,
 				CompareConstantValues = compareConstantValues
 			});
 		}
@@ -77,6 +79,7 @@ namespace LinqToDB.Expressions
 		{
 			public HashSet<Expression>                      Visited = new HashSet<Expression>();
 			public Dictionary<Expression,QueryableAccessor> QueryableAccessorDic;
+			public Dictionary<Expression,object>            QueryDependedObjects;
 			public bool                                     CompareConstantValues;
 		}
 
@@ -469,7 +472,10 @@ namespace LinqToDB.Expressions
 
 					if (dependentAttribute != null)
 					{
-						if (!dependentAttribute.ExpressionsEqual(expr1.Arguments[i], expr2.Arguments[i], (e1, e2) => e1.EqualsTo(e2, info)))
+						var prevArg = expr1.Arguments[i];
+						if (info.QueryDependedObjects != null && info.QueryDependedObjects.TryGetValue(expr1.Arguments[i], out var prevValue))
+							prevArg = Expression.Constant(prevValue);
+						if (!dependentAttribute.ExpressionsEqual(prevArg, expr2.Arguments[i], (e1, e2) => e1.EqualsTo(e2, info)))
 							return false;
 					}
 					else

--- a/Source/LinqToDB/Expressions/InternalExtensions.cs
+++ b/Source/LinqToDB/Expressions/InternalExtensions.cs
@@ -64,7 +64,7 @@ namespace LinqToDB.Expressions
 
 		internal static bool EqualsTo(this Expression expr1, Expression expr2,
 			Dictionary<Expression,QueryableAccessor> queryableAccessorDic,
-			Dictionary<Expression,object>            queryDependedObjects,
+			Dictionary<Expression,Expression>        queryDependedObjects,
 			bool compareConstantValues = false)
 		{
 			return EqualsTo(expr1, expr2, new EqualsToInfo
@@ -79,7 +79,7 @@ namespace LinqToDB.Expressions
 		{
 			public HashSet<Expression>                      Visited = new HashSet<Expression>();
 			public Dictionary<Expression,QueryableAccessor> QueryableAccessorDic;
-			public Dictionary<Expression,object>            QueryDependedObjects;
+			public Dictionary<Expression,Expression>        QueryDependedObjects;
 			public bool                                     CompareConstantValues;
 		}
 
@@ -473,8 +473,8 @@ namespace LinqToDB.Expressions
 					if (dependentAttribute != null)
 					{
 						var prevArg = expr1.Arguments[i];
-						if (info.QueryDependedObjects != null && info.QueryDependedObjects.TryGetValue(expr1.Arguments[i], out var prevValue))
-							prevArg = Expression.Constant(prevValue);
+						if (info.QueryDependedObjects != null && info.QueryDependedObjects.TryGetValue(expr1.Arguments[i], out var nevValue))
+							prevArg = nevValue;
 						if (!dependentAttribute.ExpressionsEqual(prevArg, expr2.Arguments[i], (e1, e2) => e1.EqualsTo(e2, info)))
 							return false;
 					}

--- a/Source/LinqToDB/Expressions/SqlQueryDependentAttribute.cs
+++ b/Source/LinqToDB/Expressions/SqlQueryDependentAttribute.cs
@@ -59,5 +59,15 @@ namespace LinqToDB.Expressions
 		{
 			return ObjectsEqual(expr1.EvaluateExpression(), expr2.EvaluateExpression());
 		}
+
+		/// <summary>
+		/// Used for preparation method argument to cached expression value.
+		/// </summary>
+		/// <param name="expression">Expression for caching.</param>
+		/// <returns>Ready to cache expression.</returns>
+		public virtual Expression PrepareForCache(Expression expression)
+		{
+			return Expression.Constant(expression.EvaluateExpression());
+		}
 	}
 }

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.QueryBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.QueryBuilder.cs
@@ -499,7 +499,7 @@ namespace LinqToDB.Linq.Builder
 
 			foreach (var item in sbi)
 			{
-				if (expr.EqualsTo(item.Method, new Dictionary<Expression,QueryableAccessor>()))
+				if (expr.EqualsTo(item.Method, new Dictionary<Expression,QueryableAccessor>(), null))
 					return item;
 			}
 

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -1418,7 +1418,7 @@ namespace LinqToDB.Linq.Builder
 
 			if (!DataContext.SqlProviderFlags.IsParameterOrderDependent)
 				foreach (var accessor in _parameters)
-					if (accessor.Key.EqualsTo(expr, new Dictionary<Expression, QueryableAccessor>(), compareConstantValues: true))
+					if (accessor.Key.EqualsTo(expr, new Dictionary<Expression, QueryableAccessor>(), null, compareConstantValues: true))
 						p = accessor.Value;
 
 			if (p == null)

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
@@ -719,6 +719,13 @@ namespace LinqToDB.Linq.Builder
 					{
 						var call = (MethodCallExpression)expr;
 
+						var parameters = call.Method.GetParameters();
+						for (int i = 0; i < parameters.Length; i++)
+						{
+							if (parameters[i].GetCustomAttributes(typeof(SqlQueryDependentAttribute), false).Any())
+								_query.AddQueryDependedObject(call.Arguments[i]);
+						}
+
 						if (call.IsQueryable() || call.IsAsyncExtension())
 						{
 							switch (call.Method.Name)

--- a/Source/LinqToDB/Linq/Builder/SetOperationBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/SetOperationBuilder.cs
@@ -334,7 +334,7 @@ namespace LinqToDB.Linq.Builder
 										var assignment1 = (MemberAssignment)binding;
 										var assignment2 = (MemberAssignment)foundBinding;
 
-										if (!assignment1.Expression.EqualsTo(assignment2.Expression, accessorDic) || 
+										if (!assignment1.Expression.EqualsTo(assignment2.Expression, accessorDic, null) || 
 										    !(assignment1.Expression.NodeType == ExpressionType.MemberAccess || assignment1.Expression.NodeType == ExpressionType.Parameter))
 										{
 											needsRewrite = true;

--- a/Source/LinqToDB/Linq/Query.cs
+++ b/Source/LinqToDB/Linq/Query.cs
@@ -69,7 +69,7 @@ namespace LinqToDB.Linq
 
 		readonly Dictionary<Expression,QueryableAccessor> _queryableAccessorDic  = new Dictionary<Expression,QueryableAccessor>();
 		readonly List<QueryableAccessor>                  _queryableAccessorList = new List<QueryableAccessor>();
-		readonly Dictionary<Expression,object>            _queryDependedObjects  = new Dictionary<Expression,object>();
+		readonly Dictionary<Expression,Expression>        _queryDependedObjects  = new Dictionary<Expression,Expression>();
 
 		internal int AddQueryableAccessors(Expression expr, Expression<Func<Expression,IQueryable>> qe)
 		{
@@ -85,13 +85,13 @@ namespace LinqToDB.Linq
 			return _queryableAccessorList.Count - 1;
 		}
 
-		internal void AddQueryDependedObject(Expression expr)
+		internal void AddQueryDependedObject(Expression expr, SqlQueryDependentAttribute attr)
 		{
 			if (_queryDependedObjects.ContainsKey(expr))
 				return;
 
-			var value = expr.EvaluateExpression();
-			_queryDependedObjects.Add(expr, value);
+			var prepared = attr.PrepareForCache(expr);
+			_queryDependedObjects.Add(expr, prepared);
 		}
 
 		internal Expression GetIQueryable(int n, Expression expr)


### PR DESCRIPTION
> The more you know, the more you can fix :)

Fixed wrong algorithm with handling `SqlQueryDependentAttrinute`. For now in cache we store original values which were used in building query. It gives possibility to correctly handle query cache problems.

Fixes #1928