### PR TITLE
Implemented member mapping when used Fabric Method or constructor.

### DIFF
--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Data.SqlTypes;
 using System.Linq;
 using System.Linq.Expressions;
@@ -3131,6 +3132,34 @@ namespace LinqToDB.Linq.Builder
 
 		public bool ProcessProjection(Dictionary<MemberInfo,Expression> members, Expression expression)
 		{
+			void CollectParameters(Type forType, MethodBase method, ReadOnlyCollection<Expression> arguments)
+			{
+				var pms = method.GetParameters();
+
+				var typeMembers = TypeAccessor.GetAccessor(forType).Members;
+
+				for (var i = 0; i < pms.Length; i++)
+				{
+					var param = pms[i];
+					var foundMember = typeMembers.Find(tm => tm.Name == param.Name);
+					if (foundMember == null)
+						foundMember = typeMembers.Find(tm =>
+							tm.Name.Equals(param.Name, StringComparison.OrdinalIgnoreCase));
+					if (foundMember == null)
+						continue;
+
+					if (members.ContainsKey(foundMember.MemberInfo))
+						continue;
+
+					var converted = arguments[i].Transform(e => RemoveNullPropagation(e));
+
+					if (!foundMember.MemberInfo.GetMemberType().IsAssignableFrom(converted.Type))
+						continue;
+
+					members.Add(foundMember.MemberInfo, converted);
+				}
+			}
+
 			switch (expression.NodeType)
 			{
 				// new { ... }
@@ -3139,25 +3168,23 @@ namespace LinqToDB.Linq.Builder
 					{
 						var expr = (NewExpression)expression;
 
-// ReSharper disable ConditionIsAlwaysTrueOrFalse
-// ReSharper disable HeuristicUnreachableCode
-						if (expr.Members == null)
-							return false;
-// ReSharper restore HeuristicUnreachableCode
-// ReSharper restore ConditionIsAlwaysTrueOrFalse
-
-						for (var i = 0; i < expr.Members.Count; i++)
+						if (expr.Members != null)
 						{
-							var member = expr.Members[i];
+							for (var i = 0; i < expr.Members.Count; i++)
+							{
+								var member = expr.Members[i];
 
-							var converted = expr.Arguments[i].Transform(e => RemoveNullPropagation(e));
-							members.Add(member, converted);
+								var converted = expr.Arguments[i].Transform(e => RemoveNullPropagation(e));
+								members.Add(member, converted);
 
-							if (member is MethodInfo info)
-								members.Add(info.GetPropertyInfo(), converted);
+								if (member is MethodInfo info)
+									members.Add(info.GetPropertyInfo(), converted);
+							}
 						}
+						
+						CollectParameters(expr.Type, expr.Constructor, expr.Arguments);
 
-						return true;
+						return members.Count > 0;
 					}
 
 				// new MyObject { ... }
@@ -3165,7 +3192,9 @@ namespace LinqToDB.Linq.Builder
 				case ExpressionType.MemberInit :
 					{
 						var expr = (MemberInitExpression)expression;
-						var dic  = TypeAccessor.GetAccessor(expr.Type).Members
+						var typeMembers = TypeAccessor.GetAccessor(expr.Type).Members;
+
+						var dic  = typeMembers
 							.Select((m,i) => new { m, i })
 							.ToDictionary(_ => _.m.MemberInfo.Name, _ => _.i);
 
@@ -3179,6 +3208,17 @@ namespace LinqToDB.Linq.Builder
 						}
 
 						return true;
+					}
+
+				case ExpressionType.Call:
+					{
+						var mc = (MethodCallExpression)expression;
+
+						// process fabric methods
+
+						CollectParameters(mc.Type, mc.Method, mc.Arguments);
+
+						return members.Count > 0;
 					}
 
 				// .Select(p => everything else)

--- a/Tests/Linq/Linq/SelectTests.cs
+++ b/Tests/Linq/Linq/SelectTests.cs
@@ -10,7 +10,7 @@ using LinqToDB;
 using LinqToDB.Data;
 using LinqToDB.Reflection;
 using LinqToDB.Mapping;
-
+using LinqToDB.Tools.Comparers;
 using NUnit.Framework;
 
 namespace Tests.Linq
@@ -1109,6 +1109,68 @@ namespace Tests.Linq
 					};
 
 				_ = query.ToList();
+			}
+		}
+
+		class ParentResult
+		{
+			public ParentResult(int parentID, int? value1)
+			{
+				ParentID = parentID;
+				Value1 = value1;
+			}
+
+			public int? Value1 { get; }
+			public int ParentID { get; }
+		}
+
+		[Test]
+		public void TestConstructorProjection([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var query =
+					from p in db.Parent
+					select new ParentResult(p.ParentID, p.Value1);
+
+				var resultQuery = from q in query
+					where q.Value1 != null
+					select q;
+
+				var queryExpected =
+					from p in Parent
+					select new ParentResult(p.ParentID, p.Value1);
+
+				var resultExpected = from q in queryExpected
+					where q.Value1 != null
+					select q;
+
+				AreEqual(resultExpected, resultQuery, ComparerBuilder.GetEqualityComparer<ParentResult>());
+			}
+		}
+
+		[Test]
+		public void TestMethodFabricProjection([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var query =
+					from p in db.Parent
+					select Tuple.Create(p.ParentID, p.Value1);
+
+				var resultQuery = from q in query
+					where q.Item2 != null
+					select q;
+
+				var queryExpected =
+					from p in Parent
+					select Tuple.Create(p.ParentID, p.Value1);
+
+				var resultExpected = from q in queryExpected
+					where q.Item2 != null
+					select q;
+
+				AreEqual(resultExpected, resultQuery);
 			}
 		}
 


### PR DESCRIPTION
Added possibility of using tuples 'Tuple.Create' and constructors for tracking members in continuous queries.

Fixes #1953 
