### PR TITLE
Update dependencies

### DIFF
--- a/Build/Azure/README.md
+++ b/Build/Azure/README.md
@@ -49,7 +49,7 @@ Legend:
 |TestNoopProvider<sup>[1](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |SQLite [3.13.0](https://www.sqlite.org/releaselog/3_13_0.html)<sup>[2](#notes)</sup><br>[Microsoft.Data.SQLite](https://www.nuget.org/packages/Microsoft.Data.SQLite/) 1.1.1<br>with NorthwindDB Tests|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
 |SQLite [3.28.0](https://www.sqlite.org/releaselog/3_28_0.html)<br>[Microsoft.Data.SQLite](https://www.nuget.org/packages/Microsoft.Data.SQLite/) 3.0.0<br>with NorthwindDB Tests|:heavy_minus_sign:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-|SQLite [3.28.0](https://www.sqlite.org/releaselog/3_28_0.html)<br>[System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite.Core/) 1.0.112<br>with NorthwindDB Tests|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+|SQLite [3.30.1](https://www.sqlite.org/releaselog/3_28_0.html)<br>[System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite.Core/) 1.0.112<br>with NorthwindDB Tests|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |Access<sup>[3](#notes)</sup><br>Jet 4.0 OLE DB|:heavy_check_mark:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
 |Access<sup>[3](#notes)</sup><br>ACE 12 OLE DB|:heavy_check_mark:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL CE<sup>[4](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|

--- a/Build/Azure/README.md
+++ b/Build/Azure/README.md
@@ -67,12 +67,12 @@ Legend:
 |MySQL 8<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.18|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |MySQL 8<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 0.61.0|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |MariaDB 10<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.18|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 9.2<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.0.10 (netfx) / 4.1.1 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 9.3<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.0.10 (netfx) / 4.1.1 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 9.5<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.0.10 (netfx) / 4.1.1 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 10<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.0.10 (netfx) / 4.1.1 (core)|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 11<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.0.10 (netfx) / 4.1.1 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 12<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.0.10 (netfx) / 4.1.1 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 9.2<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.0.10 (netfx) / 4.1.2 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 9.3<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.0.10 (netfx) / 4.1.2 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 9.5<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.0.10 (netfx) / 4.1.2 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 10<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.0.10 (netfx) / 4.1.2 (core)|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 11<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.0.10 (netfx) / 4.1.2 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 12<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.0.10 (netfx) / 4.1.2 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |DB2 LUW 11.5.0.0a<br>[IBM.Data.DB2](https://www.nuget.org/packages/IBM.Data.DB.Provider/) 11.1.4040.4 (netfx)<br>[IBM.Data.DB2.Core](https://www.nuget.org/packages/IBM.Data.DB2.Core/) ([osx](https://www.nuget.org/packages/IBM.Data.DB2.Core-osx/), [lin](https://www.nuget.org/packages/IBM.Data.DB2.Core-lnx/)) 1.3.0.100 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |Informix 12.10.FC12W1DE<br>IBM.Data.Informix ? (netfx)<br>[IBM.Data.DB2.Core](https://www.nuget.org/packages/IBM.Data.DB2.Core/) ([osx](https://www.nuget.org/packages/IBM.Data.DB2.Core-osx/), [lin](https://www.nuget.org/packages/IBM.Data.DB2.Core-lnx/)) 1.3.0.100 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |Informix 14.10.FC1DE<br>IBM.Data.Informix ? (netfx)<br>[IBM.Data.DB2.Core](https://www.nuget.org/packages/IBM.Data.DB2.Core/) ([osx](https://www.nuget.org/packages/IBM.Data.DB2.Core-osx/), [lin](https://www.nuget.org/packages/IBM.Data.DB2.Core-lnx/)) 1.3.0.100 (core)|:x:|:x:|:x:|:x:|

--- a/Build/Azure/README.md
+++ b/Build/Azure/README.md
@@ -49,7 +49,7 @@ Legend:
 |TestNoopProvider<sup>[1](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |SQLite [3.13.0](https://www.sqlite.org/releaselog/3_13_0.html)<sup>[2](#notes)</sup><br>[Microsoft.Data.SQLite](https://www.nuget.org/packages/Microsoft.Data.SQLite/) 1.1.1<br>with NorthwindDB Tests|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
 |SQLite [3.28.0](https://www.sqlite.org/releaselog/3_28_0.html)<br>[Microsoft.Data.SQLite](https://www.nuget.org/packages/Microsoft.Data.SQLite/) 3.0.0<br>with NorthwindDB Tests|:heavy_minus_sign:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-|SQLite [3.28.0](https://www.sqlite.org/releaselog/3_28_0.html)<br>[System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite.Core/) 1.0.111<br>with NorthwindDB Tests|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+|SQLite [3.28.0](https://www.sqlite.org/releaselog/3_28_0.html)<br>[System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite.Core/) 1.0.112<br>with NorthwindDB Tests|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |Access<sup>[3](#notes)</sup><br>Jet 4.0 OLE DB|:heavy_check_mark:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
 |Access<sup>[3](#notes)</sup><br>ACE 12 OLE DB|:heavy_check_mark:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL CE<sup>[4](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
@@ -65,7 +65,7 @@ Legend:
 |Azure SQL<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.7.0|:x:|:x:|:x:|:x:|
 |MySQL 5.6<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.18|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |MySQL 8<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.18|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|MySQL 8<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 0.60.2|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|MySQL 8<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 0.60.3|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |MariaDB 10<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.18|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |PostgreSQL 9.2<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.0.10 (netfx) / 4.1.1 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |PostgreSQL 9.3<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.0.10 (netfx) / 4.1.1 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
@@ -78,7 +78,7 @@ Legend:
 |Informix 14.10.FC1DE<br>IBM.Data.Informix ? (netfx)<br>[IBM.Data.DB2.Core](https://www.nuget.org/packages/IBM.Data.DB2.Core/) ([osx](https://www.nuget.org/packages/IBM.Data.DB2.Core-osx/), [lin](https://www.nuget.org/packages/IBM.Data.DB2.Core-lnx/)) 1.3.0.100 (core)|:x:|:x:|:x:|:x:|
 |SAP HANA 2.0 SPS 04r40<br>Native Provider|:x:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
 |SAP HANA 2.0 SPS 04r40<br>ODBC Provider|:x:|:x:|:x:|:x:|
-|SAP/Sybase ASE 16.2<br>[AdoNetCore.AseClient](https://www.nuget.org/packages/AdoNetCore.AseClient/) 0.15.0|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|SAP/Sybase ASE 16.2<br>[AdoNetCore.AseClient](https://www.nuget.org/packages/AdoNetCore.AseClient/) 0.16.0|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |SAP/Sybase ASE 16.2<br>Native Client|:x:|:x:|:x:|:x:|
 |Oracle 11g XE<br>Native Client 4.122.19.1 |:x:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
 |Oracle 11g XE<br>[Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) 19.5.0 (netfx)<br>[Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core/) 2.19.50 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|

--- a/Build/Azure/README.md
+++ b/Build/Azure/README.md
@@ -48,7 +48,7 @@ Legend:
 |:---|:---:|:---:|:---:|:---:|
 |TestNoopProvider<sup>[1](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |SQLite [3.13.0](https://www.sqlite.org/releaselog/3_13_0.html)<sup>[2](#notes)</sup><br>[Microsoft.Data.SQLite](https://www.nuget.org/packages/Microsoft.Data.SQLite/) 1.1.1<br>with NorthwindDB Tests|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
-|SQLite [3.28.0](https://www.sqlite.org/releaselog/3_28_0.html)<br>[Microsoft.Data.SQLite](https://www.nuget.org/packages/Microsoft.Data.SQLite/) 3.0.0<br>with NorthwindDB Tests|:heavy_minus_sign:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+|SQLite [3.28.0](https://www.sqlite.org/releaselog/3_28_0.html)<br>[Microsoft.Data.SQLite](https://www.nuget.org/packages/Microsoft.Data.SQLite/) 3.1.0<br>with NorthwindDB Tests|:heavy_minus_sign:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |SQLite [3.30.1](https://www.sqlite.org/releaselog/3_28_0.html)<br>[System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite.Core/) 1.0.112<br>with NorthwindDB Tests|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |Access<sup>[3](#notes)</sup><br>Jet 4.0 OLE DB|:heavy_check_mark:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
 |Access<sup>[3](#notes)</sup><br>ACE 12 OLE DB|:heavy_check_mark:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
@@ -61,7 +61,7 @@ Legend:
 |MS SQL Server 2016<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.0|:x:|:x:|:x:|:x:|
 |MS SQL Server 2017<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.0<br>with NorthwindDB<sup>[5](#notes)</sup> Tests|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |MS SQL Server 2019<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.0|:x:|:x:|:x:|:x:|
-|MS SQL Server 2017<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 1.0.19269.1<br>with NorthwindDB<sup>[5](#notes)</sup> Tests|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+|MS SQL Server 2017<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 1.1.0<br>with NorthwindDB<sup>[5](#notes)</sup> Tests|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |Azure SQL<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.0|:x:|:x:|:x:|:x:|
 |MySQL 5.6<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.18|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |MySQL 8<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.18|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|

--- a/Build/Azure/README.md
+++ b/Build/Azure/README.md
@@ -53,16 +53,16 @@ Legend:
 |Access<sup>[3](#notes)</sup><br>Jet 4.0 OLE DB|:heavy_check_mark:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
 |Access<sup>[3](#notes)</sup><br>ACE 12 OLE DB|:heavy_check_mark:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL CE<sup>[4](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
-|MS SQL Server 2000<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.7.0|:x:|:x:|:x:|:x:|
-|MS SQL Server 2005<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.7.0|:x:|:x:|:x:|:x:|
-|MS SQL Server 2008<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.7.0|:x:|:x:|:x:|:x:|
-|MS SQL Server 2012<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.7.0|:x:|:x:|:x:|:x:|
-|MS SQL Server 2014<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.7.0|:x:|:x:|:x:|:x:|
-|MS SQL Server 2016<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.7.0|:x:|:x:|:x:|:x:|
-|MS SQL Server 2017<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.7.0<br>with NorthwindDB<sup>[5](#notes)</sup> Tests|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-|MS SQL Server 2019<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.7.0|:x:|:x:|:x:|:x:|
+|MS SQL Server 2000<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.0|:x:|:x:|:x:|:x:|
+|MS SQL Server 2005<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.0|:x:|:x:|:x:|:x:|
+|MS SQL Server 2008<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.0|:x:|:x:|:x:|:x:|
+|MS SQL Server 2012<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.0|:x:|:x:|:x:|:x:|
+|MS SQL Server 2014<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.0|:x:|:x:|:x:|:x:|
+|MS SQL Server 2016<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.0|:x:|:x:|:x:|:x:|
+|MS SQL Server 2017<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.0<br>with NorthwindDB<sup>[5](#notes)</sup> Tests|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+|MS SQL Server 2019<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.0|:x:|:x:|:x:|:x:|
 |MS SQL Server 2017<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 1.0.19269.1<br>with NorthwindDB<sup>[5](#notes)</sup> Tests|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-|Azure SQL<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.7.0|:x:|:x:|:x:|:x:|
+|Azure SQL<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.0|:x:|:x:|:x:|:x:|
 |MySQL 5.6<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.18|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |MySQL 8<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.18|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |MySQL 8<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 0.60.3|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|

--- a/Build/Azure/README.md
+++ b/Build/Azure/README.md
@@ -65,7 +65,7 @@ Legend:
 |Azure SQL<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.0|:x:|:x:|:x:|:x:|
 |MySQL 5.6<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.18|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |MySQL 8<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.18|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|MySQL 8<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 0.60.3|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|MySQL 8<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 0.61.0|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |MariaDB 10<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.18|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |PostgreSQL 9.2<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.0.10 (netfx) / 4.1.1 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |PostgreSQL 9.3<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.0.10 (netfx) / 4.1.1 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|

--- a/Build/Azure/README.md
+++ b/Build/Azure/README.md
@@ -81,9 +81,9 @@ Legend:
 |SAP/Sybase ASE 16.2<br>[AdoNetCore.AseClient](https://www.nuget.org/packages/AdoNetCore.AseClient/) 0.16.0|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |SAP/Sybase ASE 16.2<br>Native Client|:x:|:x:|:x:|:x:|
 |Oracle 11g XE<br>Native Client 4.122.19.1 |:x:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
-|Oracle 11g XE<br>[Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) 19.5.0 (netfx)<br>[Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core/) 2.19.50 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|Oracle 11g XE<br>[Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) 19.6.0 (netfx)<br>[Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core/) 2.19.60 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |Oracle 18c XE<br>Native Client|:x:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
-|Oracle 18c XE<br>[Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) 19.5.0 (netfx)<br>[Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core/) 2.19.50 (core)|:x:|:x:|:x:|:x:|
+|Oracle 18c XE<br>[Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) 19.6.0 (netfx)<br>[Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core/) 2.19.60 (core)|:x:|:x:|:x:|:x:|
 |Firebird 2.1<br>[FirebirdSql.Data.FirebirdClient](https://www.nuget.org/packages/FirebirdSql.Data.FirebirdClient/) 7.1.1|:x:|:x:|:x:|:x:|
 |Firebird 2.5<br>[FirebirdSql.Data.FirebirdClient](https://www.nuget.org/packages/FirebirdSql.Data.FirebirdClient/) 7.1.1|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |Firebird 3.0<br>[FirebirdSql.Data.FirebirdClient](https://www.nuget.org/packages/FirebirdSql.Data.FirebirdClient/) 7.1.1|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|

--- a/Build/linq2db.Source.props
+++ b/Build/linq2db.Source.props
@@ -12,7 +12,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01">
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/Build/linq2db.Tests.Providers.props
+++ b/Build/linq2db.Tests.Providers.props
@@ -10,11 +10,11 @@
 		<PackageReference Include="System.Memory" Version="4.5.3" />
 		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
 
-		<PackageReference Include="System.Data.SQLite.Core" Version="1.0.111" />
+		<PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" />
 		<PackageReference Include="MySql.Data" Version="8.0.18" Alias="MySqlData" />
-		<PackageReference Include="MySqlConnector" Version="0.60.2" Alias="MySqlConnector" />
+		<PackageReference Include="MySqlConnector" Version="0.60.3" Alias="MySqlConnector" />
 		<PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="7.1.1" />
-		<PackageReference Include="AdoNetCore.AseClient" Version="0.15.0" />
+		<PackageReference Include="AdoNetCore.AseClient" Version="0.16.0" />
 
 		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
@@ -79,7 +79,7 @@
 		Needed because 2.0.0 has this bug which fails TestBinary test
 		https://github.com/aspnet/EntityFrameworkCore/issues/17494
 		-->
-		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.1" />
+		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.2" />
 		<PackageReference Include="MiniProfiler.Shared" Version="4.1.0" />
 
 		<!--magic-->

--- a/Build/linq2db.Tests.Providers.props
+++ b/Build/linq2db.Tests.Providers.props
@@ -17,7 +17,7 @@
 		<PackageReference Include="AdoNetCore.AseClient" Version="0.16.0" />
 
 		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
 		<PackageReference Include="System.Data.SqlClient" Version="4.8.0" />
 		<PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.0" />
 

--- a/Build/linq2db.Tests.Providers.props
+++ b/Build/linq2db.Tests.Providers.props
@@ -12,7 +12,7 @@
 
 		<PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" />
 		<PackageReference Include="MySql.Data" Version="8.0.18" Alias="MySqlData" />
-		<PackageReference Include="MySqlConnector" Version="0.60.3" Alias="MySqlConnector" />
+		<PackageReference Include="MySqlConnector" Version="0.61.0" Alias="MySqlConnector" />
 		<PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="7.1.1" />
 		<PackageReference Include="AdoNetCore.AseClient" Version="0.16.0" />
 

--- a/Build/linq2db.Tests.Providers.props
+++ b/Build/linq2db.Tests.Providers.props
@@ -72,7 +72,7 @@
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
 		<PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.60" />
 		<PackageReference Include="Microsoft.Data.SQLite" Version="3.1.0" />
-		<PackageReference Include="Npgsql" Version="4.1.1" />
+		<PackageReference Include="Npgsql" Version="4.1.2" />
 		<PackageReference Include="MiniProfiler.Shared" Version="4.1.0" />
 
 		<!--magic-->

--- a/Build/linq2db.Tests.Providers.props
+++ b/Build/linq2db.Tests.Providers.props
@@ -19,7 +19,7 @@
 		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
 		<PackageReference Include="System.Data.SqlClient" Version="4.8.0" />
-		<PackageReference Include="Microsoft.Data.SqlClient" Version="1.0.19269.1" />
+		<PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.0" />
 
 		<ProjectReference Include="..\Base\Tests.Base.csproj" />
 

--- a/Build/linq2db.Tests.Providers.props
+++ b/Build/linq2db.Tests.Providers.props
@@ -18,7 +18,7 @@
 
 		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-		<PackageReference Include="System.Data.SqlClient" Version="4.7.0" />
+		<PackageReference Include="System.Data.SqlClient" Version="4.8.0" />
 		<PackageReference Include="Microsoft.Data.SqlClient" Version="1.0.19269.1" />
 
 		<ProjectReference Include="..\Base\Tests.Base.csproj" />

--- a/Build/linq2db.Tests.Providers.props
+++ b/Build/linq2db.Tests.Providers.props
@@ -56,7 +56,7 @@
 		</Reference>
 
 		<PackageReference Include="MiniProfiler" Version="3.2.0.157" />
-		<PackageReference Include="Oracle.ManagedDataAccess" Version="19.5.0" />
+		<PackageReference Include="Oracle.ManagedDataAccess" Version="19.6.0" />
 		<PackageReference Include="Microsoft.SqlServer.Types" Version="14.0.1016.290" />
 		<PackageReference Include="Npgsql" Version="4.0.10" />
 
@@ -70,7 +70,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-		<PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.50" />
+		<PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.60" />
 		<PackageReference Include="Microsoft.Data.SQLite" Version="3.1.0" />
 		<PackageReference Include="Npgsql" Version="4.1.1" />
 		<PackageReference Include="MiniProfiler.Shared" Version="4.1.0" />

--- a/Build/linq2db.Tests.Providers.props
+++ b/Build/linq2db.Tests.Providers.props
@@ -71,15 +71,8 @@
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
 		<PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.50" />
-		<PackageReference Include="Microsoft.Data.SQLite" Version="3.0.0" />
+		<PackageReference Include="Microsoft.Data.SQLite" Version="3.1.0" />
 		<PackageReference Include="Npgsql" Version="4.1.1" />
-		<!--
-		TEMPORARY EXPLICIT TRANSIENT DEPENDENCY FROM Microsoft.Data.SQLite 3.0.0
-		REMOVE WHEN dependency updated to 2.0.1+ (expected in 3.1.0)
-		Needed because 2.0.0 has this bug which fails TestBinary test
-		https://github.com/aspnet/EntityFrameworkCore/issues/17494
-		-->
-		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.2" />
 		<PackageReference Include="MiniProfiler.Shared" Version="4.1.0" />
 
 		<!--magic-->

--- a/Build/linq2db.Tests.props
+++ b/Build/linq2db.Tests.props
@@ -29,7 +29,7 @@
 		<Reference Include="System.Data.Linq" />
 		<Reference Include="System.ServiceModel" />
 
-		<PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
+		<PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
 	</ItemGroup>
 
 </Project>

--- a/Build/linq2db.Tests.props
+++ b/Build/linq2db.Tests.props
@@ -22,7 +22,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="NUnit" Version="3.12.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net46' ">

--- a/NuGet/linq2db.Access.nuspec
+++ b/NuGet/linq2db.Access.nuspec
@@ -19,11 +19,11 @@
 			</group>
 			<group targetFramework=".NETStandard2.0">
 				<dependency id="linq2db"                  version="3.0.0"/>
-				<dependency id="System.Data.OleDb"        version="4.6.0" />
+				<dependency id="System.Data.OleDb"        version="4.7.0" />
 			</group>
 			<group targetFramework=".NETCoreApp2.1">
 				<dependency id="linq2db"                  version="3.0.0"/>
-				<dependency id="System.Data.OleDb"        version="4.6.0" />
+				<dependency id="System.Data.OleDb"        version="4.7.0" />
 			</group>
 		</dependencies>
 		<contentFiles>

--- a/NuGet/linq2db.MySqlConnector.nuspec
+++ b/NuGet/linq2db.MySqlConnector.nuspec
@@ -11,7 +11,7 @@
 		</summary>
 		<tags>linq linq2db MySql LinqToDB ORM database DB SQL</tags>
 		<dependencies>
-			<dependency id="MySqlConnector" version="0.60.3" />
+			<dependency id="MySqlConnector" version="0.61.0" />
 			<dependency id="linq2db"        version="3.0.0"  />
 		</dependencies>
 		<contentFiles>

--- a/NuGet/linq2db.MySqlConnector.nuspec
+++ b/NuGet/linq2db.MySqlConnector.nuspec
@@ -11,7 +11,7 @@
 		</summary>
 		<tags>linq linq2db MySql LinqToDB ORM database DB SQL</tags>
 		<dependencies>
-			<dependency id="MySqlConnector" version="0.60.2" />
+			<dependency id="MySqlConnector" version="0.60.3" />
 			<dependency id="linq2db"        version="3.0.0"  />
 		</dependencies>
 		<contentFiles>

--- a/NuGet/linq2db.Oracle.Managed.nuspec
+++ b/NuGet/linq2db.Oracle.Managed.nuspec
@@ -14,19 +14,19 @@
 		<dependencies>
 			<group targetFramework=".NETFramework4.5">
 				<dependency id="linq2db"                  version="3.0.0"/>
-				<dependency id="Oracle.ManagedDataAccess" version="19.5.0"/>
+				<dependency id="Oracle.ManagedDataAccess" version="19.6.0"/>
 			</group>
 			<group targetFramework=".NETFramework4.6">
 				<dependency id="linq2db"                  version="3.0.0"/>
-				<dependency id="Oracle.ManagedDataAccess" version="19.5.0"/>
+				<dependency id="Oracle.ManagedDataAccess" version="19.6.0"/>
 			</group>
 			<group targetFramework=".NETStandard2.0">
 				<dependency id="linq2db"                       version="3.0.0"/>
-				<dependency id="Oracle.ManagedDataAccess.Core" version="2.19.50"/>
+				<dependency id="Oracle.ManagedDataAccess.Core" version="2.19.60"/>
 			</group>
 			<group targetFramework=".NETCoreApp2.1">
 				<dependency id="linq2db"                       version="3.0.0"/>
-				<dependency id="Oracle.ManagedDataAccess.Core" version="2.19.50"/>
+				<dependency id="Oracle.ManagedDataAccess.Core" version="2.19.60"/>
 			</group>
 		</dependencies>
 		<contentFiles>

--- a/NuGet/linq2db.PostgreSQL.nuspec
+++ b/NuGet/linq2db.PostgreSQL.nuspec
@@ -16,15 +16,15 @@
 				<dependency id="linq2db" version="3.0.0" />
 			</group>
 			<group targetFramework=".NETFramework4.6.1">
-				<dependency id="Npgsql"  version="4.1.1" />
+				<dependency id="Npgsql"  version="4.1.2" />
 				<dependency id="linq2db" version="3.0.0" />
 			</group>
 			<group targetFramework=".NETStandard2.0">
-				<dependency id="Npgsql"  version="4.1.1" />
+				<dependency id="Npgsql"  version="4.1.2" />
 				<dependency id="linq2db" version="3.0.0" />
 			</group>
 			<group targetFramework=".NETCoreApp2.1">
-				<dependency id="Npgsql"  version="4.1.1" />
+				<dependency id="Npgsql"  version="4.1.2" />
 				<dependency id="linq2db" version="3.0.0" />
 			</group>
 		</dependencies>

--- a/NuGet/linq2db.SQLite.MS.nuspec
+++ b/NuGet/linq2db.SQLite.MS.nuspec
@@ -12,7 +12,7 @@
 		<tags>linq linq2db SQLite LinqToDB ORM database DB SQL</tags>
 		<dependencies>
 			<dependency id="linq2db"                version="3.0.0"/>
-			<dependency id="Microsoft.Data.Sqlite"  version="3.0.0"/>
+			<dependency id="Microsoft.Data.Sqlite"  version="3.1.0"/>
 		</dependencies>
 		<contentFiles>
 			<files include="**\*" buildAction="None"/>

--- a/NuGet/linq2db.SQLite.nuspec
+++ b/NuGet/linq2db.SQLite.nuspec
@@ -12,7 +12,7 @@
 		<tags>linq linq2db SQLite LinqToDB ORM database DB SQL</tags>
 		<dependencies>
 			<dependency id="linq2db"                  version="3.0.0"/>
-			<dependency id="System.Data.SQLite.Core"  version="1.0.111"/>
+			<dependency id="System.Data.SQLite.Core"  version="1.0.112"/>
 		</dependencies>
 		<contentFiles>
 			<files include="**\*" buildAction="None"/>

--- a/NuGet/linq2db.SqlServer.MS.nuspec
+++ b/NuGet/linq2db.SqlServer.MS.nuspec
@@ -11,8 +11,8 @@
 		</summary>
 		<tags>linq linq2db SqlServer LinqToDB ORM database DB SQL</tags>
 		<dependencies>
-			<dependency id="linq2db"                   version="3.0.0"       />
-			<dependency id="Microsoft.Data.SqlClient"  version="1.0.19269.1" />
+			<dependency id="linq2db"                   version="3.0.0" />
+			<dependency id="Microsoft.Data.SqlClient"  version="1.1.0" />
 		</dependencies>
 		<contentFiles>
 			<files include="**\*" buildAction="None"/>

--- a/NuGet/linq2db.Sybase.DataAction.nuspec
+++ b/NuGet/linq2db.Sybase.DataAction.nuspec
@@ -12,7 +12,7 @@
 		<tags>linq linq2db SAP Sybase LinqToDB ORM database DB SQL</tags>
 		<dependencies>
 			<dependency id="linq2db"              version="3.0.0"  />
-			<dependency id="AdoNetCore.AseClient" version="0.15.0" />
+			<dependency id="AdoNetCore.AseClient" version="0.16.0" />
 		</dependencies>
 		<contentFiles>
 			<files include="**\*" buildAction="None"/>

--- a/NuGet/linq2db.nuspec
+++ b/NuGet/linq2db.nuspec
@@ -14,14 +14,14 @@
 			<group targetFramework=".NETStandard2.0">
 				<dependency id="Microsoft.CSharp"                     version="4.6.0" />
 				<dependency id="System.ComponentModel.Annotations"    version="4.6.0" />
-				<dependency id="System.Data.Odbc"                     version="4.6.0" />
-				<dependency id="System.Data.OleDb"                    version="4.6.0" />
+				<dependency id="System.Data.Odbc"                     version="4.7.0" />
+				<dependency id="System.Data.OleDb"                    version="4.7.0" />
 				<dependency id="System.Data.DataSetExtensions"        version="4.5.0" />
 			</group>
 			<group targetFramework=".NETCoreApp2.1">
 				<dependency id="System.ComponentModel.Annotations"    version="4.6.0" />
-				<dependency id="System.Data.Odbc"                     version="4.6.0" />
-				<dependency id="System.Data.OleDb"                    version="4.6.0" />
+				<dependency id="System.Data.Odbc"                     version="4.7.0" />
+				<dependency id="System.Data.OleDb"                    version="4.7.0" />
 				<dependency id="System.Data.DataSetExtensions"        version="4.5.0" />
 			</group>
 		</dependencies>

--- a/NuGet/linq2db.nuspec
+++ b/NuGet/linq2db.nuspec
@@ -12,14 +12,14 @@
 			<group targetFramework=".NETFramework4.5" />
 			<group targetFramework=".NETFramework4.6" />
 			<group targetFramework=".NETStandard2.0">
-				<dependency id="Microsoft.CSharp"                     version="4.6.0" />
-				<dependency id="System.ComponentModel.Annotations"    version="4.6.0" />
+				<dependency id="Microsoft.CSharp"                     version="4.7.0" />
+				<dependency id="System.ComponentModel.Annotations"    version="4.7.0" />
 				<dependency id="System.Data.Odbc"                     version="4.7.0" />
 				<dependency id="System.Data.OleDb"                    version="4.7.0" />
 				<dependency id="System.Data.DataSetExtensions"        version="4.5.0" />
 			</group>
 			<group targetFramework=".NETCoreApp2.1">
-				<dependency id="System.ComponentModel.Annotations"    version="4.6.0" />
+				<dependency id="System.ComponentModel.Annotations"    version="4.7.0" />
 				<dependency id="System.Data.Odbc"                     version="4.7.0" />
 				<dependency id="System.Data.OleDb"                    version="4.7.0" />
 				<dependency id="System.Data.DataSetExtensions"        version="4.5.0" />

--- a/Source/LinqToDB/Async/AsyncFactory.cs
+++ b/Source/LinqToDB/Async/AsyncFactory.cs
@@ -115,6 +115,7 @@ namespace LinqToDB.Async
 			// ValueTask DisposeAsync()
 			// Availability:
 			// - DbTransaction (netstandard2.1, netcoreapp3.0)
+			// - Npgsql 4.1.2+
 			var disposeAsync  = CreateDelegate<Func<IDbConnection                    , Task>, IDbConnection >(type, "DisposeAsync" , Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, true )
 			// Task DisposeAsync()
 			// Availability:
@@ -176,6 +177,7 @@ namespace LinqToDB.Async
 			// ValueTask DisposeAsync()
 			// Availability:
 			// - (stub) DbConnection (netstandard2.1, netcoreapp3.0)
+			// - Npgsql 4.1.2+
 			var disposeAsync            = CreateDelegate<Func<IDbConnection, Task>, IDbConnection>(type, "DisposeAsync", Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, true )
 			// Task DisposeAsync()
 			// Availability:

--- a/Source/LinqToDB/Async/AsyncFactory.cs
+++ b/Source/LinqToDB/Async/AsyncFactory.cs
@@ -137,6 +137,7 @@ namespace LinqToDB.Async
 			// Availability:
 			// - (stub) DbConnection (netstandard2.1, netcoreapp3.0)
 			// - MySqlConnector 0.57+
+			// - Npgsql 4.1.2+
 			var beginTransactionAsync   = CreateTaskTDelegate<Func<IDbConnection, CancellationToken                , Task<IAsyncDbTransaction>>, IDbConnection, IDbTransaction>(type, "BeginTransactionAsync", _tokenParams           , _transactionWrap, true)
 			// Task<IDbTransaction> BeginTransactionAsync(CancellationToken)
 			// Availability:
@@ -148,6 +149,7 @@ namespace LinqToDB.Async
 			// Availability:
 			// - (stub) DbConnection (netstandard2.1, netcoreapp3.0)
 			// - MySqlConnector 0.57+
+			// - Npgsql 4.1.2+
 			var beginTransactionIlAsync = CreateTaskTDelegate<Func<IDbConnection, IsolationLevel, CancellationToken, Task<IAsyncDbTransaction>>, IDbConnection, IDbTransaction>(type, "BeginTransactionAsync", _beginTransactionParams, _transactionWrap, true)
 			// Task<IDbTransaction> BeginTransactionAsync(IsolationLevel, CancellationToken)
 			// Availability:

--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteDataProvider.cs
@@ -126,9 +126,7 @@ namespace LinqToDB.DataProvider.SQLite
 			// handles situation, when char values were serialized as character hex value for some
 			// versions of Microsoft.Data.Sqlite
 			if (Name == ProviderName.SQLiteMS && value is char)
-			{
 				value = value.ToString();
-			}
 
 			// reverting compatibility breaking change in Microsoft.Data.Sqlite 3.0.0
 			// https://github.com/aspnet/EntityFrameworkCore/issues/15078

--- a/Source/LinqToDB/LinqToDB.csproj
+++ b/Source/LinqToDB/LinqToDB.csproj
@@ -69,9 +69,9 @@
 		<Compile Include="Compatibility\System\Data\Linq\Binary.cs" />
 		<Compile Include="Compatibility\System\Diagnostics\CodeAnalysis\NullableAttributes.cs" />
 
-		<PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
+		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-		<PackageReference Include="System.ComponentModel.Annotations" Version="4.6.0" />
+		<PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
 		<PackageReference Include="System.Data.Odbc" Version="4.7.0" />
 		<PackageReference Include="System.Data.OleDb" Version="4.7.0" />
 	</ItemGroup>

--- a/Source/LinqToDB/LinqToDB.csproj
+++ b/Source/LinqToDB/LinqToDB.csproj
@@ -72,8 +72,8 @@
 		<PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
 		<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
 		<PackageReference Include="System.ComponentModel.Annotations" Version="4.6.0" />
-		<PackageReference Include="System.Data.Odbc" Version="4.6.0" />
-		<PackageReference Include="System.Data.OleDb" Version="4.6.0" />
+		<PackageReference Include="System.Data.Odbc" Version="4.7.0" />
+		<PackageReference Include="System.Data.OleDb" Version="4.7.0" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/Tests/Base/Tests.Base.csproj
+++ b/Tests/Base/Tests.Base.csproj
@@ -10,7 +10,7 @@
 		<ProjectReference Include="..\Model\Tests.Model.csproj" />
 
 		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net46' ">

--- a/Tests/Linq/DataProvider/SQLiteTests.cs
+++ b/Tests/Linq/DataProvider/SQLiteTests.cs
@@ -562,7 +562,7 @@ namespace Tests.DataProvider
 			switch (context)
 			{
 				case ProviderName.SQLiteClassic:
-					expectedVersion = "3.28.0";
+					expectedVersion = "3.30.1";
 					break;
 				case ProviderName.SQLiteMS:
 #if NET46

--- a/Tests/Linq/Linq/FullTextTests.SQLite.cs
+++ b/Tests/Linq/Linq/FullTextTests.SQLite.cs
@@ -497,13 +497,9 @@ namespace Tests.Linq
 				{
 					Assert.AreEqual("INSERT INTO [FTS5_TABLE]([FTS5_TABLE], rowid, [text1], [text2]) VALUES('delete', 2, @p0, @p1)", db.LastQuery);
 					
-					// TODO: remove condition after moving from Microsoft.Data.Sqlite 3.0.0
-					if (db.Command.CommandText != null)
-					{
-						Assert.AreEqual(2, db.Command.Parameters.Count);
-						Assert.AreEqual("one", ((DbParameter)db.Command.Parameters[0]).Value);
-						Assert.AreEqual("two", ((DbParameter)db.Command.Parameters[1]).Value);
-					}
+					Assert.AreEqual(2, db.Command.Parameters.Count);
+					Assert.AreEqual("one", ((DbParameter)db.Command.Parameters[0]).Value);
+					Assert.AreEqual("two", ((DbParameter)db.Command.Parameters[1]).Value);
 				}
 			}
 		}
@@ -637,12 +633,8 @@ namespace Tests.Linq
 				{
 					Assert.AreEqual("INSERT INTO [FTS5_TABLE]([FTS5_TABLE], rank) VALUES('rank', @rank)", db.LastQuery);
 
-					// TODO: remove condition after moving from Microsoft.Data.Sqlite 3.0.0
-					if (db.Command.CommandText != null)
-					{
-						Assert.AreEqual(1, db.Command.Parameters.Count);
-						Assert.AreEqual("strange('function\")", ((DbParameter)db.Command.Parameters[0]).Value);
-					}
+					Assert.AreEqual(1, db.Command.Parameters.Count);
+					Assert.AreEqual("strange('function\")", ((DbParameter)db.Command.Parameters[0]).Value);
 				}
 			}
 		}

--- a/Tests/Tests.Android/packages.config
+++ b/Tests/Tests.Android/packages.config
@@ -20,8 +20,8 @@
   <package id="System.Configuration.ConfigurationManager" version="4.6.0" targetFramework="monoandroid81" />
   <package id="System.Console" version="4.0.0" targetFramework="monoandroid81" />
   <package id="System.Data.DataSetExtensions" version="4.5.0" targetFramework="monoandroid81" />
-  <package id="System.Data.Odbc" version="4.6.0" targetFramework="monoandroid81" />
-  <package id="System.Data.OleDb" version="4.6.0" targetFramework="monoandroid81" />
+  <package id="System.Data.Odbc" version="4.7.0" targetFramework="monoandroid81" />
+  <package id="System.Data.OleDb" version="4.7.0" targetFramework="monoandroid81" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="monoandroid81" />
   <package id="System.Diagnostics.Tools" version="4.0.1" targetFramework="monoandroid81" />
   <package id="System.Diagnostics.Tracing" version="4.1.0" targetFramework="monoandroid81" />

--- a/Tests/Tests.Android/packages.config
+++ b/Tests/Tests.Android/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Data.Sqlite" version="3.0.0" targetFramework="monoandroid81" />
-  <package id="Microsoft.Data.Sqlite.Core" version="3.0.0" targetFramework="monoandroid81" />
+  <package id="Microsoft.Data.Sqlite" version="3.1.0" targetFramework="monoandroid81" />
+  <package id="Microsoft.Data.Sqlite.Core" version="3.1.0" targetFramework="monoandroid81" />
   <package id="Microsoft.NETCore.Platforms" version="1.0.1" targetFramework="monoandroid81" />
   <package id="Microsoft.Win32.Primitives" version="4.0.1" targetFramework="monoandroid81" />
   <package id="Microsoft.Win32.Registry" version="4.6.0" targetFramework="monoandroid81" />

--- a/Tests/Tests.Benchmarks/Tests.Benchmarks.csproj
+++ b/Tests/Tests.Benchmarks/Tests.Benchmarks.csproj
@@ -9,6 +9,6 @@
 		<Nullable>disable</Nullable>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
+		<PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
 	</ItemGroup>
 </Project>

--- a/Tests/Tests.T4/Tests.T4.csproj
+++ b/Tests/Tests.T4/Tests.T4.csproj
@@ -126,7 +126,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-		<PackageReference Include="Npgsql" Version="4.1.1" />
+		<PackageReference Include="Npgsql" Version="4.1.2" />
 		<!--nuget doesn't have strong name, so we use local self-signed copy-->
 		<!--<PackageReference Include="dotMorten.Microsoft.SqlServer.Types" Version="1.1.0" />-->
 		<Reference Include="Microsoft.SqlServer.Types">

--- a/Tests/Tests.T4/Tests.T4.csproj
+++ b/Tests/Tests.T4/Tests.T4.csproj
@@ -135,7 +135,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="System.ComponentModel.Annotations" Version="4.6.0" />
+		<PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
 	<None Remove="Models\bbb.txt" />
 	<Content Include="Models\bbb.txt" />
 	</ItemGroup>


### PR DESCRIPTION
Update dependencies, changed since last update.

Buld and test tools:
- [nuget.exe](https://docs.microsoft.com/en-us/nuget/release-notes/nuget-5.4) 5.3.0 -> 5.4.0
- [BenchmarkDotNet](https://www.nuget.org/packages/BenchmarkDotNet) 0.11.5 -> 0.12.0
- [System.ComponentModel.Annotations](https://www.nuget.org/packages/System.ComponentModel.Annotations) 4.6.0 -> 4.7.0
- [Microsoft.CSharp](https://www.nuget.org/packages/Microsoft.CSharp) 4.6.0 -> 4.7.0
- [System.Collections.Immutable](https://www.nuget.org/packages/System.Collections.Immutable) 1.6.0 -> 1.7.0
- [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json) 12.0.2 -> 12.0.3
- [Microsoft.NET.Test.Sdk](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk) 16.3.0 -> 16.4.0
- [Microsoft.SourceLink.GitHub](https://www.nuget.org/packages/Microsoft.SourceLink.GitHub) 1.0.0-beta2-19367-01  -> 1.0.0 (also need to do it in master for 2.x)

Providers:
- [AdoNetCore.AseClient](https://www.nuget.org/packages/AdoNetCore.AseClient) 0.15.0 -> 0.16.0
- [System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite) 1.0.111 -> 1.0.112
- [MySqlConnector](https://www.nuget.org/packages/MySqlConnector) 0.60.2 -> 0.61.0
- [Microsoft.Data.SQLite](https://www.nuget.org/packages/Microsoft.Data.SQLite) 3.0.0 -> 3.1.0
- [Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient) 1.0.19269.1 -> 1.1.0
- [System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient) 4.7.0 -> 4.8.0
- [System.Data.OleDb](https://www.nuget.org/packages/System.Data.OleDb) 4.6.0 -> 4.7.0
- [System.Data.Odbc](https://www.nuget.org/packages/System.Data.Odbc) 4.6.0 -> 4.7.0
- [Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess) 19.5.0 -> 19.6.0
- [Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core) 2.19.50 -> 2.19.60
- [Npgsql](https://www.nuget.org/packages/Npgsql) 4.1.1 -> 4.1.2

No functional changes needed. MySqlConnector added useful `CloneWith` connection method, but I hope we should finalize eager loading feature soon and remove connection cloning from linq2db