### PR TITLE
Fix for #1965. Redirecting to specific association context methods.

### DIFF
--- a/Source/LinqToDB/Linq/Builder/TableBuilder.AssociatedTableContext.cs
+++ b/Source/LinqToDB/Linq/Builder/TableBuilder.AssociatedTableContext.cs
@@ -130,6 +130,9 @@ namespace LinqToDB.Linq.Builder
 
 					// add rest of tables
 					SelectQuery.From.Tables.AddRange(associationQuery.Select.From.Tables.Where(t => t != sourceToReplace));
+
+					//TODO: Change AssociatedTableContext base class
+					//SqlTable = null;
 				}
 				else
 				{

--- a/Tests/Linq/UserTests/Issue1965Tests.cs
+++ b/Tests/Linq/UserTests/Issue1965Tests.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using LinqToDB;
+using LinqToDB.Mapping;
+using NUnit.Framework;
+
+namespace Tests.UserTests
+{
+	[TestFixture]
+	public class Issue1965Tests : TestBase
+	{
+		[Table("Issue1965Person")]
+		public class Issue1965Person
+		{
+			[Column]
+			public int Id {get; set;}
+			[Column]
+			public string Name {get; set;}
+			[Column]
+			public int Age {get; set;}
+	
+	
+		}
+
+		[Table("Chipcard")]
+		public class Chipcard
+		{
+			[Column]
+			public int PersonId {get; set;}
+			[Column]
+			public DateTime ValidationEnd {get; set;}	
+	
+//			[Association(ThisKey="PersonId", OtherKey="Id", CanBeNull=true, Relationship=Relationship.ManyToOne, KeyName="FK_CHIPCARD")]
+//			public Person PersonData {get; set;}
+	
+			[Association(QueryExpressionMethod = nameof(Chipcard_Person), CanBeNull = true)]
+			public Issue1965Person PersonData {get; set;}
+	
+			public static Expression<Func<Chipcard, IDataContext, IQueryable<Issue1965Person>>> Chipcard_Person()
+			{
+				return (c, db) => db.GetTable<Issue1965Person>().Where(p => p.Id == c.PersonId);
+			}
+		}
+
+		[Test]
+		public void SampleSelectTest([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (db.CreateLocalTable<Issue1965Person>())
+			using (db.CreateLocalTable<Chipcard>())
+			{
+				var q = db.GetTable<Chipcard>().LoadWith(c => c.PersonData);
+	
+				var result = q.Where(ka => ka.PersonData != null).ToList();			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1965

Looks like we have to find time to review this functionality in 3.X 