### PR TITLE
Fix Sql.ConcatString for MSSQL 2016-

### DIFF
--- a/Source/LinqToDB/Sql/Sql.Strings.cs
+++ b/Source/LinqToDB/Sql/Sql.Strings.cs
@@ -377,7 +377,9 @@ namespace LinqToDB
 
 			protected override SqlExpression TruncateExpression(ISqlExpression value, ISqlExpression separator)
 			{
-				return new SqlExpression(typeof(string), "SUBSTRING({0}, LEN({1}) + 2, 8000)",
+				// you can read more about this gore code here:
+				// https://stackoverflow.com/questions/2025585
+				return new SqlExpression(typeof(string), "SUBSTRING({0}, LEN(CONVERT(NVARCHAR(MAX), {1}) + N'!'), 8000)",
 					Precedence.Primary, value, separator);
 			}
 		}

--- a/Tests/Linq/UserTests/Issue1977Tests.cs
+++ b/Tests/Linq/UserTests/Issue1977Tests.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using LinqToDB;
+using LinqToDB.Mapping;
+using NUnit.Framework;
+
+namespace Tests.UserTests
+{
+	[TestFixture]
+	public class Issue1977Tests : TestBase
+	{
+		public class Issue1977Table
+		{
+			public Guid firstField;
+			public Guid secondField;
+
+			public static Issue1977Table[] TestData { get; }
+				= new[]
+				{
+					new Issue1977Table()
+					{
+						firstField = Guid.NewGuid(),
+						secondField = Guid.NewGuid()
+					}
+				};
+		}
+
+		[Test]
+		public void Test([IncludeDataSources(TestProvName.AllSqlServer)] string context)
+		{
+			using (var db    = GetDataContext(context))
+			using (var table = db.CreateLocalTable(Issue1977Table.TestData))
+			{
+				var itemsQuery = table
+				.Select
+				(
+					f => new
+					{
+						oldStr = nameof(Issue1977Table)
+						 + "/" + f.firstField
+						 + "/" + f.secondField,
+						newStr = Sql.AsSql(Sql.ConcatStrings("/",
+							nameof(Issue1977Table),
+							Sql.Convert<string, Guid>(f.firstField),
+							Sql.Convert<string, Guid>(f.secondField)))
+					}
+				)
+				.Select
+				(
+					f => new
+					{
+						equals = Sql.AsSql(f.oldStr == f.newStr)
+					}
+				);
+
+				Assert.True(itemsQuery.ToArray().All(r => r.equals));
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fix #1977

Quite interesting issue - function was working correctly with existing tests due to two bugs negate each other:
- incorrect position passed to substring
- use of separator, for which mssql LEN produce incorrect (I insist!) result