### PR TITLE
Fix support for pre-evaluated IQueryable sources with nested lambdas in queries

### DIFF
--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2012SqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2012SqlOptimizer.cs
@@ -1,13 +1,17 @@
-﻿using System;
-
-namespace LinqToDB.DataProvider.SqlServer
+﻿namespace LinqToDB.DataProvider.SqlServer
 {
 	using SqlProvider;
 	using SqlQuery;
 
 	class SqlServer2012SqlOptimizer : SqlServerSqlOptimizer
 	{
-		public SqlServer2012SqlOptimizer(SqlProviderFlags sqlProviderFlags, SqlServerVersion sqlVersion = SqlServerVersion.v2012) : base(sqlProviderFlags, sqlVersion)
+		public SqlServer2012SqlOptimizer(SqlProviderFlags sqlProviderFlags)
+			: this(sqlProviderFlags, SqlServerVersion.v2012)
+		{
+		}
+
+		protected SqlServer2012SqlOptimizer(SqlProviderFlags sqlProviderFlags, SqlServerVersion sqlVersion = SqlServerVersion.v2012)
+			: base(sqlProviderFlags, sqlVersion)
 		{
 		}
 

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
@@ -1580,7 +1580,20 @@ namespace LinqToDB.Linq.Builder
 				var exas = expression.GetExpressionAccessors(p);
 				var expr = ReplaceParameter(exas, expression, _ => {}).ValueExpression;
 
-				if (expr.Find(e => e.NodeType == ExpressionType.Parameter && e != p) != null)
+				var allowedParameters = new HashSet<ParameterExpression>() { p };
+
+				if (null != expr.Find(e => {
+					if (e is LambdaExpression lambda)
+					{
+						// allow parameters, declared inside expr
+						foreach (var param in lambda.Parameters)
+							allowedParameters.Add(param);
+					}
+					else if (e is ParameterExpression pe)
+						return !allowedParameters.Contains(pe);
+
+					return false;
+				}))
 					return expression;
 
 				var l    = Expression.Lambda<Func<Expression,IQueryable>>(Expression.Convert(expr, typeof(IQueryable)), new [] { p });


### PR DESCRIPTION
- add tests with fix
- also fixed sql server remote context regression, introduced by  #1985

Also tests found another parameter evaluation issue. Created test without fix