### PR TITLE
MySql CreateTable and DateTimeOffset improvements

### DIFF
--- a/Source/LinqToDB/DataProvider/MySql/MySqlDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlDataProvider.cs
@@ -62,9 +62,17 @@ namespace LinqToDB.DataProvider.MySql
 				_mySqlDateTimeValueGetter = TypeAccessor.GetAccessor(_mySqlDateTimeType)["Value"].Getter;
 
 				SetProviderField(_mySqlDecimalType, "GetMySqlDecimal");
-				SetToTypeField(_mySqlDecimalType,   "GetMySqlDecimal");
+				SetToTypeField  (_mySqlDecimalType, "GetMySqlDecimal");
 
 				MappingSchema.SetDataType(_mySqlDecimalType, DataType.Decimal);
+
+				// TODO: first we need to be able to read TIMESTAMP columns with MySQL.Data provider
+				//SetProviderField<IDataReader, DateTimeOffset>((r, i) => new DateTimeOffset(r.GetDateTime(i), TimeSpan.Zero));
+			}
+			else
+			{
+				SetProviderField(typeof(DateTimeOffset), "GetDateTimeOffset");
+				SetToTypeField  (typeof(DateTimeOffset), "GetDateTimeOffset");
 			}
 
 			SetProviderField(_mySqlDateTimeType, "GetMySqlDateTime");

--- a/Source/LinqToDB/DataProvider/MySql/MySqlSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlSqlBuilder.cs
@@ -8,6 +8,7 @@ namespace LinqToDB.DataProvider.MySql
 {
 	using SqlQuery;
 	using SqlProvider;
+	using LinqToDB.Extensions;
 
 	class MySqlSqlBuilder : BasicSqlBuilder
 	{
@@ -75,34 +76,135 @@ namespace LinqToDB.DataProvider.MySql
 		{
 			switch (type.DataType)
 			{
-				case DataType.Int16         :
-				case DataType.Int32         :
-				case DataType.Int64         :
-					if (createDbType) goto default;
-					StringBuilder.Append("Signed");
-					break;
-				case DataType.SByte         :
-				case DataType.Byte          :
-				case DataType.UInt16        :
-				case DataType.UInt32        :
-				case DataType.UInt64        :
-					if (createDbType) goto default;
-					StringBuilder.Append("Unsigned");
-					break;
-				case DataType.Money         : StringBuilder.Append("Decimal(19,4)");                 break;
-				case DataType.SmallMoney    : StringBuilder.Append("Decimal(10,4)");                 break;
+				case DataType.SByte         : StringBuilder.Append("TINYINT");                       break;
+				case DataType.Int16         : StringBuilder.Append("SMALLINT");                      break;
+				case DataType.Int32         : StringBuilder.Append("INT");                           break;
+				case DataType.Int64         : StringBuilder.Append("BIGINT");                        break;
+				case DataType.Byte          : StringBuilder.Append("TINYINT UNSIGNED");              break;
+				case DataType.UInt16        : StringBuilder.Append("SMALLINT UNSIGNED");             break;
+				case DataType.UInt32        : StringBuilder.Append("INT UNSIGNED");                  break;
+				case DataType.UInt64        : StringBuilder.Append("BIGINT UNSIGNED");               break;
+				case DataType.Money         : StringBuilder.Append("DECIMAL(19,4)");                 break;
+				case DataType.SmallMoney    : StringBuilder.Append("DECIMAL(10,4)");                 break;
+				case DataType.Decimal       :
+					if (type.Scale != null && type.Scale != 0)
+						StringBuilder.Append($"DECIMAL({type.Precision ?? 10},{type.Scale})");
+					else if (type.Precision != null && type.Precision != 10)
+						StringBuilder.Append($"DECIMAL({type.Precision})");
+					else
+						StringBuilder.Append("DECIMAL"); break;
+				case DataType.DateTime      :
 				case DataType.DateTime2     :
-				case DataType.SmallDateTime : StringBuilder.Append("DateTime");                      break;
-				case DataType.Boolean       : StringBuilder.Append("Boolean");                       break;
+				case DataType.SmallDateTime :
+					if (type.Precision > 0 && type.Precision <= 6)
+						StringBuilder.Append($"DATETIME({type.Precision})");
+					else
+						StringBuilder.Append("DATETIME");
+					break;
+				case DataType.DateTimeOffset:
+					if (type.Precision > 0 && type.Precision <= 6)
+						StringBuilder.Append($"TIMESTAMP({type.Precision})");
+					else
+						StringBuilder.Append("TIMESTAMP");
+					break;
+				case DataType.Time:
+					if (type.Precision > 0 && type.Precision <= 6)
+						StringBuilder.Append($"TIME({type.Precision})");
+					else
+						StringBuilder.Append("TIME");
+					break;
+				case DataType.Boolean       : StringBuilder.Append("BOOLEAN");                       break;
 				case DataType.Double        :
-				case DataType.Single        : base.BuildDataType(SqlDataType.Decimal, createDbType); break;
+					if (type.Precision >= 0 && type.Precision <= 53)
+						StringBuilder.Append($"FLOAT({type.Precision})"); // this is correct, FLOAT(p)
+					else
+						StringBuilder.Append("DOUBLE");
+					break;
+				case DataType.Single        :
+					if (type.Precision >= 0 && type.Precision <= 53)
+						StringBuilder.Append($"FLOAT({type.Precision})");
+					else
+						StringBuilder.Append("FLOAT");
+					break;
+				case DataType.BitArray:
+					{
+						var length = type.Length;
+						if (length == null)
+						{
+							var columnType = type.Type?.ToNullableUnderlying();
+							if (columnType == typeof(byte) || columnType == typeof(sbyte))
+								length = 8;
+							else if (columnType == typeof(short) || columnType == typeof(ushort))
+								length = 16;
+							else if (columnType == typeof(int) || columnType == typeof(uint))
+								length = 32;
+							else if (columnType == typeof(long) || columnType == typeof(ulong))
+								length = 64;
+						}
+
+						if (length != null && length != 1 && length >= 0)
+							StringBuilder.Append($"BIT({length})");
+						else
+							StringBuilder.Append("BIT");
+					}
+					break;
+				case DataType.Date          : StringBuilder.Append("DATE");                          break;
+				case DataType.Json          : StringBuilder.Append("JSON");                          break;
+				case DataType.Guid          : StringBuilder.Append("CHAR(36)");                      break;
+				case DataType.Char          :
+				case DataType.NChar         :
+					if (type.Length == null || type.Length > 255 || type.Length < 0)
+						StringBuilder.Append("CHAR(255)");
+					else if (type.Length == 1)
+						StringBuilder.Append("CHAR");
+					else
+						StringBuilder.Append($"CHAR({type.Length})");
+					break;
 				case DataType.VarChar       :
 				case DataType.NVarChar      :
-					// yep, char(0) is allowed
 					if (type.Length == null || type.Length > 255 || type.Length < 0)
-						StringBuilder.Append("Char(255)");
+						StringBuilder.Append("VARCHAR(255)");
 					else
-						StringBuilder.Append($"Char({type.Length})");
+						StringBuilder.Append($"VARCHAR({type.Length})");
+					break;
+				case DataType.Binary:
+					if (type.Length == null || type.Length < 0)
+						StringBuilder.Append("BINARY(255)");
+					else if (type.Length == 1)
+						StringBuilder.Append("BINARY");
+					else
+						StringBuilder.Append($"BINARY({type.Length})");
+					break;
+				case DataType.VarBinary:
+					if (type.Length == null || type.Length < 0)
+						StringBuilder.Append("VARBINARY(255)");
+					else
+						StringBuilder.Append($"VARBINARY({type.Length})");
+					break;
+				case DataType.Blob:
+					if (type.Length == null || type.Length < 0)
+						StringBuilder.Append("BLOB");
+					else if (type.Length <= 255)
+						StringBuilder.Append("TINYBLOB");
+					else if (type.Length <= 65535)
+						StringBuilder.Append("BLOB");
+					else if (type.Length <= 16777215)
+						StringBuilder.Append("MEDIUMBLOB");
+					else
+						StringBuilder.Append("LONGBLOB");
+					break;
+				case DataType.NText:
+				case DataType.Text:
+					if (type.Length == null || type.Length < 0)
+						StringBuilder.Append("TEXT");
+					else if (type.Length <= 255)
+						StringBuilder.Append("TINYTEXT");
+					else if (type.Length <= 65535)
+						StringBuilder.Append("TEXT");
+					else if (type.Length <= 16777215)
+						StringBuilder.Append("MEDIUMTEXT");
+					else
+						StringBuilder.Append("LONGTEXT");
 					break;
 				default: base.BuildDataType(type, createDbType);                                     break;
 			}

--- a/Tests/Linq/DataProvider/MySqlTests.cs
+++ b/Tests/Linq/DataProvider/MySqlTests.cs
@@ -834,6 +834,278 @@ namespace Tests.DataProvider
 				Assert.AreEqual(1, res);
 			}
 		}
+
+		[Table]
+		public class CreateTable
+		{
+			[Column                                                 ] public string VarChar255;
+			[Column(Length = 1)                                     ] public string VarChar1;
+			[Column(Length = 112)                                   ] public string VarChar112;
+			[Column                                                 ] public char Char;
+			[Column(DataType = DataType.Char)                       ] public string Char255;
+			[Column(DataType = DataType.Char, Length = 1)           ] public string Char1;
+			[Column(DataType = DataType.Char, Length = 112)         ] public string Char112;
+			[Column(Length = 1)                                     ] public byte[] VarBinary1;
+			[Column                                                 ] public byte[] VarBinary255;
+			[Column(Length = 3)                                     ] public byte[] VarBinary3;
+			[Column(DataType = DataType.Binary, Length = 1)         ] public byte[] Binary1;
+			[Column(DataType = DataType.Binary)                     ] public byte[] Binary255;
+			[Column(DataType = DataType.Binary, Length = 3)         ] public byte[] Binary3;
+			[Column(DataType = DataType.Blob, Length = 200)         ] public byte[] TinyBlob;
+			[Column(DataType = DataType.Blob, Length = 2000)        ] public byte[] Blob;
+			[Column(DataType = DataType.Blob, Length = 200000)      ] public byte[] MediumBlob;
+			[Column(DataType = DataType.Blob)                       ] public byte[] BlobDefault;
+			[Column(DataType = DataType.Blob, Length = int.MaxValue)] public byte[] LongBlob;
+			[Column(DataType = DataType.Text, Length = 200)         ] public string TinyText;
+			[Column(DataType = DataType.Text, Length = 2000)        ] public string Text;
+			[Column(DataType = DataType.Text, Length = 200000)      ] public string MediumText;
+			[Column(DataType = DataType.Text, Length = int.MaxValue)] public string LongText;
+			[Column(DataType = DataType.Text)                       ] public string TextDefault;
+			[Column(DataType = DataType.Date)                       ] public DateTime Date;
+			[Column                                                 ] public DateTime DateTime;
+			[Column(Precision = 3)                                  ] public DateTime DateTime3;
+			// MySQL.Data provider has issues with timestamps
+			// TODO: look into it later
+			[Column(Configuration = ProviderName.MySqlConnector)    ] public DateTimeOffset TimeStamp;
+			[Column(Precision = 5, Configuration = ProviderName.MySqlConnector)] public DateTimeOffset TimeStamp5;
+			[Column                                                 ] public TimeSpan Time;
+			[Column(Precision = 2)                                  ] public TimeSpan Time2;
+			[Column                                                 ] public sbyte TinyInt;
+			[Column                                                 ] public byte UnsignedTinyInt;
+			[Column                                                 ] public short SmallInt;
+			[Column                                                 ] public ushort UnsignedSmallInt;
+			[Column                                                 ] public int Int;
+			[Column                                                 ] public uint UnsignedInt;
+			[Column                                                 ] public long BigInt;
+			[Column                                                 ] public ulong UnsignedBigInt;
+			[Column                                                 ] public decimal Decimal;
+			[Column(Precision = 15)                                 ] public decimal Decimal15_0;
+			[Column(Scale = 5)                                      ] public decimal Decimal10_5;
+			[Column(Precision = 20, Scale = 2)                      ] public decimal Decimal20_2;
+			[Column                                                 ] public float Float;
+			[Column(Precision = 10)                                 ] public float Float10;
+			[Column                                                 ] public double Double;
+			[Column(Precision = 30)                                 ] public double Float30;
+			[Column                                                 ] public bool Bool;
+			[Column(DataType = DataType.BitArray)                   ] public bool Bit1;
+			[Column(DataType = DataType.BitArray)                   ] public byte Bit8;
+			[Column(DataType = DataType.BitArray)                   ] public short Bit16;
+			[Column(DataType = DataType.BitArray)                   ] public int Bit32;
+			[Column(DataType = DataType.BitArray, Length = 10)      ] public int Bit10;
+			[Column(DataType = DataType.BitArray)                   ] public long Bit64;
+			[Column(DataType = DataType.Json)                       ] public string Json;
+			// not mysql type, just mapping testing
+			[Column                                                 ] public Guid Guid;
+		}
+
+		[ActiveIssue(Configuration = ProviderName.MySql, Details = "Disable test for MySql test provider, as it use old mysql version, which is fixed in 3.0 branch")]
+		[Test]
+		public void TestCreateTable([IncludeDataSources(false, TestProvName.AllMySql)] string context)
+		{
+			var isMySqlConnector = context == ProviderName.MySqlConnector;
+
+			// TODO: Following types not mapped to DataType enum now and should be defined explicitly using DbType:
+			// - ENUM      : https://dev.mysql.com/doc/refman/8.0/en/enum.html
+			// - SET       : https://dev.mysql.com/doc/refman/8.0/en/set.html
+			// - YEAR      : https://dev.mysql.com/doc/refman/8.0/en/year.html
+			// - MEDIUMINT : https://dev.mysql.com/doc/refman/8.0/en/integer-types.html
+			// - SERIAL    : https://dev.mysql.com/doc/refman/8.0/en/numeric-type-syntax.html
+			// - spatial types : https://dev.mysql.com/doc/refman/8.0/en/spatial-type-overview.html
+			// - any additional attributes for column create clause
+			//
+			// Also we deliberatly don't support various deprecated modifiers:
+			// - display width
+			// - unsigned for non-integer types
+			// - floating point (M,D) specifiers
+			// - synonyms (except BOOLEAN)
+			// etc
+			using (var db = new TestDataConnection(context))
+			using (var table = db.CreateLocalTable<CreateTable>())
+			{
+				var sql = db.LastQuery;
+
+				Assert.True(sql.Contains("\t`VarChar255`       VARCHAR(255)          NULL"));
+				Assert.True(sql.Contains("\t`VarChar1`         VARCHAR(1)            NULL"));
+				Assert.True(sql.Contains("\t`VarChar112`       VARCHAR(112)          NULL"));
+				Assert.True(sql.Contains("\t`Char`             CHAR              NOT NULL"));
+				Assert.True(sql.Contains("\t`Char1`            CHAR                  NULL"));
+				Assert.True(sql.Contains("\t`Char255`          CHAR(255)             NULL"));
+				Assert.True(sql.Contains("\t`Char112`          CHAR(112)             NULL"));
+				Assert.True(sql.Contains("\t`VarBinary1`       VARBINARY(1)          NULL"));
+				Assert.True(sql.Contains("\t`VarBinary255`     VARBINARY(255)        NULL"));
+				Assert.True(sql.Contains("\t`VarBinary3`       VARBINARY(3)          NULL"));
+				Assert.True(sql.Contains("\t`Binary1`          BINARY                NULL"));
+				Assert.True(sql.Contains("\t`Binary255`        BINARY(255)           NULL"));
+				Assert.True(sql.Contains("\t`Binary3`          BINARY(3)             NULL"));
+				Assert.True(sql.Contains("\t`TinyBlob`         TINYBLOB              NULL"));
+				Assert.True(sql.Contains("\t`Blob`             BLOB                  NULL"));
+				Assert.True(sql.Contains("\t`MediumBlob`       MEDIUMBLOB            NULL"));
+				Assert.True(sql.Contains("\t`LongBlob`         LONGBLOB              NULL"));
+				Assert.True(sql.Contains("\t`BlobDefault`      BLOB                  NULL"));
+				Assert.True(sql.Contains("\t`TinyText`         TINYTEXT              NULL"));
+				Assert.True(sql.Contains("\t`Text`             TEXT                  NULL"));
+				Assert.True(sql.Contains("\t`MediumText`       MEDIUMTEXT            NULL"));
+				Assert.True(sql.Contains("\t`LongText`         LONGTEXT              NULL"));
+				Assert.True(sql.Contains("\t`TextDefault`      TEXT                  NULL"));
+				Assert.True(sql.Contains("\t`Date`             DATE              NOT NULL"));
+				Assert.True(sql.Contains("\t`DateTime`         DATETIME          NOT NULL"));
+				Assert.True(sql.Contains("\t`DateTime3`        DATETIME(3)       NOT NULL"));
+				if (isMySqlConnector)
+				{
+					Assert.True(sql.Contains("\t`TimeStamp`        TIMESTAMP         NOT NULL"));
+					Assert.True(sql.Contains("\t`TimeStamp5`       TIMESTAMP(5)      NOT NULL"));
+				}
+				Assert.True(sql.Contains("\t`Time`             TIME              NOT NULL"));
+				Assert.True(sql.Contains("\t`Time2`            TIME(2)           NOT NULL"));
+				Assert.True(sql.Contains("\t`TinyInt`          TINYINT           NOT NULL"));
+				Assert.True(sql.Contains("\t`UnsignedTinyInt`  TINYINT UNSIGNED  NOT NULL"));
+				Assert.True(sql.Contains("\t`SmallInt`         SMALLINT          NOT NULL"));
+				Assert.True(sql.Contains("\t`UnsignedSmallInt` SMALLINT UNSIGNED NOT NULL"));
+				Assert.True(sql.Contains("\t`Int`              INT               NOT NULL"));
+				Assert.True(sql.Contains("\t`UnsignedInt`      INT UNSIGNED      NOT NULL"));
+				Assert.True(sql.Contains("\t`BigInt`           BIGINT            NOT NULL"));
+				Assert.True(sql.Contains("\t`UnsignedBigInt`   BIGINT UNSIGNED   NOT NULL"));
+				Assert.True(sql.Contains("\t`Decimal`          DECIMAL           NOT NULL"));
+				Assert.True(sql.Contains("\t`Decimal15_0`      DECIMAL(15)       NOT NULL"));
+				Assert.True(sql.Contains("\t`Decimal10_5`      DECIMAL(10,5)     NOT NULL"));
+				Assert.True(sql.Contains("\t`Decimal20_2`      DECIMAL(20,2)     NOT NULL"));
+				Assert.True(sql.Contains("\t`Float`            FLOAT             NOT NULL"));
+				Assert.True(sql.Contains("\t`Float10`          FLOAT(10)         NOT NULL"));
+				Assert.True(sql.Contains("\t`Double`           DOUBLE            NOT NULL"));
+				Assert.True(sql.Contains("\t`Float30`          FLOAT(30)         NOT NULL"));
+				Assert.True(sql.Contains("\t`Bool`             BOOLEAN           NOT NULL"));
+				Assert.True(sql.Contains("\t`Bit1`             BIT               NOT NULL"));
+				Assert.True(sql.Contains("\t`Bit8`             BIT(8)            NOT NULL"));
+				Assert.True(sql.Contains("\t`Bit16`            BIT(16)           NOT NULL"));
+				Assert.True(sql.Contains("\t`Bit32`            BIT(32)           NOT NULL"));
+				Assert.True(sql.Contains("\t`Bit10`            BIT(10)           NOT NULL"));
+				Assert.True(sql.Contains("\t`Bit64`            BIT(64)           NOT NULL"));
+				Assert.True(sql.Contains("\t`Json`             JSON                  NULL"));
+				Assert.True(sql.Contains("\t`Guid`             CHAR(36)          NOT NULL"));
+
+				var testRecord = new CreateTable()
+				{
+					VarChar1         = "ы",
+					VarChar255       = "ыsdf",
+					VarChar112       = "ы123",
+					Char             = 'я',
+					Char1            = "!",
+					Char255          = "!sdg3@",
+					Char112          = "123 fd",
+					VarBinary1       = new byte[] { 1 },
+					VarBinary255     = new byte[] { 1, 4, 22 },
+					VarBinary3       = new byte[] { 1, 2, 4 },
+					Binary1          = new byte[] { 22 },
+					Binary255        = new byte[] { 22, 44, 21 },
+					Binary3          = new byte[] { 1, 33 },
+					TinyBlob         = new byte[] { 3, 2, 1 },
+					Blob             = new byte[] { 13, 2, 1 },
+					MediumBlob       = new byte[] { 23, 2, 1 },
+					BlobDefault      = new byte[] { 33, 2, 1 },
+					LongBlob         = new byte[] { 133, 2, 1 },
+					TinyText         = "12я3",
+					Text             = "1232354",
+					MediumText       = "1df3",
+					LongText         = "1v23",
+					TextDefault      = "12 #3",
+					Date             = new DateTime(2123, 2, 3),
+					DateTime         = new DateTime(2123, 2, 3, 11, 22, 33),
+					DateTime3        = new DateTime(2123, 2, 3, 11, 22, 33, 123),
+					TimeStamp        = new DateTimeOffset(2023, 2, 3, 11, 22, 33, TimeSpan.FromMinutes(60)),
+					TimeStamp5       = new DateTimeOffset(2013, 2, 3, 11, 22, 33, 123, TimeSpan.FromMinutes(-60)).AddTicks(45000),
+					Time             = new TimeSpan(-5, 56, 7),
+					Time2            = new TimeSpan(5, 56, 7, 12),
+					TinyInt          = -123,
+					UnsignedTinyInt  = 223,
+					SmallInt         = short.MinValue,
+					UnsignedSmallInt = ushort.MaxValue,
+					Int              = int.MinValue,
+					UnsignedInt      = uint.MaxValue,
+					BigInt           = long.MinValue,
+					UnsignedBigInt   = ulong.MaxValue,
+					Decimal          = 1234m,
+					Decimal15_0      = 123456789012345m,
+					Decimal10_5      = -12345.2345m,
+					Decimal20_2      = -3412345.23m,
+					Float            = 3244.23999f,
+					Float10          = 124.354f,
+					Double           = 452.23523d,
+					Float30          = 332.235d,
+					Bool             = true,
+					Bit1             = true,
+					Bit8             = 0x07,
+					Bit16            = 0xFE,
+					Bit32            = 0xADFE,
+					Bit10            = 0x003F,
+					Bit64            = 0xDEADBEAF,
+					Json             = "{\"x\": 10}",
+					Guid             = Guid.NewGuid()
+				};
+
+				db.Insert(testRecord);
+				var readRecord = table.Single();
+
+				Assert.AreEqual(testRecord.VarChar1        , readRecord.VarChar1);
+				Assert.AreEqual(testRecord.VarChar255      , readRecord.VarChar255);
+				Assert.AreEqual(testRecord.VarChar112      , readRecord.VarChar112);
+				Assert.AreEqual(testRecord.Char            , readRecord.Char);
+				Assert.AreEqual(testRecord.Char1           , readRecord.Char1);
+				Assert.AreEqual(testRecord.Char255         , readRecord.Char255);
+				Assert.AreEqual(testRecord.Char112         , readRecord.Char112);
+				Assert.AreEqual(testRecord.VarBinary1      , readRecord.VarBinary1);
+				Assert.AreEqual(testRecord.VarBinary255    , readRecord.VarBinary255);
+				Assert.AreEqual(testRecord.VarBinary3      , readRecord.VarBinary3);
+				Assert.AreEqual(testRecord.Binary1         , readRecord.Binary1);
+				// we trim padding only from char fields
+				Assert.AreEqual(testRecord.Binary255.Concat(new byte[252]), readRecord.Binary255);
+				Assert.AreEqual(testRecord.Binary3.Concat(new byte[1]), readRecord.Binary3);
+				Assert.AreEqual(testRecord.TinyBlob        , readRecord.TinyBlob);
+				Assert.AreEqual(testRecord.Blob            , readRecord.Blob);
+				Assert.AreEqual(testRecord.MediumBlob      , readRecord.MediumBlob);
+				Assert.AreEqual(testRecord.BlobDefault     , readRecord.BlobDefault);
+				Assert.AreEqual(testRecord.LongBlob        , readRecord.LongBlob);
+				Assert.AreEqual(testRecord.TinyText        , readRecord.TinyText);
+				Assert.AreEqual(testRecord.Text            , readRecord.Text);
+				Assert.AreEqual(testRecord.MediumText      , readRecord.MediumText);
+				Assert.AreEqual(testRecord.LongText        , readRecord.LongText);
+				Assert.AreEqual(testRecord.TextDefault     , readRecord.TextDefault);
+				Assert.AreEqual(testRecord.Date            , readRecord.Date);
+				Assert.AreEqual(testRecord.DateTime        , readRecord.DateTime);
+				Assert.AreEqual(testRecord.DateTime3       , readRecord.DateTime3);
+				if (isMySqlConnector)
+				{
+					Assert.AreEqual(testRecord.TimeStamp,  readRecord.TimeStamp);
+					Assert.AreEqual(testRecord.TimeStamp5, readRecord.TimeStamp5);
+				}
+				Assert.AreEqual(testRecord.Time            , readRecord.Time);
+				Assert.AreEqual(testRecord.Time2           , readRecord.Time2);
+				Assert.AreEqual(testRecord.TinyInt         , readRecord.TinyInt);
+				Assert.AreEqual(testRecord.UnsignedTinyInt , readRecord.UnsignedTinyInt);
+				Assert.AreEqual(testRecord.SmallInt        , readRecord.SmallInt);
+				Assert.AreEqual(testRecord.UnsignedSmallInt, readRecord.UnsignedSmallInt);
+				Assert.AreEqual(testRecord.Int             , readRecord.Int);
+				Assert.AreEqual(testRecord.UnsignedInt     , readRecord.UnsignedInt);
+				Assert.AreEqual(testRecord.BigInt          , readRecord.BigInt);
+				Assert.AreEqual(testRecord.UnsignedBigInt  , readRecord.UnsignedBigInt);
+				Assert.AreEqual(testRecord.Decimal         , readRecord.Decimal);
+				Assert.AreEqual(testRecord.Decimal15_0     , readRecord.Decimal15_0);
+				Assert.AreEqual(testRecord.Decimal10_5     , readRecord.Decimal10_5);
+				Assert.AreEqual(testRecord.Decimal20_2     , readRecord.Decimal20_2);
+				Assert.AreEqual(testRecord.Float           , readRecord.Float);
+				Assert.AreEqual(testRecord.Float10         , readRecord.Float10);
+				Assert.AreEqual(testRecord.Double          , readRecord.Double);
+				Assert.AreEqual(testRecord.Float30         , readRecord.Float30);
+				Assert.AreEqual(testRecord.Bool            , readRecord.Bool);
+				Assert.AreEqual(testRecord.Bit1            , readRecord.Bit1);
+				Assert.AreEqual(testRecord.Bit8            , readRecord.Bit8);
+				Assert.AreEqual(testRecord.Bit16           , readRecord.Bit16);
+				Assert.AreEqual(testRecord.Bit32           , readRecord.Bit32);
+				Assert.AreEqual(testRecord.Bit10           , readRecord.Bit10);
+				Assert.AreEqual(testRecord.Bit64           , readRecord.Bit64);
+				Assert.AreEqual(testRecord.Json            , readRecord.Json);
+				Assert.AreEqual(testRecord.Guid            , readRecord.Guid);
+			}
+		}
 	}
 
 	internal static class MySqlTestFunctions


### PR DESCRIPTION
Fix #1206, fix #2020 

This PR address issues with CreateTable API for MySQL by adding support for most of MySQL types.
Also fixes TIMESPAN values read into DateTimeOffset for MySqlConnector provider (MySql.Data provider is broken heavily here, will look into it on request)

Changes:
- DataType.VarChar/DataType.NVarChar generate VARCHAR type. Was: Char
- Guid generates CHAR(36) type. Was: Guid (invalid type name).
- DataType.Binary/VarBinary default length set to 255. Was: Binary, VarBinary (invalid type name)
- DataType.Blob/Text/NText generate corresponding subtypes based on length: TINY-/MEDIUM-/LONG- BLOB/TEXT.
- DataType.DateTime/DateTime2/SmallDateTime generates fractional seconds if precision specified. Was: no fractional size (=0)
- DataType.DateTimeOffset generates TIMESPAN type. Fractional seconds generated if precision specified. Was: DateTimeOffset (invalid type name)
- DataType.Time properly generates fractional seconds if precision specified. Was: TIME(x, ) (invalid type name due to extra comma)
- DataType.Byte generates TINYINT UNSIGNED type. Was: TINYINT
- DataType.Uint16 generates SMALLINT UNSIGNED type. Was: INT
- DataType.Uint32 generates INT UNSIGNED type. Was: BIGINT
- DataType.Uint64 generates BIGINT UNSIGNED type. Was: DECIMAL
- DataType.Decimal generates proper precision and scale values. WAS: generated incorrect type if only precision or scale specified
- DataType.Single/Double generates proper Float/Double type names, including Float(precision). WAS: DECIMAL(29,10)
- Data.Type.BitArray generates BIT/BIT(N) type. Was: incorrect type name BitArray/BitArray(N)
- Fixed DateTimeOffset values read for MySqlConnector provider to read values with proper offset
