### PR TITLE
Fix for #2047. Added CommandTimeout property for DataContext class.

### DIFF
--- a/Source/LinqToDB/DataContext.cs
+++ b/Source/LinqToDB/DataContext.cs
@@ -187,6 +187,35 @@ namespace LinqToDB
 		/// </summary>
 		internal int LockDbManagerCounter;
 
+
+		private int? _commandTimeout;
+
+		/// <summary>
+		/// Gets or sets command execution timeout in seconds.
+		/// Negative timeout value means that default timeout will be used.
+		/// 0 timeout value corresponds to infinite timeout.
+		/// By default timeout is not set and default value for current provider used.
+		/// </summary>
+		public  int   CommandTimeout
+		{
+			get => _commandTimeout ?? -1;
+			set
+			{
+				if (value < 0)
+				{
+					_commandTimeout = null;
+					if (_dataConnection != null)
+						_dataConnection.CommandTimeout = -1;
+				}
+				else
+				{
+					_commandTimeout = value;
+					if (_dataConnection != null)
+						_dataConnection.CommandTimeout = value;
+				}
+			}
+		}
+
 		/// <summary>
 		/// Underlying active database connection.
 		/// </summary>
@@ -204,6 +233,9 @@ namespace LinqToDB
 				_dataConnection = ConnectionString != null
 					? new DataConnection(DataProvider, ConnectionString)
 					: new DataConnection(ConfigurationString);
+
+				if (_commandTimeout != null)
+					_dataConnection.CommandTimeout = CommandTimeout;
 
 				if (_queryHints != null && _queryHints.Count > 0)
 				{

--- a/Tests/Linq/Linq/DataContextTests.cs
+++ b/Tests/Linq/Linq/DataContextTests.cs
@@ -142,5 +142,25 @@ namespace Tests.Linq
 				var items1 = await db.GetTable<Child>().ToArrayAsync();
 			}
 		}
+
+		[Test]
+		public void CommandTimeoutTests([IncludeDataSources(false, TestProvName.AllSqlServer)] string context)
+		{
+			var db = new DataContext(context);
+
+			db.CommandTimeout = 10;
+			var dataConnection = db.GetDataConnection();
+			Assert.That(dataConnection.CommandTimeout, Is.EqualTo(10));
+
+			db.CommandTimeout = -10;
+			Assert.That(dataConnection.CommandTimeout, Is.EqualTo(-1));
+
+			db.CommandTimeout = 11;
+			var record = db.GetTable<Child>().First();
+
+			dataConnection = db.GetDataConnection();
+			Assert.That(dataConnection.CommandTimeout, Is.EqualTo(11));
+		}
+
 	}
 }


### PR DESCRIPTION
Fixes #2047