### PR TITLE
[T4] Don't generate partial Init* methods if constructors generation disabled

### DIFF
--- a/Source/LinqToDB.Templates/LinqToDB.PostgreSQL.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.PostgreSQL.ttinclude
@@ -26,7 +26,7 @@ bool GenerateCaseSensitiveNames = false; // Defines whether to generate case sen
 // exception: functions with only one out parameter treat it as return parameter
 void FixRecordResultFunctions()
 {
-	var initMappingSchema = new Method(() => "void", "InitMappingSchema") { AccessModifier = AccessModifier.Partial };
+	var initMappingSchema = new Method(() => "void", "InitMappingSchema") { AccessModifier = GenerateConstructors ? AccessModifier.Partial : AccessModifier.Protected };
 	DataContextObject.Members.Add(initMappingSchema);
 	foreach (var proc in Procedures.Values
 		.Where(p => p.IsFunction && !p.IsAggregateFunction && !p.IsTableFunction && p.ProcParameters.Any(pr => pr.IsOut)))

--- a/Source/LinqToDB.Templates/LinqToDB.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.ttinclude
@@ -156,17 +156,17 @@ void GenerateTypesFromMetadata()
 
 			DataContextObject.Members.Add(c);
 		}
-	}
 
-	DataContextObject.Members.Add(new MemberGroup
-	{
-		IsCompact = true,
-		Members   =
+		DataContextObject.Members.Add(new MemberGroup
 		{
-			new Method(() => "void", "InitDataContext"  ) { AccessModifier = AccessModifier.Partial },
-			new Method(() => "void", "InitMappingSchema") { AccessModifier = AccessModifier.Partial }
-		}
-	});
+			IsCompact = true,
+			Members   =
+			{
+				new Method(() => "void", "InitDataContext"  ) { AccessModifier = AccessModifier.Partial },
+				new Method(() => "void", "InitMappingSchema") { AccessModifier = AccessModifier.Partial }
+			}
+		});
+	}
 
 	if (Tables.Count > 0)
 		DataContextObject.Members.Insert(0, defProps);

--- a/Tests/T4.Linq/PostgreSQL.generated.cs
+++ b/Tests/T4.Linq/PostgreSQL.generated.cs
@@ -35,6 +35,10 @@ namespace PostreSQLDataContext
 		public ITable<GrandChild>                     GrandChildren             { get { return this.GetTable<GrandChild>(); } }
 		public ITable<InheritanceChild>               InheritanceChildren       { get { return this.GetTable<InheritanceChild>(); } }
 		public ITable<InheritanceParent>              InheritanceParents        { get { return this.GetTable<InheritanceParent>(); } }
+		/// <summary>
+		/// This is the Issue2023 matview
+		/// </summary>
+		public ITable<Issue2023>                      Issue2023                 { get { return this.GetTable<Issue2023>(); } }
 		public ITable<LinqDataType>                   LinqDataTypes             { get { return this.GetTable<LinqDataType>(); } }
 		public ITable<Parent>                         Parents                   { get { return this.GetTable<Parent>(); } }
 		public ITable<Patient>                        Patients                  { get { return this.GetTable<Patient>(); } }
@@ -54,7 +58,7 @@ namespace PostreSQLDataContext
 		public ITable<test_schema_Testserialidentity> Testserialidentities      { get { return this.GetTable<test_schema_Testserialidentity>(); } }
 		public ITable<Transaction>                    Transactions              { get { return this.GetTable<Transaction>(); } }
 
-		partial void InitMappingSchema()
+		protected void InitMappingSchema()
 		{
 			MappingSchema.SetConvertExpression<object[], pg_control_checkpointResult>(tuple => new pg_control_checkpointResult() { checkpoint_location = (object)tuple[0], prior_location = (object)tuple[1], redo_location = (object)tuple[2], redo_wal_file = (string)tuple[3], timeline_id = (int?)tuple[4], prev_timeline_id = (int?)tuple[5], full_page_writes = (bool?)tuple[6], next_xid = (string)tuple[7], next_oid = (int?)tuple[8], next_multixact_id = (int?)tuple[9], next_multi_offset = (int?)tuple[10], oldest_xid = (int?)tuple[11], oldest_xid_dbid = (int?)tuple[12], oldest_active_xid = (int?)tuple[13], oldest_multi_xid = (int?)tuple[14], oldest_multi_dbid = (int?)tuple[15], oldest_commit_ts_xid = (int?)tuple[16], newest_commit_ts_xid = (int?)tuple[17], checkpoint_time = (DateTimeOffset?)tuple[18] });
 			MappingSchema.SetConvertExpression<object[], pg_control_initResult>(tuple => new pg_control_initResult() { max_data_alignment = (int?)tuple[0], database_block_size = (int?)tuple[1], blocks_per_segment = (int?)tuple[2], wal_block_size = (int?)tuple[3], bytes_per_wal_segment = (int?)tuple[4], max_identifier_length = (int?)tuple[5], max_index_columns = (int?)tuple[6], max_toast_chunk_size = (int?)tuple[7], large_object_chunk_size = (int?)tuple[8], bigint_timestamps = (bool?)tuple[9], float4_pass_by_value = (bool?)tuple[10], float8_pass_by_value = (bool?)tuple[11], data_page_checksum_version = (int?)tuple[12] });
@@ -73,22 +77,6 @@ namespace PostreSQLDataContext
 			MappingSchema.SetConvertExpression<object[], pg_xlogfile_name_offsetResult>(tuple => new pg_xlogfile_name_offsetResult() { file_name = (string)tuple[0], file_offset = (int?)tuple[1] });
 			MappingSchema.SetConvertExpression<object[], TestFunctionParametersResult>(tuple => new TestFunctionParametersResult() { param2 = (int?)tuple[0], param3 = (int?)tuple[1] });
 		}
-
-		public TestdbDB()
-		{
-			InitDataContext();
-			InitMappingSchema();
-		}
-
-		public TestdbDB(string configuration)
-			: base(configuration)
-		{
-			InitDataContext();
-			InitMappingSchema();
-		}
-
-		partial void InitDataContext  ();
-		partial void InitMappingSchema();
 
 		#region Table Functions
 
@@ -1580,6 +1568,22 @@ namespace PostreSQLDataContext
 		[PrimaryKey, NotNull    ] public int    InheritanceParentId { get; set; } // integer
 		[Column,        Nullable] public int?   TypeDiscriminator   { get; set; } // integer
 		[Column,        Nullable] public string Name                { get; set; } // character varying(50)
+	}
+
+	/// <summary>
+	/// This is the Issue2023 matview
+	/// </summary>
+	[Table(Schema="public", Name="Issue2023", IsView=true)]
+	public partial class Issue2023
+	{
+		/// <summary>
+		/// This is the Issue2023.PersonID column
+		/// </summary>
+		[Column(SkipOnInsert=true, SkipOnUpdate=true), Nullable] public int?   PersonID   { get; set; } // int4
+		[Column(SkipOnInsert=true, SkipOnUpdate=true), Nullable] public string FirstName  { get; set; } // character varying(50)
+		[Column(SkipOnInsert=true, SkipOnUpdate=true), Nullable] public string LastName   { get; set; } // character varying(50)
+		[Column(SkipOnInsert=true, SkipOnUpdate=true), Nullable] public string MiddleName { get; set; } // character varying(50)
+		[Column(SkipOnInsert=true, SkipOnUpdate=true), Nullable] public char?  Gender     { get; set; } // character(1)
 	}
 
 	[Table(Schema="public", Name="LinqDataTypes")]

--- a/Tests/T4.Linq/PostgreSQL.tt
+++ b/Tests/T4.Linq/PostgreSQL.tt
@@ -5,6 +5,7 @@
 <#@ assembly name="$(SolutionDir)Tests\Linq\bin\Debug\net46\Npgsql.dll"         #>
 <#
 	NamespaceName = "PostreSQLDataContext";
+	GenerateConstructors = false;
 
 	LoadPostgreSQLMetadata(GetConnectionString("PostgreSQL"));
 

--- a/Tests/T4.Linq/SqlServer.generated.cs
+++ b/Tests/T4.Linq/SqlServer.generated.cs
@@ -53,22 +53,6 @@ namespace DataModel
 		public ITable<Supplier>                   Suppliers                    { get { return this.GetTable<Supplier>(); } }
 		public ITable<Territory>                  Territories                  { get { return this.GetTable<Territory>(); } }
 
-		public NorthwindDB(int i)
-		{
-			InitDataContext();
-			InitMappingSchema();
-		}
-
-		public NorthwindDB(string configuration)
-			: base(configuration)
-		{
-			InitDataContext();
-			InitMappingSchema();
-		}
-
-		partial void InitDataContext  ();
-		partial void InitMappingSchema();
-
 		#region Alias members
 
 		[Obsolete("Use Categories instead.")  ] public ITable<Category>    CATEG         { get { return Categories; } }
@@ -1135,24 +1119,6 @@ namespace DataModel
 		}
 
 		#endregion
-
-		public TestData2014DB(int i)
-		{
-			InitSchemas();
-			InitDataContext();
-			InitMappingSchema();
-		}
-
-		public TestData2014DB(string configuration)
-			: base(configuration)
-		{
-			InitSchemas();
-			InitDataContext();
-			InitMappingSchema();
-		}
-
-		partial void InitDataContext  ();
-		partial void InitMappingSchema();
 
 		#region Table Functions
 

--- a/Tests/T4.Linq/SqlServer.tt
+++ b/Tests/T4.Linq/SqlServer.tt
@@ -15,6 +15,7 @@
 	GenerateAssociationExtensions = true;
 //	BaseEntityClass = "object";
 //GenerateSqlServerFreeText = true;
+	GenerateConstructors = false;
 
 //	GenerateBackReferences = false;
 //	GenerateAssociations = true;


### PR DESCRIPTION
Fix #2049

Also marks `InitMappingSchema` implementation as protected for PostgreSQL instead of partial if constructors disabled (we don't generate this method implementation for other providers).