### PR TITLE
Fix debugger failures on some configurations

### DIFF
--- a/Source/LinqToDB/DataProvider/DB2/DB2Tools.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2Tools.cs
@@ -142,7 +142,7 @@ namespace LinqToDB.DataProvider.DB2
 
 		private static  bool                  _isInitialized;
 		static readonly object                _syncAfterInitialized    = new object();
-		private static  ConcurrentBag<Action> _afterInitializedActions = new ConcurrentBag<Action>();
+		private static  ConcurrentQueue<Action> _afterInitializedActions = new ConcurrentQueue<Action>();
 
 		internal static void Initialized()
 		{
@@ -178,7 +178,7 @@ namespace LinqToDB.DataProvider.DB2
 					}
 					else
 					{
-						_afterInitializedActions.Add(action);
+						_afterInitializedActions.Enqueue(action);
 					}
 				}
 			}

--- a/Source/LinqToDB/Linq/Query.cs
+++ b/Source/LinqToDB/Linq/Query.cs
@@ -132,7 +132,7 @@ namespace LinqToDB.Linq
 
 		#region Cache Support
 
-		internal static readonly ConcurrentBag<Action> CacheCleaners = new ConcurrentBag<Action>();
+		internal static readonly ConcurrentQueue<Action> CacheCleaners = new ConcurrentQueue<Action>();
 
 		/// <summary>
 		/// Clears query caches for all typed queries.
@@ -212,7 +212,7 @@ namespace LinqToDB.Linq
 			_sync         = new object();
 			_orderedCache = new List<Query<T>>(CacheSize);
 
-			CacheCleaners.Add(ClearCache);
+			CacheCleaners.Enqueue(ClearCache);
 		}
 
 		/// <summary>

--- a/Source/LinqToDB/Linq/QueryRunner.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.cs
@@ -25,7 +25,7 @@ namespace LinqToDB.Linq
 		{
 			static Cache()
 			{
-				Query.CacheCleaners.Add(ClearCache);
+				Query.CacheCleaners.Enqueue(ClearCache);
 			}
 
 			public static void ClearCache()


### PR DESCRIPTION
Removed uses of `ConcurrentBag<T>`, which (due to use of `ThreadLocal<T>`) doesn't work well with some debugger configurations (see #2064, #1795)

This alone will fix debugger issue, but I plan to see if we can improve related caching functionality.