### PR TITLE
Restore enums in expressions

### DIFF
--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -1708,8 +1708,8 @@ namespace LinqToDB.Linq.Builder
 
 			switch (nodeType)
 			{
-				case ExpressionType.Equal:
-				case ExpressionType.NotEqual:
+				case ExpressionType.Equal    :
+				case ExpressionType.NotEqual :
 
 					var p = ConvertObjectComparison(nodeType, context, left, context, right);
 					if (p != null)
@@ -1737,12 +1737,12 @@ namespace LinqToDB.Linq.Builder
 
 			switch (nodeType)
 			{
-				case ExpressionType.Equal: op = SqlPredicate.Operator.Equal; break;
-				case ExpressionType.NotEqual: op = SqlPredicate.Operator.NotEqual; break;
-				case ExpressionType.GreaterThan: op = SqlPredicate.Operator.Greater; break;
+				case ExpressionType.Equal             : op = SqlPredicate.Operator.Equal;          break;
+				case ExpressionType.NotEqual          : op = SqlPredicate.Operator.NotEqual;       break;
+				case ExpressionType.GreaterThan       : op = SqlPredicate.Operator.Greater;        break;
 				case ExpressionType.GreaterThanOrEqual: op = SqlPredicate.Operator.GreaterOrEqual; break;
-				case ExpressionType.LessThan: op = SqlPredicate.Operator.Less; break;
-				case ExpressionType.LessThanOrEqual: op = SqlPredicate.Operator.LessOrEqual; break;
+				case ExpressionType.LessThan          : op = SqlPredicate.Operator.Less;           break;
+				case ExpressionType.LessThanOrEqual   : op = SqlPredicate.Operator.LessOrEqual;    break;
 				default: throw new InvalidOperationException();
 			}
 
@@ -1767,7 +1767,7 @@ namespace LinqToDB.Linq.Builder
 
 			switch (nodeType)
 			{
-				case ExpressionType.Equal:
+				case ExpressionType.Equal   :
 				case ExpressionType.NotEqual:
 
 					if (!context.SelectQuery.IsParameterDependent &&

--- a/Tests/Linq/Linq/EnumMappingTests.cs
+++ b/Tests/Linq/Linq/EnumMappingTests.cs
@@ -1782,5 +1782,369 @@ namespace Tests.Linq
 				}
 			}
 		}
+
+		public enum CharEnum
+		{
+			[MapValue('A')]
+			A = 6,
+			[MapValue('B')]
+			B = 5,
+			[MapValue('C')]
+			C = 4
+		}
+
+		public enum CharEnumS : ushort
+		{
+			[MapValue('A')]
+			A = 6,
+			[MapValue('B')]
+			B = 5,
+			[MapValue('C')]
+			C = 4
+		}
+
+		public enum CharEnumL : ulong
+		{
+			[MapValue('A')]
+			A = 0xFFFFFFFFFFFFFFFF,
+			[MapValue('B')]
+			B = 0xFFFFFFFFFFFFFFFE,
+			[MapValue('C')]
+			C = 0xFFFFFFFFFFFFFFFD
+		}
+
+		[Table]
+		public class EnumCardinality
+		{
+			[Column]
+			public int Id { get; set; }
+
+			[Column] public CharEnum   Property1 { get; set; }
+			[Column] public CharEnum?  Property2 { get; set; }
+			[Column] public CharEnumS  Property3 { get; set; }
+			[Column] public CharEnumS? Property4 { get; set; }
+			[Column] public CharEnumL  Property5 { get; set; }
+			[Column] public CharEnumL? Property6 { get; set; }
+
+			public static EnumCardinality[] Seed { get; }
+				= new[]
+				{
+					new EnumCardinality() { Id = 1, Property1 = CharEnum.A, Property2 = CharEnum.A, Property3 = CharEnumS.A, Property4 = CharEnumS.A, Property5 = CharEnumL.A, Property6 = CharEnumL.A },
+					new EnumCardinality() { Id = 2, Property1 = CharEnum.B, Property2 = CharEnum.B, Property3 = CharEnumS.B, Property4 = CharEnumS.B, Property5 = CharEnumL.B, Property6 = CharEnumL.B },
+					new EnumCardinality() { Id = 3, Property1 = CharEnum.C, Property2 = CharEnum.C, Property3 = CharEnumS.C, Property4 = CharEnumS.C, Property5 = CharEnumL.C, Property6 = CharEnumL.C },
+				};
+		}
+
+		[Test]
+		public void TestCardinalityOperators_Less([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db    = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property1 < CharEnum.B).Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.AreEqual(CharEnum.A, res.Property1);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_LessOrEqual([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db    = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property1 <= CharEnum.A).Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.AreEqual(CharEnum.A, res.Property1);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_Greater([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db    = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property1 > CharEnum.B).Single();
+
+				Assert.AreEqual(3, res.Id);
+				Assert.AreEqual(CharEnum.C, res.Property1);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_GreaterOrEqual([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db    = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property1 >= CharEnum.C).Single();
+
+				Assert.AreEqual(3, res.Id);
+				Assert.AreEqual(CharEnum.C, res.Property1);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_Less_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property2 < CharEnum.B).Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.AreEqual(CharEnum.A, res.Property2);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_LessOrEqual_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property2 <= CharEnum.A).Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.AreEqual(CharEnum.A, res.Property2);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_Greater_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property2 > CharEnum.B).Single();
+
+				Assert.AreEqual(3, res.Id);
+				Assert.AreEqual(CharEnum.C, res.Property2);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_GreaterOrEqual_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property2 >= CharEnum.C).Single();
+
+				Assert.AreEqual(3, res.Id);
+				Assert.AreEqual(CharEnum.C, res.Property2);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_Less_Short([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property3 < CharEnumS.B).Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.AreEqual(CharEnumS.A, res.Property3);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_LessOrEqual_Short([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property3 <= CharEnumS.A).Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.AreEqual(CharEnumS.A, res.Property3);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_Greater_Short([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property3 > CharEnumS.B).Single();
+
+				Assert.AreEqual(3, res.Id);
+				Assert.AreEqual(CharEnumS.C, res.Property3);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_GreaterOrEqual_Short([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property3 >= CharEnumS.C).Single();
+
+				Assert.AreEqual(3, res.Id);
+				Assert.AreEqual(CharEnumS.C, res.Property3);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_Less_Short_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property4 < CharEnumS.B).Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.AreEqual(CharEnumS.A, res.Property4);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_LessOrEqual_Short_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property4 <= CharEnumS.A).Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.AreEqual(CharEnumS.A, res.Property4);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_Greater_Short_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property4 > CharEnumS.B).Single();
+
+				Assert.AreEqual(3, res.Id);
+				Assert.AreEqual(CharEnumS.C, res.Property4);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_GreaterOrEqual_Short_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property4 >= CharEnumS.C).Single();
+
+				Assert.AreEqual(3, res.Id);
+				Assert.AreEqual(CharEnumS.C, res.Property4);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_Less_Long([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property5 < CharEnumL.B).Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.AreEqual(CharEnumL.A, res.Property5);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_LessOrEqual_Long([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property5 <= CharEnumL.A).Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.AreEqual(CharEnumL.A, res.Property5);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_Greater_Long([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property5 > CharEnumL.B).Single();
+
+				Assert.AreEqual(3, res.Id);
+				Assert.AreEqual(CharEnumL.C, res.Property5);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_GreaterOrEqual_Long([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property5 >= CharEnumL.C).Single();
+
+				Assert.AreEqual(3, res.Id);
+				Assert.AreEqual(CharEnumL.C, res.Property5);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_Less_Long_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property6 < CharEnumL.B).Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.AreEqual(CharEnumL.A, res.Property6);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_LessOrEqual_Long_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property6 <= CharEnumL.A).Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.AreEqual(CharEnumL.A, res.Property6);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_Greater_Long_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property6 > CharEnumL.B).Single();
+
+				Assert.AreEqual(3, res.Id);
+				Assert.AreEqual(CharEnumL.C, res.Property6);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_GreaterOrEqual_Long_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property6 >= CharEnumL.C).Single();
+
+				Assert.AreEqual(3, res.Id);
+				Assert.AreEqual(CharEnumL.C, res.Property6);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Fix #2041

PS:
Perfect example of premature optimization:
- first your optimize expression in wrong place instead of doing it in expression compiler
- then you still need same optimization in expression compiler, because of manually created expressions