### PR TITLE
Remove redundant converts, inserted by compiler

### DIFF
--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -1708,8 +1708,8 @@ namespace LinqToDB.Linq.Builder
 
 			switch (nodeType)
 			{
-				case ExpressionType.Equal:
-				case ExpressionType.NotEqual:
+				case ExpressionType.Equal    :
+				case ExpressionType.NotEqual :
 
 					var p = ConvertObjectComparison(nodeType, context, left, context, right);
 					if (p != null)
@@ -1737,12 +1737,12 @@ namespace LinqToDB.Linq.Builder
 
 			switch (nodeType)
 			{
-				case ExpressionType.Equal: op = SqlPredicate.Operator.Equal; break;
-				case ExpressionType.NotEqual: op = SqlPredicate.Operator.NotEqual; break;
-				case ExpressionType.GreaterThan: op = SqlPredicate.Operator.Greater; break;
+				case ExpressionType.Equal             : op = SqlPredicate.Operator.Equal;          break;
+				case ExpressionType.NotEqual          : op = SqlPredicate.Operator.NotEqual;       break;
+				case ExpressionType.GreaterThan       : op = SqlPredicate.Operator.Greater;        break;
 				case ExpressionType.GreaterThanOrEqual: op = SqlPredicate.Operator.GreaterOrEqual; break;
-				case ExpressionType.LessThan: op = SqlPredicate.Operator.Less; break;
-				case ExpressionType.LessThanOrEqual: op = SqlPredicate.Operator.LessOrEqual; break;
+				case ExpressionType.LessThan          : op = SqlPredicate.Operator.Less;           break;
+				case ExpressionType.LessThanOrEqual   : op = SqlPredicate.Operator.LessOrEqual;    break;
 				default: throw new InvalidOperationException();
 			}
 
@@ -1767,7 +1767,7 @@ namespace LinqToDB.Linq.Builder
 
 			switch (nodeType)
 			{
-				case ExpressionType.Equal:
+				case ExpressionType.Equal   :
 				case ExpressionType.NotEqual:
 
 					if (!context.SelectQuery.IsParameterDependent &&

--- a/Tests/Linq/Linq/ConvertTests.cs
+++ b/Tests/Linq/Linq/ConvertTests.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 
 using LinqToDB;
-
+using LinqToDB.Mapping;
 using NUnit.Framework;
 using Tests.Model;
 
@@ -704,5 +704,582 @@ namespace Tests.Linq
 				}
 			}
 		}
+
+		#region redundant convert https://github.com/linq2db/linq2db/issues/2039
+
+		[Table]
+		public class IntegerConverts
+		{
+			[Column] public int Id { get; set; }
+
+			[Column] public byte    Byte    { get; set; }
+			[Column] public sbyte   SByte   { get; set; }
+			[Column] public short   Int16   { get; set; }
+			[Column] public ushort  UInt16  { get; set; }
+			[Column] public int     Int32   { get; set; }
+			[Column] public uint    UInt32  { get; set; }
+			[Column] public long    Int64   { get; set; }
+			[Column] public ulong   UInt64  { get; set; }
+
+			[Column] public byte?   ByteN   { get; set; }
+			[Column] public sbyte?  SByteN  { get; set; }
+			[Column] public short?  Int16N  { get; set; }
+			[Column] public ushort? UInt16N { get; set; }
+			[Column] public int?    Int32N  { get; set; }
+			[Column] public uint?   UInt32N { get; set; }
+			[Column] public long?   Int64N  { get; set; }
+			[Column] public ulong?  UInt64N { get; set; }
+
+			public static IntegerConverts[] Seed { get; }
+				= new[]
+				{
+					new IntegerConverts() { Id = 1 },
+				};
+		}
+
+		[Test]
+		public void TestNoConvert_Byte([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							join y in db.GetTable<IntegerConverts>() on x.Byte equals y.Byte
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvertWithExtension_Byte([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							from y in db.GetTable<IntegerConverts>().InnerJoin(y => y.Byte == x.Byte)
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvert_SByte([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							join y in db.GetTable<IntegerConverts>() on x.SByte equals y.SByte
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvertWithExtension_SByte([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							from y in db.GetTable<IntegerConverts>().InnerJoin(y => y.SByte == x.SByte)
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvert_Int16([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							join y in db.GetTable<IntegerConverts>() on x.Int16 equals y.Int16
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvertWithExtension_Int16([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							from y in db.GetTable<IntegerConverts>().InnerJoin(y => y.Int16 == x.Int16)
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvert_UInt16([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							join y in db.GetTable<IntegerConverts>() on x.UInt16 equals y.UInt16
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvertWithExtension_UInt16([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							from y in db.GetTable<IntegerConverts>().InnerJoin(y => y.UInt16 == x.UInt16)
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvert_Int32([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							join y in db.GetTable<IntegerConverts>() on x.Int32 equals y.Int32
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvertWithExtension_Int32([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							from y in db.GetTable<IntegerConverts>().InnerJoin(y => y.Int32 == x.Int32)
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvert_UInt32([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							join y in db.GetTable<IntegerConverts>() on x.UInt32 equals y.UInt32
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvertWithExtension_UInt32([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							from y in db.GetTable<IntegerConverts>().InnerJoin(y => y.UInt32 == x.UInt32)
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvert_Int64([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							join y in db.GetTable<IntegerConverts>() on x.Int64 equals y.Int64
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvertWithExtension_Int64([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							from y in db.GetTable<IntegerConverts>().InnerJoin(y => y.Int64 == x.Int64)
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvert_UInt64([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							join y in db.GetTable<IntegerConverts>() on x.UInt64 equals y.UInt64
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvertWithExtension_UInt64([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							from y in db.GetTable<IntegerConverts>().InnerJoin(y => y.UInt64 == x.UInt64)
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvert_ByteN([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							join y in db.GetTable<IntegerConverts>() on x.ByteN equals y.ByteN
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvertWithExtension_ByteN([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							from y in db.GetTable<IntegerConverts>().InnerJoin(y => y.ByteN == x.ByteN)
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvert_SByteN([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							join y in db.GetTable<IntegerConverts>() on x.SByteN equals y.SByteN
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvertWithExtension_SByteN([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							from y in db.GetTable<IntegerConverts>().InnerJoin(y => y.SByteN == x.SByteN)
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvert_Int16N([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							join y in db.GetTable<IntegerConverts>() on x.Int16N equals y.Int16N
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvertWithExtension_Int16N([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							from y in db.GetTable<IntegerConverts>().InnerJoin(y => y.Int16N == x.Int16N)
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvert_UInt16N([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							join y in db.GetTable<IntegerConverts>() on x.UInt16N equals y.UInt16N
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvertWithExtension_UInt16N([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							from y in db.GetTable<IntegerConverts>().InnerJoin(y => y.UInt16N == x.UInt16N)
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvert_Int32N([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							join y in db.GetTable<IntegerConverts>() on x.Int32N equals y.Int32N
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvertWithExtension_Int32N([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							from y in db.GetTable<IntegerConverts>().InnerJoin(y => y.Int32N == x.Int32N)
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvert_UInt32N([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							join y in db.GetTable<IntegerConverts>() on x.UInt32N equals y.UInt32N
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvertWithExtension_UInt32N([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							from y in db.GetTable<IntegerConverts>().InnerJoin(y => y.UInt32N == x.UInt32N)
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvert_Int64N([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							join y in db.GetTable<IntegerConverts>() on x.Int64N equals y.Int64N
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvertWithExtension_Int64N([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							from y in db.GetTable<IntegerConverts>().InnerJoin(y => y.Int64N == x.Int64N)
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvert_UInt64N([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							join y in db.GetTable<IntegerConverts>() on x.UInt64N equals y.UInt64N
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+
+		[Test]
+		public void TestNoConvertWithExtension_UInt64N([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable(IntegerConverts.Seed))
+			{
+				var query = from x in db.GetTable<IntegerConverts>()
+							from y in db.GetTable<IntegerConverts>().InnerJoin(y => y.UInt64N == x.UInt64N)
+							select x;
+
+				var res = query.Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.False(db.LastQuery.Contains(" Convert("));
+			}
+		}
+		#endregion
 	}
 }

--- a/Tests/Linq/Linq/EnumMappingTests.cs
+++ b/Tests/Linq/Linq/EnumMappingTests.cs
@@ -1782,5 +1782,369 @@ namespace Tests.Linq
 				}
 			}
 		}
+
+		public enum CharEnum
+		{
+			[MapValue('A')]
+			A = 6,
+			[MapValue('B')]
+			B = 5,
+			[MapValue('C')]
+			C = 4
+		}
+
+		public enum CharEnumS : ushort
+		{
+			[MapValue('A')]
+			A = 6,
+			[MapValue('B')]
+			B = 5,
+			[MapValue('C')]
+			C = 4
+		}
+
+		public enum CharEnumL : ulong
+		{
+			[MapValue('A')]
+			A = 0xFFFFFFFFFFFFFFFF,
+			[MapValue('B')]
+			B = 0xFFFFFFFFFFFFFFFE,
+			[MapValue('C')]
+			C = 0xFFFFFFFFFFFFFFFD
+		}
+
+		[Table]
+		public class EnumCardinality
+		{
+			[Column]
+			public int Id { get; set; }
+
+			[Column] public CharEnum   Property1 { get; set; }
+			[Column] public CharEnum?  Property2 { get; set; }
+			[Column] public CharEnumS  Property3 { get; set; }
+			[Column] public CharEnumS? Property4 { get; set; }
+			[Column] public CharEnumL  Property5 { get; set; }
+			[Column] public CharEnumL? Property6 { get; set; }
+
+			public static EnumCardinality[] Seed { get; }
+				= new[]
+				{
+					new EnumCardinality() { Id = 1, Property1 = CharEnum.A, Property2 = CharEnum.A, Property3 = CharEnumS.A, Property4 = CharEnumS.A, Property5 = CharEnumL.A, Property6 = CharEnumL.A },
+					new EnumCardinality() { Id = 2, Property1 = CharEnum.B, Property2 = CharEnum.B, Property3 = CharEnumS.B, Property4 = CharEnumS.B, Property5 = CharEnumL.B, Property6 = CharEnumL.B },
+					new EnumCardinality() { Id = 3, Property1 = CharEnum.C, Property2 = CharEnum.C, Property3 = CharEnumS.C, Property4 = CharEnumS.C, Property5 = CharEnumL.C, Property6 = CharEnumL.C },
+				};
+		}
+
+		[Test]
+		public void TestCardinalityOperators_Less([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db    = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property1 < CharEnum.B).Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.AreEqual(CharEnum.A, res.Property1);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_LessOrEqual([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db    = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property1 <= CharEnum.A).Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.AreEqual(CharEnum.A, res.Property1);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_Greater([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db    = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property1 > CharEnum.B).Single();
+
+				Assert.AreEqual(3, res.Id);
+				Assert.AreEqual(CharEnum.C, res.Property1);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_GreaterOrEqual([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db    = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property1 >= CharEnum.C).Single();
+
+				Assert.AreEqual(3, res.Id);
+				Assert.AreEqual(CharEnum.C, res.Property1);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_Less_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property2 < CharEnum.B).Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.AreEqual(CharEnum.A, res.Property2);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_LessOrEqual_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property2 <= CharEnum.A).Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.AreEqual(CharEnum.A, res.Property2);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_Greater_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property2 > CharEnum.B).Single();
+
+				Assert.AreEqual(3, res.Id);
+				Assert.AreEqual(CharEnum.C, res.Property2);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_GreaterOrEqual_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property2 >= CharEnum.C).Single();
+
+				Assert.AreEqual(3, res.Id);
+				Assert.AreEqual(CharEnum.C, res.Property2);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_Less_Short([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property3 < CharEnumS.B).Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.AreEqual(CharEnumS.A, res.Property3);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_LessOrEqual_Short([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property3 <= CharEnumS.A).Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.AreEqual(CharEnumS.A, res.Property3);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_Greater_Short([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property3 > CharEnumS.B).Single();
+
+				Assert.AreEqual(3, res.Id);
+				Assert.AreEqual(CharEnumS.C, res.Property3);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_GreaterOrEqual_Short([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property3 >= CharEnumS.C).Single();
+
+				Assert.AreEqual(3, res.Id);
+				Assert.AreEqual(CharEnumS.C, res.Property3);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_Less_Short_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property4 < CharEnumS.B).Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.AreEqual(CharEnumS.A, res.Property4);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_LessOrEqual_Short_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property4 <= CharEnumS.A).Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.AreEqual(CharEnumS.A, res.Property4);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_Greater_Short_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property4 > CharEnumS.B).Single();
+
+				Assert.AreEqual(3, res.Id);
+				Assert.AreEqual(CharEnumS.C, res.Property4);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_GreaterOrEqual_Short_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property4 >= CharEnumS.C).Single();
+
+				Assert.AreEqual(3, res.Id);
+				Assert.AreEqual(CharEnumS.C, res.Property4);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_Less_Long([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property5 < CharEnumL.B).Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.AreEqual(CharEnumL.A, res.Property5);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_LessOrEqual_Long([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property5 <= CharEnumL.A).Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.AreEqual(CharEnumL.A, res.Property5);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_Greater_Long([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property5 > CharEnumL.B).Single();
+
+				Assert.AreEqual(3, res.Id);
+				Assert.AreEqual(CharEnumL.C, res.Property5);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_GreaterOrEqual_Long([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property5 >= CharEnumL.C).Single();
+
+				Assert.AreEqual(3, res.Id);
+				Assert.AreEqual(CharEnumL.C, res.Property5);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_Less_Long_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property6 < CharEnumL.B).Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.AreEqual(CharEnumL.A, res.Property6);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_LessOrEqual_Long_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property6 <= CharEnumL.A).Single();
+
+				Assert.AreEqual(1, res.Id);
+				Assert.AreEqual(CharEnumL.A, res.Property6);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_Greater_Long_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property6 > CharEnumL.B).Single();
+
+				Assert.AreEqual(3, res.Id);
+				Assert.AreEqual(CharEnumL.C, res.Property6);
+			}
+		}
+
+		[Test]
+		public void TestCardinalityOperators_GreaterOrEqual_Long_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
+			{
+				var res = table.Where(_ => _.Property6 >= CharEnumL.C).Single();
+
+				Assert.AreEqual(3, res.Id);
+				Assert.AreEqual(CharEnumL.C, res.Property6);
+			}
+		}
 	}
 }

--- a/Tests/Linq/Linq/EnumMappingTests.cs
+++ b/Tests/Linq/Linq/EnumMappingTests.cs
@@ -1838,7 +1838,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestCardinalityOperators_Less([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
-			using (var db    = GetDataContext(context, new MappingSchema()))
+			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
 			{
 				var res = table.Where(_ => _.Property1 < CharEnum.B).Single();
@@ -1851,7 +1851,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestCardinalityOperators_LessOrEqual([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
-			using (var db    = GetDataContext(context, new MappingSchema()))
+			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
 			{
 				var res = table.Where(_ => _.Property1 <= CharEnum.A).Single();
@@ -1864,7 +1864,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestCardinalityOperators_Greater([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
-			using (var db    = GetDataContext(context, new MappingSchema()))
+			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
 			{
 				var res = table.Where(_ => _.Property1 > CharEnum.B).Single();
@@ -1877,7 +1877,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestCardinalityOperators_GreaterOrEqual([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
-			using (var db    = GetDataContext(context, new MappingSchema()))
+			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
 			{
 				var res = table.Where(_ => _.Property1 >= CharEnum.C).Single();
@@ -1890,7 +1890,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestCardinalityOperators_Less_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
-			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
 			{
 				var res = table.Where(_ => _.Property2 < CharEnum.B).Single();
@@ -1903,7 +1903,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestCardinalityOperators_LessOrEqual_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
-			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
 			{
 				var res = table.Where(_ => _.Property2 <= CharEnum.A).Single();
@@ -1916,7 +1916,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestCardinalityOperators_Greater_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
-			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
 			{
 				var res = table.Where(_ => _.Property2 > CharEnum.B).Single();
@@ -1929,7 +1929,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestCardinalityOperators_GreaterOrEqual_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
-			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
 			{
 				var res = table.Where(_ => _.Property2 >= CharEnum.C).Single();
@@ -1942,7 +1942,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestCardinalityOperators_Less_Short([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
-			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
 			{
 				var res = table.Where(_ => _.Property3 < CharEnumS.B).Single();
@@ -1955,7 +1955,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestCardinalityOperators_LessOrEqual_Short([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
-			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
 			{
 				var res = table.Where(_ => _.Property3 <= CharEnumS.A).Single();
@@ -1968,7 +1968,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestCardinalityOperators_Greater_Short([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
-			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
 			{
 				var res = table.Where(_ => _.Property3 > CharEnumS.B).Single();
@@ -1981,7 +1981,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestCardinalityOperators_GreaterOrEqual_Short([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
-			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
 			{
 				var res = table.Where(_ => _.Property3 >= CharEnumS.C).Single();
@@ -1994,7 +1994,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestCardinalityOperators_Less_Short_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
-			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
 			{
 				var res = table.Where(_ => _.Property4 < CharEnumS.B).Single();
@@ -2007,7 +2007,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestCardinalityOperators_LessOrEqual_Short_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
-			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
 			{
 				var res = table.Where(_ => _.Property4 <= CharEnumS.A).Single();
@@ -2020,7 +2020,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestCardinalityOperators_Greater_Short_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
-			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
 			{
 				var res = table.Where(_ => _.Property4 > CharEnumS.B).Single();
@@ -2033,7 +2033,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestCardinalityOperators_GreaterOrEqual_Short_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
-			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
 			{
 				var res = table.Where(_ => _.Property4 >= CharEnumS.C).Single();
@@ -2046,7 +2046,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestCardinalityOperators_Less_Long([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
-			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
 			{
 				var res = table.Where(_ => _.Property5 < CharEnumL.B).Single();
@@ -2059,7 +2059,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestCardinalityOperators_LessOrEqual_Long([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
-			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
 			{
 				var res = table.Where(_ => _.Property5 <= CharEnumL.A).Single();
@@ -2072,7 +2072,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestCardinalityOperators_Greater_Long([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
-			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
 			{
 				var res = table.Where(_ => _.Property5 > CharEnumL.B).Single();
@@ -2085,7 +2085,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestCardinalityOperators_GreaterOrEqual_Long([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
-			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
 			{
 				var res = table.Where(_ => _.Property5 >= CharEnumL.C).Single();
@@ -2098,7 +2098,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestCardinalityOperators_Less_Long_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
-			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
 			{
 				var res = table.Where(_ => _.Property6 < CharEnumL.B).Single();
@@ -2111,7 +2111,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestCardinalityOperators_LessOrEqual_Long_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
-			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
 			{
 				var res = table.Where(_ => _.Property6 <= CharEnumL.A).Single();
@@ -2124,7 +2124,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestCardinalityOperators_Greater_Long_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
-			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
 			{
 				var res = table.Where(_ => _.Property6 > CharEnumL.B).Single();
@@ -2137,7 +2137,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestCardinalityOperators_GreaterOrEqual_Long_Nullable([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
-			using (var db = GetDataContext(context, new MappingSchema()))
+			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable(EnumCardinality.Seed))
 			{
 				var res = table.Where(_ => _.Property6 >= CharEnumL.C).Single();


### PR DESCRIPTION
Fix #2039

Another case of #2041. Compiler adds unnecessary converts for byte, sbyte and ushort values comparisons.