### PR TITLE
Make by-name member mapping case-sensitive

### DIFF
--- a/Source/LinqToDB.Tools/EntityServices/EntityMap.cs
+++ b/Source/LinqToDB.Tools/EntityServices/EntityMap.cs
@@ -11,6 +11,7 @@ namespace LinqToDB.Tools.EntityServices
 {
 	using System.Diagnostics.CodeAnalysis;
 	using Common;
+	using LinqToDB.Expressions;
 	using Mapper;
 	using Mapping;
 	using Reflection;
@@ -119,16 +120,16 @@ namespace LinqToDB.Tools.EntityServices
 					var keyExpression = Expression.Constant(new { Value = key });
 
 					bodyExpression = Expression.Equal(
-						Expression.PropertyOrField(p, _keyColumns![0].Name),
-						Expression.Convert(Expression.PropertyOrField(keyExpression, "Value"), _keyColumns[0].Type));
+						ExpressionHelper.PropertyOrField(p, _keyColumns![0].Name),
+						Expression.Convert(ExpressionHelper.PropertyOrField(keyExpression, "Value"), _keyColumns[0].Type));
 				}
 				else
 				{
 					var keyExpression = Expression.Constant(key);
 					var expressions   = _keyColumns.Select(kc =>
 						Expression.Equal(
-							Expression.PropertyOrField(p, kc.Name),
-							Expression.Convert(Expression.PropertyOrField(keyExpression, kc.Name), kc.Type)) as Expression);
+							ExpressionHelper.PropertyOrField(p, kc.Name),
+							Expression.Convert(ExpressionHelper.PropertyOrField(keyExpression, kc.Name), kc.Type)) as Expression);
 
 					bodyExpression = expressions.Aggregate(Expression.AndAlso);
 				}

--- a/Source/LinqToDB/Common/ConvertBuilder.cs
+++ b/Source/LinqToDB/Common/ConvertBuilder.cs
@@ -541,7 +541,7 @@ namespace LinqToDB.Common
 
 				if (from.IsNullable())
 					ex = Tuple.Create(
-						Expression.Condition(Expression.PropertyOrField(p, "HasValue"), ex.Item1, new DefaultValueExpression(mappingSchema, to)) as Expression,
+						Expression.Condition(ExpressionHelper.Property(p, nameof(Nullable<int>.HasValue)), ex.Item1, new DefaultValueExpression(mappingSchema, to)) as Expression,
 						ex.Item2);
 				else if (from.IsClass)
 					ex = Tuple.Create(

--- a/Source/LinqToDB/Data/CommandInfo.cs
+++ b/Source/LinqToDB/Data/CommandInfo.cs
@@ -1323,7 +1323,7 @@ namespace LinqToDB.Data
 											new[] { pobj },
 											new Expression[]
 											{
-												Expression.Assign(pobj, Expression.PropertyOrField(obj, column.MemberName)),
+												Expression.Assign(pobj, ExpressionHelper.PropertyOrField(obj, column.MemberName)),
 												Expression.MemberInit(
 													Expression.New(typeof(DataParameter)),
 													Expression.Bind(
@@ -1343,7 +1343,7 @@ namespace LinqToDB.Data
 									}
 
 									var memberType  = column.MemberType.ToNullableUnderlying();
-									var valueGetter = Expression.PropertyOrField(obj, column.MemberName) as Expression;
+									var valueGetter = ExpressionHelper.PropertyOrField(obj, column.MemberName) as Expression;
 									var mapper      = dataConnection.MappingSchema.GetConvertExpression(memberType, typeof(DataParameter), createDefault : false);
 
 									if (mapper != null)

--- a/Source/LinqToDB/DataProvider/DB2/DB2ProviderAdapter.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2ProviderAdapter.cs
@@ -300,7 +300,7 @@ namespace LinqToDB.DataProvider.DB2
 
 							if (register)
 							{
-								var getNullValue = Expression.Lambda<Func<object>>(Expression.Convert(Expression.Field(null, type, "Null"), typeof(object))).Compile();
+								var getNullValue = Expression.Lambda<Func<object>>(Expression.Convert(ExpressionHelper.Field(type, "Null"), typeof(object))).Compile();
 								mappingSchema.AddScalarType(type, getNullValue(), true, dataType);
 							}
 

--- a/Source/LinqToDB/DataProvider/Informix/InformixProviderAdapter.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixProviderAdapter.cs
@@ -274,7 +274,7 @@ namespace LinqToDB.DataProvider.Informix
 
 				if (register)
 				{
-					var getNullValue = Expression.Lambda<Func<object>>(Expression.Convert(Expression.Field(null, type, "Null"), typeof(object))).Compile();
+					var getNullValue = Expression.Lambda<Func<object>>(Expression.Convert(ExpressionHelper.Field(type, "Null"), typeof(object))).Compile();
 					mappingSchema.AddScalarType(type, getNullValue(), true, dataType);
 				}
 

--- a/Source/LinqToDB/DataProvider/Oracle/OracleProviderAdapter.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleProviderAdapter.cs
@@ -441,7 +441,7 @@ namespace LinqToDB.DataProvider.Oracle
 				if (hasNull)
 				{
 					// if native provider fails here, check that you have ODAC installed properly
-					var getNullValue = Expression.Lambda<Func<object>>(Expression.Convert(Expression.Field(null, type, "Null"), typeof(object))).Compile();
+					var getNullValue = Expression.Lambda<Func<object>>(Expression.Convert(ExpressionHelper.Field(type, "Null"), typeof(object))).Compile();
 					mappingSchema.AddScalarType(type, getNullValue(), true, dataType);
 				}
 				else
@@ -457,10 +457,10 @@ namespace LinqToDB.DataProvider.Oracle
 				if (!hasValue)
 					memberExpression = valueParam;
 				else
-					memberExpression = Expression.Property(valueParam, "Value");
+					memberExpression = ExpressionHelper.Property(valueParam, "Value");
 
 				var condition = Expression.Condition(
-					Expression.Equal(valueParam, Expression.Field(null, type, "Null")),
+					Expression.Equal(valueParam, ExpressionHelper.Field(type, "Null")),
 					Expression.Constant(null, typeof(object)),
 					Expression.Convert(memberExpression, typeof(object)));
 

--- a/Source/LinqToDB/DataProvider/PostgreSQL/NpgsqlProviderAdapter.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/NpgsqlProviderAdapter.cs
@@ -179,7 +179,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			var pEntity   = Expression.Parameter(typeof(TEntity));
 
 			var pWriter = generator.AddVariable(Expression.Parameter(_npgsqlBinaryImporterType));
-			generator.Assign(pWriter, Expression.Convert(Expression.PropertyOrField(pWriterIn, "instance_"), _npgsqlBinaryImporterType));
+			generator.Assign(pWriter, Expression.Convert(ExpressionHelper.Property(pWriterIn, nameof(TypeWrapper.instance_)), _npgsqlBinaryImporterType));
 
 			generator.AddExpression(generator.MapAction((NpgsqlBinaryImporter importer) => importer.StartRow(), pWriter));
 
@@ -319,8 +319,8 @@ namespace LinqToDB.DataProvider.PostgreSQL
 								var tupleToInetTypeMapper = Expression.Lambda(
 										Expression.New(
 											npgsqlInetType.GetConstructor(new[] { typeof(IPAddress), typeof(int) }),
-											Expression.Field(p, "Item1"),
-											Expression.Field(p, "Item2")),
+											ExpressionHelper.Field(p, "Item1"),
+											ExpressionHelper.Field(p, "Item2")),
 										p);
 								mappingSchema.SetConvertExpression(inetTupleType!, npgsqlInetType, tupleToInetTypeMapper);
 							}

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerTypes.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerTypes.cs
@@ -5,6 +5,7 @@ namespace LinqToDB.DataProvider.SqlServer
 	using System.Linq.Expressions;
 	using System.Reflection;
 	using LinqToDB.Common;
+	using LinqToDB.Expressions;
 	using LinqToDB.Mapping;
 
 	internal static class SqlServerTypes
@@ -71,7 +72,7 @@ namespace LinqToDB.DataProvider.SqlServer
 			{
 				var type = assembly.GetType($"{TypesNamespace}.{typeName}", true);
 
-				var getNullValue = Expression.Lambda<Func<object>>(Expression.Convert(Expression.Property(null, type, "Null"), typeof(object))).Compile();
+				var getNullValue = Expression.Lambda<Func<object>>(Expression.Convert(ExpressionHelper.Property(type, "Null"), typeof(object))).Compile();
 
 				return new TypeInfo()
 				{ 

--- a/Source/LinqToDB/Expressions/ExpressionHelper.cs
+++ b/Source/LinqToDB/Expressions/ExpressionHelper.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace LinqToDB.Expressions
+{
+	public static class ExpressionHelper
+	{
+		/// <summary>
+		/// Compared to <see cref="Expression.Field(Expression, string)"/>, performs case-sensitive field search.
+		/// </summary>
+		public static MemberExpression Field(Expression obj, string name)
+		{
+			var fi = obj.Type.GetField(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy);
+
+			if (fi == null)
+				fi = obj.Type.GetField(name, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy);
+			
+			if (fi == null)
+				throw new InvalidOperationException($"Instance field with name {name} not found on type {obj.Type}");
+
+			return Expression.Field(obj, fi);
+		}
+
+		/// <summary>
+		/// Compared to <see cref="Expression.Field(Expression, Type, string)"/>, performs case-sensitive field search and search
+		/// only for static fields.
+		/// </summary>
+		public static MemberExpression Field(Type type, string name)
+		{
+			var fi = type.GetField(name, BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy);
+
+			if (fi == null)
+				fi = type.GetField(name, BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy);
+
+			if (fi == null)
+				throw new InvalidOperationException($"Static field with name {name} not found on type {type}");
+
+			return Expression.Field(null, fi);
+		}
+
+		/// <summary>
+		/// Compared to <see cref="Expression.Property(Expression, string)"/>, performs case-sensitive property search.
+		/// </summary>
+		public static MemberExpression Property(Expression obj, string name)
+		{
+			var pi = obj.Type.GetProperty(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy);
+
+			if (pi == null)
+				pi = obj.Type.GetProperty(name, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy);
+
+			if (pi == null)
+				throw new InvalidOperationException($"Instance property with name {name} not found on type {obj.Type}");
+
+			return Expression.Property(obj, pi);
+		}
+
+		/// <summary>
+		/// Compared to <see cref="Expression.Property(Expression, Type, string)"/>, performs case-sensitive property search and search
+		/// only for static properties.
+		/// </summary>
+		public static MemberExpression Property(Type type, string name)
+		{
+			var pi = type.GetProperty(name, BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy);
+
+			if (pi == null)
+				pi = type.GetProperty(name, BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy);
+
+			if (pi == null)
+				throw new InvalidOperationException($"Static property with name {name} not found on type {type}");
+
+			return Expression.Property(null, pi);
+		}
+
+		/// <summary>
+		/// Compared to <see cref="Expression.PropertyOrField(Expression, string)"/>, performs case-sensitive member search.
+		/// </summary>
+		public static MemberExpression PropertyOrField(Expression obj, string name)
+		{
+			var pi = obj.Type.GetProperty(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy);
+
+			if (pi != null)
+				return Expression.Property(obj, pi);
+
+			var fi = obj.Type.GetField(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy);
+			if (fi != null)
+				return Expression.Field(obj, fi);
+
+			pi = obj.Type.GetProperty(name, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy);
+			if (pi != null)
+				return Expression.Property(obj, pi);
+
+			fi = obj.Type.GetField(name, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy);
+			if (fi != null)
+				return Expression.Field(obj, fi);
+
+			throw new InvalidOperationException($"Instance property or field with name {name} not found on type {obj.Type}");
+		}
+	}
+}

--- a/Source/LinqToDB/Expressions/Extensions.cs
+++ b/Source/LinqToDB/Expressions/Extensions.cs
@@ -32,7 +32,7 @@ namespace LinqToDB.Expressions
 				try
 				{
 					var l = Expression.Lambda<Func<Expression,string>>(
-						Expression.PropertyOrField(p, "DebugView"),
+						ExpressionHelper.PropertyOrField(p, "DebugView"),
 						p);
 
 					_getDebugView = l.Compile();
@@ -1717,7 +1717,7 @@ namespace LinqToDB.Expressions
 					Expression.Constant(mi.Name));
 			}
 			else
-				return Expression.PropertyOrField(obj, mi.Name);
+				return Expression.MakeMemberAccess(obj, mi);
 		}
 	}
 }

--- a/Source/LinqToDB/Expressions/TypeMapper.cs
+++ b/Source/LinqToDB/Expressions/TypeMapper.cs
@@ -280,7 +280,7 @@ namespace LinqToDB.Expressions
 					var handlerGenerator = new ExpressionGenerator(this);
 					var delegateVariable = handlerGenerator.DeclareVariable(wrapperEvent.EventHandlerType, "handler");
 
-					handlerGenerator.Assign(delegateVariable, Expression.Field(pWrapper, "_" + eventName));
+					handlerGenerator.Assign(delegateVariable, ExpressionHelper.Field(pWrapper, "_" + eventName));
 
 					// returning event is a bad idea
 					if (returnType != typeof(void))
@@ -297,7 +297,7 @@ namespace LinqToDB.Expressions
 
 					subscribeGenerator.AddExpression(
 						Expression.Call(
-							Expression.Convert(Expression.Property(pWrapper, nameof(TypeWrapper.instance_)), targetType),
+							Expression.Convert(ExpressionHelper.Property(pWrapper, nameof(TypeWrapper.instance_)), targetType),
 							ei.AddMethod,
 							Expression.Lambda(delegateType, handlerGenerator.ResultExpression, parameters)));
 				}
@@ -326,7 +326,7 @@ namespace LinqToDB.Expressions
 					expr = MapExpressionInternal(Expression.Lambda(expr, paramExpressions), paramValues);
 
 					if (returnType != null && typeof(TypeWrapper).IsSameOrParentOf(returnType))
-						expr = Expression.Property(Expression.Convert(expr, returnType), nameof(TypeWrapper.instance_));
+						expr = ExpressionHelper.Property(Expression.Convert(expr, returnType), nameof(TypeWrapper.instance_));
 
 					return expr;
 				}
@@ -1011,7 +1011,7 @@ namespace LinqToDB.Expressions
 					if (typeof(TypeWrapper).IsSameOrParentOf(oldParameter.Type))
 						parametersMap.Add(
 							mappedLambda.Parameters[i],
-							Expression.Convert(Expression.Property(oldParameter, nameof(TypeWrapper.instance_)), mappedType));
+							Expression.Convert(ExpressionHelper.Property(oldParameter, nameof(TypeWrapper.instance_)), mappedType));
 					else if (oldParameter.Type.IsEnum)
 						parametersMap.Add(
 							mappedLambda.Parameters[i],

--- a/Source/LinqToDB/Linq/Builder/EagerLoading.cs
+++ b/Source/LinqToDB/Linq/Builder/EagerLoading.cs
@@ -662,7 +662,7 @@ namespace LinqToDB.Linq.Builder
 				var prevKeys       = ExtractKeys(context, keyExpression).ToArray();
 				var subMasterKeys  = ExtractKeys(context, detailExpression).ToArray();
 
-				var prevKeysByParameter = ExtractTupleValues(keyExpression, Expression.PropertyOrField(masterParm, "Key")).ToArray();
+				var prevKeysByParameter = ExtractTupleValues(keyExpression, ExpressionHelper.Property(masterParm, nameof(KeyDetailEnvelope<object, object>.Key))).ToArray();
 
 				var correctLookup = prevKeysByParameter.ToLookup(tv => tv.Item1, tv => tv.Item2, new ExpressionEqualityComparer());
 				foreach (var key in prevKeys)
@@ -671,7 +671,7 @@ namespace LinqToDB.Linq.Builder
 						key.ForSelect = correctLookup[key.ForSelect].First();
 				}
 
-				var detailProp = Expression.PropertyOrField(masterParm, "Detail");
+				var detailProp = ExpressionHelper.Property(masterParm, nameof(KeyDetailEnvelope<object, object>.Detail));
 				var subMasterObj = detailExpression;
 				foreach (var key in subMasterKeys)
 				{
@@ -1065,7 +1065,7 @@ namespace LinqToDB.Linq.Builder
 					var keyExpression = ((MemberAssignment)envelopeCreateMethod.Bindings[0]).Expression;
 					var prevKeys      = ExtractKeys(context, keyExpression).ToArray();
 
-					var keysPath      = Expression.PropertyOrField(Expression.PropertyOrField(resultParameter, "Data"), "Key");
+					var keysPath      = ExpressionHelper.PropertyOrField(ExpressionHelper.PropertyOrField(resultParameter, "Data"), "Key");
 					var prevPairs     = ExtractTupleValues(keyExpression, keysPath)
 						.ToLookup(p => p.Item1);
 
@@ -1081,7 +1081,7 @@ namespace LinqToDB.Linq.Builder
 				var keySelectExpression     = GenerateKeyExpression(keysInfo.Select(k => k.ForSelect).ToArray(), 0);
 				var keyParametersExpression = GenerateKeyExpression(dependencyParameters.Cast<Expression>().ToArray(), 0);
 
-				var keyField = Expression.PropertyOrField(resultParameter, "Key");
+				var keyField = ExpressionHelper.PropertyOrField(resultParameter, "Key");
 				var pairs    = ExtractTupleValues(keyParametersExpression, keyField)
 					.ToArray();
 
@@ -1673,7 +1673,7 @@ namespace LinqToDB.Linq.Builder
 														newParameters[j] = newParam;
 
 														var accessExpr =
-															Expression.PropertyOrField(newParam, "Data");
+															ExpressionHelper.PropertyOrField(newParam, "Data");
 														newBody = newBody.Transform(e => e == prm ? accessExpr : e);
 													}
 													else if (typeof(IGrouping<,>).IsSameOrParentOf(replacedType))
@@ -1705,7 +1705,7 @@ namespace LinqToDB.Linq.Builder
 														if (i == mc.Arguments.Count - 1)
 														{
 															var neededKey =
-																Expression.PropertyOrField(transientParam, "Key");
+																ExpressionHelper.PropertyOrField(transientParam, "Key");
 															var itemType = GetEnumerableElementType(newBody.Type,
 																replaceInfo.MappingSchema);
 															var parameter = Expression.Parameter(itemType, "t");
@@ -1732,7 +1732,7 @@ namespace LinqToDB.Linq.Builder
 														if (!isTransient)
 														{
 															var neededKey =
-																Expression.PropertyOrField(transientParam, "Key");
+																ExpressionHelper.PropertyOrField(transientParam, "Key");
 															newBody = CreateKDH(neededKey, newBody);
 														}
 													}
@@ -1792,7 +1792,7 @@ namespace LinqToDB.Linq.Builder
 							{
 								updated = updated.NodeType == ExpressionType.MemberInit
 									? ((MemberAssignment)((MemberInitExpression)updated).Bindings[0]).Expression
-									: Expression.PropertyOrField(updated, "Key");
+									: ExpressionHelper.PropertyOrField(updated, "Key");
 							}	
 							newExpr = CreateKDH(updated, mi);
 						}
@@ -1820,7 +1820,7 @@ namespace LinqToDB.Linq.Builder
 							{
 								updated = updated.NodeType == ExpressionType.MemberInit
 									? ((MemberAssignment)((MemberInitExpression)updated).Bindings[0]).Expression
-									: Expression.PropertyOrField(updated, "Key");
+									: ExpressionHelper.PropertyOrField(updated, "Key");
 							}
 							else if (IsEnumerableType(updated.Type, replaceInfo.MappingSchema))
 							{
@@ -1828,7 +1828,7 @@ namespace LinqToDB.Linq.Builder
 								if (typeof(KDH<,>).IsSameOrParentOf(elementType))
 								{
 									var p          = Expression.Parameter(elementType, "t");
-									var body       = Expression.PropertyOrField(p, "Key");
+									var body       = ExpressionHelper.PropertyOrField(p, "Key");
 									var methodInfo = (typeof(IQueryable<>).IsSameOrParentOf(
 										updated.Type)
 										? Methods.Queryable.Select

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -1440,8 +1440,8 @@ namespace LinqToDB.Linq.Builder
 					{
 						var body = convertExpr.GetBody(newExpr.ValueExpression);
 
-						newExpr.ValueExpression      = Expression.PropertyOrField(body, nameof(DataParameter.Value));
-						newExpr.DbDataTypeExpression = Expression.PropertyOrField(body, nameof(DataParameter.DbDataType));
+						newExpr.ValueExpression      = ExpressionHelper.Property(body, nameof(DataParameter.Value));
+						newExpr.DbDataTypeExpression = ExpressionHelper.Property(body, nameof(DataParameter.DbDataType));
 					}
 				}
 
@@ -1581,7 +1581,7 @@ namespace LinqToDB.Linq.Builder
 
 							var expr = Expression.Call(
 								minf,
-								Expression.PropertyOrField(e.Object, "Values"),
+								ExpressionHelper.PropertyOrField(e.Object!, "Values"),
 								e.Arguments[0]);
 
 							predicate = ConvertInPredicate(context!, expr);
@@ -1595,7 +1595,7 @@ namespace LinqToDB.Linq.Builder
 
 							var expr = Expression.Call(
 								minf,
-								Expression.PropertyOrField(e.Object, "Keys"),
+								ExpressionHelper.PropertyOrField(e.Object!, "Keys"),
 								e.Arguments[0]);
 
 							predicate = ConvertInPredicate(context!, expr);
@@ -2304,8 +2304,8 @@ namespace LinqToDB.Linq.Builder
 				{
 					var body = expr.GetBody(accessorExpression);
 
-					accessorExpression           = Expression.PropertyOrField(body, nameof(DataParameter.Value));
-					dbDataTypeAccessorExpression = Expression.PropertyOrField(body, nameof(DataParameter.DbDataType));
+					accessorExpression           = ExpressionHelper.Property(body, nameof(DataParameter.Value));
+					dbDataTypeAccessorExpression = ExpressionHelper.Property(body, nameof(DataParameter.DbDataType));
 				}
 			}
 			else
@@ -2316,8 +2316,8 @@ namespace LinqToDB.Linq.Builder
 					if (dp?.Name?.IsNullOrEmpty() == false)
 						name = dp.Name;
 
-					dbDataTypeAccessorExpression = Expression.PropertyOrField(accessorExpression, nameof(DataParameter.DbDataType));
-					accessorExpression           = Expression.PropertyOrField(accessorExpression, nameof(DataParameter.Value));
+					dbDataTypeAccessorExpression = ExpressionHelper.Property(accessorExpression, nameof(DataParameter.DbDataType));
+					accessorExpression           = ExpressionHelper.Property(accessorExpression, nameof(DataParameter.Value));
 				}
 				else
 				{
@@ -2698,7 +2698,7 @@ namespace LinqToDB.Linq.Builder
 				if (obj.Type != ttype)
 					obj = Expression.Convert(expression.Expression, ttype);
 
-				var left = Expression.PropertyOrField(obj, field.Name);
+				var left = ExpressionHelper.PropertyOrField(obj, field.Name);
 				var code = m.m.Code;
 
 				if (code == null)

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
@@ -974,9 +974,9 @@ namespace LinqToDB.Linq.Builder
 					Expression ex = parm;
 
 					for (var j = i; j < exprs.Count - 1; j++)
-						ex = Expression.PropertyOrField(ex, "p");
+						ex = ExpressionHelper.PropertyOrField(ex, "p");
 
-					ex = Expression.PropertyOrField(ex, "ex");
+					ex = ExpressionHelper.PropertyOrField(ex, "ex");
 
 					dic.Add(exprs[i], ex);
 
@@ -991,7 +991,7 @@ namespace LinqToDB.Linq.Builder
 					return dic.TryGetValue(ex, out e) ? e : ex;
 				});
 
-				var nparm = exprs.Aggregate<Expression,Expression>(parm, (c,t) => Expression.PropertyOrField(c, "p"));
+				var nparm = exprs.Aggregate<Expression,Expression>(parm, (c,t) => ExpressionHelper.PropertyOrField(c, "p"));
 
 				newBody   = newBody.Transform(ex => ReferenceEquals(ex, lparam) ? nparm : ex);
 				predicate = Expression.Lambda(newBody, parm);
@@ -1018,7 +1018,7 @@ namespace LinqToDB.Linq.Builder
 					methodInfo = methodInfo.MakeGenericMethod(expr.Type, lparam.Type);
 					method     = Expression.Call(methodInfo, method,
 						Expression.Lambda(
-							exprs.Aggregate((Expression)parameter, (current,_) => Expression.PropertyOrField(current, "p")),
+							exprs.Aggregate((Expression)parameter, (current,_) => ExpressionHelper.PropertyOrField(current, "p")),
 							parameter));
 				}
 			}
@@ -1222,7 +1222,7 @@ namespace LinqToDB.Linq.Builder
 						Expression obj = elemArg!;
 
 						if (_wrapInSubQuery)
-							obj = Expression.PropertyOrField(elemArg, "Element");
+							obj = ExpressionHelper.PropertyOrField(elemArg!, "Element");
 
 						if (_elementSelector == null)
 							return obj;
@@ -1234,7 +1234,7 @@ namespace LinqToDB.Linq.Builder
 						return _resultSelector!.Body.Transform(e =>
 						{
 							if (ReferenceEquals(e, _resultSelector.Parameters[0]))
-								return Expression.PropertyOrField(resArg, "Key");
+								return ExpressionHelper.PropertyOrField(resArg!, "Key");
 
 							if (ReferenceEquals(e, _resultSelector.Parameters[1]))
 								return resArg!;

--- a/Source/LinqToDB/Linq/Builder/GroupByBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/GroupByBuilder.cs
@@ -682,7 +682,7 @@ namespace LinqToDB.Linq.Builder
 							Builder.MappingSchema,
 							Sequence.Expression,
 							_key.Lambda.Parameters[0],
-							Expression.PropertyOrField(sm.Lambda.Parameters[0], "Key"),
+							ExpressionHelper.PropertyOrField(sm.Lambda.Parameters[0], "Key"),
 							_key.Lambda.Body);
 
 						return Builder.BuildSequence(new BuildInfo(buildInfo, expr));
@@ -696,7 +696,7 @@ namespace LinqToDB.Linq.Builder
 							Builder.MappingSchema,
 							_sequenceExpr,
 							_key.Lambda.Parameters[0],
-							Expression.PropertyOrField(buildInfo.Expression, "Key"),
+							ExpressionHelper.PropertyOrField(buildInfo.Expression, "Key"),
 							_key.Lambda.Body);
 
 						var ctx = Builder.BuildSequence(new BuildInfo(buildInfo, expr));

--- a/Source/LinqToDB/Linq/Builder/SetOperationBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/SetOperationBuilder.cs
@@ -291,7 +291,7 @@ namespace LinqToDB.Linq.Builder
 
 							expr = Expression.New(
 								nctor.Constructor,
-								members.Select(m => Expression.PropertyOrField(_unionParameter, m.Name)),
+								members.Select(m => ExpressionHelper.PropertyOrField(_unionParameter!, m.Name)),
 								members);
 
 							var ex = Builder.BuildExpression(this, expr, enforceServerSide);

--- a/Source/LinqToDB/Linq/Builder/TableBuilder.AssociatedTableContext.cs
+++ b/Source/LinqToDB/Linq/Builder/TableBuilder.AssociatedTableContext.cs
@@ -470,8 +470,8 @@ namespace LinqToDB.Linq.Builder
 
 						for (var i = 0; i < tableContext.Association.ThisKey.Length; i++)
 						{
-							var thisProp  = Expression.PropertyOrField(Expression.Convert(lParent, parentObject.Type), tableContext.Association.ThisKey[i]);
-							var otherProp = Expression.PropertyOrField(pWhere, tableContext.Association.OtherKey[i]);
+							var thisProp  = ExpressionHelper.PropertyOrField(Expression.Convert(lParent, parentObject.Type), tableContext.Association.ThisKey[i]);
+							var otherProp = ExpressionHelper.PropertyOrField(pWhere, tableContext.Association.OtherKey[i]);
 
 							var ex = ExpressionBuilder.Equal(tableContext.Builder.MappingSchema, otherProp, thisProp);
 

--- a/Source/LinqToDB/Linq/Builder/TableBuilder.TableContext.cs
+++ b/Source/LinqToDB/Linq/Builder/TableBuilder.TableContext.cs
@@ -214,7 +214,7 @@ namespace LinqToDB.Linq.Builder
 						{
 							exprs.Add(Expression.Assign(
 								attr?.Storage != null
-									? Expression.PropertyOrField(parentObject, attr.Storage)
+									? ExpressionHelper.PropertyOrField(parentObject, attr.Storage)
 									: Expression.MakeMemberAccess(parentObject, member.MemberInfo),
 								ex));
 						}
@@ -1317,7 +1317,7 @@ namespace LinqToDB.Linq.Builder
 								{
 									if (column.MemberInfo.EqualsTo(memberExpression.Member, SqlTable.ObjectType))
 									{
-										expression = memberExpression = Expression.PropertyOrField(
+										expression = memberExpression = ExpressionHelper.PropertyOrField(
 											Expression.Convert(memberExpression.Expression, column.MemberInfo.DeclaringType), column.MemberName);
 										break;
 									}
@@ -1330,7 +1330,7 @@ namespace LinqToDB.Linq.Builder
 								if (alias.MemberInfo.DeclaringType != memberExpression.Member.DeclaringType)
 									expr = Expression.Convert(memberExpression.Expression, alias.MemberInfo.DeclaringType);
 
-								expression = memberExpression = Expression.PropertyOrField(expr, alias.MemberName);
+								expression = memberExpression = ExpressionHelper.PropertyOrField(expr, alias.MemberName);
 							}
 						}
 					}

--- a/Source/LinqToDB/Linq/QueryRunner.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.cs
@@ -430,7 +430,7 @@ namespace LinqToDB.Linq
 			var exprParam = Expression.Parameter(typeof(Expression), "expr");
 
 			var argAccess = Expression.MakeIndex(
-				Expression.PropertyOrField(Expression.Convert(exprParam, typeof(MethodCallExpression)), "Arguments"),
+				ExpressionHelper.PropertyOrField(Expression.Convert(exprParam, typeof(MethodCallExpression)), "Arguments"),
 				typeof(ReadOnlyCollection<Expression>).GetProperty("Item"),
 				new[] { Expression.Constant(argIndex) });
 
@@ -452,8 +452,8 @@ namespace LinqToDB.Linq
 			if (convertExpression != null)
 			{
 				var body             = convertExpression.GetBody(getter);
-				getter               = Expression.PropertyOrField(body, nameof(DataParameter.Value));
-				dbDataTypeExpression = Expression.PropertyOrField(body, nameof(DataParameter.DbDataType));
+				getter               = ExpressionHelper.Property(body, nameof(DataParameter.Value));
+				dbDataTypeExpression = ExpressionHelper.Property(body, nameof(DataParameter.DbDataType));
 			}
 
 			var param = ExpressionBuilder.CreateParameterAccessor(
@@ -493,8 +493,8 @@ namespace LinqToDB.Linq
 			if (convertExpression != null)
 			{
 				var body             = convertExpression.GetBody(getter);
-				getter               = Expression.PropertyOrField(body, nameof(DataParameter.Value));
-				dbDataTypeExpression = Expression.PropertyOrField(body, nameof(DataParameter.DbDataType));
+				getter               = ExpressionHelper.Property(body, nameof(DataParameter.Value));
+				dbDataTypeExpression = ExpressionHelper.Property(body, nameof(DataParameter.DbDataType));
 			}
 
 			var param = ExpressionBuilder.CreateParameterAccessor(

--- a/Source/LinqToDB/Mapping/ColumnDescriptor.cs
+++ b/Source/LinqToDB/Mapping/ColumnDescriptor.cs
@@ -82,7 +82,7 @@ namespace LinqToDB.Mapping
 			}
 			else
 			{
-				var expr = Expression.PropertyOrField(Expression.Constant(null, MemberInfo.DeclaringType), Storage);
+				var expr = ExpressionHelper.PropertyOrField(Expression.Constant(null, MemberInfo.DeclaringType), Storage);
 				StorageType = expr.Type;
 				StorageInfo = expr.Member;
 			}
@@ -433,7 +433,7 @@ namespace LinqToDB.Mapping
 					getterExpr = Expression.Block(new[] { variable },
 						Expression.Assign(variable, expr.GetBody(getterExpr)),
 						Expression.Condition(Expression.NotEqual(variable, Expression.Constant(null)),
-							Expression.PropertyOrField(variable, "Value"), Expression.Constant(null))
+							ExpressionHelper.PropertyOrField(variable, "Value"), Expression.Constant(null))
 					);
 				}
 				else

--- a/Source/LinqToDB/Mapping/MappingSchema.cs
+++ b/Source/LinqToDB/Mapping/MappingSchema.cs
@@ -569,7 +569,7 @@ namespace LinqToDB.Mapping
 			if (p.Type.IsNullable())
 				return Expression.Lambda(
 					Expression.Condition(
-						Expression.PropertyOrField(p, "HasValue"),
+						ExpressionHelper.Property(p, nameof(Nullable<int>.HasValue)),
 						expr.Body,
 						new DefaultValueExpression(this, expr.Body.Type)),
 					expr.Parameters);

--- a/Source/LinqToDB/Reflection/MemberAccessor.cs
+++ b/Source/LinqToDB/Reflection/MemberAccessor.cs
@@ -24,7 +24,7 @@ namespace LinqToDB.Reflection
 
 			if (memberName.IndexOf('.') < 0)
 			{
-				SetSimple(Expression.PropertyOrField(Expression.Constant(null, typeAccessor.Type), memberName).Member, ed);
+				SetSimple(ExpressionHelper.PropertyOrField(Expression.Constant(null, typeAccessor.Type), memberName).Member, ed);
 			}
 			else
 			{
@@ -37,7 +37,7 @@ namespace LinqToDB.Reflection
 				var expr     = (Expression)objParam;
 				var infos    = members.Select(m =>
 				{
-					expr = Expression.PropertyOrField(expr, m);
+					expr = ExpressionHelper.PropertyOrField(expr, m);
 					return new
 					{
 						member = ((MemberExpression)expr).Member,

--- a/Source/LinqToDB/ServiceModel/DataService.cs
+++ b/Source/LinqToDB/ServiceModel/DataService.cs
@@ -8,6 +8,7 @@ namespace LinqToDB.ServiceModel
 {
 	using Extensions;
 	using Linq;
+	using LinqToDB.Expressions;
 	using Mapping;
 	using SqlQuery;
 
@@ -281,7 +282,7 @@ namespace LinqToDB.ServiceModel
 					{
 						var p = Expression.Parameter(typeof(object), "p");
 						var l = Expression.Lambda<Func<object?,IQueryable>>(
-							Expression.PropertyOrField(
+							ExpressionHelper.PropertyOrField(
 								Expression.Convert(p, typeof(T)),
 								resourceSet.Name),
 							p);

--- a/Source/LinqToDB/TempTable.cs
+++ b/Source/LinqToDB/TempTable.cs
@@ -197,7 +197,7 @@ namespace LinqToDB
 					return Expression.Lambda<Func<T,T>>(
 						Expression.New(
 							nctor.Constructor,
-							members.Select(m => Expression.PropertyOrField(p, m.Name)),
+							members.Select(m => ExpressionHelper.PropertyOrField(p, m.Name)),
 							members),
 						p);
 				}

--- a/Tests/Linq/Mapping/MappingAmbiguityTests.cs
+++ b/Tests/Linq/Mapping/MappingAmbiguityTests.cs
@@ -45,7 +45,7 @@ namespace Tests.Mapping
 			{
 				var sql = db.LastQuery;
 
-				Assert.AreEqual(sql, @"CREATE TABLE [TestTable]
+				Assert.AreEqual(sql.Replace("\r", ""), @"CREATE TABLE [TestTable]
 (
 	[ID]      INTEGER       NOT NULL,
 	[Field1]  INTEGER       NOT NULL,
@@ -57,12 +57,12 @@ namespace Tests.Mapping
 
 	CONSTRAINT [PK_TestTable] PRIMARY KEY ([ID])
 )
-");
+".Replace("\r", ""));
 			}
 		}
 
 		[Test]
-		public void TestDefaultInsertUpdateMerge([MergeTests.MergeDataContextSource] string context)
+		public void TestDefaultInsertUpdateMerge([MergeTests.MergeDataContextSource(true, TestProvName.AllSybase)] string context)
 		{
 			using (var db = GetDataContext(context))
 			using (db.CreateLocalTable<TestTable>())

--- a/Tests/Linq/Mapping/MappingAmbiguityTests.cs
+++ b/Tests/Linq/Mapping/MappingAmbiguityTests.cs
@@ -1,0 +1,82 @@
+﻿using System.Linq;
+
+using LinqToDB;
+using LinqToDB.Mapping;
+
+using NUnit.Framework;
+using Tests.Model;
+using Tests.xUpdate;
+
+namespace Tests.Mapping
+{
+	public class MappingAmbiguityTests : TestBase
+	{
+		[Table]
+		public class TestTable
+		{
+			[PrimaryKey] public int ID { get; set; }
+
+			// mapped field and property with same name different cases and types
+			[Column]            public int    Field1 { get; set; }
+			[Column("field11")] public string field1;
+
+			// mapped property and unmapped field with same name different cases and types
+			[Column]    public int    Field2 { get; set; }
+			[NotColumn] public string field2;
+
+			// mapped field and unmapped property with same name different cases and types
+			[Column]    public int    Field3 { get; set; }
+			[NotColumn] public string field3;
+
+			// mapped and unmapped property with same name different cases and types
+			[Column]    public int    Field4 { get; set; }
+			[NotColumn] public string field4 { get; set; }
+
+			// mapped and unmapped field with same name different cases and types
+			[Column]    public int    Field5;
+			[NotColumn] public string field5;
+		}
+
+		[Test]
+		public void TestCreate([IncludeDataSources(false, TestProvName.AllSQLite)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable<TestTable>())
+			{
+				var sql = db.LastQuery;
+
+				Assert.AreEqual(sql, @"CREATE TABLE [TestTable]
+(
+	[ID]      INTEGER       NOT NULL,
+	[Field1]  INTEGER       NOT NULL,
+	[Field2]  INTEGER       NOT NULL,
+	[Field3]  INTEGER       NOT NULL,
+	[Field4]  INTEGER       NOT NULL,
+	[field11] NVarChar(255)     NULL,
+	[Field5]  INTEGER       NOT NULL,
+
+	CONSTRAINT [PK_TestTable] PRIMARY KEY ([ID])
+)
+");
+			}
+		}
+
+		[Test]
+		public void TestDefaultInsertUpdateMerge([MergeTests.MergeDataContextSource] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (db.CreateLocalTable<TestTable>())
+			{
+				var res = db.GetTable<TestTable>()
+					.Merge()
+					.UsingTarget()
+					.OnTargetKey()
+					.InsertWhenNotMatched()
+					.UpdateWhenMatched()
+					.Merge();
+
+				Assert.AreEqual(0, res);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Enforce case-sensitivity for member mapping to avoid exceptions, when case-insensitive member search creates ambiguety.

Fixes issue with Merge failing, when mapped type has fields or properties with names differ only by case.