### PR TITLE
Release 2.9.8

### DIFF
--- a/Build/linq2db.Default.props
+++ b/Build/linq2db.Default.props
@@ -1,6 +1,6 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<Version>2.9.7.0</Version>
+		<Version>2.9.8.0</Version>
 
 		<Description>LINQ to DB is a data access technology that provides a run-time infrastructure for managing relational data as objects.</Description>
 		<Authors>Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</Authors>

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,2 @@
+This project has adopted the code of conduct defined by the Contributor Covenant to clarify expected behavior in our community.
+For more information, see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct).

--- a/Data/Create Scripts/Oracle.sql
+++ b/Data/Create Scripts/Oracle.sql
@@ -593,8 +593,8 @@ INSERT INTO DataTypeTest
 	 Single_,       Stream_,  String_,    UInt16_, UInt32_,   UInt64_,     Xml_)
 VALUES
 	(   NULL,          NULL,     NULL,       NULL,    NULL,      NULL,     NULL,
-	    NULL,          NULL,     NULL,       NULL,    NULL,      NULL,     NULL,
-	    NULL,          NULL,     NULL,       NULL,    NULL,      NULL,     NULL)
+		NULL,          NULL,     NULL,       NULL,    NULL,      NULL,     NULL,
+		NULL,          NULL,     NULL,       NULL,    NULL,      NULL,     NULL)
 /
 
 INSERT INTO DataTypeTest
@@ -985,5 +985,24 @@ CREATE OR REPLACE
 PROCEDURE AddIssue792Record() IS
 BEGIN
 	INSERT INTO dbo.AllTypes(char20DataType) VALUES('issue792');
+END;
+/
+
+CREATE OR REPLACE PACKAGE ISSUE2132 AS
+procedure test;
+END;
+/
+
+CREATE OR REPLACE PACKAGE BODY ISSUE2132 AS 
+procedure test is
+	begin
+		return 4;
+	end test;
+END;
+/
+
+CREATE OR REPLACE PROCEDURE TEST2132
+BEGIN
+	return 6;
 END;
 /

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In other words **LINQ to DB is type-safe SQL**.
 
 linq2db is a [.NET Foundation](https://dotnetfoundation.org/) project.
 
-![.NET Foundation Logo](docs/images/dotnetfoundationhorizontal.svg)
+<img alt=".NET Foundation Logo" src="https://github.com/dotnet/swag/blob/master/logo/dotnetfoundation_v4_horizontal.png" width="250px" >
 
 ## Standout Features
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ However, it's not as heavy as LINQ to SQL or Entity Framework. There is no chang
 
 In other words **LINQ to DB is type-safe SQL**.
 
+linq2db is a [.NET Foundation](https://dotnetfoundation.org/) project.
+
+![.NET Foundation Logo](docs/images/dotnetfoundationhorizontal.svg)
+
 ## Standout Features
 
  - Rich Querying API:

--- a/Source/LinqToDB/Common/ConvertUtils.cs
+++ b/Source/LinqToDB/Common/ConvertUtils.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using LinqToDB.Extensions;
+
+namespace LinqToDB.Common
+{
+	internal static class ConvertUtils
+	{
+		private static readonly IDictionary<Type, ISet<Type>> _alwaysConvert = new Dictionary<Type, ISet<Type>>()
+		{
+			{ typeof(byte)  , new HashSet<Type>() { typeof(short), typeof(ushort), typeof(int) , typeof(uint), typeof(long), typeof(ulong) } },
+			{ typeof(sbyte) , new HashSet<Type>() { typeof(short), typeof(ushort), typeof(int) , typeof(uint), typeof(long), typeof(ulong) } },
+			{ typeof(short) , new HashSet<Type>() { typeof(int)  , typeof(uint)  , typeof(long), typeof(ulong) } },
+			{ typeof(ushort), new HashSet<Type>() { typeof(int)  , typeof(uint)  , typeof(long), typeof(ulong) } },
+			{ typeof(int)   , new HashSet<Type>() { typeof(long) , typeof(ulong) } },
+			{ typeof(uint)  , new HashSet<Type>() { typeof(long) , typeof(ulong) } },
+			{ typeof(long)  , new HashSet<Type>() { } },
+			{ typeof(ulong) , new HashSet<Type>() { } },
+		};
+
+		private static readonly IDictionary<Type, IDictionary<Type, Tuple<IComparable, IComparable>>> _rangedConvert = new Dictionary<Type, IDictionary<Type, Tuple<IComparable, IComparable>>>()
+		{
+			{ typeof(byte)  , new Dictionary<Type, Tuple<IComparable, IComparable>>()
+				{
+					{ typeof(sbyte), Tuple.Create((IComparable)(byte)0, (IComparable)(byte)sbyte.MaxValue) }
+				}
+			},
+			{ typeof(sbyte) , new Dictionary<Type, Tuple<IComparable, IComparable>>()
+				{
+					{ typeof(byte), Tuple.Create((IComparable)(sbyte)0, (IComparable)sbyte.MaxValue) }
+				}
+			},
+			{ typeof(short) , new Dictionary<Type, Tuple<IComparable, IComparable>>()
+				{
+					{ typeof(sbyte) , Tuple.Create((IComparable)(short)sbyte.MinValue, (IComparable)(short)sbyte.MaxValue) },
+					{ typeof(byte ) , Tuple.Create((IComparable)(short)byte .MinValue, (IComparable)(short)byte .MaxValue) },
+					{ typeof(ushort), Tuple.Create((IComparable)(short)0             , (IComparable)       short.MaxValue) },
+				}
+			},
+			{ typeof(ushort) , new Dictionary<Type, Tuple<IComparable, IComparable>>()
+				{
+					{ typeof(sbyte) , Tuple.Create((IComparable)(ushort)0, (IComparable)(ushort)sbyte.MaxValue) },
+					{ typeof(byte ) , Tuple.Create((IComparable)(ushort)0, (IComparable)(ushort)byte .MaxValue) },
+					{ typeof(short) , Tuple.Create((IComparable)(ushort)0, (IComparable)(ushort)short.MaxValue) },
+				}
+			},
+			{ typeof(int) , new Dictionary<Type, Tuple<IComparable, IComparable>>()
+				{
+					{ typeof(sbyte) , Tuple.Create((IComparable)(int)sbyte .MinValue, (IComparable)(int)sbyte    .MaxValue) },
+					{ typeof(byte ) , Tuple.Create((IComparable)(int)byte  .MinValue, (IComparable)(int)byte     .MaxValue) },
+					{ typeof(short) , Tuple.Create((IComparable)(int)short .MinValue, (IComparable)(int)short    .MaxValue) },
+					{ typeof(ushort), Tuple.Create((IComparable)(int)ushort.MinValue, (IComparable)(int)ushort   .MaxValue) },
+					{ typeof(uint)  , Tuple.Create((IComparable)(int)0              , (IComparable)     int      .MaxValue) },
+				}
+			},
+			{ typeof(uint) , new Dictionary<Type, Tuple<IComparable, IComparable>>()
+				{
+					{ typeof(sbyte ), Tuple.Create((IComparable)(uint)0, (IComparable)(uint)sbyte .MaxValue) },
+					{ typeof(byte  ), Tuple.Create((IComparable)(uint)0, (IComparable)(uint)byte  .MaxValue) },
+					{ typeof(short ), Tuple.Create((IComparable)(uint)0, (IComparable)(uint)short .MaxValue) },
+					{ typeof(ushort), Tuple.Create((IComparable)(uint)0, (IComparable)(uint)ushort.MaxValue) },
+					{ typeof(int   ), Tuple.Create((IComparable)(uint)0, (IComparable)(uint)int   .MaxValue) },
+				}
+			},
+			{ typeof(long) , new Dictionary<Type, Tuple<IComparable, IComparable>>()
+				{
+					{ typeof(sbyte ), Tuple.Create((IComparable)(long)sbyte .MinValue, (IComparable)(long)sbyte .MaxValue) },
+					{ typeof(byte  ), Tuple.Create((IComparable)(long)byte  .MinValue, (IComparable)(long)byte  .MaxValue) },
+					{ typeof(short ), Tuple.Create((IComparable)(long)short .MinValue, (IComparable)(long)short .MaxValue) },
+					{ typeof(ushort), Tuple.Create((IComparable)(long)ushort.MinValue, (IComparable)(long)ushort.MaxValue) },
+					{ typeof(int   ), Tuple.Create((IComparable)(long)int   .MinValue, (IComparable)(long)int   .MaxValue) },
+					{ typeof(uint  ), Tuple.Create((IComparable)(long)uint  .MinValue, (IComparable)(long)uint  .MaxValue) },
+					{ typeof(ulong ), Tuple.Create((IComparable)(long)0              , (IComparable)      long  .MaxValue) },
+				}
+			},
+			{ typeof(ulong) , new Dictionary<Type, Tuple<IComparable, IComparable>>()
+				{
+					{ typeof(sbyte ), Tuple.Create((IComparable)(ulong)0, (IComparable)(ulong)sbyte .MaxValue) },
+					{ typeof(byte  ), Tuple.Create((IComparable)(ulong)0, (IComparable)(ulong)byte  .MaxValue) },
+					{ typeof(short ), Tuple.Create((IComparable)(ulong)0, (IComparable)(ulong)short .MaxValue) },
+					{ typeof(ushort), Tuple.Create((IComparable)(ulong)0, (IComparable)(ulong)ushort.MaxValue) },
+					{ typeof(int   ), Tuple.Create((IComparable)(ulong)0, (IComparable)(ulong)int   .MaxValue) },
+					{ typeof(uint  ), Tuple.Create((IComparable)(ulong)0, (IComparable)(ulong)uint  .MaxValue) },
+					{ typeof(long  ), Tuple.Create((IComparable)(ulong)0, (IComparable)(ulong)long  .MaxValue) },
+				}
+			},
+		};
+
+		public static bool TryConvert(object value, Type toType, out object convertedValue)
+		{
+			convertedValue = null;
+
+			if (value == null)
+				return  toType.IsClassEx() || toType.IsNullable();
+
+			var from = value.GetType().ToNullableUnderlying();
+			var to   = toType         .ToNullableUnderlying();
+
+			if (from == to)
+			{
+				convertedValue = value;
+				return true;
+			}
+
+			if (_alwaysConvert.TryGetValue(from, out var types) && types.Contains(to))
+			{
+				convertedValue = Convert.ChangeType(value, to);
+				return true;
+			}
+
+			if (!_rangedConvert.TryGetValue(from, out var rangedTypes)
+				|| !rangedTypes.TryGetValue(to, out var ranges))
+				return false;
+
+			if (   ranges.Item1.CompareTo(value) <= 0
+				&& ranges.Item2.CompareTo(value) >= 0)
+			{
+				convertedValue = Convert.ChangeType(value, to);
+				return true;
+			}
+
+			return false;
+		}
+	}
+}

--- a/Source/LinqToDB/Data/DataConnection.Linq.cs
+++ b/Source/LinqToDB/Data/DataConnection.Linq.cs
@@ -10,6 +10,7 @@ namespace LinqToDB.Data
 	using Mapping;
 	using SqlQuery;
 	using SqlProvider;
+	using System.Linq;
 
 	public partial class DataConnection : IDataContext
 	{
@@ -68,10 +69,23 @@ namespace LinqToDB.Data
 			if (forNestedQuery && _connection != null && IsMarsEnabled)
 				return new DataConnection(DataProvider, _connection)
 				{
-					MappingSchema    = MappingSchema,
-					TransactionAsync = TransactionAsync,
-					IsMarsEnabled    = IsMarsEnabled,
-					ConnectionString = ConnectionString,
+					MappingSchema               = MappingSchema,
+					TransactionAsync            = TransactionAsync,
+					IsMarsEnabled               = IsMarsEnabled,
+					ConnectionString            = ConnectionString,
+					OnEntityCreated             = OnEntityCreated,
+					RetryPolicy                 = RetryPolicy,
+					CommandTimeout              = CommandTimeout,
+					InlineParameters            = InlineParameters,
+					ThrowOnDisposed             = ThrowOnDisposed,
+					_queryHints                 = _queryHints?.Count > 0 ? _queryHints.ToList() : null,
+					OnTraceConnection           = OnTraceConnection,
+					OnClosed                    = OnClosed,
+					OnClosing                   = OnClosing,
+					OnBeforeConnectionOpen      = OnBeforeConnectionOpen,
+					OnConnectionOpened          = OnConnectionOpened,
+					OnBeforeConnectionOpenAsync = OnBeforeConnectionOpenAsync,
+					OnConnectionOpenedAsync     = OnConnectionOpenedAsync,
 				};
 
 			return (DataConnection)Clone();

--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -1516,7 +1516,22 @@ namespace LinqToDB.Data
 			// will not work for providers that remove security information from connection string
 			var connectionString = ConnectionString ?? (connection == null ? _connection?.ConnectionString : null);
 
-			return new DataConnection(ConfigurationString, DataProvider, connectionString, connection, MappingSchema);
+			return new DataConnection(ConfigurationString, DataProvider, connectionString, connection, MappingSchema)
+			{
+				OnEntityCreated             = OnEntityCreated,
+				RetryPolicy                 = RetryPolicy,
+				CommandTimeout              = CommandTimeout,
+				InlineParameters            = InlineParameters,
+				ThrowOnDisposed             = ThrowOnDisposed,
+				_queryHints                 = _queryHints?.Count > 0 ? _queryHints.ToList() : null,
+				OnTraceConnection           = OnTraceConnection,
+				OnClosed                    = OnClosed,
+				OnClosing                   = OnClosing,
+				OnBeforeConnectionOpen      = OnBeforeConnectionOpen,
+				OnConnectionOpened          = OnConnectionOpened,
+				OnBeforeConnectionOpenAsync = OnBeforeConnectionOpenAsync,
+				OnConnectionOpenedAsync     = OnConnectionOpenedAsync,
+			};
 		}
 
 		#endregion

--- a/Source/LinqToDB/Linq/Builder/AsSubQueryBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/AsSubQueryBuilder.cs
@@ -1,5 +1,7 @@
-﻿using System.Linq.Expressions;
+﻿using System.Linq;
+using System.Linq.Expressions;
 using LinqToDB.Expressions;
+using LinqToDB.Extensions;
 
 namespace LinqToDB.Linq.Builder
 {
@@ -14,8 +16,23 @@ namespace LinqToDB.Linq.Builder
 		{
 			var sequence = builder.BuildSequence(new BuildInfo(buildInfo, methodCall.Arguments[0]));
 			sequence.SelectQuery.DoNotRemove = true;
+
+			var elementType = methodCall.Arguments[0].Type.GetGenericArgumentsEx()[0];
+			if (typeof(IGrouping<,>).IsSameOrParentOf(elementType))
+			{
+				// It is special case when we are trying to make subquery from GroupBy
+
+				sequence.ConvertToIndex(null, 0, ConvertFlags.Key);
+				var param  = Expression.Parameter(elementType);
+				var lambda = Expression.Lambda(Expression.PropertyOrField(param, "Key"), param);
+
+				sequence = new SubQueryContext(sequence);
+				sequence = new SelectContext(buildInfo.Parent, lambda, sequence);
+			}
+			else 
+				sequence = new SubQueryContext(sequence);
 			
-			return new SubQueryContext(sequence);
+			return sequence;
 		}
 
 		protected override SequenceConvertInfo Convert(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo,

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -1867,6 +1867,20 @@ namespace LinqToDB.Linq.Builder
 					op2 = op2conv1.Operand;
 					return true;
 				}
+
+				// https://github.com/linq2db/linq2db/issues/2166
+				// generates expression:
+				// Convert(member, int) == const(value, int)
+				// we must replace it with:
+				// member == const(value, member_type)
+				if (op2 is ConstantExpression const2
+					&& const2.Type == typeof(int)
+					&& ConvertUtils.TryConvert(const2.Value, op1conv.Operand.Type, out var convertedValue))
+				{
+					op1 = op1conv.Operand;
+					op2 = Expression.Constant(convertedValue, op1conv.Operand.Type);
+					return true;
+				}
 			}
 
 			return false;

--- a/Source/LinqToDB/LinqExtensions.cs
+++ b/Source/LinqToDB/LinqExtensions.cs
@@ -3127,6 +3127,25 @@ namespace LinqToDB
 					MethodHelper.GetMethodInfo(AsSubQuery, source), source.Expression));
 		}
 
+		/// <summary>
+		/// Defines that sub-query is mandatory for <paramref name="grouping"/> query.
+		/// </summary>
+		/// <typeparam name="TKey">The type of the key of the <see cref="T:System.Linq.IGrouping`2" />.</typeparam>
+		/// <typeparam name="TElement">The type of the values in the <see cref="T:System.Linq.IGrouping`2" />.</typeparam>
+		/// <param name="grouping">Source data query.</param>
+		/// <returns>Query covered in sub-query.</returns>
+		[Pure]
+		[LinqTunnel]
+		public static IQueryable<TKey> AsSubQuery<TKey, TElement>([NotNull] this IQueryable<IGrouping<TKey, TElement>> grouping)
+		{
+			if (grouping == null) throw new ArgumentNullException(nameof(grouping));
+
+			return grouping.Provider.CreateQuery<TKey>(
+				Expression.Call(
+					null,
+					MethodHelper.GetMethodInfo(AsSubQuery, grouping), grouping.Expression));
+		}
+
 		#endregion
 
 		#region HasUniqueKey

--- a/Tests/Linq/Data/DataConnectionTests.cs
+++ b/Tests/Linq/Data/DataConnectionTests.cs
@@ -18,7 +18,10 @@ namespace Tests.Data
 {
 #if !NETSTANDARD1_6
 	using System.Configuration;
+	using System.Transactions;
+	using LinqToDB.Data.RetryPolicy;
 #endif
+	using LinqToDB.Mapping;
 
 	using Model;
 
@@ -33,7 +36,7 @@ namespace Tests.Data
 
 			using (var conn = new DataConnection(dataProvider, connectionString))
 			{
-				Assert.That(conn.Connection.State,    Is.EqualTo(ConnectionState.Open));
+				Assert.That(conn.Connection.State, Is.EqualTo(ConnectionState.Open));
 				Assert.That(conn.ConfigurationString, Is.Null);
 			}
 		}
@@ -43,7 +46,7 @@ namespace Tests.Data
 		{
 			using (var conn = new DataConnection())
 			{
-				Assert.That(conn.Connection.State,    Is.EqualTo(ConnectionState.Open));
+				Assert.That(conn.Connection.State, Is.EqualTo(ConnectionState.Open));
 				Assert.That(conn.ConfigurationString, Is.EqualTo(DataConnection.DefaultConfiguration));
 			}
 		}
@@ -60,7 +63,7 @@ namespace Tests.Data
 		{
 			using (var conn = new DataConnection(context))
 			{
-				Assert.That(conn.Connection.State,    Is.EqualTo(ConnectionState.Open));
+				Assert.That(conn.Connection.State, Is.EqualTo(ConnectionState.Open));
 				Assert.That(conn.ConfigurationString, Is.EqualTo(context));
 
 				if (context.EndsWith(".2005"))
@@ -111,89 +114,89 @@ namespace Tests.Data
 			switch (context)
 			{
 				case ProviderName.DB2:
-				{
-					dataProvider = DataConnection.GetDataProvider("DB2", connectionString);
+					{
+						dataProvider = DataConnection.GetDataProvider("DB2", connectionString);
 
-					Assert.That(dataProvider, Is.TypeOf<DB2DataProvider>());
+						Assert.That(dataProvider, Is.TypeOf<DB2DataProvider>());
 
-					var sqlServerDataProvider = (DB2DataProvider)dataProvider;
+						var sqlServerDataProvider = (DB2DataProvider)dataProvider;
 
-					Assert.That(sqlServerDataProvider.Version, Is.EqualTo(DB2Version.LUW));
+						Assert.That(sqlServerDataProvider.Version, Is.EqualTo(DB2Version.LUW));
 
-					break;
-				}
+						break;
+					}
 
 				case ProviderName.SqlServer2005:
-				{
-					dataProvider = DataConnection.GetDataProvider("System.Data.SqlClient", "MyConfig.2005", connectionString);
+					{
+						dataProvider = DataConnection.GetDataProvider("System.Data.SqlClient", "MyConfig.2005", connectionString);
 
-					Assert.That(dataProvider, Is.TypeOf<SqlServerDataProvider>());
+						Assert.That(dataProvider, Is.TypeOf<SqlServerDataProvider>());
 
-					var sqlServerDataProvider = (SqlServerDataProvider)dataProvider;
+						var sqlServerDataProvider = (SqlServerDataProvider)dataProvider;
 
-					Assert.That(sqlServerDataProvider.Version, Is.EqualTo(SqlServerVersion.v2005));
+						Assert.That(sqlServerDataProvider.Version, Is.EqualTo(SqlServerVersion.v2005));
 
-					dataProvider = DataConnection.GetDataProvider("System.Data.SqlClient", connectionString);
-					sqlServerDataProvider = (SqlServerDataProvider)dataProvider;
+						dataProvider = DataConnection.GetDataProvider("System.Data.SqlClient", connectionString);
+						sqlServerDataProvider = (SqlServerDataProvider)dataProvider;
 
-					Assert.That(sqlServerDataProvider.Version, Is.EqualTo(SqlServerVersion.v2005));
+						Assert.That(sqlServerDataProvider.Version, Is.EqualTo(SqlServerVersion.v2005));
 
-					break;
-				}
+						break;
+					}
 
 				case ProviderName.SqlServer2008:
-				{
-					dataProvider = DataConnection.GetDataProvider("SqlServer", connectionString);
+					{
+						dataProvider = DataConnection.GetDataProvider("SqlServer", connectionString);
 
-					Assert.That(dataProvider, Is.TypeOf<SqlServerDataProvider>());
+						Assert.That(dataProvider, Is.TypeOf<SqlServerDataProvider>());
 
-					var sqlServerDataProvider = (SqlServerDataProvider)dataProvider;
+						var sqlServerDataProvider = (SqlServerDataProvider)dataProvider;
 
-					Assert.That(sqlServerDataProvider.Version, Is.EqualTo(SqlServerVersion.v2008));
+						Assert.That(sqlServerDataProvider.Version, Is.EqualTo(SqlServerVersion.v2008));
 
-					dataProvider = DataConnection.GetDataProvider("System.Data.SqlClient", connectionString);
-					sqlServerDataProvider = (SqlServerDataProvider)dataProvider;
+						dataProvider = DataConnection.GetDataProvider("System.Data.SqlClient", connectionString);
+						sqlServerDataProvider = (SqlServerDataProvider)dataProvider;
 
-					Assert.That(sqlServerDataProvider.Version, Is.EqualTo(SqlServerVersion.v2008));
+						Assert.That(sqlServerDataProvider.Version, Is.EqualTo(SqlServerVersion.v2008));
 
-					break;
-				}
+						break;
+					}
 
 				case ProviderName.SqlServer2012:
-				{
-					dataProvider = DataConnection.GetDataProvider("SqlServer.2012", connectionString);
+					{
+						dataProvider = DataConnection.GetDataProvider("SqlServer.2012", connectionString);
 
-					Assert.That(dataProvider, Is.TypeOf<SqlServerDataProvider>());
+						Assert.That(dataProvider, Is.TypeOf<SqlServerDataProvider>());
 
-					var sqlServerDataProvider = (SqlServerDataProvider)dataProvider;
+						var sqlServerDataProvider = (SqlServerDataProvider)dataProvider;
 
-					Assert.That(sqlServerDataProvider.Version, Is.EqualTo(SqlServerVersion.v2012));
+						Assert.That(sqlServerDataProvider.Version, Is.EqualTo(SqlServerVersion.v2012));
 
-					dataProvider = DataConnection.GetDataProvider("System.Data.SqlClient", connectionString);
-					sqlServerDataProvider = (SqlServerDataProvider)dataProvider;
+						dataProvider = DataConnection.GetDataProvider("System.Data.SqlClient", connectionString);
+						sqlServerDataProvider = (SqlServerDataProvider)dataProvider;
 
-					Assert.That(sqlServerDataProvider.Version, Is.EqualTo(SqlServerVersion.v2012));
+						Assert.That(sqlServerDataProvider.Version, Is.EqualTo(SqlServerVersion.v2012));
 
-					break;
-				}
+						break;
+					}
 
 				case ProviderName.SqlServer2014:
-				{
-					dataProvider = DataConnection.GetDataProvider("SqlServer", "SqlServer.2012", connectionString);
+					{
+						dataProvider = DataConnection.GetDataProvider("SqlServer", "SqlServer.2012", connectionString);
 
-					Assert.That(dataProvider, Is.TypeOf<SqlServerDataProvider>());
+						Assert.That(dataProvider, Is.TypeOf<SqlServerDataProvider>());
 
-					var sqlServerDataProvider = (SqlServerDataProvider)dataProvider;
+						var sqlServerDataProvider = (SqlServerDataProvider)dataProvider;
 
-					Assert.That(sqlServerDataProvider.Version, Is.EqualTo(SqlServerVersion.v2012));
+						Assert.That(sqlServerDataProvider.Version, Is.EqualTo(SqlServerVersion.v2012));
 
-					dataProvider = DataConnection.GetDataProvider("System.Data.SqlClient", connectionString);
-					sqlServerDataProvider = (SqlServerDataProvider)dataProvider;
+						dataProvider = DataConnection.GetDataProvider("System.Data.SqlClient", connectionString);
+						sqlServerDataProvider = (SqlServerDataProvider)dataProvider;
 
-					Assert.That(sqlServerDataProvider.Version, Is.EqualTo(SqlServerVersion.v2012));
+						Assert.That(sqlServerDataProvider.Version, Is.EqualTo(SqlServerVersion.v2012));
 
-					break;
-				}
+						break;
+					}
 
 				case ProviderName.SqlServer2017:
 					{
@@ -376,7 +379,7 @@ namespace Tests.Data
 						if (cn.State == ConnectionState.Closed)
 							open = true;
 					};
-				conn.OnBeforeConnectionOpenAsync += async (dc, cn, token) => await Task.Run(() => 
+				conn.OnBeforeConnectionOpenAsync += async (dc, cn, token) => await Task.Run(() =>
 						{
 							if (cn.State == ConnectionState.Closed)
 								openAsync = true;
@@ -432,6 +435,718 @@ namespace Tests.Data
 				Assert.True(time2 < TimeSpan.FromSeconds(62));
 			}
 		}
+
+		[Test]
+		public void TestCloneOnEntityCreated([DataSources(false)] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var size = db.GetTable<Person>().ToList().Count;
+
+				var counter = 0;
+
+				db.GetTable<Person>().ToList();
+				Assert.AreEqual(0, counter);
+
+				db.OnEntityCreated = OnCreated;
+
+				db.GetTable<Person>().ToList();
+				Assert.AreEqual(size, counter);
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					// tests different clone execution branches for MARS-enabled and disabled connections
+					counter = 0;
+					cdb.GetTable<Person>().ToList();
+					Assert.AreEqual(size, counter);
+
+					db.OnEntityCreated = null;
+
+					counter = 0;
+					db.GetTable<Person>().ToList();
+					Assert.AreEqual(0, counter);
+
+					// because we:
+					// - don't track cloned connections
+					// - clonned connections are used internally, so this scenario is not possible for linq2db itself
+					cdb.GetTable<Person>().ToList();
+					Assert.AreEqual(size, counter);
+				}
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					counter = 0;
+					cdb.GetTable<Person>().ToList();
+
+					Assert.AreEqual(0, counter);
+				}
+
+				void OnCreated(EntityCreatedEventArgs args) => counter++;
+			}
+		}
+
+#if !NETSTANDARD1_6
+		class TestRetryPolicy : IRetryPolicy
+		{
+			TResult IRetryPolicy.Execute<TResult>(Func<TResult> operation) => operation();
+			void IRetryPolicy.Execute(Action operation) => operation();
+			Task<TResult> IRetryPolicy.ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> operation, CancellationToken cancellationToken) => operation(cancellationToken);
+			Task IRetryPolicy.ExecuteAsync(Func<CancellationToken, Task> operation, CancellationToken cancellationToken) => operation(cancellationToken);
+		}
+
+		[Test]
+		public void TestCloneCommandTimeout([DataSources(false)] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				// to enable MARS-enabled cloning branch
+				var _ = db.Connection;
+
+				Assert.AreEqual(-1, db.CommandTimeout);
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					Assert.AreEqual(-1, cdb.CommandTimeout);
+				}
+
+				db.CommandTimeout = 0;
+
+				Assert.AreEqual(0, db.CommandTimeout);
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					Assert.AreEqual(0, cdb.CommandTimeout);
+				}
+
+				db.CommandTimeout = 10;
+
+				Assert.AreEqual(10, db.CommandTimeout);
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					Assert.AreEqual(10, cdb.CommandTimeout);
+				}
+
+				db.CommandTimeout = -5;
+				Assert.AreEqual(-1, db.CommandTimeout);
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					Assert.AreEqual(-1, cdb.CommandTimeout);
+				}
+			}
+		}
+
+		[Test]
+		public void TestCloneInlineParameters([DataSources(false)] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				// to enable MARS-enabled cloning branch
+				var _ = db.Connection;
+
+				Assert.False(db.InlineParameters);
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					Assert.False(cdb.InlineParameters);
+				}
+
+				db.InlineParameters = true;
+
+				Assert.True(db.InlineParameters);
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					Assert.True(cdb.InlineParameters);
+				}
+
+				db.InlineParameters = false;
+				Assert.False(db.InlineParameters);
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					Assert.False(cdb.InlineParameters);
+				}
+			}
+		}
+
+		[Test]
+		public void TestCloneQueryHints([DataSources(false)] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				// to enable MARS-enabled cloning branch
+				var _ = db.Connection;
+
+				Assert.AreEqual(0, db.QueryHints.Count);
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					Assert.AreEqual(0, cdb.QueryHints.Count);
+				}
+
+				db.QueryHints.Add("test");
+
+				Assert.AreEqual(1, db.QueryHints.Count);
+				Assert.AreEqual("test", db.QueryHints[0]);
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					Assert.AreEqual(1, cdb.QueryHints.Count);
+					Assert.AreEqual("test", cdb.QueryHints[0]);
+
+					db.QueryHints.Clear();
+
+					Assert.AreEqual(1, cdb.QueryHints.Count);
+					Assert.AreEqual("test", cdb.QueryHints[0]);
+				}
+
+				Assert.AreEqual(0, db.QueryHints.Count);
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					Assert.AreEqual(0, cdb.QueryHints.Count);
+				}
+			}
+		}
+
+		[Test]
+		public void TestCloneThrowOnDisposed([DataSources(false)] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				// to enable MARS-enabled cloning branch
+				var _ = db.Connection;
+
+				Assert.IsNull(db.ThrowOnDisposed);
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					Assert.IsNull(cdb.ThrowOnDisposed);
+				}
+
+				db.ThrowOnDisposed = false;
+
+				Assert.False(db.ThrowOnDisposed);
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					Assert.False(cdb.ThrowOnDisposed);
+				}
+
+				db.ThrowOnDisposed = true;
+
+				Assert.True(db.ThrowOnDisposed);
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					Assert.True(cdb.ThrowOnDisposed);
+				}
+
+				db.ThrowOnDisposed = null;
+				Assert.IsNull(db.ThrowOnDisposed);
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					Assert.IsNull(cdb.ThrowOnDisposed);
+				}
+			}
+		}
+
+		[Test]
+		public void TestCloneOnTraceConnection([DataSources(false)] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				// to enable MARS-enabled cloning branch
+				var _ = db.Connection;
+				Action<TraceInfo> onTrace = OnTrace;
+
+				Assert.AreEqual(DataConnection.OnTrace, db.OnTraceConnection);
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					Assert.AreEqual(DataConnection.OnTrace, cdb.OnTraceConnection);
+				}
+
+				db.OnTraceConnection = onTrace;
+
+				Assert.AreEqual(onTrace, db.OnTraceConnection);
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					Assert.AreEqual(onTrace, cdb.OnTraceConnection);
+				}
+
+				db.OnTraceConnection = null;
+
+				Assert.IsNull(db.OnTraceConnection);
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					Assert.IsNull(cdb.OnTraceConnection);
+				}
+
+				db.OnTraceConnection = DataConnection.OnTrace;
+
+				Assert.AreEqual(DataConnection.OnTrace, db.OnTraceConnection);
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					Assert.AreEqual(DataConnection.OnTrace, cdb.OnTraceConnection);
+				}
+			}
+
+			void OnTrace(TraceInfo ti) { };
+		}
+
+		[Test]
+		public void TestCloneOnClosingOnClosed([DataSources(false)] string context)
+		{
+			var closing = 0;
+			var closed  = 0;
+
+			using (var db = new DataConnection(context))
+			{
+				// to enable MARS-enabled cloning branch
+				var _ = db.Connection;
+
+				Assert.AreEqual(0, closing);
+				Assert.AreEqual(0, closed);
+				db.Close();
+				Assert.AreEqual(0, closing);
+				Assert.AreEqual(0, closed);
+				_ = db.Connection;
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					_ = cdb.Connection;
+					Assert.AreEqual(0, closing);
+					Assert.AreEqual(0, closed);
+					cdb.Close();
+					Assert.AreEqual(0, closing);
+					Assert.AreEqual(0, closed);
+				}
+
+				_ = db.Connection;
+				db.OnClosing += OnClosing;
+				db.OnClosed += OnClosed;
+				Assert.AreEqual(0, closing);
+				Assert.AreEqual(0, closed);
+				db.Close();
+				Assert.AreEqual(1, closing);
+				Assert.AreEqual(1, closed);
+				_ = db.Connection;
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					closing = 0;
+					closed  = 0;
+					_ = cdb.Connection;
+					Assert.AreEqual(0, closing);
+					Assert.AreEqual(0, closed);
+					cdb.Close();
+					Assert.AreEqual(1, closing);
+					Assert.AreEqual(1, closed);
+
+					closing = 0;
+					closed  = 0;
+					db.OnClosing -= OnClosing;
+					db.OnClosed  -= OnClosed;
+					_ = cdb.Connection;
+					cdb.Close();
+					Assert.AreEqual(1, closing);
+					Assert.AreEqual(1, closed);
+				}
+
+				closing = 0;
+				closed  = 0;
+				_ = db.Connection;
+				Assert.AreEqual(0, closing);
+				Assert.AreEqual(0, closed);
+				db.Close();
+				Assert.AreEqual(0, closing);
+				Assert.AreEqual(0, closed);
+				_ = db.Connection;
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					_ = cdb.Connection;
+					Assert.AreEqual(0, closing);
+					Assert.AreEqual(0, closed);
+					cdb.Close();
+					Assert.AreEqual(0, closing);
+					Assert.AreEqual(0, closed);
+				}
+			}
+
+			void OnClosing(object sender, EventArgs e) => closing++;
+			void OnClosed(object sender, EventArgs e) => closed++;
+		}
+
+		[Test]
+		public void TestCloneOnBeforeConnectionOpenOnConnectionOpened([DataSources(false)] string context)
+		{
+			var open   = 0;
+			var opened = 0;
+
+			using (var db = new DataConnection(context))
+			{
+				Assert.AreEqual(0, open);
+				Assert.AreEqual(0, opened);
+				var _ = db.Connection;
+				Assert.AreEqual(0, open);
+				Assert.AreEqual(0, opened);
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					Assert.AreEqual(0, open);
+					Assert.AreEqual(0, opened);
+					_ = cdb.Connection;
+					Assert.AreEqual(0, open);
+					Assert.AreEqual(0, opened);
+				}
+
+				db.Close();
+				db.OnBeforeConnectionOpen += OnBeforeConnectionOpen;
+				db.OnConnectionOpened     += OnConnectionOpened;
+				Assert.AreEqual(0, open);
+				Assert.AreEqual(0, opened);
+				_ = db.Connection;
+				Assert.AreEqual(1, open);
+				Assert.AreEqual(1, opened);
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					open   = 0;
+					opened = 0;
+					Assert.AreEqual(0, open);
+					Assert.AreEqual(0, opened);
+					cdb.Connection.Close();
+					open   = 0;
+					opened = 0;
+					_ = cdb.Connection;
+					Assert.AreEqual(1, open);
+					Assert.AreEqual(1, opened);
+
+					open   = 0;
+					opened = 0;
+					cdb.Close();
+					db.OnBeforeConnectionOpen -= OnBeforeConnectionOpen;
+					db.OnConnectionOpened     -= OnConnectionOpened;
+					_ = cdb.Connection;
+					Assert.AreEqual(1, open);
+					Assert.AreEqual(1, opened);
+				}
+
+				open   = 0;
+				opened = 0;
+				db.Close();
+				Assert.AreEqual(0, open);
+				Assert.AreEqual(0, opened);
+				_ = db.Connection;
+				Assert.AreEqual(0, open);
+				Assert.AreEqual(0, opened);
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					Assert.AreEqual(0, open);
+					Assert.AreEqual(0, opened);
+					_ = cdb.Connection;
+					Assert.AreEqual(0, open);
+					Assert.AreEqual(0, opened);
+				}
+			}
+
+			void OnBeforeConnectionOpen(DataConnection dc, IDbConnection cn) => open++;
+			void OnConnectionOpened    (DataConnection dc, IDbConnection cn) => opened++;
+		}
+
+		[Test]
+		public async Task TestCloneOnBeforeConnectionOpenAsyncOnConnectionOpenedAsync([DataSources(false)] string context)
+		{
+			var open   = 0;
+			var opened = 0;
+
+			using (var db = new DataConnection(context))
+			{
+				Assert.AreEqual(0, open);
+				Assert.AreEqual(0, opened);
+				await db.EnsureConnectionAsync();
+				Assert.AreEqual(0, open);
+				Assert.AreEqual(0, opened);
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					Assert.AreEqual(0, open);
+					Assert.AreEqual(0, opened);
+					await db.EnsureConnectionAsync();
+					Assert.AreEqual(0, open);
+					Assert.AreEqual(0, opened);
+				}
+
+				db.Close();
+				db.OnBeforeConnectionOpenAsync += OnBeforeConnectionOpenAsync;
+				db.OnConnectionOpenedAsync     += OnConnectionOpenedAsync;
+				Assert.AreEqual(0, open);
+				Assert.AreEqual(0, opened);
+				await db.EnsureConnectionAsync();
+				Assert.AreEqual(1, open);
+				Assert.AreEqual(1, opened);
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					open   = 0;
+					opened = 0;
+					Assert.AreEqual(0, open);
+					Assert.AreEqual(0, opened);
+					cdb.Connection.Close();
+					open   = 0;
+					opened = 0;
+					await cdb.EnsureConnectionAsync();
+					Assert.AreEqual(1, open);
+					Assert.AreEqual(1, opened);
+
+					open   = 0;
+					opened = 0;
+					cdb.Close();
+					db.OnBeforeConnectionOpenAsync -= OnBeforeConnectionOpenAsync;
+					db.OnConnectionOpenedAsync     -= OnConnectionOpenedAsync;
+					await cdb.EnsureConnectionAsync();
+					Assert.AreEqual(1, open);
+					Assert.AreEqual(1, opened);
+				}
+
+				open   = 0;
+				opened = 0;
+				db.Close();
+				Assert.AreEqual(0, open);
+				Assert.AreEqual(0, opened);
+				await db.EnsureConnectionAsync();
+				Assert.AreEqual(0, open);
+				Assert.AreEqual(0, opened);
+
+				using (var cdb = (DataConnection)((IDataContext)db).Clone(true))
+				{
+					Assert.AreEqual(0, open);
+					Assert.AreEqual(0, opened);
+					await cdb.EnsureConnectionAsync();
+					Assert.AreEqual(0, open);
+					Assert.AreEqual(0, opened);
+				}
+			}
+
+			Task OnBeforeConnectionOpenAsync(DataConnection dc, IDbConnection cn, CancellationToken ct)
+			{
+				open++;
+				return Task.CompletedTask;
+			}
+
+			Task OnConnectionOpenedAsync(DataConnection dc, IDbConnection cn, CancellationToken ct)
+			{
+				opened++;
+				return Task.CompletedTask;
+		}
+		}
+#endif
+
+		// strange provider errors, review in v3 with more recent providers
+		[ActiveIssue(Configurations = new[] { ProviderName.MySqlConnector, ProviderName.SapHana })]
+		[Test]
+		public void TestDisposeFlagCloning([DataSources(false)] string context, [Values] bool dispose)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var cn = db.Connection;
+				using (var testDb = new DataConnection(db.DataProvider, cn, dispose))
+				{
+					Assert.AreEqual(ConnectionState.Open, cn.State);
+
+					IDbConnection clonedConnection = null;
+					using (var clonedDb = (DataConnection)((IDataContext)testDb).Clone(true))
+					{
+						clonedConnection = clonedDb.Connection;
+
+						// fails in v2 for MARS-enabled connections, already fixed in v3
+						Assert.AreEqual(db.IsMarsEnabled, testDb.IsMarsEnabled);
+
+						if (testDb.IsMarsEnabled)
+						{
+							// connection reused
+							Assert.AreEqual(cn, clonedConnection);
+							Assert.AreEqual(ConnectionState.Open, cn.State);
+						}
+						else
+						{
+							Assert.AreNotEqual(cn, clonedConnection);
+							Assert.AreEqual(ConnectionState.Open, cn.State);
+							Assert.AreEqual(ConnectionState.Open, clonedConnection.State);
+						}
+					}
+
+					if (testDb.IsMarsEnabled)
+					{
+						// cloned DC doesn't dispose parent connection
+						Assert.AreEqual(ConnectionState.Open, cn.State);
+					}
+					else
+					{
+						// cloned DC dispose own connection
+						Assert.AreEqual(ConnectionState.Open, cn.State);
+						try
+						{
+							Assert.AreEqual(ConnectionState.Closed, clonedConnection.State);
+						}
+						catch (ObjectDisposedException)
+						{
+							// API consistency FTW!
+						}
+					}
+				}
+			}
+		}
+
+		#region issue 962
+#if !NETSTANDARD1_6
+		[Table("Categories")]
+		public class Category
+		{
+			[PrimaryKey, Identity] public int    CategoryID;
+			[Column, NotNull]      public string CategoryName;
+			[Column]               public string Description;
+
+			[Association(ThisKey = "CategoryID", OtherKey = "CategoryID")]
+			public List<Product> Products;
+
+			public static readonly Category[] Data = new[]
+			{
+				new Category() { CategoryID = 1, CategoryName = "Name 1", Description = "Desc 1" },
+				new Category() { CategoryID = 2, CategoryName = "Name 2", Description = "Desc 2" },
+			};
+		}
+
+		[Table(Name = "Products")]
+		public class Product
+		{
+			[PrimaryKey, Identity]                                         public int      ProductID;
+			[Column, NotNull]                                              public string   ProductName;
+			[Column]                                                       public int?     CategoryID;
+			[Column]                                                       public string   QuantityPerUnit;
+			[Association(ThisKey = "CategoryID", OtherKey = "CategoryID")] public Category Category;
+
+			public static readonly Product[] Data = new[]
+			{
+				new Product() { ProductID = 1, ProductName = "Prod 1", CategoryID = 1, QuantityPerUnit = "q 1" },
+				new Product() { ProductID = 2, ProductName = "Prod 2", CategoryID = 1, QuantityPerUnit = "q 2" },
+				new Product() { ProductID = 3, ProductName = "Prod 3", CategoryID = 3, QuantityPerUnit = "q 3" },
+				new Product() { ProductID = 4, ProductName = "Prod 4", CategoryID = 3, QuantityPerUnit = "q 4" },
+				new Product() { ProductID = 5, ProductName = "Prod 5", CategoryID = 1, QuantityPerUnit = "q 5" },
+				new Product() { ProductID = 6, ProductName = "Prod 6", CategoryID = 1, QuantityPerUnit = "q 6" },
+			};
+		}
+
+		[Test]
+		public void TestDisposeFlagCloning962Test1([DataSources(false)] string context, [Values] bool withScope)
+		{
+			if (withScope && (
+				// The ITransactionLocal interface is not supported by the 'Microsoft.Jet.OLEDB.4.0' provider.  Local transactions are unavailable with the current provider.
+				context == ProviderName.Access ||
+				// SQL0902 An unexpected exception has occurred. AllocateandLinkStatementHandle. There are no context policies.
+				context == ProviderName.DB2 ||
+				// Table unknown CATEGORIES
+				context.Contains("Firebird") ||
+				// MySql.Data: NotSupportedException : Multiple simultaneous connections or connections with different connection strings inside the same transaction are not currently supported.
+				// MySqlConnector: MySqlException : XAER_RMFAIL: The command cannot be executed when global transaction is in the  ACTIVE state
+				context.Contains("MySql") ||
+				context.Contains("MariaDB") ||
+				// OracleException : ORA-02089: COMMIT is not allowed in a subordinate session
+				context == ProviderName.OracleManaged ||
+				// SQLiteException : database is locked
+				context == ProviderName.SQLiteClassic ||
+				// HanaException : The rollback was caused by an unspecified reason: XA Transaction is rolled back.
+				context == ProviderName.SapHana ||
+				// InvalidOperationException : The connection object can not be enlisted in transaction scope.
+				context == ProviderName.SqlCe ||
+				// Something about CREATE TABLE in multi-statement transaction
+				context == ProviderName.Sybase ||
+				// surprisingly SqlServer provider has issues with DDL in TransactionScope
+				// MARS=OFF: InvalidOperationException : The transaction associated with the current connection has completed but has not been disposed.  The transaction must be disposed before the connection can be used to execute SQL statements.
+				// MARS=ON: SqlException : Cannot drop the table 'Categories', because it does not exist or you do not have permission.
+				context.Contains("SqlServer") ||
+				context.Contains("SqlAzure")
+				))
+			{
+				Assert.Inconclusive("Provider not configured or has issues with TransactionScope");
+			}
+
+			TransactionScope scope = withScope ? new TransactionScope() : null;
+			try
+			{
+				using (new AllowMultipleQuery())
+				using (var db = new DataConnection(context))
+				using (db.CreateLocalTable(Category.Data))
+				using (db.CreateLocalTable(Product.Data))
+				{
+					var categoryDtos = db.GetTable<Category>().LoadWith(c => c.Products).ToList();
+
+					scope?.Dispose();
+					scope = null;
+				}
+			}
+			finally
+			{
+				scope?.Dispose();
+			}
+		}
+
+		[Test]
+		public void TestDisposeFlagCloning962Test2([DataSources(false)] string context, [Values] bool withScope)
+		{
+			// errors are different for some providers compared to TestDisposeFlagCloning962Test1
+			// because we don't use DDL (CREATE TABLE)
+			if (withScope && (
+				// The ITransactionLocal interface is not supported by the 'Microsoft.Jet.OLEDB.4.0' provider.  Local transactions are unavailable with the current provider.
+				context == ProviderName.Access ||
+				// SQL0998N  Error occurred during transaction or heuristic processing.  Reason Code = "16". Subcode = "2-8004D026".
+				context == ProviderName.DB2 ||
+				// MySql.Data: NotSupportedException : Multiple simultaneous connections or connections with different connection strings inside the same transaction are not currently supported.
+				(context.Contains("MySql") && context != ProviderName.MySqlConnector) ||
+				context.Contains("MariaDB") ||
+				// SQLiteException : database is locked
+				context == ProviderName.SQLiteClassic ||
+				// InvalidOperationException : The connection object can not be enlisted in transaction scope.
+				context == ProviderName.SqlCe ||
+				// AseException : Only One Local connection allowed in the TransactionScope
+				context == ProviderName.Sybase
+				))
+			{
+				Assert.Inconclusive("Provider not configured or has issues with TransactionScope");
+			}
+
+			TransactionScope scope = withScope ? new TransactionScope() : null;
+			try
+			{
+				using (new AllowMultipleQuery())
+				using (var db = new DataConnection(context))
+				{
+					// test cloned data connection without LoadWith, as it doesn't use cloning in v3
+					db.Select(() => "test1");
+					using (var cdb = ((IDataContext)db).Clone(true))
+					{
+						cdb.Select(() => "test2");
+
+						scope?.Complete();
+					}
+				}
+			}
+			finally
+			{
+				scope?.Dispose();
+			}
+		}
+#endif
+		#endregion
 
 	}
 }

--- a/Tests/Linq/Data/DataConnectionTests.cs
+++ b/Tests/Linq/Data/DataConnectionTests.cs
@@ -952,7 +952,16 @@ namespace Tests.Data
 #endif
 
 		// strange provider errors, review in v3 with more recent providers
-		[ActiveIssue(Configurations = new[] { ProviderName.MySqlConnector, ProviderName.SapHana })]
+		// also some providers remove credentials from connection string in non-design mode
+		[ActiveIssue(Configurations = new[] 
+		{ 
+			ProviderName.MySqlConnector,
+			ProviderName.SapHana,
+			// Providers remove credentials in non-design mode:
+			TestProvName.AllPostgreSQL,
+			TestProvName.AllSqlServer,
+			TestProvName.AllMySqlData
+		})]
 		[Test]
 		public void TestDisposeFlagCloning([DataSources(false)] string context, [Values] bool dispose)
 		{
@@ -1101,7 +1110,11 @@ namespace Tests.Data
 		}
 
 		[Test]
-		public void TestDisposeFlagCloning962Test2([DataSources(false)] string context, [Values] bool withScope)
+		public void TestDisposeFlagCloning962Test2([DataSources(false
+#if NETSTANDARD2_0
+			, TestProvName.AllSqlServer, TestProvName.AllOracle
+#endif
+			)] string context, [Values] bool withScope)
 		{
 			// errors are different for some providers compared to TestDisposeFlagCloning962Test1
 			// because we don't use DDL (CREATE TABLE)
@@ -1146,7 +1159,7 @@ namespace Tests.Data
 			}
 		}
 #endif
-		#endregion
+#endregion
 
 	}
 }

--- a/Tests/Linq/Linq/ConvertExpressionTests.cs
+++ b/Tests/Linq/Linq/ConvertExpressionTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using LinqToDB;
 
 using NUnit.Framework;
+using Tests.Model;
 
 namespace Tests.Linq
 {
@@ -505,5 +506,406 @@ namespace Tests.Linq
 						First2 = ch2.FirstOrDefault()
 					});
 		}
+
+				#region Removal of compiler-generated conversions
+		class ConversionsTestTable
+		{
+			public sbyte   SByte  { get; set; }
+			public byte    Byte   { get; set; }
+			public short   Int16  { get; set; }
+			public ushort  UInt16 { get; set; }
+			public int     Int32  { get; set; }
+			public uint    UInt32 { get; set; }
+			public long    Int64  { get; set; }
+			public ulong   UInt64 { get; set; }
+
+			public sbyte?  SByteN  { get; set; }
+			public byte?   ByteN   { get; set; }
+			public short?  Int16N  { get; set; }
+			public ushort? UInt16N { get; set; }
+			public int?    Int32N  { get; set; }
+			public uint?   UInt32N { get; set; }
+			public long?   Int64N  { get; set; }
+			public ulong?  UInt64N { get; set; }
+		}
+
+		enum EnumByte   : byte   { TestValue = 4 }
+		enum EnumSByte  : sbyte  { TestValue = 4 }
+		enum EnumInt16  : short  { TestValue = 4 }
+		enum EnumUInt16 : ushort { TestValue = 4 }
+		enum EnumInt32           { TestValue = 4 }
+		enum EnumUInt32 : uint   { TestValue = 4 }
+		enum EnumInt64  : long   { TestValue = 4 }
+		enum EnumUInt64 : ulong  { TestValue = 4 }
+
+		[Test]
+		public void TestConversionRemovedForEnumOfTypeByte([IncludeDataSources(false, TestProvName.AllSqlServer)] string context)
+		{
+			using (var db    = new TestDataConnection(context))
+			using (var table = db.CreateLocalTable<ConversionsTestTable>())
+			{
+				table
+					.Where(x => x.Byte    == (byte  )EnumByte.TestValue
+							 || x.SByte   == (sbyte )EnumByte.TestValue
+							 || x.Int16   == (short )EnumByte.TestValue
+							 || x.UInt16  == (ushort)EnumByte.TestValue
+							 || x.Int32   == (int   )EnumByte.TestValue
+							 || x.UInt32  == (uint  )EnumByte.TestValue
+							 || x.Int64   == (long  )EnumByte.TestValue
+							 || x.UInt64  == (ulong )EnumByte.TestValue
+							 || x.ByteN   == (byte  )EnumByte.TestValue
+							 || x.SByteN  == (sbyte )EnumByte.TestValue
+							 || x.Int16N  == (short )EnumByte.TestValue
+							 || x.UInt16N == (ushort)EnumByte.TestValue
+							 || x.Int32N  == (int   )EnumByte.TestValue
+							 || x.UInt32N == (uint  )EnumByte.TestValue
+							 || x.Int64N  == (long  )EnumByte.TestValue
+							 || x.UInt64N == (ulong )EnumByte.TestValue
+
+							 || (byte  )EnumByte.TestValue == x.Byte
+							 || (sbyte )EnumByte.TestValue == x.SByte
+							 || (short )EnumByte.TestValue == x.Int16
+							 || (ushort)EnumByte.TestValue == x.UInt16
+							 || (int   )EnumByte.TestValue == x.Int32
+							 || (uint  )EnumByte.TestValue == x.UInt32
+							 || (long  )EnumByte.TestValue == x.Int64
+							 || (ulong )EnumByte.TestValue == x.UInt64
+							 || (byte  )EnumByte.TestValue == x.ByteN
+							 || (sbyte )EnumByte.TestValue == x.SByteN
+							 || (short )EnumByte.TestValue == x.Int16N
+							 || (ushort)EnumByte.TestValue == x.UInt16N
+							 || (int   )EnumByte.TestValue == x.Int32N
+							 || (uint  )EnumByte.TestValue == x.UInt32N
+							 || (long  )EnumByte.TestValue == x.Int64N
+							 || (ulong )EnumByte.TestValue == x.UInt64N)
+					.ToList();
+
+				Assert.False(db.LastQuery.ToLower().Contains("convert"));
+			}
+		}
+
+		[Test]
+		public void TestConversionRemovedForEnumOfTypeSByte([IncludeDataSources(false, TestProvName.AllSqlServer)] string context)
+		{
+			using (var db    = new TestDataConnection(context))
+			using (var table = db.CreateLocalTable<ConversionsTestTable>())
+			{
+				table
+					.Where(x => x.Byte    == (byte  )EnumSByte.TestValue
+							 || x.SByte   == (sbyte )EnumSByte.TestValue
+							 || x.Int16   == (short )EnumSByte.TestValue
+							 || x.UInt16  == (ushort)EnumSByte.TestValue
+							 || x.Int32   == (int   )EnumSByte.TestValue
+							 || x.UInt32  == (uint  )EnumSByte.TestValue
+							 || x.Int64   == (long  )EnumSByte.TestValue
+							 || x.UInt64  == (ulong )EnumSByte.TestValue
+							 || x.ByteN   == (byte  )EnumSByte.TestValue
+							 || x.SByteN  == (sbyte )EnumSByte.TestValue
+							 || x.Int16N  == (short )EnumSByte.TestValue
+							 || x.UInt16N == (ushort)EnumSByte.TestValue
+							 || x.Int32N  == (int   )EnumSByte.TestValue
+							 || x.UInt32N == (uint  )EnumSByte.TestValue
+							 || x.Int64N  == (long  )EnumSByte.TestValue
+							 || x.UInt64N == (ulong )EnumSByte.TestValue
+
+							 || (byte  )EnumSByte.TestValue == x.Byte
+							 || (sbyte )EnumSByte.TestValue == x.SByte
+							 || (short )EnumSByte.TestValue == x.Int16
+							 || (ushort)EnumSByte.TestValue == x.UInt16
+							 || (int   )EnumSByte.TestValue == x.Int32
+							 || (uint  )EnumSByte.TestValue == x.UInt32
+							 || (long  )EnumSByte.TestValue == x.Int64
+							 || (ulong )EnumSByte.TestValue == x.UInt64
+							 || (byte  )EnumSByte.TestValue == x.ByteN
+							 || (sbyte )EnumSByte.TestValue == x.SByteN
+							 || (short )EnumSByte.TestValue == x.Int16N
+							 || (ushort)EnumSByte.TestValue == x.UInt16N
+							 || (int   )EnumSByte.TestValue == x.Int32N
+							 || (uint  )EnumSByte.TestValue == x.UInt32N
+							 || (long  )EnumSByte.TestValue == x.Int64N
+							 || (ulong )EnumSByte.TestValue == x.UInt64N)
+					.ToList();
+
+				Assert.False(db.LastQuery.ToLower().Contains("convert"));
+			}
+		}
+
+		[Test]
+		public void TestConversionRemovedForEnumOfTypeInt16([IncludeDataSources(false, TestProvName.AllSqlServer)] string context)
+		{
+			using (var db    = new TestDataConnection(context))
+			using (var table = db.CreateLocalTable<ConversionsTestTable>())
+			{
+				table
+					.Where(x => x.Byte    == (byte  )EnumInt16.TestValue
+							 || x.SByte   == (sbyte )EnumInt16.TestValue
+							 || x.Int16   == (short )EnumInt16.TestValue
+							 || x.UInt16  == (ushort)EnumInt16.TestValue
+							 || x.Int32   == (int   )EnumInt16.TestValue
+							 || x.UInt32  == (uint  )EnumInt16.TestValue
+							 || x.Int64   == (long  )EnumInt16.TestValue
+							 || x.UInt64  == (ulong )EnumInt16.TestValue
+							 || x.ByteN   == (byte  )EnumInt16.TestValue
+							 || x.SByteN  == (sbyte )EnumInt16.TestValue
+							 || x.Int16N  == (short )EnumInt16.TestValue
+							 || x.UInt16N == (ushort)EnumInt16.TestValue
+							 || x.Int32N  == (int   )EnumInt16.TestValue
+							 || x.UInt32N == (uint  )EnumInt16.TestValue
+							 || x.Int64N  == (long  )EnumInt16.TestValue
+							 || x.UInt64N == (ulong )EnumInt16.TestValue
+
+							 || (byte  )EnumInt16.TestValue == x.Byte
+							 || (sbyte )EnumInt16.TestValue == x.SByte
+							 || (short )EnumInt16.TestValue == x.Int16
+							 || (ushort)EnumInt16.TestValue == x.UInt16
+							 || (int   )EnumInt16.TestValue == x.Int32
+							 || (uint  )EnumInt16.TestValue == x.UInt32
+							 || (long  )EnumInt16.TestValue == x.Int64
+							 || (ulong )EnumInt16.TestValue == x.UInt64
+							 || (byte  )EnumInt16.TestValue == x.ByteN
+							 || (sbyte )EnumInt16.TestValue == x.SByteN
+							 || (short )EnumInt16.TestValue == x.Int16N
+							 || (ushort)EnumInt16.TestValue == x.UInt16N
+							 || (int   )EnumInt16.TestValue == x.Int32N
+							 || (uint  )EnumInt16.TestValue == x.UInt32N
+							 || (long  )EnumInt16.TestValue == x.Int64N
+							 || (ulong )EnumInt16.TestValue == x.UInt64N)
+					.ToList();
+
+				Assert.False(db.LastQuery.ToLower().Contains("convert"));
+			}
+		}
+
+		[Test]
+		public void TestConversionRemovedForEnumOfTypeUInt16([IncludeDataSources(false, TestProvName.AllSqlServer)] string context)
+		{
+			using (var db    = new TestDataConnection(context))
+			using (var table = db.CreateLocalTable<ConversionsTestTable>())
+			{
+				table
+					.Where(x => x.Byte    == (byte  )EnumUInt16.TestValue
+							 || x.SByte   == (sbyte )EnumUInt16.TestValue
+							 || x.Int16   == (short )EnumUInt16.TestValue
+							 || x.UInt16  == (ushort)EnumUInt16.TestValue
+							 || x.Int32   == (int   )EnumUInt16.TestValue
+							 || x.UInt32  == (uint  )EnumUInt16.TestValue
+							 || x.Int64   == (long  )EnumUInt16.TestValue
+							 || x.UInt64  == (ulong )EnumUInt16.TestValue
+							 || x.ByteN   == (byte  )EnumUInt16.TestValue
+							 || x.SByteN  == (sbyte )EnumUInt16.TestValue
+							 || x.Int16N  == (short )EnumUInt16.TestValue
+							 || x.UInt16N == (ushort)EnumUInt16.TestValue
+							 || x.Int32N  == (int   )EnumUInt16.TestValue
+							 || x.UInt32N == (uint  )EnumUInt16.TestValue
+							 || x.Int64N  == (long  )EnumUInt16.TestValue
+							 || x.UInt64N == (ulong )EnumUInt16.TestValue
+
+							 || (byte  )EnumUInt16.TestValue == x.Byte
+							 || (sbyte )EnumUInt16.TestValue == x.SByte
+							 || (short )EnumUInt16.TestValue == x.Int16
+							 || (ushort)EnumUInt16.TestValue == x.UInt16
+							 || (int   )EnumUInt16.TestValue == x.Int32
+							 || (uint  )EnumUInt16.TestValue == x.UInt32
+							 || (long  )EnumUInt16.TestValue == x.Int64
+							 || (ulong )EnumUInt16.TestValue == x.UInt64
+							 || (byte  )EnumUInt16.TestValue == x.ByteN
+							 || (sbyte )EnumUInt16.TestValue == x.SByteN
+							 || (short )EnumUInt16.TestValue == x.Int16N
+							 || (ushort)EnumUInt16.TestValue == x.UInt16N
+							 || (int   )EnumUInt16.TestValue == x.Int32N
+							 || (uint  )EnumUInt16.TestValue == x.UInt32N
+							 || (long  )EnumUInt16.TestValue == x.Int64N
+							 || (ulong )EnumUInt16.TestValue == x.UInt64N)
+					.ToList();
+
+				Assert.False(db.LastQuery.ToLower().Contains("convert"));
+			}
+		}
+
+		[Test]
+		public void TestConversionRemovedForEnumOfTypeInt32([IncludeDataSources(false, TestProvName.AllSqlServer)] string context)
+		{
+			using (var db    = new TestDataConnection(context))
+			using (var table = db.CreateLocalTable<ConversionsTestTable>())
+			{
+				table
+					.Where(x => x.Byte    == (byte  )EnumInt32.TestValue
+							 || x.SByte   == (sbyte )EnumInt32.TestValue
+							 || x.Int16   == (short )EnumInt32.TestValue
+							 || x.UInt16  == (ushort)EnumInt32.TestValue
+							 || x.Int32   == (int   )EnumInt32.TestValue
+							 || x.UInt32  == (uint  )EnumInt32.TestValue
+							 || x.Int64   == (long  )EnumInt32.TestValue
+							 || x.UInt64  == (ulong )EnumInt32.TestValue
+							 || x.ByteN   == (byte  )EnumInt32.TestValue
+							 || x.SByteN  == (sbyte )EnumInt32.TestValue
+							 || x.Int16N  == (short )EnumInt32.TestValue
+							 || x.UInt16N == (ushort)EnumInt32.TestValue
+							 || x.Int32N  == (int   )EnumInt32.TestValue
+							 || x.UInt32N == (uint  )EnumInt32.TestValue
+							 || x.Int64N  == (long  )EnumInt32.TestValue
+							 || x.UInt64N == (ulong )EnumInt32.TestValue
+
+							 || (byte  )EnumInt32.TestValue == x.Byte
+							 || (sbyte )EnumInt32.TestValue == x.SByte
+							 || (short )EnumInt32.TestValue == x.Int16
+							 || (ushort)EnumInt32.TestValue == x.UInt16
+							 || (int   )EnumInt32.TestValue == x.Int32
+							 || (uint  )EnumInt32.TestValue == x.UInt32
+							 || (long  )EnumInt32.TestValue == x.Int64
+							 || (ulong )EnumInt32.TestValue == x.UInt64
+							 || (byte  )EnumInt32.TestValue == x.ByteN
+							 || (sbyte )EnumInt32.TestValue == x.SByteN
+							 || (short )EnumInt32.TestValue == x.Int16N
+							 || (ushort)EnumInt32.TestValue == x.UInt16N
+							 || (int   )EnumInt32.TestValue == x.Int32N
+							 || (uint  )EnumInt32.TestValue == x.UInt32N
+							 || (long  )EnumInt32.TestValue == x.Int64N
+							 || (ulong )EnumInt32.TestValue == x.UInt64N)
+					.ToList();
+
+				Assert.False(db.LastQuery.ToLower().Contains("convert"));
+			}
+		}
+
+		[Test]
+		public void TestConversionRemovedForEnumOfTypeUInt32([IncludeDataSources(false, TestProvName.AllSqlServer)] string context)
+		{
+			using (var db    = new TestDataConnection(context))
+			using (var table = db.CreateLocalTable<ConversionsTestTable>())
+			{
+				table
+					.Where(x => x.Byte    == (byte  )EnumUInt32.TestValue
+							 || x.SByte   == (sbyte )EnumUInt32.TestValue
+							 || x.Int16   == (short )EnumUInt32.TestValue
+							 || x.UInt16  == (ushort)EnumUInt32.TestValue
+							 || x.Int32   == (int   )EnumUInt32.TestValue
+							 || x.UInt32  == (uint  )EnumUInt32.TestValue
+							 || x.Int64   == (long  )EnumUInt32.TestValue
+							 || x.UInt64  == (ulong )EnumUInt32.TestValue
+							 || x.ByteN   == (byte  )EnumUInt32.TestValue
+							 || x.SByteN  == (sbyte )EnumUInt32.TestValue
+							 || x.Int16N  == (short )EnumUInt32.TestValue
+							 || x.UInt16N == (ushort)EnumUInt32.TestValue
+							 || x.Int32N  == (int   )EnumUInt32.TestValue
+							 || x.UInt32N == (uint  )EnumUInt32.TestValue
+							 || x.Int64N  == (long  )EnumUInt32.TestValue
+							 || x.UInt64N == (ulong )EnumUInt32.TestValue
+
+							 || (byte  )EnumUInt32.TestValue == x.Byte
+							 || (sbyte )EnumUInt32.TestValue == x.SByte
+							 || (short )EnumUInt32.TestValue == x.Int16
+							 || (ushort)EnumUInt32.TestValue == x.UInt16
+							 || (int   )EnumUInt32.TestValue == x.Int32
+							 || (uint  )EnumUInt32.TestValue == x.UInt32
+							 || (long  )EnumUInt32.TestValue == x.Int64
+							 || (ulong )EnumUInt32.TestValue == x.UInt64
+							 || (byte  )EnumUInt32.TestValue == x.ByteN
+							 || (sbyte )EnumUInt32.TestValue == x.SByteN
+							 || (short )EnumUInt32.TestValue == x.Int16N
+							 || (ushort)EnumUInt32.TestValue == x.UInt16N
+							 || (int   )EnumUInt32.TestValue == x.Int32N
+							 || (uint  )EnumUInt32.TestValue == x.UInt32N
+							 || (long  )EnumUInt32.TestValue == x.Int64N
+							 || (ulong )EnumUInt32.TestValue == x.UInt64N)
+					.ToList();
+
+				Assert.False(db.LastQuery.ToLower().Contains("convert"));
+			}
+		}
+
+		[Test]
+		public void TestConversionRemovedForEnumOfTypeInt64([IncludeDataSources(false, TestProvName.AllSqlServer)] string context)
+		{
+			using (var db    = new TestDataConnection(context))
+			using (var table = db.CreateLocalTable<ConversionsTestTable>())
+			{
+				table
+					.Where(x => x.Byte    == (byte  )EnumInt64.TestValue
+							 || x.SByte   == (sbyte )EnumInt64.TestValue
+							 || x.Int16   == (short )EnumInt64.TestValue
+							 || x.UInt16  == (ushort)EnumInt64.TestValue
+							 || x.Int32   == (int   )EnumInt64.TestValue
+							 || x.UInt32  == (uint  )EnumInt64.TestValue
+							 || x.Int64   == (long  )EnumInt64.TestValue
+							 || x.UInt64  == (ulong )EnumInt64.TestValue
+							 || x.ByteN   == (byte  )EnumInt64.TestValue
+							 || x.SByteN  == (sbyte )EnumInt64.TestValue
+							 || x.Int16N  == (short )EnumInt64.TestValue
+							 || x.UInt16N == (ushort)EnumInt64.TestValue
+							 || x.Int32N  == (int   )EnumInt64.TestValue
+							 || x.UInt32N == (uint  )EnumInt64.TestValue
+							 || x.Int64N  == (long  )EnumInt64.TestValue
+							 || x.UInt64N == (ulong )EnumInt64.TestValue
+
+							 || (byte  )EnumInt64.TestValue == x.Byte
+							 || (sbyte )EnumInt64.TestValue == x.SByte
+							 || (short )EnumInt64.TestValue == x.Int16
+							 || (ushort)EnumInt64.TestValue == x.UInt16
+							 || (int   )EnumInt64.TestValue == x.Int32
+							 || (uint  )EnumInt64.TestValue == x.UInt32
+							 || (long  )EnumInt64.TestValue == x.Int64
+							 || (ulong )EnumInt64.TestValue == x.UInt64
+							 || (byte  )EnumInt64.TestValue == x.ByteN
+							 || (sbyte )EnumInt64.TestValue == x.SByteN
+							 || (short )EnumInt64.TestValue == x.Int16N
+							 || (ushort)EnumInt64.TestValue == x.UInt16N
+							 || (int   )EnumInt64.TestValue == x.Int32N
+							 || (uint  )EnumInt64.TestValue == x.UInt32N
+							 || (long  )EnumInt64.TestValue == x.Int64N
+							 || (ulong )EnumInt64.TestValue == x.UInt64N)
+					.ToList();
+
+				Assert.False(db.LastQuery.ToLower().Contains("convert"));
+			}
+		}
+
+		[Test]
+		public void TestConversionRemovedForEnumOfTypeUInt64([IncludeDataSources(false, TestProvName.AllSqlServer)] string context)
+		{
+			using (var db    = new TestDataConnection(context))
+			using (var table = db.CreateLocalTable<ConversionsTestTable>())
+			{
+				table
+					.Where(x => x.Byte    == (byte  )EnumUInt64.TestValue
+							 || x.SByte   == (sbyte )EnumUInt64.TestValue
+							 || x.Int16   == (short )EnumUInt64.TestValue
+							 || x.UInt16  == (ushort)EnumUInt64.TestValue
+							 || x.Int32   == (int   )EnumUInt64.TestValue
+							 || x.UInt32  == (uint  )EnumUInt64.TestValue
+							 || x.Int64   == (long  )EnumUInt64.TestValue
+							 || x.UInt64  == (ulong )EnumUInt64.TestValue
+							 || x.ByteN   == (byte  )EnumUInt64.TestValue
+							 || x.SByteN  == (sbyte )EnumUInt64.TestValue
+							 || x.Int16N  == (short )EnumUInt64.TestValue
+							 || x.UInt16N == (ushort)EnumUInt64.TestValue
+							 || x.Int32N  == (int   )EnumUInt64.TestValue
+							 || x.UInt32N == (uint  )EnumUInt64.TestValue
+							 || x.Int64N  == (long  )EnumUInt64.TestValue
+							 || x.UInt64N == (ulong )EnumUInt64.TestValue
+
+							 || (byte  )EnumUInt64.TestValue == x.Byte
+							 || (sbyte )EnumUInt64.TestValue == x.SByte
+							 || (short )EnumUInt64.TestValue == x.Int16
+							 || (ushort)EnumUInt64.TestValue == x.UInt16
+							 || (int   )EnumUInt64.TestValue == x.Int32
+							 || (uint  )EnumUInt64.TestValue == x.UInt32
+							 || (long  )EnumUInt64.TestValue == x.Int64
+							 || (ulong )EnumUInt64.TestValue == x.UInt64
+							 || (byte  )EnumUInt64.TestValue == x.ByteN
+							 || (sbyte )EnumUInt64.TestValue == x.SByteN
+							 || (short )EnumUInt64.TestValue == x.Int16N
+							 || (ushort)EnumUInt64.TestValue == x.UInt16N
+							 || (int   )EnumUInt64.TestValue == x.Int32N
+							 || (uint  )EnumUInt64.TestValue == x.UInt32N
+							 || (long  )EnumUInt64.TestValue == x.Int64N
+							 || (ulong )EnumUInt64.TestValue == x.UInt64N)
+					.ToList();
+
+				Assert.False(db.LastQuery.ToLower().Contains("convert"));
+			}
+		}
+
+		#endregion
 	}
 }

--- a/Tests/Linq/Linq/DataContextTests.cs
+++ b/Tests/Linq/Linq/DataContextTests.cs
@@ -7,6 +7,8 @@ using NUnit.Framework;
 
 namespace Tests.Linq
 {
+	using LinqToDB.Async;
+	using LinqToDB.Data;
 	using Model;
 
 	[TestFixture]
@@ -15,27 +17,28 @@ namespace Tests.Linq
 		[Test]
 		public void TestContext([IncludeDataSources(TestProvName.AllSqlServer2008Plus, ProviderName.SapHana)] string context)
 		{
-			var ctx = new DataContext(context);
-
-			ctx.GetTable<Person>().ToList();
-
-			ctx.KeepConnectionAlive = true;
-
-			ctx.GetTable<Person>().ToList();
-			ctx.GetTable<Person>().ToList();
-
-			ctx.KeepConnectionAlive = false;
-
-			using (var tran = new DataContextTransaction(ctx))
+			using (var ctx = new DataContext(context))
 			{
 				ctx.GetTable<Person>().ToList();
 
-				tran.BeginTransaction();
+				ctx.KeepConnectionAlive = true;
 
 				ctx.GetTable<Person>().ToList();
 				ctx.GetTable<Person>().ToList();
 
-				tran.CommitTransaction();
+				ctx.KeepConnectionAlive = false;
+
+				using (var tran = new DataContextTransaction(ctx))
+				{
+					ctx.GetTable<Person>().ToList();
+
+					tran.BeginTransaction();
+
+					ctx.GetTable<Person>().ToList();
+					ctx.GetTable<Person>().ToList();
+
+					tran.CommitTransaction();
+				}
 			}
 		}
 
@@ -103,22 +106,22 @@ namespace Tests.Linq
 		[Test]
 		public void LoopTest([IncludeDataSources(false, TestProvName.AllSqlServer)] string context)
 		{
-			var db = new DataContext(context);
-			for (int i = 0; i < 1000; i++)
-			{
-				var items1 = db.GetTable<Child>().ToArray();
-			}
+			using (var db = new DataContext(context))
+				for (int i = 0; i < 1000; i++)
+				{
+					var items1 = db.GetTable<Child>().ToArray();
+				}
 		}
 
 		// sdanyliv: Disabled other providers for performance purposes
 		[Test]
 		public async Task LoopTestAsync([IncludeDataSources(false, TestProvName.AllSqlServer)] string context)
 		{
-			var db = new DataContext(context);
-			for (int i = 0; i < 1000; i++)
-			{
-				var items1 = await db.GetTable<Child>().ToArrayAsync();
-			}
+			using (var db = new DataContext(context))
+				for (int i = 0; i < 1000; i++)
+				{
+					var items1 = await db.GetTable<Child>().ToArrayAsync();
+				}
 		}
 
 		// sdanyliv: Disabled other providers for performance purposes
@@ -127,8 +130,10 @@ namespace Tests.Linq
 		{
 			for (int i = 0; i < 1000; i++)
 			{
-				var db     = new DataContext(context);
-				var items1 = db.GetTable<Child>().ToArray();
+				using (var db = new DataContext(context))
+				{
+					var items1 = db.GetTable<Child>().ToArray();
+				}
 			}
 		}
 
@@ -138,28 +143,95 @@ namespace Tests.Linq
 		{
 			for (int i = 0; i < 1000; i++)
 			{
-				var db     = new DataContext(context);
-				var items1 = await db.GetTable<Child>().ToArrayAsync();
+				using (var db = new DataContext(context))
+				{
+					var items1 = await db.GetTable<Child>().ToArrayAsync();
+				}
 			}
 		}
 
 		[Test]
 		public void CommandTimeoutTests([IncludeDataSources(false, TestProvName.AllSqlServer)] string context)
 		{
-			var db = new DataContext(context);
+			using (var db = new DataContext(context))
+			{
 
-			db.CommandTimeout = 10;
-			var dataConnection = db.GetDataConnection();
-			Assert.That(dataConnection.CommandTimeout, Is.EqualTo(10));
+				db.CommandTimeout = 10;
+				var dataConnection = db.GetDataConnection();
+				Assert.That(dataConnection.CommandTimeout, Is.EqualTo(10));
 
-			db.CommandTimeout = -10;
-			Assert.That(dataConnection.CommandTimeout, Is.EqualTo(-1));
+				db.CommandTimeout = -10;
+				Assert.That(dataConnection.CommandTimeout, Is.EqualTo(-1));
 
-			db.CommandTimeout = 11;
-			var record = db.GetTable<Child>().First();
+				db.CommandTimeout = 11;
+				var record = db.GetTable<Child>().First();
 
-			dataConnection = db.GetDataConnection();
-			Assert.That(dataConnection.CommandTimeout, Is.EqualTo(11));
+				dataConnection = db.GetDataConnection();
+				Assert.That(dataConnection.CommandTimeout, Is.EqualTo(11));
+			}
+		}
+
+		[Test]
+		public void TestCreateConnection([DataSources(false)] string context)
+		{
+			using (var db = new NewDataContext(context))
+			{
+				Assert.AreEqual(0, db.CreateCalled);
+				using (db.GetDataConnection())
+				{
+					Assert.AreEqual(1, db.CreateCalled);
+					using (db.GetDataConnection())
+					{
+						Assert.AreEqual(1, db.CreateCalled);
+					}
+				}
+			}
+		}
+
+		[Test]
+		public void TestCloneConnection([DataSources(false)] string context)
+		{
+			using (var db = new NewDataContext(context))
+			{
+				Assert.AreEqual(0, db.CloneCalled);
+				using (new NewDataContext(context))
+				{
+					using (((IDataContext)db).Clone(true))
+					{
+						Assert.False(db.IsMarsEnabled);
+						Assert.AreEqual(0, db.CloneCalled);
+
+						using (db.GetDataConnection())
+						{
+							using (((IDataContext)db).Clone(true))
+								Assert.AreEqual(db.IsMarsEnabled ? 1 : 0, db.CloneCalled);
+						}
+					}
+				}
+			}
+		}
+
+		class NewDataContext : DataContext
+		{
+			public NewDataContext(string context)
+				: base(context)
+			{
+			}
+
+			public int CreateCalled;
+			public int CloneCalled;
+
+			protected override DataConnection CreateDataConnection()
+			{
+				CreateCalled++;
+				return base.CreateDataConnection();
+			}
+
+			protected override DataConnection CloneDataConnection(DataConnection currentConnection, IAsyncDbTransaction dbTransaction, IAsyncDbConnection dbConnection)
+			{
+				CloneCalled++;
+				return base.CloneDataConnection(currentConnection, dbTransaction, dbConnection);
+			}
 		}
 
 	}

--- a/Tests/Linq/Linq/OptimizerTests.cs
+++ b/Tests/Linq/Linq/OptimizerTests.cs
@@ -130,6 +130,44 @@ namespace Tests.Linq
 			}
 		}
 
+		[Test]
+		public void AsSubQueryGrouping1([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			var testData = GenerateTestData();
+
+			using (var db = GetDataContext(context))
+			using (var first = db.CreateLocalTable("FirstOptimizerData", testData))
+			using (var second = db.CreateLocalTable("SecondOptimizerData", testData))
+			{
+				var query1 = first.GroupBy(f => f.Key1)
+					.AsSubQuery()
+					.Select(x => new { Count = Sql.Ext.Count().ToValue() });
+
+				var result1 = query1.ToArray();
+			}
+		}
+
+		[Test]
+		public void AsSubQueryGrouping2([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			var testData = GenerateTestData();
+
+			using (var db = GetDataContext(context))
+			using (var first = db.CreateLocalTable("FirstOptimizerData", testData))
+			using (var second = db.CreateLocalTable("SecondOptimizerData", testData))
+			{
+				var query2 = first.GroupBy(f => new { f.Key1, f.Key2 })
+					.AsSubQuery()
+					.Select(x => new
+					{
+						Count2 = Sql.Ext.Count(x.Key2).ToValue(),
+						Count1 = Sql.Ext.Count(x.Key1).ToValue()
+					});
+
+				var result2 = query2.ToArray();
+			}
+		}
+
 
 		[Test]
 		public void DistinctOptimization([IncludeDataSources(true, TestProvName.AllSQLite)] string context)

--- a/Tests/Tests.Playground/Tests.Playground.csproj
+++ b/Tests/Tests.Playground/Tests.Playground.csproj
@@ -9,6 +9,7 @@
 
 	<ItemGroup>
 		<Compile Include="..\Linq\Create\CreateData.cs" Link="CreateData.cs" />
+		<Compile Include="..\Linq\Linq\OptimizerTests.cs" Link="OptimizerTests.cs" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,8 @@ branches:
     - /dev.*/
 
 environment:
-  assemblyVersion: 2.9.7
-  packageVersion: 2.9.7
+  assemblyVersion: 2.9.8
+  packageVersion: 2.9.8
 
 cache:
 - packages -> appveyor.yml


### PR DESCRIPTION
- run tests
    - [x] netfx
    - [x] netcore1
    - [x] netcore2

We plan this release as last one in v2 branch with 3.0.0 as next non-preview release.
After this release we will replace `master` branch content with v3 code and archive v2 to separate branch.

@linq2db/testers we plan to release on thursday (16/04)

[release notes](https://github.com/linq2db/linq2db/wiki/Releases-and-Roadmap#release-298)