### PR TITLE
fix next release version name, update dependencies

### DIFF
--- a/Build/Azure/README.md
+++ b/Build/Azure/README.md
@@ -67,10 +67,10 @@ Legend:
 |MS SQL Server 2019<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.1|:x:|:x:|:x:|:x:|
 |MS SQL Server 2017<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 1.1.2<br>with NorthwindDB<sup>[5](#notes)</sup> Tests|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |Azure SQL<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.1|:x:|:x:|:x:|:x:|
-|MySQL 5.6<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.19|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|MySQL 8<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.19|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|MySQL 8<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 0.64.1|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|MariaDB 10<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.19|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+|MySQL 5.6<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.20|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|MySQL 8<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.20|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|MySQL 8<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 0.66.0|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|MariaDB 10<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.20|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |PostgreSQL 9.2<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.0.10 (netfx) / 4.1.3.1 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |PostgreSQL 9.3<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.0.10 (netfx) / 4.1.3.1 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |PostgreSQL 9.5<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.0.10 (netfx) / 4.1.3.1 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
@@ -89,11 +89,11 @@ Legend:
 |SAP/Sybase ASE 16.2<br>[AdoNetCore.AseClient](https://www.nuget.org/packages/AdoNetCore.AseClient/) 0.18.0|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |SAP/Sybase ASE 16.2<br>Native Client|:x:|:x:|:x:|:x:|
 |Oracle 11g XE<br>Native Client 4.122.19.1 |:x:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
-|Oracle 11g XE<br>[Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) 19.7.0 (netfx)<br>[Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core/) 2.19.60 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|Oracle 11g XE<br>[Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) 19.7.0 (netfx)<br>[Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core/) 2.19.70 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |Oracle 12c<br>Native Client|:x:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
-|Oracle 12c<br>[Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) 19.7.0 (netfx)<br>[Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core/) 2.19.60 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|Oracle 12c<br>[Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) 19.7.0 (netfx)<br>[Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core/) 2.19.70 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |Oracle 18c XE<br>Native Client|:x:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
-|Oracle 18c XE<br>[Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) 19.7.0 (netfx)<br>[Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core/) 2.19.60 (core)|:x:|:x:|:x:|:x:|
+|Oracle 18c XE<br>[Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) 19.7.0 (netfx)<br>[Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core/) 2.19.70 (core)|:x:|:x:|:x:|:x:|
 |Firebird 2.1<br>[FirebirdSql.Data.FirebirdClient](https://www.nuget.org/packages/FirebirdSql.Data.FirebirdClient/) 7.5.0|:x:|:x:|:x:|:x:|
 |Firebird 2.5<br>[FirebirdSql.Data.FirebirdClient](https://www.nuget.org/packages/FirebirdSql.Data.FirebirdClient/) 7.5.0|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |Firebird 3.0<br>[FirebirdSql.Data.FirebirdClient](https://www.nuget.org/packages/FirebirdSql.Data.FirebirdClient/) 7.5.0|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|

--- a/Build/Azure/pipelines/default.yml
+++ b/Build/Azure/pipelines/default.yml
@@ -2,7 +2,7 @@ variables:
   solution: 'linq2db.sln'
   build_configuration: 'Azure'
   assemblyVersion: 3.0.0
-  nugetVersion: 3.0.0-preview.3
+  nugetVersion: 3.0.0-rc.0
   nugetDevVersion: 3.0.0
   artifact_nugets: 'nugets'
   artifact_linq2db_binaries: 'linq2db_binaries'

--- a/Build/linq2db.Tests.Providers.props
+++ b/Build/linq2db.Tests.Providers.props
@@ -11,8 +11,8 @@
 		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
 
 		<PackageReference Include="System.Data.SQLite.Core" Version="1.0.112.2" />
-		<PackageReference Include="MySql.Data" Version="8.0.19" Alias="MySqlData" />
-		<PackageReference Include="MySqlConnector" Version="0.64.1" Alias="MySqlConnector" />
+		<PackageReference Include="MySql.Data" Version="8.0.20" Alias="MySqlData" />
+		<PackageReference Include="MySqlConnector" Version="0.66.0" Alias="MySqlConnector" />
 		<PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="7.5.0" />
 		<PackageReference Include="AdoNetCore.AseClient" Version="0.18.0" />
 
@@ -71,7 +71,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-		<PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.60" />
+		<PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.70" />
 		<PackageReference Include="Microsoft.Data.SQLite" Version="3.1.3" />
 		<PackageReference Include="Npgsql" Version="4.1.3.1" />
 		<PackageReference Include="System.Data.Odbc" Version="4.7.0" />

--- a/NuGet/linq2db.MySql.nuspec
+++ b/NuGet/linq2db.MySql.nuspec
@@ -11,7 +11,7 @@
 		</summary>
 		<tags>linq linq2db MySql LinqToDB ORM database DB SQL</tags>
 		<dependencies>
-			<dependency id="MySql.Data" version="8.0.19" />
+			<dependency id="MySql.Data" version="8.0.20" />
 			<dependency id="linq2db"    version="3.0.0"  />
 		</dependencies>
 		<contentFiles>

--- a/NuGet/linq2db.MySqlConnector.nuspec
+++ b/NuGet/linq2db.MySqlConnector.nuspec
@@ -11,7 +11,7 @@
 		</summary>
 		<tags>linq linq2db MySql LinqToDB ORM database DB SQL</tags>
 		<dependencies>
-			<dependency id="MySqlConnector" version="0.64.1" />
+			<dependency id="MySqlConnector" version="0.66.0" />
 			<dependency id="linq2db"        version="3.0.0"  />
 		</dependencies>
 		<contentFiles>

--- a/NuGet/linq2db.Oracle.Managed.nuspec
+++ b/NuGet/linq2db.Oracle.Managed.nuspec
@@ -22,11 +22,11 @@
 			</group>
 			<group targetFramework=".NETStandard2.0">
 				<dependency id="linq2db"                       version="3.0.0"/>
-				<dependency id="Oracle.ManagedDataAccess.Core" version="2.19.60"/>
+				<dependency id="Oracle.ManagedDataAccess.Core" version="2.19.70"/>
 			</group>
 			<group targetFramework=".NETCoreApp2.1">
 				<dependency id="linq2db"                       version="3.0.0"/>
-				<dependency id="Oracle.ManagedDataAccess.Core" version="2.19.60"/>
+				<dependency id="Oracle.ManagedDataAccess.Core" version="2.19.70"/>
 			</group>
 		</dependencies>
 		<contentFiles>

--- a/Tests/Tests.T4/Tests.T4.csproj
+++ b/Tests/Tests.T4/Tests.T4.csproj
@@ -13,7 +13,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\Source\LinqToDB\LinqToDB.csproj" />
-		<PackageReference Include="Humanizer.Core" Version="2.8.2" />
+		<PackageReference Include="Humanizer.Core" Version="2.8.11" />
 		
 		<Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
 		


### PR DESCRIPTION
- set next release version to 3.0.0-rc.0
- updated: [Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core) 2.19.60 -> 2.19.70
- updated: [Humanizer.Core](https://www.nuget.org/packages/Humanizer.Core) 2.8.2 -> 2.8.11
- updated: [MySql.Data](https://www.nuget.org/packages/MySql.Data) 8.0.19 -> 8.0.20
- updated: [MySqlConnector](https://www.nuget.org/packages/MySqlConnector) 0.64.1 -> 0.66.0
