### PR TITLE
Fix for #2226. Added possibility to use DataConnection's properties as query parameters.

### DIFF
--- a/Source/LinqToDB/Linq/Builder/ContextParser.cs
+++ b/Source/LinqToDB/Linq/Builder/ContextParser.cs
@@ -47,7 +47,7 @@ namespace LinqToDB.Linq.Builder
 				QueryRunner.SetNonQueryQuery(query);
 
 				SqlOptimizer  = query.SqlOptimizer;
-				SetParameters = () => QueryRunner.SetParameters(query, query.Expression!, null, 0);
+				SetParameters = () => QueryRunner.SetParameters(query, query.Expression!, null, null, 0);
 
 				query.GetElement = (db, expr, ps, preambles) => this;
 			}

--- a/Source/LinqToDB/Linq/Builder/ExpressionTreeOptimizationContext.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionTreeOptimizationContext.cs
@@ -356,7 +356,7 @@ namespace LinqToDB.Linq.Builder
 			if (_lastExpr2 == expr)
 				return _lastResult2;
 
-			var allowedParams = new HashSet<Expression> { ExpressionBuilder.ParametersParam };
+			var allowedParams = new HashSet<Expression> { ExpressionBuilder.ParametersParam, ExpressionBuilder.DataContextParam };
 
 			var result = null == expr.Find(ex =>
 			{

--- a/Source/LinqToDB/Linq/Builder/GroupByBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/GroupByBuilder.cs
@@ -274,7 +274,7 @@ namespace LinqToDB.Linq.Builder
 						var ps = new object?[_parameters.Count];
 
 						for (var i = 0; i < ps.Length; i++)
-							ps[i] = _parameters[i].Accessor(_queryRunner.Expression, _queryRunner.Parameters);
+							ps[i] = _parameters[i].Accessor(_queryRunner.Expression, _queryRunner.DataContext, _queryRunner.Parameters);
 
 						return _itemReader(db, Key, ps).ToList();
 					}

--- a/Source/LinqToDB/Linq/Builder/InsertBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/InsertBuilder.cs
@@ -145,7 +145,7 @@ namespace LinqToDB.Linq.Builder
 
 									var column    = into.ConvertToSql(pe, 1, ConvertFlags.Field);
 									var parameter = 
-										QueryRunner.GetParameterFromMethod(argIndex, objType, builder.DataContext, field, ExpressionBuilder.ParametersParam);
+										QueryRunner.GetParameterFromMethod(argIndex, objType, builder.DataContext, field, ExpressionBuilder.ParametersParam, ExpressionBuilder.DataContextParam);
 									builder.AddCurrentSqlParameter(parameter);
 
 									insertStatement.Insert.Items.Add(new SqlSetExpression(column[0].Sql, parameter.SqlParameter));

--- a/Source/LinqToDB/Linq/Query.cs
+++ b/Source/LinqToDB/Linq/Query.cs
@@ -436,8 +436,8 @@ namespace LinqToDB.Linq
 	{
 		public ParameterAccessor(
 			Expression                             expression,
-			Func<Expression,object?[]?,object?>    accessor,
-			Func<Expression,object?[]?,DbDataType> dbDataTypeAccessor,
+			Func<Expression,IDataContext?,object?[]?,object?>    accessor,
+			Func<Expression,IDataContext?,object?[]?,DbDataType> dbDataTypeAccessor,
 			SqlParameter                           sqlParameter)
 		{
 			Expression         = expression;
@@ -446,9 +446,9 @@ namespace LinqToDB.Linq
 			SqlParameter       = sqlParameter;
 		}
 
-		public          Expression                             Expression;
-		public readonly Func<Expression,object?[]?,object?>    Accessor;
-		public readonly Func<Expression,object?[]?,DbDataType> DbDataTypeAccessor;
-		public readonly SqlParameter                           SqlParameter;
+		public          Expression                                           Expression;
+		public readonly Func<Expression,IDataContext?,object?[]?,object?>    Accessor;
+		public readonly Func<Expression,IDataContext?,object?[]?,DbDataType> DbDataTypeAccessor;
+		public readonly SqlParameter                                         SqlParameter;
 	}
 }

--- a/Source/LinqToDB/Linq/QueryRunnerBase.cs
+++ b/Source/LinqToDB/Linq/QueryRunnerBase.cs
@@ -63,7 +63,7 @@ namespace LinqToDB.Linq
 						DataContext.NextQueryHints.Clear();
 				}
 
-				QueryRunner.SetParameters(Query, Expression, Parameters, QueryNumber);
+				QueryRunner.SetParameters(Query, Expression, DataContext, Parameters, QueryNumber);
 				SetQuery();
 			}
 		}


### PR DESCRIPTION
Based on `feature/association_query_filter` branch.