### PR TITLE
Before release cleanup

### DIFF
--- a/Build/Azure/README.md
+++ b/Build/Azure/README.md
@@ -53,7 +53,7 @@ Legend:
 |SQLite [3.31.1](https://www.sqlite.org/releaselog/3_31_1.html)<br>[System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite.Core/) 1.0.112.2<br>with [MiniProfiler](https://www.nuget.org/packages/MiniProfiler.Shared/) 4.1.0 (core)<br>[MiniProfiler](https://www.nuget.org/packages/MiniProfiler/) 3.2.0.157 (netfx)<br>without mappings to underlying provider|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |SQLite [3.31.1](https://www.sqlite.org/releaselog/3_31_1.html)<br>[System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite.Core/) 1.0.112.2<br>with [MiniProfiler](https://www.nuget.org/packages/MiniProfiler.Shared/) 4.1.0 (core)<br>[MiniProfiler](https://www.nuget.org/packages/MiniProfiler/) 3.2.0.157 (netfx)<br>with mappings to underlying provider|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |Access<sup>[3](#notes)</sup><br>Jet 4.0 OLE DB|:heavy_check_mark:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
-|Access<sup>[3](#notes)</sup><br>ACE 12 OLE DB|:heavy_check_mark:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
+|Access<sup>[3](#notes)</sup><br>ACE 12 OLE DB|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
 |Access<br>MDB ODBC|:heavy_check_mark:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
 |Access<br>MDB+ACCDB ODBC|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL CE<sup>[4](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
@@ -102,7 +102,7 @@ Legend:
 ###### Notes:
 1. `TestNoopProvider` is a fake test provider to perform tests without database dependencies
 2. `1.1.1` is the last version of `Microsoft.Data.SQLite`, that supports .NET Framework, so we use it for `net46` test configuration and recent version for `netcoreapp2.1`
-3. needs update to OLE DB provider for .net core support
+3. needs System.Data.OleDb 4.7.1+ for .Net Core support
 4. for SQL CE right now we don't run .net core tests
 5. Northwind SQL Server tests not enabled yet, as we need SQL Server images with full-text search included
 

--- a/Build/Azure/README.md
+++ b/Build/Azure/README.md
@@ -48,7 +48,7 @@ Legend:
 |:---|:---:|:---:|:---:|:---:|
 |TestNoopProvider<sup>[1](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |SQLite [3.13.0](https://www.sqlite.org/releaselog/3_13_0.html)<sup>[2](#notes)</sup><br>[Microsoft.Data.SQLite](https://www.nuget.org/packages/Microsoft.Data.SQLite/) 1.1.1<br>with NorthwindDB Tests|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
-|SQLite [3.28.0](https://www.sqlite.org/releaselog/3_28_0.html)<br>[Microsoft.Data.SQLite](https://www.nuget.org/packages/Microsoft.Data.SQLite/) 3.1.3<br>with NorthwindDB Tests|:heavy_minus_sign:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+|SQLite [3.28.0](https://www.sqlite.org/releaselog/3_28_0.html)<br>[Microsoft.Data.SQLite](https://www.nuget.org/packages/Microsoft.Data.SQLite/) 3.1.4<br>with NorthwindDB Tests|:heavy_minus_sign:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |SQLite [3.31.1](https://www.sqlite.org/releaselog/3_31_1.html)<br>[System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite.Core/) 1.0.112.2<br>with NorthwindDB Tests|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |SQLite [3.31.1](https://www.sqlite.org/releaselog/3_31_1.html)<br>[System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite.Core/) 1.0.112.2<br>with [MiniProfiler](https://www.nuget.org/packages/MiniProfiler.Shared/) 4.1.0 (core)<br>[MiniProfiler](https://www.nuget.org/packages/MiniProfiler/) 3.2.0.157 (netfx)<br>without mappings to underlying provider|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |SQLite [3.31.1](https://www.sqlite.org/releaselog/3_31_1.html)<br>[System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite.Core/) 1.0.112.2<br>with [MiniProfiler](https://www.nuget.org/packages/MiniProfiler.Shared/) 4.1.0 (core)<br>[MiniProfiler](https://www.nuget.org/packages/MiniProfiler/) 3.2.0.157 (netfx)<br>with mappings to underlying provider|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
@@ -65,7 +65,7 @@ Legend:
 |MS SQL Server 2016<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.1|:x:|:x:|:x:|:x:|
 |MS SQL Server 2017<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.1<br>with NorthwindDB<sup>[5](#notes)</sup> Tests|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |MS SQL Server 2019<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.1|:x:|:x:|:x:|:x:|
-|MS SQL Server 2017<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 1.1.2<br>with NorthwindDB<sup>[5](#notes)</sup> Tests|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+|MS SQL Server 2017<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 1.1.3<br>with NorthwindDB<sup>[5](#notes)</sup> Tests|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |Azure SQL<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.1|:x:|:x:|:x:|:x:|
 |MySQL 5.6<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.20|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |MySQL 8<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.20|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|

--- a/Build/Azure/pipelines/default.yml
+++ b/Build/Azure/pipelines/default.yml
@@ -238,10 +238,10 @@ stages:
         SQLite_MS:
           title: 'SQLite.MS'
           config: 'sqlite.ms'
-        Access_JET:
+        Access_OLEDB_JET:
           title: 'Access Jet'
           config: 'access'
-        Access_ACE:
+        Access_OLEDB_ACE:
           title: 'Access ACE'
           config: 'access.ace'
           script: 'access.ace.cmd'
@@ -389,6 +389,10 @@ stages:
         Access_ODBC_ACE:
           title: 'Access ODBC ACE'
           config: 'access.odbc.ace'
+          script: 'access.ace.x64.cmd'
+        Access_OLEDB_ACE:
+          title: 'Access OleDb ACE'
+          config: 'access.ace'
           script: 'access.ace.x64.cmd'
         SQLite:
           title: 'SQLite'

--- a/Build/Azure/pipelines/experimental.yml
+++ b/Build/Azure/pipelines/experimental.yml
@@ -370,9 +370,16 @@ stages:
         platform: '$(buildPlatform)'
         configuration: '$(buildConfiguration)'
         testFilterCriteria: 'TestCategory != SkipCI'
-        otherConsoleOptions: '/Framework:.NETCoreApp,Version=v2.1'
+        otherConsoleOptions: '/Framework:.NETCoreApp,Version=v2.1 /Diag:diag.logz /Blame'
         testRunTitle: 'Windows / NETCOREAPP2.1 / $(title)'
       displayName: '$(title)'
+
+    - task: PublishPipelineArtifact@1
+      inputs:
+        archiveFilePatterns: '**/*.logz'
+        path: '$(System.DefaultWorkingDirectory)'
+        artifact: 'win_core_test_logs'
+      displayName: Publish test diagnostics
 
 ###########################
 #  Tests: Windows (NETFX) #

--- a/Build/Azure/pipelines/experimental.yml
+++ b/Build/Azure/pipelines/experimental.yml
@@ -121,8 +121,8 @@ stages:
       vmImage: 'ubuntu-16.04'
     displayName: 'Tests: Lin / NETCOREAPP2.1 / '
     dependsOn: build_job
-    condition: ne(variables['Build.SourceBranchName'], 'release')
-#    condition: eq(variables['Build.SourceBranchName'], 'fake')
+#    condition: ne(variables['Build.SourceBranchName'], 'release')
+    condition: eq(variables['Build.SourceBranchName'], 'fake')
 
     strategy:
       matrix:
@@ -209,8 +209,8 @@ stages:
       vmImage: 'macOS-10.14'
     displayName: 'Tests: Mac / NETCOREAPP2.1 / '
     dependsOn: build_job
-#    condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'release'))
-    condition: eq(variables['Build.SourceBranchName'], 'fake')
+    condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'release'))
+#    condition: eq(variables['Build.SourceBranchName'], 'fake')
 
     strategy:
       matrix:
@@ -226,15 +226,10 @@ stages:
 #          script: 'mac.hana2.sh'
 #          docker: 'true'
 #          docker_login: 'true'
-        Oracle11:
-          title: 'Oracle 11g XE'
-          config: 'oracle11'
-          script: 'oracle11.sh'
-          docker: 'true'
-        Oracle12:
-          title: 'Oracle 12c'
-          config: 'oracle12'
-          script: 'oracle12.sh'
+        SqlServer2017_MS:
+          title: 'SQL Server 2017 (Microsoft.Data.SqlClient)'
+          config: 'sqlserver.2017.ms'
+          script: 'mac.sqlserver.2017.sh'
           docker: 'true'
 
     steps:
@@ -293,10 +288,9 @@ stages:
       condition: and(succeeded(), variables['script'])
       displayName: Setup tests
 
-    - script: dotnet vstest linq2db.Tests.dll /TestCaseFilter:"TestCategory != SkipCI" /Framework:.NETCoreApp,Version=v2.1 /logger:trx
+    - script: dotnet vstest linq2db.Tests.dll /TestCaseFilter:"TestCategory != SkipCI" /Framework:.NETCoreApp,Version=v2.1 /logger:trx /Diag:diag.logz /Blame
       condition: succeeded()
       displayName: '$(title)'
-
 
     - task: PublishTestResults@2
       condition: succeededOrFailed()
@@ -304,6 +298,14 @@ stages:
         testRunner: VsTest
         testResultsFiles: '**/*.trx'
         testRunTitle: 'Mac / NETCOREAPP2.1 / $(title)'
+
+    - task: PublishPipelineArtifact@1
+      inputs:
+        archiveFilePatterns: '**/*.logz'
+        path: '$(System.DefaultWorkingDirectory)'
+        artifact: 'mac_test_logs'
+      displayName: Publish test diagnostics
+
 
 ###################################
 #  Tests: Windows (NETCOREAPP2_1) #
@@ -315,19 +317,19 @@ stages:
       vmImage: 'windows-2019'
     displayName: 'Tests: Win / NETCOREAPP2.1 / '
     dependsOn: build_job
-#    condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'release'))
-    condition: eq(variables['Build.SourceBranchName'], 'fake')
+    condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'release'))
+#    condition: eq(variables['Build.SourceBranchName'], 'fake')
 
     strategy:
       matrix:
-        Access_ODBC_ACE:
-          title: 'Access ODBC ACE'
-          config: 'access.odbc.ace'
-          script: 'access.ace.x64.cmd'
-#        Access_ACE:
-#          title: 'Access ACE (x64)'
-#          config: 'access.ace'
+#        Access_ODBC_ACE:
+#          title: 'Access ODBC ACE'
+#          config: 'access.odbc.ace'
 #          script: 'access.ace.x64.cmd'
+        Access_ACE:
+          title: 'Access OleDb ACE'
+          config: 'access.ace'
+          script: 'access.ace.x64.cmd'
     steps:
     - checkout: none
 

--- a/Build/Azure/pipelines/test-all.yml
+++ b/Build/Azure/pipelines/test-all.yml
@@ -135,10 +135,10 @@ stages:
         SQLite_MS:
           title: 'SQLite.MS'
           config: 'sqlite.ms'
-        Access_JET:
+        Access_OLEDB_JET:
           title: 'Access Jet'
           config: 'access'
-        Access_ACE:
+        Access_OLEDB_ACE:
           title: 'Access ACE'
           config: 'access.ace'
           script: 'access.ace.cmd'
@@ -286,6 +286,10 @@ stages:
         Access_ODBC_ACE:
           title: 'Access ODBC ACE'
           config: 'access.odbc.ace'
+          script: 'access.ace.x64.cmd'
+        Access_OLEDB_ACE:
+          title: 'Access OleDb ACE'
+          config: 'access.ace'
           script: 'access.ace.x64.cmd'
         SQLite:
           title: 'SQLite'

--- a/Build/Azure/scripts/mac.docker.sh
+++ b/Build/Azure/scripts/mac.docker.sh
@@ -8,8 +8,21 @@ retries=0
 brew cask install docker
 # install working 2.0.0.3-ce-mac81,31259
 #brew cask install https://raw.githubusercontent.com/Homebrew/homebrew-cask/8ce4e89d10716666743b28c5a46cd54af59a9cc2/Casks/docker.rb
-sudo /Applications/Docker.app/Contents/MacOS/Docker --quit-after-install --unattended
-/Applications/Docker.app/Contents/MacOS/Docker --unattended &
+
+# https://github.com/docker/for-mac/issues/2359#issuecomment-607154849
+# allow the app to run without confirmation
+xattr -d -r com.apple.quarantine /Applications/Docker.app
+# preemptively do docker.app's setup to avoid any gui prompts
+sudo /bin/cp /Applications/Docker.app/Contents/Library/LaunchServices/com.docker.vmnetd /Library/PrivilegedHelperTools
+sudo /bin/cp /Applications/Docker.app/Contents/Resources/com.docker.vmnetd.plist /Library/LaunchDaemons/
+sudo /bin/chmod 544 /Library/PrivilegedHelperTools/com.docker.vmnetd
+sudo /bin/chmod 644 /Library/LaunchDaemons/com.docker.vmnetd.plist
+sudo /bin/launchctl load /Library/LaunchDaemons/com.docker.vmnetd.plist
+
+open -g -a Docker.app || exit
+
+#sudo /Applications/Docker.app/Contents/MacOS/Docker --quit-after-install --unattended
+#/Applications/Docker.app/Contents/MacOS/Docker --unattended &
 while ! docker info 2>/dev/null ; do
     sleep 5
     retries=`expr $retries + 1`
@@ -17,7 +30,8 @@ while ! docker info 2>/dev/null ; do
         echo 'docker still running'
     else
         echo 'docker not running, restart'
-        /Applications/Docker.app/Contents/MacOS/Docker --unattended &
+        #/Applications/Docker.app/Contents/MacOS/Docker --unattended &
+        open -g -a Docker.app || exit
     fi
     if [ $retries -gt 30 ]; then
         >&2 echo 'Failed to run docker'

--- a/Build/Azure/scripts/mac.docker.sh
+++ b/Build/Azure/scripts/mac.docker.sh
@@ -1,15 +1,11 @@
 #!/bin/bash
 
 # osx agent doesn't have docker pre-installed, so we need to do it manually
-# unfortunatelly, installer is not very good and sometimes just doesn't work
-#https://github.com/microsoft/azure-pipelines-image-generation/issues/738
 retries=0
-# recent 37199 version of docker fails to start, so we need to specify most recent working one
 brew cask install docker
-# install working 2.0.0.3-ce-mac81,31259
-#brew cask install https://raw.githubusercontent.com/Homebrew/homebrew-cask/8ce4e89d10716666743b28c5a46cd54af59a9cc2/Casks/docker.rb
 
-# https://github.com/docker/for-mac/issues/2359#issuecomment-607154849
+# manually setup docker, as versions after 2.0.0.3-ce-mac81,31259 cannot be installed without mouse-fu :facepalm:
+# thanks to https://github.com/docker/for-mac/issues/2359#issuecomment-607154849
 # allow the app to run without confirmation
 xattr -d -r com.apple.quarantine /Applications/Docker.app
 # preemptively do docker.app's setup to avoid any gui prompts
@@ -21,8 +17,6 @@ sudo /bin/launchctl load /Library/LaunchDaemons/com.docker.vmnetd.plist
 
 open -g -a Docker.app || exit
 
-#sudo /Applications/Docker.app/Contents/MacOS/Docker --quit-after-install --unattended
-#/Applications/Docker.app/Contents/MacOS/Docker --unattended &
 while ! docker info 2>/dev/null ; do
     sleep 5
     retries=`expr $retries + 1`
@@ -30,7 +24,6 @@ while ! docker info 2>/dev/null ; do
         echo 'docker still running'
     else
         echo 'docker not running, restart'
-        #/Applications/Docker.app/Contents/MacOS/Docker --unattended &
         open -g -a Docker.app || exit
     fi
     if [ $retries -gt 30 ]; then

--- a/Build/Azure/scripts/mac.docker.sh
+++ b/Build/Azure/scripts/mac.docker.sh
@@ -5,9 +5,9 @@
 #https://github.com/microsoft/azure-pipelines-image-generation/issues/738
 retries=0
 # recent 37199 version of docker fails to start, so we need to specify most recent working one
-#brew cask install docker
+brew cask install docker
 # install working 2.0.0.3-ce-mac81,31259
-brew cask install https://raw.githubusercontent.com/Homebrew/homebrew-cask/8ce4e89d10716666743b28c5a46cd54af59a9cc2/Casks/docker.rb
+#brew cask install https://raw.githubusercontent.com/Homebrew/homebrew-cask/8ce4e89d10716666743b28c5a46cd54af59a9cc2/Casks/docker.rb
 sudo /Applications/Docker.app/Contents/MacOS/Docker --quit-after-install --unattended
 /Applications/Docker.app/Contents/MacOS/Docker --unattended &
 while ! docker info 2>/dev/null ; do

--- a/Build/linq2db.Tests.Providers.props
+++ b/Build/linq2db.Tests.Providers.props
@@ -19,7 +19,7 @@
 		<PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
 		<PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
-		<PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.2" />
+		<PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.3" />
 
 		<ProjectReference Include="..\Base\Tests.Base.csproj" />
 
@@ -59,7 +59,7 @@
 		<PackageReference Include="Oracle.ManagedDataAccess" Version="19.7.0" />
 		<PackageReference Include="Microsoft.SqlServer.Types" Version="14.0.1016.290" />
 		<PackageReference Include="Npgsql" Version="4.0.10" />
-		<PackageReference Include="Microsoft.AspNet.OData" Version="7.4.0" />
+		<PackageReference Include="Microsoft.AspNet.OData" Version="7.4.1" />
 
 		<PackageReference Include="Microsoft.Data.SQLite" Version="1.1.1" />
 		<!--Copy sqlite3.dll manually, as package copy scripts doesn't work properly for our project -->
@@ -72,10 +72,10 @@
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
 		<PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.70" />
-		<PackageReference Include="Microsoft.Data.SQLite" Version="3.1.3" />
+		<PackageReference Include="Microsoft.Data.SQLite" Version="3.1.4" />
 		<PackageReference Include="Npgsql" Version="4.1.3.1" />
 		<PackageReference Include="System.Data.Odbc" Version="4.7.0" />
-		<PackageReference Include="System.Data.OleDb" Version="4.7.0" />
+		<PackageReference Include="System.Data.OleDb" Version="4.7.1" />
 		<PackageReference Include="MiniProfiler.Shared" Version="4.1.0" />
 
 		<!--magic-->

--- a/Build/linq2db.Tests.props
+++ b/Build/linq2db.Tests.props
@@ -29,7 +29,7 @@
 		<Reference Include="System.Data.Linq" />
 		<Reference Include="System.ServiceModel" />
 
-		<PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
+		<PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
 	</ItemGroup>
 
 </Project>

--- a/NuGet/linq2db.Access.nuspec
+++ b/NuGet/linq2db.Access.nuspec
@@ -19,11 +19,11 @@
 			</group>
 			<group targetFramework=".NETStandard2.0">
 				<dependency id="linq2db"                  version="3.0.0"/>
-				<dependency id="System.Data.OleDb"        version="4.7.0" />
+				<dependency id="System.Data.OleDb"        version="4.7.1" />
 			</group>
 			<group targetFramework=".NETCoreApp2.1">
 				<dependency id="linq2db"                  version="3.0.0"/>
-				<dependency id="System.Data.OleDb"        version="4.7.0" />
+				<dependency id="System.Data.OleDb"        version="4.7.1" />
 			</group>
 		</dependencies>
 		<contentFiles>

--- a/NuGet/linq2db.AspNet.nuspec
+++ b/NuGet/linq2db.AspNet.nuspec
@@ -11,9 +11,13 @@
 		<dependencies>
 			<group targetFramework=".NETFramework4.5" >
 				<dependency id="linq2db" version="3.0.0"/>
+				<dependency id="Microsoft.Extensions.DependencyInjection" version="1.1.1"/>
+				<dependency id="Microsoft.Extensions.Logging.Abstractions" version="1.1.2"/>
 			</group>
 			<group targetFramework=".NETStandard2.0">
 				<dependency id="linq2db" version="3.0.0"/>
+				<dependency id="Microsoft.Extensions.DependencyInjection" version="3.1.4"/>
+				<dependency id="Microsoft.Extensions.Logging.Abstractions" version="3.1.4"/>
 			</group>
 		</dependencies>
 	</metadata>

--- a/NuGet/linq2db.SQLite.MS.nuspec
+++ b/NuGet/linq2db.SQLite.MS.nuspec
@@ -12,7 +12,7 @@
 		<tags>linq linq2db SQLite LinqToDB ORM database DB SQL</tags>
 		<dependencies>
 			<dependency id="linq2db"                version="3.0.0"/>
-			<dependency id="Microsoft.Data.Sqlite"  version="3.1.3"/>
+			<dependency id="Microsoft.Data.Sqlite"  version="3.1.4"/>
 		</dependencies>
 		<contentFiles>
 			<files include="**\*" buildAction="None"/>

--- a/NuGet/linq2db.SqlServer.MS.nuspec
+++ b/NuGet/linq2db.SqlServer.MS.nuspec
@@ -12,7 +12,7 @@
 		<tags>linq linq2db SqlServer LinqToDB ORM database DB SQL</tags>
 		<dependencies>
 			<dependency id="linq2db"                   version="3.0.0" />
-			<dependency id="Microsoft.Data.SqlClient"  version="1.1.2" />
+			<dependency id="Microsoft.Data.SqlClient"  version="1.1.3" />
 		</dependencies>
 		<contentFiles>
 			<files include="**\*" buildAction="None"/>

--- a/NuGet/linq2db.nuspec
+++ b/NuGet/linq2db.nuspec
@@ -14,14 +14,10 @@
 			<group targetFramework=".NETStandard2.0">
 				<dependency id="Microsoft.CSharp"                     version="4.7.0" />
 				<dependency id="System.ComponentModel.Annotations"    version="4.7.0" />
-				<dependency id="System.Data.Odbc"                     version="4.7.0" />
-				<dependency id="System.Data.OleDb"                    version="4.7.0" />
 				<dependency id="System.Data.DataSetExtensions"        version="4.5.0" />
 			</group>
 			<group targetFramework=".NETCoreApp2.1">
 				<dependency id="System.ComponentModel.Annotations"    version="4.7.0" />
-				<dependency id="System.Data.Odbc"                     version="4.7.0" />
-				<dependency id="System.Data.OleDb"                    version="4.7.0" />
 				<dependency id="System.Data.DataSetExtensions"        version="4.5.0" />
 			</group>
 		</dependencies>

--- a/Source/LinqToDB.AspNet/LinqToDB.AspNet.csproj
+++ b/Source/LinqToDB.AspNet/LinqToDB.AspNet.csproj
@@ -20,7 +20,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.3" />
-	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.3" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
 	</ItemGroup>
 </Project>

--- a/Source/LinqToDB/Compatibility/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
+++ b/Source/LinqToDB/Compatibility/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
@@ -8,27 +8,27 @@ namespace System.Diagnostics.CodeAnalysis
 {
 	/// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
 	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
-		sealed class AllowNullAttribute : Attribute
+	sealed class AllowNullAttribute : Attribute
 	{ }
 
 	/// <summary>Specifies that null is disallowed as an input even if the corresponding type allows it.</summary>
 	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
-		sealed class DisallowNullAttribute : Attribute
+	sealed class DisallowNullAttribute : Attribute
 	{ }
 
 	/// <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
 	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
-		sealed class MaybeNullAttribute : Attribute
+	sealed class MaybeNullAttribute : Attribute
 	{ }
 
 	/// <summary>Specifies that an output will not be null even if the corresponding type allows it. Specifies that an input argument was not null when the call returns.</summary>
 	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
-		sealed class NotNullAttribute : Attribute
+	sealed class NotNullAttribute : Attribute
 	{ }
 
 	/// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter may be null even if the corresponding type disallows it.</summary>
 	[AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
-		sealed class MaybeNullWhenAttribute : Attribute
+	sealed class MaybeNullWhenAttribute : Attribute
 	{
 		/// <summary>Initializes the attribute with the specified return value condition.</summary>
 		/// <param name="returnValue">
@@ -42,7 +42,7 @@ namespace System.Diagnostics.CodeAnalysis
 
 	/// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
 	[AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
-		sealed class NotNullWhenAttribute : Attribute
+	sealed class NotNullWhenAttribute : Attribute
 	{
 		/// <summary>Initializes the attribute with the specified return value condition.</summary>
 		/// <param name="returnValue">
@@ -56,7 +56,7 @@ namespace System.Diagnostics.CodeAnalysis
 
 	/// <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
 	[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
-		sealed class NotNullIfNotNullAttribute : Attribute
+	sealed class NotNullIfNotNullAttribute : Attribute
 	{
 		/// <summary>Initializes the attribute with the associated parameter name.</summary>
 		/// <param name="parameterName">
@@ -70,12 +70,12 @@ namespace System.Diagnostics.CodeAnalysis
 
 	/// <summary>Applied to a method that will never return under any circumstance.</summary>
 	[AttributeUsage(AttributeTargets.Method, Inherited = false)]
-		sealed class DoesNotReturnAttribute : Attribute
+	sealed class DoesNotReturnAttribute : Attribute
 	{ }
 
 	/// <summary>Specifies that the method will not return if the associated Boolean parameter is passed the specified value.</summary>
 	[AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
-		sealed class DoesNotReturnIfAttribute : Attribute
+	sealed class DoesNotReturnIfAttribute : Attribute
 	{
 		/// <summary>Initializes the attribute with the specified parameter value.</summary>
 		/// <param name="parameterValue">
@@ -86,5 +86,44 @@ namespace System.Diagnostics.CodeAnalysis
 
 		/// <summary>Gets the condition parameter value.</summary>
 		public bool ParameterValue { get; }
+	}
+
+	/// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
+	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false)]
+	sealed class MemberNotNullAttribute : Attribute
+	{
+		/// <summary>Initializes the attribute with the list of field and property members.</summary>
+		/// <param name="members">
+		/// The list of field and property members that are promised to be not-null.
+		/// </param>
+		public MemberNotNullAttribute(params string[] members)
+			=> Members = members;
+
+		/// <summary>Gets field or property member names.</summary>
+		public string[] Members { get; }
+	}
+
+	/// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values when returning with the specified return value condition.</summary>
+	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false)]
+	sealed class MemberNotNullWhenAttribute : Attribute
+	{
+		/// <summary>Initializes the attribute with the specified return value condition and list of field and property members.</summary>
+		/// <param name="returnValue">
+		/// The return value condition. If the method returns this value, the associated parameter will not be null.
+		/// </param>
+		/// <param name="members">
+		/// The list of field and property members that are promised to be not-null.
+		/// </param>
+		public MemberNotNullWhenAttribute(bool returnValue, params string[] members)
+		{
+			ReturnValue = returnValue;
+			Members = members;
+		}
+
+		/// <summary>Gets the return value condition.</summary>
+		public bool ReturnValue { get; }
+
+		/// <summary>Gets field or property member names.</summary>
+		public string[] Members { get; }
 	}
 }

--- a/Source/LinqToDB/Compatibility/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
+++ b/Source/LinqToDB/Compatibility/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
@@ -89,9 +89,15 @@ namespace System.Diagnostics.CodeAnalysis
 	}
 
 	/// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
-	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false)]
+	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
 	sealed class MemberNotNullAttribute : Attribute
 	{
+		/// <summary>Initializes the attribute with a field or property member.</summary>
+		/// <param name="member">
+		/// The field or property member that is promised to be not-null.
+		/// </param>
+		public MemberNotNullAttribute(string member) => Members = new[] { member };
+
 		/// <summary>Initializes the attribute with the list of field and property members.</summary>
 		/// <param name="members">
 		/// The list of field and property members that are promised to be not-null.
@@ -104,9 +110,22 @@ namespace System.Diagnostics.CodeAnalysis
 	}
 
 	/// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values when returning with the specified return value condition.</summary>
-	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false)]
+	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
 	sealed class MemberNotNullWhenAttribute : Attribute
 	{
+		/// <summary>Initializes the attribute with the specified return value condition and a field or property member.</summary>
+		/// <param name="returnValue">
+		/// The return value condition. If the method returns this value, the associated parameter will not be null.
+		/// </param>
+		/// <param name="member">
+		/// The field or property member that is promised to be not-null.
+		/// </param>
+		public MemberNotNullWhenAttribute(bool returnValue, string member)
+		{
+			ReturnValue = returnValue;
+			Members = new[] { member };
+		}
+
 		/// <summary>Initializes the attribute with the specified return value condition and list of field and property members.</summary>
 		/// <param name="returnValue">
 		/// The return value condition. If the method returns this value, the associated parameter will not be null.

--- a/Source/LinqToDB/Linq/Builder/ParameterContainer.cs
+++ b/Source/LinqToDB/Linq/Builder/ParameterContainer.cs
@@ -17,9 +17,9 @@ namespace LinqToDB.Linq.Builder
 			return _accessors.Count - 1;
 		}
 
-		public Expression ParameterExpression { get; set; }
-		public object?[]? CompiledParameters { get; set; }
-		public IDataContext DataContext { get; set; }
+		public Expression?   ParameterExpression { get; set; }
+		public object?[]?    CompiledParameters  { get; set; }
+		public IDataContext? DataContext         { get; set; }
 
 		public static readonly MethodInfo GetValueMethodInfo =
 			MemberHelper.MethodOf<ParameterContainer>(c => c.GetValue(0));
@@ -31,7 +31,7 @@ namespace LinqToDB.Linq.Builder
 			
 			var accessor = _accessors[index];
 			
-			return accessor.Accessor(ParameterExpression, DataContext, CompiledParameters);
+			return accessor.Accessor(ParameterExpression!, DataContext, CompiledParameters);
 		}
 	}
 }

--- a/Source/LinqToDB/Linq/QueryRunner.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.cs
@@ -104,9 +104,16 @@ namespace LinqToDB.Linq
 
 					var expression = TransformMapperExpression(context, dataReader, dataReaderType, true);
 
-					mapperInfo.Mapper = expression.Compile();
+					// create new instance to avoid race conditions without locks
+					var expr   = mapperInfo.MapperExpression;
+					mapperInfo = new ReaderMapperInfo()
+					{
+						MapperExpression = expr,
+						Mapper           = expression.Compile(),
+						IsFaulted        = true
+					};
 
-					mapperInfo.IsFaulted = true;
+					_mappers[dataReaderType] = mapperInfo;
 
 					return mapperInfo.Mapper(queryRunner, dataReader);
 				}

--- a/Source/LinqToDB/LinqToDB.csproj
+++ b/Source/LinqToDB/LinqToDB.csproj
@@ -77,7 +77,6 @@
 		<Compile Include="Compatibility\System\Data\Linq\Binary.cs" />
 		<Compile Include="Compatibility\System\Diagnostics\CodeAnalysis\NullableAttributes.cs" />
 
-		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
 		<PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
 	</ItemGroup>
@@ -85,5 +84,7 @@
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
 		<Compile Remove="DataProvider\SapHana\SapHanaDataProvider.cs" />
 		<Compile Remove="DataProvider\SapHana\SapHanaBulkCopy.cs" />
+
+		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 	</ItemGroup>
 </Project>

--- a/Tests/FSharp/Tests.FSharp.fsproj
+++ b/Tests/FSharp/Tests.FSharp.fsproj
@@ -21,7 +21,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Update="FSharp.Core" Version="4.7.1" />
+		<PackageReference Update="FSharp.Core" Version="4.7.2" />
 		<PackageReference Update="System.ValueTuple" Version="4.5.0" />
 	</ItemGroup>
 </Project>

--- a/Tests/Linq/Data/DataConnectionTests.cs
+++ b/Tests/Linq/Data/DataConnectionTests.cs
@@ -1002,7 +1002,7 @@ namespace Tests.Data
 		[ActiveIssue(Configurations = new[]
 		{
 			ProviderName.MySqlConnector,
-			ProviderName.SapHana,
+			ProviderName.SapHanaNative, // HanaException: error while parsing protocol
 			// Providers remove credentials in non-design mode:
 			TestProvName.AllPostgreSQL,
 			TestProvName.AllSqlServer,
@@ -1164,7 +1164,8 @@ namespace Tests.Data
 				context == ProviderName.SqlCe               ||
 				context == ProviderName.Sybase              ||
 #if NETCOREAPP2_1
-				(!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && context.Contains("Oracle") && context.Contains("Managed")) ||
+				(context.Contains("Oracle") && context.Contains("Managed")) ||
+				context == ProviderName.SapHanaNative       ||
 #endif
 				TestProvName.AllMySqlData.Contains(context) ||
 				context.StartsWith("Access")                ||
@@ -1185,6 +1186,7 @@ namespace Tests.Data
 				// SQLCE: The connection object can not be enlisted in transaction scope.
 				// Sybase native: Only One Local connection allowed in the TransactionScope
 				// Oracle managed: Operation is not supported on this platform.
+				// SAP.Native: Operation is not supported on this platform.
 				// SqlServer: The operation is not valid for the state of the transaction.
 				Assert.Inconclusive("Provider not configured or has issues with TransactionScope");
 			}

--- a/Tests/Linq/Data/MiniProfilerTests.cs
+++ b/Tests/Linq/Data/MiniProfilerTests.cs
@@ -1126,7 +1126,7 @@ namespace Tests.Data
 
 				void TestBulkCopy()
 				{
-					using (db.CreateTempTable<OracleBulkCopyTable>())
+					using (db.CreateLocalTable<OracleBulkCopyTable>())
 					{
 						long copied = 0;
 						var options = new BulkCopyOptions()

--- a/Tests/Linq/DataProvider/AccessTests.cs
+++ b/Tests/Linq/DataProvider/AccessTests.cs
@@ -394,6 +394,10 @@ namespace Tests.DataProvider
 		[Test]
 		public void CreateDatabase([IncludeDataSources(ProviderName.Access)] string context)
 		{
+			var cs = DataConnection.GetConnectionString(context);
+			if (!cs.Contains("Microsoft.Jet.OLEDB"))
+				Assert.Inconclusive("Test requires JET provider");
+
 			AccessTools.CreateDatabase("TestDatabase", deleteIfExists: true);
 			Assert.IsTrue(File.Exists("TestDatabase.mdb"));
 

--- a/Tests/Linq/DataProvider/OracleTests.cs
+++ b/Tests/Linq/DataProvider/OracleTests.cs
@@ -120,16 +120,11 @@ namespace Tests.DataProvider
 				TestType(conn, "datetime2DataType",      new DateTime(2012, 12, 12, 12, 12, 12, 012));
 				TestType(conn, "datetimeoffsetDataType", new DateTimeOffset(2012, 12, 12, 12, 12, 12, 12, new TimeSpan(-5, 0, 0)));
 
-				try
+				// TODO: fix timezones handling
+				if (!context.Contains("Native"))
 				{
 					var dt = new DateTimeOffset(2012, 12, 12, 12, 12, 12, 12, TimeSpan.Zero);
 					TestType(conn, "localZoneDataType", new DateTimeOffset(2012, 12, 12, 12, 12, 12, 12, TimeZoneInfo.Local.GetUtcOffset(dt) /* new TimeSpan(-4, 0, 0)*/), throwException:true);
-				}
-				catch (Exception ex)
-					when (
-						ex.Message.Replace(" ", "") == "Expected: 2012-12-12 12:12:12.012-05:00 But was: 2012-12-12 12:12:12.012-04:00".Replace(" ", "") ||
-						ex.Message.Replace(" ", "") == "Expected: 12/12/2012 12:12:12 PM -05:00 But was: 12/12/2012 12:12:12 PM -04:00".Replace(" ", ""))
-				{
 				}
 
 				TestType(conn, "charDataType",           '1');
@@ -2418,7 +2413,11 @@ namespace Tests.DataProvider
 				Assert.AreEqual(new DateTime(2012, 12, 12, 12, 12, 12), pms[12].Value);
 				Assert.AreEqual(new DateTime(2012, 12, 12, 12, 12, 12, 12), pms[13].Value);
 				Assert.AreEqual(new DateTimeOffset(2012, 12, 12, 12, 12, 12, isNative ? 0 : 12, TimeSpan.FromHours(-5)), pms[14].Value);
-				Assert.AreEqual(new DateTimeOffset(2012, 12, 12, 11, 12, 12, isNative ? 0 : 12, TimeSpan.Zero), pms[15].Value);
+
+				// TODO: fix timezones handling
+				if (!context.Contains("Native"))
+					Assert.AreEqual(new DateTimeOffset(2012, 12, 12, 11, 12, 12, isNative ? 0 : 12, TimeSpan.Zero), pms[15].Value);
+
 				Assert.AreEqual("1"                   , pms[16].Value);
 				Assert.IsNull(pms[17].Value);
 				Assert.AreEqual("234"                 , pms[18].Value);

--- a/Tests/Linq/Linq/AsyncTests.cs
+++ b/Tests/Linq/Linq/AsyncTests.cs
@@ -22,7 +22,7 @@ namespace Tests.Linq
 			TestImpl(context);
 		}
 
-		async void TestImpl(string context)
+		async Task TestImpl(string context)
 		{
 			Test1(context);
 
@@ -49,7 +49,7 @@ namespace Tests.Linq
 			TestForEachImpl(context);
 		}
 
-		async void TestForEachImpl(string context)
+		async Task TestForEachImpl(string context)
 		{
 			using (var db = GetDataContext(context + ".LinqService"))
 			{
@@ -67,7 +67,7 @@ namespace Tests.Linq
 			TestExecute1Impl(context);
 		}
 
-		async void TestExecute1Impl(string context)
+		async Task TestExecute1Impl(string context)
 		{
 			using (var conn = new TestDataConnection(context))
 			{
@@ -106,7 +106,7 @@ namespace Tests.Linq
 			TestQueryToArrayImpl(context);
 		}
 
-		async void TestQueryToArrayImpl(string context)
+		async Task TestQueryToArrayImpl(string context)
 		{
 			using (var conn = new TestDataConnection(context))
 			{

--- a/Tests/Linq/Linq/AsyncTests.cs
+++ b/Tests/Linq/Linq/AsyncTests.cs
@@ -17,9 +17,9 @@ namespace Tests.Linq
 	public class AsyncTests : TestBase
 	{
 		[Test]
-		public void Test([DataSources(false)] string context)
+		public async Task Test([DataSources(false)] string context)
 		{
-			TestImpl(context);
+			await TestImpl(context);
 		}
 
 		async Task TestImpl(string context)
@@ -44,9 +44,9 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void TestForEach([DataSources(false)] string context)
+		public async Task TestForEach([DataSources(false)] string context)
 		{
-			TestForEachImpl(context);
+			await TestForEachImpl(context);
 		}
 
 		async Task TestForEachImpl(string context)
@@ -62,9 +62,9 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void TestExecute1([DataSources(false)] string context)
+		public async Task TestExecute1([DataSources(false)] string context)
 		{
-			TestExecute1Impl(context);
+			await TestExecute1Impl(context);
 		}
 
 		async Task TestExecute1Impl(string context)
@@ -101,9 +101,9 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void TestQueryToArray([DataSources(false)] string context)
+		public async Task TestQueryToArray([DataSources(false)] string context)
 		{
-			TestQueryToArrayImpl(context);
+			await TestQueryToArrayImpl(context);
 		}
 
 		async Task TestQueryToArrayImpl(string context)

--- a/Tests/Linq/Linq/ConvertTests.cs
+++ b/Tests/Linq/Linq/ConvertTests.cs
@@ -606,7 +606,15 @@ namespace Tests.Linq
 
 		#endregion
 
-		[ActiveIssue("CI: SQL0245N  The invocation of routine DECIMAL is ambiguous. The argument in position 1 does not have a best fit", Configuration = ProviderName.DB2)]
+		[ActiveIssue("CI: SQL0245N  The invocation of routine DECIMAL is ambiguous. The argument in position 1 does not have a best fit",
+			Configurations = new[]
+			{
+				ProviderName.DB2
+#if NETCOREAPP2_1
+				// to avoid crashes due to https://github.com/dotnet/runtime/issues/36954
+				, ProviderName.Access
+#endif
+})]
 		[Test]
 		public void ConvertFromOneToAnother([DataSources] string context)
 		{
@@ -702,7 +710,7 @@ namespace Tests.Linq
 			}
 		}
 
-		#region redundant convert https://github.com/linq2db/linq2db/issues/2039
+#region redundant convert https://github.com/linq2db/linq2db/issues/2039
 
 		[Table]
 		public class IntegerConverts
@@ -1277,6 +1285,6 @@ namespace Tests.Linq
 				Assert.False(db.LastQuery!.Contains(" Convert("));
 			}
 		}
-		#endregion
+#endregion
 	}
 }

--- a/Tests/Linq/Linq/ParameterTests.cs
+++ b/Tests/Linq/Linq/ParameterTests.cs
@@ -367,7 +367,7 @@ namespace Tests.Linq
 
 		[Repeat(2)] // don't ever remove Repeat, as it used to test issue #2174
 		[Test]
-		public void Issue404Test([DataSources] string context)
+		public void Issue404Test([DataSources(TestProvName.AllSybase)] string context)
 		{
 			using (new AllowMultipleQuery(true))
 			using (var db = GetDataContext(context))

--- a/Tests/Linq/Linq/QueryableAssociationTests.cs
+++ b/Tests/Linq/Linq/QueryableAssociationTests.cs
@@ -604,7 +604,7 @@ WHERE
 		}
 
 		[Test]
-		public void SelectAssociations([IncludeDataSources(TestProvName.AllSqlServer)] string context)
+		public void SelectAssociations([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
 		{
 			using (var db = GetDataContext(context))
 			using (db.CreateLocalTable(new[]

--- a/Tests/Linq/Mapping/MappingAmbiguityTests.cs
+++ b/Tests/Linq/Mapping/MappingAmbiguityTests.cs
@@ -75,7 +75,10 @@ namespace Tests.Mapping
 					.UpdateWhenMatched()
 					.Merge();
 
-				Assert.AreEqual(0, res);
+				if (context.Contains("Oracle") && context.Contains("Native"))
+					Assert.AreEqual(-1, res);
+				else
+					Assert.AreEqual(0, res);
 			}
 		}
 	}

--- a/Tests/Linq/Update/CreateTableTypesTests.cs
+++ b/Tests/Linq/Update/CreateTableTypesTests.cs
@@ -108,8 +108,8 @@ namespace Tests.xUpdate
 				yield return (e => e.Property (_ => _.String).IsNullable(),                    v => v.String = "test max value nullable"                       , null,                                                                                                                        null,                            null);
 				// Oracle treats empty string as null in this context
 				// Sybase roundtrips empty string to " " (WAT?)
-				yield return (e => e.Property (_ => _.String).IsNullable(false).HasLength(10), v => v.String             = "test 10"                           , (ctx, v) => { if (ctx.Contains("Oracle") || ctx.Contains("Sybase")) { v.String = " "; } else { v.String = string.Empty; } }, null,                            null);
-				yield return (e => e.Property (_ => _.String).HasLength(10),                   v => v.String = "test 10 n"                                     , null,                                                                                                                        null,                            null);
+				yield return (e => e.Property (_ => _.String).IsNullable(false).HasLength(10), v => v.String             = "test 10"                           , (ctx, v) => { if (ctx.Contains("Oracle") || ctx.Contains("Sybase")) { v.String = " "; } else { v.String = string.Empty; } }, ctx => ctx.Contains("Oracle") && ctx.Contains("Native"), null);
+				yield return (e => e.Property (_ => _.String).HasLength(10),                   v => v.String = "test 10 n"                                     , null,                                                                                                                        ctx => ctx.Contains("Oracle") && ctx.Contains("Native"), null);
 				// https://github.com/linq2db/linq2db/issues/1032 with DataType specified
 				yield return (e => e.Property(_ => _.StringConverted).IsNullable(false).HasDataType(DataType.NVarChar), v => v.StringConverted = CreateTableTypes.StringConvertedTestValue, null,                                                                                             null,                            null);
 				yield return (e => e.Property(_ => _.StringConverted).HasDataType(DataType.NVarChar), v => v.StringConverted = CreateTableTypes.StringConvertedTestValue, null,                                                                                                               null,                            null);
@@ -119,6 +119,7 @@ namespace Tests.xUpdate
 			}
 		}
 
+		// TODO: fix
 		// oracle native tests could fail due to bug in provider:
 		// InitialLONGFetchSize option makes it read garbage for String/StringNullable testcases
 		[Test]

--- a/Tests/Linq/Update/InsertTests.cs
+++ b/Tests/Linq/Update/InsertTests.cs
@@ -1077,7 +1077,14 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		[ActiveIssue("InsertOrUpdate() == -1", Configuration = TestProvName.AllOracleNative)]
+		[ActiveIssue("InsertOrUpdate() == -1", Configurations = new[]
+		{
+			TestProvName.AllOracleNative
+#if NETCOREAPP2_1
+				// to avoid crashes due to https://github.com/dotnet/runtime/issues/36954
+				, ProviderName.Access
+#endif
+		})]
 		public void InsertOrUpdate2([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))

--- a/Tests/Linq/app.config
+++ b/Tests/Linq/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+	<runtime>
+		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.SqlServer.Types" publicKeyToken="89845dcd8080cc91" culture="neutral" />
+				<bindingRedirect oldVersion="10.0.0.0" newVersion="14.0.0.0" />
+			</dependentAssembly>
+		</assemblyBinding>
+	</runtime>
+</configuration>

--- a/Tests/Tests.Android/packages.config
+++ b/Tests/Tests.Android/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Data.Sqlite" version="3.1.3" targetFramework="monoandroid81" />
-  <package id="Microsoft.Data.Sqlite.Core" version="3.1.3" targetFramework="monoandroid81" />
+  <package id="Microsoft.Data.Sqlite" version="3.1.4" targetFramework="monoandroid81" />
+  <package id="Microsoft.Data.Sqlite.Core" version="3.1.4" targetFramework="monoandroid81" />
   <package id="Microsoft.NETCore.Platforms" version="3.1.0" targetFramework="monoandroid81" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="monoandroid81" />
   <package id="Microsoft.Win32.Registry" version="4.7.0" targetFramework="monoandroid81" />
@@ -23,7 +23,7 @@
   <package id="System.Console" version="4.3.1" targetFramework="monoandroid81" />
   <package id="System.Data.DataSetExtensions" version="4.5.0" targetFramework="monoandroid81" />
   <package id="System.Data.Odbc" version="4.7.0" targetFramework="monoandroid81" />
-  <package id="System.Data.OleDb" version="4.7.0" targetFramework="monoandroid81" />
+  <package id="System.Data.OleDb" version="4.7.1" targetFramework="monoandroid81" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="monoandroid81" />

--- a/Tests/Tests.Playground/app.config
+++ b/Tests/Tests.Playground/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+	<runtime>
+		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.SqlServer.Types" publicKeyToken="89845dcd8080cc91" culture="neutral" />
+				<bindingRedirect oldVersion="10.0.0.0" newVersion="14.0.0.0" />
+			</dependentAssembly>
+		</assemblyBinding>
+	</runtime>
+</configuration>


### PR DESCRIPTION
- fix nuget dependencies for linq2db and linq2db.AspNet packages
- update nuget.exe
- add new nullable attributes (MemberNotNull/MemberNotNullWhen)
- enable OleDb Access tests for .Net Core (requires System.Data.OleDb 4.7.1+)
- use latest docker desktop for macos
- update dependencies:
  - [System.Data.OleDb](https://www.nuget.org/packages/System.Data.OleDb) 4.7.0 -> 4.7.1
  - [System.Collections.Immutable](https://www.nuget.org/packages/System.Collections.Immutable) 1.7.0 -> 1.7.1
  - [Microsoft.Extensions.Logging.Abstractions](https://www.nuget.org/packages/Microsoft.Extensions.Logging.Abstractions) 3.1.3 -> 3.1.4
  - [Microsoft.Extensions.DependencyInjection](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection) 3.1.3 -> 3.1.4
  - [Microsoft.Data.Sqlite](https://www.nuget.org/packages/Microsoft.Data.Sqlite) 3.1.3 -> 3.1.4
  - [Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient) 1.1.2 -> 1.1.3
  - [Microsoft.AspNet.OData](https://www.nuget.org/packages/Microsoft.AspNet.OData) 7.4.0 -> 7.4.1
  - [FSharp.Core](https://www.nuget.org/packages/FSharp.Core) 4.7.1 -> 4.7.2


TODO:
- [ ] fix sql server tests crashing in macos
- [ ] review activeissue tests
- [ ] recreate xamarin test project, as current one too old and cannot be updated