### PR TITLE
[Feature] Weak Join

### DIFF
--- a/Source/LinqToDB/Linq/Builder/AllJoinsBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/AllJoinsBuilder.cs
@@ -17,7 +17,7 @@ namespace LinqToDB.Linq.Builder
 		{
 			return
 				methodCall.IsQueryable("Join") && methodCall.Arguments.Count == 3
-				|| !rightNullableOnly && methodCall.IsQueryable("InnerJoin", "LeftJoin", "RightJoin", "FullJoin") && methodCall.Arguments.Count == 2
+				|| !rightNullableOnly && methodCall.IsQueryable("InnerJoin", "WeakInnerJoin", "LeftJoin", "WeakLeftJoin", "RightJoin", "FullJoin") && methodCall.Arguments.Count == 2
 				|| rightNullableOnly && methodCall.IsQueryable("RightJoin", "FullJoin") && methodCall.Arguments.Count == 2;
 		}
 
@@ -30,10 +30,12 @@ namespace LinqToDB.Linq.Builder
 
 			switch (methodCall.Method.Name)
 			{
-				case "InnerJoin" : joinType = JoinType.Inner; break;
-				case "LeftJoin"  : joinType = JoinType.Left;  break;
-				case "RightJoin" : joinType = JoinType.Right; break;
-				case "FullJoin"  : joinType = JoinType.Full;  break;
+				case "InnerJoin"     : joinType = JoinType.Inner; break;
+				case "WeakInnerJoin" : joinType = JoinType.Inner; buildInfo.IsWeakJoin = true; break;
+				case "LeftJoin"      : joinType = JoinType.Left;  break;
+				case "WeakLeftJoin"  : joinType = JoinType.Left;  buildInfo.IsWeakJoin = true; break;
+				case "RightJoin"     : joinType = JoinType.Right; break;
+				case "FullJoin"      : joinType = JoinType.Full;  break;
 				default:
 					conditionIndex = 2;
 

--- a/Source/LinqToDB/Linq/Builder/BuildInfo.cs
+++ b/Source/LinqToDB/Linq/Builder/BuildInfo.cs
@@ -35,6 +35,7 @@ namespace LinqToDB.Linq.Builder
 		public bool                 CreateSubQuery           { get; set; }
 		public bool                 AssociationsAsSubQueries { get; set; }
 		public JoinType             JoinType                 { get; set; }
+		public bool                 IsWeakJoin               { get; set; }
 		public bool                 IsSubQuery => Parent != null;
 
 		private bool _isAssociationBuilt;

--- a/Source/LinqToDB/Linq/Builder/SelectManyBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/SelectManyBuilder.cs
@@ -76,6 +76,7 @@ namespace LinqToDB.Linq.Builder
 						if (foundJoin != null)
 						{
 							foundJoin.JoinType = leftJoin ? JoinType.OuterApply : JoinType.CrossApply;
+							foundJoin.IsWeak = collectionInfo.IsWeakJoin;
 
 							collection.SelectQuery.Where.ConcatSearchCondition(foundJoin.Condition);
 
@@ -108,6 +109,7 @@ namespace LinqToDB.Linq.Builder
 				else
 				{
 					var join = sql.OuterApply();
+					join.JoinedTable.IsWeak = collectionInfo.IsWeakJoin;
 					sequence.SelectQuery.From.Tables[0].Joins.Add(join.JoinedTable);
 					context.Collection = new SubQueryContext(collection, sequence.SelectQuery, false);
 
@@ -140,6 +142,7 @@ namespace LinqToDB.Linq.Builder
 
 				var join = CreateJoin(joinType, sql);
 				join.JoinedTable.CanConvertApply = false;
+				join.JoinedTable.IsWeak = collectionInfo.IsWeakJoin;
 
 				if (!(joinType == JoinType.CrossApply || joinType == JoinType.OuterApply))
 				{
@@ -178,6 +181,7 @@ namespace LinqToDB.Linq.Builder
 					joinType = leftJoin ? JoinType.OuterApply : JoinType.CrossApply;
 
 				var join = CreateJoin(joinType, sql);
+				join.JoinedTable.IsWeak = collectionInfo.IsWeakJoin;
 
 				if (!(joinType == JoinType.CrossApply || joinType == JoinType.OuterApply))
 				{

--- a/Source/LinqToDB/LinqExtensions.cs
+++ b/Source/LinqToDB/LinqExtensions.cs
@@ -2857,6 +2857,37 @@ namespace LinqToDB
 		}
 
 		/// <summary>
+		/// Defines inner join between two sub-queries or tables.
+		/// It is special case of INNER JOIN which can be removed by optimizer if joined data is not used for projection or in other parts of SQL.
+		/// </summary>
+		/// <typeparam name="TSource">Type of record for right join operand.</typeparam>
+		/// <param name="source">Right join operand.</param>
+		/// <param name="predicate">Join predicate.</param>
+		/// <remarks>Ensure that INNER JOIN do not filter out or multiply records, otherwise for different projections count of result records can be changed.</remarks>
+		/// <returns>Right operand.</returns>
+		[Pure]
+		[LinqTunnel]
+		public static IQueryable<TSource> WeakInnerJoin<TSource>(
+			[NotNull] this IQueryable<TSource>        source,
+			[NotNull, InstantHandle] Expression<Func<TSource, bool>> predicate)
+		{
+			if (source    == null) throw new ArgumentNullException(nameof(source));
+			if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+			var currentSource = ProcessSourceQueryable?.Invoke(source) ?? source;
+
+			return currentSource.Provider.CreateQuery<TSource>(
+				Expression.Call(
+					null,
+					MethodHelper.GetMethodInfo(WeakInnerJoin, source, predicate),
+					new[]
+					{
+						currentSource.Expression,
+						Expression.Quote(predicate)
+					}));
+		}
+
+		/// <summary>
 		/// Defines inner or outer join between two sub-queries or tables.
 		/// </summary>
 		/// <typeparam name="TOuter">Type of record for left join operand.</typeparam>
@@ -2893,6 +2924,38 @@ namespace LinqToDB
 		{
 			return Join(source, SqlJoinType.Left, predicate);
 		}
+
+		/// <summary>
+		/// Defines weak left outer join between two sub-queries or tables.
+		/// It is special case of LEFT JOIN which can be removed by optimizer if joined data is not used for projection or in other parts of SQL.
+		/// </summary>
+		/// <typeparam name="TSource">Type of record for right join operand.</typeparam>
+		/// <param name="source">Right join operand.</param>
+		/// <param name="predicate">Join predicate.</param>
+		/// <remarks>Ensure that LEFT JOIN do not multiply records, otherwise for different projections count of result records can be changed.</remarks>
+		/// <returns>Right operand.</returns>
+		[Pure]
+		[LinqTunnel]
+		public static IQueryable<TSource> WeakLeftJoin<TSource>(
+			[NotNull] this IQueryable<TSource>        source,
+			[NotNull, InstantHandle] Expression<Func<TSource, bool>> predicate)
+		{
+			if (source    == null) throw new ArgumentNullException(nameof(source));
+			if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+			var currentSource = ProcessSourceQueryable?.Invoke(source) ?? source;
+
+			return currentSource.Provider.CreateQuery<TSource>(
+				Expression.Call(
+					null,
+					MethodHelper.GetMethodInfo(WeakLeftJoin, source, predicate),
+					new[]
+					{
+						currentSource.Expression,
+						Expression.Quote(predicate)
+					}));
+		}
+
 
 		/// <summary>
 		/// Defines left outer join between two sub-queries or tables.

--- a/Tests/Linq/Linq/WeakJoinTests.cs
+++ b/Tests/Linq/Linq/WeakJoinTests.cs
@@ -5,7 +5,7 @@ using LinqToDB.Mapping;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
 
-namespace Tests.Playground
+namespace Tests.Linq
 {
 	[TestFixture]
 	public class WeakJoinTests : TestBase
@@ -62,25 +62,27 @@ namespace Tests.Playground
 						J2 = j2
 					};
 
-				//var projection1 =
-				//	from q in query
-				//	select new
-				//	{
-				//		q.T,
-				//		q.J2.Value
-				//	};
+				var projection1 =
+					from q in query
+					select new
+					{
+						q.T,
+						q.J2.Value
+					};
 
-				//var result1 = projection1.ToArray();
+				var result1 = projection1.ToArray();
+				Assert.That(projection1.GetTableSource().Joins.Count, Is.EqualTo(2));
 
-				//var projection2 =
-				//	from q in query
-				//	select new
-				//	{
-				//		q.T,
-				//		q.J1.Value
-				//	};
+				var projection2 =
+					from q in query
+					select new
+					{
+						q.T,
+						q.J1.Value
+					};
 
-				//var result2 = projection2.ToArray();
+				var result2 = projection2.ToArray();
+				Assert.That(projection2.GetTableSource().Joins.Count, Is.EqualTo(1));
 
 				var projection3 =
 					from q in query
@@ -91,6 +93,7 @@ namespace Tests.Playground
 					};
 
 				var result3 = projection3.ToArray();
+				Assert.That(projection3.GetTableSource().Joins.Count, Is.EqualTo(0));
 			}
 		}
 	}

--- a/Tests/Tests.Playground/WeakJoinTests.cs
+++ b/Tests/Tests.Playground/WeakJoinTests.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Linq;
+using LinqToDB;
+using LinqToDB.Mapping;
+using NUnit.Framework;
+using NUnit.Framework.Constraints;
+
+namespace Tests.Playground
+{
+	[TestFixture]
+	public class WeakJoinTests : TestBase
+	{
+		[Table]
+		class SampleTable
+		{
+			[Column] public int Id    { get; set; }
+			[Column] public int Value { get; set; }
+		}
+
+		[Table]
+		class JointedTable
+		{
+			[Column] public int Id       { get; set; }
+			[Column] public int Value    { get; set; }
+			[Column] public int ParentId { get; set; }
+		}
+
+		static Tuple<SampleTable[], JointedTable[]> GenerateTestData()
+		{
+			var items1 = Enumerable.Range(0, 10).Select((e, i) => new SampleTable
+			{
+				Id = i,
+				Value = i * 100
+			}).ToArray();
+				
+			var items2 = Enumerable.Range(0, 10).Select((e, i) => new JointedTable
+			{
+				Id = i,
+				Value = i * 1000,
+				ParentId = i
+			}).ToArray();
+
+			return Tuple.Create(items1, items2);
+		}
+
+		[Test]
+		public void WeakInnerJoinTests([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			var (items, joinedItems) = GenerateTestData();
+			using (var db = GetDataContext(context))
+			using (var table = db.CreateLocalTable(items))
+			using (var forJoin = db.CreateLocalTable(joinedItems))
+			{
+				var query =
+					from t in table
+					from j1 in forJoin.WeakInnerJoin(j1 => t.Id == j1.ParentId)
+					from j2 in forJoin.WeakInnerJoin(j2 => t.Id == j1.Id)
+					select new
+					{
+						T = t,
+						J1 = j1,
+						J2 = j2
+					};
+
+				//var projection1 =
+				//	from q in query
+				//	select new
+				//	{
+				//		q.T,
+				//		q.J2.Value
+				//	};
+
+				//var result1 = projection1.ToArray();
+
+				//var projection2 =
+				//	from q in query
+				//	select new
+				//	{
+				//		q.T,
+				//		q.J1.Value
+				//	};
+
+				//var result2 = projection2.ToArray();
+
+				var projection3 =
+					from q in query
+					select new
+					{
+						q.T,
+						q.T.Value
+					};
+
+				var result3 = projection3.ToArray();
+			}
+		}
+	}
+}


### PR DESCRIPTION
Added possibility to define `WeakInnerJoin` and `WeakLeftJoin`.
Example of usage:
```cs
var query =
	from t in table
	from j1 in forJoin.WeakInnerJoin(j1 => t.Id == j1.ParentId)
	from j2 in forJoin.WeakInnerJoin(j2 => t.Id == j1.Id)
	select new
	{
		T = t,
		J1 = j1,
		J2 = j2
	};
```
It adds benefits if you simplify projection. For example if you select from this query field which do not belong to Weak join, it will be removed automatically.
The following query will contain NO JOINS and will run a lot faster.
```cs
query.Select(e => e.t);
```

TODO:
- [x] More tests

