### PR TITLE
Fix SQL Server connection initialization for T4 template

### DIFF
--- a/Source/LinqToDB.Templates/LinqToDB.SqlServer.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.SqlServer.ttinclude
@@ -70,7 +70,7 @@ LinqToDB.Data.DataConnection GetSqlServerConnection(
 	SqlServerVersion  version  = SqlServerVersion.v2008,
 	SqlServerProvider provider = SqlServerProvider.SystemDataSqlClient)
 {
-	return GetSqlServerConnection(string.Format("Data Source={0};Database={1};Integrated Security=SSPI", server, database, version, provider));
+	return GetSqlServerConnection(string.Format("Data Source={0};Database={1};Integrated Security=SSPI", server, database), version, provider);
 }
 
 LinqToDB.Data.DataConnection GetSqlServerConnection(string server, string database, string user, string password,


### PR DESCRIPTION
I have noticed a typo, where parameters were passed to `string.Format` instead of `GetSqlServerConnection` method. I do not think there is an active issue for that.