### PR TITLE
Updates for SQL Server 2000 testing

### DIFF
--- a/Data/Create Scripts/SqlServer2000.sql
+++ b/Data/Create Scripts/SqlServer2000.sql
@@ -690,10 +690,6 @@ CREATE TABLE Issue1144
 	CONSTRAINT PK_Issue1144 PRIMARY KEY CLUSTERED (id ASC)
 )
 GO
--- EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Column description' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1name=N'Issue1144', @level2type=N'COLUMN',@level2name=N'id'
--- EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Index description' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1name=N'Issue1144', @level2type=N'INDEX',@level2name=N'PK_Issue1144'
-
--- GO
 
 DROP Procedure Issue1897
 GO

--- a/Data/Create Scripts/SqlServer2000.sql
+++ b/Data/Create Scripts/SqlServer2000.sql
@@ -690,10 +690,10 @@ CREATE TABLE Issue1144
 	CONSTRAINT PK_Issue1144 PRIMARY KEY CLUSTERED (id ASC)
 )
 GO
-EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Column description' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1name=N'Issue1144', @level2type=N'COLUMN',@level2name=N'id'
-EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Index description' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1name=N'Issue1144', @level2type=N'INDEX',@level2name=N'PK_Issue1144'
+-- EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Column description' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1name=N'Issue1144', @level2type=N'COLUMN',@level2name=N'id'
+-- EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Index description' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1name=N'Issue1144', @level2type=N'INDEX',@level2name=N'PK_Issue1144'
 
-GO
+-- GO
 
 DROP Procedure Issue1897
 GO

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2000SchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2000SchemaProvider.cs
@@ -15,10 +15,8 @@ namespace LinqToDB.DataProvider.SqlServer
 
 		protected override void InitProvider(DataConnection dataConnection)
 		{
-			var version = dataConnection.Execute<string>("select @@version");
-
-			_isAzure = false;
-			_compatibilityLevel = dataConnection.Execute<int>("SELECT cmptlevel FROM master.dbo.sysdatabases WHERE name = db_name()");
+			IsAzure            = false;
+			CompatibilityLevel = dataConnection.Execute<int>("SELECT cmptlevel FROM master.dbo.sysdatabases WHERE name = db_name()");
 		}
 
 		protected override List<TableInfo> GetTables(DataConnection dataConnection)

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2000SchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2000SchemaProvider.cs
@@ -13,6 +13,14 @@ namespace LinqToDB.DataProvider.SqlServer
 		{
 		}
 
+		protected override void InitProvider(DataConnection dataConnection)
+		{
+			var version = dataConnection.Execute<string>("select @@version");
+
+			_isAzure = false;
+			_compatibilityLevel = dataConnection.Execute<int>("SELECT cmptlevel FROM master.dbo.sysdatabases WHERE name = db_name()");
+		}
+
 		protected override List<TableInfo> GetTables(DataConnection dataConnection)
 		{
 			return dataConnection.Query<TableInfo>(@"
@@ -99,6 +107,5 @@ namespace LinqToDB.DataProvider.SqlServer
 					Ordinal")
 				.ToList();
 		}
-
 	}
 }

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerSchemaProvider.cs
@@ -11,8 +11,8 @@ namespace LinqToDB.DataProvider.SqlServer
 
 	class SqlServerSchemaProvider : SchemaProviderBase
 	{
-		bool _isAzure;
-		int _compatibilityLevel;
+		protected bool _isAzure;
+		protected int _compatibilityLevel;
 
 		protected readonly SqlServerDataProvider Provider;
 

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerSchemaProvider.cs
@@ -11,8 +11,8 @@ namespace LinqToDB.DataProvider.SqlServer
 
 	class SqlServerSchemaProvider : SchemaProviderBase
 	{
-		protected bool _isAzure;
-		protected int _compatibilityLevel;
+		protected bool IsAzure;
+		protected int  CompatibilityLevel;
 
 		protected readonly SqlServerDataProvider Provider;
 
@@ -25,14 +25,14 @@ namespace LinqToDB.DataProvider.SqlServer
 		{
 			var version = dataConnection.Execute<string>("select @@version");
 
-			_isAzure            = version.IndexOf("Azure", StringComparison.Ordinal) >= 0;
-			_compatibilityLevel = dataConnection.Execute<int>("SELECT compatibility_level FROM sys.databases WHERE name = db_name()");
+			IsAzure            = version.IndexOf("Azure", StringComparison.Ordinal) >= 0;
+			CompatibilityLevel = dataConnection.Execute<int>("SELECT compatibility_level FROM sys.databases WHERE name = db_name()");
 		}
 
 		protected override List<TableInfo> GetTables(DataConnection dataConnection)
 		{
 			return dataConnection.Query<TableInfo>(
-				_isAzure ? @"
+				IsAzure ? @"
 				SELECT
 					TABLE_CATALOG COLLATE DATABASE_DEFAULT + '.' + TABLE_SCHEMA + '.' + TABLE_NAME as TableID,
 					TABLE_CATALOG                                                                  as CatalogName,
@@ -90,7 +90,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		protected override IReadOnlyCollection<PrimaryKeyInfo> GetPrimaryKeys(DataConnection dataConnection, IEnumerable<TableSchema> tables)
 		{
 			return dataConnection.Query<PrimaryKeyInfo>(
-				_isAzure
+				IsAzure
 				? @"
 				SELECT
 					k.TABLE_CATALOG COLLATE DATABASE_DEFAULT + '.' + k.TABLE_SCHEMA + '.' + k.TABLE_NAME as TableID,
@@ -129,7 +129,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		protected override List<ColumnInfo> GetColumns(DataConnection dataConnection, GetSchemaOptions options)
 		{
 			return dataConnection.Query<ColumnInfo>(
-				_isAzure ? @"
+				IsAzure ? @"
 				SELECT
 					TABLE_CATALOG COLLATE DATABASE_DEFAULT + '.' + TABLE_SCHEMA + '.' + TABLE_NAME                      as TableID,
 					COLUMN_NAME                                                                                         as Name,
@@ -264,7 +264,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		protected override List<ProcedureInfo> GetProcedures(DataConnection dataConnection)
 		{
 			return dataConnection.Query<ProcedureInfo>(
-				_isAzure
+				IsAzure
 				? @"SELECT
 					SPECIFIC_CATALOG COLLATE DATABASE_DEFAULT + '.' + SPECIFIC_SCHEMA + '.' + SPECIFIC_NAME as ProcedureID,
 					SPECIFIC_CATALOG                                                                        as CatalogName,
@@ -295,7 +295,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		protected override List<ProcedureParameterInfo> GetProcedureParameters(DataConnection dataConnection, IEnumerable<ProcedureInfo> procedures, GetSchemaOptions options)
 		{
 			return dataConnection.Query<ProcedureParameterInfo>(
-				_isAzure
+				IsAzure
 				? @"SELECT
 					SPECIFIC_CATALOG COLLATE DATABASE_DEFAULT + '.' + SPECIFIC_SCHEMA + '.' + SPECIFIC_NAME as ProcedureID,
 					ORDINAL_POSITION                                                                        as Ordinal,
@@ -471,7 +471,7 @@ namespace LinqToDB.DataProvider.SqlServer
 
 			// TODO: refactor method to use query as parameter instead of manual escaping...
 			// https://github.com/linq2db/linq2db/issues/1921
-			if (_compatibilityLevel >= 140)
+			if (CompatibilityLevel >= 140)
 				sql = $"EXEC('{sql.Replace("'", "''")}')";
 
 			return sql;

--- a/Source/LinqToDB/Sql/Sql.Strings.cs
+++ b/Source/LinqToDB/Sql/Sql.Strings.cs
@@ -383,6 +383,27 @@ namespace LinqToDB
 			}
 		}
 
+		class SqlServer2000ConcatWsBuilder : BaseEmulationConcatWsBuilder
+		{
+			protected override SqlExpression IsNullExpression(ISqlExpression value)
+			{
+				return new SqlExpression(typeof(string), "ISNULL({0}, '')", Precedence.Primary, value);
+			}
+
+			protected override SqlExpression StringConcatExpression(ISqlExpression value1, ISqlExpression value2)
+			{
+				return new SqlExpression(typeof(string), "{0} + {1}", value1, value2);
+			}
+
+			protected override SqlExpression TruncateExpression(ISqlExpression value, ISqlExpression separator)
+			{
+				// you can read more about this gore code here:
+				// https://stackoverflow.com/questions/2025585
+				return new SqlExpression(typeof(string), "SUBSTRING({0}, LEN(CONVERT(NVARCHAR(4000), {1}) + N'!'), 4000)",
+					Precedence.Primary, value, separator);
+			}
+		}
+
 		class SqliteConcatWsBuilder : BaseEmulationConcatWsBuilder
 		{
 			protected override SqlExpression IsNullExpression(ISqlExpression value)
@@ -412,6 +433,7 @@ namespace LinqToDB
 		[Sql.Extension(PN.PostgreSQL,    "CONCAT_WS({separator}, {argument, ', '})", BuilderType = typeof(CommonConcatWsArgumentsBuilder), BuilderValue = null)]
 		[Sql.Extension(PN.MySql,         "CONCAT_WS({separator}, {argument, ', '})", BuilderType = typeof(CommonConcatWsArgumentsBuilder), BuilderValue = null)]
 		[Sql.Extension(PN.SqlServer,     "", BuilderType = typeof(OldSqlServerConcatWsBuilder))]
+		[Sql.Extension(PN.SqlServer2000, "", BuilderType = typeof(SqlServer2000ConcatWsBuilder))]
 		[Sql.Extension(PN.SQLite,        "", BuilderType = typeof(SqliteConcatWsBuilder))]
 		public static string ConcatStrings(
 			[ExprParameter] string separator,

--- a/Tests/Base/TestUtils.cs
+++ b/Tests/Base/TestUtils.cs
@@ -103,7 +103,6 @@ namespace Tests
 				case ProviderName.DB2:
 				case ProviderName.Sybase:
 				case ProviderName.SybaseManaged:
-				case ProviderName.SqlServer2000:
 				case ProviderName.SqlServer2005:
 				case ProviderName.SqlServer2008:
 				case ProviderName.SqlServer2012:
@@ -113,6 +112,8 @@ namespace Tests
 				case ProviderName.SapHanaNative:
 				case ProviderName.SapHanaOdbc:
 					return db.GetTable<LinqDataTypes>().Select(_ => SchemaName()).First();
+				case ProviderName.SqlServer2000:
+					return db.FromSql<string>($"SELECT TABLE_SCHEMA FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = {nameof(LinqDataTypes)}").First();
 			}
 
 			return NO_SCHEMA_NAME;

--- a/Tests/Linq/Data/MiniProfilerTests.cs
+++ b/Tests/Linq/Data/MiniProfilerTests.cs
@@ -537,6 +537,7 @@ namespace Tests.Data
 			}
 
 			var tvpSupported = version >= SqlServerVersion.v2008;
+			var hierarchyidSupported = version >= SqlServerVersion.v2008;
 
 			var unmapped = type == ConnectionType.MiniProfilerNoMappings;
 #if NET46
@@ -565,11 +566,14 @@ namespace Tests.Data
 				Assert.AreEqual(2, db.Execute<int>("SELECT ID FROM AllTypes WHERE smalldatetimeDataType = @p", new DataParameter("@p", new DateTime(2012, 12, 12, 12, 12, 00), DataType.SmallDateTime)));
 				Assert.True    (trace.Contains("DECLARE @p SmallDateTime "));
 
-				//// assert UDT type name
-				var hid = SqlHierarchyId.Parse("/1/3/");
-				Assert.AreEqual(hid, db.Execute<SqlHierarchyId>("SELECT Cast(@p as hierarchyid)", new DataParameter("@p", hid, DataType.Udt)));
-				Assert.True    (trace.Contains("DECLARE @p hierarchyid -- Udt"));
-				Assert.AreEqual(hid, db.Execute<object>("SELECT Cast(@p as hierarchyid)", new DataParameter("@p", hid, DataType.Udt)));
+				if (hierarchyidSupported)
+				{
+					//// assert UDT type name
+					var hid = SqlHierarchyId.Parse("/1/3/");
+					Assert.AreEqual(hid, db.Execute<SqlHierarchyId>("SELECT Cast(@p as hierarchyid)", new DataParameter("@p", hid, DataType.Udt)));
+					Assert.True(trace.Contains("DECLARE @p hierarchyid -- Udt"));
+					Assert.AreEqual(hid, db.Execute<object>("SELECT Cast(@p as hierarchyid)", new DataParameter("@p", hid, DataType.Udt)));
+				}
 
 				if (tvpSupported)
 				{

--- a/Tests/Linq/DataProvider/SqlServerTests.cs
+++ b/Tests/Linq/DataProvider/SqlServerTests.cs
@@ -399,7 +399,15 @@ namespace Tests.DataProvider
 				Assert.That(conn.Execute<string>("SELECT Cast('12345' as varchar(20))"),   Is.EqualTo("12345"));
 				Assert.That(conn.Execute<string>("SELECT Cast(NULL    as varchar(20))"),   Is.Null);
 
-				var isScCollation = conn.Execute<int>("SELECT COUNT(*) FROM sys.Databases WHERE database_id = DB_ID() AND collation_name LIKE '%_SC'") > 0;
+				bool isScCollation; 
+				if (context == ProviderName.SqlServer2000)
+				{
+					isScCollation = false;
+				}
+				else
+				{
+					isScCollation = conn.Execute<int>("SELECT COUNT(*) FROM sys.Databases WHERE database_id = DB_ID() AND collation_name LIKE '%_SC'") > 0;
+				}
 				if (isScCollation)
 				{
 					// explicit collation set for legacy text types as they doesn't support *_SC collations
@@ -650,7 +658,7 @@ namespace Tests.DataProvider
 		}
 
 		[Test]
-		public void TestXml([IncludeDataSources(TestProvName.AllSqlServer)] string context)
+		public void TestXml([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
 		{
 			using (var conn = new DataConnection(context))
 			{

--- a/Tests/Linq/Linq/SetOperatorTests.cs
+++ b/Tests/Linq/Linq/SetOperatorTests.cs
@@ -20,7 +20,7 @@ namespace Tests.Playground
 		}
 
 		[Test]
-		public void TestExcept([DataSources] string context)
+		public void TestExcept([DataSources(ProviderName.SqlServer2000)] string context)
 		{
 			var testData = GenerateTestData();
 			using (var db = GetDataContext(context))
@@ -88,7 +88,7 @@ namespace Tests.Playground
 		}
 
 		[Test]
-		public void TestExceptProjection([DataSources] string context)
+		public void TestExceptProjection([DataSources(ProviderName.SqlServer2000)] string context)
 		{
 			var testData = GenerateTestData();
 			using (var db = GetDataContext(context))
@@ -112,7 +112,7 @@ namespace Tests.Playground
 		}
 
 		[Test]
-		public void TestIntersect([DataSources] string context)
+		public void TestIntersect([DataSources(ProviderName.SqlServer2000)] string context)
 		{
 			var testData = GenerateTestData();
 			using (var db = GetDataContext(context))

--- a/Tests/Linq/Linq/SetTests.cs
+++ b/Tests/Linq/Linq/SetTests.cs
@@ -6,13 +6,14 @@ using NUnit.Framework;
 
 namespace Tests.Linq
 {
+	using LinqToDB;
 	using Model;
 
 	[TestFixture]
 	public class SetTests : TestBase
 	{
 		[Test]
-		public void Except1([DataSources] string context)
+		public void Except1([DataSources(ProviderName.SqlServer2000)] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -21,7 +22,7 @@ namespace Tests.Linq
 		}
 
 		//[Test]
-		public void Except2([DataSources] string context)
+		public void Except2([DataSources(ProviderName.SqlServer2000)] string context)
 		{
 			var ids = new[] { 1, 2 };
 
@@ -32,7 +33,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void Intersect([DataSources] string context)
+		public void Intersect([DataSources(ProviderName.SqlServer2000)] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(

--- a/Tests/Linq/UserTests/Issue1303Tests.cs
+++ b/Tests/Linq/UserTests/Issue1303Tests.cs
@@ -21,7 +21,7 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void TestBinary([DataSources] string context, [Values] bool inlineParameters)
+		public void TestBinary([DataSources(ProviderName.SqlServer2000)] string context, [Values] bool inlineParameters)
 		{
 			using (var db  = GetDataContext(context))
 			using (var tbl = db.CreateLocalTable<Issue1303>())

--- a/Tests/Linq/UserTests/Issue133Tests.cs
+++ b/Tests/Linq/UserTests/Issue133Tests.cs
@@ -12,7 +12,7 @@ namespace Tests.UserTests
 		public class SupportsAnalyticFunctionsContextAttribute: IncludeDataSourcesAttribute
 		{
 			public SupportsAnalyticFunctionsContextAttribute(bool includeLinqService = true)
-				: base(includeLinqService, TestProvName.AllSqlServer, TestProvName.AllOracle)
+				: base(includeLinqService, TestProvName.AllSqlServer2005Plus, TestProvName.AllOracle)
 			{
 			}
 		}

--- a/Tests/Linq/UserTests/Issue2008Tests.cs
+++ b/Tests/Linq/UserTests/Issue2008Tests.cs
@@ -36,7 +36,7 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void Issue2008Test([IncludeDataSources(TestProvName.AllSqlServer)] string context)
+		public void Issue2008Test([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
 		{
 			using (var db = GetDataContext(context))
 			using (db.CreateLocalTable<Table1>())


### PR DESCRIPTION
This fixes the following issues with testing for SQL Server 2000:
* `sys.sp_addextendedproperty` is named differently in SQL Server 2000 with different parameters.
* `sys.databases` should be accessed via `master.dbo.sysdatabases` and has different columns
* No `SCHEMA_NAME()` function
* `hierarchyid` user-defined type not supported in SQL Server 2000/2005
* User-defined types not supported in SQL Server 2000
* Cannot query `sys.databases` for collation setting (could perhaps query the `sysobjects` table)
* No `xml` data type
* `EXCEPT` not supported
* `INTERSECT` with WHERE clause not supported (it seems)
* Cannot search a binary field
* `OUTER APPLY` not supported

The only behavior change was to the `SqlServer2000SchemaProvider`, which now issues the proper query for the current database's compatibility level.  All other changes were in the tests.

In addition to the above, string concatenation contains a cast to `nvarchar(max)` in certain cases.  SQL Server 2000 does not support `nvarchar(max)` or `varchar(max)`.  I did not fix the tests failing due to that behavior, as it seemed that the behavior should be fixed:
* `Issue1977Tests.Test`
* `Tests.Linq.StringFunctionsTests.ConcatStringsTest`

This has been tested with SQL Server 2000 Standard SP4 running on Windows Server 2008 Standard x86.  Besides the two listed above, all other tests pass.