### PR TITLE
Draft: Use ValueTask for .Net 4.5 / .Net 4.6

### DIFF
--- a/NuGet/linq2db.nuspec
+++ b/NuGet/linq2db.nuspec
@@ -9,8 +9,12 @@
 			linq linq2db LinqToDB ORM database DB SQL SqlServer Access SqlCe SqlServerCe MySql Firebird SQLite Sybase Oracle ODP PostgreSQL DB2 Informix SapHana
 		</tags>
 		<dependencies>
-			<group targetFramework=".NETFramework4.5" />
-			<group targetFramework=".NETFramework4.6" />
+			<group targetFramework=".NETFramework4.5">
+				<dependency id="System.Threading.Tasks.Extensions"    version="4.5.4" />
+			</group>
+			<group targetFramework=".NETFramework4.6">
+				<dependency id="System.Threading.Tasks.Extensions"    version="4.5.4" />
+			</group>
 			<group targetFramework=".NETStandard2.0">
 				<dependency id="Microsoft.CSharp"                     version="4.7.0" />
 				<dependency id="System.ComponentModel.Annotations"    version="4.7.0" />

--- a/Source/LinqToDB/Async/AsyncDbConnection.cs
+++ b/Source/LinqToDB/Async/AsyncDbConnection.cs
@@ -97,23 +97,14 @@ namespace LinqToDB.Async
 			Connection.Dispose();
 		}
 
-#if NET45 || NET46
-		public virtual Task DisposeAsync()
-		{
-			Dispose();
-
-			return TaskEx.CompletedTask;
-		}
-#else
 		public virtual ValueTask DisposeAsync()
 		{
 			if (Connection is IAsyncDisposable asyncDisposable) 
 				return asyncDisposable.DisposeAsync();
 
 			Dispose();
-			return new ValueTask(Task.CompletedTask);
+			return new ValueTask(TaskEx.CompletedTask);
 		}
-#endif
 
 		public virtual IAsyncDbConnection? TryClone()
 		{

--- a/Source/LinqToDB/Async/AsyncDbTransaction.cs
+++ b/Source/LinqToDB/Async/AsyncDbTransaction.cs
@@ -43,23 +43,14 @@ namespace LinqToDB.Async
 			Transaction.Dispose();
 		}
 
-#if NET45 || NET46
-		public virtual Task DisposeAsync()
-		{
-			Dispose();
-
-			return TaskEx.CompletedTask;
-		}
-#else
 		public virtual ValueTask DisposeAsync()
 		{
 			if (Transaction is IAsyncDisposable asyncDisposable)
 				return asyncDisposable.DisposeAsync();
 
 			Dispose();
-			return new ValueTask(Task.CompletedTask);
+			return new ValueTask(TaskEx.CompletedTask);
 		}
-#endif
 
 		public virtual void Rollback()
 		{

--- a/Source/LinqToDB/Async/AsyncExtensions.cs
+++ b/Source/LinqToDB/Async/AsyncExtensions.cs
@@ -61,17 +61,18 @@ namespace LinqToDB.Async
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
 			var result = new List<T>();
-#if NET45 || NET46
-			using (var enumerator = source.GetAsyncEnumerator(cancellationToken))
-#else
 			var enumerator = source.GetAsyncEnumerator(cancellationToken);
-			await using (enumerator.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
-#endif
+			//await using (enumerator.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
+			try
 			{
 				while (await enumerator.MoveNextAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
 				{
 					result.Add(enumerator.Current);
 				}
+			}
+			finally
+			{
+				await enumerator.DisposeAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			}
 
 			return result;
@@ -131,16 +132,17 @@ namespace LinqToDB.Async
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
-#if NET45 || NET46
-			using (var enumerator = source.GetAsyncEnumerator(cancellationToken))
-#else
 			var enumerator = source.GetAsyncEnumerator(cancellationToken);
-			await using (enumerator.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
-#endif
+			//await using (enumerator.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
+			try
 			{
 				if (await enumerator.MoveNextAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
 					return enumerator.Current;
 				return default!;
+			}
+			finally
+			{
+				await enumerator.DisposeAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			}
 		}
 
@@ -156,15 +158,16 @@ namespace LinqToDB.Async
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
-#if NET45 || NET46
-			using (var enumerator = source.GetAsyncEnumerator(token))
-#else
 			var enumerator = source.GetAsyncEnumerator(token);
-			await using (enumerator.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
-#endif
+			//await using (enumerator.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
+			try
 			{
 				if (await enumerator.MoveNextAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
 					return enumerator.Current;
+			}
+			finally
+			{
+				await enumerator.DisposeAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			}
 
 			throw new InvalidOperationException("The source sequence is empty.");

--- a/Source/LinqToDB/Async/IAsyncDbConnection.cs
+++ b/Source/LinqToDB/Async/IAsyncDbConnection.cs
@@ -11,10 +11,7 @@ namespace LinqToDB.Async
 	/// Asynchronous version of the <see cref="IDbConnection"/> interface, allowing asynchronous operations, missing from <see cref="IDbConnection"/>.
 	/// </summary>
 	[PublicAPI]
-	public interface IAsyncDbConnection : IDbConnection
-#if !NET45 && !NET46
-		, IAsyncDisposable
-#endif
+	public interface IAsyncDbConnection : IDbConnection, IAsyncDisposable
 	{
 		/// <summary>
 		/// Starts new transaction asynchronously for current connection with default isolation level.
@@ -43,14 +40,6 @@ namespace LinqToDB.Async
 		/// <param name="cancellationToken">Asynchronous operation cancellation token.</param>
 		/// <returns>Async operation task.</returns>
 		Task OpenAsync(CancellationToken cancellationToken = default);
-
-#if NET45 || NET46
-		/// <summary>
-		/// Disposes current connection asynchonously.
-		/// </summary>
-		/// <returns>Async operation task.</returns>
-		Task DisposeAsync();
-#endif
 
 		/// <summary>
 		/// Gets underlying connection instance.

--- a/Source/LinqToDB/Async/IAsyncDbTransaction.cs
+++ b/Source/LinqToDB/Async/IAsyncDbTransaction.cs
@@ -11,10 +11,7 @@ namespace LinqToDB.Async
 	/// Asynchronous version of the <see cref="IDbTransaction"/> interface, allowing asynchronous operations, missing from <see cref="IDbTransaction"/>.
 	/// </summary>
 	[PublicAPI]
-	public interface IAsyncDbTransaction : IDbTransaction
-#if !NET45 && !NET46
-		, IAsyncDisposable
-#endif
+	public interface IAsyncDbTransaction : IDbTransaction, IAsyncDisposable
 	{
 		/// <summary>
 		/// Commits transaction asynchronously.
@@ -34,13 +31,5 @@ namespace LinqToDB.Async
 		/// Gets underlying transaction instance.
 		/// </summary>
 		IDbTransaction Transaction { get; }
-
-#if NET45 || NET46
-		/// <summary>
-		/// Disposes transaction asynchronously.
-		/// </summary>
-		/// <returns>Asynchronous operation completion task.</returns>
-		Task DisposeAsync();
-#endif
 	}
 }

--- a/Source/LinqToDB/Async/IAsyncDisposable.cs
+++ b/Source/LinqToDB/Async/IAsyncDisposable.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+
+namespace LinqToDB.Async
+{
+	/// <summary>
+	/// Provides a mechanism for releasing unmanaged resources asynchronously.
+	/// </summary>
+	public interface IAsyncDisposable
+	{
+		/// <summary>
+		/// Performs application-defined tasks associated with freeing, releasing, or resetting
+		/// unmanaged resources asynchronously.
+		/// </summary>
+		/// <returns>
+		/// A task that represents the asynchronous dispose operation.
+		/// </returns>
+		/// <returns></returns>
+		public ValueTask DisposeAsync();
+	}
+}

--- a/Source/LinqToDB/Async/IAsyncEnumerator.cs
+++ b/Source/LinqToDB/Async/IAsyncEnumerator.cs
@@ -11,7 +11,7 @@ namespace LinqToDB.Async
 	/// </summary>
 	/// <typeparam name="T">Element type.</typeparam>
 	[PublicAPI]
-	public interface IAsyncEnumerator<out T> : IDisposable
+	public interface IAsyncEnumerator<out T> : IDisposable, IAsyncDisposable
 	{
 		/// <summary>Gets the current element in the iteration.</summary>
 		T Current { get; }
@@ -23,11 +23,6 @@ namespace LinqToDB.Async
 		/// Task containing the result of the operation: true if the enumerator was successfully advanced
 		/// to the next element; false if the enumerator has passed the end of the sequence.
 		/// </returns>
-		Task<bool> MoveNextAsync();
-
-		/// <summary>
-		/// Disposes the object asynchonously.
-		/// </summary>
-		Task DisposeAsync();
+		ValueTask<bool> MoveNextAsync();
 	}
 }

--- a/Source/LinqToDB/Async/ReflectedAsyncDbConnection.cs
+++ b/Source/LinqToDB/Async/ReflectedAsyncDbConnection.cs
@@ -53,16 +53,9 @@ namespace LinqToDB.Async
 			return _closeAsync?.Invoke(Connection) ?? base.CloseAsync();
 		}
 
-#if NET45 || NET46
-		public override Task DisposeAsync()
-		{
-			return _disposeAsync?.Invoke(Connection) ?? base.DisposeAsync();
-		}
-#else
 		public override ValueTask DisposeAsync()
 		{
 			return _disposeAsync != null ? new ValueTask(_disposeAsync.Invoke(Connection)) : base.DisposeAsync();
 		}
-#endif
 	}
 }

--- a/Source/LinqToDB/Async/ReflectedAsyncDbTransaction.cs
+++ b/Source/LinqToDB/Async/ReflectedAsyncDbTransaction.cs
@@ -38,16 +38,9 @@ namespace LinqToDB.Async
 			return _rollbackAsync?.Invoke(Transaction, cancellationToken) ?? base.RollbackAsync(cancellationToken);
 		}
 
-#if NET45 || NET46
-		public override Task DisposeAsync()
-		{
-			return _disposeAsync?.Invoke(Connection) ?? base.DisposeAsync();
-		}
-#else
 		public override ValueTask DisposeAsync()
 		{
 			return _disposeAsync != null ? new ValueTask(_disposeAsync.Invoke(Connection)) : base.DisposeAsync();
 		}
-#endif
 	}
 }

--- a/Source/LinqToDB/AsyncExtensions.cs
+++ b/Source/LinqToDB/AsyncExtensions.cs
@@ -111,20 +111,20 @@ namespace LinqToDB
 		/// <param name="func">Function to apply to each sequence element. Returning <c>false</c> from function will stop numeration.</param>
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Asynchronous operation completion task.</returns>
-		public static Task ForEachUntilAsync<TSource>(
+		public static ValueTask ForEachUntilAsync<TSource>(
 			this IQueryable<TSource> source, Func<TSource,bool> func,
 			CancellationToken token = default)
 		{
 			if (source is ExpressionQuery<TSource> query)
 				return query.GetForEachUntilAsync(func, token);
 
-			return GetActionTask(() =>
+			return new ValueTask(GetActionTask(() =>
 			{
 				foreach (var item in source)
 					if (token.IsCancellationRequested || !func(item))
 						break;
 			},
-			token);
+			token));
 		}
 
 		#endregion

--- a/Source/LinqToDB/Data/CommandInfo.cs
+++ b/Source/LinqToDB/Data/CommandInfo.cs
@@ -691,19 +691,11 @@ namespace LinqToDB.Data
 			{
 			}
 
-#if NET45 || NET46
-			public Task DisposeAsync() => TaskEx.CompletedTask;
-#else
-			public ValueTask DisposeAsync() => new ValueTask(Task.CompletedTask);
-#endif
+			public ValueTask DisposeAsync() => new ValueTask(TaskEx.CompletedTask);
 
 			public T Current { get; set; } = default!;
 
-#if NET45 || NET46
-			public async Task<bool> MoveNextAsync()
-#else
 			public async ValueTask<bool> MoveNextAsync()
-#endif
 			{
 				if (_isFinished)
 					return false;

--- a/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
+++ b/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
@@ -468,18 +468,15 @@ namespace LinqToDB.Data
 					DataReader.Dispose();
 				}
 
-#if NETCOREAPP2_1 || NETSTANDARD2_0
 				public ValueTask DisposeAsync()
 				{
+#if NETCOREAPP3_1 || NETSTANDARD2_1
+					return _dataReader.DisposeAsync();
+#else
 					Dispose();
-					return new ValueTask(Task.CompletedTask);
-				}
-#elif NETCOREAPP3_1 || NETSTANDARD2_1
-				public ValueTask DisposeAsync()
-				{
-					 return _dataReader.DisposeAsync();
-				}
+					return new ValueTask(TaskEx.CompletedTask);
 #endif
+				}
 			}
 
 			public override async Task<IDataReaderAsync> ExecuteReaderAsync(CancellationToken cancellationToken)

--- a/Source/LinqToDB/Data/DataConnectionTransaction.cs
+++ b/Source/LinqToDB/Data/DataConnectionTransaction.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using LinqToDB.Async;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -7,10 +8,7 @@ namespace LinqToDB.Data
 	/// <summary>
 	/// Data connection transaction controller.
 	/// </summary>
-	public class DataConnectionTransaction : IDisposable
-#if !NET45 && !NET46
-		, IAsyncDisposable
-#endif
+	public class DataConnectionTransaction : IDisposable, IAsyncDisposable
 	{
 		/// <summary>
 		/// Creates new transaction controller for data connection.
@@ -76,14 +74,12 @@ namespace LinqToDB.Data
 				DataConnection.RollbackTransaction();
 		}
 
-#if !NET45 && !NET46
 		public ValueTask DisposeAsync()
 		{
 			if (_disposeTransaction)
 				return new ValueTask(DataConnection.RollbackTransactionAsync());
 
-			return new ValueTask(Task.CompletedTask);
+			return new ValueTask(TaskEx.CompletedTask);
 		}
-#endif
 	}
 }

--- a/Source/LinqToDB/Data/RetryPolicy/RetryingDbConnection.cs
+++ b/Source/LinqToDB/Data/RetryPolicy/RetryingDbConnection.cs
@@ -132,12 +132,10 @@ namespace LinqToDB.Data.RetryPolicy
 			return _connection.CloseAsync();
 		}
 
-#if NET45 || NET46
-		public Task DisposeAsync()
-#elif NETSTANDARD2_0 || NETCOREAPP2_1
-		public ValueTask DisposeAsync()
-#else
+#if NETSTANDARD2_1 || NETCOREAPP3_1
 		public override ValueTask DisposeAsync()
+#else
+		public ValueTask DisposeAsync()
 #endif
 		{
 			return _connection.DisposeAsync();

--- a/Source/LinqToDB/Linq/ExpressionQuery.cs
+++ b/Source/LinqToDB/Linq/ExpressionQuery.cs
@@ -156,7 +156,7 @@ namespace LinqToDB.Linq
 			}
 		}
 
-		public Task GetForEachUntilAsync(Func<T,bool> func, CancellationToken cancellationToken)
+		public ValueTask GetForEachUntilAsync(Func<T,bool> func, CancellationToken cancellationToken)
 		{
 			var expression = Expression;
 			return GetQuery(ref expression, true)

--- a/Source/LinqToDB/Linq/IDataReaderAsync.cs
+++ b/Source/LinqToDB/Linq/IDataReaderAsync.cs
@@ -1,14 +1,12 @@
-﻿using System;
+﻿using LinqToDB.Async;
+using System;
 using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace LinqToDB.Linq
 {
-	public interface IDataReaderAsync : IDisposable
-#if !NET45 && !NET46
-		, IAsyncDisposable
-#endif
+	public interface IDataReaderAsync : IDisposable, IAsyncDisposable
 	{
 		IDataReader DataReader { get; }
 		Task<bool>  ReadAsync(CancellationToken cancellationToken);

--- a/Source/LinqToDB/Linq/Query.cs
+++ b/Source/LinqToDB/Linq/Query.cs
@@ -256,7 +256,7 @@ namespace LinqToDB.Linq
 
 		public Func<IDataContext,Expression,object?[]?,object?[]?,IEnumerable<T>>      GetIEnumerable = null!;
 		public Func<IDataContext,Expression,object?[]?,object?[]?,IAsyncEnumerable<T>> GetIAsyncEnumerable = null!;
-		public Func<IDataContext,Expression,object?[]?,object?[]?,Func<T,bool>,CancellationToken,Task> GetForEachAsync = null!;
+		public Func<IDataContext,Expression,object?[]?,object?[]?,Func<T,bool>,CancellationToken,ValueTask> GetForEachAsync = null!;
 
 		#endregion
 

--- a/Source/LinqToDB/Linq/QueryRunner.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.cs
@@ -578,7 +578,7 @@ namespace LinqToDB.Linq
 			}
 		}
 
-		static async Task ExecuteQueryAsync<T>(
+		static async ValueTask ExecuteQueryAsync<T>(
 			Query                         query,
 			IDataContext                  dataContext,
 			Mapper<T>                     mapper,

--- a/Source/LinqToDB/LinqExtensions.cs
+++ b/Source/LinqToDB/LinqExtensions.cs
@@ -192,7 +192,7 @@ namespace LinqToDB
 		/// <param name="selector">Value selection expression.</param>
 		/// <returns>Requested value.</returns>
 		[Pure]
-		public static async Task<T> SelectAsync<T>(
+		public static async ValueTask<T> SelectAsync<T>(
 			                this IDataContext   dataContext,
 			[InstantHandle] Expression<Func<T>> selector)
 		{

--- a/Source/LinqToDB/LinqToDB.csproj
+++ b/Source/LinqToDB/LinqToDB.csproj
@@ -44,6 +44,7 @@
 		</None>
 
 		<Compile Remove="Compatibility\**\*.cs" />
+
 		<Compile Include="Compatibility\System\Threading\Tasks\TaskEx.cs" />
 	</ItemGroup>
 
@@ -59,6 +60,7 @@
 		<Reference Include="System.ComponentModel.DataAnnotations" />
 
 		<Compile Include="Compatibility\System\Diagnostics\CodeAnalysis\NullableAttributes.cs" />
+		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
@@ -94,6 +96,7 @@
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp2.1' ">
 		<Compile Remove="Async\IAsyncEnumerable.cs" />
 		<Compile Remove="Async\IAsyncEnumerator.cs" />
-	  <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
+		<Compile Remove="Async\IAsyncDisposable.cs" />
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
 	</ItemGroup>
 </Project>

--- a/Source/LinqToDB/Properties/AssemblyInfo.cs
+++ b/Source/LinqToDB/Properties/AssemblyInfo.cs
@@ -16,7 +16,7 @@ using LinqToDB;
 [assembly: Guid                    ("080146c6-967e-4bbf-afdf-a9e0fa01d9c2")]
 [assembly: CLSCompliant            (true)]
 [assembly: NeutralResourcesLanguage("en-US")]
-[assembly: AllowPartiallyTrustedCallers]
+//[assembly: AllowPartiallyTrustedCallers]
 
 [assembly: InternalsVisibleTo("linq2db.Tools, PublicKey=" +
 	"002400000480000094000000060200000024000052534131000400000100010021259e121b7fbc" +

--- a/Source/LinqToDB/ServiceModel/RemoteDataContextBase.QueryRunner.cs
+++ b/Source/LinqToDB/ServiceModel/RemoteDataContextBase.QueryRunner.cs
@@ -246,6 +246,12 @@ namespace LinqToDB.ServiceModel
 				{
 					DataReader.Dispose();
 				}
+
+				public ValueTask DisposeAsync()
+				{
+					DataReader.Dispose();
+					return new ValueTask(TaskEx.CompletedTask);
+				}
 			}
 
 			public override async Task<IDataReaderAsync> ExecuteReaderAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
This builds on #2303 and imports the `System.Threading.Tasks.Extensions` nuget package for .Net 4.5 and .Net 4.6.  However, it doesn't work.  So far I get this error:
```
System.MethodAccessException : Attempt by method 'LinqToDB.Linq.QueryRunner+<ExecuteQueryAsync>d__14`1<T>.MoveNext()' to access method 'LinqToDB.Async.IAsyncDisposable.DisposeAsync()' failed.
```
It seems that the problem occurs when the JiT compiler attempts to compile the `QueryRunner.ExecuteQueryAsync` code, which contains a reference to the `DisposeAsync()` method -- so in a sense, it's not a runtime error, although it's occurring at runtime.

I've tried multiple techniques to get past this problem, but all have failed.  If anyone has any ideas, please take a look and/or try making additional changes to the code.

I've also changed the `await using` blocks to use more basic `try..finally` blocks, but that didn't help either.  Once the underlying problem is solved, it would probably be fairly trivial to write a `ConfigureAwait` handler for `IAsyncDisposable` so that `await using` can be used.