### PR TITLE
Fix RC2 regression with EXISTS function being wrapped in CASE/IIF

### DIFF
--- a/Source/LinqToDB/SqlProvider/BasicSqlOptimizer.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlOptimizer.cs
@@ -980,7 +980,9 @@ namespace LinqToDB.SqlProvider
 					{
 						var expr = (SqlPredicate.IsTrue)predicate;
 
-						if (expr.Expr1 is SqlParameter)
+						if (expr.Reduce() is SqlPredicate.ExprExpr exprExpr)
+							predicate = ConvertPredicate(selectQuery, exprExpr);
+						else if (expr.Expr1 is SqlParameter)
 							selectQuery.IsParameterDependent = true;
 
 						break;

--- a/Tests/Linq/Linq/WhereTests.cs
+++ b/Tests/Linq/Linq/WhereTests.cs
@@ -1504,5 +1504,29 @@ namespace Tests.Linq
 					Assert.AreEqual(flag == null ? 0 : 1, Regex.Matches(sql, " AND ").Count);
 			}
 		}
+
+		[Test]
+		public void ExistsSqlTest1([DataSources(false)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.BeginTransaction())
+			{
+				db.Parent.Where(p => db.Child.Select(c => c.ParentID).Contains(p.ParentID)).Delete();
+
+				Assert.False(db.LastQuery!.ToLower().Contains("iif(exists(") || db.LastQuery!.ToLower().Contains("when exists("));
+			}
+		}
+
+		[Test]
+		public void ExistsSqlTest2([DataSources(false)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.BeginTransaction())
+			{
+				db.Parent.Where(p => p.Children.Any()).Delete();
+
+				Assert.False(db.LastQuery!.ToLower().Contains("iif(exists(") || db.LastQuery!.ToLower().Contains("when exists("));
+			}
+		}
 	}
 }


### PR DESCRIPTION
With new IsTrue predicate we were skipping optimizations for ExprExpr simple cases.