### PR TITLE
Fixes found problem with query caching.

### DIFF
--- a/Source/LinqToDB/Linq/ExpressionQuery.cs
+++ b/Source/LinqToDB/Linq/ExpressionQuery.cs
@@ -52,6 +52,8 @@ namespace LinqToDB.Linq
 			{
 				var expression = Expression;
 				var info       = GetQuery(ref expression, true);
+				Expression     = expression;
+
 				var sqlText    = QueryRunner.GetSqlText(info, DataContext, expression, Parameters, Preambles);
 
 				return sqlText;
@@ -161,8 +163,10 @@ namespace LinqToDB.Linq
 		public Task GetForEachUntilAsync(Func<T,bool> func, CancellationToken cancellationToken)
 		{
 			var expression = Expression;
-			return GetQuery(ref expression, true)
-				.GetForEachAsync(DataContext, expression, Parameters, Preambles, func, cancellationToken);
+			var query      = GetQuery(ref expression, true);
+			Expression     = expression;
+
+			return query.GetForEachAsync(DataContext, expression, Parameters, Preambles, func, cancellationToken);
 		}
 
 		public IAsyncEnumerable<T> GetAsyncEnumerable()
@@ -173,7 +177,10 @@ namespace LinqToDB.Linq
 		public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
 		{
 			var expression = Expression;
-			return GetQuery(ref expression, true)
+			var query      = GetQuery(ref expression, true);
+			Expression     = expression;
+
+			return query
 				.GetIAsyncEnumerable(DataContext, expression, Parameters, Preambles)
 				.GetAsyncEnumerator(cancellationToken);
 		}

--- a/Tests/Linq/Linq/ExpandTests.cs
+++ b/Tests/Linq/Linq/ExpandTests.cs
@@ -90,6 +90,10 @@ namespace Tests.Playground
 					from t2 in table.Where(predicate)
 					select t;
 
+				//DO NOT REMOVE, it forces caching query
+				var str = query.ToString();
+				Console.WriteLine(str);
+
 				var expected = from t in sampleData
 					from t2 in sampleData.Where(predicate.Compile())
 					select t;


### PR DESCRIPTION
Problem that if you call `GetQuery(ref expression, true)` - better to remember corrected expression, otherwise parameters accessors will be broken.