### PR TITLE
Cleanup ifdefs

### DIFF
--- a/Build/linq2db.Default.props
+++ b/Build/linq2db.Default.props
@@ -31,4 +31,8 @@
 		<GenerateAssemblyFileVersionAttribute>true</GenerateAssemblyFileVersionAttribute>
 		<GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
 	</PropertyGroup>
+	
+	<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netcoreapp3.1'">
+		<DefineConstants>NETSTANDARD2_1PLUS;$(DefineConstants)</DefineConstants>
+	</PropertyGroup>
 </Project>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,13 @@ Solutions:
 | `.\Source\LinqToDB\LinqToDB.csproj`              |    √    |    √    |         √         |       √       |         √         |       √       |
 | `.\Source\LinqToDB\LinqToDB.Tools.csproj`        |    √    |         |         √         |               |                   |               |
 
-Allowed target defines:
+Preferred target defines:
+- `NETFRAMEWORK` - `net45` and `net46` target ifdef
+- `!NETFRAMEWORK` - `netstandard2.0` and newer target ifdef
+- `NETCOREAPP` - `netcoreapp2.1` and `netcoreapp3.1` target ifdef
+- `NETSTANDARD2_1PLUS` - `netstandard2.1` and `netcoreapp3.1` target ifdef
+
+Other allowed target defines:
 - `NETSTANDARD2_1` - `netstandard2.1` target ifdef
 - `NETCOREAPP3_1` - `netcoreapp3.1` target ifdef
 - `NETSTANDARD2_0` - `netstandard2.0` target ifdef

--- a/Source/LinqToDB/Async/AsyncDbConnection.cs
+++ b/Source/LinqToDB/Async/AsyncDbConnection.cs
@@ -37,7 +37,7 @@ namespace LinqToDB.Async
 
 		public virtual IDbConnection Connection => _connection;
 
-#if NET45 || NET46
+#if NETFRAMEWORK
 		public virtual Task<IAsyncDbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
 			=> Task.FromResult(AsyncFactory.Create(BeginTransaction()));
 #elif NETSTANDARD2_0 || NETCOREAPP2_1
@@ -56,7 +56,7 @@ namespace LinqToDB.Async
 		}
 #endif
 
-#if NET45 || NET46
+#if NETFRAMEWORK
 		public virtual Task<IAsyncDbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
 			=> Task.FromResult(AsyncFactory.Create(BeginTransaction(isolationLevel)));
 #elif NETSTANDARD2_0 || NETCOREAPP2_1
@@ -77,7 +77,7 @@ namespace LinqToDB.Async
 
 		public virtual Task CloseAsync()
 		{
-#if NETSTANDARD2_1 || NETCOREAPP3_1
+#if NETSTANDARD2_1PLUS
 			if (Connection is DbConnection dbConnection)
 				return dbConnection.CloseAsync();
 #endif
@@ -129,7 +129,7 @@ namespace LinqToDB.Async
 			Connection.Dispose();
 		}
 
-#if NET45 || NET46
+#if NETFRAMEWORK
 		public virtual Task DisposeAsync()
 		{
 			Dispose();

--- a/Source/LinqToDB/Async/AsyncDbConnection.cs
+++ b/Source/LinqToDB/Async/AsyncDbConnection.cs
@@ -40,7 +40,7 @@ namespace LinqToDB.Async
 #if NETFRAMEWORK
 		public virtual Task<IAsyncDbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
 			=> Task.FromResult(AsyncFactory.Create(BeginTransaction()));
-#elif NETSTANDARD2_0 || NETCOREAPP2_1
+#elif !NETSTANDARD2_1PLUS
 		public virtual ValueTask<IAsyncDbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
 			=> new ValueTask<IAsyncDbTransaction>(AsyncFactory.Create(BeginTransaction()));
 #else
@@ -59,7 +59,7 @@ namespace LinqToDB.Async
 #if NETFRAMEWORK
 		public virtual Task<IAsyncDbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
 			=> Task.FromResult(AsyncFactory.Create(BeginTransaction(isolationLevel)));
-#elif NETSTANDARD2_0 || NETCOREAPP2_1
+#elif !NETSTANDARD2_1PLUS
 		public virtual ValueTask<IAsyncDbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
 			=> new ValueTask<IAsyncDbTransaction>(AsyncFactory.Create(BeginTransaction(isolationLevel)));
 #else

--- a/Source/LinqToDB/Async/AsyncDbConnection.cs
+++ b/Source/LinqToDB/Async/AsyncDbConnection.cs
@@ -56,13 +56,7 @@ namespace LinqToDB.Async
 		}
 #endif
 
-#if NETFRAMEWORK
-		public virtual Task<IAsyncDbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
-			=> Task.FromResult(AsyncFactory.Create(BeginTransaction(isolationLevel)));
-#elif !NETSTANDARD2_1PLUS
-		public virtual ValueTask<IAsyncDbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
-			=> new ValueTask<IAsyncDbTransaction>(AsyncFactory.Create(BeginTransaction(isolationLevel)));
-#else
+#if NETSTANDARD2_1PLUS
 		public virtual async ValueTask<IAsyncDbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
 		{
 			if (Connection is DbConnection dbConnection)
@@ -73,6 +67,12 @@ namespace LinqToDB.Async
 			}
 			return AsyncFactory.Create(BeginTransaction(isolationLevel));
 		}
+#elif !NETFRAMEWORK
+		public virtual ValueTask<IAsyncDbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
+			=> new ValueTask<IAsyncDbTransaction>(AsyncFactory.Create(BeginTransaction(isolationLevel)));
+#else
+		public virtual Task<IAsyncDbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
+			=> Task.FromResult(AsyncFactory.Create(BeginTransaction(isolationLevel)));
 #endif
 
 		public virtual Task CloseAsync()

--- a/Source/LinqToDB/Async/AsyncDbTransaction.cs
+++ b/Source/LinqToDB/Async/AsyncDbTransaction.cs
@@ -34,7 +34,7 @@ namespace LinqToDB.Async
 
 		public virtual Task CommitAsync(CancellationToken cancellationToken = default)
 		{
-#if NETSTANDARD2_1 || NETCOREAPP3_1
+#if NETSTANDARD2_1PLUS
 			if (Transaction is DbTransaction dbTransaction)
 				return dbTransaction.CommitAsync(cancellationToken);
 #endif
@@ -49,7 +49,7 @@ namespace LinqToDB.Async
 			Transaction.Dispose();
 		}
 
-#if NET45 || NET46
+#if NETFRAMEWORK
 		public virtual Task DisposeAsync()
 		{
 			Dispose();
@@ -74,7 +74,7 @@ namespace LinqToDB.Async
 
 		public virtual Task RollbackAsync(CancellationToken cancellationToken = default)
 		{
-#if NETSTANDARD2_1 || NETCOREAPP3_1
+#if NETSTANDARD2_1PLUS
 			if (Transaction is DbTransaction dbTransaction)
 				return dbTransaction.RollbackAsync(cancellationToken);
 #endif

--- a/Source/LinqToDB/Async/AsyncExtensions.cs
+++ b/Source/LinqToDB/Async/AsyncExtensions.cs
@@ -61,7 +61,7 @@ namespace LinqToDB.Async
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
 			var result = new List<T>();
-#if NET45 || NET46
+#if NETFRAMEWORK
 			using (var enumerator = source.GetAsyncEnumerator(cancellationToken))
 #else
 			var enumerator = source.GetAsyncEnumerator(cancellationToken);
@@ -131,7 +131,7 @@ namespace LinqToDB.Async
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
-#if NET45 || NET46
+#if NETFRAMEWORK
 			using (var enumerator = source.GetAsyncEnumerator(cancellationToken))
 #else
 			var enumerator = source.GetAsyncEnumerator(cancellationToken);
@@ -156,7 +156,7 @@ namespace LinqToDB.Async
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
-#if NET45 || NET46
+#if NETFRAMEWORK
 			using (var enumerator = source.GetAsyncEnumerator(token))
 #else
 			var enumerator = source.GetAsyncEnumerator(token);

--- a/Source/LinqToDB/Async/AsyncFactory.cs
+++ b/Source/LinqToDB/Async/AsyncFactory.cs
@@ -33,7 +33,7 @@ namespace LinqToDB.Async
 		private static readonly ConcurrentDictionary<Type, Func<IDbTransaction, IAsyncDbTransaction>> _transactionFactories
 			= new ConcurrentDictionary<Type, Func<IDbTransaction, IAsyncDbTransaction>>();
 
-#if NET45 || NET46
+#if NETFRAMEWORK
 		private static readonly MethodInfo _transactionWrap      = MemberHelper.MethodOf(() => Wrap<IDbTransaction>(default!)).GetGenericMethodDefinition();
 #else
 		private static readonly MethodInfo _transactionValueWrap = MemberHelper.MethodOf(() => WrapValue<IDbTransaction>(default!)).GetGenericMethodDefinition();
@@ -101,7 +101,7 @@ namespace LinqToDB.Async
 			return Create(await transaction.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext));
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		private static async ValueTask<IAsyncDbTransaction> WrapValue<TTransaction>(ValueTask<TTransaction> transaction)
 			where TTransaction : IDbTransaction
 		{
@@ -129,7 +129,7 @@ namespace LinqToDB.Async
 			// Availability:
 			// - DbTransaction (netstandard2.1, netcoreapp3.0)
 			// - Npgsql 4.1.2+
-#if NET45 || NET46
+#if NETFRAMEWORK
 			var disposeAsync  = CreateDelegate<Func<IDbConnection               ,      Task>, IDbConnection >(type, "DisposeAsync" , Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, true , false)
 #else
 			var disposeAsync  = CreateDelegate<Func<IDbConnection               , ValueTask>, IDbConnection >(type, "DisposeAsync" , Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, true , true )
@@ -137,7 +137,7 @@ namespace LinqToDB.Async
 			// Task DisposeAsync()
 			// Availability:
 			// - MySqlConnector 0.57+
-#if NET45 || NET46
+#if NETFRAMEWORK
 							 ?? CreateDelegate<Func<IDbConnection               ,      Task>, IDbConnection >(type, "DisposeAsync" , Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, false, false);
 #else
 							 ?? CreateDelegate<Func<IDbConnection               , ValueTask>, IDbConnection >(type, "DisposeAsync" , Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, false, true );
@@ -160,7 +160,7 @@ namespace LinqToDB.Async
 			// - (stub) DbConnection (netstandard2.1, netcoreapp3.0)
 			// - MySqlConnector 0.57+
 			// - Npgsql 4.1.2+
-#if NET45 || NET46
+#if NETFRAMEWORK
 			var beginTransactionAsync   = CreateTaskTDelegate<Func<IDbConnection, CancellationToken           ,      Task<IAsyncDbTransaction>>, IDbConnection, IDbTransaction>(type, "BeginTransactionAsync", _tokenParams           , _transactionWrap,      true, false)
 #else
 			var beginTransactionAsync   = CreateTaskTDelegate<Func<IDbConnection, CancellationToken           , ValueTask<IAsyncDbTransaction>>, IDbConnection, IDbTransaction>(type, "BeginTransactionAsync", _tokenParams           , _transactionValueWrap, true, true)
@@ -169,7 +169,7 @@ namespace LinqToDB.Async
 			// Availability:
 			// - MySql.Data
 			// - MySqlConnector < 0.57
-#if NET45 || NET46
+#if NETFRAMEWORK
 									   ?? CreateTaskTDelegate<Func<IDbConnection, CancellationToken           ,      Task<IAsyncDbTransaction>>, IDbConnection, IDbTransaction>(type, "BeginTransactionAsync", _tokenParams           , _transactionWrap,      false, false);
 #else
 									   ?? CreateTaskTDelegate<Func<IDbConnection, CancellationToken           , ValueTask<IAsyncDbTransaction>>, IDbConnection, IDbTransaction>(type, "BeginTransactionAsync", _tokenParams           , _transactionValueWrap, false, true);
@@ -180,7 +180,7 @@ namespace LinqToDB.Async
 			// - (stub) DbConnection (netstandard2.1, netcoreapp3.0)
 			// - MySqlConnector 0.57+
 			// - Npgsql 4.1.2+
-#if NET45 || NET46
+#if NETFRAMEWORK
 			var beginTransactionIlAsync = CreateTaskTDelegate<Func<IDbConnection, IsolationLevel, CancellationToken,      Task<IAsyncDbTransaction>>, IDbConnection, IDbTransaction>(type, "BeginTransactionAsync", _beginTransactionParams, _transactionWrap,      true, false)
 #else
 			var beginTransactionIlAsync = CreateTaskTDelegate<Func<IDbConnection, IsolationLevel, CancellationToken, ValueTask<IAsyncDbTransaction>>, IDbConnection, IDbTransaction>(type, "BeginTransactionAsync", _beginTransactionParams, _transactionValueWrap, true, true)
@@ -189,7 +189,7 @@ namespace LinqToDB.Async
 			// Availability:
 			// - MySql.Data
 			// - MySqlConnector < 0.57
-#if NET45 || NET46
+#if NETFRAMEWORK
 									   ?? CreateTaskTDelegate<Func<IDbConnection, IsolationLevel, CancellationToken,      Task<IAsyncDbTransaction>>, IDbConnection, IDbTransaction>(type, "BeginTransactionAsync", _beginTransactionParams, _transactionWrap,      false, false);
 #else
 									   ?? CreateTaskTDelegate<Func<IDbConnection, IsolationLevel, CancellationToken, ValueTask<IAsyncDbTransaction>>, IDbConnection, IDbTransaction>(type, "BeginTransactionAsync", _beginTransactionParams, _transactionValueWrap, false, true);
@@ -215,7 +215,7 @@ namespace LinqToDB.Async
 			// Availability:
 			// - (stub) DbConnection (netstandard2.1, netcoreapp3.0)
 			// - Npgsql 4.1.2+
-#if NET45 || NET46
+#if NETFRAMEWORK
 			var disposeAsync            = CreateDelegate<Func<IDbConnection, Task     >, IDbConnection>(type, "DisposeAsync", Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, true , false)
 #else
 			var disposeAsync            = CreateDelegate<Func<IDbConnection, ValueTask>, IDbConnection>(type, "DisposeAsync", Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, true , true)
@@ -223,7 +223,7 @@ namespace LinqToDB.Async
 			// Task DisposeAsync()
 			// Availability:
 			// - MySqlConnector 0.57+
-#if NET45 || NET46
+#if NETFRAMEWORK
 									   ?? CreateDelegate<Func<IDbConnection,      Task>, IDbConnection>(type, "DisposeAsync", Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, false, false);
 #else
 									   ?? CreateDelegate<Func<IDbConnection, ValueTask>, IDbConnection>(type, "DisposeAsync", Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, false, true);
@@ -282,7 +282,7 @@ namespace LinqToDB.Async
 				//convert a ValueTask result to a Task
 				body = ToTask(body);
 			}
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 			else if (!returnsValueTask && returnValueTask)
 			{
 				//convert a Task result to a ValueTask
@@ -305,7 +305,7 @@ namespace LinqToDB.Async
 			return Expression.Call(body, "AsTask", Array<Type>.Empty);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		/// <summary>
 		/// Returns an expression which returns a <see cref="ValueTask"/> from a <see cref="Task"/>.
 		/// </summary>
@@ -373,7 +373,7 @@ namespace LinqToDB.Async
 				//convert a ValueTask result to a Task
 				body = ToTask(body);
 			}
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 			else if (!returnsValueTask && returnValueTask)
 			{
 				//convert a Task result to a ValueTask

--- a/Source/LinqToDB/Async/IAsyncDbConnection.cs
+++ b/Source/LinqToDB/Async/IAsyncDbConnection.cs
@@ -12,7 +12,7 @@ namespace LinqToDB.Async
 	/// </summary>
 	[PublicAPI]
 	public interface IAsyncDbConnection : IDbConnection
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		, IAsyncDisposable
 #endif
 	{
@@ -21,7 +21,7 @@ namespace LinqToDB.Async
 		/// </summary>
 		/// <param name="cancellationToken">Asynchronous operation cancellation token.</param>
 		/// <returns>Database transaction object.</returns>
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		ValueTask<IAsyncDbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default);
 #else
 		Task<IAsyncDbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default);
@@ -33,7 +33,7 @@ namespace LinqToDB.Async
 		/// <param name="isolationLevel">Transaction isolation level.</param>
 		/// <param name="cancellationToken">Asynchronous operation cancellation token.</param>
 		/// <returns>Database transaction object.</returns>
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		ValueTask<IAsyncDbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default);
 #else
 		Task<IAsyncDbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default);
@@ -52,7 +52,7 @@ namespace LinqToDB.Async
 		/// <returns>Async operation task.</returns>
 		Task OpenAsync(CancellationToken cancellationToken = default);
 
-#if NET45 || NET46
+#if NETFRAMEWORK
 		/// <summary>
 		/// Disposes current connection asynchonously.
 		/// </summary>

--- a/Source/LinqToDB/Async/IAsyncDbTransaction.cs
+++ b/Source/LinqToDB/Async/IAsyncDbTransaction.cs
@@ -12,7 +12,7 @@ namespace LinqToDB.Async
 	/// </summary>
 	[PublicAPI]
 	public interface IAsyncDbTransaction : IDbTransaction
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		, IAsyncDisposable
 #endif
 	{
@@ -35,7 +35,7 @@ namespace LinqToDB.Async
 		/// </summary>
 		IDbTransaction Transaction { get; }
 
-#if NET45 || NET46
+#if NETFRAMEWORK
 		/// <summary>
 		/// Disposes transaction asynchronously.
 		/// </summary>

--- a/Source/LinqToDB/Async/ReflectedAsyncDbConnection.cs
+++ b/Source/LinqToDB/Async/ReflectedAsyncDbConnection.cs
@@ -13,7 +13,7 @@ namespace LinqToDB.Async
 	{
 		private readonly Func<IDbConnection, CancellationToken, Task>?                                           _openAsync;
 		private readonly Func<IDbConnection, Task>?                                                              _closeAsync;
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		private readonly Func<IDbConnection, CancellationToken, ValueTask<IAsyncDbTransaction>>?                 _beginTransactionAsync;
 		private readonly Func<IDbConnection, IsolationLevel, CancellationToken, ValueTask<IAsyncDbTransaction>>? _beginTransactionIlAsync;
 		private readonly Func<IDbConnection, ValueTask>?                                                         _disposeAsync;
@@ -25,7 +25,7 @@ namespace LinqToDB.Async
 
 		public ReflectedAsyncDbConnection(
 			IDbConnection connection,
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 			Func<IDbConnection, CancellationToken, ValueTask<IAsyncDbTransaction>>?                 beginTransactionAsync,
 			Func<IDbConnection, IsolationLevel, CancellationToken, ValueTask<IAsyncDbTransaction>>? beginTransactionIlAsync,
 #else
@@ -34,7 +34,7 @@ namespace LinqToDB.Async
 #endif
 			Func<IDbConnection, CancellationToken, Task>?                                           openAsync,
 			Func<IDbConnection, Task>?                                                              closeAsync,
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 			Func<IDbConnection, ValueTask>?                                                         disposeAsync)
 #else
 			Func<IDbConnection, Task>?                                                              disposeAsync)
@@ -48,7 +48,7 @@ namespace LinqToDB.Async
 			_disposeAsync            = disposeAsync;
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		public override ValueTask<IAsyncDbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
 #else
 		public override Task<IAsyncDbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
@@ -57,7 +57,7 @@ namespace LinqToDB.Async
 			return _beginTransactionAsync?.Invoke(Connection, cancellationToken) ?? base.BeginTransactionAsync(cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		public override ValueTask<IAsyncDbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
 #else
 		public override Task<IAsyncDbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
@@ -76,7 +76,7 @@ namespace LinqToDB.Async
 			return _closeAsync?.Invoke(Connection) ?? base.CloseAsync();
 		}
 
-#if NET45 || NET46
+#if NETFRAMEWORK
 		public override Task DisposeAsync()
 		{
 			return _disposeAsync?.Invoke(Connection) ?? base.DisposeAsync();

--- a/Source/LinqToDB/Async/ReflectedAsyncDbTransaction.cs
+++ b/Source/LinqToDB/Async/ReflectedAsyncDbTransaction.cs
@@ -14,7 +14,7 @@ namespace LinqToDB.Async
 	{
 		private readonly Func<IDbTransaction, CancellationToken, Task>? _commitAsync;
 		private readonly Func<IDbTransaction, CancellationToken, Task>? _rollbackAsync;
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		private readonly Func<IDbConnection, ValueTask>?                _disposeAsync;
 #else
 		private readonly Func<IDbConnection, Task>?                     _disposeAsync;
@@ -24,7 +24,7 @@ namespace LinqToDB.Async
 			IDbTransaction                                 transaction,
 			Func<IDbTransaction, CancellationToken, Task>? commitAsync,
 			Func<IDbTransaction, CancellationToken, Task>? rollbackAsync,
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 			Func<IDbConnection, ValueTask>?                disposeAsync)
 #else
 			Func<IDbConnection, Task>?                     disposeAsync)
@@ -46,7 +46,7 @@ namespace LinqToDB.Async
 			return _rollbackAsync?.Invoke(Transaction, cancellationToken) ?? base.RollbackAsync(cancellationToken);
 		}
 
-#if NET45 || NET46
+#if NETFRAMEWORK
 		public override Task DisposeAsync()
 		{
 			return _disposeAsync?.Invoke(Connection) ?? base.DisposeAsync();

--- a/Source/LinqToDB/AsyncExtensions.cs
+++ b/Source/LinqToDB/AsyncExtensions.cs
@@ -70,7 +70,7 @@ namespace LinqToDB
 		}
 
 		#region AsAsyncEnumerable
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		/// <summary>
 		/// Returns an <see cref="IAsyncEnumerable{T}"/> that can be enumerated asynchronously.
 		/// </summary>

--- a/Source/LinqToDB/Common/EnumerableHelper.cs
+++ b/Source/LinqToDB/Common/EnumerableHelper.cs
@@ -7,7 +7,7 @@ namespace LinqToDB.Common
 {
 	internal class EnumerableHelper
 	{
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		public static IEnumerable<T> AsyncToSyncEnumerable<T>(IAsyncEnumerator<T> enumerator)
 		{
 			while (enumerator.MoveNextAsync().GetAwaiter().GetResult())
@@ -114,7 +114,7 @@ namespace LinqToDB.Common
 			}
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		/// <summary>
 		/// Split enumerable source into batches of specified size.
 		/// Limitation: each batch should be enumerated only once or exception will be generated.

--- a/Source/LinqToDB/Data/CommandInfo.cs
+++ b/Source/LinqToDB/Data/CommandInfo.cs
@@ -692,7 +692,7 @@ namespace LinqToDB.Data
 			{
 			}
 
-#if NET45 || NET46
+#if NETFRAMEWORK
 			public Task DisposeAsync() => TaskEx.CompletedTask;
 #else
 			public ValueTask DisposeAsync() => new ValueTask(Task.CompletedTask);
@@ -700,7 +700,7 @@ namespace LinqToDB.Data
 
 			public T Current { get; set; } = default!;
 
-#if NET45 || NET46
+#if NETFRAMEWORK
 			public async Task<bool> MoveNextAsync()
 #else
 			public async ValueTask<bool> MoveNextAsync()

--- a/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
+++ b/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
@@ -468,16 +468,16 @@ namespace LinqToDB.Data
 					DataReader.Dispose();
 				}
 
-#if NETCOREAPP2_1 || NETSTANDARD2_0
+#if NETSTANDARD2_1PLUS
+				public ValueTask DisposeAsync()
+				{
+					 return _dataReader.DisposeAsync();
+				}
+#elif !NETFRAMEWORK
 				public ValueTask DisposeAsync()
 				{
 					Dispose();
 					return new ValueTask(Task.CompletedTask);
-				}
-#elif NETCOREAPP3_1 || NETSTANDARD2_1
-				public ValueTask DisposeAsync()
-				{
-					 return _dataReader.DisposeAsync();
 				}
 #endif
 			}

--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -643,7 +643,7 @@ namespace LinqToDB.Data
 		{
 			get
 			{
-#if NET45 || NET46
+#if NETFRAMEWORK
 				return _defaultSettings ??= LinqToDBSection.Instance;
 #else
 				return _defaultSettings;

--- a/Source/LinqToDB/Data/DataConnectionExtensions.cs
+++ b/Source/LinqToDB/Data/DataConnectionExtensions.cs
@@ -2250,7 +2250,7 @@ namespace LinqToDB.Data
 		#endregion
 
 		#region BulkCopy IAsyncEnumerable async
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 
 		/// <summary>
 		/// Asynchronously performs bulk insert operation.

--- a/Source/LinqToDB/Data/DataConnectionTransaction.cs
+++ b/Source/LinqToDB/Data/DataConnectionTransaction.cs
@@ -8,7 +8,7 @@ namespace LinqToDB.Data
 	/// Data connection transaction controller.
 	/// </summary>
 	public class DataConnectionTransaction : IDisposable
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		, IAsyncDisposable
 #endif
 	{
@@ -76,7 +76,7 @@ namespace LinqToDB.Data
 				DataConnection.RollbackTransaction();
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		public ValueTask DisposeAsync()
 		{
 			if (_disposeTransaction)

--- a/Source/LinqToDB/Data/RetryPolicy/RetryingDbConnection.cs
+++ b/Source/LinqToDB/Data/RetryPolicy/RetryingDbConnection.cs
@@ -113,7 +113,7 @@ namespace LinqToDB.Data.RetryPolicy
 			return _dataConnection.DataProvider.CreateConnection(_dataConnection.ConnectionString!);
 		}
 
-#if NET45 || NET46
+#if NETFRAMEWORK
 		public Task<IAsyncDbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
 			=> _connection.BeginTransactionAsync(cancellationToken);
 
@@ -137,7 +137,7 @@ namespace LinqToDB.Data.RetryPolicy
 #endif
 
 
-#if !NETSTANDARD2_1 && !NETCOREAPP3_1
+#if !NETSTANDARD2_1PLUS
 		public Task CloseAsync()
 #else
 		public override Task CloseAsync()
@@ -146,7 +146,7 @@ namespace LinqToDB.Data.RetryPolicy
 			return _connection.CloseAsync();
 		}
 
-#if NET45 || NET46
+#if NETFRAMEWORK
 		public Task DisposeAsync()
 #elif NETSTANDARD2_0 || NETCOREAPP2_1
 		public ValueTask DisposeAsync()

--- a/Source/LinqToDB/Data/RetryPolicy/RetryingDbConnection.cs
+++ b/Source/LinqToDB/Data/RetryPolicy/RetryingDbConnection.cs
@@ -113,19 +113,7 @@ namespace LinqToDB.Data.RetryPolicy
 			return _dataConnection.DataProvider.CreateConnection(_dataConnection.ConnectionString!);
 		}
 
-#if NETFRAMEWORK
-		public Task<IAsyncDbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
-			=> _connection.BeginTransactionAsync(cancellationToken);
-
-		public Task<IAsyncDbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
-			=> _connection.BeginTransactionAsync(isolationLevel, cancellationToken);
-#elif !NETSTANDARD2_1PLUS
-		public ValueTask<IAsyncDbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
-			=> _connection.BeginTransactionAsync(cancellationToken);
-
-		public ValueTask<IAsyncDbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
-			=> _connection.BeginTransactionAsync(isolationLevel, cancellationToken);
-#else
+#if NETSTANDARD2_1PLUS
 		public new ValueTask<IAsyncDbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
 			=> _connection.BeginTransactionAsync(cancellationToken);
 
@@ -134,8 +122,19 @@ namespace LinqToDB.Data.RetryPolicy
 
 		protected override ValueTask<DbTransaction> BeginDbTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken)
 			=> _dbConnection.BeginTransactionAsync(isolationLevel, cancellationToken);
-#endif
+#elif !NETFRAMEWORK
+		public ValueTask<IAsyncDbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
+			=> _connection.BeginTransactionAsync(cancellationToken);
 
+		public ValueTask<IAsyncDbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
+			=> _connection.BeginTransactionAsync(isolationLevel, cancellationToken);
+#else
+		public Task<IAsyncDbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
+			=> _connection.BeginTransactionAsync(cancellationToken);
+
+		public Task<IAsyncDbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
+			=> _connection.BeginTransactionAsync(isolationLevel, cancellationToken);
+#endif
 
 #if !NETSTANDARD2_1PLUS
 		public Task CloseAsync()
@@ -146,12 +145,12 @@ namespace LinqToDB.Data.RetryPolicy
 			return _connection.CloseAsync();
 		}
 
-#if NETFRAMEWORK
-		public Task DisposeAsync()
-#elif !NETSTANDARD2_1PLUS
+#if NETSTANDARD2_1PLUS
+		public override ValueTask DisposeAsync()
+#elif !NETFRAMEWORK
 		public ValueTask DisposeAsync()
 #else
-		public override ValueTask DisposeAsync()
+		public Task DisposeAsync()
 #endif
 		{
 			return _connection.DisposeAsync();

--- a/Source/LinqToDB/Data/RetryPolicy/RetryingDbConnection.cs
+++ b/Source/LinqToDB/Data/RetryPolicy/RetryingDbConnection.cs
@@ -119,7 +119,7 @@ namespace LinqToDB.Data.RetryPolicy
 
 		public Task<IAsyncDbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
 			=> _connection.BeginTransactionAsync(isolationLevel, cancellationToken);
-#elif NETSTANDARD2_0 || NETCOREAPP2_1
+#elif !NETSTANDARD2_1PLUS
 		public ValueTask<IAsyncDbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
 			=> _connection.BeginTransactionAsync(cancellationToken);
 
@@ -148,7 +148,7 @@ namespace LinqToDB.Data.RetryPolicy
 
 #if NETFRAMEWORK
 		public Task DisposeAsync()
-#elif NETSTANDARD2_0 || NETCOREAPP2_1
+#elif !NETSTANDARD2_1PLUS
 		public ValueTask DisposeAsync()
 #else
 		public override ValueTask DisposeAsync()

--- a/Source/LinqToDB/DataProvider/Access/AccessODBCDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessODBCDataProvider.cs
@@ -159,7 +159,7 @@ namespace LinqToDB.DataProvider.Access
 				cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/Access/AccessOleDbDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessOleDbDataProvider.cs
@@ -125,7 +125,7 @@ namespace LinqToDB.DataProvider.Access
 				cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/BasicBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/BasicBulkCopy.cs
@@ -35,7 +35,7 @@ namespace LinqToDB.DataProvider
 			};
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		public virtual Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			BulkCopyType bulkCopyType, ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
@@ -60,7 +60,7 @@ namespace LinqToDB.DataProvider
 			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected virtual Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
@@ -80,7 +80,7 @@ namespace LinqToDB.DataProvider
 			return RowByRowCopyAsync(table, options, source, cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected virtual Task<BulkCopyRowsCopied> MultipleRowsCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
@@ -142,7 +142,7 @@ namespace LinqToDB.DataProvider
 			return rowsCopied;
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected virtual async Task<BulkCopyRowsCopied> RowByRowCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
@@ -324,7 +324,7 @@ namespace LinqToDB.DataProvider
 			return helper.RowsCopied;
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected static async Task<BulkCopyRowsCopied> MultipleRowsCopyHelperAsync<T>(
 			MultipleRowsHelper                          helper,
 			IAsyncEnumerable<T>                         source,
@@ -372,7 +372,7 @@ namespace LinqToDB.DataProvider
 		protected Task<BulkCopyRowsCopied> MultipleRowsCopy1Async(MultipleRowsHelper helper, IEnumerable source, CancellationToken cancellationToken)
 			=> MultipleRowsCopyHelperAsync(helper, source, null, MultipleRowsCopy1Prep, MultipleRowsCopy1Add, MultipleRowsCopy1Finish, cancellationToken);
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected Task<BulkCopyRowsCopied> MultipleRowsCopy1Async<T>(ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 			=> MultipleRowsCopy1Async(new MultipleRowsHelper<T>(table, options), source, cancellationToken);
 
@@ -436,7 +436,7 @@ namespace LinqToDB.DataProvider
 		protected Task<BulkCopyRowsCopied> MultipleRowsCopy2Async(MultipleRowsHelper helper, IEnumerable source, string from, CancellationToken cancellationToken)
 			=> MultipleRowsCopyHelperAsync(helper, source, from, MultipleRowsCopy2Prep, MultipleRowsCopy2Add, MultipleRowsCopy2Finish, cancellationToken);
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected Task<BulkCopyRowsCopied> MultipleRowsCopy2Async<T>(ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, string from, CancellationToken cancellationToken)
 			=> MultipleRowsCopy2Async(new MultipleRowsHelper<T>(table, options), source, from, cancellationToken);
 
@@ -491,7 +491,7 @@ namespace LinqToDB.DataProvider
 		protected Task<BulkCopyRowsCopied> MultipleRowsCopy3Async(MultipleRowsHelper helper, BulkCopyOptions options, IEnumerable source, string from, CancellationToken cancellationToken)
 			=> MultipleRowsCopyHelperAsync(helper, source, from, MultipleRowsCopy3Prep, MultipleRowsCopy3Add, MultipleRowsCopy3Finish, cancellationToken);
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected Task<BulkCopyRowsCopied> MultipleRowsCopy3Async<T>(MultipleRowsHelper helper, BulkCopyOptions options, IAsyncEnumerable<T> source, string from, CancellationToken cancellationToken)
 			=> MultipleRowsCopyHelperAsync(helper, source, from, MultipleRowsCopy3Prep, MultipleRowsCopy3Add, MultipleRowsCopy3Finish, cancellationToken);
 #endif

--- a/Source/LinqToDB/DataProvider/BulkCopyReader.cs
+++ b/Source/LinqToDB/DataProvider/BulkCopyReader.cs
@@ -15,12 +15,12 @@ namespace LinqToDB.DataProvider
 	using System.Threading.Tasks;
 
 	public class BulkCopyReader<T> : BulkCopyReader
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		, IAsyncDisposable
 #endif
 	{
 		readonly IEnumerator<T>?      _enumerator;
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		readonly IAsyncEnumerator<T>? _asyncEnumerator;
 #endif
 
@@ -30,7 +30,7 @@ namespace LinqToDB.DataProvider
 			_enumerator = collection.GetEnumerator();
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		public BulkCopyReader(DataConnection dataConnection, List<ColumnDescriptor> columns, IAsyncEnumerable<T> collection, CancellationToken cancellationToken)
 			: base(dataConnection, columns)
 		{
@@ -55,7 +55,7 @@ namespace LinqToDB.DataProvider
 
 		#region Implementation of IDisposable
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected override void Dispose(bool disposing)
 		{
 			if (disposing)
@@ -64,7 +64,7 @@ namespace LinqToDB.DataProvider
 			}
 		}
 
-#if NETSTANDARD2_1 || NETCOREAPP3_1
+#if NETSTANDARD2_1PLUS
 		public override ValueTask DisposeAsync()
 #else
 		public ValueTask DisposeAsync()
@@ -90,7 +90,7 @@ namespace LinqToDB.DataProvider
 		readonly IReadOnlyDictionary<string, int> _ordinals;
 
 		protected abstract bool MoveNext();
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected abstract ValueTask<bool> MoveNextAsync();
 #endif
 		protected abstract object Current { get; }
@@ -262,7 +262,7 @@ namespace LinqToDB.DataProvider
 			return b;
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		public override async Task<bool> ReadAsync(CancellationToken cancellationToken)
 		{
 			var b = await MoveNextAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);

--- a/Source/LinqToDB/DataProvider/CallOnExceptionRegion.cs
+++ b/Source/LinqToDB/DataProvider/CallOnExceptionRegion.cs
@@ -20,7 +20,7 @@ namespace LinqToDB
 		{
 			// https://stackoverflow.com/questions/2830073/
 			if (
-#if (!NETSTANDARD2_0 && !NETCOREAPP2_1 && !NETSTANDARD2_1)
+#if NETFRAMEWORK || NETCOREAPP3_1
 				// API not exposed till netcoreapp3.0
 				// https://github.com/dotnet/corefx/pull/31169
 				Marshal.GetExceptionPointers() != IntPtr.Zero ||

--- a/Source/LinqToDB/DataProvider/DB2/DB2BulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2BulkCopy.cs
@@ -62,7 +62,7 @@ namespace LinqToDB.DataProvider.DB2
 			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected override async Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
 			if (table.DataContext is DataConnection dataConnection)
@@ -174,7 +174,7 @@ namespace LinqToDB.DataProvider.DB2
 			return MultipleRowsCopy1Async(table, options, source, cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected override Task<BulkCopyRowsCopied> MultipleRowsCopyAsync<T>(ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
 			var dataConnection = (DataConnection)table.DataContext;

--- a/Source/LinqToDB/DataProvider/DB2/DB2DataProvider.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2DataProvider.cs
@@ -212,7 +212,7 @@ namespace LinqToDB.DataProvider.DB2
 				cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/DB2/DB2ProviderAdapter.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2ProviderAdapter.cs
@@ -14,7 +14,7 @@ namespace LinqToDB.DataProvider.DB2
 		public const string NetFxClientNamespace = "IBM.Data.DB2";
 		public const string CoreClientNamespace  = "IBM.Data.DB2.Core";
 
-#if NET45 || NET46
+#if NETFRAMEWORK
 		public const string AssemblyName         = "IBM.Data.DB2";
 		public const string ClientNamespace      = "IBM.Data.DB2";
 #else

--- a/Source/LinqToDB/DataProvider/DataProviderBase.cs
+++ b/Source/LinqToDB/DataProvider/DataProviderBase.cs
@@ -417,7 +417,7 @@ namespace LinqToDB.DataProvider
 			return new BasicBulkCopy().BulkCopyAsync(options.BulkCopyType, table, options, source, cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		public virtual Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdBulkCopy.cs
@@ -28,7 +28,7 @@ namespace LinqToDB.DataProvider.Firebird
 			return MultipleRowsCopy2Async(table, options, source, " FROM rdb$database", cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected override Task<BulkCopyRowsCopied> MultipleRowsCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdDataProvider.cs
@@ -122,7 +122,7 @@ namespace LinqToDB.DataProvider.Firebird
 				cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/IDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/IDataProvider.cs
@@ -56,7 +56,7 @@ namespace LinqToDB.DataProvider
 		
 		Task<BulkCopyRowsCopied> BulkCopyAsync<T>(ITable<T> table, BulkCopyOptions options, IEnumerable<T> source, CancellationToken cancellationToken);
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		Task<BulkCopyRowsCopied> BulkCopyAsync<T>(ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken);
 #endif
 	}

--- a/Source/LinqToDB/DataProvider/Informix/InformixBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixBulkCopy.cs
@@ -90,7 +90,7 @@ namespace LinqToDB.DataProvider.Informix
 			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected override async Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T>           table,
 			BulkCopyOptions     options,
@@ -207,7 +207,7 @@ namespace LinqToDB.DataProvider.Informix
 				return base.MultipleRowsCopyAsync(table, options, source, cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected override Task<BulkCopyRowsCopied> MultipleRowsCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/Informix/InformixDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixDataProvider.cs
@@ -217,7 +217,7 @@ namespace LinqToDB.DataProvider.Informix
 				cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/Informix/InformixTools.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixTools.cs
@@ -12,7 +12,7 @@ namespace LinqToDB.DataProvider.Informix
 
 	public static class InformixTools
 	{
-#if NET45 || NET46
+#if NETFRAMEWORK
 		private static readonly Lazy<IDataProvider> _informixDataProvider = new Lazy<IDataProvider>(() =>
 		{
 			var provider = new InformixDataProvider(ProviderName.Informix);
@@ -38,7 +38,7 @@ namespace LinqToDB.DataProvider.Informix
 			{
 				case ProviderName.InformixDB2:
 					return _informixDB2DataProvider.Value;
-#if NET45 || NET46
+#if NETFRAMEWORK
 				case InformixProviderAdapter.IfxClientNamespace:
 					return _informixDataProvider.Value;
 #endif
@@ -55,7 +55,7 @@ namespace LinqToDB.DataProvider.Informix
 					if (css.Name.Contains("DB2"))
 						return _informixDB2DataProvider.Value;
 
-#if NET45 || NET46
+#if NETFRAMEWORK
 					return _informixDataProvider.Value;
 #else
 					return _informixDB2DataProvider.Value;
@@ -67,7 +67,7 @@ namespace LinqToDB.DataProvider.Informix
 
 		private static string DetectProviderName()
 		{
-#if NET45 || NET46
+#if NETFRAMEWORK
 			var path = typeof(InformixTools).Assembly.GetPath();
 
 			if (File.Exists(Path.Combine(path, $"{InformixProviderAdapter.IfxAssemblyName}.dll")))
@@ -85,13 +85,13 @@ namespace LinqToDB.DataProvider.Informix
 		{
 			switch (providerName ?? DetectedProviderName)
 			{
-#if NET45 || NET46
+#if NETFRAMEWORK
 				case ProviderName.Informix   : return _informixDataProvider.Value;
 #endif
 				case ProviderName.InformixDB2: return _informixDB2DataProvider.Value;
 			}
 
-#if NET45 || NET46
+#if NETFRAMEWORK
 				return _informixDataProvider.Value;
 #else
 				return _informixDB2DataProvider.Value;

--- a/Source/LinqToDB/DataProvider/MySql/MySqlBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlBulkCopy.cs
@@ -58,7 +58,7 @@ namespace LinqToDB.DataProvider.MySql
 			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected override Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T>           table,
 			BulkCopyOptions     options,
@@ -152,7 +152,7 @@ namespace LinqToDB.DataProvider.MySql
 					dataConnection,
 					() =>
 					(runAsync && (
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 							bc.CanWriteToServerAsync2 ||
 #endif
 							bc.CanWriteToServerAsync)
@@ -161,7 +161,7 @@ namespace LinqToDB.DataProvider.MySql
 					async () => {
 						if (runAsync)
 						{
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 							if (bc.CanWriteToServerAsync2)
 								await bc.WriteToServerAsync2(rd, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 							else
@@ -185,7 +185,7 @@ namespace LinqToDB.DataProvider.MySql
 			return rc;
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		private async Task<BulkCopyRowsCopied> ProviderSpecificCopyInternal<T>(
 			ProviderConnections providerConnections,
 			ITable<T>           table,
@@ -267,7 +267,7 @@ namespace LinqToDB.DataProvider.MySql
 			return MultipleRowsCopy1Async(table, options, source, cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected override Task<BulkCopyRowsCopied> MultipleRowsCopyAsync<T>(ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
 			return MultipleRowsCopy1Async(table, options, source, cancellationToken);

--- a/Source/LinqToDB/DataProvider/MySql/MySqlDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlDataProvider.cs
@@ -79,7 +79,7 @@ namespace LinqToDB.DataProvider.MySql
 			return _sqlOptimizer;
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		public override bool? IsDBNullAllowed(IDataReader reader, int idx)
 		{
 			return true;
@@ -144,7 +144,7 @@ namespace LinqToDB.DataProvider.MySql
 				cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/MySql/MySqlProviderAdapter.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlProviderAdapter.cs
@@ -446,7 +446,7 @@ namespace LinqToDB.DataProvider.MySql
 					// [8]: WriteToServerAsync
 					new Tuple<LambdaExpression, bool>
 					((Expression<Func<MySqlBulkCopy, IDataReader, CancellationToken, Task>>     )((MySqlBulkCopy this_, IDataReader dataReader, CancellationToken cancellationToken) => this_.WriteToServerAsync (dataReader, cancellationToken)), true),
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 					// [9]: WriteToServerAsync
 					new Tuple<LambdaExpression, bool>
 					((Expression<Func<MySqlBulkCopy, IDataReader, CancellationToken, ValueTask>>)((MySqlBulkCopy this_, IDataReader dataReader, CancellationToken cancellationToken) => this_.WriteToServerAsync2(dataReader, cancellationToken)), true),
@@ -468,7 +468,7 @@ namespace LinqToDB.DataProvider.MySql
 				public void WriteToServer(IDataReader dataReader) => ((Action<MySqlBulkCopy, IDataReader>)CompiledWrappers[0])(this, dataReader);
 				public Task WriteToServerAsync      (IDataReader dataReader, CancellationToken cancellationToken) => ((Func<MySqlBulkCopy, IDataReader, CancellationToken,      Task>)CompiledWrappers[8])(this, dataReader, cancellationToken);
 				public bool CanWriteToServerAsync => CompiledWrappers[8] != null;
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 				[TypeWrapperName("WriteToServerAsync")]
 				public ValueTask WriteToServerAsync2(IDataReader dataReader, CancellationToken cancellationToken) => ((Func<MySqlBulkCopy, IDataReader, CancellationToken, ValueTask>)CompiledWrappers[9])(this, dataReader, cancellationToken);
 				public bool CanWriteToServerAsync2 => CompiledWrappers[9] != null;

--- a/Source/LinqToDB/DataProvider/OdbcProviderAdapter.cs
+++ b/Source/LinqToDB/DataProvider/OdbcProviderAdapter.cs
@@ -46,7 +46,7 @@ namespace LinqToDB.DataProvider
 				lock (_syncRoot)
 					if (_instance == null)
 					{
-#if NET45 || NET46
+#if NETFRAMEWORK
 						var assembly = typeof(System.Data.Odbc.OdbcConnection).Assembly;
 #else
 						var assembly = LinqToDB.Common.Tools.TryLoadAssembly(AssemblyName, null);

--- a/Source/LinqToDB/DataProvider/OleDbProviderAdapter.cs
+++ b/Source/LinqToDB/DataProvider/OleDbProviderAdapter.cs
@@ -51,7 +51,7 @@ namespace LinqToDB.DataProvider
 				lock (_syncRoot)
 					if (_instance == null)
 					{
-#if NET45 || NET46
+#if NETFRAMEWORK
 						var assembly = typeof(System.Data.OleDb.OleDbConnection).Assembly;
 #else
 						var assembly = LinqToDB.Common.Tools.TryLoadAssembly(AssemblyName, null);

--- a/Source/LinqToDB/DataProvider/Oracle/OracleBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleBulkCopy.cs
@@ -98,7 +98,7 @@ namespace LinqToDB.DataProvider.Oracle
 			return Task.FromResult(ProviderSpecificCopy(table, options, source));
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected override async Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
@@ -133,7 +133,7 @@ namespace LinqToDB.DataProvider.Oracle
 			}
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected override Task<BulkCopyRowsCopied> MultipleRowsCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
@@ -183,7 +183,7 @@ namespace LinqToDB.DataProvider.Oracle
 		static Task<BulkCopyRowsCopied> OracleMultipleRowsCopy1Async(MultipleRowsHelper helper, IEnumerable source, CancellationToken cancellationToken)
 			=> MultipleRowsCopyHelperAsync(helper, source, null, OracleMultipleRowsCopy1Prep, OracleMultipleRowsCopy1Add, OracleMultipleRowsCopy1Finish, cancellationToken);
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		static Task<BulkCopyRowsCopied> OracleMultipleRowsCopy1Async<T>(MultipleRowsHelper helper, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 			=> MultipleRowsCopyHelperAsync(helper, source, null, OracleMultipleRowsCopy1Prep, OracleMultipleRowsCopy1Add, OracleMultipleRowsCopy1Finish, cancellationToken);
 #endif
@@ -269,7 +269,7 @@ namespace LinqToDB.DataProvider.Oracle
 			return helper.RowsCopied;
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		static async Task<BulkCopyRowsCopied> OracleMultipleRowsCopy2Async<T>(MultipleRowsHelper helper, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
 			var list = OracleMultipleRowsCopy2Prep(helper);
@@ -386,7 +386,7 @@ namespace LinqToDB.DataProvider.Oracle
 		static Task<BulkCopyRowsCopied> OracleMultipleRowsCopy3Async(MultipleRowsHelper helper, IEnumerable source, CancellationToken cancellationToken)
 			=> MultipleRowsCopyHelperAsync(helper, source, null, OracleMultipleRowsCopy3Prep, OracleMultipleRowsCopy3Add, OracleMultipleRowsCopy3Finish, cancellationToken);
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		static Task<BulkCopyRowsCopied> OracleMultipleRowsCopy3Async<T>(MultipleRowsHelper helper, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 			=> MultipleRowsCopyHelperAsync(helper, source, null, OracleMultipleRowsCopy3Prep, OracleMultipleRowsCopy3Add, OracleMultipleRowsCopy3Finish, cancellationToken);
 #endif

--- a/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
@@ -318,7 +318,7 @@ namespace LinqToDB.DataProvider.Oracle
 				cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/Oracle/OracleProviderAdapter.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleProviderAdapter.cs
@@ -11,7 +11,7 @@ namespace LinqToDB.DataProvider.Oracle
 	{
 		const int NanosecondsPerTick = 100;
 
-#if NET45 || NET46
+#if NETFRAMEWORK
 		private static readonly object _nativeSyncRoot = new object();
 
 		public const string NativeAssemblyName        = "Oracle.DataAccess";
@@ -215,7 +215,7 @@ namespace LinqToDB.DataProvider.Oracle
 
 		public static OracleProviderAdapter GetInstance(string name)
 		{
-#if NET45 || NET46
+#if NETFRAMEWORK
 			if (name == ProviderName.OracleNative)
 			{
 				if (_nativeAdapter == null)
@@ -240,7 +240,7 @@ namespace LinqToDB.DataProvider.Oracle
 		private static OracleProviderAdapter CreateAdapter(string assemblyName, string clientNamespace, string typesNamespace, string? factoryName)
 		{
 			var isNative = false;
-#if NET45 || NET46
+#if NETFRAMEWORK
 			isNative = assemblyName == NativeAssemblyName;
 #endif
 

--- a/Source/LinqToDB/DataProvider/Oracle/OracleTools.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleTools.cs
@@ -19,7 +19,7 @@ namespace LinqToDB.DataProvider.Oracle
 
 	public static partial class OracleTools
 	{
-#if NET45 || NET46
+#if NETFRAMEWORK
 		private static readonly Lazy<IDataProvider> _oracleNativeDataProvider11 = new Lazy<IDataProvider>(() =>
 		{
 			var provider = new OracleDataProvider(ProviderName.OracleNative, OracleVersion.v11);
@@ -64,7 +64,7 @@ namespace LinqToDB.DataProvider.Oracle
 			bool? managed = null;
 			switch (css.ProviderName)
 			{
-#if NET45 || NET46
+#if NETFRAMEWORK
 				case OracleProviderAdapter.NativeAssemblyName    :
 				case OracleProviderAdapter.NativeClientNamespace :
 				case ProviderName.OracleNative                   :
@@ -84,7 +84,7 @@ namespace LinqToDB.DataProvider.Oracle
 						goto case ProviderName.Oracle;
 					break;
 				case ProviderName.Oracle                         :
-#if NET45 || NET46
+#if NETFRAMEWORK
 					if (css.Name.Contains("Native") || managed == false)
 					{
 						if (css.Name.Contains("11"))
@@ -118,7 +118,7 @@ namespace LinqToDB.DataProvider.Oracle
 			{
 				var cs = string.IsNullOrWhiteSpace(connectionString) ? css.ConnectionString : connectionString;
 
-#if NET45 || NET46
+#if NETFRAMEWORK
 				if (!managed)
 					providerAdapter = OracleProviderAdapter.GetInstance(ProviderName.OracleNative);
 				else
@@ -165,7 +165,7 @@ namespace LinqToDB.DataProvider.Oracle
 
 		private static IDataProvider GetVersionedDataProvider(OracleVersion version, bool managed)
 		{
-#if NET45 || NET46
+#if NETFRAMEWORK
 			if (!managed)
 			{
 				return version switch
@@ -187,7 +187,7 @@ namespace LinqToDB.DataProvider.Oracle
 
 		private static string DetectProviderName()
 		{
-#if NET45 || NET46
+#if NETFRAMEWORK
 			try
 			{
 				var path = typeof(OracleTools).Assembly.GetPath();
@@ -207,7 +207,7 @@ namespace LinqToDB.DataProvider.Oracle
 
 		public static IDataProvider GetDataProvider(string? providerName = null, string? assemblyName = null)
 		{
-#if NET45 || NET46
+#if NETFRAMEWORK
 			if (assemblyName == OracleProviderAdapter.NativeAssemblyName ) return GetVersionedDataProvider(DefaultVersion, false);
 			if (assemblyName == OracleProviderAdapter.ManagedAssemblyName) return GetVersionedDataProvider(DefaultVersion, true);
 
@@ -227,7 +227,7 @@ namespace LinqToDB.DataProvider.Oracle
 
 		public static void ResolveOracle(string path)       => new AssemblyResolver(
 			path,
-#if NET45 || NET46
+#if NETFRAMEWORK
 			DetectedProviderName == ProviderName.OracleManaged
 				? OracleProviderAdapter.ManagedAssemblyName
 				: OracleProviderAdapter.NativeAssemblyName

--- a/Source/LinqToDB/DataProvider/PostgreSQL/NpgsqlProviderAdapter.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/NpgsqlProviderAdapter.cs
@@ -509,7 +509,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 				(Expression<Action<NpgsqlBinaryImporter>>                                  )((NpgsqlBinaryImporter this_) => this_.Dispose()),
 				// [3]: StartRow
 				(Expression<Action<NpgsqlBinaryImporter>>                                  )((NpgsqlBinaryImporter this_) => this_.StartRow()),
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 				// [4]: CompleteAsync
 				new Tuple<LambdaExpression, bool>
 				((Expression<Func<NpgsqlBinaryImporter, CancellationToken, ValueTask<ulong>>>)((NpgsqlBinaryImporter this_, CancellationToken token) => this_.CompleteAsync(token)),         true),
@@ -549,7 +549,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			public void StartRow() => ((Action<NpgsqlBinaryImporter>)CompiledWrappers[3])(this);
 			public void Write<T>(T value, NpgsqlDbType npgsqlDbType) => ((Action<NpgsqlBinaryImporter, object?, NpgsqlDbType>)CompiledWrappers[8])(this, (object?)value, npgsqlDbType);
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 #pragma warning disable CS3002 // Return type is not CLS-compliant
 			public ValueTask<ulong> CompleteAsync(CancellationToken cancellationToken) 
 				=> ((Func<NpgsqlBinaryImporter, CancellationToken, ValueTask<ulong>>)CompiledWrappers[4])(this, cancellationToken);

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
@@ -31,7 +31,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			return MultipleRowsCopy1Async(table, options, source, cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected override Task<BulkCopyRowsCopied> MultipleRowsCopyAsync<T>(ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
 			return MultipleRowsCopy1Async(table, options, source, cancellationToken);
@@ -55,7 +55,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected override Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
@@ -305,7 +305,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			return rowsCopied;
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		private async Task<BulkCopyRowsCopied> ProviderSpecificCopyImplAsync<T>(DataConnection dataConnection, ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
 			var connection = _provider.TryGetProviderConnection(dataConnection.Connection, dataConnection.MappingSchema);

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
@@ -177,7 +177,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			return new PostgreSQLSchemaProvider(this);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		public override bool? IsDBNullAllowed(IDataReader reader, int idx)
 		{
 			return true;
@@ -281,7 +281,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 				cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteBulkCopy.cs
@@ -20,7 +20,7 @@ namespace LinqToDB.DataProvider.SQLite
 			return MultipleRowsCopy1Async(table, options, source, cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected override Task<BulkCopyRowsCopied> MultipleRowsCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteDataProvider.cs
@@ -236,7 +236,7 @@ namespace LinqToDB.DataProvider.SQLite
 				cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaBulkCopy.cs
@@ -59,7 +59,7 @@ namespace LinqToDB.DataProvider.SapHana
 			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected override Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T> table,
 			BulkCopyOptions options,

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaDataProvider.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0 && !NETSTANDARD2_1
+﻿#if NETFRAMEWORK || NETCOREAPP
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -162,7 +162,7 @@ namespace LinqToDB.DataProvider.SapHana
 				cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaMappingSchema.cs
@@ -54,7 +54,7 @@
 
 		internal static readonly SapHanaMappingSchema Instance = new SapHanaMappingSchema();
 
-#if !NETSTANDARD2_0 && !NETSTANDARD2_1
+#if NETFRAMEWORK || NETCOREAPP
 		public class NativeMappingSchema : MappingSchema
 		{
 			public NativeMappingSchema()

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaProviderAdapter.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaProviderAdapter.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0 && !NETSTANDARD2_1
+﻿#if NETFRAMEWORK || NETCOREAPP
 using System;
 using System.Data;
 
@@ -15,7 +15,7 @@ namespace LinqToDB.DataProvider.SapHana
 		private static readonly object _syncRoot = new object();
 		private static SapHanaProviderAdapter? _instance;
 
-#if NET45 || NET46
+#if NETFRAMEWORK
 		public const string AssemblyName        = "Sap.Data.Hana.v4.5";
 #else
 		public const string AssemblyName        = "Sap.Data.Hana.Core.v2.1";

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaTools.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaTools.cs
@@ -9,7 +9,7 @@ namespace LinqToDB.DataProvider.SapHana
 
 	public static class SapHanaTools
 	{
-#if !NETSTANDARD2_0 && !NETSTANDARD2_1
+#if NETFRAMEWORK || NETCOREAPP
 		private static readonly Lazy<IDataProvider> _hanaDataProvider = new Lazy<IDataProvider>(() =>
 		{
 			var provider = new SapHanaDataProvider(ProviderName.SapHanaNative);
@@ -33,7 +33,7 @@ namespace LinqToDB.DataProvider.SapHana
 		{
 			new AssemblyResolver(
 				path,
-#if !NETSTANDARD2_0 && !NETSTANDARD2_1
+#if NETFRAMEWORK || NETCOREAPP
 			DetectedProviderName == ProviderName.SapHanaNative
 						? SapHanaProviderAdapter.AssemblyName :
 #endif
@@ -47,7 +47,7 @@ namespace LinqToDB.DataProvider.SapHana
 
 		public static IDataProvider GetDataProvider(string? providerName = null, string? assemblyName = null)
 		{
-#if !NETSTANDARD2_0 && !NETSTANDARD2_1
+#if NETFRAMEWORK || NETCOREAPP
 			if (assemblyName == SapHanaProviderAdapter.AssemblyName) return _hanaDataProvider.Value;
 #endif
 			if (assemblyName == OdbcProviderAdapter.AssemblyName)    return _hanaOdbcDataProvider.Value;
@@ -56,12 +56,12 @@ namespace LinqToDB.DataProvider.SapHana
 			switch (providerName)
 			{
 				case ProviderName.SapHanaOdbc  : return _hanaOdbcDataProvider.Value;
-#if !NETSTANDARD2_0 && !NETSTANDARD2_1
+#if NETFRAMEWORK || NETCOREAPP
 				case ProviderName.SapHanaNative: return _hanaDataProvider.Value;
 #endif
 			}
 
-#if !NETSTANDARD2_0 && !NETSTANDARD2_1
+#if NETFRAMEWORK || NETCOREAPP
 			if (DetectedProviderName == ProviderName.SapHanaNative)
 				return _hanaDataProvider.Value;
 #endif
@@ -94,7 +94,7 @@ namespace LinqToDB.DataProvider.SapHana
 
 		static string DetectProviderName()
 		{
-#if !NETSTANDARD2_0 && !NETSTANDARD2_1
+#if NETFRAMEWORK || NETCOREAPP
 			return ProviderName.SapHanaNative;
 #else
 			return ProviderName.SapHanaOdbc;
@@ -108,7 +108,7 @@ namespace LinqToDB.DataProvider.SapHana
 
 			switch (css.ProviderName)
 			{
-#if !NETSTANDARD2_0 && !NETSTANDARD2_1
+#if NETFRAMEWORK || NETCOREAPP
 				case SapHanaProviderAdapter.ClientNamespace:
 				case "Sap.Data.Hana.v4.5"                  :
 				case "Sap.Data.Hana.Core"                  :

--- a/Source/LinqToDB/DataProvider/SqlCe/SqlCeBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/SqlCe/SqlCeBulkCopy.cs
@@ -43,7 +43,7 @@ namespace LinqToDB.DataProvider.SqlCe
 			return ret;
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected override async Task<BulkCopyRowsCopied> MultipleRowsCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/SqlCe/SqlCeDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlCe/SqlCeDataProvider.cs
@@ -156,7 +156,7 @@ namespace LinqToDB.DataProvider.SqlCe
 				cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerBulkCopy.cs
@@ -61,7 +61,7 @@ namespace LinqToDB.DataProvider.SqlServer
 			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected override Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T>           table,
 			BulkCopyOptions     options,
@@ -234,7 +234,7 @@ namespace LinqToDB.DataProvider.SqlServer
 			return ret;
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected override async Task<BulkCopyRowsCopied> MultipleRowsCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
@@ -416,7 +416,7 @@ namespace LinqToDB.DataProvider.SqlServer
 				cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
 			if (_bulkCopy == null)

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerProviderAdapter.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerProviderAdapter.cs
@@ -138,7 +138,7 @@ namespace LinqToDB.DataProvider.SqlServer
 			var isSystem = assemblyName == SystemAssemblyName;
 
 			Assembly? assembly;
-#if NET45 || NET46
+#if NETFRAMEWORK
 			if (isSystem)
 			{
 				assembly = typeof(System.Data.SqlClient.SqlConnection).Assembly;

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseBulkCopy.cs
@@ -56,7 +56,7 @@ namespace LinqToDB.DataProvider.Sybase
 			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected override Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T>           table,
 			BulkCopyOptions     options,
@@ -184,7 +184,7 @@ namespace LinqToDB.DataProvider.Sybase
 			return MultipleRowsCopy2Async(table, options, source, "", cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		protected override Task<BulkCopyRowsCopied> MultipleRowsCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseDataProvider.cs
@@ -224,7 +224,7 @@ namespace LinqToDB.DataProvider.Sybase
 				cancellationToken);
 		}
 
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseTools.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseTools.cs
@@ -12,7 +12,7 @@ namespace LinqToDB.DataProvider.Sybase
 
 	public static class SybaseTools
 	{
-#if NET45 || NET46
+#if NETFRAMEWORK
 		private static readonly Lazy<IDataProvider> _sybaseNativeDataProvider = new Lazy<IDataProvider>(() =>
 		{
 			var provider = new SybaseDataProvider(ProviderName.Sybase);
@@ -37,7 +37,7 @@ namespace LinqToDB.DataProvider.Sybase
 			{
 				case SybaseProviderAdapter.ManagedClientNamespace:
 				case ProviderName.SybaseManaged                  : return _sybaseManagedDataProvider.Value;
-#if NET45 || NET46
+#if NETFRAMEWORK
 				case "Sybase.Native"                             :
 				case SybaseProviderAdapter.NativeClientNamespace :
 				case SybaseProviderAdapter.NativeAssemblyName    : return _sybaseNativeDataProvider.Value;
@@ -50,7 +50,7 @@ namespace LinqToDB.DataProvider.Sybase
 				case ProviderName.Sybase                         :
 					if (css.Name.Contains("Managed"))
 						return _sybaseManagedDataProvider.Value;
-#if NET45 || NET46
+#if NETFRAMEWORK
 					if (css.Name.Contains("Native"))
 						return _sybaseNativeDataProvider.Value;
 #endif
@@ -76,7 +76,7 @@ namespace LinqToDB.DataProvider.Sybase
 
 		public static IDataProvider GetDataProvider(string? providerName = null, string? assemblyName = null)
 		{
-#if NET45 || NET46
+#if NETFRAMEWORK
 			if (assemblyName == SybaseProviderAdapter.NativeAssemblyName)  return _sybaseNativeDataProvider.Value;
 			if (assemblyName == SybaseProviderAdapter.ManagedAssemblyName) return _sybaseManagedDataProvider.Value;
 

--- a/Source/LinqToDB/IExtensionsAdapter.cs
+++ b/Source/LinqToDB/IExtensionsAdapter.cs
@@ -12,7 +12,7 @@ namespace LinqToDB
 	/// </summary>
 	public interface IExtensionsAdapter
 	{
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		IAsyncEnumerable<TSource> AsAsyncEnumerable<TSource>(
 			IQueryable<TSource> source);
 #endif

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -1627,7 +1627,7 @@ namespace LinqToDB.Linq.Builder
 
 							predicate = ConvertInPredicate(context!, expr);
 						}
-#if NET45 || NET46
+#if NETFRAMEWORK
 						else if (e.Method == ReflectionHelper.Functions.String.Like11) predicate = ConvertLikePredicate(context!, e);
 						else if (e.Method == ReflectionHelper.Functions.String.Like12) predicate = ConvertLikePredicate(context!, e);
 #endif

--- a/Source/LinqToDB/Linq/Expressions.cs
+++ b/Source/LinqToDB/Linq/Expressions.cs
@@ -531,7 +531,7 @@ namespace LinqToDB.Linq
 			{ M(() => "".Replace    (' ',' ') ), N(() => L<string?,char,char,string?>      ((string? obj,char   p0,char   p1)         => Sql.Replace  (obj, p0, p1))) },
 			{ M(() => "".Trim       ()        ), N(() => L<string?,string?>                ((string? obj)                             => Sql.Trim     (obj))) },
 
-#if NETCOREAPP2_1 || NETCOREAPP3_1
+#if NETCOREAPP
 			{ M(() => "".TrimEnd    ()        ), N(() => L<string,string?>                 ((string obj)                              =>     TrimRight(obj))) },
 			{ M(() => "".TrimStart  ()        ), N(() => L<string,string?>                 ((string obj)                              =>     TrimLeft (obj))) },
 #else

--- a/Source/LinqToDB/Linq/IDataReaderAsync.cs
+++ b/Source/LinqToDB/Linq/IDataReaderAsync.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 namespace LinqToDB.Linq
 {
 	public interface IDataReaderAsync : IDisposable
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 		, IAsyncDisposable
 #endif
 	{

--- a/Source/LinqToDB/Linq/QueryRunner.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.cs
@@ -594,7 +594,7 @@ namespace LinqToDB.Linq
 			using (var runner = dataContext.GetQueryRunner(query, queryNumber, expression, ps, preambles))
 			{
 				var dr = await runner.ExecuteReaderAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 				await using (dr.ConfigureAwait(Configuration.ContinueOnCapturedContext))
 #else
 				using (dr)
@@ -660,7 +660,7 @@ namespace LinqToDB.Linq
 
 			public T Current { get; set; } = default!;
 
-#if NET45 || NET46
+#if NETFRAMEWORK
 			public async Task<bool> MoveNextAsync()
 #else
 			public async ValueTask<bool> MoveNextAsync()
@@ -703,7 +703,7 @@ namespace LinqToDB.Linq
 				_queryRunner = null;
 			}
 
-#if NET45 || NET46
+#if NETFRAMEWORK
 			public Task DisposeAsync()
 			{
 				Dispose();
@@ -929,7 +929,7 @@ namespace LinqToDB.Linq
 			using (var runner = dataContext.GetQueryRunner(query, 0, expression, ps, preambles))
 			{
 				var dr = await runner.ExecuteReaderAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 				await using (dr.ConfigureAwait(Configuration.ContinueOnCapturedContext))
 #else
 				using (dr)

--- a/Source/LinqToDB/Linq/ReflectionHelper.cs
+++ b/Source/LinqToDB/Linq/ReflectionHelper.cs
@@ -153,7 +153,7 @@ namespace LinqToDB.Linq
 		{
 			public class String : Expressor<string>
 			{
-#if NET45 || NET46
+#if NETFRAMEWORK
 				public static MethodInfo Like11 = MethodOf(s => System.Data.Linq.SqlClient.SqlMethods.Like("", ""));
 				public static MethodInfo Like12 = MethodOf(s => System.Data.Linq.SqlClient.SqlMethods.Like("", "", ' '));
 #endif

--- a/Source/LinqToDB/Mapping/MappingSchema.cs
+++ b/Source/LinqToDB/Mapping/MappingSchema.cs
@@ -829,7 +829,7 @@ namespace LinqToDB.Mapping
 			_metadataReaders = list.ToArray();
 		}
 
-#if NET45 || NET46
+#if NETFRAMEWORK
 		/// <summary>
 		/// Gets or sets metadata attributes provider for current schema.
 		/// Metadata providers, shipped with LINQ to DB:

--- a/Source/LinqToDB/Metadata/MetadataReader.cs
+++ b/Source/LinqToDB/Metadata/MetadataReader.cs
@@ -13,7 +13,7 @@ namespace LinqToDB.Metadata
 		public static MetadataReader Default = new MetadataReader(
 			new AttributeReader()
 			, new SystemComponentModelDataAnnotationsSchemaAttributeReader()
-#if NET45 || NET46
+#if NETFRAMEWORK
 			, new SystemDataLinqAttributeReader()
 #endif
 		);

--- a/Source/LinqToDB/Metadata/SystemDataSqlServerAttributeReader.cs
+++ b/Source/LinqToDB/Metadata/SystemDataSqlServerAttributeReader.cs
@@ -26,7 +26,7 @@ namespace LinqToDB.Metadata
 		{
 			_sqlMethodAttributes = new[]
 			{
-#if NET45 || NET46
+#if NETFRAMEWORK
 				typeof(Microsoft.SqlServer.Server.SqlMethodAttribute),
 #endif
 				Type.GetType("Microsoft.SqlServer.Server.SqlMethodAttribute, System.Data.SqlClient", false),
@@ -35,7 +35,7 @@ namespace LinqToDB.Metadata
 
 			_sqlUserDefinedTypeAttributes = new[]
 			{
-#if NET45 || NET46
+#if NETFRAMEWORK
 				typeof(Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute),
 #endif
 				Type.GetType("Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute, System.Data.SqlClient", false),

--- a/Source/LinqToDB/ProviderName.cs
+++ b/Source/LinqToDB/ProviderName.cs
@@ -164,7 +164,7 @@ namespace LinqToDB
 		/// Used as configuration name for SAP HANA mapping schema <see cref="DataProvider.SapHana.SapHanaMappingSchema"/>.
 		/// </summary>
 		public const string SapHana       = "SapHana";
-#if !NETSTANDARD2_0 && !NETSTANDARD2_1
+#if NETFRAMEWORK || NETCOREAPP
 		/// <summary>
 		/// SAP HANA provider.
 		/// Used as configuration name for SAP HANA mapping schema <see cref="DataProvider.SapHana.SapHanaMappingSchema.NativeMappingSchema"/>.

--- a/Source/LinqToDB/Sql/Sql.cs
+++ b/Source/LinqToDB/Sql/Sql.cs
@@ -423,7 +423,7 @@ namespace LinqToDB
 		[Sql.Function(ServerSideOnly = true)]
 		public static bool Like(string? matchExpression, string? pattern)
 		{
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 			throw new InvalidOperationException();
 #else
 			return matchExpression != null && pattern != null &&
@@ -434,7 +434,7 @@ namespace LinqToDB
 		[Sql.Function(ServerSideOnly = true)]
 		public static bool Like(string? matchExpression, string? pattern, char? escapeCharacter)
 		{
-#if !NET45 && !NET46
+#if !NETFRAMEWORK
 			throw new InvalidOperationException();
 #else
 			return matchExpression != null && pattern != null && escapeCharacter != null &&

--- a/Tests/Linq/Common/EnumerableHelperTest.cs
+++ b/Tests/Linq/Common/EnumerableHelperTest.cs
@@ -44,7 +44,7 @@ namespace Tests.Common
 			}
 		}
 
-#if !NET45 && !NET46
+#if !NET46
 		[Test]
 		public async Task BatchAsyncTest()
 		{

--- a/Tests/Linq/Data/MiniProfilerTests.cs
+++ b/Tests/Linq/Data/MiniProfilerTests.cs
@@ -965,7 +965,7 @@ namespace Tests.Data
 							options,
 							Enumerable.Range(0, 1000).Select(n => new SapHanaTests.AllType() { ID = 2000 + n }));
 
-#if NET45 || NET46
+#if NET46
 						Assert.AreEqual(!unmapped, trace.Contains("INSERT ASYNC BULK"));
 #else
 						Assert.AreEqual(!unmapped, trace.Contains("INSERT BULK"));
@@ -1491,7 +1491,7 @@ namespace Tests.Data
 							options,
 							Enumerable.Range(0, 1000).Select(n => new PostgreSQLTests.AllTypes() { ID = 2000 + n }));
 
-#if NET45 || NET46
+#if NET46
 						// we use 4.0.10 for tests, async added in 4.1.0
 						Assert.AreEqual(!unmapped, trace.Contains("INSERT BULK"));
 #else

--- a/Tests/Linq/DataProvider/InformixTests.cs
+++ b/Tests/Linq/DataProvider/InformixTests.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using LinqToDB;
 using LinqToDB.Data;
 
-#if NET45 || NET46
+#if NET46
 using IBM.Data.Informix;
 #endif
 using NUnit.Framework;
@@ -66,7 +66,7 @@ namespace Tests.DataProvider
 				Assert.That(TestType<byte[]>      (conn, "byteDataType",     DataType.Binary,    skipPass:true), Is.EqualTo(new byte[] { 1, 2 }));
 				Assert.That(TestType<byte[]>      (conn, "byteDataType",     DataType.VarBinary, skipPass:true), Is.EqualTo(new byte[] { 1, 2 }));
 
-#if NET45 || NET46
+#if NET46
 				if (context == ProviderName.Informix)
 				{
 					Assert.That(TestType<IfxDateTime?>(conn, "datetimeDataType", DataType.DateTime), Is.EqualTo(new IfxDateTime(new DateTime(2012, 12, 12, 12, 12, 12))));

--- a/Tests/Linq/Metadata/SystemDataLinqAttributeReaderTests.cs
+++ b/Tests/Linq/Metadata/SystemDataLinqAttributeReaderTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET45 || NET46
+﻿#if NET46
 using LinqToDB;
 using LinqToDB.Metadata;
 using NUnit.Framework;


### PR DESCRIPTION
This PR reduces the number of `#if` defines for the main projects to these 3 core defines:
* `NETFRAMEWORK` - for TFMs: `net45` & `net46`
* `NETCOREAPP` - for TFMs: `netcoreapp2.1` & `netcoreapp3.1` (and in the future, `net5.0`)
* `NETSTANDARD2_1PLUS` - for TFMs: `netstandard2.1` & `netcoreapp3.1` (and in the future, `net5.0`)

The first two defines above are built-in, and `NETSTANDARD2_1PLUS` is a custom define added to `linq2db.Default.props`.  This cleans up the code quite a bit.  There's only about 5 ifdefs that don't work with the above.

Looking forward towards .Net 5.0, the framework automatically will define `NETCOREAPP`, `NETCOREAPP3_1`, `NET` and `NET5_0`, and there will be no "net standard" variation.  We will simply add the `net5.0` TFM to our custom `NETSTANDARD2_1PLUS` define, and all existing code will work seamlessly.

See: https://github.com/dotnet/designs/blob/master/accepted/2020/net5/net5.md

As for the test projects, they are mostly written with `NET46`, `NETCOREAPP2_1` and `NETCOREAPP3_1`.  I left these in place as they will already be accurate with .Net 5.0.

In order to make the changes, I used search and replace for the following, and manually edited the few `#elif` conditions:

| Search | Replace |
| ------------------------------ | -------------------------- |
| `#if NET45 \|\| NET46` | `#if NETFRAMEWORK` |
| `#if !NET45 && !NET46` | `#if !NETFRAMEWORK` |
| `#if NETCOREAPP2_1 \|\| NETCOREAPP3_1` | `#if NETCOREAPP` |
| `#if NETSTANDARD2_1 \|\| NETCOREAPP3_1` | `#if NETSTANDARD2_1PLUS` |
| `#if !NETSTANDARD2_1 && !NETCOREAPP3_1` | `#if !NETSTANDARD2_1PLUS` |
| `#if !NETSTANDARD2_0 && !NETSTANDARD2_1` | `#if NETFRAMEWORK \|\| NETCOREAPP` |
| `#if (!NETSTANDARD2_0 && !NETCOREAPP2_1 && !NETSTANDARD2_1)` | `#if NETFRAMEWORK \|\| NETCOREAPP3_1` |
| `#if NET45 \|\| NET46` | `#if NET46` (test projects only) |


Please let me know what y'all think.