### PR TITLE
Skip on Select All

### DIFF
--- a/Source/LinqToDB/Linq/Builder/TableBuilder.TableContext.cs
+++ b/Source/LinqToDB/Linq/Builder/TableBuilder.TableContext.cs
@@ -818,7 +818,7 @@ namespace LinqToDB.Linq.Builder
 									
 									{
 										result = SqlTable.Fields.Values
-											.Where(field => !field.IsDynamic)
+											.Where(field => !field.IsDynamic && !field.SkipOnEntityFetch)
 											.Select(f =>
 												f.ColumnDescriptor != null
 													? new SqlInfo(f.ColumnDescriptor.MemberInfo, f)

--- a/Source/LinqToDB/Mapping/ColumnAttribute.cs
+++ b/Source/LinqToDB/Mapping/ColumnAttribute.cs
@@ -156,6 +156,12 @@ namespace LinqToDB.Mapping
 		/// </summary>
 		public bool IsDiscriminator { get; set; }
 
+		/// <summary>
+		/// Gets or sets whether a column must be explicitly defined in a Select statement to be fetched. If <c>true</c>, a "SELECT *"-ish statement won't retrieve this column.
+		/// Default value: <c>false</c>.
+		/// </summary>
+		public bool SkipOnEntityFetch { get; set; }
+
 		private bool? _skipOnInsert;
 		/// <summary>
 		/// Gets or sets whether a column is insertable.

--- a/Source/LinqToDB/Mapping/ColumnAttribute.cs
+++ b/Source/LinqToDB/Mapping/ColumnAttribute.cs
@@ -59,16 +59,17 @@ namespace LinqToDB.Mapping
 		/// <param name="ca">Attribute to clone.</param>
 		internal ColumnAttribute(ColumnAttribute ca)
 		{
-			MemberName      = ca.MemberName;
-			Configuration   = ca.Configuration;
-			Name            = ca.Name;
-			DataType        = ca.DataType;
-			DbType          = ca.DbType;
-			Storage         = ca.Storage;
-			IsDiscriminator = ca.IsDiscriminator;
-			PrimaryKeyOrder = ca.PrimaryKeyOrder;
-			IsColumn        = ca.IsColumn;
-			CreateFormat    = ca.CreateFormat;
+			MemberName        = ca.MemberName;
+			Configuration     = ca.Configuration;
+			Name              = ca.Name;
+			DataType          = ca.DataType;
+			DbType            = ca.DbType;
+			Storage           = ca.Storage;
+			IsDiscriminator   = ca.IsDiscriminator;
+			SkipOnEntityFetch = ca.SkipOnEntityFetch;
+			PrimaryKeyOrder   = ca.PrimaryKeyOrder;
+			IsColumn          = ca.IsColumn;
+			CreateFormat      = ca.CreateFormat;
 
 			if (ca.HasSkipOnInsert()) SkipOnInsert = ca.SkipOnInsert;
 			if (ca.HasSkipOnUpdate()) SkipOnUpdate = ca.SkipOnUpdate;

--- a/Source/LinqToDB/Mapping/ColumnDescriptor.cs
+++ b/Source/LinqToDB/Mapping/ColumnDescriptor.cs
@@ -62,14 +62,15 @@ namespace LinqToDB.Mapping
 				if (dataType.Type.Scale     != null && !columnAttribute.HasScale())     columnAttribute.Scale     = dataType.Type.Scale.Value;
 			}
 
-			MemberName      = columnAttribute.MemberName ?? MemberInfo.Name;
-			ColumnName      = columnAttribute.Name       ?? MemberInfo.Name;
-			Storage         = columnAttribute.Storage;
-			PrimaryKeyOrder = columnAttribute.PrimaryKeyOrder;
-			IsDiscriminator = columnAttribute.IsDiscriminator;
-			DataType        = columnAttribute.DataType;
-			DbType          = columnAttribute.DbType;
-			CreateFormat    = columnAttribute.CreateFormat;
+			MemberName        = columnAttribute.MemberName ?? MemberInfo.Name;
+			ColumnName        = columnAttribute.Name       ?? MemberInfo.Name;
+			Storage           = columnAttribute.Storage;
+			PrimaryKeyOrder   = columnAttribute.PrimaryKeyOrder;
+			IsDiscriminator   = columnAttribute.IsDiscriminator;
+			SkipOnEntityFetch = columnAttribute.SkipOnEntityFetch;
+			DataType          = columnAttribute.DataType;
+			DbType            = columnAttribute.DbType;
+			CreateFormat      = columnAttribute.CreateFormat;
 
 			if (columnAttribute.HasLength   ()) Length    = columnAttribute.Length;
 			if (columnAttribute.HasPrecision()) Precision = columnAttribute.Precision;
@@ -316,6 +317,12 @@ namespace LinqToDB.Mapping
 		/// method and will be ignored when user explicitly specifies value for this column.
 		/// </summary>
 		public bool           SkipOnInsert    { get; }
+
+		/// <summary>
+		/// Gets whether a column must be explicitly defined in a Select statement to be fetched. If <c>true</c>, a "SELECT *"-ish statement won't retrieve this column.
+		/// Default value: <c>false</c>.
+		/// </summary>
+		public bool           SkipOnEntityFetch { get; }
 
 		/// <summary>
 		/// Gets whether the column has specific values that should be skipped on insert.

--- a/Source/LinqToDB/Mapping/PropertyMappingBuilder.cs
+++ b/Source/LinqToDB/Mapping/PropertyMappingBuilder.cs
@@ -323,6 +323,16 @@ namespace LinqToDB.Mapping
 		}
 
 		/// <summary>
+		/// Marks current column to be skipped by default during a full entity fetch
+		/// </summary>
+		/// <param name="skipOnEntityFetch">If <c>true</c>, column won't be fetched unless explicity selected in a Linq query.</param>
+		/// <returns>Returns current column mapping builder.</returns>
+		public PropertyMappingBuilder<TEntity, TProperty> SkipOnEntityFetch(bool skipOnEntityFetch = true)
+		{
+			return SetColumn(a => a.SkipOnEntityFetch = skipOnEntityFetch);
+		}
+
+		/// <summary>
 		/// Sets whether a column is insertable.
 		/// This flag will affect only insert operations with implicit columns specification like
 		/// <see cref="DataExtensions.Insert{T}(IDataContext, T, string, string, string, string)"/>

--- a/Source/LinqToDB/SqlQuery/SqlField.cs
+++ b/Source/LinqToDB/SqlQuery/SqlField.cs
@@ -63,34 +63,36 @@ namespace LinqToDB.SqlQuery
 
 		public SqlField(ColumnDescriptor column)
 		{
-			Type             = new DbDataType(column.MemberType, column.DataType, column.DbType, column.Length, column.Precision, column.Scale);
-			Name             = column.MemberName;
-			PhysicalName     = column.ColumnName;
-			CanBeNull        = column.CanBeNull;
-			IsPrimaryKey     = column.IsPrimaryKey;
-			PrimaryKeyOrder  = column.PrimaryKeyOrder;
-			IsIdentity       = column.IsIdentity;
-			IsInsertable     = !column.SkipOnInsert;
-			IsUpdatable      = !column.SkipOnUpdate;
-			CreateFormat     = column.CreateFormat;
-			CreateOrder      = column.Order;
-			ColumnDescriptor = column;
+			Type              = new DbDataType(column.MemberType, column.DataType, column.DbType, column.Length, column.Precision, column.Scale);
+			Name              = column.MemberName;
+			PhysicalName      = column.ColumnName;
+			CanBeNull         = column.CanBeNull;
+			IsPrimaryKey      = column.IsPrimaryKey;
+			PrimaryKeyOrder   = column.PrimaryKeyOrder;
+			IsIdentity        = column.IsIdentity;
+			IsInsertable      = !column.SkipOnInsert;
+			IsUpdatable       = !column.SkipOnUpdate;
+			SkipOnEntityFetch = column.SkipOnEntityFetch;
+			CreateFormat      = column.CreateFormat;
+			CreateOrder       = column.Order;
+			ColumnDescriptor  = column;
 		}
 
-		public DbDataType?       Type             { get; set; }
-		public string?           Alias            { get; set; }
-		public string            Name             { get; set; } = null!; // not always true, see ColumnDescriptor notes
-		public bool              IsPrimaryKey     { get; set; }
-		public int               PrimaryKeyOrder  { get; set; }
-		public bool              IsIdentity       { get; set; }
-		public bool              IsInsertable     { get; set; }
-		public bool              IsUpdatable      { get; set; }
-		public bool              IsDynamic        { get; set; }
-		public string?           CreateFormat     { get; set; }
-		public int?              CreateOrder      { get; set; }
+		public DbDataType?       Type              { get; set; }
+		public string?           Alias             { get; set; }
+		public string            Name              { get; set; } = null!; // not always true, see ColumnDescriptor notes
+		public bool              IsPrimaryKey      { get; set; }
+		public int               PrimaryKeyOrder   { get; set; }
+		public bool              IsIdentity        { get; set; }
+		public bool              IsInsertable      { get; set; }
+		public bool              IsUpdatable       { get; set; }
+		public bool              IsDynamic         { get; set; }
+		public bool              SkipOnEntityFetch { get; set; }
+		public string?           CreateFormat      { get; set; }
+		public int?              CreateOrder       { get; set; }
 
-		public ISqlTableSource?  Table            { get; set; }
-		public ColumnDescriptor  ColumnDescriptor { get; set; } = null!; // TODO: not true, we probably should introduce something else for non-column fields
+		public ISqlTableSource?  Table             { get; set; }
+		public ColumnDescriptor  ColumnDescriptor  { get; set; } = null!; // TODO: not true, we probably should introduce something else for non-column fields
 
 		Type ISqlExpression.SystemType => Type?.SystemType!; // !!!
 

--- a/Tests/Linq/UserTests/SkipOnEntityFetchTests.cs
+++ b/Tests/Linq/UserTests/SkipOnEntityFetchTests.cs
@@ -1,0 +1,55 @@
+﻿using System.Linq;
+using LinqToDB;
+using LinqToDB.Mapping;
+using NUnit.Framework;
+
+namespace Tests.Playground
+{
+	[TestFixture]
+	public class SkipOnEntityFetchTests : TestBase
+	{		
+		[Table("Person")]
+		public class PersonEx
+		{
+			[Column("PersonID", SkipOnEntityFetch=true)]
+			public int? ID;
+
+			[Column]
+			public string? FirstName { get; set; }
+
+			[Column]
+			public string? LastName { get; set; }
+		}
+
+		public void SelectFullEntityWithSkipColumn([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var allPeople = db.GetTable<PersonEx>().ToArray();
+				var anyGotId = allPeople.Any(p => p.ID != null);
+				Assert.IsFalse(anyGotId);
+
+				var allPeopleWithCondition = db.GetTable<PersonEx>()
+												.Where(p => (p.ID ?? 0) >= 2)
+												.ToArray();
+				var anyWithCondGotId = allPeopleWithCondition.Any(p => p.ID != null);
+				Assert.IsFalse(anyWithCondGotId);
+
+				var allAnonymWithExplicitSelect = db.GetTable<PersonEx>()
+													.Select(p => new {p.ID, p.FirstName,p.LastName});
+				var allAnonymGotId = allAnonymWithExplicitSelect.All(p => p.ID != null);
+				Assert.IsTrue(allAnonymGotId);
+
+				var allPeopleWithExplicitSelect = db.GetTable<PersonEx>()
+													.Select(p => new PersonEx()
+													{
+														ID = p.ID,
+														FirstName = p.FirstName,
+														LastName = p.LastName
+													});
+				var allExplicitGotId = allPeopleWithExplicitSelect.All(p => p.ID != null);
+				Assert.IsTrue(allExplicitGotId);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Implemented the `ColumnAttribute.SkipOnSelectAll` property.
This mapping property can be applied to columns that should not be fetched by default.
Main use case are tables with a long set of columns and in which some of them may impact performance if retrieved by default (e.g.: Blob / Clob / XMLs / etc). In these cases, such columns must be arbitrarily selected in Linq queries to be fetched if the SkipOnSelectAll = true.