### PR TITLE
Add generic constraint of class type to CreateTempTable

### DIFF
--- a/Source/LinqToDB/TempTable.cs
+++ b/Source/LinqToDB/TempTable.cs
@@ -25,7 +25,7 @@ namespace LinqToDB
 	/// </summary>
 	/// <typeparam name="T">Table record mapping class.</typeparam>
 	[PublicAPI]
-	public class TempTable<T> : ITable<T>, ITableMutable<T>, IDisposable 
+	public class TempTable<T> : ITable<T>, ITableMutable<T>, IDisposable
 	{
 		readonly ITable<T> _table;
 

--- a/Source/LinqToDB/TempTable.cs
+++ b/Source/LinqToDB/TempTable.cs
@@ -25,7 +25,7 @@ namespace LinqToDB
 	/// </summary>
 	/// <typeparam name="T">Table record mapping class.</typeparam>
 	[PublicAPI]
-	public class TempTable<T> : ITable<T>, ITableMutable<T>, IDisposable
+	public class TempTable<T> : ITable<T>, ITableMutable<T>, IDisposable 
 	{
 		readonly ITable<T> _table;
 
@@ -365,6 +365,7 @@ namespace LinqToDB
 			string? databaseName = null,
 			string? schemaName   = null,
 			string? serverName   = null)
+			where T : class
 		{
 			return new TempTable<T>(db, tableName, databaseName, schemaName, serverName);
 		}
@@ -389,6 +390,7 @@ namespace LinqToDB
 			string? databaseName = null,
 			string? schemaName   = null,
 			string? serverName   = null)
+			where T : class
 		{
 			return new TempTable<T>(db, items, options, tableName, databaseName, schemaName, serverName);
 		}
@@ -413,6 +415,7 @@ namespace LinqToDB
 			string? databaseName = null,
 			string? schemaName   = null,
 			string? serverName   = null)
+			where T : class
 		{
 			return new TempTable<T>(db, tableName, items, options, databaseName, schemaName, serverName);
 		}
@@ -437,6 +440,7 @@ namespace LinqToDB
 			string? schemaName        = null,
 			Action<ITable<T>>? action = null,
 			string? serverName        = null)
+			where T : class
 		{
 			return new TempTable<T>(db, items, tableName, databaseName, schemaName, action, serverName);
 		}
@@ -464,6 +468,7 @@ namespace LinqToDB
 			string? schemaName        = null,
 			Action<ITable<T>>? action = null,
 			string? serverName        = null)
+			where T : class
 		{
 			if (setTable == null) throw new ArgumentNullException(nameof(setTable));
 
@@ -492,6 +497,7 @@ namespace LinqToDB
 			string? schemaName        = null,
 			Action<ITable<T>>? action = null,
 			string? serverName        = null)
+			where T : class
 		{
 			return new TempTable<T>(db, tableName, items, databaseName, schemaName, action, serverName);
 		}
@@ -519,6 +525,7 @@ namespace LinqToDB
 			string? schemaName        = null,
 			Action<ITable<T>>? action = null,
 			string? serverName        = null)
+			where T : class
 		{
 			if (setTable == null) throw new ArgumentNullException(nameof(setTable));
 

--- a/Tests/Linq/UserTests/Issue1721Tests.cs
+++ b/Tests/Linq/UserTests/Issue1721Tests.cs
@@ -70,7 +70,8 @@ namespace Tests.UserTests
 		/// <typeparam name="T">Type of table to create.</typeparam>
 		/// <param name="connection"><see cref="DataConnection"/> to create temporary table in.</param>
 		/// <returns>SQL used to create the table.</returns>
-		private static string GetCreateTableSQL<T>(DataConnection connection)
+		private static string GetCreateTableSQL<T>(DataConnection connection) 
+			where T : class
 		{
 			using (var temp = connection.CreateTempTable<T>())
 			{

--- a/Tests/Linq/UserTests/Issue1721Tests.cs
+++ b/Tests/Linq/UserTests/Issue1721Tests.cs
@@ -70,7 +70,7 @@ namespace Tests.UserTests
 		/// <typeparam name="T">Type of table to create.</typeparam>
 		/// <param name="connection"><see cref="DataConnection"/> to create temporary table in.</param>
 		/// <returns>SQL used to create the table.</returns>
-		private static string GetCreateTableSQL<T>(DataConnection connection) 
+		private static string GetCreateTableSQL<T>(DataConnection connection)
 			where T : class
 		{
 			using (var temp = connection.CreateTempTable<T>())


### PR DESCRIPTION
See #1934 

This PR prevents a call of `CreateTempTable<int>(...)`.  Note that a generic constraint on `TempTable<T>` was not added due to conflicts elsewhere in the codebase.