### PR TITLE
Add asynchronous overloads for CreateTempTable

### DIFF
--- a/Source/LinqToDB/DataProvider/BasicBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/BasicBulkCopy.cs
@@ -99,7 +99,7 @@ namespace LinqToDB.DataProvider
 
 			foreach (var item in source)
 			{
-				table.DataContext.Insert(item, options.TableName, options.DatabaseName, options.SchemaName, options.ServerName);
+				table.DataContext.Insert(item, options.TableName ?? table.TableName, options.DatabaseName ?? table.DatabaseName, options.SchemaName ?? table.SchemaName, options.ServerName ?? table.ServerName);
 				rowsCopied.RowsCopied++;
 
 				if (options.NotifyAfter != 0 && options.RowsCopiedCallback != null && rowsCopied.RowsCopied % options.NotifyAfter == 0)
@@ -126,7 +126,7 @@ namespace LinqToDB.DataProvider
 
 			foreach (var item in source)
 			{
-				await table.DataContext.InsertAsync(item, options.TableName, options.DatabaseName, options.SchemaName, options.ServerName, cancellationToken)
+				await table.DataContext.InsertAsync(item, options.TableName ?? table.TableName, options.DatabaseName ?? table.DatabaseName, options.SchemaName ?? table.SchemaName, options.ServerName ?? table.ServerName, cancellationToken)
 					.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 				rowsCopied.RowsCopied++;
 
@@ -155,7 +155,7 @@ namespace LinqToDB.DataProvider
 
 			await foreach (var item in source.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext).WithCancellation(cancellationToken))
 			{
-				await table.DataContext.InsertAsync(item, options.TableName, options.DatabaseName, options.SchemaName, options.ServerName, cancellationToken)
+				await table.DataContext.InsertAsync(item, options.TableName ?? table.TableName, options.DatabaseName ?? table.DatabaseName, options.SchemaName ?? table.SchemaName, options.ServerName ?? table.ServerName, cancellationToken)
 					.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 				rowsCopied.RowsCopied++;
 

--- a/Source/LinqToDB/TempTable.cs
+++ b/Source/LinqToDB/TempTable.cs
@@ -164,7 +164,7 @@ namespace LinqToDB
 		/// <param name="table">Table instance.</param>
 		protected TempTable(ITable<T> table)
 		{
-			_table = table;
+			_table = table ?? throw new ArgumentNullException(nameof(table));
 		}
 
 		/// <summary>

--- a/Source/LinqToDB/TempTable.cs
+++ b/Source/LinqToDB/TempTable.cs
@@ -184,7 +184,7 @@ namespace LinqToDB
 			if (db == null) throw new ArgumentNullException(nameof(db));
 
 			return new TempTable<T>(await db.CreateTableAsync<T>(tableName, databaseName, schemaName, serverName: serverName)
-				.ConfigureAwait(false));
+				.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext));
 		}
 
 		/// <summary>
@@ -230,10 +230,10 @@ namespace LinqToDB
 			if (items == null) throw new ArgumentNullException(nameof(items));
 
 			var table = await CreateAsync(db, tableName, databaseName, schemaName, serverName)
-				.ConfigureAwait(false);
+				.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 			await table.CopyAsync(items, options)
-				.ConfigureAwait(false);
+				.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 			return table;
 		}
@@ -260,14 +260,14 @@ namespace LinqToDB
 			if (items == null) throw new ArgumentNullException(nameof(items));
 
 			var table = await CreateAsync(db, tableName, databaseName, schemaName, serverName)
-				.ConfigureAwait(false);
+				.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 			if (action != null)
 				await action.Invoke(table)
-					.ConfigureAwait(false);
+					.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 			await table.InsertAsync(items)
-				.ConfigureAwait(false);
+				.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 			return table;
 		}
@@ -319,8 +319,8 @@ namespace LinqToDB
 		public async Task<long> CopyAsync(IEnumerable<T> items, BulkCopyOptions? options = null)
 		{
 			var count = options != null ?
-				await _table.BulkCopyAsync(options, items).ConfigureAwait(false) :
-				await _table.BulkCopyAsync(items).ConfigureAwait(false);
+				await _table.BulkCopyAsync(options, items).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext) :
+				await _table.BulkCopyAsync(items).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 			TotalCopied += count.RowsCopied;
 
@@ -354,7 +354,7 @@ namespace LinqToDB
 		{
 			var l = GenerateInsertSetter(items ?? throw new ArgumentNullException(nameof(items)));
 
-			var count = await items.InsertAsync(_table, l).ConfigureAwait(false);
+			var count = await items.InsertAsync(_table, l).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 			TotalCopied += count;
 

--- a/Source/LinqToDB/TempTable.cs
+++ b/Source/LinqToDB/TempTable.cs
@@ -43,7 +43,7 @@ namespace LinqToDB
 		/// <param name="db">Database connection instance.</param>
 		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
-		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
 		public TempTable(IDataContext db,
 			string? tableName    = null,
@@ -64,7 +64,7 @@ namespace LinqToDB
 		/// <param name="options">Optional BulkCopy options.</param>
 		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
-		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
 		public TempTable(IDataContext db,
 			IEnumerable<T> items,
@@ -89,7 +89,7 @@ namespace LinqToDB
 		/// <param name="items">Initial records to insert into created table.</param>
 		/// <param name="options">Optional BulkCopy options.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
-		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
 		public TempTable(IDataContext db,
 			string? tableName,
@@ -113,7 +113,7 @@ namespace LinqToDB
 		/// <param name="items">Query to get records to populate created table with initial data.</param>
 		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
-		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="action">Optional action that will be executed after table creation but before it populated with data from <paramref name="items"/>.</param>
 		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
 		public TempTable(IDataContext db,
@@ -139,7 +139,7 @@ namespace LinqToDB
 		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
 		/// <param name="items">Query to get records to populate created table with initial data.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
-		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="action">Optional action that will be executed after table creation but before it populated with data from <paramref name="items"/>.</param>
 		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
 		public TempTable(IDataContext db,
@@ -173,13 +173,13 @@ namespace LinqToDB
 		/// <param name="db">Database connection instance.</param>
 		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
-		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
 		public static async Task<TempTable<T>> CreateAsync(IDataContext db,
-			string? tableName = null,
+			string? tableName    = null,
 			string? databaseName = null,
-			string? schemaName = null,
-			string? serverName = null)
+			string? schemaName   = null,
+			string? serverName   = null)
 		{
 			if (db == null) throw new ArgumentNullException(nameof(db));
 
@@ -195,15 +195,15 @@ namespace LinqToDB
 		/// <param name="options">Optional BulkCopy options.</param>
 		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
-		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
 		public static Task<TempTable<T>> CreateAsync(IDataContext db,
 			IEnumerable<T> items,
 			BulkCopyOptions? options = null,
-			string? tableName = null,
-			string? databaseName = null,
-			string? schemaName = null,
-			string? serverName = null)
+			string? tableName        = null,
+			string? databaseName     = null,
+			string? schemaName       = null,
+			string? serverName       = null)
 		{
 			return CreateAsync(db, tableName, items, options, databaseName, schemaName, serverName);
 		}
@@ -216,23 +216,25 @@ namespace LinqToDB
 		/// <param name="items">Initial records to insert into created table.</param>
 		/// <param name="options">Optional BulkCopy options.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
-		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
 		public static async Task<TempTable<T>> CreateAsync(IDataContext db,
 			string? tableName,
 			IEnumerable<T> items,
 			BulkCopyOptions? options = null,
-			string? databaseName = null,
-			string? schemaName = null,
-			string? serverName = null)
+			string? databaseName     = null,
+			string? schemaName       = null,
+			string? serverName       = null)
 		{
 			if (db == null) throw new ArgumentNullException(nameof(db));
 			if (items == null) throw new ArgumentNullException(nameof(items));
 
 			var table = await CreateAsync(db, tableName, databaseName, schemaName, serverName)
 				.ConfigureAwait(false);
+
 			await table.CopyAsync(items, options)
 				.ConfigureAwait(false);
+
 			return table;
 		}
 
@@ -243,29 +245,30 @@ namespace LinqToDB
 		/// <param name="items">Query to get records to populate created table with initial data.</param>
 		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
-		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="action">Optional asynchronous action that will be executed after table creation but before it populated with data from <paramref name="items"/>.</param>
 		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
 		public static async Task<TempTable<T>> CreateAsync(IDataContext db,
 			IQueryable<T> items,
-			string? tableName = null,
-			string? databaseName = null,
-			string? schemaName = null,
+			string? tableName             = null,
+			string? databaseName          = null,
+			string? schemaName            = null,
 			Func<ITable<T>, Task>? action = null,
-			string? serverName = null)
+			string? serverName            = null)
 		{
 			if (db == null) throw new ArgumentNullException(nameof(db));
 			if (items == null) throw new ArgumentNullException(nameof(items));
 
 			var table = await CreateAsync(db, tableName, databaseName, schemaName, serverName)
 				.ConfigureAwait(false);
+
 			if (action != null)
-			{
 				await action.Invoke(table)
 					.ConfigureAwait(false);
-			}
+
 			await table.InsertAsync(items)
 				.ConfigureAwait(false);
+
 			return table;
 		}
 
@@ -276,16 +279,16 @@ namespace LinqToDB
 		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
 		/// <param name="items">Query to get records to populate created table with initial data.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
-		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="action">Optional asynchronous action that will be executed after table creation but before it populated with data from <paramref name="items"/>.</param>
 		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
 		public static Task<TempTable<T>> CreateAsync(IDataContext db,
 			string? tableName,
 			IQueryable<T> items,
-			string? databaseName = null,
-			string? schemaName = null,
+			string? databaseName          = null,
+			string? schemaName            = null,
 			Func<ITable<T>, Task>? action = null,
-			string? serverName = null)
+			string? serverName            = null)
 		{
 			return CreateAsync(db, items, tableName, databaseName, schemaName, action, serverName);
 		}
@@ -557,7 +560,7 @@ namespace LinqToDB
 		/// <param name="db">Database connection instance.</param>
 		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
-		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
 		/// <returns>Returns temporary table instance.</returns>
 		public static TempTable<T> CreateTempTable<T>(
@@ -579,7 +582,7 @@ namespace LinqToDB
 		/// <param name="options">Optional BulkCopy options.</param>
 		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
-		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
 		/// <returns>Returns temporary table instance.</returns>
 		public static TempTable<T> CreateTempTable<T>(
@@ -603,7 +606,7 @@ namespace LinqToDB
 		/// <param name="items">Initial records to insert into created table.</param>
 		/// <param name="options">Optional BulkCopy options.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
-		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
 		/// <returns>Returns temporary table instance.</returns>
 		public static TempTable<T> CreateTempTable<T>(
@@ -626,7 +629,7 @@ namespace LinqToDB
 		/// <param name="items">Query to get records to populate created table with initial data.</param>
 		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
-		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="action">Optional action that will be executed after table creation but before it populated with data from <paramref name="items"/>.</param>
 		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
 		/// <returns>Returns temporary table instance.</returns>
@@ -652,7 +655,7 @@ namespace LinqToDB
 		/// <param name="setTable">Action to modify <typeparamref name="T"/> entity's mapping using fluent mapping.</param>
 		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
-		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="action">Optional action that will be executed after table creation but before it populated with data from <paramref name="items"/>.</param>
 		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
 		/// <returns>Returns temporary table instance.</returns>
@@ -681,7 +684,7 @@ namespace LinqToDB
 		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
 		/// <param name="items">Query to get records to populate created table with initial data.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
-		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="action">Optional action that will be executed after table creation but before it populated with data from <paramref name="items"/>.</param>
 		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
 		/// <returns>Returns temporary table instance.</returns>
@@ -707,7 +710,7 @@ namespace LinqToDB
 		/// <param name="items">Query to get records to populate created table with initial data.</param>
 		/// <param name="setTable">Action to modify <typeparamref name="T"/> entity's mapping using fluent mapping.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
-		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="action">Optional action that will be executed after table creation but before it populated with data from <paramref name="items"/>.</param>
 		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
 		/// <returns>Returns temporary table instance.</returns>
@@ -735,15 +738,16 @@ namespace LinqToDB
 		/// <param name="db">Database connection instance.</param>
 		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
-		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
 		/// <returns>Returns temporary table instance.</returns>
 		public static Task<TempTable<T>> CreateTempTableAsync<T>(
 			this IDataContext db,
-			string? tableName = null,
+			string? tableName    = null,
 			string? databaseName = null,
-			string? schemaName = null,
-			string? serverName = null)
+			string? schemaName   = null,
+			string? serverName   = null)
+			where T : class
 		{
 			return TempTable<T>.CreateAsync(db, tableName, databaseName, schemaName, serverName);
 		}
@@ -757,17 +761,18 @@ namespace LinqToDB
 		/// <param name="options">Optional BulkCopy options.</param>
 		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
-		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
 		/// <returns>Returns temporary table instance.</returns>
 		public static Task<TempTable<T>> CreateTempTableAsync<T>(
 			this IDataContext db,
 			IEnumerable<T> items,
 			BulkCopyOptions? options = null,
-			string? tableName = null,
-			string? databaseName = null,
-			string? schemaName = null,
-			string? serverName = null)
+			string? tableName        = null,
+			string? databaseName     = null,
+			string? schemaName       = null,
+			string? serverName       = null)
+			where T : class
 		{
 			return TempTable<T>.CreateAsync(db, items, options, tableName, databaseName, schemaName, serverName);
 		}
@@ -781,7 +786,7 @@ namespace LinqToDB
 		/// <param name="items">Initial records to insert into created table.</param>
 		/// <param name="options">Optional BulkCopy options.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
-		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
 		/// <returns>Returns temporary table instance.</returns>
 		public static Task<TempTable<T>> CreateTempTableAsync<T>(
@@ -789,9 +794,10 @@ namespace LinqToDB
 			string? tableName,
 			IEnumerable<T> items,
 			BulkCopyOptions? options = null,
-			string? databaseName = null,
-			string? schemaName = null,
-			string? serverName = null)
+			string? databaseName     = null,
+			string? schemaName       = null,
+			string? serverName       = null)
+			where T : class
 		{
 			return TempTable<T>.CreateAsync(db, tableName, items, options, databaseName, schemaName, serverName);
 		}
@@ -804,18 +810,19 @@ namespace LinqToDB
 		/// <param name="items">Query to get records to populate created table with initial data.</param>
 		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
-		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="action">Optional asynchronous action that will be executed after table creation but before it populated with data from <paramref name="items"/>.</param>
 		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
 		/// <returns>Returns temporary table instance.</returns>
 		public static Task<TempTable<T>> CreateTempTableAsync<T>(
 			this IDataContext db,
 			IQueryable<T> items,
-			string? tableName = null,
-			string? databaseName = null,
-			string? schemaName = null,
+			string? tableName             = null,
+			string? databaseName          = null,
+			string? schemaName            = null,
 			Func<ITable<T>, Task>? action = null,
-			string? serverName = null)
+			string? serverName            = null)
+			where T : class
 		{
 			return TempTable<T>.CreateAsync(db, items, tableName, databaseName, schemaName, action, serverName);
 		}
@@ -830,7 +837,7 @@ namespace LinqToDB
 		/// <param name="setTable">Action to modify <typeparamref name="T"/> entity's mapping using fluent mapping.</param>
 		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
-		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="action">Optional asynchronous action that will be executed after table creation but before it populated with data from <paramref name="items"/>.</param>
 		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
 		/// <returns>Returns temporary table instance.</returns>
@@ -838,11 +845,12 @@ namespace LinqToDB
 			this IDataContext db,
 			IQueryable<T> items,
 			Action<EntityMappingBuilder<T>> setTable,
-			string? tableName = null,
-			string? databaseName = null,
-			string? schemaName = null,
+			string? tableName             = null,
+			string? databaseName          = null,
+			string? schemaName            = null,
 			Func<ITable<T>, Task>? action = null,
-			string? serverName = null)
+			string? serverName            = null)
+			where T : class
 		{
 			if (setTable == null) throw new ArgumentNullException(nameof(setTable));
 
@@ -859,7 +867,7 @@ namespace LinqToDB
 		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
 		/// <param name="items">Query to get records to populate created table with initial data.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
-		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="action">Optional asynchronous action that will be executed after table creation but before it populated with data from <paramref name="items"/>.</param>
 		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
 		/// <returns>Returns temporary table instance.</returns>
@@ -867,10 +875,11 @@ namespace LinqToDB
 			this IDataContext db,
 			string? tableName,
 			IQueryable<T> items,
-			string? databaseName = null,
-			string? schemaName = null,
+			string? databaseName          = null,
+			string? schemaName            = null,
 			Func<ITable<T>, Task>? action = null,
-			string? serverName = null)
+			string? serverName            = null)
+			where T : class
 		{
 			return TempTable<T>.CreateAsync(db, tableName, items, databaseName, schemaName, action, serverName);
 		}
@@ -885,7 +894,7 @@ namespace LinqToDB
 		/// <param name="items">Query to get records to populate created table with initial data.</param>
 		/// <param name="setTable">Action to modify <typeparamref name="T"/> entity's mapping using fluent mapping.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
-		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="action">Optional asynchronous action that will be executed after table creation but before it populated with data from <paramref name="items"/>.</param>
 		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
 		/// <returns>Returns temporary table instance.</returns>
@@ -894,10 +903,11 @@ namespace LinqToDB
 			string? tableName,
 			IQueryable<T> items,
 			Action<EntityMappingBuilder<T>> setTable,
-			string? databaseName = null,
-			string? schemaName = null,
+			string? databaseName          = null,
+			string? schemaName            = null,
 			Func<ITable<T>, Task>? action = null,
-			string? serverName = null)
+			string? serverName            = null)
+			where T : class
 		{
 			if (setTable == null) throw new ArgumentNullException(nameof(setTable));
 

--- a/Source/LinqToDB/TempTable.cs
+++ b/Source/LinqToDB/TempTable.cs
@@ -26,6 +26,9 @@ namespace LinqToDB
 	/// <typeparam name="T">Table record mapping class.</typeparam>
 	[PublicAPI]
 	public class TempTable<T> : ITable<T>, ITableMutable<T>, IDisposable
+#if !NETFRAMEWORK
+		, IAsyncDisposable
+#endif
 	{
 		readonly ITable<T> _table;
 
@@ -156,6 +159,138 @@ namespace LinqToDB
 		}
 
 		/// <summary>
+		/// Configures a temporary table that will be dropped when this instance is disposed
+		/// </summary>
+		/// <param name="table">Table instance.</param>
+		protected TempTable(ITable<T> table)
+		{
+			_table = table;
+		}
+
+		/// <summary>
+		/// Creates new temporary table.
+		/// </summary>
+		/// <param name="db">Database connection instance.</param>
+		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
+		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
+		public static async Task<TempTable<T>> CreateAsync(IDataContext db,
+			string? tableName = null,
+			string? databaseName = null,
+			string? schemaName = null,
+			string? serverName = null)
+		{
+			if (db == null) throw new ArgumentNullException(nameof(db));
+
+			return new TempTable<T>(await db.CreateTableAsync<T>(tableName, databaseName, schemaName, serverName: serverName)
+				.ConfigureAwait(false));
+		}
+
+		/// <summary>
+		/// Creates new temporary table and populate it using BulkCopy.
+		/// </summary>
+		/// <param name="db">Database connection instance.</param>
+		/// <param name="items">Initial records to insert into created table.</param>
+		/// <param name="options">Optional BulkCopy options.</param>
+		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
+		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
+		public static Task<TempTable<T>> CreateAsync(IDataContext db,
+			IEnumerable<T> items,
+			BulkCopyOptions? options = null,
+			string? tableName = null,
+			string? databaseName = null,
+			string? schemaName = null,
+			string? serverName = null)
+		{
+			return CreateAsync(db, tableName, items, options, databaseName, schemaName, serverName);
+		}
+
+		/// <summary>
+		/// Creates new temporary table and populate it using BulkCopy.
+		/// </summary>
+		/// <param name="db">Database connection instance.</param>
+		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
+		/// <param name="items">Initial records to insert into created table.</param>
+		/// <param name="options">Optional BulkCopy options.</param>
+		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
+		public static async Task<TempTable<T>> CreateAsync(IDataContext db,
+			string? tableName,
+			IEnumerable<T> items,
+			BulkCopyOptions? options = null,
+			string? databaseName = null,
+			string? schemaName = null,
+			string? serverName = null)
+		{
+			if (db == null) throw new ArgumentNullException(nameof(db));
+			if (items == null) throw new ArgumentNullException(nameof(items));
+
+			var table = await CreateAsync(db, tableName, databaseName, schemaName, serverName)
+				.ConfigureAwait(false);
+			await table.CopyAsync(items, options)
+				.ConfigureAwait(false);
+			return table;
+		}
+
+		/// <summary>
+		/// Creates new temporary table and populate it using data from provided query.
+		/// </summary>
+		/// <param name="db">Database connection instance.</param>
+		/// <param name="items">Query to get records to populate created table with initial data.</param>
+		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
+		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="action">Optional asynchronous action that will be executed after table creation but before it populated with data from <paramref name="items"/>.</param>
+		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
+		public static async Task<TempTable<T>> CreateAsync(IDataContext db,
+			IQueryable<T> items,
+			string? tableName = null,
+			string? databaseName = null,
+			string? schemaName = null,
+			Func<ITable<T>, Task>? action = null,
+			string? serverName = null)
+		{
+			if (db == null) throw new ArgumentNullException(nameof(db));
+			if (items == null) throw new ArgumentNullException(nameof(items));
+
+			var table = await CreateAsync(db, tableName, databaseName, schemaName, serverName)
+				.ConfigureAwait(false);
+			if (action != null)
+			{
+				await action.Invoke(table)
+					.ConfigureAwait(false);
+			}
+			await table.InsertAsync(items)
+				.ConfigureAwait(false);
+			return table;
+		}
+
+		/// <summary>
+		/// Creates new temporary table and populate it using data from provided query.
+		/// </summary>
+		/// <param name="db">Database connection instance.</param>
+		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
+		/// <param name="items">Query to get records to populate created table with initial data.</param>
+		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="action">Optional asynchronous action that will be executed after table creation but before it populated with data from <paramref name="items"/>.</param>
+		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
+		public static Task<TempTable<T>> CreateAsync(IDataContext db,
+			string? tableName,
+			IQueryable<T> items,
+			string? databaseName = null,
+			string? schemaName = null,
+			Func<ITable<T>, Task>? action = null,
+			string? serverName = null)
+		{
+			return CreateAsync(db, items, tableName, databaseName, schemaName, action, serverName);
+		}
+
+		/// <summary>
 		/// Insert new records into table using BulkCopy.
 		/// </summary>
 		/// <param name="items">Records to insert into table.</param>
@@ -166,6 +301,23 @@ namespace LinqToDB
 			var count = options != null ?
 				_table.BulkCopy(options, items) :
 				_table.BulkCopy(items);
+
+			TotalCopied += count.RowsCopied;
+
+			return count.RowsCopied;
+		}
+
+		/// <summary>
+		/// Insert new records into table using BulkCopy.
+		/// </summary>
+		/// <param name="items">Records to insert into table.</param>
+		/// <param name="options">Optional BulkCopy options.</param>
+		/// <returns>Number of records, inserted into table.</returns>
+		public async Task<long> CopyAsync(IEnumerable<T> items, BulkCopyOptions? options = null)
+		{
+			var count = options != null ?
+				await _table.BulkCopyAsync(options, items).ConfigureAwait(false) :
+				await _table.BulkCopyAsync(items).ConfigureAwait(false);
 
 			TotalCopied += count.RowsCopied;
 
@@ -210,6 +362,48 @@ namespace LinqToDB
 			});
 
 			var count = items.Insert(_table, l);
+
+			TotalCopied += count;
+
+			return count;
+		}
+
+		/// <summary>
+		/// Insert data into table using records, returned by provided query.
+		/// </summary>
+		/// <param name="items">Query with records to insert into temporary table.</param>
+		/// <returns>Number of records, inserted into table.</returns>
+		public async Task<long> InsertAsync(IQueryable<T> items)
+		{
+			var type = typeof(T);
+			var ed   = _table.DataContext.MappingSchema.GetEntityDescriptor(type);
+			var p    = Expression.Parameter(type, "t");
+
+			var l = _setterDic.GetOrAdd(type, t =>
+			{
+				if (t.IsAnonymous())
+				{
+					var nctor   = (NewExpression)items.Expression.Find(e => e.NodeType == ExpressionType.New && e.Type == t)!;
+					var members = nctor.Members
+						.Select(m => m is MethodInfo info ? info.GetPropertyInfo()! : m)
+						.ToList();
+
+					return Expression.Lambda<Func<T,T>>(
+						Expression.New(
+							nctor.Constructor,
+							members.Select(m => ExpressionHelper.PropertyOrField(p, m.Name)),
+							members),
+						p);
+				}
+
+				return Expression.Lambda<Func<T,T>>(
+					Expression.MemberInit(
+						Expression.New(t),
+						ed.Columns.Select(c => Expression.Bind(c.MemberInfo, Expression.MakeMemberAccess(p, c.MemberInfo)))),
+					p);
+			});
+
+			var count = await items.InsertAsync(_table, l).ConfigureAwait(false);
 
 			TotalCopied += count;
 
@@ -345,6 +539,13 @@ namespace LinqToDB
 		{
 			_table.DropTable();
 		}
+
+#if !NETFRAMEWORK
+		public ValueTask DisposeAsync()
+		{
+			return new ValueTask(_table.DropTableAsync());
+		}
+#endif
 	}
 
 	public static partial class DataExtensions
@@ -525,6 +726,184 @@ namespace LinqToDB
 			setTable(db.MappingSchema.GetFluentMappingBuilder().Entity<T>());
 
 			return new TempTable<T>(db, tableName, items, databaseName, schemaName, action, serverName);
+		}
+
+		/// <summary>
+		/// Creates new temporary table.
+		/// </summary>
+		/// <typeparam name="T">Table record mapping class.</typeparam>
+		/// <param name="db">Database connection instance.</param>
+		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
+		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
+		/// <returns>Returns temporary table instance.</returns>
+		public static Task<TempTable<T>> CreateTempTableAsync<T>(
+			this IDataContext db,
+			string? tableName = null,
+			string? databaseName = null,
+			string? schemaName = null,
+			string? serverName = null)
+		{
+			return TempTable<T>.CreateAsync(db, tableName, databaseName, schemaName, serverName);
+		}
+
+		/// <summary>
+		/// Creates new temporary table and populate it using BulkCopy.
+		/// </summary>
+		/// <typeparam name="T">Table record mapping class.</typeparam>
+		/// <param name="db">Database connection instance.</param>
+		/// <param name="items">Initial records to insert into created table.</param>
+		/// <param name="options">Optional BulkCopy options.</param>
+		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
+		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
+		/// <returns>Returns temporary table instance.</returns>
+		public static Task<TempTable<T>> CreateTempTableAsync<T>(
+			this IDataContext db,
+			IEnumerable<T> items,
+			BulkCopyOptions? options = null,
+			string? tableName = null,
+			string? databaseName = null,
+			string? schemaName = null,
+			string? serverName = null)
+		{
+			return TempTable<T>.CreateAsync(db, items, options, tableName, databaseName, schemaName, serverName);
+		}
+
+		/// <summary>
+		/// Creates new temporary table and populate it using BulkCopy.
+		/// </summary>
+		/// <typeparam name="T">Table record mapping class.</typeparam>
+		/// <param name="db">Database connection instance.</param>
+		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
+		/// <param name="items">Initial records to insert into created table.</param>
+		/// <param name="options">Optional BulkCopy options.</param>
+		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
+		/// <returns>Returns temporary table instance.</returns>
+		public static Task<TempTable<T>> CreateTempTableAsync<T>(
+			this IDataContext db,
+			string? tableName,
+			IEnumerable<T> items,
+			BulkCopyOptions? options = null,
+			string? databaseName = null,
+			string? schemaName = null,
+			string? serverName = null)
+		{
+			return TempTable<T>.CreateAsync(db, tableName, items, options, databaseName, schemaName, serverName);
+		}
+
+		/// <summary>
+		/// Creates new temporary table and populate it using data from provided query.
+		/// </summary>
+		/// <typeparam name="T">Table record mapping class.</typeparam>
+		/// <param name="db">Database connection instance.</param>
+		/// <param name="items">Query to get records to populate created table with initial data.</param>
+		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
+		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="action">Optional asynchronous action that will be executed after table creation but before it populated with data from <paramref name="items"/>.</param>
+		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
+		/// <returns>Returns temporary table instance.</returns>
+		public static Task<TempTable<T>> CreateTempTableAsync<T>(
+			this IDataContext db,
+			IQueryable<T> items,
+			string? tableName = null,
+			string? databaseName = null,
+			string? schemaName = null,
+			Func<ITable<T>, Task>? action = null,
+			string? serverName = null)
+		{
+			return TempTable<T>.CreateAsync(db, items, tableName, databaseName, schemaName, action, serverName);
+		}
+
+		/// <summary>
+		/// Creates new temporary table and populate it using data from provided query. Table mapping could be changed
+		/// using fluent mapper.
+		/// </summary>
+		/// <typeparam name="T">Table record mapping class.</typeparam>
+		/// <param name="db">Database connection instance.</param>
+		/// <param name="items">Query to get records to populate created table with initial data.</param>
+		/// <param name="setTable">Action to modify <typeparamref name="T"/> entity's mapping using fluent mapping.</param>
+		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
+		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="action">Optional asynchronous action that will be executed after table creation but before it populated with data from <paramref name="items"/>.</param>
+		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
+		/// <returns>Returns temporary table instance.</returns>
+		public static Task<TempTable<T>> CreateTempTableAsync<T>(
+			this IDataContext db,
+			IQueryable<T> items,
+			Action<EntityMappingBuilder<T>> setTable,
+			string? tableName = null,
+			string? databaseName = null,
+			string? schemaName = null,
+			Func<ITable<T>, Task>? action = null,
+			string? serverName = null)
+		{
+			if (setTable == null) throw new ArgumentNullException(nameof(setTable));
+
+			setTable(db.MappingSchema.GetFluentMappingBuilder().Entity<T>());
+
+			return TempTable<T>.CreateAsync(db, items, tableName, databaseName, schemaName, action, serverName);
+		}
+
+		/// <summary>
+		/// Creates new temporary table and populate it using data from provided query.
+		/// </summary>
+		/// <typeparam name="T">Table record mapping class.</typeparam>
+		/// <param name="db">Database connection instance.</param>
+		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
+		/// <param name="items">Query to get records to populate created table with initial data.</param>
+		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="action">Optional asynchronous action that will be executed after table creation but before it populated with data from <paramref name="items"/>.</param>
+		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
+		/// <returns>Returns temporary table instance.</returns>
+		public static Task<TempTable<T>> CreateTempTableAsync<T>(
+			this IDataContext db,
+			string? tableName,
+			IQueryable<T> items,
+			string? databaseName = null,
+			string? schemaName = null,
+			Func<ITable<T>, Task>? action = null,
+			string? serverName = null)
+		{
+			return TempTable<T>.CreateAsync(db, tableName, items, databaseName, schemaName, action, serverName);
+		}
+
+		/// <summary>
+		/// Creates new temporary table and populate it using data from provided query. Table mapping could be changed
+		/// using fluent mapper.
+		/// </summary>
+		/// <typeparam name="T">Table record mapping class.</typeparam>
+		/// <param name="db">Database connection instance.</param>
+		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
+		/// <param name="items">Query to get records to populate created table with initial data.</param>
+		/// <param name="setTable">Action to modify <typeparamref name="T"/> entity's mapping using fluent mapping.</param>
+		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
+		/// <param name="schemaName">Optional name of table shema/owner. If not specified, value from mapping will be used.</param>
+		/// <param name="action">Optional asynchronous action that will be executed after table creation but before it populated with data from <paramref name="items"/>.</param>
+		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
+		/// <returns>Returns temporary table instance.</returns>
+		public static Task<TempTable<T>> CreateTempTableAsync<T>(
+			this IDataContext db,
+			string? tableName,
+			IQueryable<T> items,
+			Action<EntityMappingBuilder<T>> setTable,
+			string? databaseName = null,
+			string? schemaName = null,
+			Func<ITable<T>, Task>? action = null,
+			string? serverName = null)
+		{
+			if (setTable == null) throw new ArgumentNullException(nameof(setTable));
+
+			setTable(db.MappingSchema.GetFluentMappingBuilder().Entity<T>());
+
+			return TempTable<T>.CreateAsync(db, tableName, items, databaseName, schemaName, action, serverName);
 		}
 	}
 }

--- a/Tests/Linq/Update/CreateTempTableTests.cs
+++ b/Tests/Linq/Update/CreateTempTableTests.cs
@@ -111,7 +111,7 @@ namespace Tests.xUpdate
 			{
 				db.DropTable<int>("TempTable", throwExceptionIfNotExists: false);
 
-#if !NETFRAMEWORK
+#if !NET46
 				await
 #endif
 				using (var tmp = await db.CreateTempTableAsync(
@@ -135,7 +135,7 @@ namespace Tests.xUpdate
 			{
 				db.DropTable<int>("TempTable", throwExceptionIfNotExists: false);
 
-#if !NETFRAMEWORK
+#if !NET46
 				await
 #endif
 				using (var tmp = await db.CreateTempTableAsync(

--- a/Tests/Linq/Update/CreateTempTableTests.cs
+++ b/Tests/Linq/Update/CreateTempTableTests.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Linq;
-
+using System.Threading.Tasks;
 using LinqToDB;
 
 using NUnit.Framework;
+using Tests.Model;
 
 namespace Tests.xUpdate
 {
@@ -71,6 +72,75 @@ namespace Tests.xUpdate
 					em => em
 						.Property(e => e.ID)
 							.IsPrimaryKey()))
+				{
+					var list =
+					(
+						from p in db.Parent
+						join t in tmp on p.ParentID equals t.ID
+						select t
+					).ToList();
+				}
+			}
+		}
+
+		[Test]
+		public void CreateTableEnumerable([DataSources(false)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				db.DropTable<int>("TempTable", throwExceptionIfNotExists: false);
+
+				using (var tmp = db.CreateTempTable(
+					"TempTable",
+					db.Parent.Select(p => new IDTable { ID = p.ParentID }).ToList()))
+				{
+					var list =
+					(
+						from p in db.Parent
+						join t in tmp on p.ParentID equals t.ID
+						select t
+					).ToList();
+				}
+			}
+		}
+
+		[Test]
+		public async Task CreateTableAsync([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				db.DropTable<int>("TempTable", throwExceptionIfNotExists: false);
+
+#if !NETFRAMEWORK
+				await
+#endif
+				using (var tmp = await db.CreateTempTableAsync(
+					"TempTable",
+					db.Parent.Select(p => new IDTable { ID = p.ParentID })))
+				{
+					var list =
+					(
+						from p in db.Parent
+						join t in tmp on p.ParentID equals t.ID
+						select t
+					).ToList();
+				}
+			}
+		}
+
+		[Test]
+		public async Task CreateTableAsyncEnumerable([DataSources(false)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				db.DropTable<int>("TempTable", throwExceptionIfNotExists: false);
+
+#if !NETFRAMEWORK
+				await
+#endif
+				using (var tmp = await db.CreateTempTableAsync(
+					"TempTable",
+					db.Parent.Select(p => new IDTable { ID = p.ParentID }).ToList()))
 				{
 					var list =
 					(


### PR DESCRIPTION
This PR adds `CreateTempTableAsync<T>` overloads to `LinqToDB.DataExtensions`.

Notes:
* `TempTable<T>` now implements `IAsyncDisposable` for compatible frameworks
* Since constructors cannot be asynchronous, I have added `CreateAsync` static methods to `TempTable` to facilitate this.  Those static methods call a protected constructor to create the class after `CreateTableAsync` has been called.
* Some of the overloads include an _optional_ `action` that will run before the table is populated via a bulk copy operation.  This optional `action` parameter is now expected to be an asynchronous delegate.  If I were to add another overload for a synchronous action, the compiler would not be able to select which overload was intended to be used.  So I only included the asynchronous `action` parameter for async calls.
* The new extension methods include a `where T : class` clause, similar to #2407 .
* I have added a few more tests to verify basic asynchronous operation.
* Xml comments are almost identical to the synchronous methods.  Lmk if I should adjust them to say "Asynchronously creates a new temporary..." and "Returns an asynchronous task representing...." and so on.
* I have not added support for `IAsyncEnumerable`; shall I?  If someone has that need, they can of course create the temp table first and bulk upload with a separate call.