### PR TITLE
Stored Procedures: async API and parameters rebind fixes

### DIFF
--- a/Data/Create Scripts/SqlServer.sql
+++ b/Data/Create Scripts/SqlServer.sql
@@ -1159,3 +1159,67 @@ BEGIN
 RETURN
 END
 GO
+
+
+IF EXISTS (SELECT * FROM sys.objects WHERE type = 'P' AND name = 'QueryProcParameters')
+BEGIN DROP Procedure QueryProcParameters END
+GO
+
+CREATE Procedure QueryProcParameters
+	@input          int,
+	@output1        int output,
+	@output2        int output
+AS
+
+SET @output1 = @input + 1
+SELECT * FROM Person
+SET @output2 = @input + 2
+
+GO
+
+IF EXISTS (SELECT * FROM sys.objects WHERE type = 'P' AND name = 'QueryProcMultipleParameters')
+BEGIN DROP Procedure QueryProcMultipleParameters END
+GO
+
+CREATE Procedure QueryProcMultipleParameters
+	@input          int,
+	@output1        int output,
+	@output2        int output,
+	@output3        int output
+AS
+
+SET @output1 = @input + 1
+SELECT * FROM Person
+SET @output2 = @input + 2
+SELECT * FROM Doctor
+SET @output3 = @input + 3
+
+GO
+
+IF EXISTS (SELECT * FROM sys.objects WHERE type = 'P' AND name = 'ExecuteProcIntParameters')
+BEGIN DROP Procedure ExecuteProcIntParameters END
+GO
+
+CREATE Procedure ExecuteProcIntParameters
+	@input          int,
+	@output         int output
+AS
+
+SET @output = @input + 1
+SELECT 5
+
+GO
+
+IF EXISTS (SELECT * FROM sys.objects WHERE type = 'P' AND name = 'ExecuteProcStringParameters')
+BEGIN DROP Procedure ExecuteProcStringParameters END
+GO
+
+CREATE Procedure ExecuteProcStringParameters
+	@input          int,
+	@output         int output
+AS
+
+SET @output = @input + 1
+SELECT N'издрасте'
+
+GO

--- a/Data/Create Scripts/SqlServer.sql
+++ b/Data/Create Scripts/SqlServer.sql
@@ -1206,7 +1206,7 @@ CREATE Procedure ExecuteProcIntParameters
 AS
 
 SET @output = @input + 1
-SELECT 5
+UPDATE Person SET FirstName = N'John' WHERE FirstName = N'John'
 
 GO
 

--- a/Source/LinqToDB/Data/CommandInfo.cs
+++ b/Source/LinqToDB/Data/CommandInfo.cs
@@ -1065,7 +1065,7 @@ namespace LinqToDB.Data
 			if (hasParameters)
 				SetParameters(DataConnection, Parameters!);
 
-			return new DataReader { CommandInfo = this, Reader = DataConnection.ExecuteReader(GetCommandBehavior()) };
+			return new DataReader { CommandInfo = this, Reader = DataConnection.ExecuteReader(GetCommandBehavior()), OnDispose = hasParameters ? () => RebindParameters(DataConnection, Parameters!) : (Action?)null };
 		}
 
 		internal IEnumerable<T> ExecuteQuery<T>(IDataReader rd, string sql)
@@ -1139,7 +1139,7 @@ namespace LinqToDB.Data
 			if (hasParameters)
 				SetParameters(DataConnection, Parameters!);
 
-			return new DataReaderAsync { CommandInfo = this, Reader = await DataConnection.ExecuteReaderAsync(GetCommandBehavior(), cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext) };
+			return new DataReaderAsync { CommandInfo = this, Reader = await DataConnection.ExecuteReaderAsync(GetCommandBehavior(), cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext), OnDispose = hasParameters ? () => RebindParameters(DataConnection, Parameters!) : (Action?)null };
 		}
 
 		internal async Task ExecuteQueryAsync<T>(DbDataReader rd, string sql, Action<T> action, CancellationToken cancellationToken)

--- a/Source/LinqToDB/Data/CommandInfo.cs
+++ b/Source/LinqToDB/Data/CommandInfo.cs
@@ -188,7 +188,7 @@ namespace LinqToDB.Data
 				DataConnection.DataProvider.ExecuteScope(DataConnection));
 		}
 
-		static IEnumerable<T> ReadEnumerator<T>(IDataReader rd, Func<IDataReader, T> objectReader, IDisposable? scope)
+		IEnumerable<T> ReadEnumerator<T>(IDataReader rd, Func<IDataReader, T> objectReader, IDisposable? scope)
 		{
 			using (scope)
 			using (rd)
@@ -196,6 +196,9 @@ namespace LinqToDB.Data
 				while (rd.Read())
 					yield return objectReader(rd);
 			}
+
+			if (Parameters?.Length > 0)
+				RebindParameters(DataConnection, Parameters!);
 		}
 
 		#endregion
@@ -361,6 +364,9 @@ namespace LinqToDB.Data
 					if (disposeReader)
 						rd.Dispose();
 				}
+
+			if (Parameters?.Length > 0)
+				RebindParameters(DataConnection, Parameters!);
 		}
 
 		#endregion

--- a/Source/LinqToDB/Data/DataConnectionExtensions.cs
+++ b/Source/LinqToDB/Data/DataConnectionExtensions.cs
@@ -104,6 +104,35 @@ namespace LinqToDB.Data
 		}
 
 		/// <summary>
+		/// Executes command asynchronously using <see cref="CommandType.StoredProcedure"/> command type and returns results as collection of values, mapped using provided mapping function.
+		/// </summary>
+		/// <typeparam name="T">Result record type.</typeparam>
+		/// <param name="connection">Database connection.</param>
+		/// <param name="objectReader">Record mapping function from data reader.</param>
+		/// <param name="sql">Command text. This is caller's responsibility to properly escape procedure name.</param>
+		/// <param name="parameters">Command parameters.</param>
+		/// <returns>Returns collection of query result records.</returns>
+		public static Task<IEnumerable<T>> QueryProcAsync<T>(this DataConnection connection, Func<IDataReader, T> objectReader, string sql, params DataParameter[] parameters)
+		{
+			return new CommandInfo(connection, sql, parameters).QueryProcAsync(objectReader);
+		}
+
+		/// <summary>
+		/// Executes command asynchronously using <see cref="CommandType.StoredProcedure"/> command type and returns results as collection of values, mapped using provided mapping function.
+		/// </summary>
+		/// <typeparam name="T">Result record type.</typeparam>
+		/// <param name="connection">Database connection.</param>
+		/// <param name="objectReader">Record mapping function from data reader.</param>
+		/// <param name="sql">Command text. This is caller's responsibility to properly escape procedure name.</param>
+		/// <param name="cancellationToken">Asynchronous operation cancellation token.</param>
+		/// <param name="parameters">Command parameters.</param>
+		/// <returns>Returns collection of query result records.</returns>
+		public static Task<IEnumerable<T>> QueryProcAsync<T>(this DataConnection connection, Func<IDataReader, T> objectReader, string sql, CancellationToken cancellationToken, params DataParameter[] parameters)
+		{
+			return new CommandInfo(connection, sql, parameters).QueryProcAsync(objectReader, cancellationToken);
+		}
+
+		/// <summary>
 		/// Executes command using <see cref="CommandType.StoredProcedure"/> command type and returns results as collection of values, mapped using provided mapping function.
 		/// </summary>
 		/// <typeparam name="T">Result record type.</typeparam>
@@ -121,9 +150,33 @@ namespace LinqToDB.Data
 		/// <para> - otherwise column value will be converted to <see cref="DataParameter"/> using column name as parameter name and column value will be converted to parameter value using conversion, defined by mapping schema.</para>
 		/// </param>
 		/// <returns>Returns collection of query result records.</returns>
-		public static IEnumerable<T> QueryProc<T>(this DataConnection connection, Func<IDataReader,T> objectReader, string sql, object parameters)
+		public static IEnumerable<T> QueryProc<T>(this DataConnection connection, Func<IDataReader,T> objectReader, string sql, object? parameters)
 		{
 			return new CommandInfo(connection, sql, parameters).QueryProc(objectReader);
+		}
+
+		/// <summary>
+		/// Executes command asynchronously using <see cref="CommandType.StoredProcedure"/> command type and returns results as collection of values, mapped using provided mapping function.
+		/// </summary>
+		/// <typeparam name="T">Result record type.</typeparam>
+		/// <param name="connection">Database connection.</param>
+		/// <param name="objectReader">Record mapping function from data reader.</param>
+		/// <param name="sql">Command text. This is caller's responsibility to properly escape procedure name.</param>
+		/// <param name="parameters">Command parameters. Supported values:
+		/// <para> - <c>null</c> for command without parameters;</para>
+		/// <para> - single <see cref="DataParameter"/> instance;</para>
+		/// <para> - array of <see cref="DataParameter"/> parameters;</para>
+		/// <para> - mapping class entity.</para>
+		/// <para>Last case will convert all mapped columns to <see cref="DataParameter"/> instances using following logic:</para>
+		/// <para> - if column is of <see cref="DataParameter"/> type, column value will be used. If parameter name (<see cref="DataParameter.Name"/>) is not set, column name will be used;</para>
+		/// <para> - if converter from column type to <see cref="DataParameter"/> is defined in mapping schema, it will be used to create parameter with colum name passed to converter;</para>
+		/// <para> - otherwise column value will be converted to <see cref="DataParameter"/> using column name as parameter name and column value will be converted to parameter value using conversion, defined by mapping schema.</para>
+		/// </param>
+		/// <param name="cancellationToken">Asynchronous operation cancellation token.</param>
+		/// <returns>Returns collection of query result records.</returns>
+		public static Task<IEnumerable<T>> QueryProcAsync<T>(this DataConnection connection, Func<IDataReader, T> objectReader, string sql, object? parameters, CancellationToken cancellationToken = default)
+		{
+			return new CommandInfo(connection, sql, parameters).QueryProcAsync(objectReader, cancellationToken);
 		}
 
 		/// <summary>
@@ -557,6 +610,33 @@ namespace LinqToDB.Data
 		/// <typeparam name="T">Result record type.</typeparam>
 		/// <param name="connection">Database connection.</param>
 		/// <param name="sql">Command text. This is caller's responsibility to properly escape procedure name.</param>
+		/// <param name="parameters">Command parameters.</param>
+		/// <returns>Returns collection of query result records.</returns>
+		public static Task<IEnumerable<T>> QueryProcAsync<T>(this DataConnection connection, string sql, params DataParameter[] parameters)
+		{
+			return new CommandInfo(connection, sql, parameters).QueryProcAsync<T>();
+		}
+
+		/// <summary>
+		/// Executes command using <see cref="CommandType.StoredProcedure"/> command type and returns results as collection of values of specified type.
+		/// </summary>
+		/// <typeparam name="T">Result record type.</typeparam>
+		/// <param name="connection">Database connection.</param>
+		/// <param name="sql">Command text. This is caller's responsibility to properly escape procedure name.</param>
+		/// <param name="cancellationToken">Asynchronous operation cancellation token.</param>
+		/// <param name="parameters">Command parameters.</param>
+		/// <returns>Returns collection of query result records.</returns>
+		public static Task<IEnumerable<T>> QueryProcAsync<T>(this DataConnection connection, string sql, CancellationToken cancellationToken, params DataParameter[] parameters)
+		{
+			return new CommandInfo(connection, sql, parameters).QueryProcAsync<T>(cancellationToken);
+		}
+
+		/// <summary>
+		/// Executes command using <see cref="CommandType.StoredProcedure"/> command type and returns results as collection of values of specified type.
+		/// </summary>
+		/// <typeparam name="T">Result record type.</typeparam>
+		/// <param name="connection">Database connection.</param>
+		/// <param name="sql">Command text. This is caller's responsibility to properly escape procedure name.</param>
 		/// <param name="parameters">Command parameters. Supported values:
 		/// <para> - <c>null</c> for command without parameters;</para>
 		/// <para> - single <see cref="DataParameter"/> instance;</para>
@@ -568,9 +648,32 @@ namespace LinqToDB.Data
 		/// <para> - otherwise column value will be converted to <see cref="DataParameter"/> using column name as parameter name and column value will be converted to parameter value using conversion, defined by mapping schema.</para>
 		/// </param>
 		/// <returns>Returns collection of query result records.</returns>
-		public static IEnumerable<T> QueryProc<T>(this DataConnection connection, string sql, object parameters)
+		public static IEnumerable<T> QueryProc<T>(this DataConnection connection, string sql, object? parameters)
 		{
 			return new CommandInfo(connection, sql, parameters).QueryProc<T>();
+		}
+
+		/// <summary>
+		/// Executes command asynchronously using <see cref="CommandType.StoredProcedure"/> command type and returns results as collection of values of specified type.
+		/// </summary>
+		/// <typeparam name="T">Result record type.</typeparam>
+		/// <param name="connection">Database connection.</param>
+		/// <param name="sql">Command text. This is caller's responsibility to properly escape procedure name.</param>
+		/// <param name="parameters">Command parameters. Supported values:
+		/// <para> - <c>null</c> for command without parameters;</para>
+		/// <para> - single <see cref="DataParameter"/> instance;</para>
+		/// <para> - array of <see cref="DataParameter"/> parameters;</para>
+		/// <para> - mapping class entity.</para>
+		/// <para>Last case will convert all mapped columns to <see cref="DataParameter"/> instances using following logic:</para>
+		/// <para> - if column is of <see cref="DataParameter"/> type, column value will be used. If parameter name (<see cref="DataParameter.Name"/>) is not set, column name will be used;</para>
+		/// <para> - if converter from column type to <see cref="DataParameter"/> is defined in mapping schema, it will be used to create parameter with colum name passed to converter;</para>
+		/// <para> - otherwise column value will be converted to <see cref="DataParameter"/> using column name as parameter name and column value will be converted to parameter value using conversion, defined by mapping schema.</para>
+		/// </param>
+		/// <param name="cancellationToken">Asynchronous operation cancellation token.</param>
+		/// <returns>Returns collection of query result records.</returns>
+		public static Task<IEnumerable<T>> QueryProcAsync<T>(this DataConnection connection, string sql, object? parameters, CancellationToken cancellationToken = default)
+		{
+			return new CommandInfo(connection, sql, parameters).QueryProcAsync<T>(cancellationToken);
 		}
 
 		/// <summary>
@@ -670,7 +773,7 @@ namespace LinqToDB.Data
 		///		- if there is missing index in properties that are marked with <see cref="Mapping.ResultSetIndexAttribute"/>, then result set under missing index will be ignored.<para/>
 		///		- if there is no <see cref="Mapping.ResultSetIndexAttribute"/>, then all non readonly fields or properties with setter will read from multiple result set. Order is based on their appearance in class.
 		/// </remarks>
-		public static Task<T> QueryProcMultipleAsync<T>(this DataConnection connection, string sql, CancellationToken cancellationToken, object parameters)
+		public static Task<T> QueryProcMultipleAsync<T>(this DataConnection connection, string sql, CancellationToken cancellationToken, object? parameters)
 			where T : class
 		{
 			return new CommandInfo(connection, sql, parameters).QueryProcMultipleAsync<T>(cancellationToken);
@@ -771,7 +874,7 @@ namespace LinqToDB.Data
 		///		- if there is missing index in properties that are marked with <see cref="Mapping.ResultSetIndexAttribute"/>, then result set under missing index will be ignored.<para/>
 		///		- if there is no <see cref="Mapping.ResultSetIndexAttribute"/>, then all non readonly fields or properties with setter will read from multiple result set. Order is based on their appearance in class.
 		/// </remarks>
-		public static Task<T> QueryProcMultipleAsync<T>(this DataConnection connection, string sql, object parameters)
+		public static Task<T> QueryProcMultipleAsync<T>(this DataConnection connection, string sql, object? parameters)
 			where T : class
 		{
 			return new CommandInfo(connection, sql, parameters).QueryProcMultipleAsync<T>();
@@ -866,7 +969,7 @@ namespace LinqToDB.Data
 		///		- if there is missing index in properties that are marked with <see cref="Mapping.ResultSetIndexAttribute"/>, then result set under missing index will be ignored.<para/>
 		///		- if there is no <see cref="Mapping.ResultSetIndexAttribute"/>, then all non readonly fields or properties with setter will read from multiple result set. Order is based on their appearance in class.
 		/// </remarks>
-		public static T QueryProcMultiple<T>(this DataConnection connection, string sql, object parameters)
+		public static T QueryProcMultiple<T>(this DataConnection connection, string sql, object? parameters)
 			where T : class
 		{
 			return new CommandInfo(connection, sql, parameters).QueryProcMultiple<T>();
@@ -1215,6 +1318,35 @@ namespace LinqToDB.Data
 		}
 
 		/// <summary>
+		/// Executes stored procedure asynchronously and returns results as collection of values of specified type.
+		/// </summary>
+		/// <typeparam name="T">Result record type.</typeparam>
+		/// <param name="connection">Database connection.</param>
+		/// <param name="template">This value used only for <typeparamref name="T"/> parameter type inference, which makes this method usable with anonymous types.</param>
+		/// <param name="sql">Command text.</param>
+		/// <param name="parameters">Command parameters.</param>
+		/// <returns>Returns collection of query result records.</returns>
+		public static Task<IEnumerable<T>> QueryProcAsync<T>(this DataConnection connection, T template, string sql, params DataParameter[] parameters)
+		{
+			return new CommandInfo(connection, sql, parameters).QueryProcAsync(template);
+		}
+
+		/// <summary>
+		/// Executes stored procedure asynchronously and returns results as collection of values of specified type.
+		/// </summary>
+		/// <typeparam name="T">Result record type.</typeparam>
+		/// <param name="connection">Database connection.</param>
+		/// <param name="template">This value used only for <typeparamref name="T"/> parameter type inference, which makes this method usable with anonymous types.</param>
+		/// <param name="sql">Command text.</param>
+		/// <param name="cancellationToken">Asynchronous operation cancellation token.</param>
+		/// <param name="parameters">Command parameters.</param>
+		/// <returns>Returns collection of query result records.</returns>
+		public static Task<IEnumerable<T>> QueryProcAsync<T>(this DataConnection connection, T template, string sql, CancellationToken cancellationToken, params DataParameter[] parameters)
+		{
+			return new CommandInfo(connection, sql, parameters).QueryProcAsync(template, cancellationToken);
+		}
+
+		/// <summary>
 		/// Executes stored procedure and returns results as collection of values of specified type.
 		/// </summary>
 		/// <typeparam name="T">Result record type.</typeparam>
@@ -1235,6 +1367,30 @@ namespace LinqToDB.Data
 		public static IEnumerable<T> QueryProc<T>(this DataConnection connection, T template, string sql, object? parameters)
 		{
 			return new CommandInfo(connection, sql, parameters).QueryProc(template);
+		}
+
+		/// <summary>
+		/// Executes stored procedure asynchronously and returns results as collection of values of specified type.
+		/// </summary>
+		/// <typeparam name="T">Result record type.</typeparam>
+		/// <param name="connection">Database connection.</param>
+		/// <param name="template">This value used only for <typeparamref name="T"/> parameter type inference, which makes this method usable with anonymous types.</param>
+		/// <param name="sql">Command text.</param>
+		/// <param name="parameters">Command parameters. Supported values:
+		/// <para> - <c>null</c> for command without parameters;</para>
+		/// <para> - single <see cref="DataParameter"/> instance;</para>
+		/// <para> - array of <see cref="DataParameter"/> parameters;</para>
+		/// <para> - mapping class entity.</para>
+		/// <para>Last case will convert all mapped columns to <see cref="DataParameter"/> instances using following logic:</para>
+		/// <para> - if column is of <see cref="DataParameter"/> type, column value will be used. If parameter name (<see cref="DataParameter.Name"/>) is not set, column name will be used;</para>
+		/// <para> - if converter from column type to <see cref="DataParameter"/> is defined in mapping schema, it will be used to create parameter with colum name passed to converter;</para>
+		/// <para> - otherwise column value will be converted to <see cref="DataParameter"/> using column name as parameter name and column value will be converted to parameter value using conversion, defined by mapping schema.</para>
+		/// </param>
+		/// <param name="cancellationToken">Asynchronous operation cancellation token.</param>
+		/// <returns>Returns collection of query result records.</returns>
+		public static Task<IEnumerable<T>> QueryProcAsync<T>(this DataConnection connection, T template, string sql, object? parameters, CancellationToken cancellationToken = default)
+		{
+			return new CommandInfo(connection, sql, parameters).QueryProcAsync(template, cancellationToken);
 		}
 
 		#endregion
@@ -1448,7 +1604,7 @@ namespace LinqToDB.Data
 		/// <para> - otherwise column value will be converted to <see cref="DataParameter"/> using column name as parameter name and column value will be converted to parameter value using conversion, defined by mapping schema.</para>
 		/// </param>
 		/// <returns>Number of records, affected by command execution.</returns>
-		public static int ExecuteProc(this DataConnection connection, string sql, object parameters)
+		public static int ExecuteProc(this DataConnection connection, string sql, object? parameters)
 		{
 			return new CommandInfo(connection, sql, parameters).ExecuteProc();
 		}
@@ -1593,7 +1749,7 @@ namespace LinqToDB.Data
 		/// <para> - otherwise column value will be converted to <see cref="DataParameter"/> using column name as parameter name and column value will be converted to parameter value using conversion, defined by mapping schema.</para>
 		/// </param>
 		/// <returns>Task with number of records, affected by command execution.</returns>
-		public static Task<int> ExecuteProcAsync(this DataConnection connection, string sql, object parameters)
+		public static Task<int> ExecuteProcAsync(this DataConnection connection, string sql, object? parameters)
 		{
 			return new CommandInfo(connection, sql, parameters).ExecuteProcAsync();
 		}
@@ -1628,7 +1784,7 @@ namespace LinqToDB.Data
 		/// <para> - otherwise column value will be converted to <see cref="DataParameter"/> using column name as parameter name and column value will be converted to parameter value using conversion, defined by mapping schema.</para>
 		/// </param>
 		/// <returns>Task with number of records, affected by command execution.</returns>
-		public static Task<int> ExecuteProcAsync(this DataConnection connection, string sql, CancellationToken cancellationToken, object parameters)
+		public static Task<int> ExecuteProcAsync(this DataConnection connection, string sql, CancellationToken cancellationToken, object? parameters)
 		{
 			return new CommandInfo(connection, sql, parameters).ExecuteProcAsync(cancellationToken);
 		}
@@ -1727,7 +1883,7 @@ namespace LinqToDB.Data
 		/// <para> - otherwise column value will be converted to <see cref="DataParameter"/> using column name as parameter name and column value will be converted to parameter value using conversion, defined by mapping schema.</para>
 		/// </param>
 		/// <returns>Resulting value.</returns>
-		public static T ExecuteProc<T>(this DataConnection connection, string sql, object parameters)
+		public static T ExecuteProc<T>(this DataConnection connection, string sql, object? parameters)
 		{
 			return new CommandInfo(connection, sql, parameters).ExecuteProc<T>();
 		}
@@ -1889,7 +2045,7 @@ namespace LinqToDB.Data
 		/// <para> - otherwise column value will be converted to <see cref="DataParameter"/> using column name as parameter name and column value will be converted to parameter value using conversion, defined by mapping schema.</para>
 		/// </param>
 		/// <returns>Task with resulting value.</returns>
-		public static Task<T> ExecuteProcAsync<T>(this DataConnection connection, string sql, object parameters)
+		public static Task<T> ExecuteProcAsync<T>(this DataConnection connection, string sql, object? parameters)
 		{
 			return new CommandInfo(connection, sql, parameters).ExecuteProcAsync<T>();
 		}
@@ -1926,7 +2082,7 @@ namespace LinqToDB.Data
 		/// <para> - otherwise column value will be converted to <see cref="DataParameter"/> using column name as parameter name and column value will be converted to parameter value using conversion, defined by mapping schema.</para>
 		/// </param>
 		/// <returns>Resulting value.</returns>
-		public static Task<T> ExecuteProcAsync<T>(this DataConnection connection, string sql, CancellationToken cancellationToken, object parameters)
+		public static Task<T> ExecuteProcAsync<T>(this DataConnection connection, string sql, CancellationToken cancellationToken, object? parameters)
 		{
 			return new CommandInfo(connection, sql, parameters).ExecuteProcAsync<T>(cancellationToken);
 		}

--- a/Source/LinqToDB/Data/DataConnectionExtensions.cs
+++ b/Source/LinqToDB/Data/DataConnectionExtensions.cs
@@ -781,6 +781,7 @@ namespace LinqToDB.Data
 
 		/// <summary>
 		/// Executes command asynchronously using <see cref="CommandType.StoredProcedure"/> command type and returns a result containing multiple result sets.
+		/// Sets result values for output and reference parameters to corresponding parameters in <paramref name="parameters"/>.
 		/// </summary>
 		/// <typeparam name="T">Result set type.</typeparam>
 		/// <param name="connection">Database connection.</param>
@@ -882,6 +883,7 @@ namespace LinqToDB.Data
 
 		/// <summary>
 		/// Executes command using <see cref="CommandType.StoredProcedure"/> command type and returns a result containing multiple result sets.
+		/// Sets result values for output and reference parameters to corresponding parameters in <paramref name="parameters"/>.
 		/// </summary>
 		/// <typeparam name="T">Result set type.</typeparam>
 		/// <param name="connection">Database connection.</param>
@@ -1578,6 +1580,7 @@ namespace LinqToDB.Data
 
 		/// <summary>
 		/// Executes command using <see cref="CommandType.StoredProcedure"/> command type and returns number of affected records.
+		/// Sets result values for output and reference parameters to corresponding parameters in <paramref name="parameters"/>.
 		/// </summary>
 		/// <param name="connection">Database connection.</param>
 		/// <param name="sql">Command text. This is caller's responsibility to properly escape procedure name.</param>
@@ -1723,6 +1726,7 @@ namespace LinqToDB.Data
 
 		/// <summary>
 		/// Executes command using <see cref="CommandType.StoredProcedure"/> command type asynchronously and returns number of affected records.
+		/// Sets result values for output and reference parameters to corresponding parameters in <paramref name="parameters"/>.
 		/// </summary>
 		/// <param name="connection">Database connection.</param>
 		/// <param name="sql">Command text. This is caller's responsibility to properly escape procedure name.</param>
@@ -1855,6 +1859,7 @@ namespace LinqToDB.Data
 
 		/// <summary>
 		/// Executes command using <see cref="CommandType.StoredProcedure"/> command type and returns single value.
+		/// Sets result values for output and reference parameters to corresponding parameters in <paramref name="parameters"/>.
 		/// </summary>
 		/// <typeparam name="T">Resulting value type.</typeparam>
 		/// <param name="connection">Database connection.</param>
@@ -2017,6 +2022,7 @@ namespace LinqToDB.Data
 
 		/// <summary>
 		/// Executes command using <see cref="CommandType.StoredProcedure"/> command type asynchronously and returns single value.
+		/// Sets result values for output and reference parameters to corresponding parameters in <paramref name="parameters"/>.
 		/// </summary>
 		/// <typeparam name="T">Resulting value type.</typeparam>
 		/// <param name="connection">Database connection.</param>

--- a/Source/LinqToDB/Data/DataReader.cs
+++ b/Source/LinqToDB/Data/DataReader.cs
@@ -14,6 +14,7 @@ namespace LinqToDB.Data
 		internal int          ReadNumber  { get; set; }
 		private  DateTime     StartedOn   { get; }      = DateTime.UtcNow;
 		private  Stopwatch    Stopwatch   { get; }      = Stopwatch.StartNew();
+		internal Action?      OnDispose   { get; set; }
 
 		public void Dispose()
 		{
@@ -33,6 +34,8 @@ namespace LinqToDB.Data
 					});
 				}
 			}
+
+			OnDispose?.Invoke();
 		}
 
 		#region Query with object reader

--- a/Source/LinqToDB/Data/DataReaderAsync.cs
+++ b/Source/LinqToDB/Data/DataReaderAsync.cs
@@ -16,7 +16,7 @@ namespace LinqToDB.Data
 		internal CancellationToken CancellationToken { get; set; }
 		private  DateTime          StartedOn         { get; }      = DateTime.UtcNow;
 		private  Stopwatch         Stopwatch         { get; }      = Stopwatch.StartNew();
-
+		internal Action?           OnDispose         { get; set; }
 		public void Dispose()
 		{
 			if (Reader != null)
@@ -35,6 +35,8 @@ namespace LinqToDB.Data
 					});
 				}
 			}
+
+			OnDispose?.Invoke();
 		}
 
 		#region Query with object reader

--- a/Tests/Linq/Data/ProcedureTests.cs
+++ b/Tests/Linq/Data/ProcedureTests.cs
@@ -153,7 +153,7 @@ namespace Tests.Data
 		}
 
 		[Test]
-		public void TestQueryProcRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		public void TestQueryProcNoRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
 		{
 			using (var db = new DataConnection(context))
 			{
@@ -163,20 +163,18 @@ namespace Tests.Data
 				var persons = db.QueryProc<Person>("QueryProcParameters", input, output1, output2);
 				Assert.IsNull(output1.Value);
 				Assert.IsNull(output2.Value);
-				foreach (var person in persons)
-				{
-					Assert.IsNull(output1.Value);
-					Assert.IsNull(output2.Value);
-					break;
-				}
 
-				Assert.AreEqual(2, output1.Value);
-				Assert.AreEqual(3, output2.Value);
+				persons.ToList();
+
+				Assert.IsNull(output1.Value);
+				Assert.IsNull(output2.Value);
+				Assert.AreEqual(2, ((IDataParameter)db.Command.Parameters["output1"]).Value);
+				Assert.AreEqual(3, ((IDataParameter)db.Command.Parameters["output2"]).Value);
 			}
 		}
 
 		[Test]
-		public async Task TestQueryProcAsyncRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		public async Task TestQueryProcAsyncNoRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
 		{
 			using (var db = new DataConnection(context))
 			{
@@ -186,20 +184,19 @@ namespace Tests.Data
 				var persons = await db.QueryProcAsync<Person>("QueryProcParameters", input, output1, output2);
 				Assert.IsNull(output1.Value);
 				Assert.IsNull(output2.Value);
-				foreach (var person in persons)
-				{
-					Assert.IsNull(output1.Value);
-					Assert.IsNull(output2.Value);
-					break;
-				}
 
-				Assert.AreEqual(2, output1.Value);
-				Assert.AreEqual(3, output2.Value);
+				persons.ToList();
+
+				Assert.IsNull(output1.Value);
+				Assert.IsNull(output2.Value);
+				Assert.AreEqual(2, ((IDataParameter)db.Command.Parameters["output1"]).Value);
+				Assert.AreEqual(3, ((IDataParameter)db.Command.Parameters["output2"]).Value);
+
 			}
 		}
 
 		[Test]
-		public void TestQueryProcTemplateRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		public void TestQueryProcTemplateNoRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
 		{
 			using (var db = new DataConnection(context))
 			{
@@ -207,22 +204,18 @@ namespace Tests.Data
 				var output1 = new DataParameter("output1", null, DataType.Int32) { Direction = ParameterDirection.Output };
 				var output2 = new DataParameter("output2", null, DataType.Int32) { Direction = ParameterDirection.Output };
 				var persons = db.QueryProc(new Person(), "QueryProcParameters", input, output1, output2);
+
+				persons.ToList();
+
 				Assert.IsNull(output1.Value);
 				Assert.IsNull(output2.Value);
-				foreach (var person in persons)
-				{
-					Assert.IsNull(output1.Value);
-					Assert.IsNull(output2.Value);
-					break;
-				}
-
-				Assert.AreEqual(2, output1.Value);
-				Assert.AreEqual(3, output2.Value);
+				Assert.AreEqual(2, ((IDataParameter)db.Command.Parameters["output1"]).Value);
+				Assert.AreEqual(3, ((IDataParameter)db.Command.Parameters["output2"]).Value);
 			}
 		}
 
 		[Test]
-		public async Task TestQueryProcAsyncTemplateRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		public async Task TestQueryProcAsyncTemplateNoRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
 		{
 			using (var db = new DataConnection(context))
 			{
@@ -232,20 +225,18 @@ namespace Tests.Data
 				var persons = await db.QueryProcAsync(new Person(), "QueryProcParameters", input, output1, output2);
 				Assert.IsNull(output1.Value);
 				Assert.IsNull(output2.Value);
-				foreach (var person in persons)
-				{
-					Assert.IsNull(output1.Value);
-					Assert.IsNull(output2.Value);
-					break;
-				}
 
-				Assert.AreEqual(2, output1.Value);
-				Assert.AreEqual(3, output2.Value);
+				persons.ToList();
+
+				Assert.IsNull(output1.Value);
+				Assert.IsNull(output2.Value);
+				Assert.AreEqual(2, ((IDataParameter)db.Command.Parameters["output1"]).Value);
+				Assert.AreEqual(3, ((IDataParameter)db.Command.Parameters["output2"]).Value);
 			}
 		}
 
 		[Test]
-		public void TestQueryProcReaderRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		public void TestQueryProcReaderNoRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
 		{
 			using (var db = new DataConnection(context))
 			{
@@ -255,20 +246,18 @@ namespace Tests.Data
 				var persons = db.QueryProc(reader => new Person(), "QueryProcParameters", input, output1, output2);
 				Assert.IsNull(output1.Value);
 				Assert.IsNull(output2.Value);
-				foreach (var person in persons)
-				{
-					Assert.IsNull(output1.Value);
-					Assert.IsNull(output2.Value);
-					break;
-				}
 
-				Assert.AreEqual(2, output1.Value);
-				Assert.AreEqual(3, output2.Value);
+				persons.ToList();
+
+				Assert.IsNull(output1.Value);
+				Assert.IsNull(output2.Value);
+				Assert.AreEqual(2, ((IDataParameter)db.Command.Parameters["output1"]).Value);
+				Assert.AreEqual(3, ((IDataParameter)db.Command.Parameters["output2"]).Value);
 			}
 		}
 
 		[Test]
-		public async Task TestQueryProcAsyncReaderRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		public async Task TestQueryProcAsyncReaderNoRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
 		{
 			using (var db = new DataConnection(context))
 			{
@@ -278,15 +267,13 @@ namespace Tests.Data
 				var persons = await db.QueryProcAsync(reader => new Person(), "QueryProcParameters", input, output1, output2);
 				Assert.IsNull(output1.Value);
 				Assert.IsNull(output2.Value);
-				foreach (var person in persons)
-				{
-					Assert.IsNull(output1.Value);
-					Assert.IsNull(output2.Value);
-					break;
-				}
 
-				Assert.AreEqual(2, output1.Value);
-				Assert.AreEqual(3, output2.Value);
+				persons.ToList();
+
+				Assert.IsNull(output1.Value);
+				Assert.IsNull(output2.Value);
+				Assert.AreEqual(2, ((IDataParameter)db.Command.Parameters["output1"]).Value);
+				Assert.AreEqual(3, ((IDataParameter)db.Command.Parameters["output2"]).Value);
 			}
 		}
 
@@ -337,7 +324,7 @@ namespace Tests.Data
 				var output = new DataParameter("output", null, DataType.Int32) { Direction = ParameterDirection.Output };
 				var result = db.ExecuteProc("ExecuteProcIntParameters", input, output);
 				Assert.AreEqual(2, output.Value);
-				Assert.AreEqual(5, result);
+				Assert.AreEqual(1, result);
 			}
 		}
 
@@ -350,7 +337,7 @@ namespace Tests.Data
 				var output = new DataParameter("output", null, DataType.Int32) { Direction = ParameterDirection.Output };
 				var result = await db.ExecuteProcAsync("ExecuteProcIntParameters", input, output);
 				Assert.AreEqual(2, output.Value);
-				Assert.AreEqual(5, result);
+				Assert.AreEqual(1, result);
 			}
 		}
 
@@ -362,8 +349,8 @@ namespace Tests.Data
 				var input = DataParameter.Int32("input", 1);
 				var output = new DataParameter("output", null, DataType.Int32) { Direction = ParameterDirection.Output };
 				var result = db.ExecuteProc<string>("ExecuteProcStringParameters", input, output);
-				Assert.AreEqual("издрасте", output.Value);
-				Assert.AreEqual(5, result);
+				Assert.AreEqual(2, output.Value);
+				Assert.AreEqual("издрасте", result);
 			}
 		}
 
@@ -375,13 +362,13 @@ namespace Tests.Data
 				var input = DataParameter.Int32("input", 1);
 				var output = new DataParameter("output", null, DataType.Int32) { Direction = ParameterDirection.Output };
 				var result = await db.ExecuteProcAsync<string>("ExecuteProcStringParameters", input, output);
-				Assert.AreEqual("издрасте", output.Value);
-				Assert.AreEqual(5, result);
+				Assert.AreEqual(2, output.Value);
+				Assert.AreEqual("издрасте", result);
 			}
 		}
 
 		[Test]
-		public void TestExecuteReaderProcRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		public void TestExecuteReaderProcNoRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
 		{
 			using (var db = new DataConnection(context))
 			{
@@ -391,21 +378,20 @@ namespace Tests.Data
 				var reader = new CommandInfo(db, "QueryProcParameters", input, output1, output2).ExecuteReaderProc();
 				Assert.IsNull(output1.Value);
 				Assert.IsNull(output2.Value);
-				while (reader.Reader!.Read())
-				{ 
-					Assert.IsNull(output1.Value);
-					Assert.IsNull(output2.Value);
-					reader.Dispose();
-					break;
-				}
+				using (reader)
+					while (reader.Reader!.Read())
+					{
+					}
 
-				Assert.AreEqual(2, output1.Value);
-				Assert.AreEqual(3, output2.Value);
+				Assert.IsNull(output1.Value);
+				Assert.IsNull(output2.Value);
+				Assert.AreEqual(2, ((IDataParameter)db.Command.Parameters["output1"]).Value);
+				Assert.AreEqual(3, ((IDataParameter)db.Command.Parameters["output2"]).Value);
 			}
 		}
 
 		[Test]
-		public async Task TestExecuteReaderProcAsyncRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		public async Task TestExecuteReaderProcAsyncNoRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
 		{
 			using (var db = new DataConnection(context))
 			{
@@ -415,16 +401,15 @@ namespace Tests.Data
 				var reader = await new CommandInfo(db, "QueryProcParameters", input, output1, output2).ExecuteReaderProcAsync();
 				Assert.IsNull(output1.Value);
 				Assert.IsNull(output2.Value);
-				while (await reader.Reader!.ReadAsync())
-				{
-					Assert.IsNull(output1.Value);
-					Assert.IsNull(output2.Value);
-					reader.Dispose();
-					break;
-				}
+				using (reader)
+					while (await reader.Reader!.ReadAsync())
+					{
+					}
 
-				Assert.AreEqual(2, output1.Value);
-				Assert.AreEqual(3, output2.Value);
+				Assert.IsNull(output1.Value);
+				Assert.IsNull(output2.Value);
+				Assert.AreEqual(2, ((IDataParameter)db.Command.Parameters["output1"]).Value);
+				Assert.AreEqual(3, ((IDataParameter)db.Command.Parameters["output2"]).Value);
 			}
 		}
 	}

--- a/Tests/Linq/Data/ProcedureTests.cs
+++ b/Tests/Linq/Data/ProcedureTests.cs
@@ -153,7 +153,7 @@ namespace Tests.Data
 		}
 
 		[Test]
-		public void TestQueryProcNoRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		public void TestQueryProcRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
 		{
 			using (var db = new DataConnection(context))
 			{
@@ -166,15 +166,16 @@ namespace Tests.Data
 
 				persons.ToList();
 
-				Assert.IsNull(output1.Value);
-				Assert.IsNull(output2.Value);
+				Assert.AreEqual(2, output1.Value);
+				Assert.AreEqual(3, output2.Value);
+
 				Assert.AreEqual(2, ((IDataParameter)db.Command.Parameters["output1"]).Value);
 				Assert.AreEqual(3, ((IDataParameter)db.Command.Parameters["output2"]).Value);
 			}
 		}
 
 		[Test]
-		public async Task TestQueryProcAsyncNoRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		public async Task TestQueryProcAsyncRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
 		{
 			using (var db = new DataConnection(context))
 			{
@@ -187,8 +188,9 @@ namespace Tests.Data
 
 				persons.ToList();
 
-				Assert.IsNull(output1.Value);
-				Assert.IsNull(output2.Value);
+				Assert.AreEqual(2, output1.Value);
+				Assert.AreEqual(3, output2.Value);
+
 				Assert.AreEqual(2, ((IDataParameter)db.Command.Parameters["output1"]).Value);
 				Assert.AreEqual(3, ((IDataParameter)db.Command.Parameters["output2"]).Value);
 
@@ -196,7 +198,7 @@ namespace Tests.Data
 		}
 
 		[Test]
-		public void TestQueryProcTemplateNoRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		public void TestQueryProcTemplateRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
 		{
 			using (var db = new DataConnection(context))
 			{
@@ -207,15 +209,16 @@ namespace Tests.Data
 
 				persons.ToList();
 
-				Assert.IsNull(output1.Value);
-				Assert.IsNull(output2.Value);
+				Assert.AreEqual(2, output1.Value);
+				Assert.AreEqual(3, output2.Value);
+
 				Assert.AreEqual(2, ((IDataParameter)db.Command.Parameters["output1"]).Value);
 				Assert.AreEqual(3, ((IDataParameter)db.Command.Parameters["output2"]).Value);
 			}
 		}
 
 		[Test]
-		public async Task TestQueryProcAsyncTemplateNoRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		public async Task TestQueryProcAsyncTemplateRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
 		{
 			using (var db = new DataConnection(context))
 			{
@@ -228,15 +231,16 @@ namespace Tests.Data
 
 				persons.ToList();
 
-				Assert.IsNull(output1.Value);
-				Assert.IsNull(output2.Value);
+				Assert.AreEqual(2, output1.Value);
+				Assert.AreEqual(3, output2.Value);
+
 				Assert.AreEqual(2, ((IDataParameter)db.Command.Parameters["output1"]).Value);
 				Assert.AreEqual(3, ((IDataParameter)db.Command.Parameters["output2"]).Value);
 			}
 		}
 
 		[Test]
-		public void TestQueryProcReaderNoRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		public void TestQueryProcReaderRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
 		{
 			using (var db = new DataConnection(context))
 			{
@@ -249,15 +253,16 @@ namespace Tests.Data
 
 				persons.ToList();
 
-				Assert.IsNull(output1.Value);
-				Assert.IsNull(output2.Value);
+				Assert.AreEqual(2, output1.Value);
+				Assert.AreEqual(3, output2.Value);
+
 				Assert.AreEqual(2, ((IDataParameter)db.Command.Parameters["output1"]).Value);
 				Assert.AreEqual(3, ((IDataParameter)db.Command.Parameters["output2"]).Value);
 			}
 		}
 
 		[Test]
-		public async Task TestQueryProcAsyncReaderNoRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		public async Task TestQueryProcAsyncReaderRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
 		{
 			using (var db = new DataConnection(context))
 			{
@@ -270,8 +275,9 @@ namespace Tests.Data
 
 				persons.ToList();
 
-				Assert.IsNull(output1.Value);
-				Assert.IsNull(output2.Value);
+				Assert.AreEqual(2, output1.Value);
+				Assert.AreEqual(3, output2.Value);
+
 				Assert.AreEqual(2, ((IDataParameter)db.Command.Parameters["output1"]).Value);
 				Assert.AreEqual(3, ((IDataParameter)db.Command.Parameters["output2"]).Value);
 			}
@@ -355,7 +361,7 @@ namespace Tests.Data
 		}
 
 		[Test]
-		public async Task TestExecuteProcAsyncTRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		public async Task TestExecuteProcAsyncRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
 		{
 			using (var db = new DataConnection(context))
 			{

--- a/Tests/Linq/Data/ProcedureTests.cs
+++ b/Tests/Linq/Data/ProcedureTests.cs
@@ -6,7 +6,11 @@ using NUnit.Framework;
 
 namespace Tests.Data
 {
+	using System.Data;
+	using System.Threading.Tasks;
+	using LinqToDB;
 	using LinqToDB.DataProvider.SqlServer;
+	using LinqToDB.Mapping;
 	using Model;
 
 	[TestFixture]
@@ -145,6 +149,282 @@ namespace Tests.Data
 
 				Assert.AreEqual(set1, set11);
 				Assert.AreEqual(set2, set22);
+			}
+		}
+
+		[Test]
+		public void TestQueryProcRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var input = DataParameter.Int32("input", 1);
+				var output1 = new DataParameter("output1", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				var output2 = new DataParameter("output2", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				var persons = db.QueryProc<Person>("QueryProcParameters", input, output1, output2);
+				Assert.IsNull(output1.Value);
+				Assert.IsNull(output2.Value);
+				foreach (var person in persons)
+				{
+					Assert.IsNull(output1.Value);
+					Assert.IsNull(output2.Value);
+					break;
+				}
+
+				Assert.AreEqual(2, output1.Value);
+				Assert.AreEqual(3, output2.Value);
+			}
+		}
+
+		[Test]
+		public async Task TestQueryProcAsyncRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var input = DataParameter.Int32("input", 1);
+				var output1 = new DataParameter("output1", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				var output2 = new DataParameter("output2", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				var persons = await db.QueryProcAsync<Person>("QueryProcParameters", input, output1, output2);
+				Assert.IsNull(output1.Value);
+				Assert.IsNull(output2.Value);
+				foreach (var person in persons)
+				{
+					Assert.IsNull(output1.Value);
+					Assert.IsNull(output2.Value);
+					break;
+				}
+
+				Assert.AreEqual(2, output1.Value);
+				Assert.AreEqual(3, output2.Value);
+			}
+		}
+
+		[Test]
+		public void TestQueryProcTemplateRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var input = DataParameter.Int32("input", 1);
+				var output1 = new DataParameter("output1", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				var output2 = new DataParameter("output2", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				var persons = db.QueryProc(new Person(), "QueryProcParameters", input, output1, output2);
+				Assert.IsNull(output1.Value);
+				Assert.IsNull(output2.Value);
+				foreach (var person in persons)
+				{
+					Assert.IsNull(output1.Value);
+					Assert.IsNull(output2.Value);
+					break;
+				}
+
+				Assert.AreEqual(2, output1.Value);
+				Assert.AreEqual(3, output2.Value);
+			}
+		}
+
+		[Test]
+		public async Task TestQueryProcAsyncTemplateRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var input = DataParameter.Int32("input", 1);
+				var output1 = new DataParameter("output1", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				var output2 = new DataParameter("output2", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				var persons = await db.QueryProcAsync(new Person(), "QueryProcParameters", input, output1, output2);
+				Assert.IsNull(output1.Value);
+				Assert.IsNull(output2.Value);
+				foreach (var person in persons)
+				{
+					Assert.IsNull(output1.Value);
+					Assert.IsNull(output2.Value);
+					break;
+				}
+
+				Assert.AreEqual(2, output1.Value);
+				Assert.AreEqual(3, output2.Value);
+			}
+		}
+
+		[Test]
+		public void TestQueryProcReaderRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var input = DataParameter.Int32("input", 1);
+				var output1 = new DataParameter("output1", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				var output2 = new DataParameter("output2", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				var persons = db.QueryProc(reader => new Person(), "QueryProcParameters", input, output1, output2);
+				Assert.IsNull(output1.Value);
+				Assert.IsNull(output2.Value);
+				foreach (var person in persons)
+				{
+					Assert.IsNull(output1.Value);
+					Assert.IsNull(output2.Value);
+					break;
+				}
+
+				Assert.AreEqual(2, output1.Value);
+				Assert.AreEqual(3, output2.Value);
+			}
+		}
+
+		[Test]
+		public async Task TestQueryProcAsyncReaderRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var input = DataParameter.Int32("input", 1);
+				var output1 = new DataParameter("output1", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				var output2 = new DataParameter("output2", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				var persons = await db.QueryProcAsync(reader => new Person(), "QueryProcParameters", input, output1, output2);
+				Assert.IsNull(output1.Value);
+				Assert.IsNull(output2.Value);
+				foreach (var person in persons)
+				{
+					Assert.IsNull(output1.Value);
+					Assert.IsNull(output2.Value);
+					break;
+				}
+
+				Assert.AreEqual(2, output1.Value);
+				Assert.AreEqual(3, output2.Value);
+			}
+		}
+
+		class QueryProcMultipleResult
+		{
+			[ResultSetIndex(0)] public IEnumerable<Person> Persons { get; set; } = null!;
+			[ResultSetIndex(1)] public IEnumerable<Doctor> Doctors { get; set; } = null!;
+		}
+
+		[Test]
+		public void TestQueryProcMultipleRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var input = DataParameter.Int32("input", 1);
+				var output1 = new DataParameter("output1", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				var output2 = new DataParameter("output2", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				var output3 = new DataParameter("output3", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				db.QueryProcMultiple<Person>("QueryProcMultipleParameters", input, output1, output2, output3);
+				Assert.AreEqual(2, output1.Value);
+				Assert.AreEqual(3, output2.Value);
+				Assert.AreEqual(4, output3.Value);
+			}
+		}
+
+		[Test]
+		public async Task TestQueryProcMultipleAsyncRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var input = DataParameter.Int32("input", 1);
+				var output1 = new DataParameter("output1", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				var output2 = new DataParameter("output2", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				var output3 = new DataParameter("output3", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				await db.QueryProcMultipleAsync<Person>("QueryProcMultipleParameters", input, output1, output2, output3);
+				Assert.AreEqual(2, output1.Value);
+				Assert.AreEqual(3, output2.Value);
+				Assert.AreEqual(4, output3.Value);
+			}
+		}
+
+		[Test]
+		public void TestExecuteProcIntRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var input = DataParameter.Int32("input", 1);
+				var output = new DataParameter("output", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				var result = db.ExecuteProc("ExecuteProcIntParameters", input, output);
+				Assert.AreEqual(2, output.Value);
+				Assert.AreEqual(5, result);
+			}
+		}
+
+		[Test]
+		public async Task TestExecuteProcAsyncIntRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var input = DataParameter.Int32("input", 1);
+				var output = new DataParameter("output", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				var result = await db.ExecuteProcAsync("ExecuteProcIntParameters", input, output);
+				Assert.AreEqual(2, output.Value);
+				Assert.AreEqual(5, result);
+			}
+		}
+
+		[Test]
+		public void TestExecuteProcTRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var input = DataParameter.Int32("input", 1);
+				var output = new DataParameter("output", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				var result = db.ExecuteProc<string>("ExecuteProcStringParameters", input, output);
+				Assert.AreEqual("издрасте", output.Value);
+				Assert.AreEqual(5, result);
+			}
+		}
+
+		[Test]
+		public async Task TestExecuteProcAsyncTRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var input = DataParameter.Int32("input", 1);
+				var output = new DataParameter("output", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				var result = await db.ExecuteProcAsync<string>("ExecuteProcStringParameters", input, output);
+				Assert.AreEqual("издрасте", output.Value);
+				Assert.AreEqual(5, result);
+			}
+		}
+
+		[Test]
+		public void TestExecuteReaderProcRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var input = DataParameter.Int32("input", 1);
+				var output1 = new DataParameter("output1", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				var output2 = new DataParameter("output2", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				var reader = new CommandInfo(db, "QueryProcParameters", input, output1, output2).ExecuteReaderProc();
+				Assert.IsNull(output1.Value);
+				Assert.IsNull(output2.Value);
+				while (reader.Reader!.Read())
+				{ 
+					Assert.IsNull(output1.Value);
+					Assert.IsNull(output2.Value);
+					reader.Dispose();
+					break;
+				}
+
+				Assert.AreEqual(2, output1.Value);
+				Assert.AreEqual(3, output2.Value);
+			}
+		}
+
+		[Test]
+		public async Task TestExecuteReaderProcAsyncRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new DataConnection(context))
+			{
+				var input = DataParameter.Int32("input", 1);
+				var output1 = new DataParameter("output1", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				var output2 = new DataParameter("output2", null, DataType.Int32) { Direction = ParameterDirection.Output };
+				var reader = await new CommandInfo(db, "QueryProcParameters", input, output1, output2).ExecuteReaderProcAsync();
+				Assert.IsNull(output1.Value);
+				Assert.IsNull(output2.Value);
+				while (await reader.Reader!.ReadAsync())
+				{
+					Assert.IsNull(output1.Value);
+					Assert.IsNull(output2.Value);
+					reader.Dispose();
+					break;
+				}
+
+				Assert.AreEqual(2, output1.Value);
+				Assert.AreEqual(3, output2.Value);
 			}
 		}
 	}

--- a/Tests/Linq/Data/ProcedureTests.cs
+++ b/Tests/Linq/Data/ProcedureTests.cs
@@ -368,7 +368,7 @@ namespace Tests.Data
 		}
 
 		[Test]
-		public void TestExecuteReaderProcNoRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		public void TestExecuteReaderProcRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
 		{
 			using (var db = new DataConnection(context))
 			{
@@ -383,15 +383,13 @@ namespace Tests.Data
 					{
 					}
 
-				Assert.IsNull(output1.Value);
-				Assert.IsNull(output2.Value);
-				Assert.AreEqual(2, ((IDataParameter)db.Command.Parameters["output1"]).Value);
-				Assert.AreEqual(3, ((IDataParameter)db.Command.Parameters["output2"]).Value);
+				Assert.AreEqual(2, output1.Value);
+				Assert.AreEqual(3, output2.Value);
 			}
 		}
 
 		[Test]
-		public async Task TestExecuteReaderProcAsyncNoRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		public async Task TestExecuteReaderProcAsyncRebind([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
 		{
 			using (var db = new DataConnection(context))
 			{
@@ -406,10 +404,8 @@ namespace Tests.Data
 					{
 					}
 
-				Assert.IsNull(output1.Value);
-				Assert.IsNull(output2.Value);
-				Assert.AreEqual(2, ((IDataParameter)db.Command.Parameters["output1"]).Value);
-				Assert.AreEqual(3, ((IDataParameter)db.Command.Parameters["output2"]).Value);
+				Assert.AreEqual(2, output1.Value);
+				Assert.AreEqual(3, output2.Value);
 			}
 		}
 	}


### PR DESCRIPTION
- add missing async overloads for stored procedure APIs. Fix #1501
- removed duplicate overloads in CommandInfo
- add parameter tests for all proc execution APIs and implement parameter rebind for `ExecuteProc<T>` and `QueryProcMultiple`. Fix #2361