### PR TITLE
CreateTempTable cancellation token support and failure cleanup

### DIFF
--- a/Source/LinqToDB/TempTable.cs
+++ b/Source/LinqToDB/TempTable.cs
@@ -110,24 +110,8 @@ namespace LinqToDB
 			string? databaseName = null,
 			string? schemaName   = null,
 			string? serverName   = null)
+			: this(db, items, options, tableName, databaseName, schemaName, serverName)
 		{
-			if (db    == null) throw new ArgumentNullException(nameof(db));
-			if (items == null) throw new ArgumentNullException(nameof(items));
-
-			_table = db.CreateTable<T>(tableName, databaseName, schemaName, serverName: serverName);
-			try
-			{
-				Copy(items, options);
-			}
-			catch
-			{
-				try
-				{
-					_table.DropTable();
-				}
-				catch { }
-				throw;
-			}
 		}
 
 		/// <summary>
@@ -185,25 +169,8 @@ namespace LinqToDB
 			string? schemaName        = null,
 			Action<ITable<T>>? action = null,
 			string? serverName        = null)
+			: this(db, items, tableName, databaseName, schemaName, action, serverName)
 		{
-			if (db    == null) throw new ArgumentNullException(nameof(db));
-			if (items == null) throw new ArgumentNullException(nameof(items));
-
-			_table = db.CreateTable<T>(tableName, databaseName, schemaName, serverName: serverName);
-			try
-			{
-				action?.Invoke(_table);
-				Insert(items);
-			}
-			catch
-			{
-				try
-				{
-					_table.DropTable();
-				}
-				catch { }
-				throw;
-			}
 		}
 
 		/// <summary>

--- a/Source/LinqToDB/TempTable.cs
+++ b/Source/LinqToDB/TempTable.cs
@@ -451,7 +451,7 @@ namespace LinqToDB
 			});
 		}
 
-#region ITable<T> implementation
+		#region ITable<T> implementation
 
 		public string? ServerName   => _table.ServerName;
 		public string? DatabaseName => _table.DatabaseName;
@@ -463,9 +463,9 @@ namespace LinqToDB
 			return _table.GetTableName();
 		}
 
-#endregion
+		#endregion
 
-#region ITableMutable<T> implementation
+		#region ITableMutable<T> implementation
 
 		ITable<T> ITableMutable<T>.ChangeServerName(string? serverName)
 		{
@@ -487,9 +487,9 @@ namespace LinqToDB
 			return ((ITableMutable<T>)_table).ChangeTableName(tableName);
 		}
 
-#endregion
+		#endregion
 
-#region IQueryProvider
+		#region IQueryProvider
 
 		IQueryable IQueryProvider.CreateQuery(Expression expression)
 		{
@@ -511,9 +511,9 @@ namespace LinqToDB
 			return _table.Execute<TResult>(expression);
 		}
 
-#endregion
+		#endregion
 
-#region IQueryProviderAsync
+		#region IQueryProviderAsync
 
 		Task<TResult> IQueryProviderAsync.ExecuteAsync<TResult>(Expression expression, CancellationToken token)
 		{
@@ -525,9 +525,9 @@ namespace LinqToDB
 			return _table.ExecuteAsync<TResult>(expression);
 		}
 
-#endregion
+		#endregion
 
-#region IExpressionQuery<T>
+		#region IExpressionQuery<T>
 
 		Expression IExpressionQuery<T>.Expression
 		{
@@ -535,9 +535,9 @@ namespace LinqToDB
 			set => _table.Expression = value;
 		}
 
-#endregion
+		#endregion
 
-#region IExpressionQuery
+		#region IExpressionQuery
 
 		/// <summary>
 		/// Gets data connection, associated with current table.
@@ -547,34 +547,34 @@ namespace LinqToDB
 		string       IExpressionQuery.SqlText    => _table.SqlText;
 		Expression   IExpressionQuery.Expression => ((IExpressionQuery)_table).Expression;
 
-#endregion
+		#endregion
 
-#region IQueryable
+		#region IQueryable
 
 		Expression IQueryable.Expression => ((IQueryable)_table).Expression;
 
 		Type           IQueryable.ElementType => _table.ElementType;
 		IQueryProvider IQueryable.Provider    => _table.Provider;
 
-#endregion
+		#endregion
 
-#region IEnumerable<T>
+		#region IEnumerable<T>
 
 		IEnumerator<T> IEnumerable<T>.GetEnumerator()
 		{
 			return _table.GetEnumerator();
 		}
 
-#endregion
+		#endregion
 
-#region IEnumerable
+		#region IEnumerable
 
 		IEnumerator IEnumerable.GetEnumerator()
 		{
 			return ((IEnumerable)_table).GetEnumerator();
 		}
 
-#endregion
+		#endregion
 
 		public virtual void Dispose()
 		{

--- a/Tests/Linq/Update/CreateTempTableTests.cs
+++ b/Tests/Linq/Update/CreateTempTableTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using LinqToDB;
 
@@ -149,6 +150,92 @@ namespace Tests.xUpdate
 						select t
 					).ToList();
 				}
+			}
+		}
+
+		[Test]
+		public void CreateTableAsyncCanceled([DataSources(false)] string context)
+		{
+			var cts = new CancellationTokenSource();
+			cts.Cancel();
+			using (var db = GetDataContext(context))
+			{
+				db.DropTable<int>("TempTable", throwExceptionIfNotExists: false);
+
+				Assert.ThrowsAsync<TaskCanceledException>(async () =>
+				{
+#if !NET46
+					await
+#endif
+					using (var tmp = await db.CreateTempTableAsync(
+						"TempTable",
+						db.Parent.Select(p => new IDTable { ID = p.ParentID }).ToList(),
+						cancellationToken: cts.Token))
+					{
+						var list =
+						(
+							from p in db.Parent
+							join t in tmp on p.ParentID equals t.ID
+							select t
+						).ToList();
+					}
+				});
+
+				var tableExists = true;
+				try
+				{
+					db.DropTable<int>("TempTable", throwExceptionIfNotExists: true);
+				}
+				catch
+				{
+					tableExists = false;
+				}
+				Assert.AreEqual(false, tableExists);
+			}
+		}
+
+		[Test]
+		public void CreateTableAsyncCanceled2([DataSources(false)] string context)
+		{
+			var cts = new CancellationTokenSource();
+			using (var db = GetDataContext(context))
+			{
+				db.DropTable<int>("TempTable", throwExceptionIfNotExists: false);
+
+				Assert.ThrowsAsync<TaskCanceledException>(async () =>
+				{
+#if !NET46
+					await
+#endif
+					using (var tmp = await db.CreateTempTableAsync(
+						"TempTable",
+						db.Parent.Select(p => new IDTable { ID = p.ParentID }),
+						action: (table) =>
+						{
+							cts.Cancel();
+							return Task.CompletedTask;
+						},
+						cancellationToken: cts.Token))
+					{
+						var list =
+						(
+							from p in db.Parent
+							join t in tmp on p.ParentID equals t.ID
+							select t
+						).ToList();
+					}
+				});
+
+				var tableExists = true;
+				try
+				{
+					db.DropTable<int>("TempTable", throwExceptionIfNotExists: true);
+				}
+				catch
+				{
+					tableExists = false;
+				}
+				Assert.AreEqual(false, tableExists);
 			}
 		}
 	}

--- a/Tests/Linq/Update/CreateTempTableTests.cs
+++ b/Tests/Linq/Update/CreateTempTableTests.cs
@@ -154,7 +154,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public void CreateTableAsyncCanceled([DataSources(false)] string context)
+		public async Task CreateTableAsyncCanceled([DataSources(false)] string context)
 		{
 			var cts = new CancellationTokenSource();
 			cts.Cancel();
@@ -162,7 +162,7 @@ namespace Tests.xUpdate
 			{
 				db.DropTable<int>("TempTable", throwExceptionIfNotExists: false);
 
-				Assert.ThrowsAsync<TaskCanceledException>(async () =>
+				try
 				{
 #if !NET46
 					await
@@ -179,7 +179,10 @@ namespace Tests.xUpdate
 							select t
 						).ToList();
 					}
-				});
+					Assert.Fail("Task should have been canceled but was not");
+				}
+				catch (OperationCanceledException) { }
+				
 
 				var tableExists = true;
 				try
@@ -195,14 +198,14 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public void CreateTableAsyncCanceled2([DataSources(false)] string context)
+		public async Task CreateTableAsyncCanceled2([DataSources(false)] string context)
 		{
 			var cts = new CancellationTokenSource();
 			using (var db = GetDataContext(context))
 			{
 				db.DropTable<int>("TempTable", throwExceptionIfNotExists: false);
 
-				Assert.ThrowsAsync<TaskCanceledException>(async () =>
+				try
 				{
 #if !NET46
 					await
@@ -224,7 +227,9 @@ namespace Tests.xUpdate
 							select t
 						).ToList();
 					}
-				});
+					Assert.Fail("Task should have been canceled but was not");
+				}
+				catch (OperationCanceledException) { }
 
 				var tableExists = true;
 				try


### PR DESCRIPTION
This PR does the following:
1. Adds cancellation tokens to all existing asynchronous CreateTempTable overloads, passing it both to the CreateTable function, and also to the optional `Copy` (bulk import) or `Insert` (from another table) operation.
2. If an exception occurs during the `Copy` / `Insert` phase, the temporary table is dropped from the database.  If an error occurs during the drop, it is ignored; the original exception is still thrown back onto the stack.  Applies to both synchronous and asynchronous operations.