### PR TITLE
Fix IAsyncEnumerable support for Eager Load

### DIFF
--- a/Source/LinqToDB/Async/AsyncEnumeratorAsyncWrapper.cs
+++ b/Source/LinqToDB/Async/AsyncEnumeratorAsyncWrapper.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LinqToDB.Async
+{
+	internal class AsyncEnumeratorAsyncWrapper<T> : IAsyncEnumerator<T>
+	{
+		private IAsyncEnumerator<T>? _enumerator;
+#if NETFRAMEWORK
+		private readonly Func<Task<Tuple<IAsyncEnumerator<T>, IDisposable?>>> _init;
+		private IDisposable? _disposable;
+#else
+		private readonly Func<Task<Tuple<IAsyncEnumerator<T>, IAsyncDisposable?>>> _init;
+		private IAsyncDisposable? _disposable;
+#endif
+
+#if NETFRAMEWORK
+		public AsyncEnumeratorAsyncWrapper(Func<Task<Tuple<IAsyncEnumerator<T>, IDisposable?>>> init)
+#else
+		public AsyncEnumeratorAsyncWrapper(Func<Task<Tuple<IAsyncEnumerator<T>, IAsyncDisposable?>>> init)
+#endif
+		{
+			_init = init;
+		}
+
+		T IAsyncEnumerator<T>.Current => _enumerator!.Current;
+
+#if NETFRAMEWORK
+		void IDisposable.Dispose()
+		{
+			_enumerator!.Dispose();
+			_disposable?.Dispose();
+		}
+
+		async Task IAsyncEnumerator<T>.DisposeAsync()
+		{
+			await _enumerator!.DisposeAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+			_disposable?.Dispose();
+		}
+
+		async Task<bool> IAsyncEnumerator<T>.MoveNextAsync()
+		{
+			if (_enumerator == null)
+			{
+				var tuple   = await _init().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+				_enumerator = tuple.Item1;
+				_disposable = tuple.Item2;
+			}
+
+			return await _enumerator.MoveNextAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+		}
+#else
+		async ValueTask IAsyncDisposable.DisposeAsync()
+		{
+			await _enumerator!.DisposeAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+			_disposable?.DisposeAsync();
+		}
+
+		async ValueTask<bool> IAsyncEnumerator<T>.MoveNextAsync()
+		{
+			if (_enumerator == null)
+			{
+				var tuple   = await _init().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+				_enumerator = tuple.Item1;
+				_disposable = tuple.Item2;
+			}
+
+			return await _enumerator.MoveNextAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+		}
+#endif
+	}
+}

--- a/Source/LinqToDB/Async/IAsyncEnumerable.cs
+++ b/Source/LinqToDB/Async/IAsyncEnumerable.cs
@@ -24,6 +24,6 @@ namespace LinqToDB.Async
 		/// This API supports the LinqToDB infrastructure and is not intended to be used  directly from your code.
 		/// This API may change or be removed in future releases.
 		/// </summary>
-		IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken);
+		IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default);
 	}
 }

--- a/Source/LinqToDB/Async/IQueryProviderAsync.cs
+++ b/Source/LinqToDB/Async/IQueryProviderAsync.cs
@@ -16,7 +16,7 @@ namespace LinqToDB.Async
 		/// This is internal API and is not intended for use by Linq To DB applications.
 		/// It may change or be removed without further notice.
 		/// </summary>
-		IAsyncEnumerable<TResult> ExecuteAsync<TResult>(Expression expression);
+		Task<IAsyncEnumerable<TResult>> ExecuteAsyncEnumerable<TResult>(Expression expression, CancellationToken token);
 
 		/// <summary>
 		/// This is internal API and is not intended for use by Linq To DB applications.

--- a/Source/LinqToDB/Linq/Builder/EagerLoading.cs
+++ b/Source/LinqToDB/Linq/Builder/EagerLoading.cs
@@ -1467,7 +1467,7 @@ namespace LinqToDB.Linq.Builder
 					var details = queryable.ToList();
 					return details;
 				},
-				async (dc, expr, ps) =>
+				async (dc, expr, ps, ct) =>
 				{
 					//TODO: needed more performant way
 					PrepareParameters(detailQuery.Expression, builder, out var container, out var detailExpression);
@@ -1477,7 +1477,7 @@ namespace LinqToDB.Linq.Builder
 					container.ParameterExpression = expr;
 
 					var queryable = new ExpressionQueryImpl<TD>(dc, detailExpression);
-					var details = await queryable.ToListAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+					var details = await queryable.ToListAsync(ct).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 					return details;
 				}
 			);
@@ -1513,7 +1513,7 @@ namespace LinqToDB.Linq.Builder
 
 					return eagerLoadingContext;
 				},
-				async (dc, expr, ps) =>
+				async (dc, expr, ps, ct) =>
 				{
 					//TODO: needed more performant way
 					PrepareParameters(expression, builder, out var container, out var detailExpression);
@@ -1523,7 +1523,7 @@ namespace LinqToDB.Linq.Builder
 					container.ParameterExpression = expr;
 
 					var queryable           = new ExpressionQueryImpl<KeyDetailEnvelope<TKey, TD>>(dc, detailExpression);
-					var detailsWithKey      = await queryable.ToListAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+					var detailsWithKey      = await queryable.ToListAsync(ct).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 					var eagerLoadingContext = new EagerLoadingContext<TD, TKey>();
 
 					foreach (var d in detailsWithKey)

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -20,6 +20,7 @@ namespace LinqToDB.Linq.Builder
 	using SqlQuery;
 	using SqlProvider;
 	using Tools;
+	using System.Threading;
 
 	partial class ExpressionBuilder
 	{
@@ -3478,19 +3479,19 @@ namespace LinqToDB.Linq.Builder
 
 		#region Eager Loading
 
-		private List<Tuple<Func<IDataContext, Expression, object?[]?, object?>, Func<IDataContext, Expression, object?[]?, Task<object?>>>>? _preambles;
+		private List<Tuple<Func<IDataContext, Expression, object?[]?, object?>, Func<IDataContext, Expression, object?[]?, CancellationToken, Task<object?>>>>? _preambles;
 
 		public static readonly ParameterExpression PreambleParam =
 			Expression.Parameter(typeof(object[]), "preamble");
 
-		public int RegisterPreamble<T>(Func<IDataContext, Expression, object?[]?, T> func, Func<IDataContext, Expression, object?[]?, Task<T>> funcAsync)
+		public int RegisterPreamble<T>(Func<IDataContext, Expression, object?[]?, T> func, Func<IDataContext, Expression, object?[]?, CancellationToken, Task<T>> funcAsync)
 		{
 			if (_preambles == null)
-				_preambles = new List<Tuple<Func<IDataContext, Expression, object?[]?, object?>,Func<IDataContext, Expression, object?[]?, Task<object?>>>>();
+				_preambles = new List<Tuple<Func<IDataContext, Expression, object?[]?, object?>,Func<IDataContext, Expression, object?[]?, CancellationToken, Task<object?>>>>();
 			_preambles.Add(
-				Tuple.Create< Func<IDataContext, Expression, object?[]?, object?>, Func<IDataContext, Expression, object?[]?, Task<object?>>>(
+				Tuple.Create< Func<IDataContext, Expression, object?[]?, object?>, Func<IDataContext, Expression, object?[]?, CancellationToken, Task<object?>>>(
 					(dc, e, ps) => func(dc, e, ps),
-					async (dc, e, ps) => await funcAsync(dc, e, ps)));
+					async (dc, e, ps, ct) => await funcAsync(dc, e, ps, ct)));
 			return _preambles.Count - 1;
 		}
 

--- a/Source/LinqToDB/Linq/ExpressionQuery.cs
+++ b/Source/LinqToDB/Linq/ExpressionQuery.cs
@@ -180,9 +180,16 @@ namespace LinqToDB.Linq
 			var query      = GetQuery(ref expression, true);
 			Expression     = expression;
 
-			return query
-				.GetIAsyncEnumerable(DataContext, expression, Parameters, Preambles)
-				.GetAsyncEnumerator(cancellationToken);
+			//TODO: need async call
+
+			using (StartLoadTransaction(query))
+			{
+				Preambles = query.InitPreambles(DataContext, expression, Parameters);
+
+				return query
+					.GetIAsyncEnumerable(DataContext, expression, Parameters, Preambles)
+					.GetAsyncEnumerator(cancellationToken);
+			}
 		}
 
 		#endregion

--- a/Source/LinqToDB/Linq/PersistentTableT.cs
+++ b/Source/LinqToDB/Linq/PersistentTableT.cs
@@ -31,8 +31,8 @@ namespace LinqToDB.Linq
 		public Expression Expression => _query.Expression;
 		Expression IExpressionQuery<T>.Expression
 		{
-			get { return _query.Expression; }
-			set { throw new NotImplementedException(); }
+			get => _query.Expression;
+			set => throw new NotImplementedException();
 		}
 
 		public string         SqlText        { get; } = null!;
@@ -60,7 +60,7 @@ namespace LinqToDB.Linq
 			return _query.Provider.Execute<TResult>(expression);
 		}
 
-		public IAsyncEnumerable<TResult> ExecuteAsync<TResult>(Expression expression)
+		public Task<IAsyncEnumerable<TResult>> ExecuteAsyncEnumerable<TResult>(Expression expression, CancellationToken token)
 		{
 			throw new NotImplementedException();
 		}

--- a/Source/LinqToDB/TempTable.cs
+++ b/Source/LinqToDB/TempTable.cs
@@ -520,9 +520,9 @@ namespace LinqToDB
 			return _table.ExecuteAsync<TResult>(expression, token);
 		}
 
-		IAsyncEnumerable<TResult> IQueryProviderAsync.ExecuteAsync<TResult>(Expression expression)
+		Task<IAsyncEnumerable<TResult>> IQueryProviderAsync.ExecuteAsyncEnumerable<TResult>(Expression expression, CancellationToken token)
 		{
-			return _table.ExecuteAsync<TResult>(expression);
+			return _table.ExecuteAsyncEnumerable<TResult>(expression, token);
 		}
 
 		#endregion

--- a/Tests/Linq/Linq/EagerLoadingTests.cs
+++ b/Tests/Linq/Linq/EagerLoadingTests.cs
@@ -186,7 +186,7 @@ namespace Tests.Linq
 			var intParam = 0;
 
 			using (new AllowMultipleQuery())
-			using (var db = GetDataContext(context))
+			using (var db     = GetDataContext(context))
 			using (var master = db.CreateLocalTable(masterRecords))
 			using (var detail = db.CreateLocalTable(detailRecords))
 			{
@@ -198,10 +198,10 @@ namespace Tests.Linq
 									where m.Id1 >= intParam
 									select new MasterClass
 									{
-										Id1 = m.Id1,
-										Id2 = m.Id2,
-										Value = m.Value,
-										Details = detailRecords.Where(d => d.MasterId == m.Id1).ToList(),
+										Id1          = m.Id1,
+										Id2          = m.Id2,
+										Value        = m.Value,
+										Details      = detailRecords.Where(d => d.MasterId == m.Id1).ToList(),
 										DetailsQuery = detailRecords.Where(d => d.MasterId == m.Id1 && d.MasterId == m.Id2 && d.DetailId % 2 == 0).ToArray(),
 									};
 

--- a/Tests/Linq/Linq/EagerLoadingTests.cs
+++ b/Tests/Linq/Linq/EagerLoadingTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using LinqToDB;
+using LinqToDB.Async;
 using LinqToDB.Mapping;
 using LinqToDB.Tools;
 using LinqToDB.Tools.Comparers;
@@ -172,6 +173,43 @@ namespace Tests.Linq
 					};
 
 				var result = query.ToList();
+				var expected = expectedQuery.ToList();
+
+				AreEqual(expected, result, ComparerBuilder.GetEqualityComparer(expected));
+			}
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/2442")]
+		public async Task TestLoadWithAsyncEnumerator([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			var (masterRecords, detailRecords) = GenerateData();
+			var intParam = 0;
+
+			using (new AllowMultipleQuery())
+			using (var db = GetDataContext(context))
+			using (var master = db.CreateLocalTable(masterRecords))
+			using (var detail = db.CreateLocalTable(detailRecords))
+			{
+				var query = from m in master.LoadWith(m => m.Details).LoadWith(m => m.DetailsQuery)
+							where m.Id1 >= intParam
+							select m;
+
+				var expectedQuery = from m in masterRecords
+									where m.Id1 >= intParam
+									select new MasterClass
+									{
+										Id1 = m.Id1,
+										Id2 = m.Id2,
+										Value = m.Value,
+										Details = detailRecords.Where(d => d.MasterId == m.Id1).ToList(),
+										DetailsQuery = detailRecords.Where(d => d.MasterId == m.Id1 && d.MasterId == m.Id2 && d.DetailId % 2 == 0).ToArray(),
+									};
+
+				var result = new List<MasterClass>();
+
+				await foreach (var item in (IAsyncEnumerable<MasterClass>)query)
+					result.Add(item);
+
 				var expected = expectedQuery.ToList();
 
 				AreEqual(expected, result, ComparerBuilder.GetEqualityComparer(expected));
@@ -991,7 +1029,7 @@ FROM
 			}
 		}
 
-		#region issue 1862
+#region issue 1862
 		[Table]
 		public partial class Blog
 		{
@@ -1139,10 +1177,10 @@ FROM
 				Assert.AreEqual("SqlKata", result.Blog[0].Posts[3].Tags[0].Name);
 			}
 		}
-		#endregion
+#endregion
 
 
-		#region issue 2196
+#region issue 2196
 		public class EventScheduleItemBase
 		{
 			public EventScheduleItemBase()
@@ -1264,9 +1302,9 @@ FROM
 				Assert.That(result[0].Persons.Count, Is.EqualTo(1));
 			}
 		}
-		#endregion
+#endregion
 
-		#region issue 2307
+#region issue 2307
 		[Table]
 		class AttendanceSheet
 		{
@@ -1330,6 +1368,6 @@ FROM
 				query.ToList();
 			}
 		}
-		#endregion
+#endregion
 	}
 }

--- a/Tests/Linq/Update/MergeTests.ApiParametersValidation.cs
+++ b/Tests/Linq/Update/MergeTests.ApiParametersValidation.cs
@@ -226,7 +226,7 @@ namespace Tests.xUpdate
 				throw new NotImplementedException();
 			}
 
-			IAsyncEnumerable<TResult> IQueryProviderAsync.ExecuteAsync<TResult>(Expression expression)
+			Task<IAsyncEnumerable<TResult>> IQueryProviderAsync.ExecuteAsyncEnumerable<TResult>(Expression expression, CancellationToken token)
 			{
 				throw new NotImplementedException();
 			}


### PR DESCRIPTION
- fix support for eager load queries with IAsyncEnumerable. Fix #2442
- fix `IAsyncEnumerable<T>.GetAsyncEnumerator` signature for netfx targets
- fix async path for eager load to use async operations