### PR TITLE
[Firebird] Add escaping of table aliases

### DIFF
--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdSqlBuilder.cs
@@ -181,6 +181,7 @@ namespace LinqToDB.DataProvider.Firebird
 			switch (convertType)
 			{
 				case ConvertType.NameToQueryFieldAlias :
+				case ConvertType.NameToQueryTableAlias :
 				case ConvertType.NameToQueryField      :
 				case ConvertType.NameToQueryTable      :
 				case ConvertType.SequenceName          :


### PR DESCRIPTION
Adds missing escaping of table aliases (column aliases already escaped) for firebird. Fix #2445