### PR TITLE
Update dependencies

### DIFF
--- a/Build/Azure/README.md
+++ b/Build/Azure/README.md
@@ -94,7 +94,7 @@ Legend:
 |Informix 14.10<br>[IBM.Data.DB2](https://www.nuget.org/packages/IBM.Data.DB.Provider/) IDS 11.5.4000.4 (netfx)<br>[IBM.Data.DB2.Core](https://www.nuget.org/packages/IBM.Data.DB2.Core/) 2.2.0.100 ([osx](https://www.nuget.org/packages/IBM.Data.DB2.Core-osx/) 2.0.0.100, [lin](https://www.nuget.org/packages/IBM.Data.DB2.Core-lnx/) 2.2.0.100) (core)|:x:|:x:|:x:|:x:|
 |SAP HANA 2.0 SPS 04r40<br>Native Provider|:x:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
 |SAP HANA 2.0 SPS 04r40<br>ODBC Provider|:x:|:x:|:x:|:x:|
-|SAP/Sybase ASE 16.2<br>[AdoNetCore.AseClient](https://www.nuget.org/packages/AdoNetCore.AseClient/) 0.19.0|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|SAP/Sybase ASE 16.2<br>[AdoNetCore.AseClient](https://www.nuget.org/packages/AdoNetCore.AseClient/) 0.19.1|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |SAP/Sybase ASE 16.2<br>Native Client|:x:|:x:|:x:|:x:|
 |Oracle 11g XE<br>Native Client 4.122.19.1 |:x:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
 |Oracle 11g XE<br>[Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) 19.8.0 (netfx)<br>[Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core/) 2.19.80 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|

--- a/Build/Azure/README.md
+++ b/Build/Azure/README.md
@@ -94,7 +94,7 @@ Legend:
 |Informix 14.10<br>[IBM.Data.DB2](https://www.nuget.org/packages/IBM.Data.DB.Provider/) IDS 11.5.4000.4 (netfx)<br>[IBM.Data.DB2.Core](https://www.nuget.org/packages/IBM.Data.DB2.Core/) 2.2.0.100 ([osx](https://www.nuget.org/packages/IBM.Data.DB2.Core-osx/) 2.0.0.100, [lin](https://www.nuget.org/packages/IBM.Data.DB2.Core-lnx/) 2.2.0.100) (core)|:x:|:x:|:x:|:x:|
 |SAP HANA 2.0 SPS 04r40<br>Native Provider|:x:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
 |SAP HANA 2.0 SPS 04r40<br>ODBC Provider|:x:|:x:|:x:|:x:|
-|SAP/Sybase ASE 16.2<br>[AdoNetCore.AseClient](https://www.nuget.org/packages/AdoNetCore.AseClient/) 0.18.0|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|SAP/Sybase ASE 16.2<br>[AdoNetCore.AseClient](https://www.nuget.org/packages/AdoNetCore.AseClient/) 0.19.0|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |SAP/Sybase ASE 16.2<br>Native Client|:x:|:x:|:x:|:x:|
 |Oracle 11g XE<br>Native Client 4.122.19.1 |:x:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
 |Oracle 11g XE<br>[Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) 19.8.0 (netfx)<br>[Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core/) 2.19.80 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|

--- a/Build/linq2db.Tests.Providers.props
+++ b/Build/linq2db.Tests.Providers.props
@@ -14,7 +14,7 @@
 		<PackageReference Include="MySql.Data" Version="8.0.21" />
 		<PackageReference Include="MySqlConnector" Version="1.0.1" />
 		<PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="7.5.0" />
-		<PackageReference Include="AdoNetCore.AseClient" Version="0.19.0" />
+		<PackageReference Include="AdoNetCore.AseClient" Version="0.19.1" />
 
 		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />

--- a/Build/linq2db.Tests.Providers.props
+++ b/Build/linq2db.Tests.Providers.props
@@ -14,7 +14,7 @@
 		<PackageReference Include="MySql.Data" Version="8.0.21" />
 		<PackageReference Include="MySqlConnector" Version="1.0.1" />
 		<PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="7.5.0" />
-		<PackageReference Include="AdoNetCore.AseClient" Version="0.18.0" />
+		<PackageReference Include="AdoNetCore.AseClient" Version="0.19.0" />
 
 		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />

--- a/NuGet/linq2db.Sybase.DataAction.nuspec
+++ b/NuGet/linq2db.Sybase.DataAction.nuspec
@@ -12,7 +12,7 @@
 		<tags>linq linq2db SAP Sybase LinqToDB ORM database DB SQL</tags>
 		<dependencies>
 			<dependency id="linq2db"              version="3.0.0"  />
-			<dependency id="AdoNetCore.AseClient" version="0.19.0" />
+			<dependency id="AdoNetCore.AseClient" version="0.19.1" />
 		</dependencies>
 		<contentFiles>
 			<files include="**\*" buildAction="None"/>

--- a/NuGet/linq2db.Sybase.DataAction.nuspec
+++ b/NuGet/linq2db.Sybase.DataAction.nuspec
@@ -12,7 +12,7 @@
 		<tags>linq linq2db SAP Sybase LinqToDB ORM database DB SQL</tags>
 		<dependencies>
 			<dependency id="linq2db"              version="3.0.0"  />
-			<dependency id="AdoNetCore.AseClient" version="0.18.0" />
+			<dependency id="AdoNetCore.AseClient" version="0.19.0" />
 		</dependencies>
 		<contentFiles>
 			<files include="**\*" buildAction="None"/>


### PR DESCRIPTION
- [AdoNetCore.AseClient](https://www.nuget.org/packages/AdoNetCore.AseClient) 0.18.0 -> 0.19.0

not included in 3.1.2 release due to https://github.com/DataAction/AdoNetCore.AseClient/issues/194. We can fix it on our side easily, but it is quite niche case, so I prefer to skip version for now.