### PR TITLE
Allow different type of predicate when converting FuncLike in optimizer

### DIFF
--- a/Source/LinqToDB/SqlQuery/ConvertVisitor.cs
+++ b/Source/LinqToDB/SqlQuery/ConvertVisitor.cs
@@ -387,10 +387,17 @@ namespace LinqToDB.SqlQuery
 					case QueryElementType.FuncLikePredicate:
 						{
 							var p = (SqlPredicate.FuncLike)element;
-							var f = (SqlFunction?)ConvertInternal(p.Function);
+							var f = (ISqlExpression?)ConvertInternal(p.Function);
 
 							if (f != null && !ReferenceEquals(p.Function, f))
-								newElement = new SqlPredicate.FuncLike(f);
+							{
+								if (f is SqlFunction function)
+									newElement = new SqlPredicate.FuncLike(function);
+								else if (f is ISqlPredicate predicate)
+									newElement = predicate;
+								else
+									throw new InvalidCastException("Converted FuncLikePredicate expression is not a Predicate expression.");
+							}
 
 							break;
 						}


### PR DESCRIPTION
All the predicate type conversion cases in ConvertVisitor allow a different type to be returned from the conversion implemented by the provider. FuncLike predicate does not follow this and attempts to cast the converted inner function expression to an SqlFunction. This of course will throw a cast exception when trying to replace the function expression with another valid expression.

This came up because the i Series has limitations on EXISTS predicates, so the EXISTS pseudo function needs to be replaced with a condition expression. This used to work in 2.x, but got broken in 3.x.

This patch attempts to identify the convert expression, and if it is a function expression uses it to rebuild the FuncLike predicate, otherwise if it is another predicate it simpy returns it. I added an InvalidCastExpresssion if it is neither.

@MaceWindu this is one of the two fixes required to release the 3.x version of Linq2db4iseries