### PR TITLE
Fix SystemType on column descriptor when falling back to underlying d…

### DIFF
--- a/Source/LinqToDB/Mapping/ColumnDescriptor.cs
+++ b/Source/LinqToDB/Mapping/ColumnDescriptor.cs
@@ -42,7 +42,7 @@ namespace LinqToDB.Mapping
 
 			var dataType = mappingSchema.GetDataType(MemberType);
 			if (dataType.Type.DataType == DataType.Undefined)
-				dataType = mappingSchema.GetUnderlyingDataType(dataType.SystemType, out var _);
+				dataType = mappingSchema.GetUnderlyingDataType(MemberType, out var _);
 
 			if (columnAttribute == null)
 			{


### PR DESCRIPTION
When building the columns in EntityDescriptor, the implementation tryies to identify the column datatype from the systemtype and falls back to the underlying datatype to handle enums and nullables. However, when GetDataType finds no matching type it returns the SqlDataType.Undefined constant, which has an object systemtype, so when falling back to underlying datatype the systemtype is always System.Object. I think MemberType was supposed to go there.

@MaceWindu this is the second patch needed for linq2db4iseries