### PR TITLE
Add missing field cloning for merge source queries

### DIFF
--- a/Source/LinqToDB/SqlQuery/ConvertVisitor.cs
+++ b/Source/LinqToDB/SqlQuery/ConvertVisitor.cs
@@ -815,20 +815,35 @@ namespace LinqToDB.SqlQuery
 						{
 							var source = (SqlMergeSourceTable)element;
 
-							var enumerableSource = (SqlValuesTable?)ConvertInternal(source.SourceEnumerable);
-							var querySource      = (SelectQuery?)   ConvertInternal(source.SourceQuery);
-							var fields           = ConvertSafe(source.SourceFields);
+							var enumerableSource         = (SqlValuesTable?)ConvertInternal(source.SourceEnumerable);
+							var querySource              = (SelectQuery?)   ConvertInternal(source.SourceQuery);
+							IEnumerable<SqlField> fields = Convert(source.SourceFields, f => new SqlField(f));
+
+							var fe = fields != null && !ReferenceEquals(source.SourceFields, fields);
 
 							if (enumerableSource != null && !ReferenceEquals(source.SourceEnumerable, enumerableSource) ||
 								querySource      != null && !ReferenceEquals(source.SourceQuery, querySource)           ||
-								fields           != null && !ReferenceEquals(source.SourceFields, fields))
+								!fe)
 							{
+								if (!fe)
+								{
+									var newFields = source.SourceFields.ToArray();
+									for (var i = 0; i < newFields.Length; i++)
+									{
+										var field              = newFields[i];
+										newFields[i]           = new SqlField(field);
+										VisitedElements[field] = newFields[i];
+									}
+									fields = newFields;
+								}
+
 								newElement = new SqlMergeSourceTable(
 									source.SourceID,
 									enumerableSource ?? source.SourceEnumerable!,
 									querySource ?? source.SourceQuery!,
-									fields ?? source.SourceFields);
-							}
+									fields!);
+								VisitedElements[((ISqlTableSource)source).All] = ((ISqlTableSource)newElement).All;
+						}
 
 								break;
 							}
@@ -951,7 +966,7 @@ namespace LinqToDB.SqlQuery
 
 								newElement = new SqlRawSqlTable(table, fields2!, targs ?? table.Parameters!);
 
-								VisitedElements[((SqlRawSqlTable)newElement).All] = table.All;
+								VisitedElements[table.All] = ((SqlRawSqlTable)newElement).All;
 							}
 
 							break;

--- a/Tests/Linq/Update/MergeTests.Issues.cs
+++ b/Tests/Linq/Update/MergeTests.Issues.cs
@@ -789,5 +789,48 @@ namespace Tests.xUpdate
 		}
 
 		#endregion
+
+		#region TestNullableParameterInSourceQuery
+		[Table]
+		public class TestNullableParameterTarget
+		{
+			[PrimaryKey] public int Id1 { get; set; }
+			[PrimaryKey] public int Id2 { get; set; }
+		}
+
+		[Table]
+		public class TestNullableParameterSource
+		{
+			[PrimaryKey] public int Id { get; set; }
+		}
+
+		[Test]
+		public void TestNullableParameterInSourceQuery([IncludeDataSources(true, TestProvName.AllSqlServer2008Plus)] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var target = db.CreateLocalTable<TestNullableParameterTarget>())
+			using (var source = db.CreateLocalTable<TestNullableParameterSource>())
+			{
+				run(null);
+				run(1);
+
+				void run(int? id)
+				{
+					target
+						.Merge()
+						.Using(source
+							.Where(_ => _.Id == id)
+							.Select(_ => new TestNullableParameterTarget()
+							{
+								Id1 = 2,
+								Id2 = _.Id
+							}))
+						.OnTargetKey()
+						.InsertWhenNotMatched()
+						.Merge();
+				}
+			}
+		}
+		#endregion
 	}
 }


### PR DESCRIPTION
Fixes `Table 'LinqToDB.SqlQuery.SqlMergeSourceTable' not found` exceptions from merge queries with queryable source.