### PR TITLE
Don't create new command instance for logging

### DIFF
--- a/Source/LinqToDB/Data/DataConnection.Async.cs
+++ b/Source/LinqToDB/Data/DataConnection.Async.cs
@@ -234,7 +234,7 @@ namespace LinqToDB.Data
 				{
 					TraceLevel     = TraceLevel.Info,
 					StartTime      = now,
-					Command        = Command,
+					Command        = GetCurrentCommand(),
 					IsAsync        = true,
 				});
 			}
@@ -250,7 +250,7 @@ namespace LinqToDB.Data
 					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute)
 					{
 						TraceLevel      = TraceLevel.Info,
-						Command         = Command,
+						Command         = GetCurrentCommand(),
 						StartTime       = now,
 						ExecutionTime   = sw.Elapsed,
 						RecordsAffected = ret,
@@ -267,7 +267,7 @@ namespace LinqToDB.Data
 					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error)
 					{
 						TraceLevel     = TraceLevel.Error,
-						Command        = Command,
+						Command        = GetCurrentCommand(),
 						StartTime      = now,
 						ExecutionTime  = sw.Elapsed,
 						Exception      = ex,
@@ -302,7 +302,7 @@ namespace LinqToDB.Data
 				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute)
 				{
 					TraceLevel     = TraceLevel.Info,
-					Command        = Command,
+					Command        = GetCurrentCommand(),
 					StartTime      = now,
 					IsAsync        = true,
 				});
@@ -319,7 +319,7 @@ namespace LinqToDB.Data
 					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute)
 					{
 						TraceLevel      = TraceLevel.Info,
-						Command         = Command,
+						Command         = GetCurrentCommand(),
 						StartTime       = now,
 						ExecutionTime   = sw.Elapsed,
 						IsAsync         = true,
@@ -335,7 +335,7 @@ namespace LinqToDB.Data
 					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error)
 					{
 						TraceLevel     = TraceLevel.Error,
-						Command        = Command,
+						Command        = GetCurrentCommand(),
 						StartTime      = now,
 						ExecutionTime  = sw.Elapsed,
 						Exception      = ex,
@@ -376,7 +376,7 @@ namespace LinqToDB.Data
 				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute)
 				{
 					TraceLevel     = TraceLevel.Info,
-					Command        = Command,
+					Command        = GetCurrentCommand(),
 					StartTime      = now,
 					IsAsync        = true,
 				});
@@ -395,7 +395,7 @@ namespace LinqToDB.Data
 					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute)
 					{
 						TraceLevel     = TraceLevel.Info,
-						Command        = Command,
+						Command        = GetCurrentCommand(),
 						StartTime      = now,
 						ExecutionTime  = sw.Elapsed,
 						IsAsync        = true,
@@ -411,7 +411,7 @@ namespace LinqToDB.Data
 					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error)
 					{
 						TraceLevel     = TraceLevel.Error,
-						Command        = Command,
+						Command        = GetCurrentCommand(),
 						StartTime      = now,
 						ExecutionTime  = sw.Elapsed,
 						Exception      = ex,

--- a/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
+++ b/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
@@ -124,7 +124,7 @@ namespace LinqToDB.Data
 					_dataConnection.OnTraceConnection(new TraceInfo(_dataConnection, TraceInfoStep.Completed)
 					{
 						TraceLevel       = TraceLevel.Info,
-						Command          = _dataConnection.Command,
+						Command          = _dataConnection.GetCurrentCommand(),
 						MapperExpression = MapperExpression,
 						StartTime        = _startedOn,
 						ExecutionTime    = _stopwatch.Elapsed,

--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -1212,6 +1212,13 @@ namespace LinqToDB.Data
 		}
 
 		private IDbCommand? _command;
+
+		/// <summary>
+		/// Provides acess to current <see cref="_command"/> instance. Used for logs to avoid command instance creation
+		/// in <see cref="Command"/> getter if <see cref="_command"/> is not initialized.
+		/// </summary>
+		internal IDbCommand? GetCurrentCommand() => _command;
+
 		/// <summary>
 		/// Gets or sets command object, used by current connection.
 		/// </summary>
@@ -1270,7 +1277,7 @@ namespace LinqToDB.Data
 				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute)
 				{
 					TraceLevel     = TraceLevel.Info,
-					Command        = Command,
+					Command        = GetCurrentCommand(),
 					StartTime      = now,
 				});
 			}
@@ -1286,7 +1293,7 @@ namespace LinqToDB.Data
 					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute)
 					{
 						TraceLevel      = TraceLevel.Info,
-						Command         = Command,
+						Command         = GetCurrentCommand(),
 						StartTime       = now,
 						ExecutionTime   = sw.Elapsed,
 						RecordsAffected = ret,
@@ -1302,7 +1309,7 @@ namespace LinqToDB.Data
 					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error)
 					{
 						TraceLevel     = TraceLevel.Error,
-						Command        = Command,
+						Command        = GetCurrentCommand(),
 						StartTime      = now,
 						ExecutionTime  = sw.Elapsed,
 						Exception      = ex,
@@ -1336,7 +1343,7 @@ namespace LinqToDB.Data
 				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute)
 				{
 					TraceLevel     = TraceLevel.Info,
-					Command        = Command,
+					Command        = GetCurrentCommand(),
 					StartTime      = now,
 				});
 			}
@@ -1352,7 +1359,7 @@ namespace LinqToDB.Data
 					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute)
 					{
 						TraceLevel     = TraceLevel.Info,
-						Command        = Command,
+						Command        = GetCurrentCommand(),
 						StartTime      = now,
 						ExecutionTime  = sw.Elapsed,
 					});
@@ -1367,7 +1374,7 @@ namespace LinqToDB.Data
 					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error)
 					{
 						TraceLevel     = TraceLevel.Error,
-						Command        = Command,
+						Command        = GetCurrentCommand(),
 						StartTime      = now,
 						ExecutionTime  = sw.Elapsed,
 						Exception      = ex,
@@ -1406,7 +1413,7 @@ namespace LinqToDB.Data
 				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute)
 				{
 					TraceLevel     = TraceLevel.Info,
-					Command        = Command,
+					Command        = GetCurrentCommand(),
 					StartTime      = now,
 				});
 			}
@@ -1423,7 +1430,7 @@ namespace LinqToDB.Data
 					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute)
 					{
 						TraceLevel     = TraceLevel.Info,
-						Command        = Command,
+						Command        = GetCurrentCommand(),
 						StartTime      = now,
 						ExecutionTime  = sw.Elapsed,
 					});
@@ -1438,7 +1445,7 @@ namespace LinqToDB.Data
 					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error)
 					{
 						TraceLevel     = TraceLevel.Error,
-						Command        = Command,
+						Command        = GetCurrentCommand(),
 						StartTime      = now,
 						ExecutionTime  = sw.Elapsed,
 						Exception      = ex,

--- a/Source/LinqToDB/Data/DataReader.cs
+++ b/Source/LinqToDB/Data/DataReader.cs
@@ -27,7 +27,7 @@ namespace LinqToDB.Data
 					CommandInfo.DataConnection.OnTraceConnection(new TraceInfo(CommandInfo.DataConnection, TraceInfoStep.Completed)
 					{
 						TraceLevel      = TraceLevel.Info,
-						Command         = CommandInfo.DataConnection.Command,
+						Command         = CommandInfo.DataConnection.GetCurrentCommand(),
 						StartTime       = StartedOn,
 						ExecutionTime   = Stopwatch.Elapsed,
 						RecordsAffected = ReadNumber,

--- a/Source/LinqToDB/Data/DataReaderAsync.cs
+++ b/Source/LinqToDB/Data/DataReaderAsync.cs
@@ -28,7 +28,7 @@ namespace LinqToDB.Data
 					CommandInfo.DataConnection.OnTraceConnection(new TraceInfo(CommandInfo.DataConnection, TraceInfoStep.Completed)
 					{
 						TraceLevel      = TraceLevel.Info,
-						Command         = CommandInfo.DataConnection.Command,
+						Command         = CommandInfo.DataConnection.GetCurrentCommand(),
 						StartTime       = StartedOn,
 						ExecutionTime   = Stopwatch.Elapsed,
 						RecordsAffected = ReadNumber,


### PR DESCRIPTION
as if it fails it could hide exception from command execution (see #2507) and is not a good idea in general to do it for logging, as it interested only in command, associated with query, not in new one.