### PR TITLE
Remove not needed sequence configuration name check in sqltable

### DIFF
--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -2936,24 +2936,7 @@ namespace LinqToDB.SqlProvider
 				else
 					return null;
 
-			SequenceNameAttribute? defaultAttr = null;
-
-			foreach (var attr in attrs)
-			{
-				if (attr.Configuration == Name)
-					return attr;
-
-				if (defaultAttr == null && attr.Configuration == null)
-					defaultAttr = attr;
-			}
-
-			if (defaultAttr == null)
-				if (throwException)
-					throw new SqlException("Sequence name can not be retrieved for the '{0}' table.", table.Name);
-				else
-					return null;
-
-			return defaultAttr;
+			return attrs[0];
 		}
 
 		static bool Wrap(int precedence, int parentPrecedence)


### PR DESCRIPTION
Fix #2504 

Actually this is another reason to do #2502 - `SequenceNameAttribute` shouldn't exists in AST in first place and sequence should be attached to `SqlField`. But for now let's just fix issue.