### PR TITLE
Moved SQL comment generation to SqlBuilder

### DIFF
--- a/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
+++ b/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
@@ -70,18 +70,19 @@ namespace LinqToDB.Data
 
 				var sb = new StringBuilder();
 
-				sb.Append("-- ").Append(_dataConnection.ConfigurationString);
+				var comments = new StringBuilder();
+
+				comments.Append(_dataConnection.ConfigurationString);
 
 				if (_dataConnection.ConfigurationString != _dataConnection.DataProvider.Name)
-					sb.Append(' ').Append(_dataConnection.DataProvider.Name);
+					comments.Append(' ').Append(_dataConnection.DataProvider.Name);
 
 				if (_dataConnection.DataProvider.Name != sqlProvider.Name)
-					sb.Append(' ').Append(sqlProvider.Name);
+					comments.Append(' ').Append(sqlProvider.Name);
 
-				sb.AppendLine();
-
+				sqlProvider.PrintComments(sb, comments.ToString());
 				sqlProvider.PrintParameters(sb, _preparedQuery.Parameters);
-
+				
 				var isFirst = true;
 
 				foreach (var command in _preparedQuery.Commands)

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -3254,6 +3254,14 @@ namespace LinqToDB.SqlProvider
 			return sb;
 		}
 
+		public virtual StringBuilder PrintComments(StringBuilder sb, string comments)
+		{
+			return sb
+				.Append("--")
+				.Append(comments)
+				.AppendLine();
+		}
+
 		// for values without literal support from provider we should generate debug string using fixed format
 		// to avoid deviations on different locales or locale settings
 		private static void FormatParameterValue(StringBuilder sb, object? value)

--- a/Source/LinqToDB/SqlProvider/ISqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/ISqlBuilder.cs
@@ -19,6 +19,7 @@ namespace LinqToDB.SqlProvider
 		ISqlExpression?  GetIdentityExpression(SqlTable table);
 
 		StringBuilder    PrintParameters      (StringBuilder sb, IEnumerable<IDbDataParameter>? parameters);
+		StringBuilder	 PrintComments		  (StringBuilder sb, string comments);
 		string           ApplyQueryHints      (string sqlText, List<string> queryHints);
 
 		string           GetReserveSequenceValuesSql(int count, string sequenceName);


### PR DESCRIPTION
Query runner built commands add SQL comments on the top, including provider details and any parameters. 

This breaks providers like the DB2i OleDb provider that don't support comments, or perhaps a provider that has different notation than double dash.

I moved the actual printing of the comments to the SQL Builder, so that each provider can override its behaviour.

This is part one of DB2i OleDb provider support.