### PR TITLE
Alternative fix for #2536

### DIFF
--- a/Source/LinqToDB.Tools/Mapper/ExpressionBuilder.cs
+++ b/Source/LinqToDB.Tools/Mapper/ExpressionBuilder.cs
@@ -258,8 +258,8 @@ namespace LinqToDB.Tools.Mapper
 		Expression? ConvertCollection(Expression fromExpression, Type toType)
 		{
 			var fromType     = fromExpression.Type;
-			var fromItemType = fromType.GetItemType();
-			var toItemType   = toType.  GetItemType();
+			var fromItemType = fromType.GetItemType()!;
+			var toItemType   = toType.  GetItemType()!;
 
 			if (toType.IsGenericType && !toType.IsGenericTypeDefinition)
 			{
@@ -543,8 +543,8 @@ namespace LinqToDB.Tools.Mapper
 
 				if (toType.IsArray && fromType.IsSubClassOf(typeof(IEnumerable<>)))
 				{
-					var fromItemType = fromType.GetItemType();
-					var toItemType   = toType.  GetItemType();
+					var fromItemType = fromType.GetItemType()!;
+					var toItemType   = toType.  GetItemType()!;
 
 					var expr = ToArray(_builder, _fromExpression, fromItemType, toItemType);
 
@@ -569,8 +569,8 @@ namespace LinqToDB.Tools.Mapper
 				if (clearMethodInfo != null)
 					_expressions.Add(Call(_localObject, clearMethodInfo));
 
-				var fromItemType = fromListType.GetItemType();
-				var toItemType   = toListType.  GetItemType();
+				var fromItemType = fromListType.GetItemType()!;
+				var toItemType   = toListType.  GetItemType()!;
 
 				var addRangeMethodInfo = toListType.GetMethod("AddRange");
 

--- a/Source/LinqToDB/DataProvider/Access/AccessSqlBuilderBase.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessSqlBuilderBase.cs
@@ -37,7 +37,7 @@ namespace LinqToDB.DataProvider.Access
 				ConvertTableName(StringBuilder, trun.Table.Server, trun.Table.Database, trun.Table.Schema, trun.Table.PhysicalName!);
 				StringBuilder.Append(" ALTER COLUMN ");
 				Convert(StringBuilder, field.PhysicalName, ConvertType.NameToQueryField);
-				StringBuilder.AppendLine(" COUNTER(1,1)");
+				StringBuilder.AppendLine(" COUNTER(1, 1)");
 			}
 			else
 			{
@@ -385,7 +385,7 @@ namespace LinqToDB.DataProvider.Access
 		{
 			AppendIndent();
 			StringBuilder.Append("CONSTRAINT ").Append(pkName).Append(" PRIMARY KEY CLUSTERED (");
-			StringBuilder.Append(fieldNames.Aggregate((f1,f2) => f1 + ", " + f2));
+			StringBuilder.Append(fieldNames.Aggregate((f1,f2) => f1 + InlineComma + f2));
 			StringBuilder.Append(")");
 		}
 

--- a/Source/LinqToDB/DataProvider/Access/AccessSqlBuilderBase.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessSqlBuilderBase.cs
@@ -385,7 +385,7 @@ namespace LinqToDB.DataProvider.Access
 		{
 			AppendIndent();
 			StringBuilder.Append("CONSTRAINT ").Append(pkName).Append(" PRIMARY KEY CLUSTERED (");
-			StringBuilder.Append(fieldNames.Aggregate((f1,f2) => f1 + InlineComma + f2));
+			StringBuilder.Append(string.Join(InlineComma, fieldNames));
 			StringBuilder.Append(")");
 		}
 

--- a/Source/LinqToDB/DataProvider/DB2/DB2LUWSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2LUWSchemaProvider.cs
@@ -482,14 +482,14 @@ WHERE
 
 				if (IncludedSchemas.Count != 0)
 				{
-					sql += string.Format(" IN ({0})", IncludedSchemas.Select(n => '\'' + n + '\'') .Aggregate((s1,s2) => s1 + ',' + s2));
+					sql += string.Format(" IN ({0})", string.Join(", ", IncludedSchemas.Select(n => '\'' + n + '\'')));
 
 					if (ExcludedSchemas.Count != 0)
 						sql += " AND " + schemaNameField;
 				}
 
 				if (ExcludedSchemas.Count != 0)
-					sql += string.Format(" NOT IN ({0})", ExcludedSchemas.Select(n => '\'' + n + '\'') .Aggregate((s1,s2) => s1 + ',' + s2));
+					sql += string.Format(" NOT IN ({0})", string.Join(", ", ExcludedSchemas.Select(n => '\'' + n + '\'')));
 
 				return sql;
 			}

--- a/Source/LinqToDB/DataProvider/DB2/DB2SqlBuilderBase.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2SqlBuilderBase.cs
@@ -251,7 +251,7 @@ namespace LinqToDB.DataProvider.DB2
 			if (parameter.DbType == DbType.Decimal && parameter.Value is decimal decValue)
 			{
 				var d = new SqlDecimal(decValue);
-				return "(" + d.Precision + ", " + d.Scale + ")";
+				return "(" + d.Precision + InlineComma + d.Scale + ")";
 			}
 
 			if (Provider != null)

--- a/Source/LinqToDB/DataProvider/DB2/DB2SqlBuilderBase.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2SqlBuilderBase.cs
@@ -89,7 +89,7 @@ namespace LinqToDB.DataProvider.DB2
 				sb.AppendLine();
 				AppendIndent().AppendLine("FROM");
 				AppendIndent().AppendLine("\tNEW TABLE");
-				AppendIndent().AppendLine("\t(");
+				AppendIndent().Append("\t").AppendLine(OpenParens);
 			}
 
 			base.BuildSql(commandNumber, statement, sb, indent, skipAlias);

--- a/Source/LinqToDB/DataProvider/DB2/DB2SqlBuilderBase.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2SqlBuilderBase.cs
@@ -248,10 +248,10 @@ namespace LinqToDB.DataProvider.DB2
 
 		protected override string? GetProviderTypeName(IDbDataParameter parameter)
 		{
-			if (parameter.DbType == DbType.Decimal && parameter.Value is decimal)
+			if (parameter.DbType == DbType.Decimal && parameter.Value is decimal decValue)
 			{
-				var d = new SqlDecimal((decimal)parameter.Value);
-				return "(" + d.Precision + "," + d.Scale + ")";
+				var d = new SqlDecimal(decValue);
+				return "(" + d.Precision + ", " + d.Scale + ")";
 			}
 
 			if (Provider != null)

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdSqlBuilder.cs
@@ -109,8 +109,8 @@ namespace LinqToDB.DataProvider.Firebird
 					break;
 				case DataType.SByte         :
 				case DataType.Byte          : StringBuilder.Append("SmallInt");        break;
-				case DataType.Money         : StringBuilder.Append("Decimal(18,4)");   break;
-				case DataType.SmallMoney    : StringBuilder.Append("Decimal(10,4)");   break;
+				case DataType.Money         : StringBuilder.Append("Decimal(18, 4)");  break;
+				case DataType.SmallMoney    : StringBuilder.Append("Decimal(10, 4)");  break;
 				case DataType.DateTime2     :
 				case DataType.SmallDateTime :
 				case DataType.DateTime      : StringBuilder.Append("TimeStamp");       break;

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdSqlBuilder.cs
@@ -106,14 +106,14 @@ namespace LinqToDB.DataProvider.Firebird
 			{
 				case DataType.Decimal       :
 					base.BuildDataTypeFromDataType(type.Type.Precision > 18 ? new SqlDataType(type.Type.DataType, type.Type.SystemType, null, 18, type.Type.Scale, type.Type.DbType) : type, forCreateTable);
-					break;
+					                                                                                      break;
 				case DataType.SByte         :
-				case DataType.Byte          : StringBuilder.Append("SmallInt");        break;
-				case DataType.Money         : StringBuilder.Append("Decimal(18, 4)");  break;
-				case DataType.SmallMoney    : StringBuilder.Append("Decimal(10, 4)");  break;
+				case DataType.Byte          : StringBuilder.Append("SmallInt");                           break;
+				case DataType.Money         : StringBuilder.AppendFormat("Decimal(18{0}4)", InlineComma); break;
+				case DataType.SmallMoney    : StringBuilder.AppendFormat("Decimal(10{0}4)", InlineComma); break;
 				case DataType.DateTime2     :
 				case DataType.SmallDateTime :
-				case DataType.DateTime      : StringBuilder.Append("TimeStamp");       break;
+				case DataType.DateTime      : StringBuilder.Append("TimeStamp");                          break;
 				case DataType.NVarChar      :
 					StringBuilder.Append("VarChar");
 
@@ -126,12 +126,12 @@ namespace LinqToDB.DataProvider.Firebird
 						StringBuilder.Append($"({type.Type.Length})");
 
 					StringBuilder.Append(" CHARACTER SET UNICODE_FSS");
-					break;
-				case DataType.VarBinary     : StringBuilder.Append("BLOB");            break;
+					                                                                                      break;
+				case DataType.VarBinary     : StringBuilder.Append("BLOB");                               break;
 				// BOOLEAN type available since FB 3.0, but FirebirdDataProvider.SetParameter converts boolean to '1'/'0'
 				// so for now we will use type, compatible with SetParameter by default
-				case DataType.Boolean       : StringBuilder.Append("CHAR");            break;
-				default: base.BuildDataTypeFromDataType(type, forCreateTable);         break;
+				case DataType.Boolean       : StringBuilder.Append("CHAR");                               break;
+				default: base.BuildDataTypeFromDataType(type, forCreateTable);                            break;
 			}
 		}
 

--- a/Source/LinqToDB/DataProvider/Informix/InformixSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixSqlBuilder.cs
@@ -140,7 +140,7 @@ namespace LinqToDB.DataProvider.Informix
 				case DataType.Date       : StringBuilder.Append("DATETIME YEAR TO DAY");      return;
 				case DataType.SByte      :
 				case DataType.Byte       : StringBuilder.Append("SmallInt");                  return;
-				case DataType.SmallMoney : StringBuilder.Append("Decimal(10,4)");             return;
+				case DataType.SmallMoney : StringBuilder.Append("Decimal(10, 4)");            return;
 				case DataType.Decimal    :
 					StringBuilder.Append("Decimal");
 					if (type.Type.Precision != null && type.Type.Scale != null)
@@ -234,7 +234,7 @@ namespace LinqToDB.DataProvider.Informix
 		{
 			AppendIndent();
 			StringBuilder.Append("PRIMARY KEY (");
-			StringBuilder.Append(fieldNames.Aggregate((f1,f2) => f1 + ", " + f2));
+			StringBuilder.Append(fieldNames.Aggregate((f1,f2) => f1 + InlineComma + f2));
 			StringBuilder.Append(")");
 		}
 

--- a/Source/LinqToDB/DataProvider/Informix/InformixSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixSqlBuilder.cs
@@ -234,7 +234,7 @@ namespace LinqToDB.DataProvider.Informix
 		{
 			AppendIndent();
 			StringBuilder.Append("PRIMARY KEY (");
-			StringBuilder.Append(fieldNames.Aggregate((f1,f2) => f1 + InlineComma + f2));
+			StringBuilder.Append(string.Join(InlineComma, fieldNames));
 			StringBuilder.Append(")");
 		}
 

--- a/Source/LinqToDB/DataProvider/MySql/MySqlSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlSqlBuilder.cs
@@ -461,7 +461,7 @@ namespace LinqToDB.DataProvider.MySql
 		{
 			AppendIndent();
 			StringBuilder.Append("CONSTRAINT ").Append(pkName).Append(" PRIMARY KEY CLUSTERED (");
-			StringBuilder.Append(fieldNames.Aggregate((f1,f2) => f1 + InlineComma + f2));
+			StringBuilder.Append(string.Join(InlineComma, fieldNames));
 			StringBuilder.Append(")");
 		}
 

--- a/Source/LinqToDB/DataProvider/MySql/MySqlSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlSqlBuilder.cs
@@ -81,7 +81,7 @@ namespace LinqToDB.DataProvider.MySql
 			{
 				AppendIndent()
 					.AppendFormat(
-						"LIMIT {0},{1}",
+						"LIMIT {0}, {1}",
 						WithStringBuilder(new StringBuilder(), () => BuildExpression(selectQuery.Select.SkipValue)),
 						selectQuery.Select.TakeValue == null ?
 							long.MaxValue.ToString() :
@@ -101,29 +101,29 @@ namespace LinqToDB.DataProvider.MySql
 					case DataType.SByte         :
 					case DataType.Int16         :
 					case DataType.Int32         :
-					case DataType.Int64         : StringBuilder.Append("SIGNED");        break;
+					case DataType.Int64         : StringBuilder.Append("SIGNED");         break;
 					case DataType.BitArray      : // wild guess
 					case DataType.Byte          :
 					case DataType.UInt16        :
 					case DataType.UInt32        :
-					case DataType.UInt64        : StringBuilder.Append("UNSIGNED");      break;
-					case DataType.Money         : StringBuilder.Append("DECIMAL(19,4)"); break;
-					case DataType.SmallMoney    : StringBuilder.Append("DECIMAL(10,4)"); break;
+					case DataType.UInt64        : StringBuilder.Append("UNSIGNED");       break;
+					case DataType.Money         : StringBuilder.Append("DECIMAL(19, 4)"); break;
+					case DataType.SmallMoney    : StringBuilder.Append("DECIMAL(10, 4)"); break;
 					case DataType.DateTime      :
 					case DataType.DateTime2     :
 					case DataType.SmallDateTime :
-					case DataType.DateTimeOffset: StringBuilder.Append("DATETIME");      break;
-					case DataType.Time          : StringBuilder.Append("TIME");          break;
-					case DataType.Date          : StringBuilder.Append("DATE");          break;
-					case DataType.Json          : StringBuilder.Append("JSON");          break;
-					case DataType.Guid          : StringBuilder.Append("CHAR(36)");      break;
+					case DataType.DateTimeOffset: StringBuilder.Append("DATETIME");       break;
+					case DataType.Time          : StringBuilder.Append("TIME");           break;
+					case DataType.Date          : StringBuilder.Append("DATE");           break;
+					case DataType.Json          : StringBuilder.Append("JSON");           break;
+					case DataType.Guid          : StringBuilder.Append("CHAR(36)");       break;
 					// TODO: FLOAT/DOUBLE support in CAST added just recently (v8.0.17)
 					// and needs version sniffing
 					case DataType.Double        :
 					case DataType.Single        : base.BuildDataTypeFromDataType(SqlDataType.Decimal, forCreateTable); break;
 					case DataType.Decimal       :
 						if (type.Type.Scale != null && type.Type.Scale != 0)
-							StringBuilder.Append($"DECIMAL({type.Type.Precision ?? 10},{type.Type.Scale})");
+							StringBuilder.Append($"DECIMAL({type.Type.Precision ?? 10}, {type.Type.Scale})");
 						else if (type.Type.Precision != null && type.Type.Precision != 10)
 							StringBuilder.Append($"DECIMAL({type.Type.Precision})");
 						else
@@ -168,11 +168,11 @@ namespace LinqToDB.DataProvider.MySql
 				case DataType.UInt16        : StringBuilder.Append("SMALLINT UNSIGNED");             break;
 				case DataType.UInt32        : StringBuilder.Append("INT UNSIGNED");                  break;
 				case DataType.UInt64        : StringBuilder.Append("BIGINT UNSIGNED");               break;
-				case DataType.Money         : StringBuilder.Append("DECIMAL(19,4)");                 break;
-				case DataType.SmallMoney    : StringBuilder.Append("DECIMAL(10,4)");                 break;
+				case DataType.Money         : StringBuilder.Append("DECIMAL(19, 4)");                break;
+				case DataType.SmallMoney    : StringBuilder.Append("DECIMAL(10, 4)");                break;
 				case DataType.Decimal       :
 					if (type.Type.Scale != null && type.Type.Scale != 0)
-						StringBuilder.Append($"DECIMAL({type.Type.Precision ?? 10},{type.Type.Scale})");
+						StringBuilder.Append($"DECIMAL({type.Type.Precision ?? 10}, {type.Type.Scale})");
 					else if (type.Type.Precision != null && type.Type.Precision != 10)
 						StringBuilder.Append($"DECIMAL({type.Type.Precision})");
 					else
@@ -422,7 +422,7 @@ namespace LinqToDB.DataProvider.MySql
 				foreach (var expr in insertOrUpdate.Update.Items)
 				{
 					if (!first)
-						StringBuilder.Append(',').AppendLine();
+						StringBuilder.AppendLine(Comma);
 					first = false;
 
 					AppendIndent();
@@ -461,7 +461,7 @@ namespace LinqToDB.DataProvider.MySql
 		{
 			AppendIndent();
 			StringBuilder.Append("CONSTRAINT ").Append(pkName).Append(" PRIMARY KEY CLUSTERED (");
-			StringBuilder.Append(fieldNames.Aggregate((f1,f2) => f1 + ", " + f2));
+			StringBuilder.Append(fieldNames.Aggregate((f1,f2) => f1 + InlineComma + f2));
 			StringBuilder.Append(")");
 		}
 
@@ -528,9 +528,9 @@ namespace LinqToDB.DataProvider.MySql
 				BuildExpression(items[i]);
 
 				if (i + 1 < items.Count)
-					StringBuilder.Append(',');
-
-				StringBuilder.AppendLine();
+					StringBuilder.AppendLine(Comma);
+				else
+					StringBuilder.AppendLine();
 			}
 
 			Indent--;

--- a/Source/LinqToDB/DataProvider/Oracle/Oracle11SqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/Oracle11SqlBuilder.cs
@@ -149,8 +149,8 @@ namespace LinqToDB.DataProvider.Oracle
 				case DataType.Int64          : StringBuilder.Append("Number(19)");                break;
 				case DataType.SByte          :
 				case DataType.Byte           : StringBuilder.Append("Number(3)");                 break;
-				case DataType.Money          : StringBuilder.Append("Number(19,4)");              break;
-				case DataType.SmallMoney     : StringBuilder.Append("Number(10,4)");              break;
+				case DataType.Money          : StringBuilder.Append("Number(19, 4)");             break;
+				case DataType.SmallMoney     : StringBuilder.Append("Number(10, 4)");             break;
 				case DataType.VarChar        :
 					if (type.Type.Length == null || type.Type.Length > 4000 || type.Type.Length < 1)
 						StringBuilder.Append("VarChar(4000)");

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLSqlBuilder.cs
@@ -73,7 +73,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 				case DataType.SByte         :
 				case DataType.Byte          : StringBuilder.Append("SmallInt");       break;
 				case DataType.Money         : StringBuilder.Append("money");          break;
-				case DataType.SmallMoney    : StringBuilder.Append("Decimal(10,4)");  break;
+				case DataType.SmallMoney    : StringBuilder.Append("Decimal(10, 4)"); break;
 				case DataType.DateTime2     :
 				case DataType.SmallDateTime :
 				case DataType.DateTime      : StringBuilder.Append("TimeStamp");      break;
@@ -180,7 +180,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			foreach (var expr in insertOrUpdate.Update.Keys)
 			{
 				if (!firstKey)
-					StringBuilder.Append(',');
+					StringBuilder.Append(InlineComma);
 				firstKey = false;
 
 				BuildExpression(expr.Column, false, true);
@@ -197,7 +197,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 				foreach (var expr in insertOrUpdate.Update.Items)
 				{
 					if (!first)
-						StringBuilder.Append(',').AppendLine();
+						StringBuilder.AppendLine(Comma);
 					first = false;
 
 					AppendIndent();
@@ -347,7 +347,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 				foreach (var oi in output.OutputItems)
 				{
 					if (!first)
-						StringBuilder.Append(',').AppendLine();
+						StringBuilder.AppendLine(Comma);
 					first = false;
 
 					AppendIndent();

--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteSqlBuilder.cs
@@ -59,7 +59,7 @@ namespace LinqToDB.DataProvider.SQLite
 			return "OFFSET {0}";
 		}
 
-		public override bool IsNestedJoinSupported { get { return false; } }
+		public override bool IsNestedJoinSupported => false;
 
 		public override StringBuilder Convert(StringBuilder sb, string value, ConvertType convertType)
 		{
@@ -124,7 +124,7 @@ namespace LinqToDB.DataProvider.SQLite
 			{
 				AppendIndent();
 				StringBuilder.Append("CONSTRAINT ").Append(pkName).Append(" PRIMARY KEY (");
-				StringBuilder.Append(fieldNames.Aggregate((f1,f2) => f1 + ", " + f2));
+				StringBuilder.Append(fieldNames.Aggregate((f1,f2) => f1 + InlineComma + f2));
 				StringBuilder.Append(")");
 			}
 		}

--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteSqlBuilder.cs
@@ -124,7 +124,7 @@ namespace LinqToDB.DataProvider.SQLite
 			{
 				AppendIndent();
 				StringBuilder.Append("CONSTRAINT ").Append(pkName).Append(" PRIMARY KEY (");
-				StringBuilder.Append(fieldNames.Aggregate((f1,f2) => f1 + InlineComma + f2));
+			StringBuilder.Append(string.Join(InlineComma, fieldNames));
 				StringBuilder.Append(")");
 			}
 		}

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaOdbcSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaOdbcSqlBuilder.cs
@@ -31,10 +31,10 @@
 			switch (type.Type.DataType)
 			{
 				case DataType.Money:
-					StringBuilder.Append("Decimal(19,4)");
+					StringBuilder.Append("Decimal(19, 4)");
 					break;
 				case DataType.SmallMoney:
-					StringBuilder.Append("Decimal(10,4)");
+					StringBuilder.Append("Decimal(10, 4)");
 					break;
 				default:
 					base.BuildDataTypeFromDataType(type, forCreateTable);

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaSqlBuilder.cs
@@ -192,7 +192,7 @@ namespace LinqToDB.DataProvider.SapHana
 		{
 			AppendIndent();
 			StringBuilder.Append("PRIMARY KEY (");
-			StringBuilder.Append(fieldNames.Aggregate((f1,f2) => f1 + InlineComma + f2));
+			StringBuilder.Append(string.Join(InlineComma, fieldNames));
 			StringBuilder.Append(")");
 		}
 

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaSqlBuilder.cs
@@ -57,7 +57,7 @@ namespace LinqToDB.DataProvider.SapHana
 			return selectQuery.Select.TakeValue == null ? "LIMIT 4200000000 OFFSET {0}" : "OFFSET {0}";
 		}
 
-		public override bool IsNestedJoinParenthesisRequired { get { return true; } }
+		public override bool IsNestedJoinParenthesisRequired => true;
 
 		protected override void BuildStartCreateTableStatement(SqlCreateTableStatement createTable)
 		{
@@ -192,7 +192,7 @@ namespace LinqToDB.DataProvider.SapHana
 		{
 			AppendIndent();
 			StringBuilder.Append("PRIMARY KEY (");
-			StringBuilder.Append(fieldNames.Aggregate((f1,f2) => f1 + ", " + f2));
+			StringBuilder.Append(fieldNames.Aggregate((f1,f2) => f1 + InlineComma + f2));
 			StringBuilder.Append(")");
 		}
 

--- a/Source/LinqToDB/DataProvider/SqlCe/SqlCeSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlCe/SqlCeSqlBuilder.cs
@@ -1,12 +1,11 @@
 ﻿using System.Data;
-using System.Linq;
 using System.Text;
 
 namespace LinqToDB.DataProvider.SqlCe
 {
-	using SqlQuery;
-	using SqlProvider;
 	using LinqToDB.Mapping;
+	using SqlProvider;
+	using SqlQuery;
 
 	class SqlCeSqlBuilder : BasicSqlBuilder
 	{
@@ -64,7 +63,7 @@ namespace LinqToDB.DataProvider.SqlCe
 				ConvertTableName(StringBuilder, trun.Table.Server, trun.Table.Database, trun.Table.Schema, trun.Table.PhysicalName!);
 				StringBuilder.Append(" ALTER COLUMN ");
 				Convert(StringBuilder, field.PhysicalName, ConvertType.NameToQueryField);
-				StringBuilder.AppendLine(" IDENTITY(1,1)");
+				StringBuilder.AppendLine(" IDENTITY(1, 1)");
 			}
 			else
 		{
@@ -89,11 +88,11 @@ namespace LinqToDB.DataProvider.SqlCe
 			{
 				case DataType.Char          : base.BuildDataTypeFromDataType(new SqlDataType(DataType.NChar,    type.Type.Length), forCreateTable); return;
 				case DataType.VarChar       : base.BuildDataTypeFromDataType(new SqlDataType(DataType.NVarChar, type.Type.Length), forCreateTable); return;
-				case DataType.SmallMoney    : StringBuilder.Append("Decimal(10,4)");                                                           return;
+				case DataType.SmallMoney    : StringBuilder.Append("Decimal(10, 4)");                                                               return;
 				case DataType.DateTime2     :
 				case DataType.Time          :
 				case DataType.Date          :
-				case DataType.SmallDateTime : StringBuilder.Append("DateTime");                                                                return;
+				case DataType.SmallDateTime : StringBuilder.Append("DateTime");                                                                     return;
 				case DataType.NVarChar:
 					if (type.Type.Length == null || type.Type.Length > 4000 || type.Type.Length < 1)
 					{

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2012SqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2012SqlBuilder.cs
@@ -28,7 +28,7 @@ namespace LinqToDB.DataProvider.SqlServer
 			return "OFFSET {0} ROWS";
 		}
 
-		protected override bool   OffsetFirst         { get { return true;              } }
+		protected override bool OffsetFirst => true;
 
 		protected override ISqlBuilder CreateSqlBuilder()
 		{

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerSchemaProvider.cs
@@ -512,8 +512,8 @@ namespace LinqToDB.DataProvider.SqlServer
 
 			try
 			{
-				var tsql  = $"exec {commandText} {parameters.Select(p => p.Name).Aggregate("", (p1, p2) => $"{p1}, {p2}", p => p.TrimStart(',', ' '))}";
-				var parms = parameters.Select(p => $"{p.Name} {p.DbType}").Aggregate("", (p1, p2) => $"{p1}, {p2}", p => p.TrimStart(',', ' '));
+				var tsql  = $"exec {commandText} {string.Join(", ", parameters.Select(p => p.Name))}";
+				var parms = string.Join(", ", parameters.Select(p => $"{p.Name} {p.DbType}"));
 
 				var dt = new DataTable();
 

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlBuilder.cs
@@ -103,7 +103,7 @@ namespace LinqToDB.DataProvider.SqlServer
 				foreach (var oi in output.OutputItems)
 				{
 					if (!first)
-						StringBuilder.Append(',').AppendLine();
+						StringBuilder.AppendLine(Comma);
 					first = false;
 
 					AppendIndent();
@@ -140,7 +140,7 @@ namespace LinqToDB.DataProvider.SqlServer
 					foreach (var oi in output.OutputItems)
 					{
 						if (!firstColumn)
-							StringBuilder.Append(',').AppendLine();
+							StringBuilder.AppendLine(Comma);
 						firstColumn = false;
 
 						AppendIndent();
@@ -344,7 +344,7 @@ namespace LinqToDB.DataProvider.SqlServer
 				StringBuilder.Append("CONSTRAINT ").Append(pkName).Append(' ');
 
 			StringBuilder.Append("PRIMARY KEY CLUSTERED (");
-			StringBuilder.Append(fieldNames.Aggregate((f1,f2) => f1 + ", " + f2));
+			StringBuilder.Append(fieldNames.Aggregate((f1,f2) => f1 + InlineComma + f2));
 			StringBuilder.Append(")");
 		}
 

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlBuilder.cs
@@ -344,7 +344,7 @@ namespace LinqToDB.DataProvider.SqlServer
 				StringBuilder.Append("CONSTRAINT ").Append(pkName).Append(' ');
 
 			StringBuilder.Append("PRIMARY KEY CLUSTERED (");
-			StringBuilder.Append(fieldNames.Aggregate((f1,f2) => f1 + InlineComma + f2));
+			StringBuilder.Append(string.Join(InlineComma, fieldNames));
 			StringBuilder.Append(")");
 		}
 

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlBuilder.cs
@@ -132,7 +132,7 @@ namespace LinqToDB.DataProvider.SqlServer
 						.AppendLine();
 
 					AppendIndent()
-						.AppendLine("(");
+						.AppendLine(OpenParens);
 
 					++Indent;
 

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseSqlBuilder.cs
@@ -232,7 +232,7 @@ namespace LinqToDB.DataProvider.Sybase
 		{
 			AppendIndent();
 			StringBuilder.Append("CONSTRAINT ").Append(pkName).Append(" PRIMARY KEY CLUSTERED (");
-			StringBuilder.Append(fieldNames.Aggregate((f1,f2) => f1 + ", " + f2));
+			StringBuilder.Append(fieldNames.Aggregate((f1,f2) => f1 + InlineComma + f2));
 			StringBuilder.Append(")");
 		}
 

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseSqlBuilder.cs
@@ -232,7 +232,7 @@ namespace LinqToDB.DataProvider.Sybase
 		{
 			AppendIndent();
 			StringBuilder.Append("CONSTRAINT ").Append(pkName).Append(" PRIMARY KEY CLUSTERED (");
-			StringBuilder.Append(fieldNames.Aggregate((f1,f2) => f1 + InlineComma + f2));
+			StringBuilder.Append(string.Join(InlineComma, fieldNames));
 			StringBuilder.Append(")");
 		}
 

--- a/Source/LinqToDB/Extensions/ReflectionExtensions.cs
+++ b/Source/LinqToDB/Extensions/ReflectionExtensions.cs
@@ -667,18 +667,17 @@ namespace LinqToDB.Extensions
 			return false;
 		}
 		
-		static readonly ConcurrentDictionary<Type,Type?> getItemTypeCache = new ConcurrentDictionary<Type, Type?>();
+		static readonly ConcurrentDictionary<Type,Type?> _getItemTypeCache = new ConcurrentDictionary<Type, Type?>();
 		
-		[return: NotNullIfNotNull("type")]
 		public static Type? GetItemType(this Type? type)
 		{
 			if (type == null)
 				return null;
-			return getItemTypeCache.GetOrAdd(type, (t) =>
+
+			return _getItemTypeCache.GetOrAdd(type, t =>
 			{
 				if (t == typeof(object))
-					// if it possible to have null here or we should remove check?
-					return t.HasElementType ? t.GetElementType() : null;
+					return null;
 
 				if (t.IsArray)
 					return t.GetElementType();

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
@@ -413,7 +413,7 @@ namespace LinqToDB.Linq.Builder
 							{
 								var mi = EnumerableMethods
 									.First(m => m.Name == "Count" && m.GetParameters().Length == 1)
-									.MakeGenericMethod(me.Expression.Type.GetItemType());
+									.MakeGenericMethod(me.Expression.Type.GetItemType()!);
 
 								return new TransformInfo(Expression.Call(null, mi, me.Expression));
 							}
@@ -1504,7 +1504,7 @@ namespace LinqToDB.Linq.Builder
 		}
 
 
-		Dictionary<Expression, Expression?> _rootExpressions = new Dictionary<Expression, Expression?>();
+		Dictionary<Expression, Expression> _rootExpressions = new Dictionary<Expression, Expression>();
 
 		[return: NotNullIfNotNull("expr")]
 		internal Expression? GetRootObject(Expression? expr)

--- a/Source/LinqToDB/Linq/Builder/ExpressionTestGenerator.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionTestGenerator.cs
@@ -532,7 +532,7 @@ namespace LinqToDB.Linq.Builder
 			var ctors = type.GetConstructors().Select(c =>
 			{
 				var attrs = c.GetCustomAttributesData();
-				var attr  = attrs.Count > 0 ? string.Join(string.Empty, attrs.Select(a => "\r\n\t\t" + a.ToString())) : string.Empty;
+				var attr  = string.Join(string.Empty, attrs.Select(a => "\r\n\t\t" + a.ToString()));
 				var ps    = c.GetParameters().Select(p => GetTypeName(p.ParameterType) + " " + MangleName(p.Name, "p")).ToArray();
 
 				return string.Format(@"{0}
@@ -542,7 +542,7 @@ namespace LinqToDB.Linq.Builder
 		}}",
 					attr,
 					name,
-					ps.Length == 0 ? "" : string.Join(", ", ps);
+					string.Join(", ", ps));
 			}).ToList();
 
 			if (ctors.Count == 1 && ctors[0].IndexOf("()") >= 0)
@@ -551,7 +551,7 @@ namespace LinqToDB.Linq.Builder
 			var members = type.GetFields().Intersect(_usedMembers.OfType<FieldInfo>()).Select(f =>
 			{
 				var attrs = f.GetCustomAttributesData();
-				var attr  = attrs.Count > 0 ? string.Join(string.Empty, attrs.Select(a => "\r\n\t\t" + a.ToString())) : string.Empty;
+				var attr  = string.Join(string.Empty, attrs.Select(a => "\r\n\t\t" + a.ToString()));
 
 				return string.Format(@"{0}
 		public {1} {2};",
@@ -565,7 +565,7 @@ namespace LinqToDB.Linq.Builder
 					var attrs = p.GetCustomAttributesData();
 					return string.Format(@"{0}
 		{3}{1} {2} {{ get; set; }}",
-						attrs.Count > 0 ? string.Join(string.Empty, attrs.Select(a => "\r\n\t\t" + a.ToString())) : string.Empty,
+						string.Join(string.Empty, attrs.Select(a => "\r\n\t\t" + a.ToString())),
 						GetTypeName(p.PropertyType),
 						MangleName(isUserName, p.Name, "P"),
 						type.IsInterface ? "" : "public ");
@@ -580,10 +580,10 @@ namespace LinqToDB.Linq.Builder
 		{{
 			throw new NotImplementedException();
 		}}",
-						attrs.Count > 0 ? string.Join(string.Empty, attrs.Select(a => "\r\n\t\t" + a.ToString())) : string.Empty,
+						string.Join(string.Empty, attrs.Select(a => "\r\n\t\t" + a.ToString())),
 						GetTypeName(m.ReturnType),
 						MangleName(isUserName, m.Name, "M"),
-						ps.Length == 0 ? "" : string.Join(", ", ps),
+						string.Join(", ", ps),
 						m.IsStatic   ? "static "   :
 						m.IsVirtual  ? "virtual "  :
 						m.IsAbstract ? "abstract " :
@@ -618,11 +618,11 @@ namespace {0}
 					type.IsInterface ? "interface" : type.IsClass ? "class" : "struct",
 					name,
 					type.IsGenericType ? GetTypeNames(type.GetGenericArguments(), ",") : null,
-					ctors.Count == 0 ? "" : string.Join("\r\n", ctors),
+					string.Join("\r\n", ctors),
 					baseClasses.Length == 0 ? "" : " : " + GetTypeNames(baseClasses),
 					type.IsPublic ? "public " : "",
 					type.IsAbstract && !type.IsInterface ? "abstract " : "",
-					attrs.Count > 0 ? string.Join(string.Empty, attrs.Select(a => "\r\n\t" + a.ToString())) : string.Empty,
+					string.Join(string.Empty, attrs.Select(a => "\r\n\t" + a.ToString())),
 					members.Length > 0 ? (ctors.Count != 0 ? "\r\n" : "") + string.Join("\r\n", members) : string.Empty);
 			}
 		}

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.Merge.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.Merge.cs
@@ -191,7 +191,7 @@ namespace LinqToDB.SqlProvider
 				foreach (var field in mergeSource.SourceFields)
 				{
 					if (!first)
-						StringBuilder.AppendLine(", ");
+						StringBuilder.AppendLine(Comma);
 
 					first = false;
 					AppendIndent();
@@ -259,7 +259,7 @@ namespace LinqToDB.SqlProvider
 				{
 					var value = row[j];
 					if (j > 0)
-						StringBuilder.Append(",");
+						StringBuilder.Append(InlineComma);
 
 					if (MergeSourceValueTypeRequired(source, rows, i, j))
 						BuildTypedExpression(columnTypes[j], value);
@@ -294,7 +294,7 @@ namespace LinqToDB.SqlProvider
 				var field = merge.Source.SourceFields[i];
 
 				if (i > 0)
-					StringBuilder.Append(", ");
+					StringBuilder.Append(InlineComma);
 
 				if (MergeSourceValueTypeRequired(merge.Source.SourceEnumerable!, Array<ISqlExpression[]>.Empty, -1, i))
 					BuildTypedExpression(new SqlDataType(field), new SqlValue(field.Type!.Value, null));
@@ -341,7 +341,7 @@ namespace LinqToDB.SqlProvider
 				var row = rows[i];
 
 				if (i != 0)
-					StringBuilder.AppendLine(",");
+					StringBuilder.AppendLine(Comma);
 				else
 					StringBuilder.AppendLine("\tVALUES");
 
@@ -350,7 +350,7 @@ namespace LinqToDB.SqlProvider
 				{
 					var value = row[j];
 					if (j > 0)
-						StringBuilder.Append(",");
+						StringBuilder.Append(InlineComma);
 
 					if (MergeSourceValueTypeRequired(source, rows, i, j))
 						BuildTypedExpression(columnTypes[j], value);

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.Merge.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.Merge.cs
@@ -183,7 +183,7 @@ namespace LinqToDB.SqlProvider
 			if (MergeSupportsColumnAliasesInSource)
 			{
 				StringBuilder.AppendLine();
-				StringBuilder.AppendLine("(");
+				StringBuilder.AppendLine(OpenParens);
 
 				++Indent;
 
@@ -285,7 +285,7 @@ namespace LinqToDB.SqlProvider
 		private void BuildMergeEmptySource(SqlMergeStatement merge)
 		{
 			StringBuilder
-				.AppendLine("(")
+				.AppendLine(OpenParens)
 				.Append("\tSELECT ")
 				;
 

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -1312,7 +1312,7 @@ namespace LinqToDB.SqlProvider
 		{
 			AppendIndent();
 			StringBuilder.Append("CONSTRAINT ").Append(pkName).Append(" PRIMARY KEY (");
-			StringBuilder.Append(fieldNames.Aggregate((f1, f2) => f1 + InlineComma + f2));
+			StringBuilder.Append(string.Join(InlineComma, fieldNames));
 			StringBuilder.Append(")");
 		}
 

--- a/Tests/Linq/DataProvider/MySqlTests.cs
+++ b/Tests/Linq/DataProvider/MySqlTests.cs
@@ -1409,8 +1409,8 @@ namespace Tests.DataProvider
 					Assert.True(sql.Contains("\t`UnsignedBigInt`   BIGINT UNSIGNED   NOT NULL"));
 					Assert.True(sql.Contains("\t`Decimal`          DECIMAL           NOT NULL"));
 					Assert.True(sql.Contains("\t`Decimal15_0`      DECIMAL(15)       NOT NULL"));
-					Assert.True(sql.Contains("\t`Decimal10_5`      DECIMAL(10,5)     NOT NULL"));
-					Assert.True(sql.Contains("\t`Decimal20_2`      DECIMAL(20,2)     NOT NULL"));
+					Assert.True(sql.Contains("\t`Decimal10_5`      DECIMAL(10, 5)    NOT NULL"));
+					Assert.True(sql.Contains("\t`Decimal20_2`      DECIMAL(20, 2)    NOT NULL"));
 					Assert.True(sql.Contains("\t`Float`            FLOAT             NOT NULL"));
 					Assert.True(sql.Contains("\t`Float10`          FLOAT(10)         NOT NULL"));
 					Assert.True(sql.Contains("\t`Double`           DOUBLE            NOT NULL"));

--- a/Tests/Linq/Linq/ParameterTests.cs
+++ b/Tests/Linq/Linq/ParameterTests.cs
@@ -181,7 +181,7 @@ namespace Tests.Linq
 
 				TestContext.WriteLine(sql);
 
-				Assert.That(sql, Contains.Substring("(6,3)"));
+				Assert.That(sql, Contains.Substring("(6, 3)"));
 			}
 		}
 


### PR DESCRIPTION
Adds following sql builder properties.
```cs
protected virtual string InlineComma => ", ";
protected virtual string Comma => ",";
protected virtual string OpenParens => "(";
```
db2 implementation should override it like that:
```cs
protected override string Comma => ", ";
protected override string OpenParens => "( ";
```

There is no fix for `BuildSelectClause` change from #2536 as I don't see any pattern here. I recommend to override whole method as it very small one.