### PR TITLE
ISSUE 1586 - WIP - Fully qualify Relationship mapping references to prevent table name conflict

### DIFF
--- a/Source/LinqToDB.Templates/LinqToDB.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.ttinclude
@@ -459,9 +459,9 @@ void GenerateTypesFromMetadata()
 
 					switch (key.AssociationType)
 					{
-						case AssociationType.OneToOne  : aa.Parameters.Add("Relationship=Relationship.OneToOne");  break;
-						case AssociationType.OneToMany : aa.Parameters.Add("Relationship=Relationship.OneToMany"); break;
-						case AssociationType.ManyToOne : aa.Parameters.Add("Relationship=Relationship.ManyToOne"); break;
+						case AssociationType.OneToOne  : aa.Parameters.Add("Relationship=LinqToDB.Mapping.Relationship.OneToOne");  break;
+						case AssociationType.OneToMany : aa.Parameters.Add("Relationship=LinqToDB.Mapping.Relationship.OneToMany"); break;
+						case AssociationType.ManyToOne : aa.Parameters.Add("Relationship=LinqToDB.Mapping.Relationship.ManyToOne"); break;
 					}
 
 					if (key.BackReference != null)


### PR DESCRIPTION
Fix #1586

This is my first open source PR, so please let me know if I did anything wrong.

To resolve issue 1586, which details how tables named "Relationship" would result in generated files with an ambiguous references to the `LinqToDB.Mapping.Relationship` enum, I have updated the generated parameter (which appears as an attribute in files generated from t4 templates) so that it is fully qualified, thus avoiding the ambiguity.

There is potential for a more sophisticated solution (such as a parameter in t4 templates that would fully qualify references), but:
1) I lack the familiarity with T4 templates
2) The solution is well beyond the scope of the reported issue
3) I don't know what other items might need to be fully qualified.

For that reason, I stuck with a simple solution with a low likelihood of breaking everything.

NOTES:

- This PR should fully resolve issue 1586
- The guidelines suggested adding work in progress to the PR on my first contribution. I've done so, but I believe the issue is fully resolved in the PR as it has been generated.
- I have an app using LinqToDB extensively and I have been using this solution for several months, so in addition to the standard tests, I can also attest that it resolves the issue "in the wild."