### PR TITLE
Issue 2168 - Modify T4 name conflict detection for data types to include table names instead of only column names

### DIFF
--- a/Source/LinqToDB.Templates/LinqToDB.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.ttinclude
@@ -274,7 +274,7 @@ void GenerateTypesFromMetadata()
 		var dbTypeMaxLen   = t.Columns.Values.Max  (c => (int?)(c.ColumnType.Length)) ?? 0;
 		var dataTypeMaxLen = t.Columns.Values.Where(c => c.DataType != null).Max  (c => (int?)(c.DataType.Length)) ?? 0;
 		var nameConflict   = t.Columns.Values.Any  (c => c.MemberName == "DataType") ||
-								Tables.Values.Any  (tbl => tbl.Name   == "DataType");
+		                        Tables.Values.Any  (tbl => tbl.Name   == "DataType");
 		var dataTypePrefix = nameConflict ? "LinqToDB." : "";
 
 		foreach (var c in t.Columns.Values)

--- a/Source/LinqToDB.Templates/LinqToDB.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.ttinclude
@@ -273,7 +273,9 @@ void GenerateTypesFromMetadata()
 			: ToStringLiteral(c.ColumnName).Length)) ?? 0;
 		var dbTypeMaxLen   = t.Columns.Values.Max  (c => (int?)(c.ColumnType.Length)) ?? 0;
 		var dataTypeMaxLen = t.Columns.Values.Where(c => c.DataType != null).Max  (c => (int?)(c.DataType.Length)) ?? 0;
-		var dataTypePrefix = t.Columns.Values.Any  (c => c.MemberName == "DataType") ? "LinqToDB." : "";
+		var nameConflict   = t.Columns.Values.Any  (c => c.MemberName == "DataType") ||
+								Tables.Values.Any  (tbl => tbl.Name   == "DataType");
+		var dataTypePrefix = nameConflict ? "LinqToDB." : "";
 
 		foreach (var c in t.Columns.Values)
 		{

--- a/Source/LinqToDB.Templates/LinqToDB.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.ttinclude
@@ -274,7 +274,7 @@ void GenerateTypesFromMetadata()
 		var dbTypeMaxLen   = t.Columns.Values.Max  (c => (int?)(c.ColumnType.Length)) ?? 0;
 		var dataTypeMaxLen = t.Columns.Values.Where(c => c.DataType != null).Max  (c => (int?)(c.DataType.Length)) ?? 0;
 		var nameConflict   = t.Columns.Values.Any  (c => c.MemberName == "DataType") ||
-		                        Tables.Values.Any  (tbl => tbl.Name   == "DataType");
+		                        Tables.Values.Any  (tbl => tbl.TypeName == "DataType");
 		var dataTypePrefix = nameConflict ? "LinqToDB." : "";
 
 		foreach (var c in t.Columns.Values)


### PR DESCRIPTION
Fixes #2168 

The issue is that `DataType` references in attributes would sometimes create ambiguous reference errors if there is a table named `DataType`. This ambiguous reference is already detected and prevented for field names; this fix expands that detection to include table names as well. When the condition is detected, `DataType` is fully qualified to `LinqToDB.DataType`.