### PR TITLE
Add QueryAsync extension methods.

### DIFF
--- a/Source/LinqToDB/Data/DataConnectionExtensions.cs
+++ b/Source/LinqToDB/Data/DataConnectionExtensions.cs
@@ -1017,6 +1017,69 @@ namespace LinqToDB.Data
 		#region Query async
 
 		/// <summary>
+		/// Executes command asynchronously and returns results as collection of values of specified type.
+		/// </summary>
+		/// <typeparam name="T">Result record type.</typeparam>
+		/// <param name="connection">Database connection.</param>
+		/// <param name="sql">Command text.</param>
+		/// <param name="cancellationToken">Asynchronous operation cancellation token.</param>
+		/// <returns>Returns a task with a collection of query result records.</returns>
+		public static Task<IEnumerable<T>> QueryAsync<T>(this DataConnection connection, string sql, CancellationToken cancellationToken = default)
+		{
+			return new CommandInfo(connection, sql).QueryAsync<T>(cancellationToken);
+		}
+
+		/// <summary>
+		/// Executes command asynchronously and returns results as collection of values of specified type.
+		/// </summary>
+		/// <typeparam name="T">Result record type.</typeparam>
+		/// <param name="connection">Database connection.</param>
+		/// <param name="sql">Command text.</param>
+		/// <param name="parameters">Command parameters.</param>
+		/// <returns>Returns a task with a collection of query result records.</returns>
+		public static Task<IEnumerable<T>> QueryAsync<T>(this DataConnection connection, string sql, params DataParameter[] parameters)
+		{
+			return new CommandInfo(connection, sql, parameters).QueryAsync<T>();
+		}
+
+		/// <summary>
+		/// Executes command asynchronously and returns results as collection of values of specified type.
+		/// </summary>
+		/// <typeparam name="T">Result record type.</typeparam>
+		/// <param name="connection">Database connection.</param>
+		/// <param name="sql">Command text.</param>
+		/// <param name="cancellationToken">Asynchronous operation cancellation token.</param>
+		/// <param name="parameters">Command parameters.</param>
+		/// <returns>Returns a task with a collection of query result records.</returns>
+		public static Task<IEnumerable<T>> QueryAsync<T>(this DataConnection connection, string sql, CancellationToken cancellationToken, params DataParameter[] parameters)
+		{
+			return new CommandInfo(connection, sql, parameters).QueryAsync<T>(cancellationToken);
+		}
+
+		/// <summary>
+		/// Executes command asynchronously and returns results as collection of values of specified type.
+		/// </summary>
+		/// <typeparam name="T">Result record type.</typeparam>
+		/// <param name="connection">Database connection.</param>
+		/// <param name="sql">Command text.</param>
+		/// <param name="parameters">Command parameters. Supported values:
+		/// <para> - <c>null</c> for command without parameters;</para>
+		/// <para> - single <see cref="DataParameter"/> instance;</para>
+		/// <para> - array of <see cref="DataParameter"/> parameters;</para>
+		/// <para> - mapping class entity.</para>
+		/// <para>Last case will convert all mapped columns to <see cref="DataParameter"/> instances using following logic:</para>
+		/// <para> - if column is of <see cref="DataParameter"/> type, column value will be used. If parameter name (<see cref="DataParameter.Name"/>) is not set, column name will be used;</para>
+		/// <para> - if converter from column type to <see cref="DataParameter"/> is defined in mapping schema, it will be used to create parameter with colum name passed to converter;</para>
+		/// <para> - otherwise column value will be converted to <see cref="DataParameter"/> using column name as parameter name and column value will be converted to parameter value using conversion, defined by mapping schema.</para>
+		/// </param>
+		/// <param name="cancellationToken">Asynchronous operation cancellation token.</param>
+		/// <returns>Returns a task with a collection of query result records.</returns>
+		public static Task<IEnumerable<T>> QueryAsync<T>(this DataConnection connection, string sql, object? parameters, CancellationToken cancellationToken = default)
+		{
+			return new CommandInfo(connection, sql, parameters).QueryAsync<T>(cancellationToken);
+		}
+
+		/// <summary>
 		/// Executes command asynchronously and returns list of values.
 		/// </summary>
 		/// <typeparam name="T">Result record type.</typeparam>


### PR DESCRIPTION
I may be missing something, but DataConnectionExtensions seems to missing the Async counterparts to `Query<T>(...)` methods. I was a little confused when they didn't show up in intellisense.

![image](https://user-images.githubusercontent.com/5839185/97933867-384b6400-1d31-11eb-9a19-0887f493692f.png)

Let me know if there is a better way to access QueryAsync, or if they're omitted intentionally.