### PR TITLE
Non-table column excluded from sub-query group by (3.1.3 regression)

### DIFF
--- a/Source/LinqToDB/DataProvider/Informix/InformixDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixDataProvider.cs
@@ -29,6 +29,7 @@ namespace LinqToDB.DataProvider.Informix
 			SqlProviderFlags.IsSubQueryOrderBySupported        = true;
 			SqlProviderFlags.IsDistinctOrderBySupported        = false;
 			SqlProviderFlags.IsUpdateFromSupported             = false;
+			SqlProviderFlags.IsGroupByColumnRequred            = true;
 
 			SetCharField("CHAR",  (r,i) => r.GetString(i).TrimEnd(' '));
 			SetCharField("NCHAR", (r,i) => r.GetString(i).TrimEnd(' '));

--- a/Source/LinqToDB/Linq/Builder/GroupByBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/GroupByBuilder.cs
@@ -131,12 +131,7 @@ namespace LinqToDB.Linq.Builder
 			{
 				var groupSql = builder.ConvertExpressions(key, keySelector.Body.Unwrap(), ConvertFlags.Key, null);
 
-				var allowed = groupSql.Where(s =>
-				{
-					var underlying = QueryHelper.GetUnderlyingExpression(s.Sql);
-					return underlying != null &&
-						   underlying.ElementType.NotIn(QueryElementType.SqlValue, QueryElementType.SqlParameter);
-				});
+				var allowed = groupSql.Where(s => !QueryHelper.IsConstant(s.Sql));
 
 				foreach (var sql in allowed)
 					sequence.SelectQuery.GroupBy.Expr(sql.Sql);
@@ -728,15 +723,13 @@ namespace LinqToDB.Linq.Builder
 			{
 				var expr = SelectQuery.Select.Columns[index].Expression;
 
-				if (!SelectQuery.GroupBy.EnumItems().Any(_ => expr.Equals(_)))
+				if (!QueryHelper.IsConstant(expr)
+					&& !SelectQuery.GroupBy.EnumItems().Any(_ => ReferenceEquals(_, expr) || (expr is SqlColumn column && ReferenceEquals(_, column.Expression))))
 				{
-					if (expr.ElementType.In(QueryElementType.SqlValue, QueryElementType.SqlParameter) == false)
-					{
-						if (SelectQuery.GroupBy.GroupingType == GroupingType.GroupBySets)
-							SelectQuery.GroupBy.Items.Add(new SqlGroupingSet(new[] { expr }));
-						else
-							SelectQuery.GroupBy.Items.Add(expr);
-					}
+					if (SelectQuery.GroupBy.GroupingType == GroupingType.GroupBySets)
+						SelectQuery.GroupBy.Items.Add(new SqlGroupingSet(new[] { expr }));
+					else
+						SelectQuery.GroupBy.Items.Add(expr);
 				}
 
 				return base.ConvertToParentIndex(index, this);

--- a/Source/LinqToDB/Linq/Builder/GroupByBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/GroupByBuilder.cs
@@ -131,8 +131,7 @@ namespace LinqToDB.Linq.Builder
 			{
 				var groupSql = builder.ConvertExpressions(key, keySelector.Body.Unwrap(), ConvertFlags.Key, null);
 
-				var allowed = groupSql.Where(s => (builder.DataContext.SqlProviderFlags.IsGroupByColumnRequred && s.Sql is SqlColumn)
-					|| !QueryHelper.IsConstant(s.Sql));
+				var allowed = groupSql.Where(s => !QueryHelper.IsConstant(s.Sql));
 
 				foreach (var sql in allowed)
 					sequence.SelectQuery.GroupBy.Expr(sql.Sql);

--- a/Source/LinqToDB/Linq/Builder/GroupByBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/GroupByBuilder.cs
@@ -131,12 +131,7 @@ namespace LinqToDB.Linq.Builder
 			{
 				var groupSql = builder.ConvertExpressions(key, keySelector.Body.Unwrap(), ConvertFlags.Key, null);
 
-				var allowed = groupSql.Where(s =>
-				{
-					var underlying = QueryHelper.GetUnderlyingExpression(s.Sql);
-					return underlying != null &&
-					       underlying.ElementType.NotIn(QueryElementType.SqlValue, QueryElementType.SqlParameter);
-				});
+				var allowed = groupSql.Where(s => s.Sql.ElementType.NotIn(QueryElementType.SqlValue, QueryElementType.SqlParameter));
 
 				foreach (var sql in allowed)
 					sequence.SelectQuery.GroupBy.Expr(sql.Sql);
@@ -728,13 +723,15 @@ namespace LinqToDB.Linq.Builder
 			{
 				var expr = SelectQuery.Select.Columns[index].Expression;
 
-				//if (!SelectQuery.GroupBy.EnumItems().Any(_ => QueryHelper.ContainsElement(expr, _)))
-				if (!SelectQuery.GroupBy.EnumItems().Any(_ => ReferenceEquals(_, expr) || (expr is SqlColumn column && ReferenceEquals(_, column.Expression))))
+				if (!SelectQuery.GroupBy.EnumItems().Any(_ => expr.Equals(_)))
 				{
-					if (SelectQuery.GroupBy.GroupingType == GroupingType.GroupBySets)
-						SelectQuery.GroupBy.Items.Add(new SqlGroupingSet(new[]{expr}));
-					else
-						SelectQuery.GroupBy.Items.Add(expr);
+					if (expr.ElementType.In(QueryElementType.SqlValue, QueryElementType.SqlParameter) == false)
+					{
+						if (SelectQuery.GroupBy.GroupingType == GroupingType.GroupBySets)
+							SelectQuery.GroupBy.Items.Add(new SqlGroupingSet(new[] { expr }));
+						else
+							SelectQuery.GroupBy.Items.Add(expr);
+					}
 				}
 
 				return base.ConvertToParentIndex(index, this);

--- a/Source/LinqToDB/Linq/Builder/GroupByBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/GroupByBuilder.cs
@@ -131,7 +131,8 @@ namespace LinqToDB.Linq.Builder
 			{
 				var groupSql = builder.ConvertExpressions(key, keySelector.Body.Unwrap(), ConvertFlags.Key, null);
 
-				var allowed = groupSql.Where(s => !QueryHelper.IsConstant(s.Sql));
+				var allowed = groupSql.Where(s => (builder.DataContext.SqlProviderFlags.IsGroupByColumnRequred && s.Sql is SqlColumn)
+					|| !QueryHelper.IsConstant(s.Sql));
 
 				foreach (var sql in allowed)
 					sequence.SelectQuery.GroupBy.Expr(sql.Sql);
@@ -723,7 +724,8 @@ namespace LinqToDB.Linq.Builder
 			{
 				var expr = SelectQuery.Select.Columns[index].Expression;
 
-				if (!QueryHelper.IsConstant(expr)
+				if (((Builder.DataContext.SqlProviderFlags.IsGroupByColumnRequred && expr is SqlColumn)
+					|| !QueryHelper.IsConstant(expr))
 					&& !SelectQuery.GroupBy.EnumItems().Any(_ => ReferenceEquals(_, expr) || (expr is SqlColumn column && ReferenceEquals(_, column.Expression))))
 				{
 					if (SelectQuery.GroupBy.GroupingType == GroupingType.GroupBySets)

--- a/Source/LinqToDB/Linq/Builder/GroupByBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/GroupByBuilder.cs
@@ -131,7 +131,12 @@ namespace LinqToDB.Linq.Builder
 			{
 				var groupSql = builder.ConvertExpressions(key, keySelector.Body.Unwrap(), ConvertFlags.Key, null);
 
-				var allowed = groupSql.Where(s => s.Sql.ElementType.NotIn(QueryElementType.SqlValue, QueryElementType.SqlParameter));
+				var allowed = groupSql.Where(s =>
+				{
+					var underlying = QueryHelper.GetUnderlyingExpression(s.Sql);
+					return underlying != null &&
+						   underlying.ElementType.NotIn(QueryElementType.SqlValue, QueryElementType.SqlParameter);
+				});
 
 				foreach (var sql in allowed)
 					sequence.SelectQuery.GroupBy.Expr(sql.Sql);

--- a/Source/LinqToDB/Linq/Builder/OrderByBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/OrderByBuilder.cs
@@ -70,7 +70,7 @@ namespace LinqToDB.Linq.Builder
 			    {
 				    // immutable expressions will be removed later
 				    //
-					var isImmutable = QueryHelper.IsImmutable(sqlInfo.Sql);
+					var isImmutable = QueryHelper.IsConstant(sqlInfo.Sql);
 					if (isImmutable)
 						continue;
 					
@@ -97,7 +97,7 @@ namespace LinqToDB.Linq.Builder
 			{
 				// we do not need sorting by immutable values, like "Some", Func("Some"), "Some1" + "Some2". It does nothing for ordering
 				//
-				if (QueryHelper.IsImmutable(expr.Sql))
+				if (QueryHelper.IsConstant(expr.Sql))
 					continue;
 			
 				var e = builder.ConvertSearchCondition(expr.Sql);

--- a/Source/LinqToDB/SqlProvider/SqlProviderFlags.cs
+++ b/Source/LinqToDB/SqlProvider/SqlProviderFlags.cs
@@ -31,6 +31,11 @@ namespace LinqToDB.SqlProvider
 		public TakeHints?  TakeHintsSupported             { get; set; }
 
 		/// <summary>
+		/// Provider requires that selected subquery column must be used in group by even for constant column.
+		/// </summary>
+		public bool        IsGroupByColumnRequred         { get; set; }
+
+		/// <summary>
 		/// Provider supports:
 		/// CROSS JOIN a Supported
 		/// </summary>

--- a/Source/LinqToDB/SqlQuery/QueryHelper.cs
+++ b/Source/LinqToDB/SqlQuery/QueryHelper.cs
@@ -646,12 +646,12 @@ namespace LinqToDB.SqlQuery
 		{
 			var current = expression;
 			HashSet<ISqlExpression>? visited = null;
-			while (current?.ElementType == QueryElementType.Column)
+			while (current is SqlColumn column && column.Parent?.HasSetOperators != true)
 			{
 				visited ??= new HashSet<ISqlExpression>();
-				if (!visited.Add(current))
+				if (!visited.Add(column))
 					return null;
-				current = ((SqlColumn)current).Expression;
+				current = column.Expression;
 			}
 
 			return current;

--- a/Source/LinqToDB/SqlQuery/QueryHelper.cs
+++ b/Source/LinqToDB/SqlQuery/QueryHelper.cs
@@ -225,16 +225,16 @@ namespace LinqToDB.SqlQuery
 		}
 			
 		/// <summary>
-		/// Returns <c>true</c> if tested expression can be constant or immutable value based on parameters.
+		/// Returns <c>true</c> if tested expression is constant during query execution (e.g. value or parameter).
 		/// </summary>
 		/// <param name="expr">Tested expression.</param>
 		/// <returns></returns>
-		public static bool IsImmutable(ISqlExpression expr)
+		public static bool IsConstant(ISqlExpression expr)
 		{
 			var result = null == new QueryVisitor()
 				.Find(expr, e =>
 				{
-					// Constants and Parameters do not changes during query execution 
+					// constants and parameters do not change during query execution
 					if (e.ElementType.In(QueryElementType.SqlValue, QueryElementType.SqlParameter))
 						return false;
 
@@ -242,12 +242,14 @@ namespace LinqToDB.SqlQuery
 					{
 						var sqlColumn = (SqlColumn) e;
 						
-						// We can not guarantee order here
+						// we can not guarantee order here
+						// set operation contains at least two expressions for column
+						// (in theory we can test that they are equal, but it is not worth it)
 						if (sqlColumn.Parent != null && sqlColumn.Parent.SetOperators.Count > 0)
 							return true;
 						
-						// column can be generated from subquery which can reference to Immutable expression
-						return !IsImmutable(sqlColumn.Expression);
+						// column can be generated from subquery which can reference to constant expression
+						return !IsConstant(sqlColumn.Expression);
 					}
 
 					if (e.ElementType == QueryElementType.SqlExpression)

--- a/Tests/Linq/Linq/GroupByTests.cs
+++ b/Tests/Linq/Linq/GroupByTests.cs
@@ -2282,5 +2282,22 @@ namespace Tests.Linq
 			}
 			Query.ClearCaches();
 		}
+
+		[Test]
+		public void IssueGroupByNonTableColumn([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var query = db.Person
+					.Select(_ => 1)
+					.Concat(db.Person.Select(_ => 2))
+					.GroupBy(_ => _)
+					.Select(_ => new { _.Key, Count = _.Count() })
+					.Where(_ => _.Key == 1)
+					.Select(_ => _.Count)
+					.Where(_ => _ > 1)
+					.Count();
+			}
+		}
 	}
 }

--- a/Tests/Linq/Linq/GroupByTests.cs
+++ b/Tests/Linq/Linq/GroupByTests.cs
@@ -1020,7 +1020,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void GroupByAssociation102([DataSources(TestProvName.AllInformix)] string context)
+		public void GroupByAssociation102([DataSources()] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -1037,7 +1037,7 @@ namespace Tests.Linq
 
 		[Test]
 		public void GroupByAssociation1022([DataSources(
-			ProviderName.SqlCe, TestProvName.AllAccess, TestProvName.AllInformix /* Can be fixed*/)]
+			ProviderName.SqlCe, TestProvName.AllAccess /* Can be fixed*/)]
 			string context)
 		{
 			using (var db = GetDataContext(context))
@@ -1055,7 +1055,7 @@ namespace Tests.Linq
 
 		[Test]
 		public void GroupByAssociation1023([DataSources(
-			ProviderName.SqlCe, TestProvName.AllAccess, TestProvName.AllInformix /* Can be fixed.*/)]
+			ProviderName.SqlCe, TestProvName.AllAccess /* Can be fixed.*/)]
 			string context)
 		{
 			using (var db = GetDataContext(context))
@@ -1079,7 +1079,7 @@ namespace Tests.Linq
 
 		[Test]
 		public void GroupByAssociation1024([DataSources(
-			ProviderName.SqlCe, TestProvName.AllAccess, TestProvName.AllInformix) /* Can be fixed. */]
+			ProviderName.SqlCe, TestProvName.AllAccess) /* Can be fixed. */]
 			string context)
 		{
 			using (var db = GetDataContext(context))
@@ -1318,7 +1318,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void Scalar4([DataSources(ProviderName.SqlCe, TestProvName.AllAccess, TestProvName.AllInformix)] string context)
+		public void Scalar4([DataSources(ProviderName.SqlCe, TestProvName.AllAccess)] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -1334,7 +1334,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void Scalar41([DataSources(ProviderName.SqlCe, TestProvName.AllAccess, TestProvName.AllInformix)] string context)
+		public void Scalar41([DataSources(ProviderName.SqlCe, TestProvName.AllAccess)] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -1819,7 +1819,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void GroupByCustomEntity2([DataSources(TestProvName.AllInformix, TestProvName.AllSybase)] string context)
+		public void GroupByCustomEntity2([DataSources(TestProvName.AllSybase)] string context)
 		{
 			var rand = new Random().Next(5);
 

--- a/Tests/Linq/UserTests/Issue2564Tests.cs
+++ b/Tests/Linq/UserTests/Issue2564Tests.cs
@@ -37,8 +37,9 @@ namespace Tests.UserTests
 				db.DropTable<Issue2564Class>(throwExceptionIfNotExists: false);
 				db.CreateTable<Issue2564Class>();
 				{
-					var from = DateTime.UtcNow.AddDays(-1);
-					var to = DateTime.UtcNow;
+					var from = TestData.DateTime.AddDays(-1);
+					var to   = TestData.DateTime;
+
 					var qry = (from m in db.GetTable<Issue2564Class>()
 							   where m.TimestampGone.HasValue &&
 								 m.TimestampGenerated >= @from &&
@@ -47,12 +48,13 @@ namespace Tests.UserTests
 							   group m by new { m.ExternID1, m.TranslatedMessageGroup, m.TimestampGenerated.Hour } into tgGroup
 							   select new
 							   {
-								   MessageText = tgGroup.Min(x => x.TranslatedMessage1)!.Trim(),
-								   GroupName = tgGroup.Key.TranslatedMessageGroup,
-								   Hour = tgGroup.Key.Hour,
-								   Count = tgGroup.Count(),
+								   MessageText       = tgGroup.Min(x => x.TranslatedMessage1)!.Trim(),
+								   GroupName         = tgGroup.Key.TranslatedMessageGroup,
+								   Hour              = tgGroup.Key.Hour,
+								   Count             = tgGroup.Count(),
 								   DurationInSeconds = (long)tgGroup.Sum(x => (x.TimestampGone!.Value - x.TimestampGenerated).TotalMilliseconds),
 							   });
+
 					var data = qry.ToList();
 				}
 			}


### PR DESCRIPTION
Added test to reproduce issue

```
Exception: Microsoft.Data.SqlClient.SqlException
    Message  : Column 't1.c1' is invalid in the select list because it is not contained in either an aggregate function or the GROUP BY clause.
```

```sql
SELECT
    	Count(*)
    FROM
    	(
    		SELECT
    			[t1].[c1] as [Key_1],
    			Count(*) as [Count_1]
    		FROM
    			(
    				SELECT
    					1 as [c1]
    				FROM
    					[Person] [_]
    				UNION ALL
    				SELECT
    					2 as [c1]
    				FROM
    					[Person] [_1]
    			) [t1]
-- GROUP BY WAS HERE
    	) [_2]
    WHERE
    	[_2].[Count_1] > 1 AND [_2].[Key_1] = 1
    ```