### PR TITLE
[Tests] Support connection string pointers.

### DIFF
--- a/Tests/Base/Tools/SettingsReader.cs
+++ b/Tests/Base/Tools/SettingsReader.cs
@@ -104,6 +104,20 @@ namespace Tests.Tools
 					Merge(settings, baseOnSettings);
 				}
 
+				//Translate connection strings enclosed in brackets as references to other existing connection strings.
+				foreach (var connection in settings.Connections)
+				{
+					var cs = connection.Value.ConnectionString;
+					if (cs.StartsWith("[") && cs.EndsWith("]"))
+					{
+						cs = cs.Substring(1, cs.Length - 2);
+						if (settings.Connections.TryGetValue(cs, out var baseConnection))
+							connection.Value.ConnectionString = baseConnection.ConnectionString;
+						else
+							throw new InvalidOperationException($"Connection {cs} not found.");
+					}
+				}
+
 				return settings;
 			}
 


### PR DESCRIPTION
Allows for a connecionstring enclosed in brackets to be translated as a reference to another connectionstring name. Due to the architecture of providers, a schema or non database related option has to spawn a different provider, so you might be able to reuse the same connection string to test different providers.

This is PR No.1 of a series related to help porting tests to 3rd party providers (like IBM i).