### PR TITLE
[Tests] multischema fix

### DIFF
--- a/Tests/Linq/SchemaProvider/SchemaProviderTests.cs
+++ b/Tests/Linq/SchemaProvider/SchemaProviderTests.cs
@@ -68,7 +68,7 @@ namespace Tests.SchemaProvider
 					}
 				}
 
-				var table = dbSchema.Tables.SingleOrDefault(t => t.TableName!.ToLower() == "parent");
+				var table = dbSchema.Tables.SingleOrDefault(t => t.IsDefaultSchema && t.TableName!.ToLower() == "parent");
 
 				Assert.That(table,                                           Is.Not.Null);
 				Assert.That(table.Columns.Count(c => c.ColumnName != "_ID"), Is.EqualTo(2));
@@ -77,7 +77,7 @@ namespace Tests.SchemaProvider
 				AssertType<Model.Parent>       (conn.MappingSchema, dbSchema);
 
 				if (context != ProviderName.AccessOdbc)
-					Assert.That(dbSchema.Tables.Single(t => t.TableName!.ToLower() == "doctor").ForeignKeys.Count, Is.EqualTo(1));
+					Assert.That(dbSchema.Tables.Single(t => t.IsDefaultSchema && t.TableName!.ToLower() == "doctor").ForeignKeys.Count, Is.EqualTo(1));
 				else // no FK information for ACCESS ODBC
 					Assert.That(dbSchema.Tables.Single(t => t.TableName!.ToLower() == "doctor").ForeignKeys.Count, Is.EqualTo(0));
 

--- a/Tests/Linq/SchemaProvider/SchemaProviderTests.cs
+++ b/Tests/Linq/SchemaProvider/SchemaProviderTests.cs
@@ -68,7 +68,12 @@ namespace Tests.SchemaProvider
 					}
 				}
 
-				var table = dbSchema.Tables.SingleOrDefault(t => t.IsDefaultSchema && t.TableName!.ToLower() == "parent");
+				//Get table from default schema and fall back to schema indifferent
+				TableSchema getTable(string name) =>
+								dbSchema.Tables.SingleOrDefault(t => t.IsDefaultSchema && t.TableName!.ToLower() == name)
+							??  dbSchema.Tables.SingleOrDefault(t => t.TableName!.ToLower() == name);
+
+				var table = getTable("parent");
 
 				Assert.That(table,                                           Is.Not.Null);
 				Assert.That(table.Columns.Count(c => c.ColumnName != "_ID"), Is.EqualTo(2));
@@ -77,7 +82,7 @@ namespace Tests.SchemaProvider
 				AssertType<Model.Parent>       (conn.MappingSchema, dbSchema);
 
 				if (context != ProviderName.AccessOdbc)
-					Assert.That(dbSchema.Tables.Single(t => t.IsDefaultSchema && t.TableName!.ToLower() == "doctor").ForeignKeys.Count, Is.EqualTo(1));
+					Assert.That(getTable("doctor").ForeignKeys.Count, Is.EqualTo(1));
 				else // no FK information for ACCESS ODBC
 					Assert.That(dbSchema.Tables.Single(t => t.TableName!.ToLower() == "doctor").ForeignKeys.Count, Is.EqualTo(0));
 


### PR DESCRIPTION
Some providers (like the IBM i ) support loading multiple schemas (libraries in IBM i) so the schema providers can load tables with the same name. This patch handles schema testing so that it looks for tables in the default schema, and fallsback to schema ignorant search in case the providers doesn't support default schema information.

This is PR No.2 of a series related to help porting tests to 3rd party providers (like IBM i).