### PR TITLE
[Tests] Stripped all SQL trace comments from tests before execution

### DIFF
--- a/Tests/Linq/Data/DataExtensionsTests.cs
+++ b/Tests/Linq/Data/DataExtensionsTests.cs
@@ -127,7 +127,7 @@ namespace Tests.Data
 				conn.InlineParameters = true;
 				var sql = conn.Person.Where(p => p.ID == 1).Select(p => p.Name).Take(1).ToString()!;
 				sql = string.Join(Environment.NewLine, sql.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-					.Where(line => !line.StartsWith("-- Access")));
+					.Where(line => !line.StartsWith("--")));
 				var res = conn.Execute<string>(sql);
 
 				Assert.That(res, Is.EqualTo("John"));

--- a/Tests/Linq/Linq/AsyncTests.cs
+++ b/Tests/Linq/Linq/AsyncTests.cs
@@ -76,7 +76,7 @@ namespace Tests.Linq
 
 				var sql = conn.Person.Where(p => p.ID == 1).Select(p => p.Name).Take(1).ToString()!;
 				sql = string.Join(Environment.NewLine, sql.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-					.Where(line => !line.StartsWith("-- Access")));
+					.Where(line => !line.StartsWith("--")));
 
 				var res = await conn.SetCommand(sql).ExecuteAsync<string>();
 
@@ -93,7 +93,7 @@ namespace Tests.Linq
 
 				var sql = conn.Person.Where(p => p.ID == 1).Select(p => p.Name).Take(1).ToString()!;
 				sql = string.Join(Environment.NewLine, sql.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-					.Where(line => !line.StartsWith("-- Access")));
+					.Where(line => !line.StartsWith("--")));
 
 				var res = conn.SetCommand(sql).ExecuteAsync<string>().Result;
 
@@ -115,7 +115,7 @@ namespace Tests.Linq
 
 				var sql = conn.Person.Where(p => p.ID == 1).Select(p => p.Name).Take(1).ToString()!;
 				sql = string.Join(Environment.NewLine, sql.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-					.Where(line => !line.StartsWith("-- Access")));
+					.Where(line => !line.StartsWith("--")));
 
 				using (var rd = await conn.SetCommand(sql).ExecuteReaderAsync())
 				{


### PR DESCRIPTION
A couple of tests stripped comments Access related comments before executing the SQL produced by the tracing mechanism when calling ToString on a query expression. To support more providers that can't handle inline comments in SQL, all comments were removed in said tests before the raw SQL is dispatched for execution.

This is PR No.3 of a series related to help porting tests to 3rd party providers (like IBM i).