### PR TITLE
[Tests] Support for DB2 iSeries week numbering in tests.

### DIFF
--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -285,6 +285,7 @@ namespace Tests.Linq
 				var usWeeksZeroBased      = new[] { 51, 51, 52, 52, 0, 0, 0, 0, 0, 1, 1, 1 };
 				var muslimWeeks           = new[] { 52, 53, 53, 53, 1, 1, 1, 1, 2, 2, 2, 2 };
 				var primitive             = new[] { 52, 52, 52, 53, 1, 1, 1, 1, 1, 1, 1, 2 };
+				var usWeeksZeroBased_byDayOfYear = new[] { 51, 51, 52, 52, 0, 0, 0, 0, 0, 0, 1, 1 };
 
 				var results = dates
 					.Select(date => db.Select(() => Sql.AsSql(Sql.DatePart(Sql.DateParts.Week, Sql.ToSql(date)))))
@@ -319,6 +320,10 @@ namespace Tests.Linq
 				else if (usWeeksZeroBased.SequenceEqual(results))
 				{
 					Assert.Pass($"Context {db.DataProvider.Name} uses US 0-based week numbering schema");
+				}
+				else if (usWeeksZeroBased_byDayOfYear.SequenceEqual(results))
+				{
+					Assert.Pass($"Context {db.DataProvider.Name} uses US 0-based week numbering schema by day of year divided by 7");
 				}
 				else
 				{


### PR DESCRIPTION
Added support for IBM i week numbering scheme (day of year divided by 7) in related test (DatePartWeekNumberingType). 

This is PR No.4 of a series related to help porting tests to 3rd party providers (like IBM i).