### PR TITLE
[Tests] Added sttribute to control Upsert tests on unsupported providers.

### DIFF
--- a/Tests/Base/InsertOrUpdateDataSourcesAttribute.cs
+++ b/Tests/Base/InsertOrUpdateDataSourcesAttribute.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Tests
+{
+	[AttributeUsage(AttributeTargets.Parameter)]
+	public class InsertOrUpdateDataSourcesAttribute : DataSourcesAttribute
+	{
+		public static List<string> Unsupported = new List<string>
+		{
+				
+		}.SelectMany(_ => _.Split(',')).ToList();
+
+		public InsertOrUpdateDataSourcesAttribute(params string[] except)
+			: base(true, Unsupported.Concat(except.SelectMany(_ => _.Split(','))).ToArray())
+		{
+		}
+
+		public InsertOrUpdateDataSourcesAttribute(bool includeLinqService, params string[] except)
+			: base(includeLinqService, Unsupported.Concat(except.SelectMany(_ => _.Split(','))).ToArray())
+		{
+		}
+	}
+}

--- a/Tests/Linq/Exceptions/DmlTests.cs
+++ b/Tests/Linq/Exceptions/DmlTests.cs
@@ -13,7 +13,7 @@ namespace Tests.Exceptions
 	public class DmlTests : TestBase
 	{
 		[Test]
-		public void InsertOrUpdate1([DataSources] string context)
+		public void InsertOrUpdate1([InsertOrUpdateDataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -37,7 +37,7 @@ namespace Tests.Exceptions
 		}
 
 		[Test]
-		public void InsertOrUpdate2([DataSources] string context)
+		public void InsertOrUpdate2([InsertOrUpdateDataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 			{

--- a/Tests/Linq/Linq/ComplexTests2.cs
+++ b/Tests/Linq/Linq/ComplexTests2.cs
@@ -432,7 +432,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void TestInsertUsingDerivedObjectUsingFluentMapping([DataSources] string context)
+		public void TestInsertUsingDerivedObjectUsingFluentMapping([InsertOrUpdateDataSources] string context)
 		{
 			var ms = SetMappings();
 
@@ -481,7 +481,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void TestInheritanceByBaseType([DataSources] string context)
+		public void TestInheritanceByBaseType([InsertOrUpdateDataSources] string context)
 		{
 			var ms = SetMappings();
 

--- a/Tests/Linq/Update/InsertTests.cs
+++ b/Tests/Linq/Update/InsertTests.cs
@@ -1041,7 +1041,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public void InsertOrUpdate1([DataSources] string context)
+		public void InsertOrUpdate1([InsertOrUpdateDataSources] string context)
 		{
 			ResetPersonIdentity(context);
 
@@ -1083,7 +1083,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public void InsertOrUpdate2([DataSources] string context)
+		public void InsertOrUpdate2([InsertOrUpdateDataSources] string context)
 		{
 			ResetPersonIdentity(context);
 
@@ -1159,7 +1159,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public void InsertOrReplace1([DataSources] string context)
+		public void InsertOrReplace1([InsertOrUpdateDataSources] string context)
 		{
 			ResetPersonIdentity(context);
 
@@ -1251,7 +1251,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public void InsertOrUpdate3([DataSources] string context)
+		public void InsertOrUpdate3([InsertOrUpdateDataSources] string context)
 		{
 			ResetPersonIdentity(context);
 
@@ -1302,7 +1302,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public async Task InsertOrUpdate3Async([DataSources] string context)
+		public async Task InsertOrUpdate3Async([InsertOrUpdateDataSources] string context)
 		{
 			ResetPersonIdentity(context);
 
@@ -1353,7 +1353,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public void InsertOrUpdate4([DataSources] string context)
+		public void InsertOrUpdate4([InsertOrUpdateDataSources] string context)
 		{
 			ResetPersonIdentity(context);
 
@@ -1825,7 +1825,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public void InsertOrReplaceByTableName([DataSources] string context)
+		public void InsertOrReplaceByTableName([InsertOrUpdateDataSources] string context)
 		{
 			const string? schemaName = null;
 			var tableName  = "xxPatient" + TestUtils.GetNext().ToString();
@@ -1994,7 +1994,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public void TestInsertOrReplaceWithColumnFilter([DataSources] string context, [Values] bool withMiddleName, [Values] bool skipOnInsert)
+		public void TestInsertOrReplaceWithColumnFilter([InsertOrUpdateDataSources] string context, [Values] bool withMiddleName, [Values] bool skipOnInsert)
 		{
 			using (var db = GetDataContext(context))
 			using (var table = db.CreateLocalTable<TestInsertOrReplaceTable>())
@@ -2037,7 +2037,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public void Issue2243([DataSources] string context, [Values(1, 2, 3)] int seed)
+		public void Issue2243([InsertOrUpdateDataSources] string context, [Values(1, 2, 3)] int seed)
 		{
 			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable<TestInsertOrReplaceInfo>())

--- a/Tests/Linq/Update/MergeTests.cs
+++ b/Tests/Linq/Update/MergeTests.cs
@@ -18,7 +18,7 @@ namespace Tests.xUpdate
 		[AttributeUsage(AttributeTargets.Parameter)]
 		public class MergeDataContextSourceAttribute : DataSourcesAttribute
 		{
-			static string[] Unsupported = new[]
+			public static List<string> Unsupported = new[]
 			{
 				TestProvName.AllAccess,
 				ProviderName.SqlCe,
@@ -26,7 +26,7 @@ namespace Tests.xUpdate
 				TestProvName.AllSqlServer2005Minus,
 				TestProvName.AllPostgreSQL,
 				TestProvName.AllMySql,
-			}.SelectMany(_ => _.Split(',')).ToArray();
+			}.SelectMany(_ => _.Split(',')).ToList();
 
 			public MergeDataContextSourceAttribute(params string[] except)
 				: base(true, Unsupported.Concat(except.SelectMany(_ => _.Split(','))).ToArray())

--- a/Tests/Linq/UserTests/Issue1238Tests.cs
+++ b/Tests/Linq/UserTests/Issue1238Tests.cs
@@ -26,7 +26,7 @@ namespace Tests.UserTests
 		// DB2 needs merge api + arraycontext features from 3.0
 		[ActiveIssue(1239, Configuration = ProviderName.DB2)]
 		[Test]
-		public void TestInsertOrUpdate([DataSources(false, TestProvName.AllPostgreSQL)] string context)
+		public void TestInsertOrUpdate([InsertOrUpdateDataSources(false, TestProvName.AllPostgreSQL)] string context)
 		{
 			using (var db = new TestDataConnection(context))
 			using (db.BeginTransaction())
@@ -70,7 +70,7 @@ namespace Tests.UserTests
 			Configuration = ProviderName.DB2,
 			Details       = "ERROR [42610] [IBM][DB2/NT64] SQL0418N  The statement was not processed because the statement contains an invalid use of one of the following: an untyped parameter marker, the DEFAULT keyword, or a null value.")]
 		[Test]
-		public void InsertOrReplaceTest([DataSources(false, TestProvName.AllPostgreSQL)] string context)
+		public void InsertOrReplaceTest([InsertOrUpdateDataSources(false, TestProvName.AllPostgreSQL)] string context)
 		{
 			using (var db = new TestDataConnection(context))
 			using (db.BeginTransaction())

--- a/Tests/Linq/UserTests/SkipValuesTestCache.cs
+++ b/Tests/Linq/UserTests/SkipValuesTestCache.cs
@@ -61,7 +61,7 @@ namespace Tests.UserTests
 
 		[Test]
 		public void TestSkipInsertOrReplace(
-			[DataSources(TestProvName.AllOracleNative)] string context,
+			[InsertOrUpdateDataSources(TestProvName.AllOracleNative)] string context,
 			[Values(1, 2)] int value)
 		{
 			using (var db = GetDataContext(context))


### PR DESCRIPTION
The default behaviour from the base DataProvider for InsertOrUpdate is to throw an unsupported exception. All of the embedded linq2db providers support it so there is no ability to skip those tests. This patch adds an attribute to control this for tests tha invoke the InsertOrUpdate / InsertOrReplace functions, similarly to Merge. The list of unsupported providers is empty by default.

This is PR No.5 of a series related to help porting tests to 3rd party providers (like IBM i).