### PR TITLE
[Tests] Customization interceptor

### DIFF
--- a/Tests/Base/CustomizationSupport/CustomizationSupport.cs
+++ b/Tests/Base/CustomizationSupport/CustomizationSupport.cs
@@ -2,7 +2,7 @@
 {
 	public static class CustomizationSupport
 	{
-		//Replace this instance with a custom implementation to ovveride default behaviour
+		//Replace this instance with a custom implementation to override default behaviour
 		public static readonly CustomizationSupportInterceptor Interceptor = new CustomizationSupportInterceptor();
 	}
 }

--- a/Tests/Base/CustomizationSupport/CustomizationSupport.cs
+++ b/Tests/Base/CustomizationSupport/CustomizationSupport.cs
@@ -1,0 +1,8 @@
+﻿namespace Tests
+{
+	public static class CustomizationSupport
+	{
+		//Replace this instance with a custom implementation to ovveride default behaviour
+		public static readonly CustomizationSupportInterceptor Interceptor = new CustomizationSupportInterceptor();
+	}
+}

--- a/Tests/Base/CustomizationSupportInterceptor.cs
+++ b/Tests/Base/CustomizationSupportInterceptor.cs
@@ -1,0 +1,39 @@
+﻿using NUnit.Framework.Interfaces;
+using System.Collections.Generic;
+
+namespace Tests
+{
+	/// <summary>
+	/// Providers an API for intercepting test filtering operations.
+	/// For use in running the tests with 3rd party DataProviders.
+	/// </summary>
+	public class CustomizationSupportInterceptor
+	{
+		/// <summary>
+		/// Intercept and mutate the set of unsupported providers for tests annotated with InsertOrUpdateDataSourcesAttribute
+		/// (tests that include InsertOrUpdate/InserOrReplace calls)
+		/// </summary>
+		/// <param name="providers">The default unsupported providers from InsertOrUpdateDataSourcesAttribute</param>
+		/// <returns></returns>
+		public virtual IEnumerable<string> GetSupportedProviders(IEnumerable<string> providers)
+			=> providers;
+
+		/// <summary>
+		/// Intercept and mutate the set of unsupported providers for tests annotated with MergeDataSourcesAttribute
+		/// (tests that include Merge API calls)
+		/// </summary>
+		/// <param name="providers">The default unsupported providers from MergeDataSourcesAttribute</param>
+		/// <returns></returns>
+		public virtual IEnumerable<string> InterceptDataSources(DataSourcesBaseAttribute dataSourcesAttribute, IEnumerable<string> contexts)
+			=> contexts;
+
+		/// <summary>
+		/// Intercept and mutate the set of unsupported providers for tests annotated with IdentityInsertMergeDataSourcesAttribute
+		/// (tests that include Merge API with Identity Insert calls)
+		/// </summary>
+		/// <param name="providers">The default unsupported providers from IdentityInsertMergeDataSourcesAttribute</param>
+		/// <returns></returns>
+		public virtual IEnumerable<string> InterceptTestDataSources(DataSourcesBaseAttribute dataSourcesAttribute, IMethodInfo testMethod, IEnumerable<string> contexts)
+			=> contexts;
+	}
+}

--- a/Tests/Base/CustomizationSupportInterceptor.cs
+++ b/Tests/Base/CustomizationSupportInterceptor.cs
@@ -4,36 +4,46 @@ using System.Collections.Generic;
 namespace Tests
 {
 	/// <summary>
-	/// Providers an API for intercepting test filtering operations.
+	/// Provides an API for intercepting test filtering operations.
 	/// For use in running the tests with 3rd party DataProviders.
 	/// </summary>
 	public class CustomizationSupportInterceptor
 	{
 		/// <summary>
-		/// Intercept and mutate the set of unsupported providers for tests annotated with InsertOrUpdateDataSourcesAttribute
-		/// (tests that include InsertOrUpdate/InserOrReplace calls)
+		/// Intercept and mutate the set of providers available globally by the testing framework
 		/// </summary>
-		/// <param name="providers">The default unsupported providers from InsertOrUpdateDataSourcesAttribute</param>
-		/// <returns></returns>
+		/// <param name="providers">The default providers supported by the testing framework.</param>
+		/// <returns>The actual providers supported at runtime.</returns>
 		public virtual IEnumerable<string> GetSupportedProviders(IEnumerable<string> providers)
 			=> providers;
 
 		/// <summary>
-		/// Intercept and mutate the set of unsupported providers for tests annotated with MergeDataSourcesAttribute
-		/// (tests that include Merge API calls)
+		/// Intercept and mutate the set of supported datasources/contexts when scanning for tests.
+		/// Use this method to replace aliases with actual providers.
 		/// </summary>
-		/// <param name="providers">The default unsupported providers from MergeDataSourcesAttribute</param>
-		/// <returns></returns>
+		/// <param name="dataSourcesAttribute">The DataSourcesAttribute instance associated with the test.</param>
+		/// <param name="contexts">The default datasources passed to a test by DataSourcesAttribute.</param>
+		/// <returns>The actual datasources that test should run with.</returns>
 		public virtual IEnumerable<string> InterceptDataSources(DataSourcesBaseAttribute dataSourcesAttribute, IEnumerable<string> contexts)
 			=> contexts;
 
 		/// <summary>
-		/// Intercept and mutate the set of unsupported providers for tests annotated with IdentityInsertMergeDataSourcesAttribute
-		/// (tests that include Merge API with Identity Insert calls)
+		/// Intercept and mutate the set of datasources/contexts passed to a specific test.
+		/// Use this method to mutate providers or switch off specific tess.
 		/// </summary>
-		/// <param name="providers">The default unsupported providers from IdentityInsertMergeDataSourcesAttribute</param>
+		/// <param name="dataSourcesAttribute">The DataSourcesAttribute instance associated with the test.</param>
+		/// <param name="testMethod">The reflected test method.</param>
+		/// <param name="contexts">The default datasources/contexts for given tests</param>
 		/// <returns></returns>
 		public virtual IEnumerable<string> InterceptTestDataSources(DataSourcesBaseAttribute dataSourcesAttribute, IMethodInfo testMethod, IEnumerable<string> contexts)
 			=> contexts;
+
+		/// <summary>
+		/// Helper method to extract the class name and method name of a test method.
+		/// </summary>
+		/// <param name="testMethod"></param>
+		/// <returns></returns>
+		protected static (string className, string methodName) ExtractMethod(IMethodInfo testMethod)
+			=> (testMethod.TypeInfo.Name, testMethod.Name);
 	}
 }

--- a/Tests/Base/TestBase.cs
+++ b/Tests/Base/TestBase.cs
@@ -322,7 +322,7 @@ namespace Tests
 		public static readonly string? DefaultProvider;
 		public static readonly HashSet<string> SkipCategories;
 
-		public static readonly List<string> Providers = new List<string>
+		public static readonly List<string> Providers = CustomizationSupport.Interceptor.GetSupportedProviders(new List<string>
 		{
 #if NET472
 			ProviderName.Sybase,
@@ -367,7 +367,7 @@ namespace Tests
 			ProviderName.SQLiteMS,
 			ProviderName.SapHanaNative,
 			ProviderName.SapHanaOdbc
-		};
+		}).ToList();
 
 		protected ITestDataContext GetDataContext(string configuration, MappingSchema? ms = null)
 		{


### PR DESCRIPTION
This patch helps control which tests will run without editing the source code. It is critical for porting and maintaining the test code base for 3rd party providers.

It basicly providers a class with 3 overridable methods that by default do nothing, and a static class that provides a singleton instance of that class. If someone wants to port the tests to their own project they only have to:

1. Create a new subclass of the interceptor class
2. Switch the singleton instance of the default implementation (this is the only change needed in the original source code)

In this way, the developer can copy the tests over to their project, inject their own list of providers globally, and control which tests should not run, or should run with different filters on a test base. 

This is PR No.6 (and last) of a series related to help porting tests to 3rd party providers (like IBM i).