### PR TITLE
Incorrect null literal handling against Nullable<T> members in expression

### DIFF
--- a/Source/LinqToDB/Expressions/InternalExtensions.cs
+++ b/Source/LinqToDB/Expressions/InternalExtensions.cs
@@ -1294,6 +1294,16 @@ namespace LinqToDB.Expressions
 				case ExpressionType.Constant:
 					return ((ConstantExpression)expr).Value;
 
+				case ExpressionType.Convert:
+				case ExpressionType.ConvertChecked:
+					{
+						var unary = (UnaryExpression)expr;
+						var operand = unary.Operand.EvaluateExpression();
+						if (operand == null)
+							return null;
+						break;
+					}
+
 				case ExpressionType.MemberAccess:
 					{
 						var member = (MemberExpression) expr;
@@ -1302,8 +1312,13 @@ namespace LinqToDB.Expressions
 							return ((FieldInfo)member.Member).GetValue(member.Expression.EvaluateExpression());
 
 						if (member.Member.IsPropertyEx())
-							return ((PropertyInfo)member.Member).GetValue(member.Expression.EvaluateExpression(), null);
-
+						{
+							var obj = member.Expression.EvaluateExpression();
+							if (obj == null && ((PropertyInfo)member.Member).IsNullableValueMember())
+								return null;
+							return ((PropertyInfo)member.Member).GetValue(obj, null);
+						}
+						
 						break;
 					}
 				case ExpressionType.Call:
@@ -1311,6 +1326,10 @@ namespace LinqToDB.Expressions
 						var mc = (MethodCallExpression)expr;
 						var arguments = mc.Arguments.Select(EvaluateExpression).ToArray();
 						var instance  = mc.Object.EvaluateExpression();
+
+						if (instance == null && mc.Method.IsNullableGetValueOrDefault())
+							return null;
+						
 						return mc.Method.Invoke(instance, arguments);
 					}
 			}

--- a/Source/LinqToDB/Extensions/ReflectionExtensions.cs
+++ b/Source/LinqToDB/Extensions/ReflectionExtensions.cs
@@ -894,6 +894,14 @@ namespace LinqToDB.Extensions
 				member.DeclaringType.GetGenericTypeDefinition() == typeof(Nullable<>);
 		}
 
+		public static bool IsNullableGetValueOrDefault(this MemberInfo member)
+		{
+			return
+				member.Name == "GetValueOrDefault" &&
+				member.DeclaringType!.IsGenericType &&
+				member.DeclaringType.GetGenericTypeDefinition() == typeof(Nullable<>);
+		}
+
 		static readonly Dictionary<Type,HashSet<Type>> _castDic = new Dictionary<Type,HashSet<Type>>
 		{
 			{ typeof(decimal), new HashSet<Type> { typeof(sbyte), typeof(byte),   typeof(short), typeof(ushort), typeof(int), typeof(uint), typeof(long), typeof(ulong), typeof(char)                } },

--- a/Tests/Linq/Linq/ExpressionsTests.cs
+++ b/Tests/Linq/Linq/ExpressionsTests.cs
@@ -815,29 +815,111 @@ namespace Tests.Linq
 			throw new InvalidOperationException();
 		}
 
-		[Test(Description = "Regression test against null.Value invocation")]
-		public void TernaryNullableNullExpressionTest([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		#region issue 2688
+		[Test]
+		public void NullableNullValueTest1([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
-				db.Person.Where(p => p.ID != GetTernaryExpressionValue(null)).ToList();
+				db.Person.Where(p => p.ID != GetTernaryExpressionValue1(null)).ToList();
 			}
 		}
 
-		[ExpressionMethod(nameof(GetTernaryExpressionValueExpr))]
-		public static int? GetTernaryExpressionValue(int? value)
+		[Test]
+		public void NullableNullValueTest2([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
 		{
-			if (value == null)
+			using (var db = GetDataContext(context))
 			{
-				return null;
+				db.Person.Where(p => p.ID != GetTernaryExpressionValue2(null)).ToList();
 			}
-
-			return GetTernaryExpressionValue(value.Value);
 		}
 
-		private static Expression<Func<int?, int?>> GetTernaryExpressionValueExpr()
+		[Test]
+		public void NullableNullValueTest3([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
 		{
+			using (var db = GetDataContext(context))
+			{
+				db.Person.Where(p => p.ID != GetTernaryExpressionValue3(null)).ToList();
+			}
+		}
+
+		[Test]
+		public void NullableNullValueTest4([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				db.Person.Where(p => p.ID != GetTernaryExpressionValue4(null)).ToList();
+			}
+		}
+
+		[Test]
+		public void NullableNullValueTest5([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				db.Person.Where(p => p.ID != GetTernaryExpressionValue5(null)).ToList();
+			}
+		}
+
+		[ExpressionMethod(nameof(GetTernaryExpressionValue1Expr))]
+		public static int? GetTernaryExpressionValue1(int? value)
+		{
+			throw new InvalidOperationException();
+		}
+
+		private static Expression<Func<int?, int?>> GetTernaryExpressionValue1Expr()
+		{
+			// null.Value
 			return value => value == null ? null : (int?)GetTernaryExpressionValueFunction(value.Value, int.MaxValue);
+		}
+
+		[ExpressionMethod(nameof(GetTernaryExpressionValue2Expr))]
+		public static int? GetTernaryExpressionValue2(int? value)
+		{
+			throw new InvalidOperationException();
+		}
+
+		private static Expression<Func<int?, int?>> GetTernaryExpressionValue2Expr()
+		{
+			// (int)null
+			return value => value == null ? null : (int?)GetTernaryExpressionValueFunction((int)value, int.MaxValue);
+		}
+
+		[ExpressionMethod(nameof(GetTernaryExpressionValue3Expr))]
+		public static int? GetTernaryExpressionValue3(int? value)
+		{
+			throw new InvalidOperationException();
+		}
+
+		private static Expression<Func<int?, int?>> GetTernaryExpressionValue3Expr()
+		{
+			// null.GetValueOrDefault()
+			return value => value == null ? null : (int?)GetTernaryExpressionValueFunction(value.GetValueOrDefault(), int.MaxValue);
+		}
+
+		[ExpressionMethod(nameof(GetTernaryExpressionValue4Expr))]
+		public static int? GetTernaryExpressionValue4(int? value)
+		{
+			throw new InvalidOperationException();
+		}
+
+		private static Expression<Func<int?, int?>> GetTernaryExpressionValue4Expr()
+		{
+			// null.GetValueOrDefault(0)
+			return value => value == null ? null : (int?)GetTernaryExpressionValueFunction(value.GetValueOrDefault(0), int.MaxValue);
+		}
+
+		[ExpressionMethod(nameof(GetTernaryExpressionValue5Expr))]
+		public static int? GetTernaryExpressionValue5(int? value)
+		{
+			throw new InvalidOperationException();
+		}
+
+		private static Expression<Func<int?, int?>> GetTernaryExpressionValue5Expr()
+		{
+			// this actually works
+			// null.HasValue
+			return value => value.HasValue ? null : (int?)GetTernaryExpressionValueFunction(1, int.MaxValue);
 		}
 
 		[Sql.Function("COALESCE", ServerSideOnly = true)]
@@ -845,6 +927,7 @@ namespace Tests.Linq
 		{
 			throw new InvalidOperationException();
 		}
+		#endregion
 
 		#region issue 2431
 		[Table]

--- a/Tests/Linq/Linq/ExpressionsTests.cs
+++ b/Tests/Linq/Linq/ExpressionsTests.cs
@@ -815,6 +815,36 @@ namespace Tests.Linq
 			throw new InvalidOperationException();
 		}
 
+		[Test(Description = "Regression test against null.Value invocation")]
+		public void TernaryNullableNullExpressionTest([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				db.Person.Where(p => p.ID != GetTernaryExpressionValue(null)).ToList();
+			}
+		}
+
+		[ExpressionMethod(nameof(GetTernaryExpressionValueExpr))]
+		public static int? GetTernaryExpressionValue(int? value)
+		{
+			if (value == null)
+			{
+				return null;
+			}
+
+			return GetTernaryExpressionValue(value.Value);
+		}
+
+		private static Expression<Func<int?, int?>> GetTernaryExpressionValueExpr()
+		{
+			return value => value == null ? null : (int?)GetTernaryExpressionValueFunction(value.Value, int.MaxValue);
+		}
+
+		[Sql.Function("COALESCE", ServerSideOnly = true)]
+		private static int GetTernaryExpressionValueFunction(int value, int defaultValue)
+		{
+			throw new InvalidOperationException();
+		}
 
 		#region issue 2431
 		[Table]


### PR DESCRIPTION
Added tests that throw exception due to call of `Nullable<T>` methods on `null` literal
```
TargetException : Non-static method requires a target.

RuntimeMethodInfo.CheckConsistency(Object target)
    RuntimeMethodInfo.InvokeArgumentsCheck(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
    RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
    RuntimePropertyInfo.GetValue(Object obj, BindingFlags invokeAttr, Binder binder, Object[] index, CultureInfo culture)
    RuntimePropertyInfo.GetValue(Object obj, Object[] index)
    InternalExtensions.EvaluateExpression(Expression expr) line 1299
    ExpressionBuilder.BuildConstant(Expression expr, ColumnDescriptor columnDescriptor) line 1346
    ExpressionBuilder.ConvertToSql(IBuildContext context, Expression expression, Boolean unwrap, ColumnDescriptor columnDescriptor, Boolean isPureExpression) line 853
    ExpressionBuilder.ConvertExtensionToSql(IBuildContext context, ExpressionAttribute attr, MethodCallExpression mc) line 1268
    ExpressionBuilder.ConvertToSql(IBuildContext context, Expression expression, Boolean unwrap, ColumnDescriptor columnDescriptor, Boolean isPureExpression) line 1144
    ExpressionBuilder.ConvertCompare(IBuildContext context, ExpressionType nodeType, Expression left, Expression right) line 1874
    ExpressionBuilder.ConvertPredicate(IBuildContext context, Expression expression) line 1684
    ExpressionBuilder.BuildSearchCondition(IBuildContext context, Expression expression, List`1 conditions, Boolean isNotExpression) line 3020
    ExpressionBuilder.BuildWhere(IBuildContext parent, IBuildContext sequence, LambdaExpression condition, Boolean checkForSubQuery, Boolean enforceHaving) line 50
    WhereBuilder.BuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo) line 23
    MethodCallBuilder.BuildSequence(ExpressionBuilder builder, BuildInfo buildInfo) line 21
    ExpressionBuilder.BuildSequence(BuildInfo buildInfo) line 191
    ExpressionBuilder.Build[T]() line 161
    Query`1.CreateQuery(IDataContext dataContext, Expression expr) line 533
    Query`1.GetQuery(IDataContext dataContext, Expression& expr) line 495
    ExpressionQuery`1.GetQuery(Expression& expression, Boolean cache) line 75
    IEnumerable<T>.GetEnumerator() line 304
    List`1.ctor(IEnumerable`1 collection)
    Enumerable.ToList[TSource](IEnumerable`1 source)
```