### PR TITLE
Improve ColumnAttribute parsing in SystemDataLinqAttributeReader

### DIFF
--- a/Source/LinqToDB/Metadata/SystemDataLinqAttributeReader.cs
+++ b/Source/LinqToDB/Metadata/SystemDataLinqAttributeReader.cs
@@ -73,12 +73,13 @@ namespace LinqToDB.Metadata
 
 					var attr = new ColumnAttribute
 					{
-						Name         = c.Name,
-                        DbType       = c.DbType,
-						CanBeNull    = c.CanBeNull,
-						Storage      = c.Storage,
-						IsPrimaryKey = c.IsPrimaryKey,
-						IsIdentity   = c.IsDbGenerated,
+						Name            = c.Name,
+                        DbType          = c.DbType,
+						CanBeNull       = c.CanBeNull,
+						Storage         = c.Storage,
+						IsPrimaryKey    = c.IsPrimaryKey,
+						IsIdentity      = c.IsDbGenerated,
+						IsDiscriminator = c.IsDiscriminator,
                     };
 
 					return new[] { (T)(Attribute)attr };

--- a/Source/LinqToDB/Metadata/SystemDataLinqAttributeReader.cs
+++ b/Source/LinqToDB/Metadata/SystemDataLinqAttributeReader.cs
@@ -73,11 +73,13 @@ namespace LinqToDB.Metadata
 
 					var attr = new ColumnAttribute
 					{
-						Name      = c.Name,
-						DbType    = c.DbType,
-						CanBeNull = c.CanBeNull,
-						Storage   = c.Storage,
-					};
+						Name         = c.Name,
+                        DbType       = c.DbType,
+						CanBeNull    = c.CanBeNull,
+						Storage      = c.Storage,
+						IsPrimaryKey = c.IsPrimaryKey,
+						IsIdentity   = c.IsDbGenerated,
+                    };
 
 					return new[] { (T)(Attribute)attr };
 				}

--- a/Source/LinqToDB/Metadata/SystemDataLinqAttributeReader.cs
+++ b/Source/LinqToDB/Metadata/SystemDataLinqAttributeReader.cs
@@ -74,13 +74,13 @@ namespace LinqToDB.Metadata
 					var attr = new ColumnAttribute
 					{
 						Name            = c.Name,
-                        DbType          = c.DbType,
+						DbType          = c.DbType,
 						CanBeNull       = c.CanBeNull,
 						Storage         = c.Storage,
 						IsPrimaryKey    = c.IsPrimaryKey,
 						IsIdentity      = c.IsDbGenerated,
 						IsDiscriminator = c.IsDiscriminator,
-                    };
+					};
 
 					return new[] { (T)(Attribute)attr };
 				}


### PR DESCRIPTION
Fixes #2692 
#
Copied 
```cs
IsPrimaryKey = c.IsPrimaryKey,
IsIdentity   = c.IsDbGenerated,
```
from donor `System.Data.Linq.Mapping.ColumnAttribute` object 