### PR TITLE
Null check in expression method transaltion to SQL

### DIFF
--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -3177,7 +3177,7 @@ namespace LinqToDB.Linq.Builder
 					if (conditional.Test.NodeType == ExpressionType.NotEqual)
 					{
 						var binary = (BinaryExpression)conditional.Test;
-						if (IsNullConstant(binary.Right) || IsNullConstant(binary.Left))
+						if (IsNullConstant(binary.Right) ^ IsNullConstant(binary.Left))
 						{
 							if (IsNullConstant(conditional.IfFalse))
 							{
@@ -3188,7 +3188,7 @@ namespace LinqToDB.Linq.Builder
 					else if (conditional.Test.NodeType == ExpressionType.Equal)
 					{
 						var binary = (BinaryExpression)conditional.Test;
-						if (IsNullConstant(binary.Right) || IsNullConstant(binary.Left))
+						if (IsNullConstant(binary.Right) ^ IsNullConstant(binary.Left))
 						{
 							if (IsNullConstant(conditional.IfTrue))
 							{

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -3176,10 +3176,16 @@ namespace LinqToDB.Linq.Builder
 					var conditional = (ConditionalExpression)expr;
 					if (conditional.Test.NodeType == ExpressionType.NotEqual)
 					{
-						var binary = (BinaryExpression)conditional.Test;
-						if (IsNullConstant(binary.Right) ^ IsNullConstant(binary.Left))
+						var binary    = (BinaryExpression)conditional.Test;
+						var nullRight = IsNullConstant(binary.Right);
+						var nullLeft  = IsNullConstant(binary.Left);
+						if (nullRight || nullLeft)
 						{
-							if (IsNullConstant(conditional.IfFalse))
+							if (nullRight && nullLeft)
+							{
+								return conditional.IfFalse.Transform(e => RemoveNullPropagation(e));
+							}
+							else if (IsNullConstant(conditional.IfFalse))
 							{
 								return conditional.IfTrue.Transform(e => RemoveNullPropagation(e));
 							}
@@ -3187,10 +3193,16 @@ namespace LinqToDB.Linq.Builder
 					}
 					else if (conditional.Test.NodeType == ExpressionType.Equal)
 					{
-						var binary = (BinaryExpression)conditional.Test;
-						if (IsNullConstant(binary.Right) ^ IsNullConstant(binary.Left))
+						var binary    = (BinaryExpression)conditional.Test;
+						var nullRight = IsNullConstant(binary.Right);
+						var nullLeft  = IsNullConstant(binary.Left);
+						if (nullRight || nullLeft)
 						{
-							if (IsNullConstant(conditional.IfTrue))
+							if (nullRight && nullLeft)
+							{
+								return conditional.IfTrue.Transform(e => RemoveNullPropagation(e));
+							}
+							else if (IsNullConstant(conditional.IfTrue))
 							{
 								return conditional.IfFalse.Transform(e => RemoveNullPropagation(e));
 							}

--- a/Tests/Linq/Linq/ExpressionsTests.cs
+++ b/Tests/Linq/Linq/ExpressionsTests.cs
@@ -1006,26 +1006,43 @@ namespace Tests.Linq
 		#region Null check generated
 
 		[Test]
-		public void TestNullCheckInExpression([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		public void TestNullCheckInExpressionLeft([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
-				db.Person.Any(p => p.ID == Function2(Function1(null)));
+				db.Person.Any(p => p.ID == Function2(Function1Left(null)));
+			}
+		}
+
+		[Test]
+		public void TestNullCheckInExpressionRight([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				db.Person.Any(p => p.ID == Function2(Function1Right(null)));
 			}
 		}
 
 		[Sql.Expression("{0}", ServerSideOnly = true, IsNullable = Sql.IsNullableType.SameAsFirstParameter)]
 		public static int? Function2(int? Value) => throw new InvalidOperationException();
 
-		[ExpressionMethod(nameof(Function1Expr))]
-		public static int? Function1(int? value) => throw new InvalidOperationException();
+		[ExpressionMethod(nameof(Function1LeftExpr))]
+		public static int? Function1Left(int? value) => throw new InvalidOperationException();
+
+		[ExpressionMethod(nameof(Function1RightExpr))]
+		public static int? Function1Right(int? value) => throw new InvalidOperationException();
 
 		[Sql.Expression("CAST(N'SHOULD NOT BE CALLED' AS INT)", ServerSideOnly = true)]
 		private static int Fail(int value) => throw new InvalidOperationException();
 
-		private static Expression<Func<int?, int?>> Function1Expr()
+		private static Expression<Func<int?, int?>> Function1LeftExpr()
 		{
 			return value => value == null ? null : Fail(value.Value);
+		}
+
+		private static Expression<Func<int?, int?>> Function1RightExpr()
+		{
+			return value => value != null ? Fail(value.Value) : null;
 		}
 
 		#endregion


### PR DESCRIPTION
(not 3.2.0 regression)

generated sql miss null check:
```sql
 SELECT
    	IIF(EXISTS(
    		SELECT
    			*
    		FROM
    			[Person] [p]
    		WHERE
    			[p].[PersonID] = CAST(N'SHOULD NOT BE CALLED' AS INT)
    	), 1, 0)
```