### PR TITLE
Bad `IS NULL` predicate generation

### DIFF
--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2012SqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2012SqlOptimizer.cs
@@ -58,7 +58,7 @@ namespace LinqToDB.DataProvider.SqlServer
 				case "CASE"     :
 
 					if (func.Parameters.Length <= 5)
-						func = ConvertCase(func.SystemType, func.Parameters, 0);
+						func = ConvertCase(func.CanBeNull, func.SystemType, func.Parameters, 0);
 
 					break;
 
@@ -80,7 +80,10 @@ namespace LinqToDB.DataProvider.SqlServer
 
 					sc.Conditions.Add(new SqlCondition(false, new SqlPredicate.IsNull(func.Parameters[0], false)));
 
-					func = new SqlFunction(func.SystemType, "IIF", sc, func.Parameters[1], func.Parameters[0]);
+					func = new SqlFunction(func.SystemType, "IIF", sc, func.Parameters[1], func.Parameters[0])
+					{
+						CanBeNull = func.CanBeNull
+					};
 
 					break;
 			}
@@ -88,7 +91,7 @@ namespace LinqToDB.DataProvider.SqlServer
 			return base.ConvertFunction(func);
 		}
 
-		static SqlFunction ConvertCase(Type systemType, ISqlExpression[] parameters, int start)
+		static SqlFunction ConvertCase(bool canBeNull, Type systemType, ISqlExpression[] parameters, int start)
 		{
 			var len  = parameters.Length - start;
 			var name = start == 0 ? "IIF" : "CASE";
@@ -101,14 +104,14 @@ namespace LinqToDB.DataProvider.SqlServer
 						false,
 						new SqlPredicate.ExprExpr(cond, SqlPredicate.Operator.Equal, new SqlValue(1), null)));
 			}
-
+			
 			if (len == 3)
-				return new SqlFunction(systemType, name, cond, parameters[start + 1], parameters[start + 2]);
+				return new SqlFunction(systemType, name, cond, parameters[start + 1], parameters[start + 2]) { CanBeNull = canBeNull };
 
 			return new SqlFunction(systemType, name,
 				cond,
 				parameters[start + 1],
-				ConvertCase(systemType, parameters, start + 2));
+				ConvertCase(canBeNull, systemType, parameters, start + 2)) { CanBeNull = canBeNull };
 		}
 
 	}

--- a/Tests/Linq/Linq/WhereTests.cs
+++ b/Tests/Linq/Linq/WhereTests.cs
@@ -1789,6 +1789,23 @@ namespace Tests.Linq
 			}
 		}
 
+		[Test]
+		public void ComplexIsNullPredicateTest([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				db.Person.Where(_ => (_.MiddleName == "123") == (ComplexIsNullPredicateTestFunc(_.MiddleName) == "test")).Any();
+			}
+		}
+
+		[ExpressionMethod(nameof(ComplexIsNullPredicateTestFuncExpr))]
+		public static string? ComplexIsNullPredicateTestFunc(string? value) => throw new NotImplementedException();
+
+		private static Expression<Func<string?, string?>> ComplexIsNullPredicateTestFuncExpr()
+		{
+			return value => value == "1" ? "test" : value;
+		}
+
 		#region issue 2424
 		class Isue2424Table
 		{


### PR DESCRIPTION
Fails at least for SQL Server (will add list of dbs a bit later)