### PR TITLE
Incorrect GROUP BY optimization when applied to subquery

### DIFF
--- a/Source/LinqToDB/Linq/Builder/GroupByBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/GroupByBuilder.cs
@@ -131,7 +131,7 @@ namespace LinqToDB.Linq.Builder
 			{
 				var groupSql = builder.ConvertExpressions(key, keySelector.Body.Unwrap(), ConvertFlags.Key, null);
 
-				var allowed = groupSql.Where(s => !QueryHelper.IsConstant(s.Sql));
+				var allowed = groupSql.Where(s => s.Sql.ElementType.NotIn(QueryElementType.SqlValue, QueryElementType.SqlParameter));
 
 				foreach (var sql in allowed)
 					sequence.SelectQuery.GroupBy.Expr(sql.Sql);

--- a/Source/LinqToDB/Linq/Builder/GroupByBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/GroupByBuilder.cs
@@ -131,7 +131,7 @@ namespace LinqToDB.Linq.Builder
 			{
 				var groupSql = builder.ConvertExpressions(key, keySelector.Body.Unwrap(), ConvertFlags.Key, null);
 
-				var allowed = groupSql.Where(s => s.Sql.ElementType.NotIn(QueryElementType.SqlValue, QueryElementType.SqlParameter));
+				var allowed = groupSql.Where(s => !QueryHelper.IsConstantFast(s.Sql));
 
 				foreach (var sql in allowed)
 					sequence.SelectQuery.GroupBy.Expr(sql.Sql);
@@ -141,7 +141,7 @@ namespace LinqToDB.Linq.Builder
 				var goupingSetBody = groupingKey!.Body;
 				var groupingSets = EnumGroupingSets(goupingSetBody).ToArray();
 				if (groupingSets.Length == 0)
-					throw new LinqException($"Invalid groping sets expression '{goupingSetBody}'.");
+					throw new LinqException($"Invalid grouping sets expression '{goupingSetBody}'.");
 
 				foreach (var groupingSet in groupingSets)
 				{

--- a/Source/LinqToDB/SqlProvider/BasicSqlOptimizer.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlOptimizer.cs
@@ -333,23 +333,36 @@ namespace LinqToDB.SqlProvider
 							switch (e.ElementType)
 							{
 								case QueryElementType.SqlField:
-
-									if (levelTables.Contains(((SqlField)e).Table!))
+								{
+									var field = (SqlField)e;
+									if (levelTables.Contains(field.Table!))
 									{
-										subQuery.GroupBy.Expr((SqlField)e);
-										ne = subQuery.Select.AddColumn((SqlField)e);
+										subQuery.GroupBy.Expr(field);
+										ne = subQuery.Select.AddColumn(field);
+									}
+									else if (!allTables.Contains(field.Table!))
+									{
+										modified = true;
 									}
 
 									break;
-
+								}
+								
 								case QueryElementType.Column:
-									if (levelTables.Contains(((SqlColumn)e).Parent!))
+								{
+									var column = (SqlColumn)e;
+									if (levelTables.Contains(column.Parent!))
 									{
-										subQuery.GroupBy.Expr((SqlColumn)e);
-										ne = subQuery.Select.AddColumn((SqlColumn)e);
+										subQuery.GroupBy.Expr(column);
+										ne = subQuery.Select.AddColumn(column);
+									}
+									else if (!allTables.Contains(column.Parent!))
+									{
+										modified = true;
 									}
 
 									break;
+								}
 							}
 
 							modified = modified || !ReferenceEquals(e, ne);

--- a/Source/LinqToDB/SqlQuery/ConvertVisitor.cs
+++ b/Source/LinqToDB/SqlQuery/ConvertVisitor.cs
@@ -838,8 +838,13 @@ namespace LinqToDB.SqlQuery
 
 								var objTree = new Dictionary<ICloneableElement, ICloneableElement>();
 
+								// try to correct if there q.* in columns expressions
+								// TODO: not performant, it is bad that Columns has reference on this select query
+								sc = ConvertAll(sc, (v, e) => ReferenceEquals(e, q.All) ? nq.All : e);
+								
 								if (ReferenceEquals(sc, q.Select))
-									sc = new SqlSelectClause (nq, sc, objTree, e => e is SqlColumn c && c.Parent == q);
+									sc = new SqlSelectClause(nq, sc, objTree, e => e is SqlColumn c && c.Parent == q);
+								
 								if (ReferenceEquals(fc, q.From))
 									fc = new SqlFromClause   (nq, fc, objTree, e => false);
 								if (ReferenceEquals(wc, q.Where))

--- a/Source/LinqToDB/SqlQuery/QueryHelper.cs
+++ b/Source/LinqToDB/SqlQuery/QueryHelper.cs
@@ -304,8 +304,8 @@ namespace LinqToDB.SqlQuery
 					// we can not guarantee order here
 					// set operation contains at least two expressions for column
 					// (in theory we can test that they are equal, but it is not worth it)
-					if (sqlColumn.Parent != null && sqlColumn.Parent.SetOperators.Count > 0)
-						return true;
+					if (sqlColumn.Parent != null && sqlColumn.Parent.HasSetOperators)
+						return false;
 
 					// column can be generated from subquery which can reference to constant expression
 					return IsConstant(sqlColumn.Expression);

--- a/Source/LinqToDB/SqlQuery/QueryHelper.cs
+++ b/Source/LinqToDB/SqlQuery/QueryHelper.cs
@@ -278,7 +278,12 @@ namespace LinqToDB.SqlQuery
 			}
 			return expr.ElementType.NotIn(QueryElementType.Column, QueryElementType.SqlField);
 		}
-			
+
+		public static bool IsConstantFast(ISqlExpression expr)
+		{
+			return expr.ElementType == QueryElementType.SqlValue || expr.ElementType == QueryElementType.SqlParameter;
+		}
+		
 		/// <summary>
 		/// Returns <c>true</c> if tested expression is constant during query execution (e.g. value or parameter).
 		/// </summary>

--- a/Source/LinqToDB/SqlQuery/QueryHelper.cs
+++ b/Source/LinqToDB/SqlQuery/QueryHelper.cs
@@ -291,44 +291,44 @@ namespace LinqToDB.SqlQuery
 		/// <returns></returns>
 		public static bool IsConstant(ISqlExpression expr)
 		{
-			var result = null == new QueryVisitor()
-				.Find(expr, e =>
+			switch (expr.ElementType)
+			{
+				case QueryElementType.SqlValue :
+				case QueryElementType.SqlParameter :
+					return true;
+
+				case QueryElementType.Column:
 				{
-					// constants and parameters do not change during query execution
-					if (e.ElementType.In(QueryElementType.SqlValue, QueryElementType.SqlParameter))
+					var sqlColumn = (SqlColumn) expr;
+
+					// we can not guarantee order here
+					// set operation contains at least two expressions for column
+					// (in theory we can test that they are equal, but it is not worth it)
+					if (sqlColumn.Parent != null && sqlColumn.Parent.SetOperators.Count > 0)
+						return true;
+
+					// column can be generated from subquery which can reference to constant expression
+					return IsConstant(sqlColumn.Expression);
+				}
+				
+				case QueryElementType.SqlExpression:
+				{
+					var sqlExpr = (SqlExpression) expr;
+					if (!sqlExpr.IsPure || sqlExpr.IsAggregate)
 						return false;
+					return sqlExpr.Parameters.All(p => IsConstant(p));
+				}
 
-					if (e.ElementType == QueryElementType.Column)
-					{
-						var sqlColumn = (SqlColumn) e;
-						
-						// we can not guarantee order here
-						// set operation contains at least two expressions for column
-						// (in theory we can test that they are equal, but it is not worth it)
-						if (sqlColumn.Parent != null && sqlColumn.Parent.SetOperators.Count > 0)
-							return true;
-						
-						// column can be generated from subquery which can reference to constant expression
-						return !IsConstant(sqlColumn.Expression);
-					}
-
-					if (e.ElementType == QueryElementType.SqlExpression)
-					{
-						var sqlExpr = (SqlExpression) e;
-						return !sqlExpr.IsPure || sqlExpr.IsAggregate;
-					}
-					
-					if (e.ElementType == QueryElementType.SqlFunction)
-					{
-						var sqlFunc = (SqlFunction) e;
-						return !sqlFunc.IsPure || sqlFunc.IsAggregate;
-					}
-
-					return e.ElementType.In(QueryElementType.SqlField,
-						QueryElementType.SelectClause);
-				});
-
-			return result;
+				case QueryElementType.SqlFunction:
+				{
+					var sqlFunc = (SqlFunction) expr;
+					if (!sqlFunc.IsPure || sqlFunc.IsAggregate)
+						return false;
+					return sqlFunc.Parameters.All(p => IsConstant(p));
+				}
+			}
+			
+			return false;
 		}
 
 		public static SelectQuery RootQuery(this SelectQuery query)

--- a/Source/LinqToDB/SqlQuery/SelectQueryOptimizer.cs
+++ b/Source/LinqToDB/SqlQuery/SelectQueryOptimizer.cs
@@ -953,6 +953,14 @@ namespace LinqToDB.SqlQuery
 			var isColumnsOK =
 				(allColumns && !query.Select.Columns.Any(c => QueryHelper.IsAggregationFunction(c.Expression))) ||
 				!query.Select.Columns.Any(c => CheckColumn(parentQuery, c, c.Expression, query, optimizeValues, optimizeColumns));
+			
+			if (isColumnsOK && !parentQuery.GroupBy.IsEmpty)
+			{
+				if (query.Select.Columns.Where(c => parentQuery.GroupBy.Items.Exists(g => g.Equals(c))).All(c => QueryHelper.IsConstant(c.Expression)))
+				{ 
+					isColumnsOK = false;
+				}
+			}
 
 			if (!isColumnsOK)
 				return childSource;

--- a/Source/LinqToDB/SqlQuery/SelectQueryOptimizer.cs
+++ b/Source/LinqToDB/SqlQuery/SelectQueryOptimizer.cs
@@ -4,6 +4,7 @@ using System.Linq;
 
 namespace LinqToDB.SqlQuery
 {
+	using Tools;
 	using Common;
 	using SqlProvider;
 
@@ -436,16 +437,43 @@ namespace LinqToDB.SqlQuery
 
 			ResolveWeakJoins();
 			RemoveEmptyJoins();
+			OptimizeGroupBy();
 			OptimizeColumns();
 			OptimizeApplies   (isApplySupported, optimizeColumns);
 			OptimizeSubQueries(isApplySupported, optimizeColumns);
 			OptimizeApplies   (isApplySupported, optimizeColumns);
 
+			OptimizeGroupBy();
 			OptimizeDistinct();
 			OptimizeDistinctOrderBy();
 			CorrectColumns();
 		}
 
+		private void OptimizeGroupBy()
+		{
+			if (!_selectQuery.GroupBy.IsEmpty)
+			{
+				// Remove constants. 
+				//
+				for (int i = _selectQuery.GroupBy.Items.Count - 1; i >= 0; i--)
+				{
+					if (QueryHelper.IsConstant(_selectQuery.GroupBy.Items[i]))
+					{
+						if (i == 0 && _selectQuery.GroupBy.Items.Count == 1)
+						{
+							// we cannot remove all group items if there is at least one aggregation function
+							//
+							var lastShouldStay = _selectQuery.Select.Columns.Any(c => QueryHelper.IsAggregationFunction(c.Expression));
+							if (lastShouldStay)
+								break;
+						}
+
+						_selectQuery.GroupBy.Items.RemoveAt(i);
+					}
+				}
+			}
+		}
+		
 		private void CorrectColumns()
 		{
 			if (!_selectQuery.GroupBy.IsEmpty && _selectQuery.Select.Columns.Count == 0)
@@ -882,7 +910,7 @@ namespace LinqToDB.SqlQuery
 		{
 			expr = QueryHelper.UnwrapExpression(expr);
 
-			if (expr is SqlField || expr is SqlColumn || expr.ElementType == QueryElementType.SqlRawSqlTable)
+			if (expr.ElementType.In(QueryElementType.SqlField, QueryElementType.Column, QueryElementType.SqlParameter, QueryElementType.SqlRawSqlTable)) 
 				return false;
 
 			if (expr is SqlValue sqlValue)

--- a/Tests/Linq/Linq/GroupByTests.cs
+++ b/Tests/Linq/Linq/GroupByTests.cs
@@ -2290,5 +2290,23 @@ namespace Tests.Linq
 					.Count();
 			}
 		}
+
+		[Test]
+		public void GroupByWithSubquery([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var emptyEquery = db.Person
+					.Select(_ => 1)
+					.Where(_ => false);
+
+				var query = emptyEquery
+					.GroupBy(_ => _)
+					.Select(_ => new { _.Key, Count = _.Count() })
+					.ToList();
+
+				Assert.AreEqual(0, query.Count);
+			}
+		}
 	}
 }

--- a/Tests/Linq/Linq/IdlTests.cs
+++ b/Tests/Linq/Linq/IdlTests.cs
@@ -621,6 +621,8 @@ namespace Tests.Linq
 						select new { Rank = p.ID, p.FirstName, p.LastName });
 
 				var resultquery = (from x in q2 orderby x.Rank, x.FirstName, x.LastName select x).ToString()!;
+				
+				TestContext.WriteLine(resultquery);
 
 				var rqr = resultquery.LastIndexOf("ORDER BY", System.StringComparison.OrdinalIgnoreCase);
 				var rqp = (resultquery.Substring(rqr + "ORDER BY".Length).Split(',')).Select(p => p.Trim()).ToArray();


### PR DESCRIPTION
count moved inside subquery, which produce incorrect results
```sql
   SELECT
    	1,
    	Count(*)
    FROM
    	[Person] [_]
    WHERE
    	1 = 0
```