### PR TITLE
DateTime(Offset) + TimeSpan parameter Support

### DIFF
--- a/Source/LinqToDB/DataProvider/MySql/MySqlDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlDataProvider.cs
@@ -43,10 +43,7 @@ namespace LinqToDB.DataProvider.MySql
 			}
 
 			if (Adapter.GetDateTimeOffsetMethodName != null)
-			{
 				SetProviderField(typeof(DateTimeOffset), Adapter.GetDateTimeOffsetMethodName, Adapter.DataReaderType);
-				SetToTypeField  (typeof(DateTimeOffset), Adapter.GetDateTimeOffsetMethodName, Adapter.DataReaderType);
-			}
 
 			SetProviderField(Adapter.MySqlDateTimeType, Adapter.GetMySqlDateTimeMethodName, Adapter.DataReaderType);
 			SetToTypeField  (Adapter.MySqlDateTimeType, Adapter.GetMySqlDateTimeMethodName, Adapter.DataReaderType);

--- a/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
@@ -186,7 +186,7 @@ namespace LinqToDB.DataProvider.Oracle
 				case DataType.Time:
 					// According to https://docs.oracle.com/database/121/ODPNT/featOraCommand.htm#ODPNT0026
 					// Inference of DbType and OracleDbType from Value: TimeSpan - Object - IntervalDS
-					if (value is TimeSpan)
+					if (value == null || value is TimeSpan)
 						dataType = dataType.WithDataType(DataType.Undefined);
 					break;
 				case DataType.BFile:

--- a/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
@@ -184,7 +184,7 @@ namespace LinqToDB.DataProvider.Oracle
 					if (value is Guid guid) value = guid.ToByteArray();
 					break;
 				case DataType.Time:
-					// According to http://docs.oracle.com/cd/E16655_01/win.121/e17732/featOraCommand.htm#ODPNT258
+					// According to https://docs.oracle.com/database/121/ODPNT/featOraCommand.htm#ODPNT0026
 					// Inference of DbType and OracleDbType from Value: TimeSpan - Object - IntervalDS
 					if (value is TimeSpan)
 						dataType = dataType.WithDataType(DataType.Undefined);

--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteSqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteSqlOptimizer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace LinqToDB.DataProvider.SQLite
 {
@@ -36,6 +37,78 @@ namespace LinqToDB.DataProvider.SQLite
 			return statement;
 		}
 
+		public override bool HasSpecialTimeSpanProcessing => true;
+
+		static SqlValue _formatValue = new SqlValue("%Y-%m-%d %H:%M:%f");
+		
+		static bool GenerateDateAdd(ISqlExpression expr1, ISqlExpression expr2, bool isSubstraction, EvaluationContext context,
+			[MaybeNullWhen(false)] out ISqlExpression generated)
+		{
+			var dbType1 = expr1.GetExpressionType();
+			var dbType2 = expr2.GetExpressionType();
+
+			if (dbType1.SystemType.ToNullableUnderlying().In(typeof(DateTime), typeof(DateTimeOffset))
+			    && dbType2.SystemType.ToNullableUnderlying() == typeof(TimeSpan)
+			    && expr2.TryEvaluateExpression(context, out var value))
+			{
+				var ts = value as TimeSpan?;
+				var interval = " day";
+				long? increment;
+
+				if (ts == null)
+				{
+					generated = new SqlValue(dbType1, null);
+					return true;
+				}
+
+				if (ts.Value.Milliseconds > 0)
+				{
+					increment = (long)ts.Value.TotalMilliseconds;
+					interval = " millisecond";
+				}
+				else if (ts.Value.Seconds > 0)
+				{
+					increment = (long)ts.Value.TotalSeconds;
+					interval = " second";
+				}
+				else if (ts.Value.Minutes > 0)
+				{
+					increment = (long)ts.Value.TotalMinutes;
+					interval = " minute";
+				}
+				else if (ts.Value.Hours > 0)
+				{
+					increment = (long)ts.Value.TotalHours;
+					interval = " hour";
+				}
+				else
+				{
+					increment = (long)ts.Value.TotalDays;
+				}
+
+				if (isSubstraction)
+					increment = -increment;
+
+				generated = new SqlFunction(
+					dbType1.SystemType!,
+					"strftime",
+					false,
+					true,
+					_formatValue,
+					expr1,
+					new SqlBinaryExpression(typeof(string),
+						CreateSqlValue(increment, new DbDataType(typeof(long)), expr2), "||", new SqlValue(interval)))
+				{
+					CanBeNull = expr1.CanBeNull || expr2.CanBeNull
+				};
+				return true;
+			}
+
+
+			generated = null;
+			return false;
+		}
+
 		public override ISqlExpression ConvertExpressionImpl(ISqlExpression expr, ConvertVisitor visitor,
 			EvaluationContext context)
 		{
@@ -45,7 +118,27 @@ namespace LinqToDB.DataProvider.SQLite
 			{
 				switch (be.Operation)
 				{
-					case "+": return be.SystemType == typeof(string)? new SqlBinaryExpression(be.SystemType, be.Expr1, "||", be.Expr2, be.Precedence) : expr;
+					case "+":
+					{
+						if (be.SystemType == typeof(string)) 
+							return new SqlBinaryExpression(be.SystemType, be.Expr1, "||", be.Expr2, be.Precedence);
+
+						if (GenerateDateAdd(be.Expr1, be.Expr2, false, context, out var generated))
+							return generated;
+
+						if (GenerateDateAdd(be.Expr2, be.Expr1, false, context, out generated))
+							return generated;
+
+						break;
+					}
+					case "-":
+					{
+						if (GenerateDateAdd(be.Expr1, be.Expr2, true, context, out var generated))
+							return generated;
+
+						break;
+					}
+
 					case "^": // (a + b) - (a & b) * 2
 						return Sub(
 							Add(be.Expr1, be.Expr2, be.SystemType),

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlOptimizer.cs
@@ -32,46 +32,7 @@ namespace LinqToDB.DataProvider.SqlServer
 			);
 		}
 
-		public override bool IsParameterDependedElement(IQueryElement element)
-		{
-			if (base.IsParameterDependedElement(element))
-				return true;
-
-			switch (element.ElementType)
-			{
-				case QueryElementType.SqlBinaryExpression:
-				{
-					var be = (SqlBinaryExpression)element;
-
-					switch (be.Operation)
-					{
-						case "+":
-						case "-":
-						{
-							var dbType1 = be.Expr1.GetExpressionType();
-							var dbType2 = be.Expr2.GetExpressionType();
-
-							if (dbType1.SystemType.ToNullableUnderlying().In(typeof(DateTime), typeof(DateTimeOffset)) && dbType2.SystemType.ToNullableUnderlying() == typeof(TimeSpan) && be.Expr2.CanBeEvaluated(true))
-							{
-								return true;
-							}
-
-							if (dbType2.SystemType.ToNullableUnderlying().In(typeof(DateTime), typeof(DateTimeOffset)) && dbType1.SystemType.ToNullableUnderlying() == typeof(TimeSpan) && be.Expr1.CanBeEvaluated(true))
-							{
-								return true;
-							}
-
-							break;
-						}
-					}
-
-
-					break;
-				}
-			}
-
-			return false;
-		}
+		public override bool HasSpecialTimeSpanProcessing => true;
 
 		static bool GenerateDateAdd(ISqlExpression expr1, ISqlExpression expr2, bool isSubstraction, EvaluationContext context,
 			[MaybeNullWhen(false)] out ISqlExpression generated)
@@ -136,7 +97,6 @@ namespace LinqToDB.DataProvider.SqlServer
 
 			generated = null;
 			return false;
-
 		}
 
 		public override ISqlExpression ConvertExpressionImpl(ISqlExpression expr, ConvertVisitor visitor,

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseSqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseSqlOptimizer.cs
@@ -1,5 +1,10 @@
 ﻿namespace LinqToDB.DataProvider.Sybase
 {
+	using System;
+	using System.Diagnostics.CodeAnalysis;
+	using LinqToDB.Common;
+	using LinqToDB.Extensions;
+	using LinqToDB.Tools;
 	using SqlProvider;
 	using SqlQuery;
 
@@ -12,6 +17,101 @@
 		protected static string[] SybaseCharactersToEscape = {"_", "%", "[", "]", "^"};
 
 		public override string[] LikeCharactersToEscape => SybaseCharactersToEscape;
+
+		static bool GenerateDateAdd(ISqlExpression expr1, ISqlExpression expr2, bool isSubstraction, EvaluationContext context,
+			[MaybeNullWhen(false)] out ISqlExpression generated)
+		{
+			var dbType1 = expr1.GetExpressionType();
+			var dbType2 = expr2.GetExpressionType();
+
+			if (dbType1.SystemType.ToNullableUnderlying().In(typeof(DateTime), typeof(DateTimeOffset))
+				&& dbType2.SystemType.ToNullableUnderlying() == typeof(TimeSpan)
+				&& expr2.TryEvaluateExpression(context, out var value))
+			{
+				var ts = value as TimeSpan?;
+
+				if (ts == null)
+				{
+					generated = new SqlValue(dbType1, null);
+					return true;
+				}
+
+				// remove last digit as max precision Sybase supports is 6 for bigdatetime
+				// in 10^-6 seconds
+				var increment = ts.Value.Ticks / 10;
+
+				if (isSubstraction)
+					increment = -increment;
+
+				var maxValue = increment < 0 ? int.MinValue : int.MaxValue;
+
+				if (increment % 1000 != 0)
+				{
+					var interval = (int)(increment % maxValue);
+					increment   -= interval;
+					expr1        = CreateDateAdd(dbType1.SystemType!, "us", interval, expr1, expr2);
+				}
+
+				// in milliseconds
+				increment /= 1000;
+
+				if (increment % 1000 != 0)
+				{
+					var interval = (int)(increment % maxValue);
+					increment   -= interval;
+					expr1        = CreateDateAdd(dbType1.SystemType!, "ms", interval, expr1, expr2);
+				}
+
+				// in seconds
+				increment /= 1000;
+
+				if (increment % 60 != 0)
+				{
+					var interval = (int)(increment % maxValue);
+					increment   -= interval;
+					expr1        = CreateDateAdd(dbType1.SystemType!, "ss", interval, expr1, expr2);
+				}
+
+				// in minutes
+				increment /= 60;
+
+				if (increment % 60 != 0)
+				{
+					var interval = (int)(increment % maxValue);
+					increment   -= interval;
+					expr1        = CreateDateAdd(dbType1.SystemType!, "mi", interval, expr1, expr2);
+				}
+
+				// in hours (hours is last interval, as max interval will fit into it)
+				increment /= 60;
+
+				if (increment != 0)
+				{
+					var interval = (int)increment;
+					expr1        = CreateDateAdd(dbType1.SystemType!, "hh", interval, expr1, expr2);
+				}
+
+				generated = expr1;
+
+				return true;
+			}
+
+			generated = null;
+			return false;
+
+			static ISqlExpression CreateDateAdd(Type resultType, string interval, int increment, ISqlExpression dateTime, ISqlExpression intervalSource)
+			{
+				return new SqlFunction(
+						resultType,
+						"DateAdd",
+						false,
+						true,
+						new SqlExpression(typeof(string), interval, Precedence.Primary),
+						CreateSqlValue(increment, new DbDataType(typeof(int)), intervalSource),
+						dateTime)
+				{ CanBeNull = dateTime.CanBeNull || intervalSource.CanBeNull };
+			}
+		}
 
 		protected override ISqlExpression ConvertFunction(SqlFunction func)
 		{
@@ -56,6 +156,45 @@
 			}
 
 			return base.ConvertFunction(func);
+		}
+
+		public override ISqlExpression ConvertExpressionImpl(ISqlExpression expr, ConvertVisitor visitor, EvaluationContext context)
+		{
+			expr = base.ConvertExpressionImpl(expr, visitor, context);
+
+			switch (expr.ElementType)
+			{
+				case QueryElementType.SqlBinaryExpression:
+				{
+					var be = (SqlBinaryExpression)expr;
+
+					switch (be.Operation)
+					{
+						case "+":
+						{
+							if (GenerateDateAdd(be.Expr1, be.Expr2, false, context, out var generated))
+								return generated;
+
+							if (GenerateDateAdd(be.Expr2, be.Expr1, false, context, out generated))
+								return generated;
+
+							break;
+						}
+						case "-":
+						{
+							if (GenerateDateAdd(be.Expr1, be.Expr2, true, context, out var generated))
+								return generated;
+
+							break;
+						}
+					}
+
+					break;
+				}
+
+			}
+
+			return expr;
 		}
 	}
 }

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -1555,7 +1555,9 @@ namespace LinqToDB.Linq.Builder
 			{
 				if (!typeof(DataParameter).IsSameOrParentOf(newExpr.ValueExpression.Type))
 				{
-					if (columnDescriptor != null && !(originalAccessor is BinaryExpression))
+					if (columnDescriptor != null 
+					    && !(originalAccessor is BinaryExpression) 
+					    && columnDescriptor.GetDbDataType(false).SystemType.ToNullableUnderlying().IsAssignableFrom(originalAccessor.Type.ToNullableUnderlying()))
 					{
 						newExpr.DataType = columnDescriptor.GetDbDataType(true);
 						if (newExpr.ValueExpression.Type != columnDescriptor.MemberType)

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -900,16 +900,28 @@ namespace LinqToDB.Linq.Builder
 						
 						ISqlExpression l;
 						ISqlExpression r;
-						var ls = GetContext(context, e.Left);
-						if (ls?.IsExpression(e.Left, 0, RequestFor.Field).Result == true)
+
+						var shouldCheckColumn =
+							e.Left.Type.ToNullableUnderlying() == e.Right.Type.ToNullableUnderlying();
+
+						if (shouldCheckColumn)
 						{
-							l = ConvertToSql(context, e.Left);
-							r = ConvertToSql(context, e.Right, true, QueryHelper.GetColumnDescriptor(l) ?? columnDescriptor);
+							var ls = GetContext(context, e.Left);
+							if (ls?.IsExpression(e.Left, 0, RequestFor.Field).Result == true)
+							{
+								l = ConvertToSql(context, e.Left);
+								r = ConvertToSql(context, e.Right, true, QueryHelper.GetColumnDescriptor(l) ?? columnDescriptor);
+							}
+							else
+							{
+								r = ConvertToSql(context, e.Right, true);
+								l = ConvertToSql(context, e.Left, false, QueryHelper.GetColumnDescriptor(r) ?? columnDescriptor);
+							}
 						}
 						else
 						{
-							r = ConvertToSql(context, e.Right, true);
-							l = ConvertToSql(context, e.Left, false, QueryHelper.GetColumnDescriptor(r) ?? columnDescriptor);
+							l = ConvertToSql(context, e.Left, true, columnDescriptor);
+							r = ConvertToSql(context, e.Right, true, null);
 						}
 
 						var t = e.Type;
@@ -1555,9 +1567,7 @@ namespace LinqToDB.Linq.Builder
 			{
 				if (!typeof(DataParameter).IsSameOrParentOf(newExpr.ValueExpression.Type))
 				{
-					if (columnDescriptor != null 
-					    && !(originalAccessor is BinaryExpression) 
-					    && columnDescriptor.GetDbDataType(false).SystemType.ToNullableUnderlying().IsAssignableFrom(originalAccessor.Type.ToNullableUnderlying()))
+					if (columnDescriptor != null && !(originalAccessor is BinaryExpression))
 					{
 						newExpr.DataType = columnDescriptor.GetDbDataType(true);
 						if (newExpr.ValueExpression.Type != columnDescriptor.MemberType)

--- a/Source/LinqToDB/Mapping/MappingSchema.cs
+++ b/Source/LinqToDB/Mapping/MappingSchema.cs
@@ -604,7 +604,7 @@ namespace LinqToDB.Mapping
 			}
 			else if (type.IsNullable())
 			{
-				var convert = GetConvertExpression(fromType, type.ToNullableUnderlying());
+				var convert = GetConvertExpression(fromType, type.ToNullableUnderlying())!;
 				return convert;
 			}
 			else if (fromType.IsClass || fromType.IsInterface)

--- a/Source/LinqToDB/Mapping/MappingSchema.cs
+++ b/Source/LinqToDB/Mapping/MappingSchema.cs
@@ -604,7 +604,8 @@ namespace LinqToDB.Mapping
 			}
 			else if (type.IsNullable())
 			{
-				body = Expression.Convert(param, type);
+				var convert = GetConvertExpression(fromType, type.ToNullableUnderlying());
+				return convert;
 			}
 			else if (fromType.IsClass || fromType.IsInterface)
 			{

--- a/Source/LinqToDB/Mapping/MappingSchema.cs
+++ b/Source/LinqToDB/Mapping/MappingSchema.cs
@@ -604,8 +604,7 @@ namespace LinqToDB.Mapping
 			}
 			else if (type.IsNullable())
 			{
-				var convert = GetConvertExpression(fromType, type.ToNullableUnderlying())!;
-				return convert;
+				body = Expression.Convert(param, type); 
 			}
 			else if (fromType.IsClass || fromType.IsInterface)
 			{

--- a/Source/LinqToDB/Sql/Sql.DateTime.cs
+++ b/Source/LinqToDB/Sql/Sql.DateTime.cs
@@ -606,7 +606,7 @@ namespace LinqToDB
 				var date    = builder.GetExpression("date");
 				var number  = builder.GetExpression("number");
 
-				string expStr = "strftime('%Y-%m-%d %H:%M:%f', {0},";
+				string expStr = "strftime('%Y-%m-%d %H:%M:%f', {0}, ";
 				switch (part)
 				{
 					case Sql.DateParts.Year        : expStr +=            "{1} || ' Year')"; break;

--- a/Source/LinqToDB/SqlProvider/BasicSqlOptimizer.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlOptimizer.cs
@@ -2645,7 +2645,7 @@ namespace LinqToDB.SqlProvider
 				}
 				case QueryElementType.SqlBinaryExpression:
 				{
-					if (element.CanBeEvaluated(true) && !element.CanBeEvaluated(false))
+					if (element.IsEvaluableMutable())
 						return true;
 					return IsParameterDependedBinary((SqlBinaryExpression)element);
 				}
@@ -2745,12 +2745,16 @@ namespace LinqToDB.SqlProvider
 					var dbType1 = binary.Expr1.GetExpressionType();
 					var dbType2 = binary.Expr2.GetExpressionType();
 
-					if (dbType1.SystemType.ToNullableUnderlying().In(typeof(DateTime), typeof(DateTimeOffset)) && dbType2.SystemType.ToNullableUnderlying() == typeof(TimeSpan) && binary.Expr2.CanBeEvaluated(true))
+					if (dbType1.SystemType.ToNullableUnderlying().In(typeof(DateTime), typeof(DateTimeOffset)) 
+					    && dbType2.SystemType.ToNullableUnderlying() == typeof(TimeSpan) 
+					    && binary.Expr2.IsEvaluableMutable())
 					{
 						return true;
 					}
 
-					if (dbType2.SystemType.ToNullableUnderlying().In(typeof(DateTime), typeof(DateTimeOffset)) && dbType1.SystemType.ToNullableUnderlying() == typeof(TimeSpan) && binary.Expr1.CanBeEvaluated(true))
+					if (dbType2.SystemType.ToNullableUnderlying().In(typeof(DateTime), typeof(DateTimeOffset)) 
+					    && dbType1.SystemType.ToNullableUnderlying() == typeof(TimeSpan) 
+					    && binary.Expr2.IsEvaluableMutable())
 					{
 						return true;
 					}

--- a/Source/LinqToDB/SqlQuery/QueryHelper.Evaluate.cs
+++ b/Source/LinqToDB/SqlQuery/QueryHelper.Evaluate.cs
@@ -32,6 +32,11 @@ namespace LinqToDB.SqlQuery
 			return expr.TryEvaluateExpression(context).IsEvaluated;
 		}
 
+		public static bool IsEvaluableMutable(this IQueryElement expr)
+		{
+			return expr.CanBeEvaluated(true) && !expr.CanBeEvaluated(false);
+		}
+
 		public static EvaluationContext.EvaluationInfo TryEvaluateExpression(this IQueryElement expr, EvaluationContext context)
 		{
 			if (!context.TryGetValue(expr, out var info))

--- a/Tests/Base/ParamSourceAttribute.cs
+++ b/Tests/Base/ParamSourceAttribute.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections;
+using System.Reflection;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+
+namespace Tests
+{
+	[AttributeUsage(AttributeTargets.Parameter)]
+	public class ParamSourceAttribute : NUnitAttribute, IParameterDataSource
+	{
+		public string MethodName { get; }
+
+		public ParamSourceAttribute(string methodName)
+		{
+			MethodName = methodName;
+		}
+
+		public IEnumerable GetData(IParameterInfo parameter)
+		{
+			var method = parameter.Method.MethodInfo.DeclaringType?.GetMethod(MethodName,
+				BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+
+			if (method == null)
+				throw new InvalidOperationException($"Static method `{MethodName}` not found.");
+
+			var result = method.Invoke(null, new object[0]) as IEnumerable;
+			
+			if (result == null)
+				throw new InvalidOperationException("Static method `{MethodName}` not returned values.");
+			
+			return result;
+		}
+	}
+}

--- a/Tests/Base/TestBase.cs
+++ b/Tests/Base/TestBase.cs
@@ -17,7 +17,7 @@ using LinqToDB.Mapping;
 using LinqToDB.Reflection;
 using LinqToDB.Tools;
 using LinqToDB.Tools.Comparers;
-
+using Newtonsoft.Json;
 #if NET472
 using System.ServiceModel;
 using System.ServiceModel.Description;
@@ -1140,6 +1140,11 @@ namespace Tests
 			{
 				expected = empty.Provider.CreateQuery<T>(newExpr).ToArray();
 			}
+
+			/*
+			var actualJson = JsonConvert.SerializeObject(actual, Formatting.Indented);
+			var exptectedJson = JsonConvert.SerializeObject(expected, Formatting.Indented);
+			*/
 
 			if (actual.Length > 0 || expected.Length > 0)
 				AreEqual(expected, actual, ComparerBuilder.GetEqualityComparer<T>());

--- a/Tests/Linq/DataProvider/OracleTests.cs
+++ b/Tests/Linq/DataProvider/OracleTests.cs
@@ -3795,5 +3795,29 @@ CREATE TABLE ""TABLE_A""(
 			public int COLUMNC { get; set; }
 		}
 		#endregion
+
+		[Test]
+		public void TestDateTimeNAddTimeSpan([IncludeDataSources(true, TestProvName.AllOracle)] string context)
+		{
+			var ts = TimeSpan.FromHours(1);
+
+			using (var db = GetDataContext(context))
+			{
+				// ORA-00975: date + date not allowed
+				// ORA-0087: Adding two datetime values is not allowed
+				//db.GetTable<AllTypes>()
+				//	.Where(_ =>
+				//		_.datetimeDataType       > _.datetimeDataType       + ts ||
+				//		_.datetimeoffsetDataType > _.datetimeoffsetDataType + ts ||
+				//		_.localZoneDataType      > _.datetimeDataType       + ts ||
+				//		_.datetime2DataType > _.datetime2DataType + ts
+				//	).ToArray();
+
+				db.GetTable<AllTypes>()
+					.Where(_ =>
+						 Sql.CurrentTimestamp > _.datetime2DataType + ts
+					).ToArray();
+			}
+		}
 	}
 }

--- a/Tests/Linq/DataProvider/OracleTests.cs
+++ b/Tests/Linq/DataProvider/OracleTests.cs
@@ -3815,8 +3815,8 @@ CREATE TABLE ""TABLE_A""(
 
 				db.GetTable<AllTypes>()
 					.Where(_ =>
-						 Sql.CurrentTimestamp > _.datetime2DataType + ts
-					).ToArray();
+						 Sql.CurrentTimestamp > _.datetime2DataType + TimeSpan.FromHours(1)
+					).Select(x => x.ID).ToArray();
 			}
 		}
 	}

--- a/Tests/Linq/DataProvider/SqlServerTests.cs
+++ b/Tests/Linq/DataProvider/SqlServerTests.cs
@@ -1836,5 +1836,20 @@ AS
 				Assert.AreEqual("This is <test> scalar function parameter!", param.Description);
 			}
 		}
+
+		[Test]
+		public void TestDateTimeNAddTimeSpan([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.BeginTransaction())
+			{
+				db.GetTable<AllTypes2>()
+					.Update(_ => new AllTypes2()
+					{
+						dateDataType = _.dateDataType + TimeSpan.FromHours(1)
+					});
+			}
+		}
+
 	}
 }

--- a/Tests/Linq/DataProvider/SqlServerTests.cs
+++ b/Tests/Linq/DataProvider/SqlServerTests.cs
@@ -1837,9 +1837,9 @@ AS
 			}
 		}
 
-		static TimeSpan[] TimespansForTest()
+		static TimeSpan?[] TimespansForTest()
 		{
-			return new[]
+			return new TimeSpan?[]
 			{
 				TimeSpan.FromHours(1), 
 				TimeSpan.FromMinutes(61), 
@@ -1847,6 +1847,7 @@ AS
 				TimeSpan.FromSeconds(61),
 				TimeSpan.FromHours(24),
 				TimeSpan.FromHours(24) + TimeSpan.FromMilliseconds(1),
+				null
 			};
 		}
 

--- a/Tests/Linq/DataProvider/SqlServerTests.cs
+++ b/Tests/Linq/DataProvider/SqlServerTests.cs
@@ -1838,18 +1838,19 @@ AS
 		}
 
 		[Test]
-		public void TestDateTimeNAddTimeSpan([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		public void TestDateTimeNAddTimeSpan([IncludeDataSources(true, TestProvName.AllSqlServer2005Plus)] string context)
 		{
-			using (var db = new TestDataConnection(context))
-			using (db.BeginTransaction())
+			var ts = TimeSpan.FromHours(1);
+
+			using (var db = GetDataContext(context))
 			{
 				db.GetTable<AllTypes2>()
-					.Update(_ => new AllTypes2()
-					{
-						dateDataType = _.dateDataType + TimeSpan.FromHours(1)
-					});
+					.Where(_ =>
+						_.dateDataType           > _.dateDataType           + ts ||
+						_.datetime2DataType      > _.datetime2DataType      + ts ||
+						_.datetimeoffsetDataType > _.datetimeoffsetDataType + ts
+					).ToArray();
 			}
 		}
-
 	}
 }

--- a/Tests/Linq/DataProvider/SqlServerTests.cs
+++ b/Tests/Linq/DataProvider/SqlServerTests.cs
@@ -1119,7 +1119,7 @@ namespace Tests.DataProvider
 		}
 
 		[Table(Name="AllTypes2")]
-		class AllTypes2
+		internal class AllTypes2
 		{
 			[Column(DbType="int"),   PrimaryKey, Identity] public int             ID                     { get; set; } // int
 			[Column(DbType="date"),              Nullable] public DateTime?       dateDataType           { get; set; } // date

--- a/Tests/Linq/DataProvider/SqlServerTests.cs
+++ b/Tests/Linq/DataProvider/SqlServerTests.cs
@@ -1837,49 +1837,5 @@ AS
 			}
 		}
 
-		static TimeSpan?[] TimespansForTest()
-		{
-			return new TimeSpan?[]
-			{
-				TimeSpan.FromHours(1), 
-				TimeSpan.FromMinutes(61), 
-				TimeSpan.FromMinutes(120), 
-				TimeSpan.FromSeconds(61),
-				TimeSpan.FromHours(24),
-				TimeSpan.FromHours(24) + TimeSpan.FromMilliseconds(1),
-				null
-			};
-		}
-
-		[Test]
-		public void TestDateTimeNAddTimeSpan([IncludeDataSources(true, TestProvName.AllSqlServer2005Plus)] string context, 
-			[ParamSource(nameof(TimespansForTest))] TimeSpan? ts)
-		{
-			using (var db = GetDataContext(context))
-			{
-
-				var query =
-					from t in db.GetTable<AllTypes>()
-					select new
-					{
-						DT = t.dateDataType + ts,
-						DT2 = t.datetime2DataType + ts,
-						DTO = t.datetimeoffsetDataType + ts,
-
-						M_DT = t.dateDataType - ts,
-						M_DT2 = t.datetime2DataType - ts,
-						M_DTO = t.datetimeoffsetDataType - ts,
-
-						C_DT = t.dateDataType + Sql.ToSql(ts),
-						C_DT2 = t.datetime2DataType + Sql.ToSql(ts),
-						C_DTO = t.datetimeoffsetDataType + Sql.ToSql(ts),
-
-					};
-
-				var concated = query.Concat(query);
-
-				AssertQuery(concated);
-			}
-		}
 	}
 }

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -1614,11 +1614,16 @@ namespace Tests.Linq
 		[Test]
 		public void DateTimeOffsetAddTimeSpan(
 			[DataSources(
-				TestProvName.AllAccess, 
+				TestProvName.AllAccess,
 				TestProvName.AllFirebird,
 				TestProvName.AllSQLite,
 				TestProvName.AllSqlServer2005Minus,
-				ProviderName.SqlCe)] 
+				ProviderName.DB2,
+				TestProvName.AllInformix,
+				TestProvName.AllSapHana,
+				TestProvName.AllSybase,
+				TestProvName.AllMySqlData, // TODO: mysql.data doesn't support DateTimeOffset
+				ProviderName.SqlCe)]
 			string context,
 			[ParamSource(nameof(TimespansForTest))] TimeSpan? ts)
 		{

--- a/Tests/Linq/Linq/ExpressionsTests.cs
+++ b/Tests/Linq/Linq/ExpressionsTests.cs
@@ -1048,19 +1048,6 @@ namespace Tests.Linq
 
 		#endregion
 
-		[Test]
-		public void TestDateTimeNAddTimeSpan([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
-		{
-			using (var db = new TestDataConnection(context))
-			using (db.BeginTransaction())
-			{
-				db.GetTable<SqlServerTests.AllTypes2>()
-					.Update(_ => new SqlServerTests.AllTypes2()
-					{
-						dateDataType = _.dateDataType + TimeSpan.FromDays(1)
-					});
-			}
-		}
 	}
 
 	static class ExpressionTestExtensions

--- a/Tests/Linq/Linq/ExpressionsTests.cs
+++ b/Tests/Linq/Linq/ExpressionsTests.cs
@@ -13,6 +13,7 @@ using NUnit.Framework;
 namespace Tests.Linq
 {
 	using Model;
+	using Tests.DataProvider;
 
 	[TestFixture]
 	public class ExpressionsTests : TestBase
@@ -1047,6 +1048,19 @@ namespace Tests.Linq
 
 		#endregion
 
+		[Test]
+		public void TestDateTimeNAddTimeSpan([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.BeginTransaction())
+			{
+				db.GetTable<SqlServerTests.AllTypes2>()
+					.Update(_ => new SqlServerTests.AllTypes2()
+					{
+						dateDataType = _.dateDataType + TimeSpan.FromDays(1)
+					});
+			}
+		}
 	}
 
 	static class ExpressionTestExtensions

--- a/Tests/Tests.Playground/TestTemplate.cs
+++ b/Tests/Tests.Playground/TestTemplate.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Linq;
-
+using System.Linq.Expressions;
+using System.Reflection;
+using LinqToDB;
+using LinqToDB.Expressions;
 using LinqToDB.Mapping;
 
 using NUnit.Framework;
@@ -23,8 +26,63 @@ namespace Tests.Playground
 			using (var db = GetDataContext(context))
 			using (var table = db.CreateLocalTable<SampleClass>())
 			{
-				var result = table.ToArray();
+				var query1 = table.Where(t => t.Id == 1);
+				var query2 = table.Where(t2 => t2.Id == 2);
+
+				var zz = query1.JoinByProperties(query2, SqlJoinType.Inner, x => x.Id).ToArray();
 			}
+		}
+	}
+
+	public static class QueryableExtensions
+	{
+		private static MethodInfo _joinMethodInfo =
+			MemberHelper.MethodOfGeneric<IQueryable<object>>(o =>
+				o.Join(o, SqlJoinType.Inner, (xo, xi) => true, (xo, xi) => xi));
+
+		public class JoinResult<TOuter, TInner>
+		{
+			public TOuter Outer { get; set; } = default!;
+			public TInner Inner { get; set; } = default!;
+		}
+
+		public static Expression? Unwrap(this Expression? ex)
+		{
+			if (ex == null)
+				return null;
+
+			switch (ex.NodeType)
+			{
+				case ExpressionType.Quote:
+				case ExpressionType.ConvertChecked:
+				case ExpressionType.Convert:
+					return ((UnaryExpression)ex).Operand.Unwrap();
+			}
+
+			return ex;
+		}
+		
+		public static IQueryable<JoinResult<T, T>> JoinByProperties<T>(this IQueryable<T> source, IQueryable<T> target, SqlJoinType joinType, params Expression<Func<T, object>>[] properties) 
+			where T : class
+		{
+			Expression<Func<T, T, JoinResult<T, T>>> selectorLambda = (outer, inner) => new JoinResult<T, T> {Outer = outer, Inner = inner};
+			
+			var outerParam = selectorLambda.Parameters[0];
+			var innerParam = selectorLambda.Parameters[1];
+			Expression predicate = properties.Length == 0
+				? Expression.Constant(true)
+				: properties.Select(property => Expression.Equal(
+					property.GetBody(outerParam).Unwrap()!,
+					property.GetBody(innerParam).Unwrap()!)).Aggregate(Expression.AndAlso);
+
+			var predicateLambda = Expression.Lambda(predicate, outerParam, innerParam);
+
+			var method = _joinMethodInfo.MakeGenericMethod(typeof(T), typeof(T), typeof(JoinResult<T, T>));
+
+			var queryExpression = Expression.Call(method, source.Expression, target.Expression, Expression.Constant(joinType),
+				Expression.Quote(predicateLambda), Expression.Quote(selectorLambda));
+
+			return source.Provider.CreateQuery<JoinResult<T, T>>(queryExpression);
 		}
 	}
 }

--- a/Tests/Tests.Playground/Tests.Playground.csproj
+++ b/Tests/Tests.Playground/Tests.Playground.csproj
@@ -9,5 +9,7 @@
 
 	<ItemGroup>
 		<Compile Include="..\Linq\Create\CreateData.cs" Link="CreateData.cs" />
+		<Compile Include="..\Linq\DataProvider\OracleTests.cs" Link="OracleTests.cs" />
+		<Compile Include="..\Linq\DataProvider\SqlServerTests.cs" Link="SqlServerTests.cs" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Another regression.

```
Message: 
    System.InvalidOperationException : No coercion operator is defined between types 'System.TimeSpan' and 'System.Nullable`1[System.DateTime]'.
    DataConnection: To generate test code to diagnose the problem set 'LinqToDB.Common.Configuration.Linq.GenerateExpressionTest = true'.
    
  Stack Trace: 
    Expression.GetUserDefinedCoercionOrThrow(ExpressionType coercionType, Expression expression, Type convertToType)
    Expression.Convert(Expression expression, Type type, MethodInfo method)
    MappingSchema.GenerateSafeConvert(Type fromType, Type type) line 600
    ExpressionBuilder.PrepareConvertersAndCreateParameter(ValueTypeExpression newExpr, Expression valueExpression, String name, ColumnDescriptor columnDescriptor, BuildParameterType buildParameterType) line 1565
    ExpressionBuilder.BuildParameter(Expression expr, ColumnDescriptor columnDescriptor, Boolean forceConstant, BuildParameterType buildParameterType) line 1420
    ExpressionBuilder.ConvertToSql(IBuildContext context, Expression expression, Boolean unwrap, ColumnDescriptor columnDescriptor, Boolean isPureExpression) line 856
    ExpressionBuilder.ConvertToSql(IBuildContext context, Expression expression, Boolean unwrap, ColumnDescriptor columnDescriptor, Boolean isPureExpression) line 907
    UpdateBuilder.<BuildSetterWithContext>g__BuildSetter|5_0(MemberExpression memberExpression, Expression expression, <>c__DisplayClass5_0& ) line 201
    UpdateBuilder.<BuildSetterWithContext>g__BuildMemberInit|5_2(MemberInitExpression expression, Expression path, <>c__DisplayClass5_0& ) line 259
    UpdateBuilder.BuildSetterWithContext(ExpressionBuilder builder, BuildInfo buildInfo, LambdaExpression setter, IBuildContext into, List`1 items, IBuildContext[] sequences) line 290
    UpdateBuilder.BuildSetter(ExpressionBuilder builder, BuildInfo buildInfo, LambdaExpression setter, IBuildContext into, List`1 items, IBuildContext sequence
```