### PR TITLE
Null check from expression missing in query

### DIFF
--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -3183,11 +3183,13 @@ namespace LinqToDB.Linq.Builder
 						{
 							if (nullRight && nullLeft)
 							{
-								return conditional.IfFalse.Transform(e => RemoveNullPropagation(e));
+								return conditional.IfFalse.Transform(RemoveNullPropagation);
 							}
-							else if (IsNullConstant(conditional.IfFalse))
+							else if (IsNullConstant(conditional.IfFalse)
+								&& ((nullRight && !MappingSchema.IsScalarType(binary.Left.Type)) ||
+									(nullLeft  && !MappingSchema.IsScalarType(binary.Right.Type))))
 							{
-								return conditional.IfTrue.Transform(e => RemoveNullPropagation(e));
+								return conditional.IfTrue.Transform(RemoveNullPropagation);
 							}
 						}
 					}
@@ -3200,11 +3202,13 @@ namespace LinqToDB.Linq.Builder
 						{
 							if (nullRight && nullLeft)
 							{
-								return conditional.IfTrue.Transform(e => RemoveNullPropagation(e));
+								return conditional.IfTrue.Transform(RemoveNullPropagation);
 							}
-							else if (IsNullConstant(conditional.IfTrue))
+							else if (IsNullConstant(conditional.IfTrue)
+								&& ((nullRight && !MappingSchema.IsScalarType(binary.Left.Type)) ||
+									(nullLeft  && !MappingSchema.IsScalarType(binary.Right.Type))))
 							{
-								return conditional.IfFalse.Transform(e => RemoveNullPropagation(e));
+								return conditional.IfFalse.Transform(RemoveNullPropagation);
 							}
 						}
 					}

--- a/Tests/Linq/Linq/ExpressionsTests.cs
+++ b/Tests/Linq/Linq/ExpressionsTests.cs
@@ -1028,7 +1028,7 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 			{
-				db.Parent.Any(p => p.ParentID == Function2(Function1Left(p.Value1)));
+				db.Parent.Where(p => p.Value1 == null).Any(p => p.ParentID == Function2(Function1Left(p.Value1)));
 			}
 		}
 
@@ -1037,7 +1037,7 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 			{
-				db.Parent.Any(p => p.ParentID == Function2(Function1Right(p.Value1)));
+				db.Parent.Where(p => p.Value1 == null).Any(p => p.ParentID == Function2(Function1Right(p.Value1)));
 			}
 		}
 

--- a/Tests/Linq/Linq/ExpressionsTests.cs
+++ b/Tests/Linq/Linq/ExpressionsTests.cs
@@ -1023,6 +1023,24 @@ namespace Tests.Linq
 			}
 		}
 
+		[Test]
+		public void TestNullCheckInExpressionUsingFieldLeft([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				db.Parent.Any(p => p.ParentID == Function2(Function1Left(p.Value1)));
+			}
+		}
+
+		[Test]
+		public void TestNullCheckInExpressionUsingFieldRight([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				db.Parent.Any(p => p.ParentID == Function2(Function1Right(p.Value1)));
+			}
+		}
+
 		[Sql.Expression("{0}", ServerSideOnly = true, IsNullable = Sql.IsNullableType.SameAsFirstParameter)]
 		public static int? Function2(int? Value) => throw new InvalidOperationException();
 


### PR DESCRIPTION
```sql
 SELECT
    	IIF(EXISTS(
    		SELECT
    			*
    		FROM
    			[Parent] [p]
    		WHERE
    			[p].[ParentID] = CAST(N'SHOULD NOT BE CALLED' AS INT)
    	), 1, 0)
```