### PR TITLE
Fix. Returning wrong identity at SapHana

### DIFF
--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaSqlBuilder.cs
@@ -34,10 +34,7 @@ namespace LinqToDB.DataProvider.SapHana
 				if (identityField == null || table == null)
 					throw new SqlException("Identity field must be defined for '{0}'.", insertClause.Into.Name);
 
-				StringBuilder.Append("SELECT MAX(");
-				BuildExpression(identityField, false, true);
-				StringBuilder.Append(") FROM ");
-				BuildPhysicalTable(table, null);
+				StringBuilder.Append("SELECT CURRENT_IDENTITY_VALUE() FROM DUMMY");
 			}
 		}
 


### PR DESCRIPTION
Issue. SapHana.
With a large number of parallel insertWithIdentity into the same table, sometimes returned wrong identity. 
SELECT MAX(id) FROM table is not best way to get last identity at SapHana. Using CURRENT_IDENTITY_VALUE() is right way.

https://help.sap.com/viewer/7c78579ce9b14a669c1f3295b0d8ca16/Cloud/en-US/01e1a30aa542448da56da76233fea779.html