### PR TITLE
Incorrest SQL generated for order by contains column

### DIFF
--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -3148,26 +3148,6 @@ namespace LinqToDB.Linq.Builder
 			return MappingSchema.GetAttribute<Sql.TableFunctionAttribute>(member.ReflectedType!, member, a => a.Configuration);
 		}
 
-		internal ISqlExpression ConvertSearchCondition(ISqlExpression sqlExpression)
-		{
-			if (sqlExpression is SqlSearchCondition)
-			{
-				if (sqlExpression.CanBeNull)
-				{
-					var notExpr = new SqlSearchCondition
-					{
-						Conditions = { new SqlCondition(true, new SqlPredicate.Expr(sqlExpression)) }
-					};
-
-					return new SqlFunction(sqlExpression.SystemType!, "CASE", sqlExpression, new SqlValue(1), notExpr, new SqlValue(0), new SqlValue(sqlExpression.SystemType!, null)) { CanBeNull = false };
-				}
-
-				return new SqlFunction(sqlExpression.SystemType!, "CASE", sqlExpression, new SqlValue(1), new SqlValue(0)) { CanBeNull = false };
-			}
-
-			return sqlExpression;
-		}
-
 		bool IsNullConstant(Expression expr)
 		{
 			return expr.NodeType == ExpressionType.Constant  && ((ConstantExpression)expr).Value == null 

--- a/Source/LinqToDB/Linq/Builder/OrderByBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/OrderByBuilder.cs
@@ -102,8 +102,7 @@ namespace LinqToDB.Linq.Builder
 				if (QueryHelper.IsConstant(expr.Sql))
 					continue;
 			
-				var e = builder.ConvertSearchCondition(expr.Sql);
-				sequence.SelectQuery.OrderBy.Expr(e, methodCall.Method.Name.EndsWith("Descending"));
+				sequence.SelectQuery.OrderBy.Expr(expr.Sql, methodCall.Method.Name.EndsWith("Descending"));
 			}
 
 			return sequence;

--- a/Source/LinqToDB/Linq/Builder/SelectContext.cs
+++ b/Source/LinqToDB/Linq/Builder/SelectContext.cs
@@ -465,19 +465,7 @@ namespace LinqToDB.Linq.Builder
 		SqlInfo[] ConvertExpressions(Expression expression, ConvertFlags flags, ColumnDescriptor? columnDescriptor)
 		{
 			return Builder.ConvertExpressions(this, expression, flags, columnDescriptor)
-				.Select (CheckExpression)
 				.ToArray();
-		}
-
-		SqlInfo CheckExpression(SqlInfo expression)
-		{
-			if (expression.Sql is SqlSearchCondition)
-			{
-				expression = expression.WithSql(
-					new SqlFunction(typeof(bool), "CASE", expression.Sql, new SqlValue(true), new SqlValue(false)) { CanBeNull = false });
-			}
-
-			return expression;
 		}
 
 		#endregion

--- a/Tests/Linq/Linq/OrderByTests.cs
+++ b/Tests/Linq/Linq/OrderByTests.cs
@@ -613,6 +613,16 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 			{
 				var ids = new int[]{ 1, 3 };
+				db.Person.OrderBy(_ => ids.Contains(_.ID)).ToList();
+			}
+		}
+
+		[Test]
+		public void OrderByContainsSubquery([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var ids = new int[]{ 1, 3 };
 				db.Person.Select(_ => new { _.ID, _.LastName, flag = ids.Contains(_.ID) }).OrderBy(_ => _.flag).ToList();
 			}
 		}

--- a/Tests/Linq/Linq/OrderByTests.cs
+++ b/Tests/Linq/Linq/OrderByTests.cs
@@ -607,5 +607,15 @@ namespace Tests.Linq
 			}
 		}
 
+		[Test]
+		public void OrderByContains([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var ids = new int[]{ 1, 3 };
+				db.Person.Select(_ => new { _.ID, _.LastName, flag = ids.Contains(_.ID) }).OrderBy(_ => _.flag).ToList();
+			}
+		}
+
 	}
 }


### PR DESCRIPTION
not all providers support IN as predicate (list below)
also minor issue - contains result not selected, but re-evaluated on server
```sql
 SELECT
    	[_].[PersonID],
    	[_].[LastName]
    FROM
    	[Person] [_]
    ORDER BY
    	[_].[PersonID] IN (1, 3)
```

Fails for:
- Firebird 2.5 (works in 3.0). Note that I'm working on versioning support for firebird so it makes sense to preserve 3.0 behavior (maybe commented for now)
- oracle (at least v11), need to test v12 on CI
- SAP HANA
- SQL Server
- SQL CE
- Sybase ASE