### PR TITLE
Association update query generates wrong SQL

### DIFF
--- a/Source/LinqToDB/SqlQuery/SelectQueryOptimizer.cs
+++ b/Source/LinqToDB/SqlQuery/SelectQueryOptimizer.cs
@@ -970,9 +970,14 @@ namespace LinqToDB.SqlQuery
 			//isQueryOK = isQueryOK && (_flags.IsDistinctOrderBySupported || query.Select.IsDistinct );
 			isQueryOK = isQueryOK && (!parentQuery.HasSetOperators || query.OrderBy.IsEmpty);
 
-			if (isQueryOK && parentJoin != JoinType.Inner && query.From.Tables[0].Joins.Count > 0)
+			if (isQueryOK && parentJoin != JoinType.Inner)
 			{
-				isQueryOK = false;
+				var sqlTableSource = query.From.Tables[0];
+				if (sqlTableSource.Joins.Count > 0)
+				{
+					if (sqlTableSource.Joins.Any(j => j.JoinType != parentJoin))
+						isQueryOK = false;
+				}
 			}
 
 			if (!isQueryOK)

--- a/Tests/Linq/Update/UpdateTests.cs
+++ b/Tests/Linq/Update/UpdateTests.cs
@@ -1779,5 +1779,22 @@ namespace Tests.xUpdate
 
 			}
 		}
+
+		[Test]
+		public void UpdateByAssociation([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var id = -1;
+
+				db.Person.Where(_ => _.ID == id)
+					.Select(_ => _.Patient!.Person)
+					.Update(auto6862 => new Person()
+					{
+						LastName = "test"
+					});
+
+			}
+		}
 	}
 }


### PR DESCRIPTION
`SqlException : The multi-part identifier "a_Patient.LastName" could not be bound.`

```sql
DECLARE @id Int -- Int32
    SET     @id = -1
    
    UPDATE
    	[Person]
    SET
    	[a_Patient].[LastName] = N'test'
    FROM
    	[Person] [_]
    		LEFT JOIN (
    			SELECT
    				[a_Person].[LastName],
    				[t1].[PersonID]
    			FROM
    				[Patient] [t1]
    					LEFT JOIN [Person] [a_Person] ON [t1].[PersonID] = [a_Person].[PersonID]
    		) [a_Patient] ON [_].[PersonID] = [a_Patient].[PersonID]
    WHERE
    	[_].[PersonID] = @id
```