### PR TITLE
Lower allocations to improve ConvertBinaryToSql performance

### DIFF
--- a/Source/LinqToDB/Common/Configuration.cs
+++ b/Source/LinqToDB/Common/Configuration.cs
@@ -45,18 +45,26 @@ namespace LinqToDB.Common
 		
 		/// <summary>
 		/// Determines the length after which logging of binary data in SQL will be truncated.
-		/// Use a value of -1 to disable. Set to 0 to truncate all binary data.
 		/// This is to avoid Out-Of-Memory exceptions when getting SqlText from <see cref="TraceInfo"/>
 		/// or <see cref="IExpressionQuery"/> for logging or other purposes.
 		/// </summary>
+		/// <remarks>
+		/// This value defaults to 100.
+		/// Use a value of -1 to disable and always log full binary.
+		/// Set to 0 to truncate all binary data.
+		/// </remarks>
 		public static int MaxBinaryParameterLengthLogging { get; set; } = 100;
 
 		/// <summary>
 		/// Determines the length after which logging of string data in SQL will be truncated.
-		/// Use a value of -1 to disable. Set to 0 to truncate all binary data.
 		/// This is to avoid Out-Of-Memory exceptions when getting SqlText from <see cref="TraceInfo"/>
 		/// or <see cref="IExpressionQuery"/> for logging or other purposes.
 		/// </summary>
+		/// <remarks>
+		/// This value defaults to 200.
+		/// Use a value of -1 to disable and always log full string.
+		/// Set to 0 to truncate all string data.
+		/// </remarks>
 		public static int MaxStringParameterLengthLogging { get; set; } = 200;
 
 		public static class Data

--- a/Source/LinqToDB/Common/Configuration.cs
+++ b/Source/LinqToDB/Common/Configuration.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 
 using JetBrains.Annotations;
+using LinqToDB.Linq;
 
 namespace LinqToDB.Common
 {
@@ -40,6 +41,13 @@ namespace LinqToDB.Common
 		/// queries, so this optimization could be used for <see cref="CommandBehavior.Default"/> too.
 		/// </summary>
 		public static bool OptimizeForSequentialAccess = false;
+		
+		/// <summary>
+		/// Determines the length after which logging of binary data in SQL will be truncated.
+		/// This is to avoid Out-Of-Memory exceptions when getting SqlText from <see cref="TraceInfo"/>
+		/// or <see cref="IExpressionQuery"/> for logging or other purposes.
+		/// </summary>
+		public static int MaxByteLengthLogging { get; set; } = 1024;
 
 		public static class Data
 		{

--- a/Source/LinqToDB/Common/Configuration.cs
+++ b/Source/LinqToDB/Common/Configuration.cs
@@ -47,7 +47,14 @@ namespace LinqToDB.Common
 		/// This is to avoid Out-Of-Memory exceptions when getting SqlText from <see cref="TraceInfo"/>
 		/// or <see cref="IExpressionQuery"/> for logging or other purposes.
 		/// </summary>
-		public static int MaxByteLengthLogging { get; set; } = 1024;
+		public static int MaxBinaryParameterLengthLogging { get; set; } = 100;
+
+		/// <summary>
+		/// Determines the length after which logging of string data in SQL will be truncated.
+		/// This is to avoid Out-Of-Memory exceptions when getting SqlText from <see cref="TraceInfo"/>
+		/// or <see cref="IExpressionQuery"/> for logging or other purposes.
+		/// </summary>
+		public static int MaxStringParameterLengthLogging { get; set; } = 200;
 
 		public static class Data
 		{

--- a/Source/LinqToDB/Common/Configuration.cs
+++ b/Source/LinqToDB/Common/Configuration.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 
 using JetBrains.Annotations;
-using LinqToDB.Linq;
+
 
 namespace LinqToDB.Common
 {
+	using LinqToDB.Linq;
 	using Data;
 	using Data.RetryPolicy;
 	using System.Data;

--- a/Source/LinqToDB/Common/Configuration.cs
+++ b/Source/LinqToDB/Common/Configuration.cs
@@ -44,6 +44,7 @@ namespace LinqToDB.Common
 		
 		/// <summary>
 		/// Determines the length after which logging of binary data in SQL will be truncated.
+		/// Use a value of -1 to disable. Set to 0 to truncate all binary data.
 		/// This is to avoid Out-Of-Memory exceptions when getting SqlText from <see cref="TraceInfo"/>
 		/// or <see cref="IExpressionQuery"/> for logging or other purposes.
 		/// </summary>
@@ -51,6 +52,7 @@ namespace LinqToDB.Common
 
 		/// <summary>
 		/// Determines the length after which logging of string data in SQL will be truncated.
+		/// Use a value of -1 to disable. Set to 0 to truncate all binary data.
 		/// This is to avoid Out-Of-Memory exceptions when getting SqlText from <see cref="TraceInfo"/>
 		/// or <see cref="IExpressionQuery"/> for logging or other purposes.
 		/// </summary>

--- a/Source/LinqToDB/Common/StringBuilderExtensions.cs
+++ b/Source/LinqToDB/Common/StringBuilderExtensions.cs
@@ -12,7 +12,7 @@ namespace LinqToDB.Common
 			var result = new uint[256];
 			for (int i = 0; i < 256; i++)
 			{
-				string s =i.ToString("X2");
+				string s = i.ToString("X2");
 				result[i] = ((uint)s[0]) + ((uint)s[1] << 16);
 			}
 			return result;

--- a/Source/LinqToDB/Common/StringBuilderExtensions.cs
+++ b/Source/LinqToDB/Common/StringBuilderExtensions.cs
@@ -35,9 +35,9 @@ namespace LinqToDB.Common
 		public static void AppendByteArrayAsHexViaLookup32(this StringBuilder sb, byte[] bytes)
 		{
 			var lookup32 = _lookup32;
-			for (int i = 0; i < bytes.Length; i++)
+			foreach (var b in bytes)
 			{
-				var val = lookup32[bytes[i]];
+				var val = lookup32[b];
 				sb.Append((char)val);
 				sb.Append((char) (val >> 16));
 			}

--- a/Source/LinqToDB/Common/StringBuilderExtensions.cs
+++ b/Source/LinqToDB/Common/StringBuilderExtensions.cs
@@ -1,0 +1,46 @@
+﻿using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace LinqToDB.Common
+{
+	public static class StringBuilderExtensions
+	{
+		private static readonly uint[] _lookup32 = CreateLookup32();
+        
+		private static uint[] CreateLookup32()
+		{
+			var result = new uint[256];
+			for (int i = 0; i < 256; i++)
+			{
+				string s =i.ToString("X2");
+				result[i] = ((uint)s[0]) + ((uint)s[1] << 16);
+			}
+			return result;
+		}
+        
+		/// <summary>
+		/// Appends an array of bytes to a <see cref="StringBuilder"/> in hex (i.e. 255->FF)
+		/// format utilizing a static lookup table to minimize allocations.
+		/// </summary>
+		/// <param name="sb">The <see cref="StringBuilder"/> to append to</param>
+		/// <param name="bytes">The byte array to append in hex</param>
+		/// <remarks>
+		/// The implementation here was chosen based on:
+		/// https://stackoverflow.com/a/624379/2937845
+		/// Which indicated that  https://stackoverflow.com/a/24343727/2937845's
+		/// implementation of ByteArrayToHexViaLookup32 was the fastest method
+		/// not involving unsafe 
+		/// </remarks>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static void AppendByteArrayAsHexViaLookup32(this StringBuilder sb, byte[] bytes)
+		{
+			var lookup32 = _lookup32;
+			for (int i = 0; i < bytes.Length; i++)
+			{
+				var val = lookup32[bytes[i]];
+				sb.Append((char)val);
+				sb.Append((char) (val >> 16));
+			}
+		}
+	}
+}

--- a/Source/LinqToDB/DataProvider/Access/AccessMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessMappingSchema.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Text;
-using LinqToDB.Common;
+
 
 namespace LinqToDB.DataProvider.Access
 {
+	using Common;
 	using Mapping;
 	using SqlQuery;
 	using System.Data.Linq;

--- a/Source/LinqToDB/DataProvider/Access/AccessMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessMappingSchema.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using LinqToDB.Common;
 
 namespace LinqToDB.DataProvider.Access
 {
@@ -34,8 +35,7 @@ namespace LinqToDB.DataProvider.Access
 		{
 			stringBuilder.Append("0x");
 
-			foreach (var b in value)
-				stringBuilder.Append(b.ToString("X2"));
+			stringBuilder.AppendByteArrayAsHexViaLookup32(value);
 		}
 
 		static void AppendConversion(StringBuilder stringBuilder, int value)

--- a/Source/LinqToDB/DataProvider/Access/AccessODBCSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessODBCSchemaProvider.cs
@@ -3,12 +3,13 @@ using System.Data;
 using System.Data.Common;
 using System.Linq;
 
-using LinqToDB.Common;
-using LinqToDB.Data;
-using LinqToDB.SchemaProvider;
+
 
 namespace LinqToDB.DataProvider.Access
 {
+	using Common;
+	using Data;
+	using SchemaProvider;
 	// https://docs.microsoft.com/en-us/dotnet/framework/data/adonet/odbc-schema-collections
 	// unused tables:
 	// DataSourceInformation - database settings

--- a/Source/LinqToDB/DataProvider/DB2/DB2MappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2MappingSchema.cs
@@ -108,8 +108,7 @@ namespace LinqToDB.DataProvider.DB2
 		{
 			stringBuilder.Append("BX'");
 
-			foreach (var b in value)
-				stringBuilder.Append(b.ToString("X2"));
+			stringBuilder.AppendByteArrayAsHexViaLookup32(value);
 
 			stringBuilder.Append("'");
 		}

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdMappingSchema.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using LinqToDB.Common;
 
 namespace LinqToDB.DataProvider.Firebird
 {
@@ -44,8 +45,7 @@ namespace LinqToDB.DataProvider.Firebird
 		{
 			stringBuilder.Append("X'");
 
-			foreach (var b in value)
-				stringBuilder.Append(b.ToString("X2"));
+			stringBuilder.AppendByteArrayAsHexViaLookup32(value);
 
 			stringBuilder.Append("'");
 		}

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdMappingSchema.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Text;
-using LinqToDB.Common;
+
 
 namespace LinqToDB.DataProvider.Firebird
 {
+	using Common;
 	using Mapping;
 	using SqlQuery;
 	using System.Data.Linq;

--- a/Source/LinqToDB/DataProvider/Informix/InformixMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixMappingSchema.cs
@@ -4,7 +4,7 @@ using System.Text;
 namespace LinqToDB.DataProvider.Informix
 {
 	using System.Globalization;
-	using LinqToDB.Common;
+	using Common;
 	using Mapping;
 	using SqlQuery;
 

--- a/Source/LinqToDB/DataProvider/MySql/MySqlMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlMappingSchema.cs
@@ -66,8 +66,7 @@ namespace LinqToDB.DataProvider.MySql
 		{
 			stringBuilder.Append("0x");
 
-			foreach (var b in value)
-				stringBuilder.Append(b.ToString("X2"));
+			stringBuilder.AppendByteArrayAsHexViaLookup32(value);
 		}
 
 		internal static readonly MappingSchema Instance = new MySqlMappingSchema();

--- a/Source/LinqToDB/DataProvider/Oracle/OracleMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleMappingSchema.cs
@@ -41,8 +41,7 @@ namespace LinqToDB.DataProvider.Oracle
 		{
 			stringBuilder.Append("HEXTORAW('");
 
-			foreach (var b in value)
-				stringBuilder.Append(b.ToString("X2"));
+			stringBuilder.AppendByteArrayAsHexViaLookup32(value);
 
 			stringBuilder.Append("')");
 		}

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
@@ -75,8 +75,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 		{
 			stringBuilder.Append("E'\\\\x");
 
-			foreach (var b in value)
-				stringBuilder.Append(b.ToString("X2"));
+			stringBuilder.AppendByteArrayAsHexViaLookup32(value);
 
 			stringBuilder.Append("'");
 		}

--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteMappingSchema.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Text;
+using LinqToDB.Common;
 
 namespace LinqToDB.DataProvider.SQLite
 {
@@ -32,8 +33,7 @@ namespace LinqToDB.DataProvider.SQLite
 		{
 			stringBuilder.Append("X'");
 
-			foreach (var b in value)
-				stringBuilder.Append(b.ToString("X2"));
+			stringBuilder.AppendByteArrayAsHexViaLookup32(value);
 
 			stringBuilder.Append("'");
 		}

--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteMappingSchema.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Globalization;
 using System.Text;
-using LinqToDB.Common;
+
 
 namespace LinqToDB.DataProvider.SQLite
 {
+	using Common;
 	using Mapping;
 	using SqlQuery;
 	using System.Data.Linq;

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaMappingSchema.cs
@@ -1,4 +1,6 @@
-﻿namespace LinqToDB.DataProvider.SapHana
+﻿using LinqToDB.Common;
+
+namespace LinqToDB.DataProvider.SapHana
 {
 	using Mapping;
 	using SqlQuery;
@@ -36,8 +38,7 @@
 		{
 			stringBuilder.Append("x'");
 
-			foreach (var b in value)
-				stringBuilder.Append(b.ToString("X2"));
+			stringBuilder.AppendByteArrayAsHexViaLookup32(value);
 
 			stringBuilder.Append("'");
 		}

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaMappingSchema.cs
@@ -1,7 +1,8 @@
-﻿using LinqToDB.Common;
+﻿
 
 namespace LinqToDB.DataProvider.SapHana
 {
+	using Common;
 	using Mapping;
 	using SqlQuery;
 	using System.Data.Linq;

--- a/Source/LinqToDB/DataProvider/SqlCe/SqlCeMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/SqlCe/SqlCeMappingSchema.cs
@@ -65,8 +65,7 @@ namespace LinqToDB.DataProvider.SqlCe
 		{
 			stringBuilder.Append("0x");
 
-			foreach (var b in value)
-				stringBuilder.Append(b.ToString("X2"));
+			stringBuilder.AppendByteArrayAsHexViaLookup32(value);
 		}
 
 		static void AppendConversion(StringBuilder stringBuilder, int value)

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerMappingSchema.cs
@@ -209,10 +209,9 @@ namespace LinqToDB.DataProvider.SqlServer
 		static void ConvertBinaryToSql(StringBuilder stringBuilder, byte[] value)
 		{
 			stringBuilder.Append("0x");
-
-			foreach (var b in value)
-				stringBuilder.Append(b.ToString("X2"));
+			stringBuilder.AppendByteArrayAsHexViaLookup32(value);
 		}
+		
 	}
 
 	public class SqlServer2000MappingSchema : MappingSchema

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseMappingSchema.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using LinqToDB.Common;
 
 namespace LinqToDB.DataProvider.Sybase
 {
@@ -28,8 +29,7 @@ namespace LinqToDB.DataProvider.Sybase
 		{
 			stringBuilder.Append("0x");
 
-			foreach (var b in value)
-				stringBuilder.Append(b.ToString("X2"));
+			stringBuilder.AppendByteArrayAsHexViaLookup32(value);
 		}
 
 		static void ConvertTimeSpanToSql(StringBuilder stringBuilder, SqlDataType sqlDataType, TimeSpan value)

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseMappingSchema.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Text;
-using LinqToDB.Common;
+
 
 namespace LinqToDB.DataProvider.Sybase
 {
+	using Common;
 	using Mapping;
 	using SqlQuery;
 	using System.Data.Linq;

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -3084,7 +3084,7 @@ namespace LinqToDB.SqlProvider
 					PrintParameterName(sb, p);
 					sb.Append(" = ");
 					if (p.Value is byte[] bytes                           &&
-					    Configuration.MaxBinaryParameterLengthLogging >=0 &&
+					    Configuration.MaxBinaryParameterLengthLogging >= 0 &&
 					    bytes.Length > Configuration.MaxBinaryParameterLengthLogging &&
 					    ValueToSqlConverter.CanConvert(typeof(byte[])))
 					{
@@ -3097,7 +3097,7 @@ namespace LinqToDB.SqlProvider
 							$"-- value above truncated for logging, actual length is {bytes.Length}");
 					}
 					else if (p.Value is Binary binaryData &&
-					         Configuration.MaxBinaryParameterLengthLogging >=0 &&
+					         Configuration.MaxBinaryParameterLengthLogging >= 0 &&
 					         binaryData.Length > Configuration.MaxBinaryParameterLengthLogging &&
 					         ValueToSqlConverter.CanConvert(typeof(Binary)))
 					{
@@ -3112,7 +3112,7 @@ namespace LinqToDB.SqlProvider
 							$"-- value above truncated for logging, actual length is {binaryData.Length}");
 					}
 					else if (p.Value is string s && 
-					         Configuration.MaxStringParameterLengthLogging >=0 &&
+					         Configuration.MaxStringParameterLengthLogging >= 0 &&
 					         s.Length > Configuration.MaxStringParameterLengthLogging &&
 					         ValueToSqlConverter.CanConvert(typeof(string)))
 					{

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -3084,30 +3084,41 @@ namespace LinqToDB.SqlProvider
 					PrintParameterName(sb, p);
 					sb.Append(" = ");
 					if (p.Value is byte[] bytes                           &&
-					    bytes.Length > Configuration.MaxByteLengthLogging &&
+					    bytes.Length > Configuration.MaxBinaryParameterLengthLogging &&
 					    ValueToSqlConverter.CanConvert(typeof(byte[])))
 					{
 						var trimmed =
-							new byte[Configuration.MaxByteLengthLogging];
+							new byte[Configuration.MaxBinaryParameterLengthLogging];
 						Array.Copy(bytes, 0, trimmed, 0,
-							Configuration.MaxByteLengthLogging);
+							Configuration.MaxBinaryParameterLengthLogging);
 						ValueToSqlConverter.TryConvert(sb, trimmed);
 						sb.Append(
-							$"-- Truncated for logging, actual length is {bytes.Length}");
+							$"-- value above truncated for logging, actual length is {bytes.Length}");
 					}
 					else if (p.Value is Binary binaryData && 
-					         binaryData.Length > Configuration.MaxByteLengthLogging &&
+					         binaryData.Length > Configuration.MaxBinaryParameterLengthLogging &&
 					         ValueToSqlConverter.CanConvert(typeof(Binary)))
 					{
 						//We aren't going to create a new Binary here,
 						//since ValueToSql always just .ToArray() anyway
 						var trimmed =
-							new byte[Configuration.MaxByteLengthLogging];
+							new byte[Configuration.MaxBinaryParameterLengthLogging];
 						Array.Copy(binaryData.ToArray(), 0, trimmed, 0,
-							Configuration.MaxByteLengthLogging);
+							Configuration.MaxBinaryParameterLengthLogging);
 						ValueToSqlConverter.TryConvert(sb, trimmed);
 						sb.Append(
-							$"-- Truncated for logging, actual length is {binaryData.Length}");
+							$"-- value above truncated for logging, actual length is {binaryData.Length}");
+					}
+					else if (p.Value is string s && 
+					         s.Length > Configuration.MaxStringParameterLengthLogging &&
+					         ValueToSqlConverter.CanConvert(typeof(string)))
+					{
+						var trimmed =
+							s.Substring(0,
+								Configuration.MaxStringParameterLengthLogging);
+						ValueToSqlConverter.TryConvert(sb, trimmed);
+						sb.Append(
+							$"-- value above truncated for logging, actual length is {s.Length}");
 					}
 					else if (!ValueToSqlConverter.TryConvert(sb, p.Value))
 						FormatParameterValue(sb, p.Value);

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -3093,6 +3093,7 @@ namespace LinqToDB.SqlProvider
 						Array.Copy(bytes, 0, trimmed, 0,
 							Configuration.MaxBinaryParameterLengthLogging);
 						ValueToSqlConverter.TryConvert(sb, trimmed);
+						sb.AppendLine();
 						sb.Append(
 							$"-- value above truncated for logging, actual length is {bytes.Length}");
 					}
@@ -3108,6 +3109,7 @@ namespace LinqToDB.SqlProvider
 						Array.Copy(binaryData.ToArray(), 0, trimmed, 0,
 							Configuration.MaxBinaryParameterLengthLogging);
 						ValueToSqlConverter.TryConvert(sb, trimmed);
+						sb.AppendLine();
 						sb.Append(
 							$"-- value above truncated for logging, actual length is {binaryData.Length}");
 					}
@@ -3120,6 +3122,7 @@ namespace LinqToDB.SqlProvider
 							s.Substring(0,
 								Configuration.MaxStringParameterLengthLogging);
 						ValueToSqlConverter.TryConvert(sb, trimmed);
+						sb.AppendLine();
 						sb.Append(
 							$"-- value above truncated for logging, actual length is {s.Length}");
 					}

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -3084,6 +3084,7 @@ namespace LinqToDB.SqlProvider
 					PrintParameterName(sb, p);
 					sb.Append(" = ");
 					if (p.Value is byte[] bytes                           &&
+					    Configuration.MaxBinaryParameterLengthLogging >=0 &&
 					    bytes.Length > Configuration.MaxBinaryParameterLengthLogging &&
 					    ValueToSqlConverter.CanConvert(typeof(byte[])))
 					{
@@ -3095,7 +3096,8 @@ namespace LinqToDB.SqlProvider
 						sb.Append(
 							$"-- value above truncated for logging, actual length is {bytes.Length}");
 					}
-					else if (p.Value is Binary binaryData && 
+					else if (p.Value is Binary binaryData &&
+					         Configuration.MaxBinaryParameterLengthLogging >=0 &&
 					         binaryData.Length > Configuration.MaxBinaryParameterLengthLogging &&
 					         ValueToSqlConverter.CanConvert(typeof(Binary)))
 					{
@@ -3110,6 +3112,7 @@ namespace LinqToDB.SqlProvider
 							$"-- value above truncated for logging, actual length is {binaryData.Length}");
 					}
 					else if (p.Value is string s && 
+					         Configuration.MaxStringParameterLengthLogging >=0 &&
 					         s.Length > Configuration.MaxStringParameterLengthLogging &&
 					         ValueToSqlConverter.CanConvert(typeof(string)))
 					{

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -8,10 +8,10 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using LinqToDB.Linq;
 
 namespace LinqToDB.SqlProvider
 {
+	using LinqToDB.Linq;
 	using Common;
 	using Mapping;
 	using SqlQuery;

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -3107,7 +3107,7 @@ namespace LinqToDB.SqlProvider
 							Configuration.MaxByteLengthLogging);
 						ValueToSqlConverter.TryConvert(sb, trimmed);
 						sb.Append(
-							$"-- Truncated for logging, actual length is {bytes.Length}");
+							$"-- Truncated for logging, actual length is {binaryData.Length}");
 					}
 					else if (!ValueToSqlConverter.TryConvert(sb, p.Value))
 						FormatParameterValue(sb, p.Value);


### PR DESCRIPTION
When profiling some benchmarks I noticed that there was a lot of traffic around `.ConvertBinaryToSql` (especially in bulk insert scenarios). 

I did some research and adapted [this](https://stackoverflow.com/a/24343727/2937845) into something that worked with StringBuilder.

Doing 'before/after' tests with this change show a pretty big improvement on paths where `.ConvertBinaryToSql` is called (with payloads in the 512b-1kb range, as much as 30% in a library benchmark against fast local IO)