### PR TITLE
chore: Set indent_size to 4 on GitHub

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,7 @@ root = true
 
 [*]
 indent_style = tab
+indent_size = 4
 insert_final_newline = true
 end_of_line = crlf
 


### PR DESCRIPTION
This PR sets `indent_size` to 4 for the linq2db repository by updating the `.editorconfig` file. With recent changes made to the GitHub online code viewer, the `indent_size` for C# (the tab size) now defaults to 8, and this might hurt the readability of the code in certain cases. E.g. without `indent_size=4` the code looks as such:

<img src="https://user-images.githubusercontent.com/6759207/104971293-66bb1000-59ff-11eb-804c-caf5dd9401fe.png" width="500"/>

With `indent_size=4` it would look like this by default:

<img src="https://user-images.githubusercontent.com/6759207/104971332-82261b00-59ff-11eb-9cbf-b43f2e20a320.png" width="500"/>

Thanks for making and maintaining the best ORM for .NET btw.