### PR TITLE
Merge: skip update operation without explicit setter for non-updateable entity

### DIFF
--- a/Source/LinqToDB/Linq/Builder/MergeBuilder.UpdateWhenMatched.cs
+++ b/Source/LinqToDB/Linq/Builder/MergeBuilder.UpdateWhenMatched.cs
@@ -22,7 +22,6 @@ namespace LinqToDB.Linq.Builder
 
 				var statement = mergeContext.Merge;
 				var operation = new SqlMergeOperationClause(MergeOperationType.Update);
-				statement.Operations.Add(operation);
 
 				var predicate = methodCall.Arguments[1];
 				var setter    = methodCall.Arguments[2];
@@ -51,7 +50,14 @@ namespace LinqToDB.Linq.Builder
 
 						operation.Items.Add(new SqlSetExpression(field, expr));
 					}
+
+					// skip empty Update operation with implicit setter
+					// per https://github.com/linq2db/linq2db/issues/2843
+					if (operation.Items.Count == 0)
+						return mergeContext;
 				}
+
+				statement.Operations.Add(operation);
 
 				if (!(predicate is ConstantExpression constPredicate) || constPredicate.Value != null)
 				{

--- a/Tests/Linq/Update/MergeTests.Operations.Combined.cs
+++ b/Tests/Linq/Update/MergeTests.Operations.Combined.cs
@@ -750,6 +750,7 @@ namespace Tests.xUpdate
 
 				var result = table.OrderBy(_ => _.ID).ToList();
 
+				Assert.AreEqual(2, rows);
 				Assert.AreEqual(3, result.Count);
 
 				Assert.AreEqual(1, result[0].ID);

--- a/Tests/Linq/Update/MergeTests.Operations.Combined.cs
+++ b/Tests/Linq/Update/MergeTests.Operations.Combined.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq;
 
 using LinqToDB;
-
+using LinqToDB.Mapping;
 using NUnit.Framework;
 
 namespace Tests.xUpdate
@@ -717,6 +717,44 @@ namespace Tests.xUpdate
 				AssertRow(InitialSourceData[0], result[2], null, 203);
 				AssertRow(InitialSourceData[2], result[3], null, null);
 				AssertRow(InitialSourceData[3], result[4], null, 216);
+			}
+		}
+
+		[Table]
+		class PKOnlyTable
+		{
+			[PrimaryKey] public int ID { get; set; }
+		}
+
+
+		[Test]
+		public void InsertUpdatePKOnly([MergeDataContextSource(TestProvName.AllSapHana)] string context)
+		{
+			var src = new []
+				{
+					new PKOnlyTable() { ID = 1 },
+					new PKOnlyTable() { ID = 2 },
+					new PKOnlyTable() { ID = 3 }
+				};
+
+			using (var db = GetDataContext(context))
+			using (var table = db.CreateLocalTable(src.Skip(1).Take(1)))
+			{
+				var rows = table
+					.Merge()
+					.Using(src)
+					.OnTargetKey()
+					.InsertWhenNotMatched()
+					.UpdateWhenMatched()
+					.Merge();
+
+				var result = table.OrderBy(_ => _.ID).ToList();
+
+				Assert.AreEqual(3, result.Count);
+
+				Assert.AreEqual(1, result[0].ID);
+				Assert.AreEqual(2, result[1].ID);
+				Assert.AreEqual(3, result[2].ID);
 			}
 		}
 	}

--- a/Tests/Linq/Update/MergeTests.Operations.Combined.cs
+++ b/Tests/Linq/Update/MergeTests.Operations.Combined.cs
@@ -728,7 +728,7 @@ namespace Tests.xUpdate
 
 
 		[Test]
-		public void InsertUpdatePKOnly([MergeDataContextSource(TestProvName.AllSapHana)] string context)
+		public void InsertUpdatePKOnly([MergeDataContextSource] string context)
 		{
 			var src = new []
 				{
@@ -750,7 +750,11 @@ namespace Tests.xUpdate
 
 				var result = table.OrderBy(_ => _.ID).ToList();
 
-				Assert.AreEqual(2, rows);
+				if (context.Contains("Sybase"))
+					Assert.AreEqual(3, rows);
+				else
+					Assert.AreEqual(2, rows);
+
 				Assert.AreEqual(3, result.Count);
 
 				Assert.AreEqual(1, result[0].ID);

--- a/Tests/Linq/UserTests/Issue2560Tests.cs
+++ b/Tests/Linq/UserTests/Issue2560Tests.cs
@@ -53,7 +53,7 @@ namespace Tests.UserTests
 			{
 				var item = new DataClass
 				{
-					Value = LocalDateTime.FromDateTime(DateTime.Now),
+					Value = LocalDateTime.FromDateTime(TestData.DateTime),
 				};
 
 				db.Insert(item);

--- a/Tests/Linq/UserTests/Issue2856Tests.cs
+++ b/Tests/Linq/UserTests/Issue2856Tests.cs
@@ -25,7 +25,7 @@ namespace Tests.UserTests
 			using (var s = GetDataContext(context))
 			using (s.CreateLocalTable<GlobalTaskDTO>())
 			{
-				var allRpIds = new[] {Guid.NewGuid(), Guid.NewGuid()};
+				var allRpIds = new[] { TestData.Guid1, TestData.Guid2 };
 
 				Assert.DoesNotThrow(() =>
 					_ = (


### PR DESCRIPTION
Fix #2843