### PR TITLE
Annotate Collate argument with SqlQueryDependent

### DIFF
--- a/Source/LinqToDB/Sql/Sql.Collate.cs
+++ b/Source/LinqToDB/Sql/Sql.Collate.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text.RegularExpressions;
+using LinqToDB.Expressions;
 using LinqToDB.SqlQuery;
 
 namespace LinqToDB
@@ -16,7 +17,7 @@ namespace LinqToDB
 		[Extension("", ServerSideOnly = true, BuilderType = typeof(DB2LUWCollationBuilder)    , Configuration = ProviderName.DB2LUW)]
 		[Extension("", ServerSideOnly = true, BuilderType = typeof(PostgreSQLCollationBuilder), Configuration = ProviderName.PostgreSQL)]
 		[Extension("", ServerSideOnly = true, BuilderType = typeof(NamedCollationBuilder))]
-		public static string Collate(this string expr, string collation)
+		public static string Collate(this string expr, [SqlQueryDependent] string collation)
 			=> throw new InvalidOperationException($"{nameof(Sql)}.{nameof(Sql.Collate)} is server-side only API.");
 
 		internal class NamedCollationBuilder : IExtensionCallBuilder


### PR DESCRIPTION
Without `[SqlQueryDependent] string collation,` Linq2DB will cache the first generation of the query and all further queries will use the same collation. This ensures that the correct SQL will be generated every time for different values of `collation`.