### PR TITLE
Update project to build with VS 16.9

### DIFF
--- a/Build/Azure/README.md
+++ b/Build/Azure/README.md
@@ -76,23 +76,23 @@ Legend:
 |Access<br>MDB+ACCDB ODBC|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL CE<sup>[4](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL Server 2000<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.2|:x:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
-|MS SQL Server 2000<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.1|:x:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
+|MS SQL Server 2000<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.2|:x:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL Server 2005<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.2|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
-|MS SQL Server 2005<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.1|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
+|MS SQL Server 2005<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.2|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL Server 2008<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.2|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
-|MS SQL Server 2008<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.1|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
+|MS SQL Server 2008<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.2|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL Server 2012<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.2|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
-|MS SQL Server 2012<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.1|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
+|MS SQL Server 2012<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.2|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL Server 2014<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.2|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
-|MS SQL Server 2014<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.1|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
+|MS SQL Server 2014<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.2|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL Server 2016<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.2|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
-|MS SQL Server 2016<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.1|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
+|MS SQL Server 2016<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.2|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL Server 2017<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.2<br>with FTS Tests|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|
-|MS SQL Server 2017<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.1<br>with FTS Tests|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|
+|MS SQL Server 2017<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.2<br>with FTS Tests|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|
 |MS SQL Server 2019<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.2<br>with FTS Tests|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|
-|MS SQL Server 2019<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.1<br>with FTS Tests|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|
+|MS SQL Server 2019<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.2<br>with FTS Tests|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|
 |Azure SQL<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.2|:x:|:x:|:x:|:x:|
-|Azure SQL<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.1|:x:|:x:|:x:|:x:|
+|Azure SQL<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.2|:x:|:x:|:x:|:x:|
 |MySQL 5.6<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.21|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |MySQL 8<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.21|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |MySQL 8<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 1.2.1|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|

--- a/Build/Azure/README.md
+++ b/Build/Azure/README.md
@@ -95,7 +95,7 @@ Legend:
 |Azure SQL<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.2|:x:|:x:|:x:|:x:|
 |MySQL 5.6<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.21|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |MySQL 8<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.21|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|MySQL 8<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 1.2.1|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|MySQL 8<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 1.3.0|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |MariaDB 10<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.21|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |PostgreSQL 9.2<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.8 (netfx) / 5.0.3 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |PostgreSQL 9.3<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.8 (netfx) / 5.0.3 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|

--- a/Build/Azure/scripts/mac.docker.sh
+++ b/Build/Azure/scripts/mac.docker.sh
@@ -2,7 +2,8 @@
 
 # osx agent doesn't have docker pre-installed, so we need to do it manually
 retries=0
-brew install --cask docker
+#brew install --cask docker
+brew install --cask https://github.com/Homebrew/homebrew-cask/blob/b5f8a9ecddbf2f1cec0891dbc17c9a56973d23a2/Casks/docker.rb
 
 # manually setup docker, as versions after 2.0.0.3-ce-mac81,31259 cannot be installed without mouse-fu :facepalm:
 # thanks to https://github.com/docker/for-mac/issues/2359#issuecomment-607154849

--- a/Build/Azure/scripts/mac.docker.sh
+++ b/Build/Azure/scripts/mac.docker.sh
@@ -2,8 +2,9 @@
 
 # osx agent doesn't have docker pre-installed, so we need to do it manually
 retries=0
-#brew install --cask docker
-brew install --cask https://github.com/Homebrew/homebrew-cask/blob/b5f8a9ecddbf2f1cec0891dbc17c9a56973d23a2/Casks/docker.rb
+brew update
+brew install --cask docker
+#brew install --cask https://github.com/Homebrew/homebrew-cask/blob/b5f8a9ecddbf2f1cec0891dbc17c9a56973d23a2/Casks/docker.rb
 
 # manually setup docker, as versions after 2.0.0.3-ce-mac81,31259 cannot be installed without mouse-fu :facepalm:
 # thanks to https://github.com/docker/for-mac/issues/2359#issuecomment-607154849

--- a/Build/Azure/scripts/mac.docker.sh
+++ b/Build/Azure/scripts/mac.docker.sh
@@ -28,7 +28,7 @@ while ! docker info 2>/dev/null ; do
         #open -g -a Docker.app || exit
         open -g /Applications/Docker.app || exit
     fi
-    if [ $retries -gt 100 ]; then
+    if [ $retries -gt 200 ]; then
         >&2 echo 'Failed to run docker'
         exit 1
     fi;

--- a/Build/Azure/scripts/mac.docker.sh
+++ b/Build/Azure/scripts/mac.docker.sh
@@ -28,7 +28,7 @@ while ! docker info 2>/dev/null ; do
         #open -g -a Docker.app || exit
         open -g /Applications/Docker.app || exit
     fi
-    if [ $retries -gt 60 ]; then
+    if [ $retries -gt 100 ]; then
         >&2 echo 'Failed to run docker'
         exit 1
     fi;

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,7 +34,7 @@
 		<PackageVersion Include="MySqlConnector" Version="1.2.1" />
 		<PackageVersion Include="AdoNetCore.AseClient" Version="0.19.2" />
 		<PackageVersion Include="System.Data.SqlClient" Version="4.8.2" />
-		<PackageVersion Include="Microsoft.Data.SqlClient" Version="2.1.1" />
+		<PackageVersion Include="Microsoft.Data.SqlClient" Version="2.1.2" />
 		<PackageVersion Include="System.Data.Odbc" Version="5.0.0" />
 		<PackageVersion Include="System.Data.OleDb" Version="5.0.0" />
 		<PackageVersion Include="Oracle.ManagedDataAccess" Version="19.10.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,7 +31,7 @@
 		<PackageVersion Include="MySql.Data" Version="8.0.21" />
 		<PackageVersion Include="System.Data.SQLite.Core" Version="1.0.113.7" />
 		<PackageVersion Include="FirebirdSql.Data.FirebirdClient" Version="7.5.0" />
-		<PackageVersion Include="MySqlConnector" Version="1.2.1" />
+		<PackageVersion Include="MySqlConnector" Version="1.3.0" />
 		<PackageVersion Include="AdoNetCore.AseClient" Version="0.19.2" />
 		<PackageVersion Include="System.Data.SqlClient" Version="4.8.2" />
 		<PackageVersion Include="Microsoft.Data.SqlClient" Version="2.1.2" />

--- a/NuGet/linq2db.MySqlConnector.nuspec
+++ b/NuGet/linq2db.MySqlConnector.nuspec
@@ -13,7 +13,7 @@
 		<tags>linq linq2db MySql LinqToDB ORM database DB SQL</tags>
 		<dependencies>
 			<dependency id="linq2db"        version="3.0.0" />
-			<dependency id="MySqlConnector" version="1.2.1" />
+			<dependency id="MySqlConnector" version="1.3.0" />
 		</dependencies>
 		<contentFiles>
 			<files include="**\*" buildAction="None" />

--- a/NuGet/linq2db.SqlServer.MS.nuspec
+++ b/NuGet/linq2db.SqlServer.MS.nuspec
@@ -13,7 +13,7 @@
 		<tags>linq linq2db SqlServer LinqToDB ORM database DB SQL</tags>
 		<dependencies>
 			<dependency id="linq2db"                  version="3.0.0" />
-			<dependency id="Microsoft.Data.SqlClient" version="2.1.1" />
+			<dependency id="Microsoft.Data.SqlClient" version="2.1.2" />
 		</dependencies>
 		<contentFiles>
 			<files include="**\*" buildAction="None" />

--- a/Source/LinqToDB.Templates/LinqToDB.SqlServer.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.SqlServer.ttinclude
@@ -50,7 +50,8 @@ void DoGenerateSqlServerFreeText()
 						"return Sql.Ext.SqlServer().FreeTextTable<TTable, TKey>(table, columns, search);"
 					})
 				{
-					GenericArguments = { "TTable", "TKey" }
+					GenericArguments = { "TTable", "TKey" },
+					AfterSignature   = !EnableNullableReferenceTypes ? new List<string>() : new List<string>() { "where TTable : notnull" }
 				},
 			}
 		}

--- a/Source/LinqToDB.Tools/EntityServices/EntityMap.cs
+++ b/Source/LinqToDB.Tools/EntityServices/EntityMap.cs
@@ -142,8 +142,7 @@ namespace LinqToDB.Tools.EntityServices
 
 		volatile ConcurrentDictionary<Type,IKeyComparer>? _keyComparers;
 
-		[return: MaybeNull]
-		public T GetEntity(IDataContext context, object key)
+		public T? GetEntity(IDataContext context, object key)
 		{
 			if (context == null) throw new ArgumentNullException(nameof(context));
 			if (key     == null) throw new ArgumentNullException(nameof(key));

--- a/Source/LinqToDB.Tools/EntityServices/IdentityMap.cs
+++ b/Source/LinqToDB.Tools/EntityServices/IdentityMap.cs
@@ -57,8 +57,7 @@ namespace LinqToDB.Tools.EntityServices
 			return (EntityMap<T>)GetOrAddEntityMap(typeof(T));
 		}
 
-		[return: MaybeNull]
-		public T GetEntity<T>(object key)
+		public T? GetEntity<T>(object key)
 			where T : class, new()
 		{
 			return GetEntityMap<T>().GetEntity(_dataContext, key);

--- a/Source/LinqToDB.Tools/Mapper/ExpressionBuilder.cs
+++ b/Source/LinqToDB.Tools/Mapper/ExpressionBuilder.cs
@@ -24,10 +24,10 @@ namespace LinqToDB.Tools.Mapper
 			public BuilderData(Tuple<MemberInfo[],LambdaExpression>[]? memberMappers) => MemberMappers = memberMappers;
 
 			public readonly Tuple<MemberInfo[],LambdaExpression>[]?          MemberMappers;
-			public readonly Dictionary<Tuple<Type,Type>,ParameterExpression> Mappers     = new Dictionary<Tuple<Type,Type>,ParameterExpression>();
-			public readonly HashSet<Tuple<Type,Type>>                        MapperTypes = new HashSet<Tuple<Type,Type>>();
-			public readonly List<ParameterExpression>                        Locals      = new List<ParameterExpression>();
-			public readonly List<Expression>                                 Expressions = new List<Expression>();
+			public readonly Dictionary<Tuple<Type,Type>,ParameterExpression> Mappers     = new ();
+			public readonly HashSet<Tuple<Type,Type>>                        MapperTypes = new ();
+			public readonly List<ParameterExpression>                        Locals      = new ();
+			public readonly List<Expression>                                 Expressions = new ();
 
 			public ParameterExpression? LocalDic;
 
@@ -217,14 +217,14 @@ namespace LinqToDB.Tools.Mapper
 			initExpression =
 				Convert(
 					binds.Count > 0
-						? (Expression)MemberInit(newExpression, binds)
+						? MemberInit(newExpression, binds)
 						: newExpression,
 					toType);
 
 			return initExpression;
 		}
 
-		static NewExpression GetNewExpression([NotNull] Type originalType)
+		static NewExpression GetNewExpression(Type originalType)
 		{
 			var type = originalType;
 
@@ -365,8 +365,8 @@ namespace LinqToDB.Tools.Mapper
 			readonly ParameterExpression       _localObject;
 			readonly TypeAccessor              _fromAccessor;
 			readonly TypeAccessor              _toAccessor;
-			readonly List<Expression>          _expressions = new List<Expression>();
-			readonly List<ParameterExpression> _locals      = new List<ParameterExpression>();
+			readonly List<Expression>          _expressions = new ();
+			readonly List<ParameterExpression> _locals      = new ();
 			readonly bool                      _cacheMapper;
 
 			public Expression GetExpression()
@@ -638,7 +638,7 @@ namespace LinqToDB.Tools.Mapper
 				dic[key] = value;
 		}
 
-		static HashSet<T> ToHashSet<T>([InstantHandle] IEnumerable<T> source) => new HashSet<T>(source);
+		static HashSet<T> ToHashSet<T>([InstantHandle] IEnumerable<T> source) => new (source);
 
 		static void AddRange<T>(ICollection<T> source, [InstantHandle] IEnumerable<T> items)
 		{

--- a/Source/LinqToDB.Tools/MappingSchemaExtensions.cs
+++ b/Source/LinqToDB.Tools/MappingSchemaExtensions.cs
@@ -138,6 +138,7 @@ namespace LinqToDB.Tools
 		public static IEqualityComparer<T> GetEqualityComparer<T>(
 			this ITable<T> table,
 			[InstantHandle] Func<ColumnDescriptor,bool> columnPredicate)
+			where T : notnull
 		{
 			if (table           == null) throw new ArgumentNullException(nameof(table));
 			if (columnPredicate == null) throw new ArgumentNullException(nameof(columnPredicate));
@@ -154,6 +155,7 @@ namespace LinqToDB.Tools
 		/// <typeparam name="T">The type of entity to compare.</typeparam>
 		[Pure]
 		public static IEqualityComparer<T> GetEntityEqualityComparer<T>(this ITable<T> table)
+			where T : notnull
 		{
 			if (table == null) throw new ArgumentNullException(nameof(table));
 
@@ -169,6 +171,7 @@ namespace LinqToDB.Tools
 		/// <typeparam name="T">The type of entity to compare.</typeparam>
 		[Pure]
 		public static IEqualityComparer<T> GetKeyEqualityComparer<T>(this ITable<T> table)
+			where T : notnull
 		{
 			if (table == null) throw new ArgumentNullException(nameof(table));
 

--- a/Source/LinqToDB/Async/AsyncExtensions.cs
+++ b/Source/LinqToDB/Async/AsyncExtensions.cs
@@ -1,14 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 
 namespace LinqToDB.Async
 {
-	using Linq;
-
 	/// <summary>
 	/// This API supports the LinqToDB infrastructure and is not intended to be used  directly from your code.
 	/// This API may change or be removed in future releases.

--- a/Source/LinqToDB/Async/AsyncFactory.cs
+++ b/Source/LinqToDB/Async/AsyncFactory.cs
@@ -250,8 +250,7 @@ namespace LinqToDB.Async
 			return connection => new AsyncDbConnection(connection);
 		}
 
-		[return: MaybeNull]
-		private static TDelegate CreateDelegate<TDelegate, TInstance>(
+		private static TDelegate? CreateDelegate<TDelegate, TInstance>(
 			Type    instanceType,
 			string  methodName,
 			Type[]  delegateParameterTypes,
@@ -266,7 +265,7 @@ namespace LinqToDB.Async
 			if (mi == null
 				|| (!returnsValueTask && mi.ReturnType          != typeof(Task))
 				|| (returnsValueTask  && mi.ReturnType.FullName != "System.Threading.Tasks.ValueTask"))
-				return default!;
+				return default;
 
 			var pInstance      = Expression.Parameter(typeof(TInstance));
 			var parameters     = delegateParameterTypes.Select(t => Expression.Parameter(t)).ToArray();
@@ -347,8 +346,7 @@ namespace LinqToDB.Async
 		}
 #endif
 
-		[return: MaybeNull]
-		private static TDelegate CreateTaskTDelegate<TDelegate, TInstance, TTask>(
+		private static TDelegate? CreateTaskTDelegate<TDelegate, TInstance, TTask>(
 			Type       instanceType,
 			string     methodName,
 			Type[]     parametersTypes,
@@ -364,7 +362,7 @@ namespace LinqToDB.Async
 				|| !typeof(TTask).IsAssignableFrom(mi.ReturnType.GetGenericArguments()[0])
 				|| (!returnsValueTask && mi.ReturnType.GetGenericTypeDefinition()          != typeof(Task<>))
 				|| ( returnsValueTask && mi.ReturnType.GetGenericTypeDefinition().FullName != "System.Threading.Tasks.ValueTask`1"))
-				return default!;
+				return default;
 
 			var pInstance  = Expression.Parameter(typeof(TInstance));
 			var parameters = parametersTypes.Select(t => Expression.Parameter(t)).ToArray();

--- a/Source/LinqToDB/Async/IAsyncEnumerator.cs
+++ b/Source/LinqToDB/Async/IAsyncEnumerator.cs
@@ -1,5 +1,4 @@
 ﻿#if NETFRAMEWORK
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Source/LinqToDB/AsyncExtensions.cs
+++ b/Source/LinqToDB/AsyncExtensions.cs
@@ -9,7 +9,9 @@ using JetBrains.Annotations;
 namespace LinqToDB
 {
 	using Linq;
+#if NETFRAMEWORK
 	using Async;
+#endif
 
 	/// <summary>
 	/// Provides helper methods for asynchronous operations.

--- a/Source/LinqToDB/Common/ConvertT.cs
+++ b/Source/LinqToDB/Common/ConvertT.cs
@@ -21,6 +21,9 @@ namespace LinqToDB.Common
 			Init();
 		}
 
+#pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
+		[MemberNotNull(nameof(_expression), nameof(_lambda))]
+#pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant
 		static void Init()
 		{
 			var expr = ConvertBuilder.GetConverter(null, typeof(TFrom), typeof(TTo));
@@ -32,7 +35,7 @@ namespace LinqToDB.Common
 			_lambda = rexpr.CompileExpression();
 		}
 
-		private static Expression<Func<TFrom,TTo>>? _expression;
+		private static Expression<Func<TFrom,TTo>> _expression;
 		/// <summary>
 		/// Gets or sets an expression that converts a value of <i>TFrom</i> type to <i>TTo</i> type.
 		/// Setter updates both expression and delegate forms of converter.
@@ -42,7 +45,7 @@ namespace LinqToDB.Common
 		[AllowNull]
 		public  static Expression<Func<TFrom,TTo>>  Expression
 		{
-			get => _expression!;
+			get => _expression;
 			set
 			{
 				var setDefault = _expression != null;
@@ -61,11 +64,11 @@ namespace LinqToDB.Common
 					ConvertInfo.Default.Set(
 						typeof(TFrom),
 						typeof(TTo),
-						new ConvertInfo.LambdaInfo(_expression!, null, _lambda!, false));
+						new ConvertInfo.LambdaInfo(_expression, null, _lambda, false));
 			}
 		}
 
-		private static Func<TFrom,TTo>? _lambda;
+		private static Func<TFrom,TTo> _lambda;
 		/// <summary>
 		/// Gets or sets a function that converts a value of <i>TFrom</i> type to <i>TTo</i> type.
 		/// Setter updates both expression and delegate forms of converter.
@@ -75,7 +78,7 @@ namespace LinqToDB.Common
 		[AllowNull]
 		public static  Func<TFrom,TTo>  Lambda
 		{
-			get => _lambda!;
+			get => _lambda;
 			set
 			{
 				var setDefault = _expression != null;
@@ -101,13 +104,13 @@ namespace LinqToDB.Common
 					ConvertInfo.Default.Set(
 						typeof(TFrom),
 						typeof(TTo),
-						new ConvertInfo.LambdaInfo(_expression!, null, _lambda!, false));
+						new ConvertInfo.LambdaInfo(_expression, null, _lambda, false));
 			}
 		}
 
 		/// <summary>
 		/// Gets conversion function delegate.
 		/// </summary>
-		public static Func<TFrom,TTo> From => _lambda!;
+		public static Func<TFrom,TTo> From => _lambda;
 	}
 }

--- a/Source/LinqToDB/Common/Internal/Cache/CacheEntryHelper.cs
+++ b/Source/LinqToDB/Common/Internal/Cache/CacheEntryHelper.cs
@@ -2,20 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace LinqToDB.Common.Internal.Cache
 {
 	internal class CacheEntryHelper
 	{
-		private static readonly AsyncLocal<CacheEntryStack> _scopes = new AsyncLocal<CacheEntryStack>();
+		private static readonly AsyncLocal<CacheEntryStack> _scopes = new ();
 
-		[MaybeNull]
-		internal static CacheEntryStack Scopes
+		internal static CacheEntryStack? Scopes
 		{
 			get => _scopes.Value;
-			set => _scopes.Value = value;
+			set => _scopes.Value = value!;
 		}
 
 		internal static CacheEntry? Current

--- a/Source/LinqToDB/Common/Internal/Cache/IMemoryCache.cs
+++ b/Source/LinqToDB/Common/Internal/Cache/IMemoryCache.cs
@@ -17,7 +17,7 @@ namespace LinqToDB.Common.Internal.Cache
 		/// <param name="key">An object identifying the requested entry.</param>
 		/// <param name="value">The located value or null.</param>
 		/// <returns>True if the key was found.</returns>
-		bool TryGetValue(object key, [MaybeNullWhen(false)] out object? value);
+		bool TryGetValue(object key, out object? value);
 
 		/// <summary>
 		/// Create or overwrite an entry in the cache.

--- a/Source/LinqToDB/Common/Internal/Cache/MemoryCache.cs
+++ b/Source/LinqToDB/Common/Internal/Cache/MemoryCache.cs
@@ -212,7 +212,7 @@ namespace LinqToDB.Common.Internal.Cache
 		}
 
 		/// <inheritdoc />
-		public bool TryGetValue(object key, [MaybeNullWhen(false)] out object? value)
+		public bool TryGetValue(object key, out object? value)
 		{
 			ValidateCacheKey(key);
 

--- a/Source/LinqToDB/Common/Internal/Cache/MemoryCacheExtensions.cs
+++ b/Source/LinqToDB/Common/Internal/Cache/MemoryCacheExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 
 namespace LinqToDB.Common.Internal.Cache
@@ -15,10 +14,9 @@ namespace LinqToDB.Common.Internal.Cache
 			return value;
 		}
 
-		[return: MaybeNull]
-		public static TItem Get<TItem>(this IMemoryCache cache, object key)
+		public static TItem? Get<TItem>(this IMemoryCache cache, object key)
 		{
-			return (TItem)(cache.Get(key) ?? default(TItem));
+			return (TItem?)(cache.Get(key) ?? default(TItem));
 		}
 
 		public static bool TryGetValue<TItem>(this IMemoryCache cache, object key, out TItem? value)

--- a/Source/LinqToDB/Common/Option.cs
+++ b/Source/LinqToDB/Common/Option.cs
@@ -49,6 +49,6 @@ namespace LinqToDB.Common
 		/// <summary>
 		/// Gets <see cref="None"/> value for option.
 		/// </summary>
-		public static readonly Option<T> None = new Option<T>(default);
+		public static readonly Option<T> None = new (default);
 	}
 }

--- a/Source/LinqToDB/Common/Utils.cs
+++ b/Source/LinqToDB/Common/Utils.cs
@@ -147,7 +147,7 @@ namespace LinqToDB.Common
 
 			#region IEqualityComparer<T> Members
 
-			public bool Equals([AllowNull] T x, [AllowNull] T y)
+			public bool Equals(T? x, T? y)
 			{
 				return ReferenceEquals(x, y);
 			}

--- a/Source/LinqToDB/Compatibility/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
+++ b/Source/LinqToDB/Compatibility/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
@@ -1,5 +1,4 @@
-﻿#if !NETSTANDARD2_1PLUS
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,6 +6,7 @@
 // https://raw.githubusercontent.com/dotnet/runtime/master/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
 namespace System.Diagnostics.CodeAnalysis
 {
+#if !NETSTANDARD2_1PLUS
 	/// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
 	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
 	sealed class AllowNullAttribute : Attribute
@@ -89,27 +89,6 @@ namespace System.Diagnostics.CodeAnalysis
 		public bool ParameterValue { get; }
 	}
 
-	/// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
-	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
-	sealed class MemberNotNullAttribute : Attribute
-	{
-		/// <summary>Initializes the attribute with a field or property member.</summary>
-		/// <param name="member">
-		/// The field or property member that is promised to be not-null.
-		/// </param>
-		public MemberNotNullAttribute(string member) => Members = new[] { member };
-
-		/// <summary>Initializes the attribute with the list of field and property members.</summary>
-		/// <param name="members">
-		/// The list of field and property members that are promised to be not-null.
-		/// </param>
-		public MemberNotNullAttribute(params string[] members)
-			=> Members = members;
-
-		/// <summary>Gets field or property member names.</summary>
-		public string[] Members { get; }
-	}
-
 	/// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values when returning with the specified return value condition.</summary>
 	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
 	sealed class MemberNotNullWhenAttribute : Attribute
@@ -146,5 +125,28 @@ namespace System.Diagnostics.CodeAnalysis
 		/// <summary>Gets field or property member names.</summary>
 		public string[] Members { get; }
 	}
-}
 #endif
+
+#if !NET5_0
+	/// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
+	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+	sealed class MemberNotNullAttribute : Attribute
+	{
+		/// <summary>Initializes the attribute with a field or property member.</summary>
+		/// <param name="member">
+		/// The field or property member that is promised to be not-null.
+		/// </param>
+		public MemberNotNullAttribute(string member) => Members = new[] { member };
+
+		/// <summary>Initializes the attribute with the list of field and property members.</summary>
+		/// <param name="members">
+		/// The list of field and property members that are promised to be not-null.
+		/// </param>
+		public MemberNotNullAttribute(params string[] members)
+			=> Members = members;
+
+		/// <summary>Gets field or property member names.</summary>
+		public string[] Members { get; }
+	}
+#endif
+}

--- a/Source/LinqToDB/Compatibility/System/Threading/AsyncLocal.cs
+++ b/Source/LinqToDB/Compatibility/System/Threading/AsyncLocal.cs
@@ -25,14 +25,12 @@ namespace System.Threading
 {
 	using System.Security;
 	using System.Runtime.Remoting.Messaging;
-	using System.Diagnostics.CodeAnalysis;
 
 	internal sealed class AsyncLocal<T>
 	{
 		private readonly string _key = Guid.NewGuid().ToString("N").Substring(0, 12);
 
-		[MaybeNull]
-		public T Value
+		public T? Value
 		{
 			[SecuritySafeCritical]
 			get

--- a/Source/LinqToDB/CompiledQuery.cs
+++ b/Source/LinqToDB/CompiledQuery.cs
@@ -22,7 +22,7 @@ namespace LinqToDB
 			_query = query;
 		}
 
-		readonly object                   _sync = new object();
+		readonly object                   _sync = new ();
 		readonly LambdaExpression         _query;
 		volatile Func<object?[],object?[]?,object?>? _compiledQuery;
 
@@ -50,6 +50,7 @@ namespace LinqToDB
 		}
 
 		class TableHelper<T> : ITableHelper
+			where T : notnull
 		{
 			public Expression CallTable(LambdaExpression query, Expression expr, ParameterExpression ps, ParameterExpression preambles, MethodType type)
 			{

--- a/Source/LinqToDB/Data/DataConnectionExtensions.cs
+++ b/Source/LinqToDB/Data/DataConnectionExtensions.cs
@@ -2241,6 +2241,7 @@ namespace LinqToDB.Data
 		/// <param name="source">Records to insert.</param>
 		/// <returns>Bulk insert operation status.</returns>
 		public static BulkCopyRowsCopied BulkCopy<T>(this ITable<T> table, BulkCopyOptions options, IEnumerable<T> source)
+			where T : notnull
 		{
 			if (table == null) throw new ArgumentNullException(nameof(table));
 
@@ -2259,6 +2260,7 @@ namespace LinqToDB.Data
 		/// <param name="source">Records to insert.</param>
 		/// <returns>Bulk insert operation status.</returns>
 		public static BulkCopyRowsCopied BulkCopy<T>(this ITable<T> table, int maxBatchSize, IEnumerable<T> source)
+			where T : notnull
 		{
 			if (table == null) throw new ArgumentNullException(nameof(table));
 
@@ -2276,6 +2278,7 @@ namespace LinqToDB.Data
 		/// <param name="source">Records to insert.</param>
 		/// <returns>Bulk insert operation status.</returns>
 		public static BulkCopyRowsCopied BulkCopy<T>(this ITable<T> table, IEnumerable<T> source)
+			where T : notnull
 		{
 			if (table == null) throw new ArgumentNullException(nameof(table));
 
@@ -2360,6 +2363,7 @@ namespace LinqToDB.Data
 		/// <param name="cancellationToken">Asynchronous operation cancellation token.</param>
 		/// <returns>Task with bulk insert operation status.</returns>
 		public static Task<BulkCopyRowsCopied> BulkCopyAsync<T>(this ITable<T> table, BulkCopyOptions options, IEnumerable<T> source, CancellationToken cancellationToken = default)
+			where T : notnull
 		{
 			if (table  == null) throw new ArgumentNullException(nameof(table));
 			if (source == null) throw new ArgumentNullException(nameof(source));
@@ -2380,6 +2384,7 @@ namespace LinqToDB.Data
 		/// <param name="cancellationToken">Asynchronous operation cancellation token.</param>
 		/// <returns>Task with bulk insert operation status.</returns>
 		public static Task<BulkCopyRowsCopied> BulkCopyAsync<T>(this ITable<T> table, int maxBatchSize, IEnumerable<T> source, CancellationToken cancellationToken = default)
+			where T : notnull
 		{
 			if (table  == null) throw new ArgumentNullException(nameof(table));
 			if (source == null) throw new ArgumentNullException(nameof(source));
@@ -2399,6 +2404,7 @@ namespace LinqToDB.Data
 		/// <param name="cancellationToken">Asynchronous operation cancellation token.</param>
 		/// <returns>Task with bulk insert operation status.</returns>
 		public static Task<BulkCopyRowsCopied> BulkCopyAsync<T>(this ITable<T> table, IEnumerable<T> source, CancellationToken cancellationToken = default)
+			where T : notnull
 		{
 			if (table  == null) throw new ArgumentNullException(nameof(table));
 			if (source == null) throw new ArgumentNullException(nameof(source));
@@ -2485,6 +2491,7 @@ namespace LinqToDB.Data
 		/// <param name="cancellationToken">Asynchronous operation cancellation token.</param>
 		/// <returns>Task with bulk insert operation status.</returns>
 		public static Task<BulkCopyRowsCopied> BulkCopyAsync<T>(this ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken = default)
+		where T: notnull
 		{
 			if (table  == null) throw new ArgumentNullException(nameof(table));
 			if (source == null) throw new ArgumentNullException(nameof(source));
@@ -2505,6 +2512,7 @@ namespace LinqToDB.Data
 		/// <param name="cancellationToken">Asynchronous operation cancellation token.</param>
 		/// <returns>Task with bulk insert operation status.</returns>
 		public static Task<BulkCopyRowsCopied> BulkCopyAsync<T>(this ITable<T> table, int maxBatchSize, IAsyncEnumerable<T> source, CancellationToken cancellationToken = default)
+		where T: notnull
 		{
 			if (table  == null) throw new ArgumentNullException(nameof(table));
 			if (source == null) throw new ArgumentNullException(nameof(source));
@@ -2524,6 +2532,7 @@ namespace LinqToDB.Data
 		/// <param name="cancellationToken">Asynchronous operation cancellation token.</param>
 		/// <returns>Task with bulk insert operation status.</returns>
 		public static Task<BulkCopyRowsCopied> BulkCopyAsync<T>(this ITable<T> table, IAsyncEnumerable<T> source, CancellationToken cancellationToken = default)
+		where T: notnull
 		{
 			if (table  == null) throw new ArgumentNullException(nameof(table));
 			if (source == null) throw new ArgumentNullException(nameof(source));

--- a/Source/LinqToDB/DataExtensions.cs
+++ b/Source/LinqToDB/DataExtensions.cs
@@ -47,7 +47,7 @@ namespace LinqToDB
 		/// <typeparam name="T">Mapping class type.</typeparam>
 		/// <param name="dataContext">Data connection context.</param>
 		/// <param name="instance">Instance object for <paramref name="methodInfo"/> method or null for static method.</param>
-		/// <param name="methodInfo">Method, decorated with expression attribute, based on <see cref="LinqToDB.Sql.TableFunctionAttribute"/>.</param>
+		/// <param name="methodInfo">Method, decorated with expression attribute, based on <see cref="Sql.TableFunctionAttribute"/>.</param>
 		/// <param name="parameters">Parameters for <paramref name="methodInfo"/> method.</param>
 		/// <returns>Queryable source.</returns>
 		[LinqTunnel]
@@ -201,6 +201,7 @@ namespace LinqToDB
 		/// <returns>Number of affected records.</returns>
 		public static int Insert<T>(this IDataContext dataContext, T obj,
 			string? tableName = default, string? databaseName = default, string? schemaName = default, string? serverName = default, TableOptions tableOptions = default)
+			where T : notnull
 		{
 			return Insert(dataContext, obj, null, tableName: tableName, databaseName: databaseName, schemaName: schemaName, serverName: serverName, tableOptions: tableOptions);
 		}
@@ -220,6 +221,7 @@ namespace LinqToDB
 		/// <returns>Number of affected records.</returns>
 		public static int Insert<T>(this IDataContext dataContext, T obj, InsertColumnFilter<T>? columnFilter,
 			string? tableName = default, string? databaseName = default, string? schemaName = default, string? serverName = default, TableOptions tableOptions = default)
+			where T : notnull
 		{
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 
@@ -248,6 +250,7 @@ namespace LinqToDB
 			string?           serverName   = default,
 			TableOptions      tableOptions = default,
 			CancellationToken token        = default)
+			where T : notnull
 		{
 			return InsertAsync(dataContext, obj, null, tableName: tableName, databaseName: databaseName, schemaName: schemaName, serverName: serverName, tableOptions: tableOptions, token);
 		}
@@ -276,6 +279,7 @@ namespace LinqToDB
 			string?                serverName   = default,
 			TableOptions           tableOptions = default,
 			CancellationToken      token        = default)
+			where T : notnull
 		{
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 			return QueryRunner.Insert<T>.QueryAsync(dataContext, obj, columnFilter, tableName: tableName, serverName: serverName, databaseName: databaseName, schemaName: schemaName, tableOptions: tableOptions, token);
@@ -304,6 +308,7 @@ namespace LinqToDB
 			string?      schemaName   = default,
 			string?      serverName   = default,
 			TableOptions tableOptions = default)
+			where T : notnull
 		{
 			return InsertOrReplace(dataContext, obj, null, tableName: tableName, serverName: serverName, databaseName: databaseName, schemaName: schemaName, tableOptions: tableOptions);
 		}
@@ -329,6 +334,7 @@ namespace LinqToDB
 			string?      schemaName   = default,
 			string?      serverName   = default,
 			TableOptions tableOptions = default)
+			where T : notnull
 		{
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 			return QueryRunner.InsertOrReplace<T>.Query(dataContext, obj, columnFilter, tableName: tableName, serverName: serverName, databaseName: databaseName, schema: schemaName, tableOptions: tableOptions);
@@ -357,6 +363,7 @@ namespace LinqToDB
 			string?           serverName   = default,
 			TableOptions      tableOptions = default,
 			CancellationToken token        = default)
+			where T : notnull
 		{
 			return InsertOrReplaceAsync(dataContext, obj, null, tableName: tableName, databaseName: databaseName, schemaName: schemaName, serverName: serverName, tableOptions: tableOptions, token);
 		}
@@ -386,6 +393,7 @@ namespace LinqToDB
 			string?                        serverName   = default,
 			TableOptions                   tableOptions = default,
 			CancellationToken              token        = default)
+			where T : notnull
 		{
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 			return QueryRunner.InsertOrReplace<T>.QueryAsync(dataContext, obj, columnFilter, tableName: tableName, serverName: serverName, databaseName: databaseName, schema: schemaName, tableOptions: tableOptions, token);
@@ -416,6 +424,7 @@ namespace LinqToDB
 			string?       schemaName   = default,
 			string?       serverName   = default,
 			TableOptions  tableOptions = default)
+			where T : notnull
 		{
 			return InsertWithIdentity(dataContext, obj, null, tableName: tableName, databaseName: databaseName, schemaName: schemaName, serverName: serverName, tableOptions: tableOptions);
 		}
@@ -443,6 +452,7 @@ namespace LinqToDB
 			string?                schemaName   = default,
 			string?                serverName   = default,
 			TableOptions           tableOptions = default)
+			where T: notnull
 		{
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 			return QueryRunner.InsertWithIdentity<T>.Query(dataContext, obj, columnFilter, tableName: tableName, serverName: serverName, databaseName: databaseName, schemaName: schemaName, tableOptions: tableOptions);
@@ -469,6 +479,7 @@ namespace LinqToDB
 			string?           schemaName   = default,
 			string?           serverName   = default,
 			TableOptions      tableOptions = default)
+			where T : notnull
 		{
 			return InsertWithInt32Identity(dataContext, obj, null, tableName: tableName, serverName: serverName, databaseName: databaseName, schemaName: schemaName, tableOptions: tableOptions);
 		}
@@ -496,6 +507,7 @@ namespace LinqToDB
 			string?                schemaName   = default,
 			string?                serverName   = default,
 			TableOptions           tableOptions = default)
+			where T : notnull
 		{
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 			return dataContext.MappingSchema.ChangeTypeTo<int>(QueryRunner.InsertWithIdentity<T>.Query(dataContext, obj, columnFilter, tableName: tableName, serverName: serverName, databaseName: databaseName, schemaName: schemaName, tableOptions: tableOptions));
@@ -522,6 +534,7 @@ namespace LinqToDB
 			string?           schemaName   = default,
 			string?           serverName   = default,
 			TableOptions      tableOptions = default)
+			where T : notnull
 		{
 			return InsertWithInt64Identity(dataContext, obj, null, tableName: tableName, serverName: serverName, databaseName: databaseName, schemaName: schemaName, tableOptions: tableOptions);
 		}
@@ -549,6 +562,7 @@ namespace LinqToDB
 			string?                schemaName   = default,
 			string?                serverName   = default,
 			TableOptions           tableOptions = default)
+			where T : notnull
 		{
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 			return dataContext.MappingSchema.ChangeTypeTo<long>(QueryRunner.InsertWithIdentity<T>.Query(dataContext, obj, columnFilter, tableName: tableName, serverName: serverName, databaseName: databaseName, schemaName: schemaName, tableOptions: tableOptions));
@@ -575,6 +589,7 @@ namespace LinqToDB
 			string?           schemaName   = default,
 			string?           serverName   = default,
 			TableOptions      tableOptions = default)
+			where T : notnull
 		{
 			return InsertWithDecimalIdentity(dataContext, obj, null, tableName: tableName, serverName: serverName, databaseName: databaseName, schemaName: schemaName, tableOptions: tableOptions);
 		}
@@ -602,6 +617,7 @@ namespace LinqToDB
 			string?                schemaName   = default,
 			string?                serverName   = default,
 			TableOptions           tableOptions = default)
+			where T : notnull
 		{
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 			return dataContext.MappingSchema.ChangeTypeTo<decimal>(QueryRunner.InsertWithIdentity<T>.Query(dataContext, obj, columnFilter, tableName: tableName, serverName: serverName, databaseName: databaseName, schemaName: schemaName, tableOptions: tableOptions));
@@ -630,6 +646,7 @@ namespace LinqToDB
 			string?           serverName   = default,
 			TableOptions      tableOptions = default,
 			CancellationToken token        = default)
+			where T : notnull
 		{
 			return InsertWithIdentityAsync(dataContext, obj, null, tableName: tableName, databaseName: databaseName, schemaName: schemaName, serverName: serverName, tableOptions: tableOptions, token);
 		}
@@ -659,6 +676,7 @@ namespace LinqToDB
 			string?                serverName   = default,
 			TableOptions           tableOptions = default,
 			CancellationToken      token        = default)
+			where T : notnull
 		{
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 			return QueryRunner.InsertWithIdentity<T>.QueryAsync(dataContext, obj, columnFilter, tableName: tableName, serverName: serverName, databaseName: databaseName, schemaName: schemaName, tableOptions: tableOptions, token);
@@ -687,6 +705,7 @@ namespace LinqToDB
 			string?           serverName   = default,
 			TableOptions      tableOptions = default,
 			CancellationToken token        = default)
+			where T : notnull
 		{
 			return InsertWithInt32IdentityAsync(dataContext, obj, null, tableName: tableName, databaseName: databaseName, schemaName: schemaName, serverName: serverName, tableOptions: tableOptions, token);
 		}
@@ -716,6 +735,7 @@ namespace LinqToDB
 			string?                serverName   = default,
 			TableOptions           tableOptions = default,
 			CancellationToken      token        = default)
+			where T : notnull
 		{
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 
@@ -748,6 +768,7 @@ namespace LinqToDB
 			string?           serverName   = default,
 			TableOptions      tableOptions = default,
 			CancellationToken token        = default)
+			where T : notnull
 		{
 			return InsertWithInt64IdentityAsync(dataContext, obj, null, tableName: tableName, databaseName: databaseName, schemaName: schemaName, serverName: serverName, tableOptions: tableOptions, token);
 		}
@@ -777,6 +798,7 @@ namespace LinqToDB
 			string?                serverName   = default,
 			TableOptions           tableOptions = default,
 			CancellationToken      token        = default)
+			where T : notnull
 		{
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 
@@ -810,6 +832,7 @@ namespace LinqToDB
 			string?           serverName   = default,
 			TableOptions      tableOptions = default,
 			CancellationToken token        = default)
+			where T : notnull
 		{
 			return InsertWithDecimalIdentityAsync(dataContext, obj, null, tableName: tableName, databaseName: databaseName, schemaName: schemaName, serverName: serverName, tableOptions: tableOptions, token);
 		}
@@ -839,6 +862,7 @@ namespace LinqToDB
 			string?                serverName   = default,
 			TableOptions           tableOptions = default,
 			CancellationToken      token        = default)
+			where T : notnull
 		{
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 
@@ -874,6 +898,7 @@ namespace LinqToDB
 			string?           schemaName   = default,
 			string?           serverName   = default,
 			TableOptions      tableOptions = default)
+			where T : notnull
 		{
 			return Update(dataContext, obj, null, tableName: tableName, serverName: serverName, databaseName: databaseName, schemaName: schemaName, tableOptions: tableOptions);
 		}
@@ -901,6 +926,7 @@ namespace LinqToDB
 			string?                schemaName   = default,
 			string?                serverName   = default,
 			TableOptions           tableOptions = default)
+			where T : notnull
 		{
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 			return QueryRunner.Update<T>.Query(dataContext, obj, columnFilter, tableName: tableName, serverName: serverName, databaseName: databaseName, schemaName: schemaName, tableOptions: tableOptions);
@@ -929,6 +955,7 @@ namespace LinqToDB
 			string?           serverName   = default,
 			TableOptions      tableOptions = default,
 			CancellationToken token        = default)
+			where T : notnull
 		{
 			return UpdateAsync(dataContext, obj, null, tableName: tableName, databaseName: databaseName, schemaName: schemaName, serverName: serverName, tableOptions: tableOptions, token);
 		}
@@ -958,6 +985,7 @@ namespace LinqToDB
 			string?                serverName   = default,
 			TableOptions           tableOptions = default,
 			CancellationToken      token        = default)
+			where T : notnull
 		{
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 			return QueryRunner.Update<T>.QueryAsync(dataContext, obj, columnFilter, tableName: tableName, serverName: serverName, databaseName: databaseName, schemaName: schemaName, tableOptions: tableOptions, token);
@@ -988,6 +1016,7 @@ namespace LinqToDB
 			string?           schemaName   = default,
 			string?           serverName   = default,
 			TableOptions      tableOptions = default)
+			where T : notnull
 		{
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 			return QueryRunner.Delete<T>.Query(dataContext, obj, tableName: tableName, serverName: serverName, databaseName: databaseName, schemaName: schemaName, tableOptions: tableOptions);
@@ -1016,6 +1045,7 @@ namespace LinqToDB
 			string?           serverName   = default,
 			TableOptions      tableOptions = default,
 			CancellationToken token        = default)
+			where T : notnull
 		{
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 			return QueryRunner.Delete<T>.QueryAsync(dataContext, obj, tableName: tableName, serverName: serverName, databaseName: databaseName, schemaName: schemaName, tableOptions: tableOptions, token);
@@ -1055,6 +1085,7 @@ namespace LinqToDB
 			DefaultNullable   defaultNullable = DefaultNullable.None,
 			string?           serverName      = default,
 			TableOptions      tableOptions    = default)
+			where T: notnull
 		{
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 			return QueryRunner.CreateTable<T>.Query(dataContext,
@@ -1093,6 +1124,7 @@ namespace LinqToDB
 			string?           serverName      = default,
 			TableOptions      tableOptions    = default,
 			CancellationToken token           = default)
+			where T : notnull
 		{
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 			return QueryRunner.CreateTable<T>.QueryAsync(dataContext,
@@ -1160,6 +1192,7 @@ namespace LinqToDB
 			bool?          throwExceptionIfNotExists = default,
 			string?        serverName                = default,
 			TableOptions   tableOptions              = default)
+			where T : notnull
 		{
 			if (table == null) throw new ArgumentNullException(nameof(table));
 
@@ -1246,6 +1279,7 @@ namespace LinqToDB
 			string?           serverName                = default,
 			TableOptions      tableOptions              = default,
 			CancellationToken token                     = default)
+			where T : notnull
 		{
 			if (table == null) throw new ArgumentNullException(nameof(table));
 
@@ -1285,6 +1319,7 @@ namespace LinqToDB
 			                this IDataContext                 dataContext,
 			[InstantHandle] Func<IQueryable<T>,IQueryable<T>> cteBody,
 			                string?                           cteTableName = null)
+			where T : notnull
 		{
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 			if (cteBody     == null) throw new ArgumentNullException(nameof(cteBody));
@@ -1313,6 +1348,7 @@ namespace LinqToDB
 			                this IDataContext                 dataContext,
 			                string?                           cteTableName,
 			[InstantHandle] Func<IQueryable<T>,IQueryable<T>> cteBody)
+			where T : notnull
 		{
 			return GetCte(dataContext, cteBody, cteTableName);
 		}
@@ -1405,9 +1441,8 @@ namespace LinqToDB
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 			if (sql         == null) throw new ArgumentNullException(nameof(sql));
 
-			var table = new Table<TEntity>(dataContext);
-
-			return ((IQueryable<TEntity>)table).Provider.CreateQuery<TEntity>(
+			return new ExpressionQueryImpl<TEntity>(
+				dataContext,
 				Expression.Call(
 					null,
 					MethodHelper.GetMethodInfo(FromSql<TEntity>, dataContext, sql),
@@ -1442,9 +1477,8 @@ namespace LinqToDB
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 			if (sql         == null) throw new ArgumentNullException(nameof(sql));
 
-			var table = new Table<TEntity>(dataContext);
-
-			return ((IQueryable<TEntity>)table).Provider.CreateQuery<TEntity>(
+			return new ExpressionQueryImpl<TEntity>(
+				dataContext,
 				Expression.Call(
 					null,
 					MethodHelper.GetMethodInfo(FromSqlScalar<TEntity>, dataContext, sql),
@@ -1486,9 +1520,8 @@ namespace LinqToDB
 		{
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 
-			var table = new Table<TEntity>(dataContext);
-
-			return ((IQueryable<TEntity>)table).Provider.CreateQuery<TEntity>(
+			return new ExpressionQueryImpl<TEntity>(
+				dataContext,
 				Expression.Call(
 					null,
 					MethodHelper.GetMethodInfo(FromSql<TEntity>, dataContext, sql, parameters),
@@ -1534,9 +1567,8 @@ namespace LinqToDB
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 			if (selector    == null) throw new ArgumentNullException(nameof(selector));
 
-			var table = new Table<TEntity>(dataContext);
-
-			return ((IQueryable<TEntity>)table).Provider.CreateQuery<TEntity>(
+			return new ExpressionQueryImpl<TEntity>(
+				dataContext,
 				Expression.Call(
 					null,
 					MethodHelper.GetMethodInfo(SelectQuery, dataContext, selector),

--- a/Source/LinqToDB/DataProvider/BasicBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/BasicBulkCopy.cs
@@ -16,6 +16,7 @@ namespace LinqToDB.DataProvider
 	public class BasicBulkCopy
 	{
 		public virtual BulkCopyRowsCopied BulkCopy<T>(BulkCopyType bulkCopyType, ITable<T> table, BulkCopyOptions options, IEnumerable<T> source)
+			where T : notnull
 		{
 			return bulkCopyType switch
 			{
@@ -27,6 +28,7 @@ namespace LinqToDB.DataProvider
 
 		public virtual Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			BulkCopyType bulkCopyType, ITable<T> table, BulkCopyOptions options, IEnumerable<T> source, CancellationToken cancellationToken)
+			where T : notnull
 		{
 			return bulkCopyType switch
 			{
@@ -39,6 +41,7 @@ namespace LinqToDB.DataProvider
 #if !NETFRAMEWORK
 		public virtual Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			BulkCopyType bulkCopyType, ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
+			where T: notnull
 		{
 			return bulkCopyType switch
 			{
@@ -51,12 +54,14 @@ namespace LinqToDB.DataProvider
 
 		protected virtual BulkCopyRowsCopied ProviderSpecificCopy<T>(
 			ITable<T> table, BulkCopyOptions options, IEnumerable<T> source)
+			where T : notnull
 		{
 			return MultipleRowsCopy(table, options, source);
 		}
 
 		protected virtual Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IEnumerable<T> source, CancellationToken cancellationToken)
+			where T : notnull
 		{
 			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
 		}
@@ -64,6 +69,7 @@ namespace LinqToDB.DataProvider
 #if !NETFRAMEWORK
 		protected virtual Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
+			where T: notnull
 		{
 			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
 		}
@@ -71,12 +77,14 @@ namespace LinqToDB.DataProvider
 
 		protected virtual BulkCopyRowsCopied MultipleRowsCopy<T>(
 			ITable<T> table, BulkCopyOptions options, IEnumerable<T> source)
+			where T : notnull
 		{
 			return RowByRowCopy(table, options, source);
 		}
 
 		protected virtual Task<BulkCopyRowsCopied> MultipleRowsCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IEnumerable<T> source, CancellationToken cancellationToken)
+			where T : notnull
 		{
 			return RowByRowCopyAsync(table, options, source, cancellationToken);
 		}
@@ -84,12 +92,14 @@ namespace LinqToDB.DataProvider
 #if !NETFRAMEWORK
 		protected virtual Task<BulkCopyRowsCopied> MultipleRowsCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
+			where T: notnull
 		{
 			return RowByRowCopyAsync(table, options, source, cancellationToken);
 		}
 #endif
 
 		protected virtual BulkCopyRowsCopied RowByRowCopy<T>(ITable<T> table, BulkCopyOptions options, IEnumerable<T> source)
+			where T : notnull
 		{
 			// This limitation could be lifted later for some providers that supports identity insert if we will get such request
 			// It will require support from DataConnection.Insert
@@ -124,6 +134,7 @@ namespace LinqToDB.DataProvider
 
 		protected virtual async Task<BulkCopyRowsCopied> RowByRowCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IEnumerable<T> source, CancellationToken cancellationToken)
+			where T : notnull
 		{
 			// This limitation could be lifted later for some providers that supports identity insert if we will get such request
 			// It will require support from DataConnection.Insert
@@ -162,6 +173,7 @@ namespace LinqToDB.DataProvider
 #if !NETFRAMEWORK
 		protected virtual async Task<BulkCopyRowsCopied> RowByRowCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
+			where T: notnull
 		{
 			// This limitation could be lifted later for some providers that supports identity insert if we will get such request
 			// It will require support from DataConnection.Insert
@@ -191,6 +203,7 @@ namespace LinqToDB.DataProvider
 #endif
 
 		protected internal static string GetTableName<T>(ISqlBuilder sqlBuilder, BulkCopyOptions options, ITable<T> table, bool escaped = true)
+			where T : notnull
 		{
 			var sqlTable = new SqlTable
 			{
@@ -386,12 +399,14 @@ namespace LinqToDB.DataProvider
 #endif
 
 		protected BulkCopyRowsCopied MultipleRowsCopy1<T>(ITable<T> table, BulkCopyOptions options, IEnumerable<T> source)
+			where T : notnull
 			=> MultipleRowsCopy1(new MultipleRowsHelper<T>(table, options), source);
 
 		protected BulkCopyRowsCopied MultipleRowsCopy1(MultipleRowsHelper helper, IEnumerable source)
 			=> MultipleRowsCopyHelper(helper, source, null, MultipleRowsCopy1Prep, MultipleRowsCopy1Add, MultipleRowsCopy1Finish);
 
 		protected Task<BulkCopyRowsCopied> MultipleRowsCopy1Async<T>(ITable<T> table, BulkCopyOptions options, IEnumerable<T> source, CancellationToken cancellationToken)
+			where T : notnull
 			=> MultipleRowsCopy1Async(new MultipleRowsHelper<T>(table, options), source, cancellationToken);
 
 		protected Task<BulkCopyRowsCopied> MultipleRowsCopy1Async(MultipleRowsHelper helper, IEnumerable source, CancellationToken cancellationToken)
@@ -399,9 +414,11 @@ namespace LinqToDB.DataProvider
 
 #if !NETFRAMEWORK
 		protected Task<BulkCopyRowsCopied> MultipleRowsCopy1Async<T>(ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
+		where T: notnull
 			=> MultipleRowsCopy1Async(new MultipleRowsHelper<T>(table, options), source, cancellationToken);
 
 		protected Task<BulkCopyRowsCopied> MultipleRowsCopy1Async<T>(MultipleRowsHelper helper, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
+		where T: notnull
 			=> MultipleRowsCopyHelperAsync(helper, source, null, MultipleRowsCopy1Prep, MultipleRowsCopy1Add, MultipleRowsCopy1Finish, cancellationToken);
 #endif
 
@@ -450,12 +467,14 @@ namespace LinqToDB.DataProvider
 		}
 
 		protected BulkCopyRowsCopied MultipleRowsCopy2<T>(ITable<T> table, BulkCopyOptions options, IEnumerable<T> source, string from)
+			where T : notnull
 			=> MultipleRowsCopy2(new MultipleRowsHelper<T>(table, options), source, from);
 
 		protected BulkCopyRowsCopied MultipleRowsCopy2(MultipleRowsHelper helper, IEnumerable source, string from)
 			=> MultipleRowsCopyHelper(helper, source, from, MultipleRowsCopy2Prep, MultipleRowsCopy2Add, MultipleRowsCopy2Finish);
 
 		protected Task<BulkCopyRowsCopied> MultipleRowsCopy2Async<T>(ITable<T> table, BulkCopyOptions options, IEnumerable<T> source, string from, CancellationToken cancellationToken)
+			where T : notnull
 			=> MultipleRowsCopy2Async(new MultipleRowsHelper<T>(table, options), source, from, cancellationToken);
 
 		protected Task<BulkCopyRowsCopied> MultipleRowsCopy2Async(MultipleRowsHelper helper, IEnumerable source, string from, CancellationToken cancellationToken)
@@ -463,9 +482,11 @@ namespace LinqToDB.DataProvider
 
 #if !NETFRAMEWORK
 		protected Task<BulkCopyRowsCopied> MultipleRowsCopy2Async<T>(ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, string from, CancellationToken cancellationToken)
+		where T: notnull
 			=> MultipleRowsCopy2Async(new MultipleRowsHelper<T>(table, options), source, from, cancellationToken);
 
 		protected Task<BulkCopyRowsCopied> MultipleRowsCopy2Async<T>(MultipleRowsHelper helper, IAsyncEnumerable<T> source, string from, CancellationToken cancellationToken)
+		where T: notnull
 			=> MultipleRowsCopyHelperAsync(helper, source, from, MultipleRowsCopy2Prep, MultipleRowsCopy2Add, MultipleRowsCopy2Finish, cancellationToken);
 #endif
 
@@ -518,6 +539,7 @@ namespace LinqToDB.DataProvider
 
 #if !NETFRAMEWORK
 		protected Task<BulkCopyRowsCopied> MultipleRowsCopy3Async<T>(MultipleRowsHelper helper, BulkCopyOptions options, IAsyncEnumerable<T> source, string from, CancellationToken cancellationToken)
+		where T: notnull
 			=> MultipleRowsCopyHelperAsync(helper, source, from, MultipleRowsCopy3Prep, MultipleRowsCopy3Add, MultipleRowsCopy3Finish, cancellationToken);
 #endif
 

--- a/Source/LinqToDB/DataProvider/BulkCopyReader.cs
+++ b/Source/LinqToDB/DataProvider/BulkCopyReader.cs
@@ -8,11 +8,11 @@ using System.Linq;
 
 namespace LinqToDB.DataProvider
 {
+	using System.Threading;
+	using System.Threading.Tasks;
 	using Common;
 	using LinqToDB.Data;
 	using Mapping;
-	using System.Threading;
-	using System.Threading.Tasks;
 
 	public class BulkCopyReader<T> : BulkCopyReader
 #if !NETFRAMEWORK
@@ -99,7 +99,7 @@ namespace LinqToDB.DataProvider
 		readonly DataConnection                   _dataConnection;
 		readonly DbDataType[]                     _columnTypes;
 		readonly List<ColumnDescriptor>           _columns;
-		readonly Parameter                        _valueConverter = new Parameter();
+		readonly Parameter                        _valueConverter = new ();
 		readonly IReadOnlyDictionary<string, int> _ordinals;
 
 		protected abstract bool MoveNext();

--- a/Source/LinqToDB/DataProvider/DB2/DB2BulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2BulkCopy.cs
@@ -71,7 +71,7 @@ namespace LinqToDB.DataProvider.DB2
 				if (connection != null)
 				{
 					var enumerator = source.GetAsyncEnumerator(cancellationToken);
-					await using (enumerator.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
+					await using (enumerator.ConfigureAwait(Configuration.ContinueOnCapturedContext))
 					{
 						// call the synchronous provider-specific implementation
 						return ProviderSpecificCopyImpl(
@@ -86,7 +86,7 @@ namespace LinqToDB.DataProvider.DB2
 				}
 			}
 
-			return await MultipleRowsCopyAsync(table, options, source, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+			return await MultipleRowsCopyAsync(table, options, source, cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 		}
 #endif
 
@@ -98,6 +98,7 @@ namespace LinqToDB.DataProvider.DB2
 			IDbConnection                                   connection,
 			DB2ProviderAdapter.BulkCopyAdapter              bulkCopy,
 			Action<DataConnection, Func<string>, Func<int>> traceAction)
+			where T : notnull
 		{
 			var descriptor = dataConnection.MappingSchema.GetEntityDescriptor(typeof(T));
 			var columns    = descriptor.Columns.Where(c => !c.SkipOnInsert || options.KeepIdentity == true && c.IsIdentity).ToList();

--- a/Source/LinqToDB/DataProvider/DB2/DB2DataProvider.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2DataProvider.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Threading;
@@ -85,7 +85,7 @@ namespace LinqToDB.DataProvider.DB2
 		public override ISqlBuilder CreateSqlBuilder(MappingSchema mappingSchema)
 		{
 			return Version == DB2Version.zOS ?
-				new DB2zOSSqlBuilder(this, mappingSchema, GetSqlOptimizer(), SqlProviderFlags) as ISqlBuilder:
+				new DB2zOSSqlBuilder(this, mappingSchema, GetSqlOptimizer(), SqlProviderFlags) :
 				new DB2LUWSqlBuilder(this, mappingSchema, GetSqlOptimizer(), SqlProviderFlags);
 		}
 

--- a/Source/LinqToDB/DataProvider/DataProviderBase.cs
+++ b/Source/LinqToDB/DataProvider/DataProviderBase.cs
@@ -129,7 +129,7 @@ namespace LinqToDB.DataProvider
 
 		#region Helpers
 
-		public readonly ConcurrentDictionary<ReaderInfo,Expression> ReaderExpressions = new ConcurrentDictionary<ReaderInfo,Expression>();
+		public readonly ConcurrentDictionary<ReaderInfo,Expression> ReaderExpressions = new ();
 
 		protected void SetCharField(string dataTypeName, Expression<Func<IDataReader,int,string>> expr)
 		{
@@ -414,12 +414,14 @@ namespace LinqToDB.DataProvider
 		#region BulkCopy
 
 		public virtual BulkCopyRowsCopied BulkCopy<T>(ITable<T> table, BulkCopyOptions options, IEnumerable<T> source)
+			where T : notnull
 		{
 			return new BasicBulkCopy().BulkCopy(options.BulkCopyType, table, options, source);
 		}
 
 		public virtual Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IEnumerable<T> source, CancellationToken cancellationToken)
+			where T : notnull
 		{
 			return new BasicBulkCopy().BulkCopyAsync(options.BulkCopyType, table, options, source, cancellationToken);
 		}
@@ -427,6 +429,7 @@ namespace LinqToDB.DataProvider
 #if !NETFRAMEWORK
 		public virtual Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
+			where T: notnull
 		{
 			return new BasicBulkCopy().BulkCopyAsync(options.BulkCopyType, table, options, source, cancellationToken);
 		}

--- a/Source/LinqToDB/DataProvider/IDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/IDataProvider.cs
@@ -32,7 +32,7 @@ namespace LinqToDB.DataProvider
 		/// <param name="commandText">Command SQL.</param>
 		/// <param name="parameters">Optional list of parameters to add to initialized command.</param>
 		/// <param name="withParameters">Flag to indicate that command has parameters. Used to configure parameters support when method called without parameters and parameters added later to command.</param>
-		void InitCommand           (DataConnection dataConnection, CommandType commandType, string commandText, DataParameter[]? parameters, bool withParameters);
+		void               InitCommand           (DataConnection dataConnection, CommandType commandType, string commandText, DataParameter[]? parameters, bool withParameters);
 		void               DisposeCommand        (DataConnection dataConnection);
 		object?            GetConnectionInfo     (DataConnection dataConnection, string parameterName);
 		Expression         GetReaderExpression   (IDataReader reader, int idx, Expression readerExpression, Type toType);
@@ -53,12 +53,15 @@ namespace LinqToDB.DataProvider
 
 		ISchemaProvider    GetSchemaProvider     ();
 
-		BulkCopyRowsCopied       BulkCopy<T>     (ITable<T> table, BulkCopyOptions options, IEnumerable<T> source);
+		BulkCopyRowsCopied       BulkCopy<T>     (ITable<T> table, BulkCopyOptions options, IEnumerable<T> source)
+			where T : notnull;
 
-		Task<BulkCopyRowsCopied> BulkCopyAsync<T>(ITable<T> table, BulkCopyOptions options, IEnumerable<T> source, CancellationToken cancellationToken);
+		Task<BulkCopyRowsCopied> BulkCopyAsync<T>(ITable<T> table, BulkCopyOptions options, IEnumerable<T> source, CancellationToken cancellationToken)
+			where T : notnull;
 
 #if !NETFRAMEWORK
-		Task<BulkCopyRowsCopied> BulkCopyAsync<T>(ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken);
+		Task<BulkCopyRowsCopied> BulkCopyAsync<T>(ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
+		where T: notnull;
 #endif
 	}
 }

--- a/Source/LinqToDB/DataProvider/Informix/InformixBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixBulkCopy.cs
@@ -104,7 +104,7 @@ namespace LinqToDB.DataProvider.Informix
 				if (connection != null)
 				{
 					var enumerator = source.GetAsyncEnumerator(cancellationToken);
-					await using (enumerator.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
+					await using (enumerator.ConfigureAwait(Configuration.ContinueOnCapturedContext))
 					{
 						// call the synchronous provider-specific implementation
 						var syncSource = EnumerableHelper.AsyncToSyncEnumerable(enumerator);
@@ -130,7 +130,7 @@ namespace LinqToDB.DataProvider.Informix
 			}
 
 			return await MultipleRowsCopyAsync(table, options, source, cancellationToken)
-				.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+				.ConfigureAwait(Configuration.ContinueOnCapturedContext);
 		}
 #endif
 
@@ -141,6 +141,7 @@ namespace LinqToDB.DataProvider.Informix
 			DataConnection                          dataConnection,
 			IDbConnection                           connection,
 			InformixProviderAdapter.BulkCopyAdapter bulkCopy)
+			where T: notnull
 		{
 			var ed      = dataConnection.MappingSchema.GetEntityDescriptor(typeof(T));
 			var columns = ed.Columns.Where(c => !c.SkipOnInsert || options.KeepIdentity == true && c.IsIdentity).ToList();

--- a/Source/LinqToDB/DataProvider/MultipleRowsHelper.cs
+++ b/Source/LinqToDB/DataProvider/MultipleRowsHelper.cs
@@ -13,6 +13,7 @@ namespace LinqToDB.DataProvider
 	using System.Threading.Tasks;
 
 	public class MultipleRowsHelper<T> : MultipleRowsHelper
+		where T : notnull
 	{
 		public MultipleRowsHelper(ITable<T> table, BulkCopyOptions options)
 			: base((DataConnection)table.DataContext, options, typeof(T))
@@ -48,9 +49,9 @@ namespace LinqToDB.DataProvider
 		public          string?             TableName;
 		public readonly string              ParameterName;
 
-		public readonly List<DataParameter> Parameters    = new List<DataParameter>();
-		public readonly StringBuilder       StringBuilder = new StringBuilder();
-		public readonly BulkCopyRowsCopied  RowsCopied    = new BulkCopyRowsCopied();
+		public readonly List<DataParameter> Parameters    = new ();
+		public readonly StringBuilder       StringBuilder = new ();
+		public readonly BulkCopyRowsCopied  RowsCopied    = new ();
 
 		public int CurrentCount;
 		public int ParameterIndex;

--- a/Source/LinqToDB/DataProvider/MySql/MySqlBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlBulkCopy.cs
@@ -81,6 +81,7 @@ namespace LinqToDB.DataProvider.MySql
 #endif
 
 		private ProviderConnections? TryGetProviderConnections<T>(ITable<T> table)
+			where T : notnull
 		{
 			if (table.DataContext is DataConnection dataConnection && _provider.Adapter.BulkCopy != null)
 			{
@@ -110,6 +111,7 @@ namespace LinqToDB.DataProvider.MySql
 			IEnumerable<T>      source,
 			bool                runAsync,
 			CancellationToken   cancellationToken)
+			where T : notnull
 		{
 			var dataConnection = providerConnections.DataConnection;
 			var connection     = providerConnections.ProviderConnection;
@@ -166,18 +168,18 @@ namespace LinqToDB.DataProvider.MySql
 						{
 #if !NETFRAMEWORK
 							if (bc.CanWriteToServerAsync2)
-								await bc.WriteToServerAsync2(rd, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+								await bc.WriteToServerAsync2(rd, cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 							else
 #endif
 								if (bc.CanWriteToServerAsync)
-									await bc.WriteToServerAsync(rd, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+									await bc.WriteToServerAsync(rd, cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 								else
 									bc.WriteToServer(rd);
 						}
 						else
 							bc.WriteToServer(rd);
 						return rd.Count;
-					}).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+					}).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 				rc.RowsCopied += rd.Count;
 			}
@@ -195,6 +197,7 @@ namespace LinqToDB.DataProvider.MySql
 			BulkCopyOptions     options,
 			IAsyncEnumerable<T> source,
 			CancellationToken   cancellationToken)
+			where T: notnull
 		{
 			var dataConnection = providerConnections.DataConnection;
 			var connection = providerConnections.ProviderConnection;
@@ -230,7 +233,7 @@ namespace LinqToDB.DataProvider.MySql
 			// emulate missing BatchSize property
 			// this is needed, because MySql fails on big batches, so users should be able to limit batch size
 			var batches = EnumerableHelper.Batch(source, options.MaxBatchSize ?? int.MaxValue);
-			await foreach (var batch in batches.WithCancellation(cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
+			await foreach (var batch in batches.WithCancellation(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 			{
 				var rd = new BulkCopyReader<T>(dataConnection, columns, batch, cancellationToken);
 
@@ -239,14 +242,14 @@ namespace LinqToDB.DataProvider.MySql
 					() => "INSERT BULK " + tableName + "(" + string.Join(", ", columns.Select(x => x.ColumnName)) + Environment.NewLine,
 					async () => {
 						if (bc.CanWriteToServerAsync2)
-							await bc.WriteToServerAsync2(rd, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+							await bc.WriteToServerAsync2(rd, cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 						else
 							if (bc.CanWriteToServerAsync)
-								await bc.WriteToServerAsync(rd, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+								await bc.WriteToServerAsync(rd, cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 							else
 								bc.WriteToServer(rd);
 						return rd.Count;
-					}).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+					}).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 				rc.RowsCopied += rd.Count;
 			}

--- a/Source/LinqToDB/DataProvider/Oracle/OracleBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleBulkCopy.cs
@@ -137,7 +137,7 @@ namespace LinqToDB.DataProvider.Oracle
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
 			var enumerator = source.GetAsyncEnumerator(cancellationToken);
-			await using (enumerator.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
+			await using (enumerator.ConfigureAwait(Configuration.ContinueOnCapturedContext))
 			{
 				// call the synchronous provider-specific implementation
 				return ProviderSpecificCopy(table, options, EnumerableHelper.AsyncToSyncEnumerable(enumerator));
@@ -288,7 +288,7 @@ namespace LinqToDB.DataProvider.Oracle
 
 				if (helper.CurrentCount >= helper.BatchSize)
 				{
-					if (!await ExecuteAsync(helper, list, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
+					if (!await ExecuteAsync(helper, list, cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 						return helper.RowsCopied;
 
 					list.Clear();
@@ -297,7 +297,7 @@ namespace LinqToDB.DataProvider.Oracle
 
 			if (helper.CurrentCount > 0)
 			{
-				await ExecuteAsync(helper, list, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+				await ExecuteAsync(helper, list, cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 			}
 
 			return helper.RowsCopied;
@@ -308,7 +308,7 @@ namespace LinqToDB.DataProvider.Oracle
 		{
 			var list = OracleMultipleRowsCopy2Prep(helper);
 
-			await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
+			await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 			{
 				list.Add(item!);
 
@@ -317,7 +317,7 @@ namespace LinqToDB.DataProvider.Oracle
 
 				if (helper.CurrentCount >= helper.BatchSize)
 				{
-					if (!await ExecuteAsync(helper, list, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
+					if (!await ExecuteAsync(helper, list, cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 						return helper.RowsCopied;
 
 					list.Clear();
@@ -326,7 +326,7 @@ namespace LinqToDB.DataProvider.Oracle
 
 			if (helper.CurrentCount > 0)
 			{
-				await ExecuteAsync(helper, list, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+				await ExecuteAsync(helper, list, cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 			}
 
 			return helper.RowsCopied;

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
@@ -1,5 +1,4 @@
-using System;
-using System.Collections.Concurrent;
+﻿using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
@@ -67,6 +66,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 #endif
 
 		private BulkCopyRowsCopied ProviderSpecificCopyImpl<T>(DataConnection dataConnection, ITable<T> table, BulkCopyOptions options, IEnumerable<T> source)
+			where T : notnull
 		{
 			var connection = _provider.TryGetProviderConnection(dataConnection.Connection, dataConnection.MappingSchema);
 
@@ -193,6 +193,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 		}
 
 		private async Task<BulkCopyRowsCopied> ProviderSpecificCopyImplAsync<T>(DataConnection dataConnection, ITable<T> table, BulkCopyOptions options, IEnumerable<T> source, CancellationToken cancellationToken)
+			where T : notnull
 		{
 			var connection = _provider.TryGetProviderConnection(dataConnection.Connection, dataConnection.MappingSchema);
 
@@ -306,6 +307,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 
 #if !NETFRAMEWORK
 		private async Task<BulkCopyRowsCopied> ProviderSpecificCopyImplAsync<T>(DataConnection dataConnection, ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
+		where T: notnull
 		{
 			var connection = _provider.TryGetProviderConnection(dataConnection.Connection, dataConnection.MappingSchema);
 

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLExtensions.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLExtensions.cs
@@ -5,11 +5,13 @@ using System.Linq.Expressions;
 
 namespace LinqToDB.DataProvider.PostgreSQL
 {
-	using SqlQuery;
-	using Mapping;
 	using Expressions;
 	using Linq;
+	using SqlQuery;
+#if !NET45
 	using LinqToDB.Common;
+	using Mapping;
+#endif
 
 	public interface IPostgreSQLExtensions
 	{

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaBulkCopy.cs
@@ -84,6 +84,7 @@ namespace LinqToDB.DataProvider.SapHana
 #endif
 
 		private ProviderConnections? TryGetProviderConnections<T>(ITable<T> table)
+			where T : notnull
 		{
 			if (table.DataContext is DataConnection dataConnection)
 			{
@@ -114,6 +115,7 @@ namespace LinqToDB.DataProvider.SapHana
 			Func<List<Mapping.ColumnDescriptor>, BulkCopyReader<T>> createDataReader,
 			bool                                                    runAsync,
 			CancellationToken                                       cancellationToken)
+			where T : notnull
 		{
 			var dataConnection = providerConnections.DataConnection;
 			var connection     = providerConnections.ProviderConnection;

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerBulkCopy.cs
@@ -84,6 +84,7 @@ namespace LinqToDB.DataProvider.SqlServer
 #endif
 
 		private ProviderConnections? TryGetProviderConnections<T>(ITable<T> table)
+			where T : notnull
 		{
 			if (table.DataContext is DataConnection dataConnection)
 			{
@@ -113,6 +114,7 @@ namespace LinqToDB.DataProvider.SqlServer
 			Func<List<Mapping.ColumnDescriptor>, BulkCopyReader<T>> createDataReader,
 			bool                                                    runAsync,
 			CancellationToken                                       cancellationToken)
+			where T : notnull
 		{
 			var dataConnection = providerConnections.DataConnection;
 			var connection     = providerConnections.ProviderConnection;

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerExtensions.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerExtensions.cs
@@ -1,4 +1,4 @@
-using LinqToDB.Linq;
+﻿using LinqToDB.Linq;
 using LinqToDB.Mapping;
 using System;
 using System.Linq;
@@ -34,11 +34,13 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns full-text search ranking table.</returns>
 		[ExpressionMethod(nameof(FreeTextTableImpl1))]
 		public static IQueryable<FreeTextKey<TKey>> FreeTextTable<TTable, TKey>(this ISqlServerExtensions? ext, ITable<TTable> table, string term)
+			where TTable : notnull
 		{
 			return table.DataContext.FromSql<FreeTextKey<TKey>>($"FREETEXTTABLE({Sql.TableExpr(table)}, *, {term})");
 		}
 
 		static Expression<Func<ISqlServerExtensions, ITable<TTable>, string, IQueryable<FreeTextKey<TKey>>>> FreeTextTableImpl1<TTable, TKey>()
+			where TTable : notnull
 		{
 			return (ext, table, term) => table.DataContext.FromSql<FreeTextKey<TKey>>($"FREETEXTTABLE({Sql.TableExpr(table)}, *, {term})");
 		}
@@ -56,11 +58,13 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns full-text search ranking table.</returns>
 		[ExpressionMethod(nameof(FreeTextTableImpl2))]
 		public static IQueryable<FreeTextKey<TKey>> FreeTextTable<TTable, TKey>(this ISqlServerExtensions? ext, ITable<TTable> table, string term, int top)
+			where TTable : notnull
 		{
 			return table.DataContext.FromSql<FreeTextKey<TKey>>($"FREETEXTTABLE({Sql.TableExpr(table)}, *, {term}, {top})");
 		}
 
 		static Expression<Func<ISqlServerExtensions, ITable<TTable>, string, int, IQueryable<FreeTextKey<TKey>>>> FreeTextTableImpl2<TTable, TKey>()
+			where TTable : notnull
 		{
 			return (ext, table, term, top) => table.DataContext.FromSql<FreeTextKey<TKey>>($"FREETEXTTABLE({Sql.TableExpr(table)}, *, {term}, {top})");
 		}
@@ -78,11 +82,13 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns full-text search ranking table.</returns>
 		[ExpressionMethod(nameof(FreeTextTableImpl3))]
 		public static IQueryable<FreeTextKey<TKey>> FreeTextTableWithLanguage<TTable, TKey>(this ISqlServerExtensions? ext, ITable<TTable> table, string term, string language)
+			where TTable : notnull
 		{
 			return table.DataContext.FromSql<FreeTextKey<TKey>>($"FREETEXTTABLE({Sql.TableExpr(table)}, *, {term}, LANGUAGE {language})");
 		}
 
 		static Expression<Func<ISqlServerExtensions, ITable<TTable>, string, string, IQueryable<FreeTextKey<TKey>>>> FreeTextTableImpl3<TTable, TKey>()
+			where TTable : notnull
 		{
 			return (ext, table, term, language) => table.DataContext.FromSql<FreeTextKey<TKey>>($"FREETEXTTABLE({Sql.TableExpr(table)}, *, {term}, LANGUAGE {language})");
 		}
@@ -101,11 +107,13 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns full-text search ranking table.</returns>
 		[ExpressionMethod(nameof(FreeTextTableImpl4))]
 		public static IQueryable<FreeTextKey<TKey>> FreeTextTableWithLanguage<TTable, TKey>(this ISqlServerExtensions? ext, ITable<TTable> table, string term, string language, int top)
+			where TTable : notnull
 		{
 			return table.DataContext.FromSql<FreeTextKey<TKey>>($"FREETEXTTABLE({Sql.TableExpr(table)}, *, {term}, LANGUAGE {language}, {top})");
 		}
 
 		static Expression<Func<ISqlServerExtensions, ITable<TTable>, string, string, int, IQueryable<FreeTextKey<TKey>>>> FreeTextTableImpl4<TTable, TKey>()
+			where TTable : notnull
 		{
 			return (ext, table, term, language, top) => table.DataContext.FromSql<FreeTextKey<TKey>>($"FREETEXTTABLE({Sql.TableExpr(table)}, *, {term}, LANGUAGE {language}, {top})");
 		}
@@ -124,11 +132,13 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns full-text search ranking table.</returns>
 		[ExpressionMethod(nameof(FreeTextTableImpl5))]
 		public static IQueryable<FreeTextKey<TKey>> FreeTextTableWithLanguage<TTable, TKey>(this ISqlServerExtensions? ext, ITable<TTable> table, string term, int language, int top)
+			where TTable : notnull
 		{
 			return table.DataContext.FromSql<FreeTextKey<TKey>>($"FREETEXTTABLE({Sql.TableExpr(table)}, *, {term}, LANGUAGE {language}, {top})");
 		}
 
 		static Expression<Func<ISqlServerExtensions, ITable<TTable>, string, int, int, IQueryable<FreeTextKey<TKey>>>> FreeTextTableImpl5<TTable, TKey>()
+			where TTable : notnull
 		{
 			return (ext, table, term, language, top) => table.DataContext.FromSql<FreeTextKey<TKey>>($"FREETEXTTABLE({Sql.TableExpr(table)}, *, {term}, LANGUAGE {language}, {top})");
 		}
@@ -146,11 +156,13 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns full-text search ranking table.</returns>
 		[ExpressionMethod(nameof(FreeTextTableImpl6))]
 		public static IQueryable<FreeTextKey<TKey>> FreeTextTableWithLanguage<TTable, TKey>(this ISqlServerExtensions? ext, ITable<TTable> table, string term, int language)
+			where TTable : notnull
 		{
 			return table.DataContext.FromSql<FreeTextKey<TKey>>($"FREETEXTTABLE({Sql.TableExpr(table)}, *, {term}, LANGUAGE {language})");
 		}
 
 		static Expression<Func<ISqlServerExtensions, ITable<TTable>, string, int, IQueryable<FreeTextKey<TKey>>>> FreeTextTableImpl6<TTable, TKey>()
+			where TTable : notnull
 		{
 			return (ext, table, term, language) => table.DataContext.FromSql<FreeTextKey<TKey>>($"FREETEXTTABLE({Sql.TableExpr(table)}, *, {term}, LANGUAGE {language})");
 		}
@@ -168,11 +180,13 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns full-text search ranking table.</returns>
 		[ExpressionMethod(nameof(FreeTextTableImpl7))]
 		public static IQueryable<FreeTextKey<TKey>> FreeTextTable<TTable, TKey>(this ISqlServerExtensions? ext, ITable<TTable> table, Expression<Func<TTable, object?>> columns, string term)
+			where TTable : notnull
 		{
 			return table.DataContext.FromSql<FreeTextKey<TKey>>($"FREETEXTTABLE({Sql.TableExpr(table)}, ({Sql.FieldsExpr(table, columns)}), {term})");
 		}
 
 		static Expression<Func<ISqlServerExtensions, ITable<TTable>, Expression<Func<TTable, object?>>, string, IQueryable<FreeTextKey<TKey>>>> FreeTextTableImpl7<TTable, TKey>()
+			where TTable : notnull
 		{
 			return (ext, table, columns, term) => table.DataContext.FromSql<FreeTextKey<TKey>>($"FREETEXTTABLE({Sql.TableExpr(table)}, ({Sql.FieldsExpr(table, columns)}), {term})");
 		}
@@ -191,11 +205,13 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns full-text search ranking table.</returns>
 		[ExpressionMethod(nameof(FreeTextTableImpl8))]
 		public static IQueryable<FreeTextKey<TKey>> FreeTextTable<TTable, TKey>(this ISqlServerExtensions? ext, ITable<TTable> table, Expression<Func<TTable, object?>> columns, string term, int top)
+			where TTable : notnull
 		{
 			return table.DataContext.FromSql<FreeTextKey<TKey>>($"FREETEXTTABLE({Sql.TableExpr(table)}, ({Sql.FieldsExpr(table, columns)}), {term}, {top})");
 		}
 
 		static Expression<Func<ISqlServerExtensions, ITable<TTable>, Expression<Func<TTable, object?>>, string, int, IQueryable<FreeTextKey<TKey>>>> FreeTextTableImpl8<TTable, TKey>()
+			where TTable : notnull
 		{
 			return (ext, table, columns, term, top) => table.DataContext.FromSql<FreeTextKey<TKey>>($"FREETEXTTABLE({Sql.TableExpr(table)}, ({Sql.FieldsExpr(table, columns)}), {term}, {top})");
 		}
@@ -214,11 +230,13 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns full-text search ranking table.</returns>
 		[ExpressionMethod(nameof(FreeTextTableImpl9))]
 		public static IQueryable<FreeTextKey<TKey>> FreeTextTableWithLanguage<TTable, TKey>(this ISqlServerExtensions? ext, ITable<TTable> table, Expression<Func<TTable, object?>> columns, string term, string language)
+			where TTable : notnull
 		{
 				return table.DataContext.FromSql<FreeTextKey<TKey>>($"FREETEXTTABLE({Sql.TableExpr(table)}, ({Sql.FieldsExpr(table, columns)}), {term}, LANGUAGE {language})");
 		}
 
 		static Expression<Func<ISqlServerExtensions, ITable<TTable>, Expression<Func<TTable, object?>>, string, string, IQueryable<FreeTextKey<TKey>>>> FreeTextTableImpl9<TTable, TKey>()
+			where TTable : notnull
 		{
 			return (ext, table, columns, term, language) => table.DataContext.FromSql<FreeTextKey<TKey>>($"FREETEXTTABLE({Sql.TableExpr(table)}, ({Sql.FieldsExpr(table, columns)}), {term}, LANGUAGE {language})");
 		}
@@ -238,11 +256,13 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns full-text search ranking table.</returns>
 		[ExpressionMethod(nameof(FreeTextTableImpl10))]
 		public static IQueryable<FreeTextKey<TKey>> FreeTextTableWithLanguage<TTable, TKey>(this ISqlServerExtensions? ext, ITable<TTable> table, Expression<Func<TTable, object?>> columns, string term, string language, int top)
+			where TTable : notnull
 		{
 			return table.DataContext.FromSql<FreeTextKey<TKey>>($"FREETEXTTABLE({Sql.TableExpr(table)}, ({Sql.FieldsExpr(table, columns)}), {term}, LANGUAGE {language}, {top})");
 		}
 
 		static Expression<Func<ISqlServerExtensions, ITable<TTable>, Expression<Func<TTable, object?>>, string, string, int, IQueryable<FreeTextKey<TKey>>>> FreeTextTableImpl10<TTable, TKey>()
+			where TTable : notnull
 		{
 			return (ext, table, columns, term, language, top) => table.DataContext.FromSql<FreeTextKey<TKey>>($"FREETEXTTABLE({Sql.TableExpr(table)}, ({Sql.FieldsExpr(table, columns)}), {term}, LANGUAGE {language}, {top})");
 		}
@@ -262,11 +282,13 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns full-text search ranking table.</returns>
 		[ExpressionMethod(nameof(FreeTextTableImpl11))]
 		public static IQueryable<FreeTextKey<TKey>> FreeTextTableWithLanguage<TTable, TKey>(this ISqlServerExtensions? ext, ITable<TTable> table, Expression<Func<TTable, object?>> columns, string term, int language, int top)
+			where TTable : notnull
 		{
 			return table.DataContext.FromSql<FreeTextKey<TKey>>($"FREETEXTTABLE({Sql.TableExpr(table)}, ({Sql.FieldsExpr(table, columns)}), {term}, LANGUAGE {language}, {top})");
 		}
 
 		static Expression<Func<ISqlServerExtensions, ITable<TTable>, Expression<Func<TTable, object?>>, string, int, int, IQueryable<FreeTextKey<TKey>>>> FreeTextTableImpl11<TTable, TKey>()
+			where TTable : notnull
 		{
 			return (ext, table, columns, term, language, top) => table.DataContext.FromSql<FreeTextKey<TKey>>($"FREETEXTTABLE({Sql.TableExpr(table)}, ({Sql.FieldsExpr(table, columns)}), {term}, LANGUAGE {language}, {top})");
 		}
@@ -285,11 +307,13 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns full-text search ranking table.</returns>
 		[ExpressionMethod(nameof(FreeTextTableImpl12))]
 		public static IQueryable<FreeTextKey<TKey>> FreeTextTableWithLanguage<TTable, TKey>(this ISqlServerExtensions? ext, ITable<TTable> table, Expression<Func<TTable, object?>> columns, string term, int language)
+			where TTable : notnull
 		{
 			return table.DataContext.FromSql<FreeTextKey<TKey>>($"FREETEXTTABLE({Sql.TableExpr(table)}, ({Sql.FieldsExpr(table, columns)}), {term}, LANGUAGE {language})");
 		}
 
 		static Expression<Func<ISqlServerExtensions, ITable<TTable>, Expression<Func<TTable, object?>>, string, int, IQueryable<FreeTextKey<TKey>>>> FreeTextTableImpl12<TTable, TKey>()
+			where TTable : notnull
 		{
 			return (ext, table, columns, term, language) => table.DataContext.FromSql<FreeTextKey<TKey>>($"FREETEXTTABLE({Sql.TableExpr(table)}, ({Sql.FieldsExpr(table, columns)}), {term}, LANGUAGE {language})");
 		}
@@ -308,11 +332,13 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns full-text search ranking table.</returns>
 		[ExpressionMethod(nameof(ContainsTableImpl1))]
 		public static IQueryable<FreeTextKey<TKey>> ContainsTable<TTable, TKey>(this ISqlServerExtensions? ext, ITable<TTable> table, string search)
+			where TTable : notnull
 		{
 			return table.DataContext.FromSql<FreeTextKey<TKey>>($"CONTAINSTABLE({Sql.TableExpr(table)}, *, {search})");
 		}
 
 		static Expression<Func<ISqlServerExtensions, ITable<TTable>, string, IQueryable<FreeTextKey<TKey>>>> ContainsTableImpl1<TTable, TKey>()
+			where TTable : notnull
 		{
 			return (ext, table, search) => table.DataContext.FromSql<FreeTextKey<TKey>>($"CONTAINSTABLE({Sql.TableExpr(table)}, *, {search})");
 		}
@@ -330,11 +356,13 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns full-text search ranking table.</returns>
 		[ExpressionMethod(nameof(ContainsTableImpl2))]
 		public static IQueryable<FreeTextKey<TKey>> ContainsTable<TTable, TKey>(this ISqlServerExtensions? ext, ITable<TTable> table, string search, int top)
+			where TTable : notnull
 		{
 			return table.DataContext.FromSql<FreeTextKey<TKey>>($"CONTAINSTABLE({Sql.TableExpr(table)}, *, {search}, {top})");
 		}
 
 		static Expression<Func<ISqlServerExtensions, ITable<TTable>, string, int, IQueryable<FreeTextKey<TKey>>>> ContainsTableImpl2<TTable, TKey>()
+			where TTable : notnull
 		{
 			return (ext, table, search, top) => table.DataContext.FromSql<FreeTextKey<TKey>>($"CONTAINSTABLE({Sql.TableExpr(table)}, *, {search}, {top})");
 		}
@@ -352,11 +380,13 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns full-text search ranking table.</returns>
 		[ExpressionMethod(nameof(ContainsTableImpl3))]
 		public static IQueryable<FreeTextKey<TKey>> ContainsTableWithLanguage<TTable, TKey>(this ISqlServerExtensions? ext, ITable<TTable> table, string search, string language)
+			where TTable : notnull
 		{
 			return table.DataContext.FromSql<FreeTextKey<TKey>>($"CONTAINSTABLE({Sql.TableExpr(table)}, *, {search}, LANGUAGE {language})");
 		}
 
 		static Expression<Func<ISqlServerExtensions, ITable<TTable>, string, string, IQueryable<FreeTextKey<TKey>>>> ContainsTableImpl3<TTable, TKey>()
+			where TTable : notnull
 		{
 			return (ext, table, search, language) => table.DataContext.FromSql<FreeTextKey<TKey>>($"CONTAINSTABLE({Sql.TableExpr(table)}, *, {search}, LANGUAGE {language})");
 		}
@@ -375,11 +405,13 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns full-text search ranking table.</returns>
 		[ExpressionMethod(nameof(ContainsTableImpl4))]
 		public static IQueryable<FreeTextKey<TKey>> ContainsTableWithLanguage<TTable, TKey>(this ISqlServerExtensions? ext, ITable<TTable> table, string search, string language, int top)
+			where TTable : notnull
 		{
 			return table.DataContext.FromSql<FreeTextKey<TKey>>($"CONTAINSTABLE({Sql.TableExpr(table)}, *, {search}, LANGUAGE {language}, {top})");
 		}
 
 		static Expression<Func<ISqlServerExtensions, ITable<TTable>, string, string, int, IQueryable<FreeTextKey<TKey>>>> ContainsTableImpl4<TTable, TKey>()
+			where TTable : notnull
 		{
 			return (ext, table, search, language, top) => table.DataContext.FromSql<FreeTextKey<TKey>>($"CONTAINSTABLE({Sql.TableExpr(table)}, *, {search}, LANGUAGE {language}, {top})");
 		}
@@ -398,11 +430,13 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns full-text search ranking table.</returns>
 		[ExpressionMethod(nameof(ContainsTableImpl5))]
 		public static IQueryable<FreeTextKey<TKey>> ContainsTableWithLanguage<TTable, TKey>(this ISqlServerExtensions? ext, ITable<TTable> table, string search, int language, int top)
+			where TTable : notnull
 		{
 			return table.DataContext.FromSql<FreeTextKey<TKey>>($"CONTAINSTABLE({Sql.TableExpr(table)}, *, {search}, LANGUAGE {language}, {top})");
 		}
 
 		static Expression<Func<ISqlServerExtensions, ITable<TTable>, string, int, int, IQueryable<FreeTextKey<TKey>>>> ContainsTableImpl5<TTable, TKey>()
+			where TTable : notnull
 		{
 			return (ext, table, search, language, top) => table.DataContext.FromSql<FreeTextKey<TKey>>($"CONTAINSTABLE({Sql.TableExpr(table)}, *, {search}, LANGUAGE {language}, {top})");
 		}
@@ -420,11 +454,13 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns full-text search ranking table.</returns>
 		[ExpressionMethod(nameof(ContainsTableImpl6))]
 		public static IQueryable<FreeTextKey<TKey>> ContainsTableWithLanguage<TTable, TKey>(this ISqlServerExtensions? ext, ITable<TTable> table, string search, int language)
+			where TTable : notnull
 		{
 			return table.DataContext.FromSql<FreeTextKey<TKey>>($"CONTAINSTABLE({Sql.TableExpr(table)}, *, {search}, LANGUAGE {language})");
 		}
 
 		static Expression<Func<ISqlServerExtensions, ITable<TTable>, string, int, IQueryable<FreeTextKey<TKey>>>> ContainsTableImpl6<TTable, TKey>()
+			where TTable : notnull
 		{
 			return (ext, table, search, language) => table.DataContext.FromSql<FreeTextKey<TKey>>($"CONTAINSTABLE({Sql.TableExpr(table)}, *, {search}, LANGUAGE {language})");
 		}
@@ -442,11 +478,13 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns full-text search ranking table.</returns>
 		[ExpressionMethod(nameof(ContainsTableImpl7))]
 		public static IQueryable<FreeTextKey<TKey>> ContainsTable<TTable, TKey>(this ISqlServerExtensions? ext, ITable<TTable> table, Expression<Func<TTable, object?>> columns, string search)
+			where TTable : notnull
 		{
 			return table.DataContext.FromSql<FreeTextKey<TKey>>($"CONTAINSTABLE({Sql.TableExpr(table)}, ({Sql.FieldsExpr(table, columns)}), {search})");
 		}
 
 		static Expression<Func<ISqlServerExtensions, ITable<TTable>, Expression<Func<TTable, object?>>, string, IQueryable<FreeTextKey<TKey>>>> ContainsTableImpl7<TTable, TKey>()
+			where TTable : notnull
 		{
 			return (ext, table, columns, term) => table.DataContext.FromSql<FreeTextKey<TKey>>($"CONTAINSTABLE({Sql.TableExpr(table)}, ({Sql.FieldsExpr(table, columns)}), {term})");
 		}
@@ -465,11 +503,13 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns full-text search ranking table.</returns>
 		[ExpressionMethod(nameof(ContainsTableImpl8))]
 		public static IQueryable<FreeTextKey<TKey>> ContainsTable<TTable, TKey>(this ISqlServerExtensions? ext, ITable<TTable> table, Expression<Func<TTable, object?>> columns, string search, int top)
+			where TTable : notnull
 		{
 			return table.DataContext.FromSql<FreeTextKey<TKey>>($"CONTAINSTABLE({Sql.TableExpr(table)}, ({Sql.FieldsExpr(table, columns)}), {search}, {top})");
 		}
 
 		static Expression<Func<ISqlServerExtensions, ITable<TTable>, Expression<Func<TTable, object?>>, string, int, IQueryable<FreeTextKey<TKey>>>> ContainsTableImpl8<TTable, TKey>()
+			where TTable : notnull
 		{
 			return (ext, table, columns, term, top) => table.DataContext.FromSql<FreeTextKey<TKey>>($"CONTAINSTABLE({Sql.TableExpr(table)}, ({Sql.FieldsExpr(table, columns)}), {term}, {top})");
 		}
@@ -489,11 +529,13 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns full-text search ranking table.</returns>
 		[ExpressionMethod(nameof(ContainsTableImpl9))]
 		public static IQueryable<FreeTextKey<TKey>> ContainsTableWithLanguage<TTable, TKey>(this ISqlServerExtensions? ext, ITable<TTable> table, Expression<Func<TTable, object?>> columns, string search, string language, int top)
+			where TTable : notnull
 		{
 			return table.DataContext.FromSql<FreeTextKey<TKey>>($"CONTAINSTABLE({Sql.TableExpr(table)}, ({Sql.FieldsExpr(table, columns)}), {search}, LANGUAGE {language}, {top})");
 		}
 
 		static Expression<Func<ISqlServerExtensions, ITable<TTable>, Expression<Func<TTable, object?>>, string, string, int, IQueryable<FreeTextKey<TKey>>>> ContainsTableImpl9<TTable, TKey>()
+			where TTable : notnull
 		{
 			return (ext, table, columns, term, language, top) => table.DataContext.FromSql<FreeTextKey<TKey>>($"CONTAINSTABLE({Sql.TableExpr(table)}, ({Sql.FieldsExpr(table, columns)}), {term}, LANGUAGE {language}, {top})");
 		}
@@ -512,11 +554,13 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns full-text search ranking table.</returns>
 		[ExpressionMethod(nameof(ContainsTableImpl10))]
 		public static IQueryable<FreeTextKey<TKey>> ContainsTableWithLanguage<TTable, TKey>(this ISqlServerExtensions? ext, ITable<TTable> table, Expression<Func<TTable, object?>> columns, string search, string language)
+			where TTable : notnull
 		{
 			return table.DataContext.FromSql<FreeTextKey<TKey>>($"CONTAINSTABLE({Sql.TableExpr(table)}, ({Sql.FieldsExpr(table, columns)}), {search}, LANGUAGE {language})");
 		}
 
 		static Expression<Func<ISqlServerExtensions, ITable<TTable>, Expression<Func<TTable, object?>>, string, string, IQueryable<FreeTextKey<TKey>>>> ContainsTableImpl10<TTable, TKey>()
+			where TTable : notnull
 		{
 			return (ext, table, columns, term, language) => table.DataContext.FromSql<FreeTextKey<TKey>>($"CONTAINSTABLE({Sql.TableExpr(table)}, ({Sql.FieldsExpr(table, columns)}), {term}, LANGUAGE {language})");
 		}
@@ -536,11 +580,13 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns full-text search ranking table.</returns>
 		[ExpressionMethod(nameof(ContainsTableImpl11))]
 		public static IQueryable<FreeTextKey<TKey>> ContainsTableWithLanguage<TTable, TKey>(this ISqlServerExtensions? ext, ITable<TTable> table, Expression<Func<TTable, object?>> columns, string search, int language, int top)
+			where TTable : notnull
 		{
 			return table.DataContext.FromSql<FreeTextKey<TKey>>($"CONTAINSTABLE({Sql.TableExpr(table)}, ({Sql.FieldsExpr(table, columns)}), {search}, LANGUAGE {language}, {top})");
 		}
 
 		static Expression<Func<ISqlServerExtensions, ITable<TTable>, Expression<Func<TTable, object?>>, string, int, int, IQueryable<FreeTextKey<TKey>>>> ContainsTableImpl11<TTable, TKey>()
+			where TTable : notnull
 		{
 			return (ext, table, columns, term, language, top) => table.DataContext.FromSql<FreeTextKey<TKey>>($"CONTAINSTABLE({Sql.TableExpr(table)}, ({Sql.FieldsExpr(table, columns)}), {term}, LANGUAGE {language}, {top})");
 		}
@@ -559,11 +605,13 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns full-text search ranking table.</returns>
 		[ExpressionMethod(nameof(ContainsTableImpl12))]
 		public static IQueryable<FreeTextKey<TKey>> ContainsTableWithLanguage<TTable, TKey>(this ISqlServerExtensions? ext, ITable<TTable> table, Expression<Func<TTable, object?>> columns, string search, int language)
+			where TTable : notnull
 		{
 			return table.DataContext.FromSql<FreeTextKey<TKey>>($"CONTAINSTABLE({Sql.TableExpr(table)}, ({Sql.FieldsExpr(table, columns)}), {search}, LANGUAGE {language})");
 		}
 
 		static Expression<Func<ISqlServerExtensions, ITable<TTable>, Expression<Func<TTable, object?>>, string, int, IQueryable<FreeTextKey<TKey>>>> ContainsTableImpl12<TTable, TKey>()
+			where TTable : notnull
 		{
 			return (ext, table, columns, term, language) => table.DataContext.FromSql<FreeTextKey<TKey>>($"CONTAINSTABLE({Sql.TableExpr(table)}, ({Sql.FieldsExpr(table, columns)}), {term}, LANGUAGE {language})");
 		}

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseBulkCopy.cs
@@ -82,6 +82,7 @@ namespace LinqToDB.DataProvider.Sybase
 #endif
 
 		private ProviderConnections? GetProviderConnection<T>(ITable<T> table)
+			where T : notnull
 		{
 			if (table.DataContext is DataConnection dataConnection && _provider.Adapter.BulkCopy != null)
 			{
@@ -112,6 +113,7 @@ namespace LinqToDB.DataProvider.Sybase
 			ITable<T>                                               table,
 			BulkCopyOptions                                         options,
 			Func<List<Mapping.ColumnDescriptor>, BulkCopyReader<T>> createDataReader)
+			where T : notnull
 		{
 			var dataConnection = providerConnections.DataConnection;
 			var connection     = providerConnections.ProviderConnection;

--- a/Source/LinqToDB/Expressions/ExpressionEqualityComparer.cs
+++ b/Source/LinqToDB/Expressions/ExpressionEqualityComparer.cs
@@ -748,7 +748,7 @@ namespace LinqToDB.Expressions
 
 				public void Add(TKey key, TValue value) => _map.Add(key, value);
 
-				public bool TryGetValue(TKey key, [MaybeNull] out TValue value)
+				public bool TryGetValue(TKey key, out TValue? value)
 				{
 					for (var scope = this; scope != null; scope = scope._previous!)
 					{

--- a/Source/LinqToDB/Expressions/TypeMapper/TypeMapper.cs
+++ b/Source/LinqToDB/Expressions/TypeMapper/TypeMapper.cs
@@ -23,16 +23,16 @@ namespace LinqToDB.Expressions
 		private readonly IDictionary<string, Type>              _types                    = new Dictionary<string, Type>();
 
 		// [wrapperType] = originalType?
-		readonly Dictionary<Type, Type?>                        _typeMappingCache         = new Dictionary<Type, Type?>();
+		readonly Dictionary<Type, Type?>                        _typeMappingCache         = new ();
 		// [originalType] = wrapperType
-		readonly Dictionary<Type, Type>                         _typeMappingReverseCache  = new Dictionary<Type, Type>();
-		readonly Dictionary<LambdaExpression, LambdaExpression> _lambdaMappingCache       = new Dictionary<LambdaExpression, LambdaExpression>();
-		readonly Dictionary<Type, Func<object, object>>         _wrapperFactoryCache      = new Dictionary<Type, Func<object, object>>();
+		readonly Dictionary<Type, Type>                         _typeMappingReverseCache  = new ();
+		readonly Dictionary<LambdaExpression, LambdaExpression> _lambdaMappingCache       = new ();
+		readonly Dictionary<Type, Func<object, object>>         _wrapperFactoryCache      = new ();
 		// [originalType] = converter
-		readonly Dictionary<Type, LambdaExpression>             _enumToWrapperCache       = new Dictionary<Type, LambdaExpression>();
+		readonly Dictionary<Type, LambdaExpression>             _enumToWrapperCache       = new ();
 		// [wrapperType] = converter
-		readonly Dictionary<Type, LambdaExpression>             _enumFromWrapperCache     = new Dictionary<Type, LambdaExpression>();
-		readonly Dictionary<Type, ICustomMapper>                _typeMapperInstancesCache = new Dictionary<Type, ICustomMapper>();
+		readonly Dictionary<Type, LambdaExpression>             _enumFromWrapperCache     = new ();
+		readonly Dictionary<Type, ICustomMapper>                _typeMapperInstancesCache = new ();
 
 		private bool _finalized;
 

--- a/Source/LinqToDB/Extensions/ReflectionExtensions.cs
+++ b/Source/LinqToDB/Extensions/ReflectionExtensions.cs
@@ -278,12 +278,12 @@ namespace LinqToDB.Extensions
 
 		static class CacheHelper<T>
 		{
-			public static readonly ConcurrentDictionary<Type,T[]> TypeAttributes = new ConcurrentDictionary<Type,T[]>();
+			public static readonly ConcurrentDictionary<Type,T[]> TypeAttributes = new ();
 		}
 
 #region Attributes cache
 
-		static readonly ConcurrentDictionary<Type, object[]> _typeAttributesTopInternal = new ConcurrentDictionary<Type, object[]>();
+		static readonly ConcurrentDictionary<Type, object[]> _typeAttributesTopInternal = new ();
 
 		static void GetAttributesInternal(List<object> list, Type type)
 		{
@@ -298,7 +298,7 @@ namespace LinqToDB.Extensions
 			}
 		}
 
-		static readonly ConcurrentDictionary<Type, object[]> _typeAttributesInternal = new ConcurrentDictionary<Type, object[]>();
+		static readonly ConcurrentDictionary<Type, object[]> _typeAttributesInternal = new ();
 
 		static void GetAttributesTreeInternal(List<object> list, Type type)
 		{
@@ -391,7 +391,7 @@ namespace LinqToDB.Extensions
 		/// Gets a value indicating whether a type (or type's element type)
 		/// instance can be null in the underlying data store.
 		/// </summary>
-		/// <param name="type">A <see cref="System.Type"/> instance. </param>
+		/// <param name="type">A <see cref="Type"/> instance. </param>
 		/// <returns> True, if the type parameter is a closed generic nullable type; otherwise, False.</returns>
 		/// <remarks>Arrays of Nullable types are treated as Nullable types.</remarks>
 		public static bool IsNullable(this Type type)
@@ -402,7 +402,7 @@ namespace LinqToDB.Extensions
 		/// <summary>
 		/// Returns the underlying type argument of the specified type.
 		/// </summary>
-		/// <param name="type">A <see cref="System.Type"/> instance. </param>
+		/// <param name="type">A <see cref="Type"/> instance. </param>
 		/// <returns><list>
 		/// <item>The type argument of the type parameter,
 		/// if the type parameter is a closed generic nullable type.</item>
@@ -639,7 +639,7 @@ namespace LinqToDB.Extensions
 		///<summary>
 		/// Gets the Type of a list item.
 		///</summary>
-		/// <param name="listType">A <see cref="System.Type"/> instance. </param>
+		/// <param name="listType">A <see cref="Type"/> instance. </param>
 		///<returns>The Type instance that represents the exact runtime type of a list item.</returns>
 		public static Type GetListItemType(this Type listType)
 		{
@@ -701,7 +701,7 @@ namespace LinqToDB.Extensions
 			return false;
 		}
 
-		static readonly ConcurrentDictionary<Type,Type?> _getItemTypeCache = new ConcurrentDictionary<Type, Type?>();
+		static readonly ConcurrentDictionary<Type,Type?> _getItemTypeCache = new ();
 
 		public static Type? GetItemType(this Type? type)
 		{
@@ -742,7 +742,7 @@ namespace LinqToDB.Extensions
 		/// <summary>
 		/// Gets a value indicating whether a type can be used as a db primitive.
 		/// </summary>
-		/// <param name="type">A <see cref="System.Type"/> instance. </param>
+		/// <param name="type">A <see cref="Type"/> instance. </param>
 		/// <param name="checkArrayElementType">True if needed to check element type for arrays</param>
 		/// <returns> True, if the type parameter is a primitive type; otherwise, False.</returns>
 		/// <remarks><see cref="System.String"/>. <see cref="Stream"/>.
@@ -769,7 +769,7 @@ namespace LinqToDB.Extensions
 		/// Returns an array of Type objects that represent the type arguments
 		/// of a generic type or the type parameters of a generic type definition.
 		///</summary>
-		/// <param name="type">A <see cref="System.Type"/> instance.</param>
+		/// <param name="type">A <see cref="Type"/> instance.</param>
 		///<param name="baseType">Non generic base type.</param>
 		///<returns>An array of Type objects that represent the type arguments
 		/// of a generic type. Returns an empty array if the current type is not a generic type.</returns>
@@ -937,7 +937,7 @@ namespace LinqToDB.Extensions
 				member.DeclaringType.GetGenericTypeDefinition() == typeof(Nullable<>);
 		}
 
-		static readonly Dictionary<Type,HashSet<Type>> _castDic = new Dictionary<Type,HashSet<Type>>
+		static readonly Dictionary<Type,HashSet<Type>> _castDic = new Dictionary<Type,HashSet<Type>>()
 		{
 			{ typeof(decimal), new HashSet<Type> { typeof(sbyte), typeof(byte),   typeof(short), typeof(ushort), typeof(int), typeof(uint), typeof(long), typeof(ulong), typeof(char)                } },
 			{ typeof(double),  new HashSet<Type> { typeof(sbyte), typeof(byte),   typeof(short), typeof(ushort), typeof(int), typeof(uint), typeof(long), typeof(ulong), typeof(char), typeof(float) } },
@@ -1096,7 +1096,7 @@ namespace LinqToDB.Extensions
 			return mi;
 		}
 
-		static ConcurrentDictionary<MethodInfo, MethodInfo> _methodDefinitionCache = new ConcurrentDictionary<MethodInfo, MethodInfo>();
+		static ConcurrentDictionary<MethodInfo, MethodInfo> _methodDefinitionCache = new ();
 
 		internal static MethodInfo GetGenericMethodDefinitionCached(this MethodInfo method)
 		{

--- a/Source/LinqToDB/ITableMutable.cs
+++ b/Source/LinqToDB/ITableMutable.cs
@@ -5,6 +5,7 @@
 	/// It may change or be removed without further notice.
 	/// </summary>
 	public interface ITableMutable<out T>
+		where T : notnull
 	{
 		/// <summary>
 		/// This is internal API and is not intended for use by Linq To DB applications.

--- a/Source/LinqToDB/ITableT.cs
+++ b/Source/LinqToDB/ITableT.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
 
 namespace LinqToDB
 {
@@ -12,6 +10,7 @@ namespace LinqToDB
 	/// <typeparam name="T">Record mapping type.</typeparam>
 	[PublicAPI]
 	public interface ITable<out T> : IExpressionQuery<T>
+		where T : notnull
 	{
 		string?      ServerName    { get; }
 		string?      DatabaseName  { get; }

--- a/Source/LinqToDB/Linq/Builder/AssociationHelper.cs
+++ b/Source/LinqToDB/Linq/Builder/AssociationHelper.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -8,8 +7,8 @@ using LinqToDB.SqlQuery;
 
 namespace LinqToDB.Linq.Builder
 {
-	using LinqToDB.Expressions;
 	using Extensions;
+	using LinqToDB.Expressions;
 	using Mapping;
 	using Reflection;
 

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
@@ -21,9 +21,9 @@ namespace LinqToDB.Linq.Builder
 	{
 		#region Sequence
 
-		static readonly object _sync = new object();
+		static readonly object _sync = new ();
 
-		static List<ISequenceBuilder> _sequenceBuilders = new List<ISequenceBuilder>
+		static List<ISequenceBuilder> _sequenceBuilders = new List<ISequenceBuilder>()
 		{
 			new TableBuilder               (),
 			new IgnoreFiltersBuilder       (),
@@ -103,10 +103,10 @@ namespace LinqToDB.Linq.Builder
 		private  HashSet<Expression>?              _subQueryExpressions;
 		readonly ExpressionTreeOptimizationContext  _optimizationContext;
 
-		public readonly List<ParameterAccessor>    CurrentSqlParameters = new List<ParameterAccessor>();
+		public readonly List<ParameterAccessor>    CurrentSqlParameters = new ();
 
-		public readonly List<ParameterExpression>  BlockVariables       = new List<ParameterExpression>();
-		public readonly List<Expression>           BlockExpressions     = new List<Expression>();
+		public readonly List<ParameterExpression>  BlockVariables       = new ();
+		public readonly List<Expression>           BlockExpressions     = new ();
 		public          bool                       IsBlockDisable;
 		public          int                        VarIndex;
 
@@ -141,7 +141,7 @@ namespace LinqToDB.Linq.Builder
 		public readonly Expression             OriginalExpression;
 		public readonly Expression             Expression;
 		public readonly ParameterExpression[]? CompiledParameters;
-		public readonly List<IBuildContext>    Contexts = new List<IBuildContext>();
+		public readonly List<IBuildContext>    Contexts = new ();
 
 		public static readonly ParameterExpression QueryRunnerParam = Expression.Parameter(typeof(IQueryRunner), "qr");
 		public static readonly ParameterExpression DataContextParam = Expression.Parameter(typeof(IDataContext), "dctx");
@@ -357,7 +357,7 @@ namespace LinqToDB.Linq.Builder
 		private MethodInfo[]? _queryableMethods;
 		public  MethodInfo[]   QueryableMethods  => _queryableMethods  ??= typeof(Queryable). GetMethods();
 
-		readonly Dictionary<Expression, Expression> _optimizedExpressions = new Dictionary<Expression, Expression>();
+		readonly Dictionary<Expression, Expression> _optimizedExpressions = new ();
 
 		static void CollectLambdaParameters(Expression expression, HashSet<ParameterExpression> foundParameters)
 		{
@@ -1487,9 +1487,9 @@ namespace LinqToDB.Linq.Builder
 					var leftIsPrimitive  = left. Type.IsPrimitive;
 					var rightIsPrimitive = right.Type.IsPrimitive;
 
-					if (leftIsPrimitive == true && rightIsPrimitive == false && rightConvert.Item2 != null)
+					if (leftIsPrimitive && !rightIsPrimitive && rightConvert.Item2 != null)
 						right = rightConvert.Item2.GetBody(right);
-					else if (leftIsPrimitive == false && rightIsPrimitive == true && leftConvert.Item2 != null)
+					else if (!leftIsPrimitive && rightIsPrimitive && leftConvert.Item2 != null)
 						left = leftConvert.Item2.GetBody(left);
 					else if (rightConvert.Item2 != null)
 						right = rightConvert.Item2.GetBody(right);
@@ -1502,7 +1502,7 @@ namespace LinqToDB.Linq.Builder
 		}
 
 
-		Dictionary<Expression, Expression> _rootExpressions = new Dictionary<Expression, Expression>();
+		Dictionary<Expression, Expression> _rootExpressions = new ();
 
 		[return: NotNullIfNotNull("expr")]
 		internal Expression? GetRootObject(Expression? expr)

--- a/Source/LinqToDB/Linq/CompiledTableT.cs
+++ b/Source/LinqToDB/Linq/CompiledTableT.cs
@@ -8,6 +8,7 @@ namespace LinqToDB.Linq
 	using Common.Internal.Cache;
 
 	class CompiledTable<T>
+		where T : notnull
 	{
 		public CompiledTable(LambdaExpression lambda, Expression expression)
 		{

--- a/Source/LinqToDB/Linq/Internals.cs
+++ b/Source/LinqToDB/Linq/Internals.cs
@@ -26,9 +26,8 @@ namespace LinqToDB.Linq
 		{
 			return queryable switch
 			{
-				ExpressionQuery<T> query => query.DataContext,
-				ITable<T> table          => table.DataContext,
-				_                        => default!,
+				IExpressionQuery query => query.DataContext,
+				_                      => default!,
 			};
 		}
 

--- a/Source/LinqToDB/Linq/PersistentTableT.cs
+++ b/Source/LinqToDB/Linq/PersistentTableT.cs
@@ -11,6 +11,7 @@ using LinqToDB.Async;
 namespace LinqToDB.Linq
 {
 	class PersistentTable<T> : ITable<T>
+		where T : notnull
 	{
 		private readonly IQueryable<T> _query;
 

--- a/Source/LinqToDB/Linq/QueryRunner.CreateTable.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.CreateTable.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq.Expressions;
+﻿using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,6 +9,7 @@ namespace LinqToDB.Linq
 	static partial class QueryRunner
 	{
 		public static class CreateTable<T>
+			where T : notnull
 		{
 			public static ITable<T> Query(
 				IDataContext    dataContext,

--- a/Source/LinqToDB/Linq/QueryRunner.InsertWithIdentity.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.InsertWithIdentity.cs
@@ -8,7 +8,6 @@ namespace LinqToDB.Linq
 	using SqlQuery;
 	using Mapping;
 	using Common.Internal.Cache;
-	using System.Diagnostics.CodeAnalysis;
 	using System.Linq;
 
 	static partial class QueryRunner
@@ -18,7 +17,7 @@ namespace LinqToDB.Linq
 			static Query<object> CreateQuery(
 				IDataContext           dataContext,
 				EntityDescriptor       descriptor,
-				[DisallowNull] T       obj,
+				T                      obj,
 				InsertColumnFilter<T>? columnFilter,
 				string?                tableName,
 				string?                serverName,

--- a/Source/LinqToDB/Linq/QueryRunner.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.cs
@@ -4,7 +4,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -13,7 +12,9 @@ using System.Threading.Tasks;
 
 namespace LinqToDB.Linq
 {
+#if NETFRAMEWORK
 	using Async;
+#endif
 	using Builder;
 	using Common;
 	using Common.Internal.Cache;
@@ -40,7 +41,7 @@ namespace LinqToDB.Linq
 			internal static MemoryCache QueryCache { get; } = new MemoryCache(new MemoryCacheOptions());
 		}
 
-		#region Mapper
+#region Mapper
 
 		class Mapper<T>
 		{
@@ -50,7 +51,7 @@ namespace LinqToDB.Linq
 			}
 
 			readonly Expression<Func<IQueryRunner,IDataReader,T>> _expression;
-			readonly ConcurrentDictionary<Type, ReaderMapperInfo> _mappers = new ConcurrentDictionary<Type, ReaderMapperInfo>();
+			readonly ConcurrentDictionary<Type, ReaderMapperInfo> _mappers = new ();
 
 
 			class ReaderMapperInfo
@@ -178,9 +179,9 @@ namespace LinqToDB.Linq
 			}
 		}
 
-		#endregion
+#endregion
 
-		#region Helpers
+#region Helpers
 
 		static void FinalizeQuery(Query query)
 		{
@@ -298,18 +299,18 @@ namespace LinqToDB.Linq
 			return param;
 		}
 
-		private static Type GetType<T>([DisallowNull] T obj, IDataContext db)
+		private static Type GetType<T>(T obj, IDataContext db)
 			//=> typeof(T);
 			//=> obj.GetType();
 			=> db.MappingSchema.GetEntityDescriptor(typeof(T)).InheritanceMapping?.Count > 0 ? obj!.GetType() : typeof(T);
 
-		#endregion
+#endregion
 
-		#region SetRunQuery
+#region SetRunQuery
 
 		public delegate int TakeSkipDelegate(
-			Query                    query, 
-			Expression               expression, 
+			Query                    query,
+			Expression               expression,
 			IDataContext?            dataContext,
 			object?[]?               ps);
 
@@ -507,7 +508,7 @@ namespace LinqToDB.Linq
 			{
 				_queryRunner?.Dispose();
 				if (_dataReader != null) 
-					await _dataReader.DisposeAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+					await _dataReader.DisposeAsync().ConfigureAwait(Configuration.ContinueOnCapturedContext);
 				
 				_queryRunner = null;
 			}
@@ -634,9 +635,9 @@ namespace LinqToDB.Linq
 					dataReaderParam);
 		}
 
-		#endregion
+#endregion
 
-		#region SetRunQuery / Cast, Concat, Union, OfType, ScalarSelect, Select, SequenceContext, Table
+#region SetRunQuery / Cast, Concat, Union, OfType, ScalarSelect, Select, SequenceContext, Table
 
 		public static void SetRunQuery<T>(
 			Query<T> query,
@@ -647,9 +648,9 @@ namespace LinqToDB.Linq
 			SetRunQuery(query, l);
 		}
 
-		#endregion
+#endregion
 
-		#region SetRunQuery / Select 2
+#region SetRunQuery / Select 2
 
 		public static void SetRunQuery<T>(
 			Query<T> query,
@@ -690,9 +691,9 @@ namespace LinqToDB.Linq
 			SetRunQuery(query, l);
 		}
 
-		#endregion
+#endregion
 
-		#region SetRunQuery / Aggregation, All, Any, Contains, Count
+#region SetRunQuery / Aggregation, All, Any, Contains, Count
 
 		public static void SetRunQuery<T>(
 			Query<T> query,
@@ -768,9 +769,9 @@ namespace LinqToDB.Linq
 			}
 		}
 
-		#endregion
+#endregion
 
-		#region ScalarQuery
+#region ScalarQuery
 
 		public static void SetScalarQuery(Query query)
 		{
@@ -803,9 +804,9 @@ namespace LinqToDB.Linq
 				return await runner.ExecuteScalarAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 		}
 
-		#endregion
+#endregion
 
-		#region NonQueryQuery
+#region NonQueryQuery
 
 		public static void SetNonQueryQuery(Query query)
 		{
@@ -838,9 +839,9 @@ namespace LinqToDB.Linq
 				return await runner.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 		}
 
-		#endregion
+#endregion
 
-		#region NonQueryQuery2
+#region NonQueryQuery2
 
 		public static void SetNonQueryQuery2(Query query)
 		{
@@ -891,9 +892,9 @@ namespace LinqToDB.Linq
 			}
 		}
 
-		#endregion
+#endregion
 
-		#region QueryQuery2
+#region QueryQuery2
 
 		public static void SetQueryQuery2(Query query)
 		{
@@ -944,9 +945,9 @@ namespace LinqToDB.Linq
 			}
 		}
 
-		#endregion
+#endregion
 
-		#region GetSqlText
+#region GetSqlText
 
 		public static string GetSqlText(Query query, IDataContext dataContext, Expression expr, object?[]? parameters, object?[]? preambles)
 		{
@@ -954,6 +955,6 @@ namespace LinqToDB.Linq
 			return runner.GetSqlText();
 		}
 
-		#endregion
+#endregion
 	}
 }

--- a/Source/LinqToDB/Linq/TableT.cs
+++ b/Source/LinqToDB/Linq/TableT.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq.Expressions;
+﻿using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 
@@ -9,6 +8,7 @@ namespace LinqToDB.Linq
 	using Reflection;
 
 	class Table<T> : ExpressionQuery<T>, ITable<T>, ITableMutable<T>, ITable
+		where T : notnull
 	{
 		public Table(IDataContext dataContext)
 		{

--- a/Source/LinqToDB/LinqExtensions.Delete.cs
+++ b/Source/LinqToDB/LinqExtensions.Delete.cs
@@ -125,8 +125,8 @@ namespace LinqToDB
 		/// <returns>Number of affected records.</returns>
 		public static int DeleteWithOutputInto<TSource,TOutput>(
 			                this IQueryable<TSource>          source,
-			                ITable<TOutput>                   outputTable
-			)
+			                ITable<TOutput>                   outputTable)
+			where TOutput : notnull
 		{
 			if (source      == null) throw new ArgumentNullException(nameof(source));
 			if (outputTable == null) throw new ArgumentNullException(nameof(outputTable));
@@ -154,6 +154,7 @@ namespace LinqToDB
 			                this IQueryable<TSource>          source,
 			                ITable<TOutput>                   outputTable,
 							CancellationToken                 token = default)
+			where TOutput : notnull
 		{
 			if (source      == null) throw new ArgumentNullException(nameof(source));
 			if (outputTable == null) throw new ArgumentNullException(nameof(outputTable));
@@ -187,6 +188,7 @@ namespace LinqToDB
 			                this IQueryable<TSource>          source,
 			                ITable<TOutput>                   outputTable,
 			                Expression<Func<TSource,TOutput>> outputExpression)
+			where TOutput : notnull
 		{
 			if (source           == null) throw new ArgumentNullException(nameof(source));
 			if (outputTable      == null) throw new ArgumentNullException(nameof(outputTable));
@@ -219,6 +221,7 @@ namespace LinqToDB
 			                ITable<TOutput>                   outputTable,
 			                Expression<Func<TSource,TOutput>> outputExpression,
 							CancellationToken                 token = default)
+			where TOutput : notnull
 		{
 			if (source           == null) throw new ArgumentNullException(nameof(source));
 			if (outputTable      == null) throw new ArgumentNullException(nameof(outputTable));

--- a/Source/LinqToDB/LinqExtensions.Insert.cs
+++ b/Source/LinqToDB/LinqExtensions.Insert.cs
@@ -25,6 +25,7 @@ namespace LinqToDB
 		public static TTarget InsertWithOutput<TTarget>(
 			                this ITable<TTarget>      target,
 			[InstantHandle] Expression<Func<TTarget>> setter)
+			where TTarget : notnull
 		{
 			if (target == null) throw new ArgumentNullException(nameof(target));
 			if (setter == null) throw new ArgumentNullException(nameof(setter));
@@ -52,6 +53,7 @@ namespace LinqToDB
 			                this ITable<TTarget>      target,
 			[InstantHandle] Expression<Func<TTarget>> setter,
 							CancellationToken         token = default)
+			where TTarget : notnull
 		{
 			if (target == null) throw new ArgumentNullException(nameof(target));
 			if (setter == null) throw new ArgumentNullException(nameof(setter));
@@ -78,6 +80,7 @@ namespace LinqToDB
 		public static TTarget InsertWithOutput<TTarget>(
 			                this ITable<TTarget> target,
 			[InstantHandle] TTarget              obj)
+			where TTarget : notnull
 		{
 			if (target == null) throw new ArgumentNullException(nameof(target));
 			if (obj    == null) throw new ArgumentNullException(nameof(obj));
@@ -102,9 +105,10 @@ namespace LinqToDB
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Inserted record.</returns>
 		public static Task<TTarget> InsertWithOutputAsync<TTarget>(
-			                this ITable<TTarget> target,
-			[InstantHandle] TTarget              obj,
-			CancellationToken                             token = default)
+			           this ITable<TTarget>   target,
+			[InstantHandle] TTarget           obj,
+			                CancellationToken token = default)
+			where TTarget : notnull
 		{
 			if (target == null) throw new ArgumentNullException(nameof(target));
 			if (obj    == null) throw new ArgumentNullException(nameof(obj));
@@ -134,6 +138,7 @@ namespace LinqToDB
 			                this ITable<TTarget>              target,
 			[InstantHandle] Expression<Func<TTarget>>         setter,
 			                Expression<Func<TTarget,TOutput>> outputExpression)
+			where TTarget : notnull
 		{
 			if (target           == null) throw new ArgumentNullException(nameof(target));
 			if (setter           == null) throw new ArgumentNullException(nameof(setter));
@@ -166,6 +171,7 @@ namespace LinqToDB
 			[InstantHandle] Expression<Func<TTarget>>         setter,
 			                Expression<Func<TTarget,TOutput>> outputExpression,
 							CancellationToken                 token = default)
+			where TTarget : notnull
 
 		{
 			if (target           == null) throw new ArgumentNullException(nameof(target));
@@ -195,6 +201,7 @@ namespace LinqToDB
 			                this ITable<TTarget>      target,
 			[InstantHandle] Expression<Func<TTarget>> setter,
 			                ITable<TTarget>           outputTable)
+			where TTarget : notnull
 		{
 			if (target      == null) throw new ArgumentNullException(nameof(target));
 			if (setter      == null) throw new ArgumentNullException(nameof(setter));
@@ -223,6 +230,7 @@ namespace LinqToDB
 			[InstantHandle] Expression<Func<TTarget>> setter,
 			                ITable<TTarget>           outputTable,
 							CancellationToken         token = default)
+			where TTarget : notnull
 		{
 			if (target      == null) throw new ArgumentNullException(nameof(target));
 			if (setter      == null) throw new ArgumentNullException(nameof(setter));
@@ -258,6 +266,8 @@ namespace LinqToDB
 			[InstantHandle] Expression<Func<TTarget>>         setter,
 			                ITable<TOutput>                   outputTable,
 			                Expression<Func<TTarget,TOutput>> outputExpression)
+			where TOutput : notnull
+			where TTarget : notnull
 		{
 			if (target           == null) throw new ArgumentNullException(nameof(target));
 			if (setter           == null) throw new ArgumentNullException(nameof(setter));
@@ -292,6 +302,8 @@ namespace LinqToDB
 			                ITable<TOutput>                   outputTable,
 			                Expression<Func<TTarget,TOutput>> outputExpression,
 							CancellationToken                 token = default)
+			where TOutput : notnull
+			where TTarget : notnull
 		{
 			if (target           == null) throw new ArgumentNullException(nameof(target));
 			if (setter           == null) throw new ArgumentNullException(nameof(setter));
@@ -330,6 +342,7 @@ namespace LinqToDB
 			                this IQueryable<TSource>          source,
 			                ITable<TTarget>                   target,
 			[InstantHandle] Expression<Func<TSource,TTarget>> setter)
+			where TTarget : notnull
 		{
 			if (source           == null) throw new ArgumentNullException(nameof(source));
 			if (target           == null) throw new ArgumentNullException(nameof(target));
@@ -361,6 +374,7 @@ namespace LinqToDB
 			                ITable<TTarget>                    target,
 			[InstantHandle] Expression<Func<TSource, TTarget>> setter,
 							CancellationToken                  token = default)
+			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (target == null) throw new ArgumentNullException(nameof(target));
@@ -395,6 +409,7 @@ namespace LinqToDB
 			                ITable<TTarget>                   target,
 			[InstantHandle] Expression<Func<TSource,TTarget>> setter,
 			                Expression<Func<TTarget,TOutput>> outputExpression)
+			where TTarget : notnull
 		{
 			if (source           == null) throw new ArgumentNullException(nameof(source));
 			if (target           == null) throw new ArgumentNullException(nameof(target));
@@ -432,6 +447,7 @@ namespace LinqToDB
 			[InstantHandle] Expression<Func<TSource,TTarget>> setter,
 			                Expression<Func<TTarget,TOutput>> outputExpression,
 							CancellationToken                 token = default)
+			where TTarget : notnull
 		{
 			if (source           == null) throw new ArgumentNullException(nameof(source));
 			if (target           == null) throw new ArgumentNullException(nameof(target));
@@ -464,8 +480,8 @@ namespace LinqToDB
 			                this IQueryable<TSource>          source,
 			                ITable<TTarget>                   target,
 			[InstantHandle] Expression<Func<TSource,TTarget>> setter,
-			                ITable<TTarget>                   outputTable
-			)
+			                ITable<TTarget>                   outputTable)
+			where TTarget : notnull
 		{
 			if (source      == null) throw new ArgumentNullException(nameof(source));
 			if (target      == null) throw new ArgumentNullException(nameof(target));
@@ -499,6 +515,7 @@ namespace LinqToDB
 			[InstantHandle] Expression<Func<TSource,TTarget>> setter,
 			                ITable<TTarget>                   outputTable,
 							CancellationToken                 token = default)
+			where TTarget : notnull
 		{
 			if (source      == null) throw new ArgumentNullException(nameof(source));
 			if (target      == null) throw new ArgumentNullException(nameof(target));
@@ -539,6 +556,8 @@ namespace LinqToDB
 			[InstantHandle] Expression<Func<TSource,TTarget>> setter,
 			                ITable<TOutput>                   outputTable,
 			                Expression<Func<TTarget,TOutput>> outputExpression)
+			where TOutput : notnull
+			where TTarget : notnull
 		{
 			if (source           == null) throw new ArgumentNullException(nameof(source));
 			if (target           == null) throw new ArgumentNullException(nameof(target));
@@ -578,6 +597,8 @@ namespace LinqToDB
 			                ITable<TOutput>                   outputTable,
 			                Expression<Func<TTarget,TOutput>> outputExpression,
 							CancellationToken                 token = default)
+			where TOutput : notnull
+			where TTarget : notnull
 		{
 			if (source           == null) throw new ArgumentNullException(nameof(source));
 			if (target           == null) throw new ArgumentNullException(nameof(target));
@@ -658,6 +679,7 @@ namespace LinqToDB
 		public static int InsertWithOutputInto<TSource,TTarget>(
 			this ISelectInsertable<TSource,TTarget> source,
 			     ITable<TTarget>                    outputTable)
+			where TTarget : notnull
 		{
 			if (source      == null) throw new ArgumentNullException(nameof(source));
 			if (outputTable == null) throw new ArgumentNullException(nameof(outputTable));
@@ -684,6 +706,7 @@ namespace LinqToDB
 			this ISelectInsertable<TSource,TTarget> source,
 			     ITable<TTarget>                    outputTable,
 			     CancellationToken                  token = default)
+			where TTarget : notnull
 
 		{
 			if (source      == null) throw new ArgumentNullException(nameof(source));

--- a/Source/LinqToDB/LinqExtensions.LoadWith.cs
+++ b/Source/LinqToDB/LinqExtensions.LoadWith.cs
@@ -47,6 +47,7 @@ namespace LinqToDB
 		public static ITable<T> LoadWithAsTable<T>(
 			                this ITable<T> table,
 			[InstantHandle] Expression<Func<T,object?>> selector)
+			where T : notnull
 		{
 			if (table == null) throw new ArgumentNullException(nameof(table));
 

--- a/Source/LinqToDB/LinqExtensions.Merge.cs
+++ b/Source/LinqToDB/LinqExtensions.Merge.cs
@@ -59,6 +59,7 @@ namespace LinqToDB
 		[Pure, LinqTunnel]
 		public static IMergeableUsing<TTarget> Merge<TTarget>(
 			 this ITable<TTarget> target)
+			where TTarget : notnull
 		{
 			if (target == null) throw new ArgumentNullException(nameof(target));
 
@@ -82,6 +83,7 @@ namespace LinqToDB
 		public static IMergeableUsing<TTarget> Merge<TTarget>(
 			                    this ITable<TTarget> target,
 			[SqlQueryDependent]      string          hint)
+			where TTarget : notnull
 		{
 			if (target == null) throw new ArgumentNullException(nameof(target));
 			if (hint   == null) throw new ArgumentNullException(nameof(hint));
@@ -107,6 +109,7 @@ namespace LinqToDB
 		public static IMergeableOn<TTarget, TSource> MergeInto<TTarget, TSource>(
 			 this IQueryable<TSource> source,
 			      ITable<TTarget>     target)
+			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (target == null) throw new ArgumentNullException(nameof(target));
@@ -134,6 +137,7 @@ namespace LinqToDB
 			                    this IQueryable<TSource> source,
 			                         ITable<TTarget>     target,
 			[SqlQueryDependent]      string              hint)
+			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (target == null) throw new ArgumentNullException(nameof(target));

--- a/Source/LinqToDB/LinqExtensions.cs
+++ b/Source/LinqToDB/LinqExtensions.cs
@@ -33,6 +33,7 @@ namespace LinqToDB
 		[LinqTunnel]
 		[Pure]
 		public static ITable<T> TableName<T>(this ITable<T> table, [SqlQueryDependent] string name)
+			where T : notnull
 		{
 			if (table == null) throw new ArgumentNullException(nameof(table));
 			if (name  == null) throw new ArgumentNullException(nameof(name));
@@ -55,6 +56,7 @@ namespace LinqToDB
 		[LinqTunnel]
 		[Pure]
 		public static ITable<T> DatabaseName<T>(this ITable<T> table, [SqlQueryDependent] string name)
+			where T : notnull
 		{
 			if (table == null) throw new ArgumentNullException(nameof(table));
 			if (name  == null) throw new ArgumentNullException(nameof(name));
@@ -75,6 +77,7 @@ namespace LinqToDB
 		[LinqTunnel]
 		[Pure]
 		public static ITable<T> ServerName<T>(this ITable<T> table, [SqlQueryDependent] string name)
+			where T : notnull
 		{
 			if (table == null) throw new ArgumentNullException(nameof(table));
 			if (name  == null) throw new ArgumentNullException(nameof(name));
@@ -95,6 +98,7 @@ namespace LinqToDB
 		[LinqTunnel]
 		[Pure]
 		public static ITable<T> SchemaName<T>(this ITable<T> table, [SqlQueryDependent] string name)
+			where T : notnull
 		{
 			var result = ((ITableMutable<T>)table).ChangeSchemaName(name);
 			return result;
@@ -117,6 +121,7 @@ namespace LinqToDB
 		[LinqTunnel]
 		[Pure]
 		public static ITable<T> WithTableExpression<T>(this ITable<T> table, [SqlQueryDependent] string expression)
+			where T : notnull
 		{
 			if (expression == null) throw new ArgumentNullException(nameof(expression));
 
@@ -143,6 +148,7 @@ namespace LinqToDB
 		[LinqTunnel]
 		[Pure]
 		public static ITable<T> With<T>(this ITable<T> table, [SqlQueryDependent] string args)
+			where T : notnull
 		{
 			if (args == null) throw new ArgumentNullException(nameof(args));
 
@@ -174,7 +180,7 @@ namespace LinqToDB
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 			if (selector    == null) throw new ArgumentNullException(nameof(selector));
 
-			var q = new Table<T>(dataContext, selector);
+			var q = new ExpressionQueryImpl<T>(dataContext, selector);
 
 			foreach (var item in q)
 				return item;
@@ -198,7 +204,7 @@ namespace LinqToDB
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 			if (selector    == null) throw new ArgumentNullException(nameof(selector));
 
-			var q = new Table<T>(dataContext, selector);
+			var q = new ExpressionQueryImpl<T>(dataContext, selector);
 
 			var read = false;
 			var item = default(T)!; // this is fine, as we never return it
@@ -332,6 +338,7 @@ namespace LinqToDB
 			                this IQueryable<TSource>          source,
 			                ITable<TTarget>                   target,
 			[InstantHandle] Expression<Func<TSource,TTarget>> setter)
+			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (target == null) throw new ArgumentNullException(nameof(target));
@@ -361,6 +368,7 @@ namespace LinqToDB
 			                ITable<TTarget>                   target,
 			[InstantHandle] Expression<Func<TSource,TTarget>> setter,
 			CancellationToken                                 token = default)
+			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (target == null) throw new ArgumentNullException(nameof(target));
@@ -901,6 +909,7 @@ namespace LinqToDB
 		public static int Insert<T>(
 			                this ITable<T>      target,
 			[InstantHandle] Expression<Func<T>> setter)
+			where T : notnull
 		{
 			if (target == null) throw new ArgumentNullException(nameof(target));
 			if (setter == null) throw new ArgumentNullException(nameof(setter));
@@ -928,6 +937,7 @@ namespace LinqToDB
 			                this ITable<T>      target,
 			[InstantHandle] Expression<Func<T>> setter,
 			CancellationToken                   token = default)
+			where T : notnull
 		{
 			if (target == null) throw new ArgumentNullException(nameof(target));
 			if (setter == null) throw new ArgumentNullException(nameof(setter));
@@ -957,6 +967,7 @@ namespace LinqToDB
 		public static object InsertWithIdentity<T>(
 			                this ITable<T>      target,
 			[InstantHandle] Expression<Func<T>> setter)
+			where T : notnull
 		{
 			if (target == null) throw new ArgumentNullException(nameof(target));
 			if (setter == null) throw new ArgumentNullException(nameof(setter));
@@ -982,6 +993,7 @@ namespace LinqToDB
 		public static int InsertWithInt32Identity<T>(
 			                this ITable<T>      target,
 			[InstantHandle] Expression<Func<T>> setter)
+			where T : notnull
 		{
 			return target.DataContext.MappingSchema.ChangeTypeTo<int>(InsertWithIdentity(target, setter));
 		}
@@ -996,6 +1008,7 @@ namespace LinqToDB
 		public static long InsertWithInt64Identity<T>(
 			                this ITable<T>      target,
 			[InstantHandle] Expression<Func<T>> setter)
+			where T : notnull
 		{
 			return target.DataContext.MappingSchema.ChangeTypeTo<long>(InsertWithIdentity(target, setter));
 		}
@@ -1010,6 +1023,7 @@ namespace LinqToDB
 		public static decimal InsertWithDecimalIdentity<T>(
 			                this ITable<T>      target,
 			[InstantHandle] Expression<Func<T>> setter)
+			where T : notnull
 		{
 			return target.DataContext.MappingSchema.ChangeTypeTo<decimal>(InsertWithIdentity(target, setter));
 		}
@@ -1026,6 +1040,7 @@ namespace LinqToDB
 			                this ITable<T>      target,
 			[InstantHandle] Expression<Func<T>> setter,
 			CancellationToken                   token = default)
+			where T : notnull
 		{
 			if (target == null) throw new ArgumentNullException(nameof(target));
 			if (setter == null) throw new ArgumentNullException(nameof(setter));
@@ -1056,7 +1071,8 @@ namespace LinqToDB
 		public static async Task<int> InsertWithInt32IdentityAsync<T>(
 			                this ITable<T>      target,
 			[InstantHandle] Expression<Func<T>> setter,
-			CancellationToken                            token = default)
+			CancellationToken                   token = default)
+			where T : notnull
 		{
 			return target.DataContext.MappingSchema.ChangeTypeTo<int>(await InsertWithIdentityAsync(target, setter, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext));
 		}
@@ -1072,7 +1088,8 @@ namespace LinqToDB
 		public static async Task<long> InsertWithInt64IdentityAsync<T>(
 			                this ITable<T>      target,
 			[InstantHandle] Expression<Func<T>> setter,
-			CancellationToken                            token = default)
+			CancellationToken                   token = default)
+			where T : notnull
 		{
 			return target.DataContext.MappingSchema.ChangeTypeTo<long>(await InsertWithIdentityAsync(target, setter, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext));
 		}
@@ -1088,7 +1105,8 @@ namespace LinqToDB
 		public static async Task<decimal> InsertWithDecimalIdentityAsync<T>(
 			                this ITable<T>      target,
 			[InstantHandle] Expression<Func<T>> setter,
-			CancellationToken                            token = default)
+			CancellationToken                   token = default)
+			where T : notnull
 		{
 			return target.DataContext.MappingSchema.ChangeTypeTo<decimal>(await InsertWithIdentityAsync(target, setter, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext));
 		}
@@ -1120,6 +1138,7 @@ namespace LinqToDB
 		[LinqTunnel]
 		[Pure]
 		public static IValueInsertable<T> Into<T>(this IDataContext dataContext, ITable<T> target)
+			where T : notnull
 		{
 			if (target == null) throw new ArgumentNullException(nameof(target));
 
@@ -1149,6 +1168,7 @@ namespace LinqToDB
 			                this ITable<T>         source,
 			[InstantHandle] Expression<Func<T,TV>> field,
 			[InstantHandle] Expression<Func<TV>>   value)
+			where T : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (field  == null) throw new ArgumentNullException(nameof(field));
@@ -1180,6 +1200,7 @@ namespace LinqToDB
 			                this ITable<T>         source,
 			[InstantHandle] Expression<Func<T,TV>> field,
 			TV                                     value)
+			where T : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (field  == null) throw new ArgumentNullException(nameof(field));
@@ -1456,6 +1477,7 @@ namespace LinqToDB
 			                this IQueryable<TSource>          source,
 			                ITable<TTarget>                   target,
 			[InstantHandle] Expression<Func<TSource,TTarget>> setter)
+			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (target == null) throw new ArgumentNullException(nameof(target));
@@ -1486,6 +1508,7 @@ namespace LinqToDB
 			                ITable<TTarget>                   target,
 			[InstantHandle] Expression<Func<TSource,TTarget>> setter,
 			CancellationToken                                 token = default)
+			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (target == null) throw new ArgumentNullException(nameof(target));
@@ -1518,6 +1541,7 @@ namespace LinqToDB
 			                this IQueryable<TSource>          source,
 			                ITable<TTarget>                   target,
 			[InstantHandle] Expression<Func<TSource,TTarget>> setter)
+			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (target == null) throw new ArgumentNullException(nameof(target));
@@ -1546,6 +1570,7 @@ namespace LinqToDB
 			                this IQueryable<TSource>          source,
 			                ITable<TTarget>                   target,
 			[InstantHandle] Expression<Func<TSource,TTarget>> setter)
+			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (target == null) throw new ArgumentNullException(nameof(target));
@@ -1571,6 +1596,7 @@ namespace LinqToDB
 			                this IQueryable<TSource>          source,
 			                ITable<TTarget>                   target,
 			[InstantHandle] Expression<Func<TSource,TTarget>> setter)
+			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (target == null) throw new ArgumentNullException(nameof(target));
@@ -1596,6 +1622,7 @@ namespace LinqToDB
 			                this IQueryable<TSource>          source,
 			                ITable<TTarget>                   target,
 			[InstantHandle] Expression<Func<TSource,TTarget>> setter)
+			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (target == null) throw new ArgumentNullException(nameof(target));
@@ -1623,6 +1650,7 @@ namespace LinqToDB
 			                ITable<TTarget>                   target,
 			[InstantHandle] Expression<Func<TSource,TTarget>> setter,
 			CancellationToken                                 token = default)
+			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (target == null) throw new ArgumentNullException(nameof(target));
@@ -1658,6 +1686,7 @@ namespace LinqToDB
 			                ITable<TTarget>                   target,
 			[InstantHandle] Expression<Func<TSource,TTarget>> setter,
 			CancellationToken                                 token = default)
+			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (target == null) throw new ArgumentNullException(nameof(target));
@@ -1685,6 +1714,7 @@ namespace LinqToDB
 			                ITable<TTarget>                   target,
 			[InstantHandle] Expression<Func<TSource,TTarget>> setter,
 			CancellationToken                                 token = default)
+			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (target == null) throw new ArgumentNullException(nameof(target));
@@ -1712,6 +1742,7 @@ namespace LinqToDB
 			                ITable<TTarget>                   target,
 			[InstantHandle] Expression<Func<TSource,TTarget>> setter,
 			CancellationToken                                 token = default)
+			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (target == null) throw new ArgumentNullException(nameof(target));
@@ -1763,6 +1794,7 @@ namespace LinqToDB
 		public static ISelectInsertable<TSource,TTarget> Into<TSource,TTarget>(
 			 this IQueryable<TSource> source,
 			 ITable<TTarget>          target)
+			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (target == null) throw new ArgumentNullException(nameof(target));
@@ -2092,6 +2124,7 @@ namespace LinqToDB
 			                this ITable<T>        target,
 			[InstantHandle] Expression<Func<T>>   insertSetter,
 			[InstantHandle] Expression<Func<T,T>> onDuplicateKeyUpdateSetter)
+			where T : notnull
 		{
 			if (target                     == null) throw new ArgumentNullException(nameof(target));
 			if (insertSetter               == null) throw new ArgumentNullException(nameof(insertSetter));
@@ -2125,6 +2158,7 @@ namespace LinqToDB
 			[InstantHandle] Expression<Func<T>>   insertSetter,
 			[InstantHandle] Expression<Func<T,T>> onDuplicateKeyUpdateSetter,
 			CancellationToken                     token = default)
+			where T : notnull
 		{
 			if (target                     == null) throw new ArgumentNullException(nameof(target));
 			if (insertSetter               == null) throw new ArgumentNullException(nameof(insertSetter));
@@ -2166,6 +2200,7 @@ namespace LinqToDB
 			[InstantHandle] Expression<Func<T>>   insertSetter,
 			[InstantHandle] Expression<Func<T,T>> onDuplicateKeyUpdateSetter,
 			[InstantHandle] Expression<Func<T>>   keySelector)
+			where T : notnull
 		{
 			if (target                     == null) throw new ArgumentNullException(nameof(target));
 			if (insertSetter               == null) throw new ArgumentNullException(nameof(insertSetter));
@@ -2206,6 +2241,7 @@ namespace LinqToDB
 			[InstantHandle] Expression<Func<T,T>> onDuplicateKeyUpdateSetter,
 			[InstantHandle] Expression<Func<T>>   keySelector,
 			CancellationToken                     token = default)
+			where T : notnull
 		{
 			if (target                     == null) throw new ArgumentNullException(nameof(target));
 			if (insertSetter               == null) throw new ArgumentNullException(nameof(insertSetter));
@@ -2247,6 +2283,7 @@ namespace LinqToDB
 		/// Default value: <c>true</c>.</param>
 		/// <returns>Number of affected records. Usually <c>-1</c> as it is not data modification operation.</returns>
 		public static int Drop<T>( this ITable<T> target, bool throwExceptionIfNotExists = true)
+			where T : notnull
 		{
 			if (target == null) throw new ArgumentNullException(nameof(target));
 
@@ -2287,9 +2324,10 @@ namespace LinqToDB
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Number of affected records. Usually <c>-1</c> as it is not data modification operation.</returns>
 		public static async Task<int> DropAsync<T>(
-			 this ITable<T> target,
-			bool                     throwExceptionIfNotExists = true,
-			CancellationToken        token = default)
+			this ITable<T>    target,
+			bool              throwExceptionIfNotExists = true,
+			CancellationToken token = default)
+			where T : notnull
 		{
 			if (target == null) throw new ArgumentNullException(nameof(target));
 
@@ -2340,6 +2378,7 @@ namespace LinqToDB
 		/// <param name="resetIdentity">Performs reset identity column.</param>
 		/// <returns>Number of affected records. Usually <c>-1</c> as it is not data modification operation.</returns>
 		public static int Truncate<T>( this ITable<T> target, bool resetIdentity = true)
+			where T : notnull
 		{
 			if (target == null) throw new ArgumentNullException(nameof(target));
 
@@ -2364,9 +2403,10 @@ namespace LinqToDB
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Number of affected records. Usually <c>-1</c> as it is not data modification operation.</returns>
 		public static async Task<int> TruncateAsync<T>(
-			 this ITable<T> target,
-			bool                     resetIdentity = true,
-			CancellationToken        token         = default)
+			this ITable<T>    target,
+			bool              resetIdentity = true,
+			CancellationToken token         = default)
+			where T : notnull
 		{
 			if (target == null) throw new ArgumentNullException(nameof(target));
 

--- a/Source/LinqToDB/MergeDefinition.cs
+++ b/Source/LinqToDB/MergeDefinition.cs
@@ -21,6 +21,7 @@ namespace LinqToDB
 		: IMergeableUsing<TTarget>,
 			IMergeableOn<TTarget, TSource>,
 			IMergeable<TTarget, TSource>
+		where TTarget : notnull
 	{
 		public MergeDefinition(ITable<TTarget> target)
 		{

--- a/Source/LinqToDB/Reflection/MemberAccessor.cs
+++ b/Source/LinqToDB/Reflection/MemberAccessor.cs
@@ -6,7 +6,6 @@ using System.Linq;
 
 namespace LinqToDB.Reflection
 {
-	using System.Diagnostics.CodeAnalysis;
 	using Common;
 	using Expressions;
 	using Extensions;
@@ -334,8 +333,7 @@ namespace LinqToDB.Reflection
 
 		#region Public Methods
 
-		[return: MaybeNull]
-		public T GetAttribute<T>() where T : Attribute
+		public T? GetAttribute<T>() where T : Attribute
 		{
 			var attrs = MemberInfo.GetCustomAttributes(typeof(T), true);
 

--- a/Source/LinqToDB/ServiceModel/ServiceModelDataReader.cs
+++ b/Source/LinqToDB/ServiceModel/ServiceModelDataReader.cs
@@ -20,7 +20,7 @@ namespace LinqToDB.ServiceModel
 
 		readonly MappingSchema          _mappingSchema;
 		readonly LinqServiceResult      _result;
-		readonly Dictionary<string,int> _ordinal = new Dictionary<string,int>();
+		readonly Dictionary<string,int> _ordinal = new ();
 
 		string?[]? _data;
 		int        _current = -1;

--- a/Source/LinqToDB/Sql/Sql.Expressions.cs
+++ b/Source/LinqToDB/Sql/Sql.Expressions.cs
@@ -17,7 +17,7 @@ namespace LinqToDB
 
 	public partial class Sql
 	{
-		private class FieldsExprBuilderDirect : Sql.IExtensionCallBuilder
+		private class FieldsExprBuilderDirect : IExtensionCallBuilder
 		{
 			public void Build(ISqExtensionBuilder builder)
 			{
@@ -30,7 +30,7 @@ namespace LinqToDB
 
 				for (var i = 0; i < columns.Length; i++)
 					columnExpressions[i] = qualified
-						? (ISqlExpression)new SqlField(columns[i])
+						? new SqlField(columns[i])
 						: new SqlExpression(columns[i].ColumnName, Precedence.Primary);
 
 				if (columns.Length == 1)
@@ -43,7 +43,7 @@ namespace LinqToDB
 			}
 		}
 
-		private class FieldNameBuilderDirect : Sql.IExtensionCallBuilder
+		private class FieldNameBuilderDirect : IExtensionCallBuilder
 		{
 			public void Build(ISqExtensionBuilder builder)
 			{
@@ -102,15 +102,17 @@ namespace LinqToDB
 		}
 
 		[Pure]
-		[Sql.Extension("", BuilderType = typeof(FieldNameBuilderDirect), ServerSideOnly = false)]
+		[Extension("", BuilderType = typeof(FieldNameBuilderDirect), ServerSideOnly = false)]
 		public static string FieldName<T>([NoEnumeration] ITable<T> table, Expression<Func<T, object>> fieldExpr)
+			where T : notnull
 		{
 			return FieldName(table, fieldExpr, true);
 		}
 
 		[Pure]
-		[Sql.Extension("", BuilderType = typeof(FieldNameBuilderDirect), ServerSideOnly = false)]
+		[Extension("", BuilderType = typeof(FieldNameBuilderDirect), ServerSideOnly = false)]
 		public static string FieldName<T>([NoEnumeration] ITable<T> table, Expression<Func<T, object>> fieldExpr, [SqlQueryDependent] bool qualified)
+			where T : notnull
 		{
 			var mappingSchema = MappingSchema.Default;
 
@@ -146,14 +148,16 @@ namespace LinqToDB
 			Full         = TableName | DatabaseName | SchemaName | ServerName | TableOptions
 		}
 
-		[Sql.Extension("", BuilderType = typeof(FieldNameBuilderDirect), ServerSideOnly = false)]
+		[Extension("", BuilderType = typeof(FieldNameBuilderDirect), ServerSideOnly = false)]
 		public static ISqlExpression FieldExpr<T, TV>([NoEnumeration] ITable<T> table, Expression<Func<T, TV>> fieldExpr)
+			where T : notnull
 		{
 			return FieldExpr(table, fieldExpr, true);
 		}
 
-		[Sql.Extension("", BuilderType = typeof(FieldNameBuilderDirect), ServerSideOnly = false)]
+		[Extension("", BuilderType = typeof(FieldNameBuilderDirect), ServerSideOnly = false)]
 		public static ISqlExpression FieldExpr<T, TV>([NoEnumeration] ITable<T> table, Expression<Func<T, TV>> fieldExpr, bool qualified)
+			where T : notnull
 		{
 			var mappingSchema = MappingSchema.Default;
 
@@ -171,14 +175,16 @@ namespace LinqToDB
 			return new SqlExpression(column.ColumnName, Precedence.Primary);
 		}
 
-		[Sql.Extension("", BuilderType = typeof(FieldsExprBuilderDirect), ServerSideOnly = false)]
+		[Extension("", BuilderType = typeof(FieldsExprBuilderDirect), ServerSideOnly = false)]
 		internal static ISqlExpression FieldsExpr<T>([NoEnumeration] ITable<T> table, Expression<Func<T, object?>> fieldsExpr)
+			where T : notnull
 		{
 			return FieldsExpr(table, fieldsExpr, true);
 		}
 
-		[Sql.Extension("", BuilderType = typeof(FieldsExprBuilderDirect), ServerSideOnly = false)]
+		[Extension("", BuilderType = typeof(FieldsExprBuilderDirect), ServerSideOnly = false)]
 		internal static ISqlExpression FieldsExpr<T>([NoEnumeration] ITable<T> table, Expression<Func<T, object?>> fieldsExpr, bool qualified)
+			where T : notnull
 		{
 			var mappingSchema = MappingSchema.Default;
 
@@ -192,7 +198,7 @@ namespace LinqToDB
 
 			for (var i = 0; i < columns.Length; i++)
 				columnExpressions[i] = qualified
-					? (ISqlExpression)new SqlField(columns[i])
+					? new SqlField(columns[i])
 					: new SqlExpression(columns[i].ColumnName, Precedence.Primary);
 
 			if (columns.Length == 1)
@@ -205,6 +211,7 @@ namespace LinqToDB
 		}
 
 		private static IDataContext? GetDataContext<T>(ITable<T> table)
+			where T : notnull
 		{
 			if (table is ExpressionQuery<T> query)
 				return query.DataContext;
@@ -254,28 +261,28 @@ namespace LinqToDB
 		}
 
 		[Pure]
-		[Sql.Extension("", BuilderType = typeof(FieldNameBuilder), ServerSideOnly = true)]
+		[Extension("", BuilderType = typeof(FieldNameBuilder), ServerSideOnly = true)]
 		public static string FieldName(object fieldExpr)
 		{
 			throw new LinqToDBException("'Sql.FieldName' is server side only method and used only for generating custom SQL parts");
 		}
 
 		[Pure]
-		[Sql.Extension("", BuilderType = typeof(FieldNameBuilder), ServerSideOnly = true)]
+		[Extension("", BuilderType = typeof(FieldNameBuilder), ServerSideOnly = true)]
 		public static string FieldName(object fieldExpr, bool qualified)
 		{
 			throw new LinqToDBException("'Sql.FieldName' is server side only method and used only for generating custom SQL parts");
 		}
 
 		[Pure]
-		[Sql.Extension("", BuilderType = typeof(FieldNameBuilder), ServerSideOnly = true)]
+		[Extension("", BuilderType = typeof(FieldNameBuilder), ServerSideOnly = true)]
 		public static ISqlExpression FieldExpr(object fieldExpr)
 		{
 			throw new LinqToDBException("'Sql.FieldExpr' is server side only method and used only for generating custom SQL parts");
 		}
 
 		[Pure]
-		[Sql.Extension("", BuilderType = typeof(FieldNameBuilder), ServerSideOnly = true)]
+		[Extension("", BuilderType = typeof(FieldNameBuilder), ServerSideOnly = true)]
 		public static ISqlExpression FieldExpr(object fieldExpr, bool qualified)
 		{
 			throw new LinqToDBException("'Sql.FieldExpr' is server side only method and used only for generating custom SQL parts");
@@ -291,6 +298,7 @@ namespace LinqToDB
 		}
 
 		private class TableHelper<T> : TableHelper
+			where T : notnull
 		{
 			private readonly ITable<T> _table;
 
@@ -394,7 +402,7 @@ namespace LinqToDB
 
 				builder.ResultExpression = isExpression
 					? new SqlExpression(name, Precedence.Primary)
-					: (ISqlExpression)new SqlValue(name);
+					: new SqlValue(name);
 			}
 		}
 
@@ -459,32 +467,34 @@ namespace LinqToDB
 			}
 		}
 
-		[Sql.Extension("", BuilderType = typeof(TableFieldBuilder))]
+		[Extension("", BuilderType = typeof(TableFieldBuilder))]
 		internal static TColumn TableField<TEntity, TColumn>([NoEnumeration] TEntity entity, string fieldName)
 		{
 			throw new LinqToDBException("'Sql.TableField' is server side only method and used only for generating custom SQL parts");
 		}
 
-		[Sql.Extension("", BuilderType = typeof(TableOrColumnAsFieldBuilder))]
+		[Extension("", BuilderType = typeof(TableOrColumnAsFieldBuilder))]
 		internal static TColumn TableOrColumnAsField<TColumn>([NoEnumeration] object? entityOrColumn)
 		{
 			throw new LinqToDBException("'Sql.TableOrColumnAsField' is server side only method and used only for generating custom SQL parts");
 		}
 
-		[Sql.Extension("", BuilderType = typeof(TableAsFieldBuilder))]
+		[Extension("", BuilderType = typeof(TableAsFieldBuilder))]
 		internal static TColumn TableAsField<TEntity, TColumn>([NoEnumeration] TEntity entity)
 		{
 			throw new LinqToDBException("'Sql.TableAsField' is server side only method and used only for generating custom SQL parts");
 		}
 
-		[Sql.Extension("", BuilderType = typeof(TableNameBuilderDirect))]
+		[Extension("", BuilderType = typeof(TableNameBuilderDirect))]
 		public static string TableName<T>([NoEnumeration] ITable<T> table)
+			where T : notnull
 		{
 			return TableName(table, TableQualification.Full);
 		}
 
-		[Sql.Extension("", BuilderType = typeof(TableNameBuilderDirect))]
+		[Extension("", BuilderType = typeof(TableNameBuilderDirect))]
 		public static string TableName<T>([NoEnumeration] ITable<T> table, [SqlQueryDependent] TableQualification qualification)
+			where T : notnull
 		{
 			var result = table.TableName;
 
@@ -508,26 +518,28 @@ namespace LinqToDB
 			return result;
 		}
 
-		[Sql.Extension("", BuilderType = typeof(TableNameBuilder), ServerSideOnly = true)]
+		[Extension("", BuilderType = typeof(TableNameBuilder), ServerSideOnly = true)]
 		public static string TableName(object tableExpr)
 		{
 			throw new LinqToDBException("'Sql.TableName' is server side only method and used only for generating custom SQL parts");
 		}
 
-		[Sql.Extension("", BuilderType = typeof(TableNameBuilder), ServerSideOnly = true)]
+		[Extension("", BuilderType = typeof(TableNameBuilder), ServerSideOnly = true)]
 		public static string TableName(object tableExpr, [SqlQueryDependent] TableQualification qualification)
 		{
 			throw new LinqToDBException("'Sql.TableName' is server side only method and used only for generating custom SQL parts");
 		}
 
-		[Sql.Extension("", BuilderType = typeof(TableNameBuilderDirect))]
+		[Extension("", BuilderType = typeof(TableNameBuilderDirect))]
 		public static ISqlExpression TableExpr<T>([NoEnumeration] ITable<T> table)
+			where T : notnull
 		{
 			return TableExpr(table, TableQualification.Full);
 		}
 
-		[Sql.Extension("", BuilderType = typeof(TableNameBuilderDirect))]
+		[Extension("", BuilderType = typeof(TableNameBuilderDirect))]
 		public static ISqlExpression TableExpr<T>([NoEnumeration] ITable<T> table, [SqlQueryDependent] TableQualification qualification)
+			where T : notnull
 		{
 			var name = table.TableName;
 
@@ -553,13 +565,13 @@ namespace LinqToDB
 			return new SqlExpression(name, Precedence.Primary);
 		}
 
-		[Sql.Extension("", BuilderType = typeof(TableNameBuilder), ServerSideOnly = true)]
+		[Extension("", BuilderType = typeof(TableNameBuilder), ServerSideOnly = true)]
 		public static ISqlExpression TableExpr(object tableExpr)
 		{
 			throw new LinqToDBException("'Sql.TableExpr' is server side only method and used only for generating custom SQL parts");
 		}
 
-		[Sql.Extension("", BuilderType = typeof(TableNameBuilder), ServerSideOnly = true)]
+		[Extension("", BuilderType = typeof(TableNameBuilder), ServerSideOnly = true)]
 		public static ISqlExpression TableExpr(object tableExpr, [SqlQueryDependent] TableQualification qualification)
 		{
 			throw new LinqToDBException("'Sql.TableExpr' is server side only method and used only for generating custom SQL parts");
@@ -580,13 +592,13 @@ namespace LinqToDB
 		/// db.FromSql&lt;int&gt;($"select 1 as value from TableA")
 		/// </code>
 		/// </example>
-		[Sql.Extension("", BuilderType = typeof(TableSourceBuilder), ServerSideOnly = true)]
+		[Extension("", BuilderType = typeof(TableSourceBuilder), ServerSideOnly = true)]
 		public static ISqlExpression AliasExpr()
 		{
 			return new SqlAliasPlaceholder();
 		}
 
-		class CustomExtensionAttribute : Sql.ExtensionAttribute
+		class CustomExtensionAttribute : ExtensionAttribute
 		{
 			public CustomExtensionAttribute(string expression) : base(expression)
 			{

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -11,7 +11,6 @@ using System.Text.RegularExpressions;
 
 namespace LinqToDB.SqlProvider
 {
-	using LinqToDB.Linq;
 	using Common;
 	using Mapping;
 	using SqlQuery;
@@ -1370,7 +1369,7 @@ namespace LinqToDB.SqlProvider
 			StringBuilder.AppendLine();
 		}
 
-		private static readonly Regex _selectDetector = new Regex(@"^[\W\r\n]*select\W+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+		private static readonly Regex _selectDetector = new (@"^[\W\r\n]*select\W+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
 		protected bool? BuildPhysicalTable(ISqlTableSource table, string? alias, string? defaultDatabaseName = null)
 		{

--- a/Source/LinqToDB/SqlProvider/BasicSqlOptimizer.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlOptimizer.cs
@@ -1072,10 +1072,10 @@ namespace LinqToDB.SqlProvider
 							if (cond.Predicate is SqlPredicate.ExprExpr ee)
 							{
 								if (ee.Operator == SqlPredicate.Operator.Equal)
-									return new SqlPredicate.ExprExpr(ee.Expr1, SqlPredicate.Operator.NotEqual, ee.Expr2, Configuration.Linq.CompareNullsAsValues ? true : (bool?)null);
+									return new SqlPredicate.ExprExpr(ee.Expr1, SqlPredicate.Operator.NotEqual, ee.Expr2, Configuration.Linq.CompareNullsAsValues ? true : null);
 
 								if (ee.Operator == SqlPredicate.Operator.NotEqual)
-									return new SqlPredicate.ExprExpr(ee.Expr1, SqlPredicate.Operator.Equal, ee.Expr2, Configuration.Linq.CompareNullsAsValues ? true : (bool?)null);
+									return new SqlPredicate.ExprExpr(ee.Expr1, SqlPredicate.Operator.Equal, ee.Expr2, Configuration.Linq.CompareNullsAsValues ? true : null);
 							}
 						}
 					}
@@ -1866,9 +1866,9 @@ namespace LinqToDB.SqlProvider
 								return new SqlPredicate.Expr(new SqlValue(p.IsNot));
 
 							if (p.IsNot)
-								return new SqlPredicate.NotExpr(sc, true, SqlQuery.Precedence.LogicalNegation);
+								return new SqlPredicate.NotExpr(sc, true, Precedence.LogicalNegation);
 
-							return new SqlPredicate.Expr(sc, SqlQuery.Precedence.LogicalDisjunction);
+							return new SqlPredicate.Expr(sc, Precedence.LogicalDisjunction);
 						}
 					}
 
@@ -1918,9 +1918,9 @@ namespace LinqToDB.SqlProvider
 							return new SqlPredicate.Expr(new SqlValue(p.IsNot));
 
 						if (p.IsNot)
-							return new SqlPredicate.NotExpr(sc, true, SqlQuery.Precedence.LogicalNegation);
+							return new SqlPredicate.NotExpr(sc, true, Precedence.LogicalNegation);
 
-						return new SqlPredicate.Expr(sc, SqlQuery.Precedence.LogicalDisjunction);
+						return new SqlPredicate.Expr(sc, Precedence.LogicalDisjunction);
 					}
 				}
 			}
@@ -1987,7 +1987,7 @@ namespace LinqToDB.SqlProvider
 				sc.Conditions.Add(
 					new SqlCondition(false,
 						new SqlPredicate.ExprExpr(par, SqlPredicate.Operator.NotEqual, new SqlValue(0),
-							Configuration.Linq.CompareNullsAsValues ? false : (bool?)null)));
+							Configuration.Linq.CompareNullsAsValues ? false : null)));
 
 				return new SqlFunction(func.SystemType, "CASE", sc, new SqlValue(true), new SqlValue(false))
 				{
@@ -2068,7 +2068,7 @@ namespace LinqToDB.SqlProvider
 					{
 						sc2.Conditions.Add(new SqlCondition(
 							false,
-							new SqlPredicate.ExprExpr(copyKeys[i], SqlPredicate.Operator.Equal, tableKeys[i], Configuration.Linq.CompareNullsAsValues ? true : (bool?)null)));
+							new SqlPredicate.ExprExpr(copyKeys[i], SqlPredicate.Operator.Equal, tableKeys[i], Configuration.Linq.CompareNullsAsValues ? true : null)));
 					}
 
 					deleteStatement.SelectQuery.Where.SearchCondition.Conditions.Clear();

--- a/Source/LinqToDB/SqlProvider/ISqlOptimizer.cs
+++ b/Source/LinqToDB/SqlProvider/ISqlOptimizer.cs
@@ -1,10 +1,9 @@
-﻿using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 
 namespace LinqToDB.SqlProvider
 {
-	using SqlQuery;
 	using Mapping;
+	using SqlQuery;
 
 	public interface ISqlOptimizer
 	{

--- a/Source/LinqToDB/SqlQuery/ConvertVisitor.cs
+++ b/Source/LinqToDB/SqlQuery/ConvertVisitor.cs
@@ -1154,7 +1154,7 @@ namespace LinqToDB.SqlQuery
 											cte.IsRecursive,
 											cte.Name);
 
-								var correctedBody = ConvertVisitor.Convert(body,
+								var correctedBody = Convert(body,
 									(v, e) =>
 									{
 										if (e.ElementType == QueryElementType.CteClause)

--- a/Source/LinqToDB/SqlQuery/EvaluationContext.cs
+++ b/Source/LinqToDB/SqlQuery/EvaluationContext.cs
@@ -31,7 +31,7 @@ namespace LinqToDB.SqlQuery
 
 		public IReadOnlyParameterValues? ParameterValues { get; }
 
-		public bool TryGetValue(IQueryElement expr, [MaybeNullWhen(false)] out EvaluationInfo? info)
+		public bool TryGetValue(IQueryElement expr, [NotNullWhen(true)] out EvaluationInfo? info)
 		{
 			if (_evaluationCache == null)
 			{

--- a/Source/LinqToDB/TableExtensions.cs
+++ b/Source/LinqToDB/TableExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-
+﻿
 using JetBrains.Annotations;
 
 namespace LinqToDB
@@ -26,6 +25,7 @@ namespace LinqToDB
 		[LinqTunnel]
 		[Pure]
 		public static ITable<T> IsTemporary<T>(this ITable<T> table, [SqlQueryDependent] bool isTemporary)
+			where T : notnull
 		{
 			return ((ITableMutable<T>)table).ChangeTableOptions(isTemporary
 				? table.TableOptions |  LinqToDB.TableOptions.IsTemporary
@@ -43,6 +43,7 @@ namespace LinqToDB
 		[LinqTunnel]
 		[Pure]
 		public static ITable<T> IsTemporary<T>(this ITable<T> table)
+			where T : notnull
 		{
 			return ((ITableMutable<T>)table).ChangeTableOptions(table.TableOptions | LinqToDB.TableOptions.IsTemporary);
 		}
@@ -58,6 +59,7 @@ namespace LinqToDB
 		[LinqTunnel]
 		[Pure]
 		public static ITable<T> TableOptions<T>(this ITable<T> table, [SqlQueryDependent] TableOptions options)
+			where T : notnull
 		{
 			return ((ITableMutable<T>)table).ChangeTableOptions(options);
 		}

--- a/Source/LinqToDB/TempTable.cs
+++ b/Source/LinqToDB/TempTable.cs
@@ -29,6 +29,7 @@ namespace LinqToDB
 #if !NETFRAMEWORK
 		, IAsyncDisposable
 #endif
+		where T : notnull
 	{
 		readonly ITable<T> _table;
 
@@ -424,7 +425,7 @@ namespace LinqToDB
 			return count.RowsCopied;
 		}
 
-		static readonly ConcurrentDictionary<Type,Expression<Func<T,T>>> _setterDic = new ConcurrentDictionary<Type,Expression<Func<T,T>>>();
+		static readonly ConcurrentDictionary<Type,Expression<Func<T,T>>> _setterDic = new ();
 
 		/// <summary>
 		/// Insert data into table using records, returned by provided query.

--- a/Tests/Base/ActiveIssueAttribute.cs
+++ b/Tests/Base/ActiveIssueAttribute.cs
@@ -96,7 +96,7 @@ namespace Tests
 
 		IEnumerable<TestMethod> ITestBuilder.BuildFrom(IMethodInfo method, Test? suite)
 		{
-			foreach (var testMethod in base.BuildFrom(method, suite))
+			foreach (var testMethod in BuildFrom(method, suite))
 			{
 				((IApplyToTest)this).ApplyToTest(testMethod);
 				yield return testMethod;
@@ -119,8 +119,8 @@ namespace Tests
 				if (provider != null)
 				{
 					explicitTest = issueConfigurations.Contains(provider)
-						&& ((!SkipForLinqService && isLinqService == true)
-							|| (!SkipForNonLinqService && isLinqService == false));
+						&& ((!SkipForLinqService && isLinqService)
+							|| (!SkipForNonLinqService && !isLinqService));
 				}
 			}
 

--- a/Tests/Base/TestBase.cs
+++ b/Tests/Base/TestBase.cs
@@ -1240,6 +1240,7 @@ namespace Tests
 		}
 
 		public static TempTable<T> CreateTempTable<T>(IDataContext db, string tableName, string context)
+			where T : notnull
 		{
 			return TempTable.Create<T>(db, GetTempTableName(tableName, context));
 		}

--- a/Tests/Base/TestUtils.cs
+++ b/Tests/Base/TestUtils.cs
@@ -269,6 +269,7 @@ namespace Tests
 		}
 
 		class FirebirdTempTable<T> : TempTable<T>
+			where T : notnull
 		{
 			public FirebirdTempTable(IDataContext db, string? tableName = null, string? databaseName = null, string? schemaName = null, TableOptions tableOptions = TableOptions.NotSet)
 				: base(db, tableName, databaseName, schemaName, tableOptions : tableOptions)
@@ -288,7 +289,8 @@ namespace Tests
 			}
 		}
 
-		static TempTable<T> CreateTable<T>(IDataContext db, string? tableName, TableOptions tableOptions = TableOptions.NotSet) =>
+		static TempTable<T> CreateTable<T>(IDataContext db, string? tableName, TableOptions tableOptions = TableOptions.NotSet)
+			where T : notnull =>
 			db.CreateSqlProvider() is FirebirdSqlBuilder ?
 				new FirebirdTempTable<T>(db, tableName, tableOptions : tableOptions) :
 				new         TempTable<T>(db, tableName, tableOptions : tableOptions);
@@ -303,6 +305,7 @@ namespace Tests
 		}
 
 		public static TempTable<T> CreateLocalTable<T>(this IDataContext db, string? tableName = null, TableOptions tableOptions = TableOptions.NotSet)
+			where T : notnull
 		{
 			try
 			{
@@ -319,6 +322,7 @@ namespace Tests
 		}
 
 		public static TempTable<T> CreateLocalTable<T>(this IDataContext db, string? tableName, IEnumerable<T> items, bool insertInTransaction = false)
+			where T : notnull
 		{
 			var table = CreateLocalTable<T>(db, tableName, TableOptions.CheckExistence);
 
@@ -344,6 +348,7 @@ namespace Tests
 		}
 
 		public static TempTable<T> CreateLocalTable<T>(this IDataContext db, IEnumerable<T> items, bool insertInTransaction = false)
+			where T : notnull
 		{
 			return CreateLocalTable(db, null, items, insertInTransaction);
 		}

--- a/Tests/Base/Tools/TempTable.cs
+++ b/Tests/Base/Tools/TempTable.cs
@@ -8,11 +8,13 @@ namespace Tests.Tools
 	public static class TempTable
 	{
 		public static TempTable<T> Create<T>(IDataContext db, string tableName)
+			where T : notnull
 		{
 			return new TempTable<T>(db, tableName);
 		}
 
 		public static TempTable<T> Create<T>(IDataContext db, IEnumerable<T> data, string tableName)
+			where T : notnull
 		{
 			var table = new TempTable<T>(db, tableName);
 			table.Table.BulkCopy(data);
@@ -21,6 +23,7 @@ namespace Tests.Tools
 	}
 
 	public class TempTable<T> : IDisposable
+		where T : notnull
 	{
 		public ITable<T> Table { get; }
 

--- a/Tests/Linq/DataProvider/FirebirdTests.cs
+++ b/Tests/Linq/DataProvider/FirebirdTests.cs
@@ -576,6 +576,7 @@ namespace Tests.DataProvider
 					test<TestDropTable>();
 
 				void test<TTable>()
+					where TTable : notnull
 				{
 					// first drop deletes table if it remains from previous test run
 					// second drop deletes non-existing table

--- a/Tests/Linq/DataProvider/InformixTests.cs
+++ b/Tests/Linq/DataProvider/InformixTests.cs
@@ -12,7 +12,6 @@ namespace Tests.DataProvider
 {
 	using System.Data.Linq;
 	using System.Diagnostics;
-	using System.Diagnostics.CodeAnalysis;
 	using System.Threading.Tasks;
 	using LinqToDB.DataProvider.Informix;
 	using LinqToDB.Mapping;
@@ -444,7 +443,8 @@ namespace Tests.DataProvider
 			}
 		}
 
-		void CompareObject<T>(MappingSchema mappingSchema, [DisallowNull] T actual, [DisallowNull] T test)
+		void CompareObject<T>(MappingSchema mappingSchema, T actual, T test)
+			where T: notnull
 		{
 			var ed = mappingSchema.GetEntityDescriptor(typeof(T));
 

--- a/Tests/Linq/DataProvider/OracleTests.cs
+++ b/Tests/Linq/DataProvider/OracleTests.cs
@@ -22,7 +22,6 @@ using Oracle.ManagedDataAccess.Types;
 
 namespace Tests.DataProvider
 {
-	using System.Diagnostics.CodeAnalysis;
 	using System.Threading;
 	using System.Threading.Tasks;
 	using LinqToDB.Data.RetryPolicy;
@@ -62,12 +61,13 @@ namespace Tests.DataProvider
 		}
 
 		static void TestType<T>(
-			DataConnection   connection,
-			string           dataTypeName,
-			[DisallowNull] T value,
-			string           tableName       = "\"AllTypes\"",
-			bool             convertToString = false,
-			bool             throwException  = false)
+			DataConnection connection,
+			string         dataTypeName,
+			T              value,
+			string         tableName       = "\"AllTypes\"",
+			bool           convertToString = false,
+			bool           throwException  = false)
+			where T : notnull
 		{
 			Assert.That(connection.Execute<T>($"SELECT {dataTypeName} FROM {tableName} WHERE ID = 1"),
 				Is.EqualTo(connection.MappingSchema.GetDefaultValue(typeof(T))));

--- a/Tests/Linq/DataProvider/SQLiteTests.cs
+++ b/Tests/Linq/DataProvider/SQLiteTests.cs
@@ -16,7 +16,6 @@ using NUnit.Framework;
 
 namespace Tests.DataProvider
 {
-	using System.Diagnostics.CodeAnalysis;
 	using System.Threading.Tasks;
 	using Model;
 
@@ -37,7 +36,8 @@ namespace Tests.DataProvider
 			}
 		}
 
-		static void TestType<T>(DataConnection connection, string dataTypeName, [DisallowNull] T value, string tableName = "AllTypes", bool convertToString = false)
+		static void TestType<T>(DataConnection connection, string dataTypeName, T value, string tableName = "AllTypes", bool convertToString = false)
+			where T : notnull
 		{
 			Assert.That(connection.Execute<T>(string.Format("SELECT {0} FROM {1} WHERE ID = 1", dataTypeName, tableName)),
 				Is.EqualTo(connection.MappingSchema.GetDefaultValue(typeof(T))));

--- a/Tests/Linq/DataProvider/SqlServerTests.cs
+++ b/Tests/Linq/DataProvider/SqlServerTests.cs
@@ -4,7 +4,6 @@ using System.Data;
 using System.Data.Linq;
 using System.Data.SqlTypes;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
@@ -1159,7 +1158,8 @@ namespace Tests.DataProvider
 			await BulkCopyAllTypesAsync(context, BulkCopyType.ProviderSpecific);
 		}
 
-		void CompareObject<T>(MappingSchema mappingSchema, [DisallowNull] T actual, [DisallowNull] T test)
+		void CompareObject<T>(MappingSchema mappingSchema, T actual, T test)
+			where T : notnull
 		{
 			var ed = mappingSchema.GetEntityDescriptor(typeof(T));
 

--- a/Tests/Linq/DataProvider/SybaseTests.cs
+++ b/Tests/Linq/DataProvider/SybaseTests.cs
@@ -15,7 +15,6 @@ using NUnit.Framework;
 namespace Tests.DataProvider
 {
 	using System.Collections.Generic;
-	using System.Diagnostics.CodeAnalysis;
 	using System.Globalization;
 	using System.Threading.Tasks;
 	using LinqToDB.Tools.Comparers;
@@ -38,7 +37,8 @@ namespace Tests.DataProvider
 			}
 		}
 
-		static void TestType<T>(DataConnection connection, string dataTypeName, [DisallowNull] T value, string tableName = "AllTypes", bool convertToString = false)
+		static void TestType<T>(DataConnection connection, string dataTypeName, T value, string tableName = "AllTypes", bool convertToString = false)
+			where T : notnull
 		{
 			Assert.That(connection.Execute<T>(string.Format("SELECT {0} FROM {1} WHERE ID = 1", dataTypeName, tableName)),
 				Is.EqualTo(connection.MappingSchema.GetDefaultValue(typeof(T))));
@@ -1009,7 +1009,8 @@ namespace Tests.DataProvider
 			}
 		}
 
-		void CompareObject<T>(MappingSchema mappingSchema, [DisallowNull] T actual, [DisallowNull] T test, bool hasBitBug)
+		void CompareObject<T>(MappingSchema mappingSchema, T actual, T test, bool hasBitBug)
+			where T: notnull
 		{
 			var ed = mappingSchema.GetEntityDescriptor(typeof(T));
 

--- a/Tests/Linq/Linq/AssociationTests.cs
+++ b/Tests/Linq/Linq/AssociationTests.cs
@@ -514,7 +514,7 @@ namespace Tests.Linq
 					.Select(s => new
 					{
 						s.ChildID,
-						s.a.c,
+						s.a!.c,
 						s.a.Parent
 					})
 					.Select(s => new

--- a/Tests/Linq/Linq/FromSqlTests.cs
+++ b/Tests/Linq/Linq/FromSqlTests.cs
@@ -51,6 +51,7 @@ namespace Tests.Linq
 		}
 
 		class ToTableName<T> : IToSqlConverter
+			where T : notnull
 		{
 			public ToTableName(ITable<T> table)
 			{
@@ -69,6 +70,7 @@ namespace Tests.Linq
 		}
 
 		ToTableName<T> GetName<T>(ITable<T> table)
+			where T : notnull
 		{
 			return new ToTableName<T>(table);
 		}
@@ -535,6 +537,7 @@ namespace Tests.Linq
 				Assert.False(ReferenceEquals(query1, query2));
 
 				IQueryable<SampleClass> GetQuery<T>(ITable<T> table, int startId, int endId)
+					where T : notnull
 				{
 					return db.FromSql<SampleClass>(
 						$"SELECT * FROM {GetName(table)} where id >= {DataParameter.Int32("startId", startId)} and id < {DataParameter.Int32("endId", endId)}");
@@ -617,6 +620,7 @@ namespace Tests.Linq
 				Assert.False(ReferenceEquals(query1, query2));
 
 				IQueryable<SampleClass> GetQuery<T>(ITable<T> table, int startId, int endId)
+					where T : notnull
 				{
 					return db.FromSql<SampleClass>(
 						"SELECT * FROM {0} where id >= {1} and id < {2}",

--- a/Tests/Linq/OrmBattle/Helper/GenericEqualityComparer.cs
+++ b/Tests/Linq/OrmBattle/Helper/GenericEqualityComparer.cs
@@ -10,7 +10,7 @@ namespace Tests.OrmBattle.Helper
 {
 	public class GenericEqualityComparer<T> : IComparable<T>, IEqualityComparer<T>
 	{
-		private readonly List<PropertyInfo> _propertyInfos = new List<PropertyInfo>();
+		private readonly List<PropertyInfo> _propertyInfos = new ();
 
 		public GenericEqualityComparer(params Expression<Func<T, object>>[] property)
 		{
@@ -21,7 +21,7 @@ namespace Tests.OrmBattle.Helper
 
 		#region IEqualityComparer Members
 
-		public bool Equals([AllowNull] T x, [AllowNull] T y)
+		public bool Equals(T? x, T? y)
 		{
 			foreach (var propertyInfo in _propertyInfos)
 			{
@@ -55,7 +55,7 @@ namespace Tests.OrmBattle.Helper
 
 		#endregion
 
-		public int CompareTo([AllowNull] T other)
+		public int CompareTo(T? other)
 		{
 			var x = this;
 			var y = other;

--- a/Tests/Linq/Tests.csproj
+++ b/Tests/Linq/Tests.csproj
@@ -18,4 +18,9 @@
 
 	</ItemGroup>
 
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+		<!-- transient -->
+		<PackageReference Include="System.Security.Cryptography.Cng" />
+	</ItemGroup>
+
 </Project>

--- a/Tests/Linq/Update/MergeTests.ApiParametersValidation.cs
+++ b/Tests/Linq/Update/MergeTests.ApiParametersValidation.cs
@@ -188,6 +188,7 @@ namespace Tests.xUpdate
 		}
 
 		class FakeTable<TEntity> : ITable<TEntity>
+			where TEntity : notnull
 		{
 			IDataContext   IExpressionQuery.DataContext => throw new NotImplementedException();
 			Expression     IExpressionQuery.Expression  => throw new NotImplementedException();

--- a/Tests/Model/Northwind.cs
+++ b/Tests/Model/Northwind.cs
@@ -8,8 +8,9 @@ namespace Tests.Model
 	public class Northwind
 	{
 		public abstract class EntityBase<T>
+			where T: notnull
+
 		{
-			[System.Diagnostics.CodeAnalysis.NotNull]
 			protected abstract T Key { get; }
 
 			public override bool Equals(object? obj)

--- a/Tests/Model/NorthwindDB.cs
+++ b/Tests/Model/NorthwindDB.cs
@@ -32,6 +32,7 @@ namespace Tests.Model
 			ITable<TTable> table,
 			Expression<Func<TTable, object?>> columns,
 			string search)
+			where TTable : notnull
 		{
 			return Sql.Ext.SqlServer().FreeTextTable<TTable, TKey>(table, columns, search);
 		}

--- a/Tests/Model/ParentChild.cs
+++ b/Tests/Model/ParentChild.cs
@@ -605,6 +605,7 @@ namespace Tests.Model
 
 		[Sql.TableExpression("{0} {1} WITH (TABLOCK)")]
 		static ITable<T> WithTabLock1<T>()
+			where T : notnull
 		{
 			throw new InvalidOperationException();
 		}
@@ -623,6 +624,7 @@ namespace Tests.Model
 	{
 		[Sql.TableExpression("{0} {1} WITH (TABLOCK)")]
 		static ITable<T> WithTabLock<T>()
+			where T : notnull
 		{
 			throw new InvalidOperationException();
 		}

--- a/Tests/Tests.Benchmarks/Models/Northwind/NorthwindDB.cs
+++ b/Tests/Tests.Benchmarks/Models/Northwind/NorthwindDB.cs
@@ -33,6 +33,7 @@ namespace LinqToDB.Benchmarks.Models
 			ITable<TTable> table,
 			Expression<Func<TTable, object?>> columns,
 			string search)
+			where TTable : notnull
 		{
 			return Sql.Ext.SqlServer().FreeTextTable<TTable, TKey>(table, columns, search);
 		}

--- a/Tests/Tests.Benchmarks/TestClasses/ProviderMocks/MockDbCommand.cs
+++ b/Tests/Tests.Benchmarks/TestClasses/ProviderMocks/MockDbCommand.cs
@@ -10,7 +10,7 @@ namespace LinqToDB.Benchmarks.TestProvider
 		private readonly QueryResult?   _result;
 		private readonly QueryResult[]? _results;
 
-		private readonly MockDbParameterCollection _parameters = new MockDbParameterCollection();
+		private readonly MockDbParameterCollection _parameters = new ();
 
 		public MockDbCommand(QueryResult result)
 		{

--- a/Tests/Tests.T4/Databases/SqlServer.2017.ProceduresFromSchema.generated.cs
+++ b/Tests/Tests.T4/Databases/SqlServer.2017.ProceduresFromSchema.generated.cs
@@ -1594,10 +1594,10 @@ namespace Sql2017ProcSchema
 		#region Associations
 
 		/// <summary>
-		/// FK_TestSchemaY_TestSchemaX
+		/// FK_TestSchemaY_OtherID
 		/// </summary>
-		[Association(ThisKey="TestSchemaXID", OtherKey="TestSchemaXID", CanBeNull=false, Relationship=LinqToDB.Mapping.Relationship.ManyToOne, KeyName="FK_TestSchemaY_TestSchemaX", BackReferenceName="TestSchemaY")]
-		public TestSchemaX FkTestSchemaYTestSchemaX { get; set; } = null!;
+		[Association(ThisKey="TestSchemaXID", OtherKey="TestSchemaXID", CanBeNull=false, Relationship=LinqToDB.Mapping.Relationship.ManyToOne, KeyName="FK_TestSchemaY_OtherID", BackReferenceName="TestSchemaYOtherIds")]
+		public TestSchemaX FkTestSchemaYOtherID { get; set; } = null!;
 
 		/// <summary>
 		/// FK_TestSchemaY_ParentTestSchemaX
@@ -1606,9 +1606,9 @@ namespace Sql2017ProcSchema
 		public TestSchemaX ParentTestSchemaX { get; set; } = null!;
 
 		/// <summary>
-		/// FK_TestSchemaY_OtherID
+		/// FK_TestSchemaY_TestSchemaX
 		/// </summary>
-		[Association(ThisKey="TestSchemaXID", OtherKey="TestSchemaXID", CanBeNull=false, Relationship=LinqToDB.Mapping.Relationship.ManyToOne, KeyName="FK_TestSchemaY_OtherID", BackReferenceName="TestSchemaYOtherIds")]
+		[Association(ThisKey="TestSchemaXID", OtherKey="TestSchemaXID", CanBeNull=false, Relationship=LinqToDB.Mapping.Relationship.ManyToOne, KeyName="FK_TestSchemaY_TestSchemaX", BackReferenceName="TestSchemaY")]
 		public TestSchemaX TestSchemaX { get; set; } = null!;
 
 		#endregion
@@ -1882,8 +1882,8 @@ namespace Sql2017ProcSchema
 
 		public partial class PersonSelectByKeyLowercaseResult
 		{
-			public int    personid  { get; set; }
-			public string firstname { get; set; } = null!;
+			public int    PersonID  { get; set; }
+			public string FirstName { get; set; } = null!;
 		}
 
 		#endregion
@@ -2381,19 +2381,19 @@ namespace Sql2017ProcSchema
 		#region TestSchemaY Associations
 
 		/// <summary>
-		/// FK_TestSchemaY_TestSchemaX
+		/// FK_TestSchemaY_OtherID
 		/// </summary>
-		[Association(ThisKey="TestSchemaXID", OtherKey="TestSchemaXID", CanBeNull=false, Relationship=LinqToDB.Mapping.Relationship.ManyToOne, KeyName="FK_TestSchemaY_TestSchemaX", BackReferenceName="TestSchemaY")]
-		public static IQueryable<TestSchemaX> FkTestSchemaYTestSchemaX(this TestSchemaY obj, IDataContext db)
+		[Association(ThisKey="TestSchemaXID", OtherKey="TestSchemaXID", CanBeNull=false, Relationship=LinqToDB.Mapping.Relationship.ManyToOne, KeyName="FK_TestSchemaY_OtherID", BackReferenceName="TestSchemaYOtherIds")]
+		public static IQueryable<TestSchemaX> FkTestSchemaYOtherIds(this TestSchemaY obj, IDataContext db)
 		{
 			return db.GetTable<TestSchemaX>().Where(c => c.TestSchemaXID == obj.TestSchemaXID);
 		}
 
 		/// <summary>
-		/// FK_TestSchemaY_TestSchemaX
+		/// FK_TestSchemaY_OtherID
 		/// </summary>
-		[Association(ThisKey="TestSchemaXID", OtherKey="TestSchemaXID", CanBeNull=false, Relationship=LinqToDB.Mapping.Relationship.ManyToOne, KeyName="FK_TestSchemaY_TestSchemaX", BackReferenceName="TestSchemaY")]
-		public static TestSchemaY FkTestSchemaYTestSchemaX0(this TestSchemaX obj, IDataContext db)
+		[Association(ThisKey="TestSchemaXID", OtherKey="TestSchemaXID", CanBeNull=false, Relationship=LinqToDB.Mapping.Relationship.ManyToOne, KeyName="FK_TestSchemaY_OtherID", BackReferenceName="TestSchemaYOtherIds")]
+		public static TestSchemaY FkTestSchemaYOtherID(this TestSchemaX obj, IDataContext db)
 		{
 			return db.GetTable<TestSchemaY>().Where(c => c.TestSchemaXID == obj.TestSchemaXID).First();
 		}
@@ -2417,18 +2417,18 @@ namespace Sql2017ProcSchema
 		}
 
 		/// <summary>
-		/// FK_TestSchemaY_OtherID
+		/// FK_TestSchemaY_TestSchemaX
 		/// </summary>
-		[Association(ThisKey="TestSchemaXID", OtherKey="TestSchemaXID", CanBeNull=false, Relationship=LinqToDB.Mapping.Relationship.ManyToOne, KeyName="FK_TestSchemaY_OtherID", BackReferenceName="TestSchemaYOtherIds")]
+		[Association(ThisKey="TestSchemaXID", OtherKey="TestSchemaXID", CanBeNull=false, Relationship=LinqToDB.Mapping.Relationship.ManyToOne, KeyName="FK_TestSchemaY_TestSchemaX", BackReferenceName="TestSchemaY")]
 		public static IQueryable<TestSchemaX> TestSchemaX(this TestSchemaY obj, IDataContext db)
 		{
 			return db.GetTable<TestSchemaX>().Where(c => c.TestSchemaXID == obj.TestSchemaXID);
 		}
 
 		/// <summary>
-		/// FK_TestSchemaY_OtherID
+		/// FK_TestSchemaY_TestSchemaX
 		/// </summary>
-		[Association(ThisKey="TestSchemaXID", OtherKey="TestSchemaXID", CanBeNull=false, Relationship=LinqToDB.Mapping.Relationship.ManyToOne, KeyName="FK_TestSchemaY_OtherID", BackReferenceName="TestSchemaYOtherIds")]
+		[Association(ThisKey="TestSchemaXID", OtherKey="TestSchemaXID", CanBeNull=false, Relationship=LinqToDB.Mapping.Relationship.ManyToOne, KeyName="FK_TestSchemaY_TestSchemaX", BackReferenceName="TestSchemaY")]
 		public static TestSchemaY TestSchemaX0(this TestSchemaX obj, IDataContext db)
 		{
 			return db.GetTable<TestSchemaY>().Where(c => c.TestSchemaXID == obj.TestSchemaXID).First();

--- a/Tests/Tests.T4/Databases/SqlServer.2017.generated.cs
+++ b/Tests/Tests.T4/Databases/SqlServer.2017.generated.cs
@@ -1594,10 +1594,10 @@ namespace Sql2017
 		#region Associations
 
 		/// <summary>
-		/// FK_TestSchemaY_TestSchemaX
+		/// FK_TestSchemaY_OtherID
 		/// </summary>
-		[Association(ThisKey="TestSchemaXID", OtherKey="TestSchemaXID", CanBeNull=false, Relationship=LinqToDB.Mapping.Relationship.ManyToOne, KeyName="FK_TestSchemaY_TestSchemaX", BackReferenceName="TestSchemaY")]
-		public TestSchemaX FkTestSchemaYTestSchemaX { get; set; } = null!;
+		[Association(ThisKey="TestSchemaXID", OtherKey="TestSchemaXID", CanBeNull=false, Relationship=LinqToDB.Mapping.Relationship.ManyToOne, KeyName="FK_TestSchemaY_OtherID", BackReferenceName="TestSchemaYOtherIds")]
+		public TestSchemaX FkTestSchemaYOtherID { get; set; } = null!;
 
 		/// <summary>
 		/// FK_TestSchemaY_ParentTestSchemaX
@@ -1606,9 +1606,9 @@ namespace Sql2017
 		public TestSchemaX ParentTestSchemaX { get; set; } = null!;
 
 		/// <summary>
-		/// FK_TestSchemaY_OtherID
+		/// FK_TestSchemaY_TestSchemaX
 		/// </summary>
-		[Association(ThisKey="TestSchemaXID", OtherKey="TestSchemaXID", CanBeNull=false, Relationship=LinqToDB.Mapping.Relationship.ManyToOne, KeyName="FK_TestSchemaY_OtherID", BackReferenceName="TestSchemaYOtherIds")]
+		[Association(ThisKey="TestSchemaXID", OtherKey="TestSchemaXID", CanBeNull=false, Relationship=LinqToDB.Mapping.Relationship.ManyToOne, KeyName="FK_TestSchemaY_TestSchemaX", BackReferenceName="TestSchemaY")]
 		public TestSchemaX TestSchemaX { get; set; } = null!;
 
 		#endregion
@@ -1882,8 +1882,8 @@ namespace Sql2017
 
 		public partial class PersonSelectByKeyLowercaseResult
 		{
-			public int    personid  { get; set; }
-			public string firstname { get; set; } = null!;
+			public int    PersonID  { get; set; }
+			public string FirstName { get; set; } = null!;
 		}
 
 		#endregion
@@ -2381,19 +2381,19 @@ namespace Sql2017
 		#region TestSchemaY Associations
 
 		/// <summary>
-		/// FK_TestSchemaY_TestSchemaX
+		/// FK_TestSchemaY_OtherID
 		/// </summary>
-		[Association(ThisKey="TestSchemaXID", OtherKey="TestSchemaXID", CanBeNull=false, Relationship=LinqToDB.Mapping.Relationship.ManyToOne, KeyName="FK_TestSchemaY_TestSchemaX", BackReferenceName="TestSchemaY")]
-		public static IQueryable<TestSchemaX> FkTestSchemaYTestSchemaX(this TestSchemaY obj, IDataContext db)
+		[Association(ThisKey="TestSchemaXID", OtherKey="TestSchemaXID", CanBeNull=false, Relationship=LinqToDB.Mapping.Relationship.ManyToOne, KeyName="FK_TestSchemaY_OtherID", BackReferenceName="TestSchemaYOtherIds")]
+		public static IQueryable<TestSchemaX> FkTestSchemaYOtherIds(this TestSchemaY obj, IDataContext db)
 		{
 			return db.GetTable<TestSchemaX>().Where(c => c.TestSchemaXID == obj.TestSchemaXID);
 		}
 
 		/// <summary>
-		/// FK_TestSchemaY_TestSchemaX
+		/// FK_TestSchemaY_OtherID
 		/// </summary>
-		[Association(ThisKey="TestSchemaXID", OtherKey="TestSchemaXID", CanBeNull=false, Relationship=LinqToDB.Mapping.Relationship.ManyToOne, KeyName="FK_TestSchemaY_TestSchemaX", BackReferenceName="TestSchemaY")]
-		public static TestSchemaY FkTestSchemaYTestSchemaX0(this TestSchemaX obj, IDataContext db)
+		[Association(ThisKey="TestSchemaXID", OtherKey="TestSchemaXID", CanBeNull=false, Relationship=LinqToDB.Mapping.Relationship.ManyToOne, KeyName="FK_TestSchemaY_OtherID", BackReferenceName="TestSchemaYOtherIds")]
+		public static TestSchemaY FkTestSchemaYOtherID(this TestSchemaX obj, IDataContext db)
 		{
 			return db.GetTable<TestSchemaY>().Where(c => c.TestSchemaXID == obj.TestSchemaXID).First();
 		}
@@ -2417,18 +2417,18 @@ namespace Sql2017
 		}
 
 		/// <summary>
-		/// FK_TestSchemaY_OtherID
+		/// FK_TestSchemaY_TestSchemaX
 		/// </summary>
-		[Association(ThisKey="TestSchemaXID", OtherKey="TestSchemaXID", CanBeNull=false, Relationship=LinqToDB.Mapping.Relationship.ManyToOne, KeyName="FK_TestSchemaY_OtherID", BackReferenceName="TestSchemaYOtherIds")]
+		[Association(ThisKey="TestSchemaXID", OtherKey="TestSchemaXID", CanBeNull=false, Relationship=LinqToDB.Mapping.Relationship.ManyToOne, KeyName="FK_TestSchemaY_TestSchemaX", BackReferenceName="TestSchemaY")]
 		public static IQueryable<TestSchemaX> TestSchemaX(this TestSchemaY obj, IDataContext db)
 		{
 			return db.GetTable<TestSchemaX>().Where(c => c.TestSchemaXID == obj.TestSchemaXID);
 		}
 
 		/// <summary>
-		/// FK_TestSchemaY_OtherID
+		/// FK_TestSchemaY_TestSchemaX
 		/// </summary>
-		[Association(ThisKey="TestSchemaXID", OtherKey="TestSchemaXID", CanBeNull=false, Relationship=LinqToDB.Mapping.Relationship.ManyToOne, KeyName="FK_TestSchemaY_OtherID", BackReferenceName="TestSchemaYOtherIds")]
+		[Association(ThisKey="TestSchemaXID", OtherKey="TestSchemaXID", CanBeNull=false, Relationship=LinqToDB.Mapping.Relationship.ManyToOne, KeyName="FK_TestSchemaY_TestSchemaX", BackReferenceName="TestSchemaY")]
 		public static TestSchemaY TestSchemaX0(this TestSchemaX obj, IDataContext db)
 		{
 			return db.GetTable<TestSchemaY>().Where(c => c.TestSchemaXID == obj.TestSchemaXID).First();

--- a/Tests/Tests.T4/Databases/SqlServer.MS.generated.cs
+++ b/Tests/Tests.T4/Databases/SqlServer.MS.generated.cs
@@ -1905,8 +1905,8 @@ namespace DataContextMS
 
 		public partial class PersonSelectByKeyLowercaseResult
 		{
-			public int    personid  { get; set; }
-			public string firstname { get; set; } = null!;
+			public int    PersonID  { get; set; }
+			public string FirstName { get; set; } = null!;
 		}
 
 		#endregion

--- a/Tests/Tests.T4/Databases/SqlServer.generated.cs
+++ b/Tests/Tests.T4/Databases/SqlServer.generated.cs
@@ -76,6 +76,7 @@ namespace DataModel
 		#region FreeTextTable
 
 		public IQueryable<SqlServerExtensions.FreeTextKey<TKey>> FreeTextTable<TTable, TKey>(ITable<TTable> table, Expression<Func<TTable,object?>> columns, string search)
+			where TTable : notnull
 		{
 			return Sql.Ext.SqlServer().FreeTextTable<TTable, TKey>(table, columns, search);
 		}
@@ -1200,6 +1201,7 @@ namespace DataModel
 		#region FreeTextTable
 
 		public IQueryable<SqlServerExtensions.FreeTextKey<TKey>> FreeTextTable<TTable, TKey>(ITable<TTable> table, Expression<Func<TTable,object?>> columns, string search)
+			where TTable : notnull
 		{
 			return Sql.Ext.SqlServer().FreeTextTable<TTable, TKey>(table, columns, search);
 		}
@@ -1892,8 +1894,8 @@ namespace DataModel
 
 		public partial class PersonSelectByKeyLowercaseResult
 		{
-			public int    personid  { get; set; }
-			public string firstname { get; set; } = null!;
+			public int    PersonID  { get; set; }
+			public string FirstName { get; set; } = null!;
 		}
 
 		#endregion

--- a/Tests/Tests.T4/Databases/SqlServerAzure.generated.cs
+++ b/Tests/Tests.T4/Databases/SqlServerAzure.generated.cs
@@ -881,8 +881,8 @@ namespace TestAzureSQL
 
 		public partial class PersonSelectByKeyLowercaseResult
 		{
-			public int    personid  { get; set; }
-			public string firstname { get; set; } = null!;
+			public int    PersonID  { get; set; }
+			public string FirstName { get; set; } = null!;
 		}
 
 		#endregion


### PR DESCRIPTION
- fix build issues after VS 16.9 migration
- fix/update NRT annotations
- fix NRT annotations in T4 outputs for sql server
- replace incorrect use of `Table<T>` to `ExpressionQueryImpl<T>` in couple of APIs
- update [Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient): 2.1.1 => 2.1.2
- update [MySqlConnector](https://www.nuget.org/packages/MySqlConnector): 1.2.1 => 1.3.0

We can merge it if it will build on current VS 16.8, otherwise we need to wait for 16.9 deployment to Azure
