### PR TITLE
Partial fix for transaction isolation level for multi-statement eager load sql server queries

### DIFF
--- a/Source/LinqToDB/DataProvider/DataProviderBase.cs
+++ b/Source/LinqToDB/DataProvider/DataProviderBase.cs
@@ -433,5 +433,8 @@ namespace LinqToDB.DataProvider
 #endif
 
 		#endregion
+
+		public virtual RawTransaction CreateRawTransaction(DataConnection dataConnection)
+			=> throw new InvalidOperationException($"{nameof(CreateRawTransaction)} API not suppored by {Name} provider");
 	}
 }

--- a/Source/LinqToDB/DataProvider/IDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/IDataProvider.cs
@@ -60,5 +60,7 @@ namespace LinqToDB.DataProvider
 #if !NETFRAMEWORK
 		Task<BulkCopyRowsCopied> BulkCopyAsync<T>(ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken);
 #endif
+
+		RawTransaction     CreateRawTransaction(DataConnection dataConnection);
 	}
 }

--- a/Source/LinqToDB/DataProvider/RawTransaction.cs
+++ b/Source/LinqToDB/DataProvider/RawTransaction.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using LinqToDB.Data;
+
+namespace LinqToDB.DataProvider
+{
+	/// <summary>
+	/// This is internal API and is not intended for use by Linq To DB applications.
+	/// It may change or be removed without further notice.
+	/// </summary>
+	public abstract class RawTransaction : IDisposable
+#if !NETFRAMEWORK
+		, IAsyncDisposable
+#endif
+	{
+		protected readonly DataConnection DataConnection;
+
+		protected RawTransaction(DataConnection dataConnection)
+		{
+			DataConnection = dataConnection;
+		}
+
+		public abstract RawTransaction BeginTransaction();
+		public abstract Task<RawTransaction> BeginTransactionAsync(CancellationToken cancellationToken);
+
+		protected abstract void RollbackTransaction();
+
+		void IDisposable.Dispose() => RollbackTransaction();
+
+#if !NETFRAMEWORK
+		protected abstract ValueTask RollbackTransactionAsync();
+		ValueTask IAsyncDisposable.DisposeAsync() => RollbackTransactionAsync();
+#endif
+	}
+}

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
@@ -15,7 +15,6 @@ namespace LinqToDB.DataProvider.SqlServer
 	using Mapping;
 	using SchemaProvider;
 	using SqlProvider;
-	using SqlQuery;
 
 	public class SqlServerDataProvider : DynamicDataProviderBase<SqlServerProviderAdapter>
 	{
@@ -40,6 +39,8 @@ namespace LinqToDB.DataProvider.SqlServer
 			SqlProviderFlags.IsDistinctSetOperationsSupported = true;
 			SqlProviderFlags.IsCountDistinctSupported         = true;
 			SqlProviderFlags.IsUpdateFromSupported            = true;
+			// https://github.com/linq2db/linq2db/issues/2790
+			SqlProviderFlags.DefaultMultiQueryIsolationLevel  = null;
 
 			if (version == SqlServerVersion.v2000)
 			{
@@ -443,5 +444,7 @@ namespace LinqToDB.DataProvider.SqlServer
 #endif
 
 		#endregion
+
+		public override RawTransaction CreateRawTransaction(DataConnection dataConnection) => new SqlServerRawTransaction(dataConnection);
 	}
 }

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerRawTransaction.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerRawTransaction.cs
@@ -1,0 +1,60 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using LinqToDB.Data;
+
+namespace LinqToDB.DataProvider.SqlServer
+{
+	public sealed class SqlServerRawTransaction : RawTransaction
+	{
+		private DataConnectionTransaction? _marsTransaction;
+
+		public SqlServerRawTransaction(DataConnection dataConnection)
+			: base(dataConnection)
+		{
+		}
+
+		public override RawTransaction BeginTransaction()
+		{
+			// explicit transaction management requires single batch when used over MARS-enabled connection
+			// https://docs.microsoft.com/en-us/archive/blogs/cbiyikoglu/mars-transactions-and-sql-error-3997-3988-or-3983
+			// in theory we can refactor eager load in future to support MARS batching to unblock this scenario
+			if (DataConnection.IsMarsEnabled)
+				_marsTransaction = DataConnection.BeginTransaction();
+			else
+				DataConnection.Execute("BEGIN TRAN");
+			return this;
+		}
+
+		protected override void RollbackTransaction()
+		{
+			if (DataConnection.IsMarsEnabled)
+				_marsTransaction!.Rollback();
+			else
+				DataConnection.Execute("ROLLBACK TRAN");
+		}
+
+		public override async Task<RawTransaction> BeginTransactionAsync(CancellationToken cancellationToken)
+		{
+			if (DataConnection.IsMarsEnabled)
+				_marsTransaction = await DataConnection.BeginTransactionAsync(cancellationToken)
+					.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+			else
+				await DataConnection.ExecuteAsync("BEGIN TRAN", cancellationToken)
+					.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+
+			return this;
+		}
+
+#if !NETFRAMEWORK
+		protected override async ValueTask RollbackTransactionAsync()
+		{
+			if (DataConnection.IsMarsEnabled)
+				await _marsTransaction!.RollbackAsync()
+					.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+			else
+				await DataConnection.ExecuteAsync("ROLLBACK TRAN")
+					.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+		}
+#endif
+	}
+}

--- a/Source/LinqToDB/SqlProvider/SqlProviderFlags.cs
+++ b/Source/LinqToDB/SqlProvider/SqlProviderFlags.cs
@@ -5,6 +5,7 @@ using System.Linq;
 namespace LinqToDB.SqlProvider
 {
 	using System.Collections.Generic;
+	using LinqToDB.DataProvider;
 	using SqlQuery;
 
 	public class SqlProviderFlags
@@ -107,10 +108,12 @@ namespace LinqToDB.SqlProvider
 		}
 
 		/// <summary>
-		/// Used when there is query which needs several additional database request for completing query.
-		/// Default is <see cref="IsolationLevel.RepeatableRead"/>
+		/// Used when there is query which needs several additional database requests for completing query.
+		/// Default is <see cref="IsolationLevel.RepeatableRead"/>.
+		/// <c>null</c> value corresponds to custom transaction management instead of BeginTransaction APIs, e.g. using BEGIN TRAN sql.
+		/// In that case provider must implement <see cref="IDataProvider.CreateRawTransaction(Data.DataConnection)"/> API.
 		/// </summary>
-		public IsolationLevel DefaultMultiQueryIsolationLevel { get; set; } = IsolationLevel.RepeatableRead;
+		public IsolationLevel? DefaultMultiQueryIsolationLevel { get; set; } = IsolationLevel.RepeatableRead;
 
 		/// <summary>
 		/// Flags for use by external providers.
@@ -152,7 +155,7 @@ namespace LinqToDB.SqlProvider
 				^ IsDistinctSetOperationsSupported             .GetHashCode()
 				^ IsCountDistinctSupported                     .GetHashCode()
 				^ IsUpdateFromSupported                        .GetHashCode()
-				^ DefaultMultiQueryIsolationLevel              .GetHashCode()
+				^ (DefaultMultiQueryIsolationLevel?            .GetHashCode() ?? 0)
 				^ CustomFlags.Aggregate(0, (hash, flag) => flag.GetHashCode() ^ hash);
 	}
 


### PR DESCRIPTION
Fix #2790

### Problem:

When user execute eager load query which requires multiple queries to load data and there is no transaction available, linq2db will automatically wrap all queries into transaction with predefined isolation level (see below).
Due to `SqlClient` behavior where it doesn't reset current transaction isolation level even after connection was returned to connection pool, it changes transaction isolation level for pooled connection.
It is not a problem, when user always use explicit transactions and specify transaction isolation level, but when auto-commit transactions used they start to use isolation level introduced by eager load transaction.

### Solutions:
1. Reset transaction isolation level after eager load query to old value. Will require two additional roundtrips to server to query and reset isolation level.
2. Manually start transaction using `BEGIN TRAN` sql query to avoid isolation level change by `BeginTransaction` API.

This PR implements 2nd option as most lightweigth and more expected when auto-commit transactions used by application. Unfortunatelly it it not possible to tell `SqlClient` to not touch transaction level for `BeginTransaction` API (`IsolationLevel.Unspecified` will be replaced with `IsolationLevel.ReadCommitted`), so we need to manage transaction manually using `BEGIN TRAN` queries.

Due to MARS limitations, this fix will not work for MARS-enabled connections https://docs.microsoft.com/en-us/archive/blogs/cbiyikoglu/mars-transactions-and-sql-error-3997-3988-or-3983. It is still possible to fix it for MARS, but it will require eager load refactoring to batch all queries into single batch.

#### Isolation levels used by providers for eager load transactions:
- Oracle: ReadCommitted
- SQLite: Serializable
- Access: Unspecified
- Others: RepeatableRead
- Sql Server: was: RepeatableRead -> new : Unspecified/ReadCommitted (MARS)