### PR TITLE
Add DROP IF EXISTS support to SQL Server 2017

### DIFF
--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2017SqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2017SqlBuilder.cs
@@ -1,6 +1,7 @@
 ﻿namespace LinqToDB.DataProvider.SqlServer
 {
 	using LinqToDB.Mapping;
+	using LinqToDB.SqlQuery;
 	using SqlProvider;
 
 	class SqlServer2017SqlBuilder : SqlServer2012SqlBuilder
@@ -18,6 +19,11 @@
 		protected override ISqlBuilder CreateSqlBuilder()
 		{
 			return new SqlServer2017SqlBuilder(Provider, MappingSchema, SqlOptimizer, SqlProviderFlags);
+		}
+
+		protected override void BuildDropTableStatement(SqlDropTableStatement dropTable)
+		{
+			BuildDropTableStatementIfExists(dropTable);
 		}
 
 		public override string Name => ProviderName.SqlServer2017;


### PR DESCRIPTION
Supported since SQL Server 2016+ and within Azure SQL Database.

Not supported in Azure Synapse Analytics and Parallel Data Warehouse

See: https://docs.microsoft.com/en-us/sql/t-sql/statements/drop-table-transact-sql?view=sql-server-ver15
