### PR TITLE
Add NET472 TFM with native support for ValueTask, IAsyncEnumerable<T> and IAsyncDisposable

### DIFF
--- a/Build/linq2db.Source.props
+++ b/Build/linq2db.Source.props
@@ -2,7 +2,6 @@
 	<Import Project="linq2db.Default.props" />
 
 	<PropertyGroup>
-		<TargetFrameworks>net45;net46;netstandard2.0;netcoreapp2.1;netstandard2.1;netcoreapp3.1</TargetFrameworks>
 		<Configurations>Debug;Release</Configurations>
 	</PropertyGroup>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,17 +39,18 @@ Solutions:
 
 #### Source projects
 
-| Project \ Target                                 |.NET 4.5 |.NET 4.6 | .NET Standard 2.0 | .NET Core 2.1 | .NET Standard 2.1 | .NET Core 3.1 |
-|-------------------------------------------------:|:-------:|:-------:|:-----------------:|:-------------:|:-----------------:|:-------------:|
-| `.\Source\LinqToDB\LinqToDB.csproj`              |    √    |    √    |         √         |       √       |         √         |       √       |
-| `.\Source\LinqToDB\LinqToDB.Tools.csproj`        |    √    |    √    |         √         |               |                   |               |
-| `.\Source\LinqToDB\LinqToDB.AspNet.csproj`       |    √    |         |         √         |               |                   |               |
+| Project \ Target                                 |.NET 4.5 |.NET 4.6 |.NET 4.7.2 | .NET Standard 2.0 | .NET Core 2.1 | .NET Standard 2.1 | .NET Core 3.1 |
+|-------------------------------------------------:|:-------:|:-------:|:---------:|:-----------------:|:-------------:|:-----------------:|:-------------:|
+| `.\Source\LinqToDB\LinqToDB.csproj`              |    √    |    √    |     √     |         √         |       √       |         √         |       √       |
+| `.\Source\LinqToDB\LinqToDB.Tools.csproj`        |    √    |    √    |           |         √         |               |                   |               |
+| `.\Source\LinqToDB\LinqToDB.AspNet.csproj`       |    √    |         |           |         √         |               |                   |               |
 
 Preferred target defines:
-- `NETFRAMEWORK` - `net45` and `net46` target ifdef
+- `NETFRAMEWORK` - `net45`, `net46` and `net472` target ifdef
 - `!NETFRAMEWORK` - `netstandard2.0` and newer target ifdef
 - `NETCOREAPP` - `netcoreapp2.1` and `netcoreapp3.1` target ifdef
 - `NETSTANDARD2_1PLUS` - `netstandard2.1` and `netcoreapp3.1` target ifdef
+- `NATIVE_ASYNC` - ifdef with native support for `ValueTask`, `IAsyncEnumerable<T>` and `IAsyncDisposable` types
 
 Other allowed target defines:
 - `NETSTANDARD2_1` - `netstandard2.1` target ifdef
@@ -58,6 +59,7 @@ Other allowed target defines:
 - `NETCOREAPP2_1` - `netcoreapp2.1` target ifdef
 - `NET45` - `net45` target ifdef
 - `NET46` - `net46` target ifdef
+- `NET472` - `net472` target ifdef
 
 Allowed debugging defines:
 - `TRACK_BUILD`
@@ -66,17 +68,16 @@ Allowed debugging defines:
 
 #### Test projects
 
-| Project \ Target                                   |.NET 4.7.2 | .NET Core 2.1 | .NET Core 3.1 | .NET 5.0 | Xamarin.Forms Android v8.1 |
-|---------------------------------------------------:|:---------:|:-------------:|:-------------:|:--------:|:--------------------------:|
-| `.\Tests\Base\Tests.Base.csproj`                   |     √     |       √       |       √       |    √     |                            |
-| `.\Tests\FSharp\Tests.FSharp.fsproj`               |     √     |       √       |       √       |    √     |                            |
-| `.\Tests\Linq\Tests.csproj`                        |     √     |       √       |       √       |    √     |                            |
-| `.\Tests\Model\Tests.Model.csproj`                 |     √     |       √       |       √       |    √     |                            |
-| `.\Tests\Tests.Android\Tests.Android.csproj`       |           |               |               |          |              √             |
-| `.\Tests\Tests.Benchmarks\Tests.Benchmarks.csproj` |     √     |       √       |       √       |    √     |                            |
-| `.\Tests\Tests.Playground\Tests.Playground.csproj` |     √     |       √       |       √       |    √     |                            |
-| `.\Tests\Tests.T4\Tests.T4.csproj`                 |     √     |       √       |       √       |    √     |                            |
-| `.\Tests\VisualBasic\Tests.VisualBasic.vbproj`     |     √     |       √       |       √       |    √     |                            |
+| Project \ Target                                   |.NET 4.7.2 | .NET Core 2.1 | .NET Core 3.1 | .NET 5.0 |
+|---------------------------------------------------:|:---------:|:-------------:|:-------------:|:--------:|
+| `.\Tests\Base\Tests.Base.csproj`                   |     √     |       √       |       √       |    √     |
+| `.\Tests\FSharp\Tests.FSharp.fsproj`               |     √     |       √       |       √       |    √     |
+| `.\Tests\Linq\Tests.csproj`                        |     √     |       √       |       √       |    √     |
+| `.\Tests\Model\Tests.Model.csproj`                 |     √     |       √       |       √       |    √     |
+| `.\Tests\Tests.Benchmarks\Tests.Benchmarks.csproj` |     √     |       √       |       √       |    √     |
+| `.\Tests\Tests.Playground\Tests.Playground.csproj` |     √     |       √       |       √       |    √     |
+| `.\Tests\Tests.T4\Tests.T4.csproj`                 |     √     |       √       |       √       |    √     |
+| `.\Tests\VisualBasic\Tests.VisualBasic.vbproj`     |     √     |       √       |       √       |    √     |
 
 
 Allowed target defines:

--- a/NuGet/linq2db.nuspec
+++ b/NuGet/linq2db.nuspec
@@ -11,6 +11,9 @@
 		<dependencies>
 			<group targetFramework=".NETFramework4.5" />
 			<group targetFramework=".NETFramework4.6" />
+			<group targetFramework=".NETFramework4.7.2">
+				<dependency id="Microsoft.Bcl.AsyncInterfaces"     version="5.0.0" />
+			</group>
 			<group targetFramework=".NETStandard2.0">
 				<dependency id="Microsoft.CSharp"                  version="4.7.0" />
 				<dependency id="System.ComponentModel.Annotations" version="5.0.0" />

--- a/Source/LinqToDB/Async/AsyncDbConnection.cs
+++ b/Source/LinqToDB/Async/AsyncDbConnection.cs
@@ -37,7 +37,7 @@ namespace LinqToDB.Async
 
 		public virtual IDbConnection Connection => _connection;
 
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 		public virtual Task<IAsyncDbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
 			=> Task.FromResult(AsyncFactory.Create(BeginTransaction()));
 #elif !NETSTANDARD2_1PLUS
@@ -67,7 +67,7 @@ namespace LinqToDB.Async
 			}
 			return AsyncFactory.Create(BeginTransaction(isolationLevel));
 		}
-#elif !NETFRAMEWORK
+#elif NATIVE_ASYNC
 		public virtual ValueTask<IAsyncDbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
 			=> new ValueTask<IAsyncDbTransaction>(AsyncFactory.Create(BeginTransaction(isolationLevel)));
 #else
@@ -129,7 +129,7 @@ namespace LinqToDB.Async
 			Connection.Dispose();
 		}
 
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 		public virtual Task DisposeAsync()
 		{
 			Dispose();
@@ -143,7 +143,7 @@ namespace LinqToDB.Async
 				return asyncDisposable.DisposeAsync();
 
 			Dispose();
-			return new ValueTask(Task.CompletedTask);
+			return default;
 		}
 #endif
 

--- a/Source/LinqToDB/Async/AsyncDbTransaction.cs
+++ b/Source/LinqToDB/Async/AsyncDbTransaction.cs
@@ -49,7 +49,7 @@ namespace LinqToDB.Async
 			Transaction.Dispose();
 		}
 
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 		public virtual Task DisposeAsync()
 		{
 			Dispose();
@@ -63,7 +63,7 @@ namespace LinqToDB.Async
 				return asyncDisposable.DisposeAsync();
 
 			Dispose();
-			return new ValueTask(Task.CompletedTask);
+			return default;
 		}
 #endif
 

--- a/Source/LinqToDB/Async/AsyncEnumeratorAsyncWrapper.cs
+++ b/Source/LinqToDB/Async/AsyncEnumeratorAsyncWrapper.cs
@@ -7,7 +7,7 @@ namespace LinqToDB.Async
 	internal class AsyncEnumeratorAsyncWrapper<T> : IAsyncEnumerator<T>
 	{
 		private IAsyncEnumerator<T>? _enumerator;
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 		private readonly Func<Task<Tuple<IAsyncEnumerator<T>, IDisposable?>>> _init;
 		private IDisposable? _disposable;
 #else
@@ -15,7 +15,7 @@ namespace LinqToDB.Async
 		private IAsyncDisposable? _disposable;
 #endif
 
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 		public AsyncEnumeratorAsyncWrapper(Func<Task<Tuple<IAsyncEnumerator<T>, IDisposable?>>> init)
 #else
 		public AsyncEnumeratorAsyncWrapper(Func<Task<Tuple<IAsyncEnumerator<T>, IAsyncDisposable?>>> init)
@@ -26,7 +26,7 @@ namespace LinqToDB.Async
 
 		T IAsyncEnumerator<T>.Current => _enumerator!.Current;
 
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 		async Task IAsyncDisposable.DisposeAsync()
 		{
 			await _enumerator!.DisposeAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);

--- a/Source/LinqToDB/Async/AsyncExtensions.cs
+++ b/Source/LinqToDB/Async/AsyncExtensions.cs
@@ -35,7 +35,7 @@ namespace LinqToDB.Async
 
 			var result = new List<T>();
 			var enumerator = source.GetAsyncEnumerator(cancellationToken);
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 			await using (enumerator)
 #else
 			await using (enumerator.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
@@ -95,7 +95,7 @@ namespace LinqToDB.Async
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
 			var enumerator = source.GetAsyncEnumerator(cancellationToken);
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 			await using (enumerator)
 #else
 			await using (enumerator.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
@@ -120,7 +120,7 @@ namespace LinqToDB.Async
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
 			var enumerator = source.GetAsyncEnumerator(token);
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 			await using (enumerator)
 #else
 			await using (enumerator.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))

--- a/Source/LinqToDB/Async/AsyncFactory.cs
+++ b/Source/LinqToDB/Async/AsyncFactory.cs
@@ -1,18 +1,16 @@
-﻿using JetBrains.Annotations;
-using LinqToDB.Common;
-using LinqToDB.Expressions;
-using LinqToDB.Extensions;
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.Common;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
+using LinqToDB.Common;
+using LinqToDB.Expressions;
+using LinqToDB.Extensions;
 
 namespace LinqToDB.Async
 {
@@ -33,7 +31,7 @@ namespace LinqToDB.Async
 		private static readonly ConcurrentDictionary<Type, Func<IDbTransaction, IAsyncDbTransaction>> _transactionFactories
 			= new ConcurrentDictionary<Type, Func<IDbTransaction, IAsyncDbTransaction>>();
 
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 		private static readonly MethodInfo _transactionWrap      = MemberHelper.MethodOf(() => Wrap<IDbTransaction>(default!)).GetGenericMethodDefinition();
 #else
 #pragma warning disable CA2012 // ValueTask instances returned from method calls should be directly awaited...
@@ -103,7 +101,7 @@ namespace LinqToDB.Async
 			return Create(await transaction.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext));
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		private static async ValueTask<IAsyncDbTransaction> WrapValue<TTransaction>(ValueTask<TTransaction> transaction)
 			where TTransaction : IDbTransaction
 		{
@@ -131,7 +129,7 @@ namespace LinqToDB.Async
 			// Availability:
 			// - DbTransaction (netstandard2.1, netcoreapp3.0)
 			// - Npgsql 4.1.2+
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 			var disposeAsync  = CreateDelegate<Func<IDbConnection               ,      Task>, IDbConnection >(type, "DisposeAsync" , Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, true , false)
 #else
 			var disposeAsync  = CreateDelegate<Func<IDbConnection               , ValueTask>, IDbConnection >(type, "DisposeAsync" , Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, true , true )
@@ -139,7 +137,7 @@ namespace LinqToDB.Async
 			// Task DisposeAsync()
 			// Availability:
 			// - MySqlConnector 0.57+
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 							 ?? CreateDelegate<Func<IDbConnection               ,      Task>, IDbConnection >(type, "DisposeAsync" , Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, false, false);
 #else
 							 ?? CreateDelegate<Func<IDbConnection               , ValueTask>, IDbConnection >(type, "DisposeAsync" , Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, false, true );
@@ -162,7 +160,7 @@ namespace LinqToDB.Async
 			// - (stub) DbConnection (netstandard2.1, netcoreapp3.0)
 			// - MySqlConnector 0.57+
 			// - Npgsql 4.1.2+
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 			var beginTransactionAsync   = CreateTaskTDelegate<Func<IDbConnection, CancellationToken           ,      Task<IAsyncDbTransaction>>, IDbConnection, IDbTransaction>(type, "BeginTransactionAsync", _tokenParams           , _transactionWrap,      true, false)
 #else
 			var beginTransactionAsync   = CreateTaskTDelegate<Func<IDbConnection, CancellationToken           , ValueTask<IAsyncDbTransaction>>, IDbConnection, IDbTransaction>(type, "BeginTransactionAsync", _tokenParams           , _transactionValueWrap, true, true)
@@ -171,7 +169,7 @@ namespace LinqToDB.Async
 			// Availability:
 			// - MySql.Data
 			// - MySqlConnector < 0.57
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 									   ?? CreateTaskTDelegate<Func<IDbConnection, CancellationToken           ,      Task<IAsyncDbTransaction>>, IDbConnection, IDbTransaction>(type, "BeginTransactionAsync", _tokenParams           , _transactionWrap,      false, false);
 #else
 									   ?? CreateTaskTDelegate<Func<IDbConnection, CancellationToken           , ValueTask<IAsyncDbTransaction>>, IDbConnection, IDbTransaction>(type, "BeginTransactionAsync", _tokenParams           , _transactionValueWrap, false, true);
@@ -182,7 +180,7 @@ namespace LinqToDB.Async
 			// - (stub) DbConnection (netstandard2.1, netcoreapp3.0)
 			// - MySqlConnector 0.57+
 			// - Npgsql 4.1.2+
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 			var beginTransactionIlAsync = CreateTaskTDelegate<Func<IDbConnection, IsolationLevel, CancellationToken,      Task<IAsyncDbTransaction>>, IDbConnection, IDbTransaction>(type, "BeginTransactionAsync", _beginTransactionParams, _transactionWrap,      true, false)
 #else
 			var beginTransactionIlAsync = CreateTaskTDelegate<Func<IDbConnection, IsolationLevel, CancellationToken, ValueTask<IAsyncDbTransaction>>, IDbConnection, IDbTransaction>(type, "BeginTransactionAsync", _beginTransactionParams, _transactionValueWrap, true, true)
@@ -191,7 +189,7 @@ namespace LinqToDB.Async
 			// Availability:
 			// - MySql.Data
 			// - MySqlConnector < 0.57
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 									   ?? CreateTaskTDelegate<Func<IDbConnection, IsolationLevel, CancellationToken,      Task<IAsyncDbTransaction>>, IDbConnection, IDbTransaction>(type, "BeginTransactionAsync", _beginTransactionParams, _transactionWrap,      false, false);
 #else
 									   ?? CreateTaskTDelegate<Func<IDbConnection, IsolationLevel, CancellationToken, ValueTask<IAsyncDbTransaction>>, IDbConnection, IDbTransaction>(type, "BeginTransactionAsync", _beginTransactionParams, _transactionValueWrap, false, true);
@@ -217,7 +215,7 @@ namespace LinqToDB.Async
 			// Availability:
 			// - (stub) DbConnection (netstandard2.1, netcoreapp3.0)
 			// - Npgsql 4.1.2+
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 			var disposeAsync            = CreateDelegate<Func<IDbConnection, Task     >, IDbConnection>(type, "DisposeAsync", Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, true , false)
 #else
 			var disposeAsync            = CreateDelegate<Func<IDbConnection, ValueTask>, IDbConnection>(type, "DisposeAsync", Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, true , true)
@@ -225,7 +223,7 @@ namespace LinqToDB.Async
 			// Task DisposeAsync()
 			// Availability:
 			// - MySqlConnector 0.57+
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 									   ?? CreateDelegate<Func<IDbConnection,      Task>, IDbConnection>(type, "DisposeAsync", Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, false, false);
 #else
 									   ?? CreateDelegate<Func<IDbConnection, ValueTask>, IDbConnection>(type, "DisposeAsync", Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, false, true);
@@ -283,7 +281,7 @@ namespace LinqToDB.Async
 				//convert a ValueTask result to a Task
 				body = ToTask(body);
 			}
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 			else if (!returnsValueTask && returnValueTask)
 			{
 				//convert a Task result to a ValueTask
@@ -306,7 +304,7 @@ namespace LinqToDB.Async
 			return Expression.Call(body, "AsTask", Array<Type>.Empty);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		/// <summary>
 		/// Returns an expression which returns a <see cref="ValueTask"/> from a <see cref="Task"/>.
 		/// </summary>
@@ -373,7 +371,7 @@ namespace LinqToDB.Async
 				//convert a ValueTask result to a Task
 				body = ToTask(body);
 			}
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 			else if (!returnsValueTask && returnValueTask)
 			{
 				//convert a Task result to a ValueTask

--- a/Source/LinqToDB/Async/IAsyncDbConnection.cs
+++ b/Source/LinqToDB/Async/IAsyncDbConnection.cs
@@ -11,17 +11,14 @@ namespace LinqToDB.Async
 	/// Asynchronous version of the <see cref="IDbConnection"/> interface, allowing asynchronous operations, missing from <see cref="IDbConnection"/>.
 	/// </summary>
 	[PublicAPI]
-	public interface IAsyncDbConnection : IDbConnection
-#if !NETFRAMEWORK
-		, IAsyncDisposable
-#endif
+	public interface IAsyncDbConnection : IDbConnection, IAsyncDisposable
 	{
 		/// <summary>
 		/// Starts new transaction asynchronously for current connection with default isolation level.
 		/// </summary>
 		/// <param name="cancellationToken">Asynchronous operation cancellation token.</param>
 		/// <returns>Database transaction object.</returns>
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		ValueTask<IAsyncDbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default);
 #else
 		Task<IAsyncDbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default);
@@ -33,7 +30,7 @@ namespace LinqToDB.Async
 		/// <param name="isolationLevel">Transaction isolation level.</param>
 		/// <param name="cancellationToken">Asynchronous operation cancellation token.</param>
 		/// <returns>Database transaction object.</returns>
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		ValueTask<IAsyncDbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default);
 #else
 		Task<IAsyncDbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default);
@@ -51,14 +48,6 @@ namespace LinqToDB.Async
 		/// <param name="cancellationToken">Asynchronous operation cancellation token.</param>
 		/// <returns>Async operation task.</returns>
 		Task OpenAsync(CancellationToken cancellationToken = default);
-
-#if NETFRAMEWORK
-		/// <summary>
-		/// Disposes current connection asynchonously.
-		/// </summary>
-		/// <returns>Async operation task.</returns>
-		Task DisposeAsync();
-#endif
 
 		/// <summary>
 		/// Gets underlying connection instance.

--- a/Source/LinqToDB/Async/IAsyncDbTransaction.cs
+++ b/Source/LinqToDB/Async/IAsyncDbTransaction.cs
@@ -11,10 +11,7 @@ namespace LinqToDB.Async
 	/// Asynchronous version of the <see cref="IDbTransaction"/> interface, allowing asynchronous operations, missing from <see cref="IDbTransaction"/>.
 	/// </summary>
 	[PublicAPI]
-	public interface IAsyncDbTransaction : IDbTransaction
-#if !NETFRAMEWORK
-		, IAsyncDisposable
-#endif
+	public interface IAsyncDbTransaction : IDbTransaction, IAsyncDisposable
 	{
 		/// <summary>
 		/// Commits transaction asynchronously.
@@ -34,13 +31,5 @@ namespace LinqToDB.Async
 		/// Gets underlying transaction instance.
 		/// </summary>
 		IDbTransaction Transaction { get; }
-
-#if NETFRAMEWORK
-		/// <summary>
-		/// Disposes transaction asynchronously.
-		/// </summary>
-		/// <returns>Asynchronous operation completion task.</returns>
-		Task DisposeAsync();
-#endif
 	}
 }

--- a/Source/LinqToDB/Async/IAsyncDisposable.cs
+++ b/Source/LinqToDB/Async/IAsyncDisposable.cs
@@ -1,4 +1,4 @@
-﻿#if NETFRAMEWORK
+﻿#if !NATIVE_ASYNC
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Source/LinqToDB/Async/IAsyncEnumerable.cs
+++ b/Source/LinqToDB/Async/IAsyncEnumerable.cs
@@ -1,4 +1,4 @@
-﻿#if NETFRAMEWORK
+﻿#if !NATIVE_ASYNC
 using System.Threading;
 
 namespace LinqToDB.Async

--- a/Source/LinqToDB/Async/IAsyncEnumerator.cs
+++ b/Source/LinqToDB/Async/IAsyncEnumerator.cs
@@ -1,4 +1,4 @@
-﻿#if NETFRAMEWORK
+﻿#if !NATIVE_ASYNC
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Source/LinqToDB/Async/ReflectedAsyncDbConnection.cs
+++ b/Source/LinqToDB/Async/ReflectedAsyncDbConnection.cs
@@ -13,7 +13,7 @@ namespace LinqToDB.Async
 	{
 		private readonly Func<IDbConnection, CancellationToken, Task>?                                           _openAsync;
 		private readonly Func<IDbConnection, Task>?                                                              _closeAsync;
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		private readonly Func<IDbConnection, CancellationToken, ValueTask<IAsyncDbTransaction>>?                 _beginTransactionAsync;
 		private readonly Func<IDbConnection, IsolationLevel, CancellationToken, ValueTask<IAsyncDbTransaction>>? _beginTransactionIlAsync;
 		private readonly Func<IDbConnection, ValueTask>?                                                         _disposeAsync;
@@ -25,7 +25,7 @@ namespace LinqToDB.Async
 
 		public ReflectedAsyncDbConnection(
 			IDbConnection connection,
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 			Func<IDbConnection, CancellationToken, ValueTask<IAsyncDbTransaction>>?                 beginTransactionAsync,
 			Func<IDbConnection, IsolationLevel, CancellationToken, ValueTask<IAsyncDbTransaction>>? beginTransactionIlAsync,
 #else
@@ -34,7 +34,7 @@ namespace LinqToDB.Async
 #endif
 			Func<IDbConnection, CancellationToken, Task>?                                           openAsync,
 			Func<IDbConnection, Task>?                                                              closeAsync,
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 			Func<IDbConnection, ValueTask>?                                                         disposeAsync)
 #else
 			Func<IDbConnection, Task>?                                                              disposeAsync)
@@ -48,7 +48,7 @@ namespace LinqToDB.Async
 			_disposeAsync            = disposeAsync;
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		public override ValueTask<IAsyncDbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
 #else
 		public override Task<IAsyncDbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
@@ -57,7 +57,7 @@ namespace LinqToDB.Async
 			return _beginTransactionAsync?.Invoke(Connection, cancellationToken) ?? base.BeginTransactionAsync(cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		public override ValueTask<IAsyncDbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
 #else
 		public override Task<IAsyncDbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
@@ -76,7 +76,7 @@ namespace LinqToDB.Async
 			return _closeAsync?.Invoke(Connection) ?? base.CloseAsync();
 		}
 
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 		public override Task DisposeAsync()
 		{
 			return _disposeAsync?.Invoke(Connection) ?? base.DisposeAsync();

--- a/Source/LinqToDB/Async/ReflectedAsyncDbTransaction.cs
+++ b/Source/LinqToDB/Async/ReflectedAsyncDbTransaction.cs
@@ -14,7 +14,7 @@ namespace LinqToDB.Async
 	{
 		private readonly Func<IDbTransaction, CancellationToken, Task>? _commitAsync;
 		private readonly Func<IDbTransaction, CancellationToken, Task>? _rollbackAsync;
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		private readonly Func<IDbConnection, ValueTask>?                _disposeAsync;
 #else
 		private readonly Func<IDbConnection, Task>?                     _disposeAsync;
@@ -24,7 +24,7 @@ namespace LinqToDB.Async
 			IDbTransaction                                 transaction,
 			Func<IDbTransaction, CancellationToken, Task>? commitAsync,
 			Func<IDbTransaction, CancellationToken, Task>? rollbackAsync,
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 			Func<IDbConnection, ValueTask>?                disposeAsync)
 #else
 			Func<IDbConnection, Task>?                     disposeAsync)
@@ -46,7 +46,7 @@ namespace LinqToDB.Async
 			return _rollbackAsync?.Invoke(Transaction, cancellationToken) ?? base.RollbackAsync(cancellationToken);
 		}
 
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 		public override Task DisposeAsync()
 		{
 			return _disposeAsync?.Invoke(Connection) ?? base.DisposeAsync();

--- a/Source/LinqToDB/AsyncExtensions.cs
+++ b/Source/LinqToDB/AsyncExtensions.cs
@@ -9,7 +9,7 @@ using JetBrains.Annotations;
 namespace LinqToDB
 {
 	using Linq;
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 	using Async;
 #endif
 
@@ -102,7 +102,7 @@ namespace LinqToDB
 				_query = query ?? throw new ArgumentNullException(nameof(query));
 			}
 
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 			IAsyncEnumerator<T> IAsyncEnumerable<T>.GetAsyncEnumerator(CancellationToken cancellationToken)
 			{
 				return new AsyncEnumeratorImpl<T>(_query.GetEnumerator(), cancellationToken);

--- a/Source/LinqToDB/Common/EnumerableHelper.cs
+++ b/Source/LinqToDB/Common/EnumerableHelper.cs
@@ -7,7 +7,7 @@ namespace LinqToDB.Common
 {
 	internal class EnumerableHelper
 	{
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		public static IEnumerable<T> AsyncToSyncEnumerable<T>(IAsyncEnumerator<T> enumerator)
 		{
 			var result = enumerator.MoveNextAsync();
@@ -116,7 +116,7 @@ namespace LinqToDB.Common
 			}
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		/// <summary>
 		/// Split enumerable source into batches of specified size.
 		/// Limitation: each batch should be enumerated only once or exception will be generated.

--- a/Source/LinqToDB/Compatibility/System/IAsyncDisposable.cs
+++ b/Source/LinqToDB/Compatibility/System/IAsyncDisposable.cs
@@ -1,4 +1,4 @@
-﻿#if NETFRAMEWORK
+﻿#if !NATIVE_ASYNC
 namespace System
 {
 	// Magic (see https://github.com/dotnet/roslyn/issues/45111)

--- a/Source/LinqToDB/Data/CommandInfo.cs
+++ b/Source/LinqToDB/Data/CommandInfo.cs
@@ -756,15 +756,15 @@ namespace LinqToDB.Data
 			{
 			}
 
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 			public Task DisposeAsync() => TaskEx.CompletedTask;
 #else
-			public ValueTask DisposeAsync() => new ValueTask(Task.CompletedTask);
+			public ValueTask DisposeAsync() => default;
 #endif
 
 			public T Current { get; private set; } = default!;
 
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 			public async Task<bool> MoveNextAsync()
 #else
 			public async ValueTask<bool> MoveNextAsync()

--- a/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
+++ b/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
@@ -502,11 +502,17 @@ namespace LinqToDB.Data
 				{
 					 return _dataReader.DisposeAsync();
 				}
-#elif !NETFRAMEWORK
+#elif NATIVE_ASYNC
 				public ValueTask DisposeAsync()
 				{
 					Dispose();
-					return new ValueTask(Task.CompletedTask);
+					return default;
+				}
+#else
+				public Task DisposeAsync()
+				{
+					Dispose();
+					return TaskEx.CompletedTask;
 				}
 #endif
 			}

--- a/Source/LinqToDB/Data/DataConnectionExtensions.cs
+++ b/Source/LinqToDB/Data/DataConnectionExtensions.cs
@@ -2418,7 +2418,7 @@ namespace LinqToDB.Data
 		#endregion
 
 		#region BulkCopy IAsyncEnumerable async
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 
 		/// <summary>
 		/// Asynchronously performs bulk insert operation.

--- a/Source/LinqToDB/Data/DataConnectionTransaction.cs
+++ b/Source/LinqToDB/Data/DataConnectionTransaction.cs
@@ -7,9 +7,11 @@ namespace LinqToDB.Data
 	/// <summary>
 	/// Data connection transaction controller.
 	/// </summary>
-	public class DataConnectionTransaction : IDisposable
-#if !NETFRAMEWORK
-		, IAsyncDisposable
+	public class DataConnectionTransaction : IDisposable,
+#if NATIVE_ASYNC
+		IAsyncDisposable
+#else
+		Async.IAsyncDisposable
 #endif
 	{
 		/// <summary>
@@ -76,13 +78,21 @@ namespace LinqToDB.Data
 				DataConnection.RollbackTransaction();
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		public ValueTask DisposeAsync()
 		{
 			if (_disposeTransaction)
 				return new ValueTask(DataConnection.RollbackTransactionAsync());
 
-			return new ValueTask(Task.CompletedTask);
+			return default;
+		}
+#else
+		public Task DisposeAsync()
+		{
+			if (_disposeTransaction)
+				return DataConnection.RollbackTransactionAsync();
+
+			return TaskEx.CompletedTask;
 		}
 #endif
 	}

--- a/Source/LinqToDB/Data/DataReaderAsync.cs
+++ b/Source/LinqToDB/Data/DataReaderAsync.cs
@@ -8,9 +8,11 @@ using System.Threading.Tasks;
 
 namespace LinqToDB.Data
 {
-	public class DataReaderAsync : IDisposable
-#if !NETFRAMEWORK
-		, IAsyncDisposable
+	public class DataReaderAsync : IDisposable,
+#if NATIVE_ASYNC
+		IAsyncDisposable
+#else
+		Async.IAsyncDisposable
 #endif
 	{
 		public   CommandInfo?      CommandInfo       { get; set; }
@@ -64,11 +66,17 @@ namespace LinqToDB.Data
 
 			OnDispose?.Invoke();
 		}
-#elif !NETFRAMEWORK
+#elif NATIVE_ASYNC
 		public ValueTask DisposeAsync()
 		{
 			Dispose();
-			return new ValueTask(Task.CompletedTask);
+			return default;
+		}
+#else
+		public Task DisposeAsync()
+		{
+			Dispose();
+			return TaskEx.CompletedTask;
 		}
 #endif
 

--- a/Source/LinqToDB/Data/RetryPolicy/RetryingDbConnection.cs
+++ b/Source/LinqToDB/Data/RetryPolicy/RetryingDbConnection.cs
@@ -122,7 +122,7 @@ namespace LinqToDB.Data.RetryPolicy
 
 		protected override ValueTask<DbTransaction> BeginDbTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken)
 			=> _dbConnection.BeginTransactionAsync(isolationLevel, cancellationToken);
-#elif !NETFRAMEWORK
+#elif NATIVE_ASYNC
 		public ValueTask<IAsyncDbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
 			=> _connection.BeginTransactionAsync(cancellationToken);
 
@@ -149,7 +149,7 @@ namespace LinqToDB.Data.RetryPolicy
 #pragma warning disable CA2215 // CA2215: Dispose methods should call base class dispose
 		public override ValueTask DisposeAsync()
 #pragma warning restore CA2215 // CA2215: Dispose methods should call base class dispose
-#elif !NETFRAMEWORK
+#elif NATIVE_ASYNC
 		public ValueTask DisposeAsync()
 #else
 		public Task DisposeAsync()

--- a/Source/LinqToDB/DataProvider/Access/AccessODBCDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessODBCDataProvider.cs
@@ -162,7 +162,7 @@ namespace LinqToDB.DataProvider.Access
 				cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/Access/AccessOleDbDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessOleDbDataProvider.cs
@@ -127,7 +127,7 @@ namespace LinqToDB.DataProvider.Access
 				cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/BasicBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/BasicBulkCopy.cs
@@ -38,7 +38,7 @@ namespace LinqToDB.DataProvider
 			};
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		public virtual Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			BulkCopyType bulkCopyType, ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 			where T: notnull
@@ -66,7 +66,7 @@ namespace LinqToDB.DataProvider
 			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected virtual Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 			where T: notnull
@@ -89,7 +89,7 @@ namespace LinqToDB.DataProvider
 			return RowByRowCopyAsync(table, options, source, cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected virtual Task<BulkCopyRowsCopied> MultipleRowsCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 			where T: notnull
@@ -170,7 +170,7 @@ namespace LinqToDB.DataProvider
 			return rowsCopied;
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected virtual async Task<BulkCopyRowsCopied> RowByRowCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 			where T: notnull
@@ -362,7 +362,7 @@ namespace LinqToDB.DataProvider
 			return helper.RowsCopied;
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected static async Task<BulkCopyRowsCopied> MultipleRowsCopyHelperAsync<T>(
 			MultipleRowsHelper                          helper,
 			IAsyncEnumerable<T>                         source,
@@ -412,7 +412,7 @@ namespace LinqToDB.DataProvider
 		protected Task<BulkCopyRowsCopied> MultipleRowsCopy1Async(MultipleRowsHelper helper, IEnumerable source, CancellationToken cancellationToken)
 			=> MultipleRowsCopyHelperAsync(helper, source, null, MultipleRowsCopy1Prep, MultipleRowsCopy1Add, MultipleRowsCopy1Finish, cancellationToken);
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected Task<BulkCopyRowsCopied> MultipleRowsCopy1Async<T>(ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		where T: notnull
 			=> MultipleRowsCopy1Async(new MultipleRowsHelper<T>(table, options), source, cancellationToken);
@@ -480,7 +480,7 @@ namespace LinqToDB.DataProvider
 		protected Task<BulkCopyRowsCopied> MultipleRowsCopy2Async(MultipleRowsHelper helper, IEnumerable source, string from, CancellationToken cancellationToken)
 			=> MultipleRowsCopyHelperAsync(helper, source, from, MultipleRowsCopy2Prep, MultipleRowsCopy2Add, MultipleRowsCopy2Finish, cancellationToken);
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected Task<BulkCopyRowsCopied> MultipleRowsCopy2Async<T>(ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, string from, CancellationToken cancellationToken)
 		where T: notnull
 			=> MultipleRowsCopy2Async(new MultipleRowsHelper<T>(table, options), source, from, cancellationToken);
@@ -537,7 +537,7 @@ namespace LinqToDB.DataProvider
 		protected Task<BulkCopyRowsCopied> MultipleRowsCopy3Async(MultipleRowsHelper helper, BulkCopyOptions options, IEnumerable source, string from, CancellationToken cancellationToken)
 			=> MultipleRowsCopyHelperAsync(helper, source, from, MultipleRowsCopy3Prep, MultipleRowsCopy3Add, MultipleRowsCopy3Finish, cancellationToken);
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected Task<BulkCopyRowsCopied> MultipleRowsCopy3Async<T>(MultipleRowsHelper helper, BulkCopyOptions options, IAsyncEnumerable<T> source, string from, CancellationToken cancellationToken)
 		where T: notnull
 			=> MultipleRowsCopyHelperAsync(helper, source, from, MultipleRowsCopy3Prep, MultipleRowsCopy3Add, MultipleRowsCopy3Finish, cancellationToken);

--- a/Source/LinqToDB/DataProvider/BulkCopyReader.cs
+++ b/Source/LinqToDB/DataProvider/BulkCopyReader.cs
@@ -5,22 +5,27 @@ using System.Data;
 using System.Data.Common;
 using System.Globalization;
 using System.Linq;
+#if NATIVE_ASYNC
+	using System.Threading;
+	using System.Threading.Tasks;
+#endif
 
 namespace LinqToDB.DataProvider
 {
-	using System.Threading;
 	using System.Threading.Tasks;
 	using Common;
 	using LinqToDB.Data;
 	using Mapping;
 
-	public class BulkCopyReader<T> : BulkCopyReader
-#if !NETFRAMEWORK
-		, IAsyncDisposable
+	public class BulkCopyReader<T> : BulkCopyReader,
+#if NATIVE_ASYNC
+		IAsyncDisposable
+#else
+		Async.IAsyncDisposable
 #endif
 	{
 		readonly IEnumerator<T>?      _enumerator;
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		readonly IAsyncEnumerator<T>? _asyncEnumerator;
 #endif
 
@@ -30,7 +35,7 @@ namespace LinqToDB.DataProvider
 			_enumerator = collection.GetEnumerator();
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		public BulkCopyReader(DataConnection dataConnection, List<ColumnDescriptor> columns, IAsyncEnumerable<T> collection, CancellationToken cancellationToken)
 			: base(dataConnection, columns)
 		{
@@ -46,9 +51,6 @@ namespace LinqToDB.DataProvider
 			return result.IsCompleted ? result.Result : result.AsTask().GetAwaiter().GetResult();
 		}
 
-		protected override ValueTask<bool> MoveNextAsync()
-			=> _enumerator != null ? new ValueTask<bool>(_enumerator.MoveNext()) : _asyncEnumerator!.MoveNextAsync();
-
 		protected override object Current
 			=> (_enumerator != null ? _enumerator.Current : _asyncEnumerator!.Current)!;
 #else
@@ -59,9 +61,14 @@ namespace LinqToDB.DataProvider
 			=> _enumerator!.Current!;
 #endif
 
-		#region Implementation of IDisposable
+#if NATIVE_ASYNC
+		protected override ValueTask<bool> MoveNextAsync()
+			=> _enumerator != null ? new ValueTask<bool>(_enumerator.MoveNext()) : _asyncEnumerator!.MoveNextAsync();
+#endif
 
-#if !NETFRAMEWORK
+#region Implementation of IDisposable
+
+#if NATIVE_ASYNC
 #pragma warning disable CA2215 // CA2215: Dispose methods should call base class dispose
 		protected override void Dispose(bool disposing)
 #pragma warning restore CA2215 // CA2215: Dispose methods should call base class dispose
@@ -74,7 +81,9 @@ namespace LinqToDB.DataProvider
 					result.AsTask().GetAwaiter().GetResult();
 			}
 		}
+#endif
 
+#if NATIVE_ASYNC
 #if NETSTANDARD2_1PLUS
 #pragma warning disable CA2215 // CA2215: Dispose methods should call base class dispose
 		public override ValueTask DisposeAsync()
@@ -83,12 +92,17 @@ namespace LinqToDB.DataProvider
 		public ValueTask DisposeAsync()
 #endif
 		{
-			return _asyncEnumerator?.DisposeAsync() ?? new ValueTask(Task.CompletedTask);
+			return _asyncEnumerator?.DisposeAsync() ?? default;
 		}
-
+#else
+		public Task DisposeAsync()
+		{
+			Dispose(true);
+			return TaskEx.CompletedTask;
+		}
 #endif
 
-		#endregion
+#endregion
 
 	}
 
@@ -103,7 +117,7 @@ namespace LinqToDB.DataProvider
 		readonly IReadOnlyDictionary<string, int> _ordinals;
 
 		protected abstract bool MoveNext();
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected abstract ValueTask<bool> MoveNextAsync();
 #endif
 		protected abstract object Current { get; }
@@ -130,7 +144,7 @@ namespace LinqToDB.DataProvider
 			public int                Size          { get; set; }
 		}
 
-		#region Implementation of IDataRecord
+#region Implementation of IDataRecord
 
 		public override string GetName(int ordinal)
 		{
@@ -197,9 +211,9 @@ namespace LinqToDB.DataProvider
 		public override object this[int i]       => throw new NotImplementedException();
 		public override object this[string name] => throw new NotImplementedException();
 
-		#endregion
+#endregion
 
-		#region Implementation of IDataReader
+#region Implementation of IDataReader
 
 		public override void Close()
 		{
@@ -277,7 +291,7 @@ namespace LinqToDB.DataProvider
 			return b;
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		public override async Task<bool> ReadAsync(CancellationToken cancellationToken)
 		{
 			var b = await MoveNextAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
@@ -295,7 +309,7 @@ namespace LinqToDB.DataProvider
 
 		public override int RecordsAffected => throw new NotImplementedException();
 
-		#endregion
+#endregion
 
 		public override IEnumerator GetEnumerator() => throw new NotImplementedException();
 

--- a/Source/LinqToDB/DataProvider/DB2/DB2BulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2BulkCopy.cs
@@ -62,7 +62,7 @@ namespace LinqToDB.DataProvider.DB2
 			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected override async Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
 			if (table.DataContext is DataConnection dataConnection)
@@ -177,7 +177,7 @@ namespace LinqToDB.DataProvider.DB2
 			return MultipleRowsCopy1Async(table, options, source, cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected override Task<BulkCopyRowsCopied> MultipleRowsCopyAsync<T>(ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
 			var dataConnection = (DataConnection)table.DataContext;

--- a/Source/LinqToDB/DataProvider/DB2/DB2DataProvider.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2DataProvider.cs
@@ -219,7 +219,7 @@ namespace LinqToDB.DataProvider.DB2
 				cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/DataProviderBase.cs
+++ b/Source/LinqToDB/DataProvider/DataProviderBase.cs
@@ -426,7 +426,7 @@ namespace LinqToDB.DataProvider
 			return new BasicBulkCopy().BulkCopyAsync(options.BulkCopyType, table, options, source, cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		public virtual Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 			where T: notnull

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdBulkCopy.cs
@@ -28,7 +28,7 @@ namespace LinqToDB.DataProvider.Firebird
 			return MultipleRowsCopy2Async(table, options, source, " FROM rdb$database", cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected override Task<BulkCopyRowsCopied> MultipleRowsCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdDataProvider.cs
@@ -128,7 +128,7 @@ namespace LinqToDB.DataProvider.Firebird
 				cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/IDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/IDataProvider.cs
@@ -59,7 +59,7 @@ namespace LinqToDB.DataProvider
 		Task<BulkCopyRowsCopied> BulkCopyAsync<T>(ITable<T> table, BulkCopyOptions options, IEnumerable<T> source, CancellationToken cancellationToken)
 			where T : notnull;
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		Task<BulkCopyRowsCopied> BulkCopyAsync<T>(ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		where T: notnull;
 #endif

--- a/Source/LinqToDB/DataProvider/Informix/InformixBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixBulkCopy.cs
@@ -90,7 +90,7 @@ namespace LinqToDB.DataProvider.Informix
 			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected override async Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T>           table,
 			BulkCopyOptions     options,
@@ -211,7 +211,7 @@ namespace LinqToDB.DataProvider.Informix
 				return base.MultipleRowsCopyAsync(table, options, source, cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected override Task<BulkCopyRowsCopied> MultipleRowsCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/Informix/InformixDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixDataProvider.cs
@@ -230,7 +230,7 @@ namespace LinqToDB.DataProvider.Informix
 				cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/MySql/MySqlBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlBulkCopy.cs
@@ -58,7 +58,7 @@ namespace LinqToDB.DataProvider.MySql
 			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected override Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T>           table,
 			BulkCopyOptions     options,
@@ -190,7 +190,7 @@ namespace LinqToDB.DataProvider.MySql
 			return rc;
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		private async Task<BulkCopyRowsCopied> ProviderSpecificCopyInternal<T>(
 			ProviderConnections providerConnections,
 			ITable<T>           table,
@@ -273,7 +273,7 @@ namespace LinqToDB.DataProvider.MySql
 			return MultipleRowsCopy1Async(table, options, source, cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected override Task<BulkCopyRowsCopied> MultipleRowsCopyAsync<T>(ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
 			return MultipleRowsCopy1Async(table, options, source, cancellationToken);

--- a/Source/LinqToDB/DataProvider/MySql/MySqlDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlDataProvider.cs
@@ -150,7 +150,7 @@ namespace LinqToDB.DataProvider.MySql
 				cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/MySql/MySqlProviderAdapter.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlProviderAdapter.cs
@@ -486,6 +486,10 @@ namespace LinqToDB.DataProvider.MySql
 				[TypeWrapperName("WriteToServerAsync")]
 				public ValueTask WriteToServerAsync2(IDataReader dataReader, CancellationToken cancellationToken) => ((Func<MySqlBulkCopy, IDataReader, CancellationToken, ValueTask>)CompiledWrappers[9])(this, dataReader, cancellationToken);
 				public bool CanWriteToServerAsync2 => CompiledWrappers[9] != null;
+#else
+				[TypeWrapperName("WriteToServerAsync")]
+				public Task WriteToServerAsync2(IDataReader dataReader, CancellationToken cancellationToken) => throw new InvalidOperationException();
+				public bool CanWriteToServerAsync2 => false;
 #endif
 
 				public int NotifyAfter

--- a/Source/LinqToDB/DataProvider/Oracle/OracleBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleBulkCopy.cs
@@ -132,7 +132,7 @@ namespace LinqToDB.DataProvider.Oracle
 			return Task.FromResult(ProviderSpecificCopy(table, options, source));
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected override async Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
@@ -167,7 +167,7 @@ namespace LinqToDB.DataProvider.Oracle
 			}
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected override Task<BulkCopyRowsCopied> MultipleRowsCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
@@ -217,7 +217,7 @@ namespace LinqToDB.DataProvider.Oracle
 		static Task<BulkCopyRowsCopied> OracleMultipleRowsCopy1Async(MultipleRowsHelper helper, IEnumerable source, CancellationToken cancellationToken)
 			=> MultipleRowsCopyHelperAsync(helper, source, null, OracleMultipleRowsCopy1Prep, OracleMultipleRowsCopy1Add, OracleMultipleRowsCopy1Finish, cancellationToken);
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		static Task<BulkCopyRowsCopied> OracleMultipleRowsCopy1Async<T>(MultipleRowsHelper helper, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 			=> MultipleRowsCopyHelperAsync(helper, source, null, OracleMultipleRowsCopy1Prep, OracleMultipleRowsCopy1Add, OracleMultipleRowsCopy1Finish, cancellationToken);
 #endif
@@ -303,7 +303,7 @@ namespace LinqToDB.DataProvider.Oracle
 			return helper.RowsCopied;
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		static async Task<BulkCopyRowsCopied> OracleMultipleRowsCopy2Async<T>(MultipleRowsHelper helper, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
 			var list = OracleMultipleRowsCopy2Prep(helper);
@@ -420,7 +420,7 @@ namespace LinqToDB.DataProvider.Oracle
 		static Task<BulkCopyRowsCopied> OracleMultipleRowsCopy3Async(MultipleRowsHelper helper, IEnumerable source, CancellationToken cancellationToken)
 			=> MultipleRowsCopyHelperAsync(helper, source, null, OracleMultipleRowsCopy3Prep, OracleMultipleRowsCopy3Add, OracleMultipleRowsCopy3Finish, cancellationToken);
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		static Task<BulkCopyRowsCopied> OracleMultipleRowsCopy3Async<T>(MultipleRowsHelper helper, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 			=> MultipleRowsCopyHelperAsync(helper, source, null, OracleMultipleRowsCopy3Prep, OracleMultipleRowsCopy3Add, OracleMultipleRowsCopy3Finish, cancellationToken);
 #endif

--- a/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
@@ -327,7 +327,7 @@ namespace LinqToDB.DataProvider.Oracle
 				cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/PostgreSQL/NpgsqlProviderAdapter.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/NpgsqlProviderAdapter.cs
@@ -514,7 +514,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 				(Expression<Action<NpgsqlBinaryImporter>>                                  )((NpgsqlBinaryImporter this_) => this_.Dispose()),
 				// [4]: StartRow
 				(Expression<Action<NpgsqlBinaryImporter>>                                  )((NpgsqlBinaryImporter this_) => this_.StartRow()),
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 				// [5]: CompleteAsync
 				new Tuple<LambdaExpression, bool>
 				((Expression<Func<NpgsqlBinaryImporter, CancellationToken, ValueTask<ulong>>>)((NpgsqlBinaryImporter this_, CancellationToken token) => this_.CompleteAsync(token)),         true),
@@ -557,7 +557,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			public void StartRow() => ((Action<NpgsqlBinaryImporter>)CompiledWrappers[4])(this);
 			public void Write<T>(T value, NpgsqlDbType npgsqlDbType) => ((Action<NpgsqlBinaryImporter, object?, NpgsqlDbType>)CompiledWrappers[9])(this, value, npgsqlDbType);
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 #pragma warning disable CS3002 // Return type is not CLS-compliant
 			public ValueTask<ulong> CompleteAsync(CancellationToken cancellationToken) 
 				=> ((Func<NpgsqlBinaryImporter, CancellationToken, ValueTask<ulong>>)CompiledWrappers[5])(this, cancellationToken);

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
@@ -30,7 +30,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			return MultipleRowsCopy1Async(table, options, source, cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected override Task<BulkCopyRowsCopied> MultipleRowsCopyAsync<T>(ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
 			return MultipleRowsCopy1Async(table, options, source, cancellationToken);
@@ -54,7 +54,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected override Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
@@ -305,7 +305,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			return rowsCopied;
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		private async Task<BulkCopyRowsCopied> ProviderSpecificCopyImplAsync<T>(DataConnection dataConnection, ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		where T: notnull
 		{

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
@@ -290,7 +290,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 				cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteBulkCopy.cs
@@ -20,7 +20,7 @@ namespace LinqToDB.DataProvider.SQLite
 			return MultipleRowsCopy1Async(table, options, source, cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected override Task<BulkCopyRowsCopied> MultipleRowsCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteDataProvider.cs
@@ -265,7 +265,7 @@ namespace LinqToDB.DataProvider.SQLite
 				cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaBulkCopy.cs
@@ -60,7 +60,7 @@ namespace LinqToDB.DataProvider.SapHana
 			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected override Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T> table,
 			BulkCopyOptions options,

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaDataProvider.cs
@@ -168,7 +168,7 @@ namespace LinqToDB.DataProvider.SapHana
 				cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/SqlCe/SqlCeBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/SqlCe/SqlCeBulkCopy.cs
@@ -43,7 +43,7 @@ namespace LinqToDB.DataProvider.SqlCe
 			return ret;
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected override async Task<BulkCopyRowsCopied> MultipleRowsCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/SqlCe/SqlCeDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlCe/SqlCeDataProvider.cs
@@ -159,7 +159,7 @@ namespace LinqToDB.DataProvider.SqlCe
 				cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerBulkCopy.cs
@@ -60,7 +60,7 @@ namespace LinqToDB.DataProvider.SqlServer
 			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected override Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T>           table,
 			BulkCopyOptions     options,
@@ -240,7 +240,7 @@ namespace LinqToDB.DataProvider.SqlServer
 			return ret;
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected override async Task<BulkCopyRowsCopied> MultipleRowsCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
@@ -431,7 +431,7 @@ namespace LinqToDB.DataProvider.SqlServer
 				cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
 			_bulkCopy ??= new SqlServerBulkCopy(this);

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseBulkCopy.cs
@@ -59,7 +59,7 @@ namespace LinqToDB.DataProvider.Sybase
 			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected override Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T>           table,
 			BulkCopyOptions     options,
@@ -194,7 +194,7 @@ namespace LinqToDB.DataProvider.Sybase
 			return MultipleRowsCopy2Async(table, options, source, "", cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		protected override Task<BulkCopyRowsCopied> MultipleRowsCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseDataProvider.cs
@@ -232,7 +232,7 @@ namespace LinqToDB.DataProvider.Sybase
 				cancellationToken);
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		public override Task<BulkCopyRowsCopied> BulkCopyAsync<T>(
 			ITable<T> table, BulkCopyOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{

--- a/Source/LinqToDB/Linq/ExpressionQuery.cs
+++ b/Source/LinqToDB/Linq/ExpressionQuery.cs
@@ -209,7 +209,7 @@ namespace LinqToDB.Linq
 				try
 				{
 					Preambles = await query.InitPreamblesAsync(DataContext, expression, Parameters, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 					return Tuple.Create<IAsyncEnumerator<T>, IDisposable?>(
 #else
 					return Tuple.Create<IAsyncEnumerator<T>, IAsyncDisposable?>(

--- a/Source/LinqToDB/Linq/Expressions.cs
+++ b/Source/LinqToDB/Linq/Expressions.cs
@@ -267,6 +267,8 @@ namespace LinqToDB.Linq
 			var targetFramework = "net45";
 #elif NET46
 			var targetFramework = "net46";
+#elif NET472
+			var targetFramework = "net472";
 #elif NETCOREAPP2_1
 			var targetFramework = "netcoreapp2.1";
 #elif NETSTANDARD2_0

--- a/Source/LinqToDB/Linq/IDataReaderAsync.cs
+++ b/Source/LinqToDB/Linq/IDataReaderAsync.cs
@@ -5,9 +5,11 @@ using System.Threading.Tasks;
 
 namespace LinqToDB.Linq
 {
-	public interface IDataReaderAsync : IDisposable
-#if !NETFRAMEWORK
-		, IAsyncDisposable
+	public interface IDataReaderAsync : IDisposable,
+#if NATIVE_ASYNC
+		IAsyncDisposable
+#else
+		Async.IAsyncDisposable
 #endif
 	{
 		IDataReader DataReader { get; }

--- a/Source/LinqToDB/Linq/QueryRunner.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace LinqToDB.Linq
 {
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 	using Async;
 #endif
 	using Builder;
@@ -388,7 +388,7 @@ namespace LinqToDB.Linq
 			using (var runner = dataContext.GetQueryRunner(query, queryNumber, expression, ps, preambles))
 			{
 				var dr = await runner.ExecuteReaderAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 				await using (dr.ConfigureAwait(Configuration.ContinueOnCapturedContext))
 #else
 				using (dr)
@@ -454,7 +454,7 @@ namespace LinqToDB.Linq
 
 			public T Current { get; set; } = default!;
 
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 			public async Task<bool> MoveNextAsync()
 #else
 			public async ValueTask<bool> MoveNextAsync()
@@ -497,7 +497,7 @@ namespace LinqToDB.Linq
 				_queryRunner = null;
 			}
 
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 			public Task DisposeAsync()
 			{
 				Dispose();
@@ -749,7 +749,7 @@ namespace LinqToDB.Linq
 			using (var runner = dataContext.GetQueryRunner(query, 0, expression, ps, preambles))
 			{
 				var dr = await runner.ExecuteReaderAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 				await using (dr.ConfigureAwait(Configuration.ContinueOnCapturedContext))
 #else
 				using (dr)

--- a/Source/LinqToDB/LinqToDB.csproj
+++ b/Source/LinqToDB/LinqToDB.csproj
@@ -6,6 +6,7 @@
 		<RootNamespace>LinqToDB</RootNamespace>
 
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\linq2db.xml</DocumentationFile>
+		<TargetFrameworks>net472;net45;net46;netstandard2.0;netcoreapp2.1;netstandard2.1;netcoreapp3.1</TargetFrameworks>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -15,6 +16,10 @@
 
 	<PropertyGroup Condition="'$(Configuration)'=='Debug'">
 		<DefineConstants>OVERRIDETOSTRING;$(DefineConstants)</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(TargetFramework)' != 'net45' AND '$(TargetFramework)' != 'net46' ">
+		<DefineConstants>NATIVE_ASYNC;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -45,7 +50,7 @@
 	</ItemGroup>
 
 
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net46' ">
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net472' ">
 		<Reference Include="Microsoft.CSharp" />
 		<Reference Include="System.Configuration" />
 		<Reference Include="System.Data.DataSetExtensions" />
@@ -66,6 +71,8 @@
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp2.1' ">
 		<PackageReference Include="System.ComponentModel.Annotations" />
+	</ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' != 'net45' AND '$(TargetFramework)' != 'net46' ">
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
 	</ItemGroup>
 </Project>

--- a/Source/LinqToDB/ServiceModel/RemoteDataContextBase.QueryRunner.cs
+++ b/Source/LinqToDB/ServiceModel/RemoteDataContextBase.QueryRunner.cs
@@ -254,6 +254,20 @@ namespace LinqToDB.ServiceModel
 				{
 					DataReader.Dispose();
 				}
+
+#if !NATIVE_ASYNC
+				public Task DisposeAsync()
+				{
+					DataReader.Dispose();
+					return TaskEx.CompletedTask;
+				}
+#else
+				public ValueTask DisposeAsync()
+				{
+					DataReader.Dispose();
+					return default;
+				}
+#endif
 			}
 
 			public override async Task<IDataReaderAsync> ExecuteReaderAsync(CancellationToken cancellationToken)

--- a/Source/LinqToDB/TempTable.cs
+++ b/Source/LinqToDB/TempTable.cs
@@ -25,10 +25,7 @@ namespace LinqToDB
 	/// </summary>
 	/// <typeparam name="T">Table record mapping class.</typeparam>
 	[PublicAPI]
-	public class TempTable<T> : ITable<T>, ITableMutable<T>, IDisposable
-#if !NETFRAMEWORK
-		, IAsyncDisposable
-#endif
+	public class TempTable<T> : ITable<T>, ITableMutable<T>, IDisposable, IAsyncDisposable
 		where T : notnull
 	{
 		readonly ITable<T> _table;
@@ -290,7 +287,7 @@ namespace LinqToDB
 			{
 				try
 				{
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 					table.Dispose();
 #else
 					await table.DisposeAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
@@ -348,7 +345,7 @@ namespace LinqToDB
 			{
 				try
 				{
-#if NETFRAMEWORK
+#if !NATIVE_ASYNC
 					table.Dispose();
 #else
 					await table.DisposeAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
@@ -621,10 +618,15 @@ namespace LinqToDB
 			_table.DropTable();
 		}
 
-#if !NETFRAMEWORK
+#if NATIVE_ASYNC
 		public ValueTask DisposeAsync()
 		{
 			return new ValueTask(_table.DropTableAsync());
+		}
+#else
+		public Task DisposeAsync()
+		{
+			return _table.DropTableAsync();
 		}
 #endif
 	}

--- a/Tests/Linq/Common/EnumerableHelperTest.cs
+++ b/Tests/Linq/Common/EnumerableHelperTest.cs
@@ -1,14 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using LinqToDB.Common;
-
-using NUnit.Framework;
-
-#if !NET472
 using System.Threading.Tasks;
 using LinqToDB.Async;
-#endif
+using LinqToDB.Common;
+using NUnit.Framework;
 
 namespace Tests.Common
 {
@@ -47,7 +43,6 @@ namespace Tests.Common
 			}
 		}
 
-#if !NET472
 		[Test]
 		public async Task BatchAsyncTest()
 		{
@@ -89,6 +84,5 @@ namespace Tests.Common
 				yield return i;
 			}
 		}
-#endif
 	}
 }

--- a/Tests/Linq/Data/ProcedureTests.cs
+++ b/Tests/Linq/Data/ProcedureTests.cs
@@ -405,10 +405,7 @@ namespace Tests.Data
 				var reader = await new CommandInfo(db, "QueryProcParameters", input, output1, output2).ExecuteReaderProcAsync();
 				Assert.IsNull(output1.Value);
 				Assert.IsNull(output2.Value);
-#if !NET472
-			await
-#endif
-				using (reader)
+				await using (reader)
 					while (await reader.Reader!.ReadAsync())
 					{
 					}

--- a/Tests/Linq/Data/TraceTests.cs
+++ b/Tests/Linq/Data/TraceTests.cs
@@ -141,10 +141,7 @@ namespace Tests.Data
 					counters[e.TraceInfoStep]++;
 				};
 
-#if !NET472
-			await
-#endif
-				using (var reader = await new CommandInfo(db, sql).ExecuteReaderAsync())
+				await using (var reader = await new CommandInfo(db, sql).ExecuteReaderAsync())
 				{
 					await reader.QueryToListAsync<Northwind.Category>();
 				}

--- a/Tests/Linq/Linq/AsyncTests.cs
+++ b/Tests/Linq/Linq/AsyncTests.cs
@@ -1,15 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
-
 using LinqToDB;
 using LinqToDB.Data;
 using NUnit.Framework;
-
-#if !NET472
-using System.Threading;
-#endif
 
 namespace Tests.Linq
 {
@@ -119,10 +115,7 @@ namespace Tests.Linq
 				sql = string.Join(Environment.NewLine, sql.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
 					.Where(line => !line.StartsWith("--")));
 
-#if !NET472
-			await
-#endif
-				using (var rd = await conn.SetCommand(sql).ExecuteReaderAsync())
+				await using (var rd = await conn.SetCommand(sql).ExecuteReaderAsync())
 				{
 					var list = await rd.QueryToArrayAsync<string>();
 
@@ -183,7 +176,6 @@ namespace Tests.Linq
 			}
 		}
 
-#if !NET472
 		[Test]
 		public async Task AsAsyncEnumerable1Test([DataSources] string context)
 		{
@@ -257,6 +249,5 @@ namespace Tests.Linq
 				}
 			});
 		}
-#endif
 	}
 }

--- a/Tests/Linq/Linq/EagerLoadingTests.cs
+++ b/Tests/Linq/Linq/EagerLoadingTests.cs
@@ -205,11 +205,7 @@ namespace Tests.Linq
 
 				var result = new List<MasterClass>();
 
-#if NET472
-				await foreach (var item in (LinqToDB.Async.IAsyncEnumerable<MasterClass>)query)
-#else
 				await foreach (var item in (IAsyncEnumerable<MasterClass>)query)
-#endif
 					result.Add(item);
 
 				var expected = expectedQuery.ToList();

--- a/Tests/Linq/Linq/PaginationExtensions.cs
+++ b/Tests/Linq/Linq/PaginationExtensions.cs
@@ -8,17 +8,6 @@ using System.Threading.Tasks;
 using LinqToDB;
 using LinqToDB.Expressions;
 
-#if NETFRAMEWORK
-using LinqToDB.Async;
-namespace System
-{
-	// Magic (see https://github.com/dotnet/roslyn/issues/45111)
-	internal class IAsyncDisposable
-	{
-	}
-}
-#endif
-
 namespace Tests.Linq
 {
 	public static class PaginationExtensions

--- a/Tests/Linq/Update/BulkCopyTests.cs
+++ b/Tests/Linq/Update/BulkCopyTests.cs
@@ -52,11 +52,7 @@ namespace Tests.xUpdate
 			[DataSources(false)]string context,
 			[Values(null, true, false)]bool? keepIdentity,
 			[Values] BulkCopyType copyType,
-#if NET472
-			[Values(0, 1)] int asyncMode) // 0 == sync, 1 == async
-#else
 			[Values(0, 1, 2)] int asyncMode) // 0 == sync, 1 == async, 2 == async with IAsyncEnumerable
-#endif
 		{
 			ResetAllTypesIdentity(context);
 
@@ -120,11 +116,9 @@ namespace Tests.xUpdate
 						}
 						else // asynchronous with IAsyncEnumerable
 						{
-#if !NET472
 							await db.BulkCopyAsync(
 								options,
 								AsAsyncEnumerable(values));
-#endif
 						}
 					}
 				}
@@ -142,11 +136,7 @@ namespace Tests.xUpdate
 			[DataSources(false)]        string       context,
 			[Values(null, true, false)] bool?        keepIdentity,
 			[Values]                    BulkCopyType copyType,
-#if NET472
-			[Values(0, 1)]              int          asyncMode) // 0 == sync, 1 == async
-#else
 			[Values(0, 1, 2)]           int          asyncMode) // 0 == sync, 1 == async, 2 == async with IAsyncEnumerable
-#endif
 		{
 			ResetAllTypesIdentity(context);
 
@@ -207,11 +197,9 @@ namespace Tests.xUpdate
 						}
 						else // asynchronous with IAsyncEnumerable
 						{
-#if !NET472
 							await db.BulkCopyAsync(
 								options,
 								AsAsyncEnumerable(values));
-#endif
 						}
 					}
 				}
@@ -223,7 +211,6 @@ namespace Tests.xUpdate
 			}
 		}
 
-#if !NET472
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 		private async IAsyncEnumerable<T> AsAsyncEnumerable<T>(IEnumerable<T> enumerable)
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
@@ -234,7 +221,6 @@ namespace Tests.xUpdate
 				yield return enumerator.Current;
 			}
 		}
-#endif
 
 		private async Task<bool> ExecuteAsync(DataConnection db, string context, Func<Task> perform, bool? keepIdentity, BulkCopyType copyType)
 		{

--- a/Tests/Linq/Update/CreateTempTableTests.cs
+++ b/Tests/Linq/Update/CreateTempTableTests.cs
@@ -118,10 +118,7 @@ namespace Tests.xUpdate
 			{
 				await db.DropTableAsync<int>("TempTable", throwExceptionIfNotExists: false);
 
-#if !NET472
-				await
-#endif
-				using (var tmp = await db.CreateTempTableAsync(
+				await using (var tmp = await db.CreateTempTableAsync(
 					"TempTable",
 					db.Parent.Select(p => new IDTable { ID = p.ParentID }),
 					tableOptions:TableOptions.CheckExistence))
@@ -143,10 +140,7 @@ namespace Tests.xUpdate
 			{
 				db.DropTable<int>("TempTable", throwExceptionIfNotExists: false);
 
-#if !NET472
-				await
-#endif
-				using (var tmp = await db.CreateTempTableAsync(
+				await using (var tmp = await db.CreateTempTableAsync(
 					"TempTable",
 					db.Parent.Select(p => new IDTable { ID = p.ParentID }).ToList(),
 					tableOptions:TableOptions.CheckExistence))
@@ -172,10 +166,7 @@ namespace Tests.xUpdate
 
 				try
 				{
-#if !NET472
-					await
-#endif
-					using (var tmp = await db.CreateTempTableAsync(
+					await using (var tmp = await db.CreateTempTableAsync(
 						"TempTable",
 						db.Parent.Select(p => new IDTable { ID = p.ParentID }).ToList(),
 						cancellationToken: cts.Token))
@@ -215,10 +206,7 @@ namespace Tests.xUpdate
 
 				try
 				{
-#if !NET472
-					await
-#endif
-					using (var tmp = await db.CreateTempTableAsync(
+					await using (var tmp = await db.CreateTempTableAsync(
 						"TempTable",
 						db.Parent.Select(p => new IDTable { ID = p.ParentID }),
 						action: (table) =>

--- a/Tests/Linq/Update/MergeTests.ApiParametersValidation.cs
+++ b/Tests/Linq/Update/MergeTests.ApiParametersValidation.cs
@@ -228,11 +228,7 @@ namespace Tests.xUpdate
 				throw new NotImplementedException();
 			}
 
-#if NET472
-			Task<LinqToDB.Async.IAsyncEnumerable<TResult>> IQueryProviderAsync.ExecuteAsyncEnumerable<TResult>(Expression expression, CancellationToken cancellationToken)
-#else
 			Task<IAsyncEnumerable<TResult>> IQueryProviderAsync.ExecuteAsyncEnumerable<TResult>(Expression expression, CancellationToken cancellationToken)
-#endif
 			{
 				throw new NotImplementedException();
 			}

--- a/Tests/Tests.Playground/Tests.Playground.csproj
+++ b/Tests/Tests.Playground/Tests.Playground.csproj
@@ -10,4 +10,9 @@
 	<ItemGroup>
 		<Compile Include="..\Linq\Create\CreateData.cs" Link="CreateData.cs" />
 	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+		<!-- transient -->
+		<PackageReference Include="System.Security.Cryptography.Cng" />
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
Replace use of Task and custom interfaces for .net framework 4.7.2+ targets where applicable:
- fix https://github.com/linq2db/linq2db.EntityFrameworkCore/issues/121
- improve async experience for users targeting latest .net framework versions without introducing dependency hell for older frameworks
- add missing IAsyncDisposable implementations for net45/net462 targets
- enable bulk copy from `IAsyncEnumerable` sources for net472 target
