### PR TITLE
fix transaction DisposeAsync implementation, replace calls to Dispose…

### DIFF
--- a/Source/LinqToDB/Async/AsyncFactory.cs
+++ b/Source/LinqToDB/Async/AsyncFactory.cs
@@ -26,10 +26,10 @@ namespace LinqToDB.Async
 		private static readonly Type[] _beginTransactionParams = new Type[] { typeof(IsolationLevel)   , typeof(CancellationToken) };
 
 		private static readonly ConcurrentDictionary<Type, Func<IDbConnection, IAsyncDbConnection>> _connectionFactories
-			= new ConcurrentDictionary<Type, Func<IDbConnection, IAsyncDbConnection>>();
+			= new ();
 
 		private static readonly ConcurrentDictionary<Type, Func<IDbTransaction, IAsyncDbTransaction>> _transactionFactories
-			= new ConcurrentDictionary<Type, Func<IDbTransaction, IAsyncDbTransaction>>();
+			= new ();
 
 #if !NATIVE_ASYNC
 		private static readonly MethodInfo _transactionWrap      = MemberHelper.MethodOf(() => Wrap<IDbTransaction>(default!)).GetGenericMethodDefinition();
@@ -130,17 +130,17 @@ namespace LinqToDB.Async
 			// - DbTransaction (netstandard2.1, netcoreapp3.0)
 			// - Npgsql 4.1.2+
 #if !NATIVE_ASYNC
-			var disposeAsync  = CreateDelegate<Func<IDbConnection               ,      Task>, IDbConnection >(type, "DisposeAsync" , Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, true , false)
+			var disposeAsync  = CreateDelegate<Func<IDbTransaction               ,      Task>, IDbTransaction>(type, "DisposeAsync" , Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, true , false)
 #else
-			var disposeAsync  = CreateDelegate<Func<IDbConnection               , ValueTask>, IDbConnection >(type, "DisposeAsync" , Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, true , true )
+			var disposeAsync  = CreateDelegate<Func<IDbTransaction               , ValueTask>, IDbTransaction>(type, "DisposeAsync" , Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, true , true )
 #endif
 			// Task DisposeAsync()
 			// Availability:
 			// - MySqlConnector 0.57+
 #if !NATIVE_ASYNC
-							 ?? CreateDelegate<Func<IDbConnection               ,      Task>, IDbConnection >(type, "DisposeAsync" , Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, false, false);
+							 ?? CreateDelegate<Func<IDbTransaction               ,      Task>, IDbTransaction>(type, "DisposeAsync" , Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, false, false);
 #else
-							 ?? CreateDelegate<Func<IDbConnection               , ValueTask>, IDbConnection >(type, "DisposeAsync" , Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, false, true );
+							 ?? CreateDelegate<Func<IDbTransaction               , ValueTask>, IDbTransaction>(type, "DisposeAsync" , Array<Type>.Empty, Array<Type>.Empty, Array<Type>.Empty, false, true );
 #endif
 
 			if (commitAsync      != null

--- a/Source/LinqToDB/Async/ReflectedAsyncDbTransaction.cs
+++ b/Source/LinqToDB/Async/ReflectedAsyncDbTransaction.cs
@@ -15,9 +15,9 @@ namespace LinqToDB.Async
 		private readonly Func<IDbTransaction, CancellationToken, Task>? _commitAsync;
 		private readonly Func<IDbTransaction, CancellationToken, Task>? _rollbackAsync;
 #if NATIVE_ASYNC
-		private readonly Func<IDbConnection, ValueTask>?                _disposeAsync;
+		private readonly Func<IDbTransaction, ValueTask>?               _disposeAsync;
 #else
-		private readonly Func<IDbConnection, Task>?                     _disposeAsync;
+		private readonly Func<IDbTransaction, Task>?                    _disposeAsync;
 #endif
 
 		public ReflectedAsyncDbTransaction(
@@ -25,9 +25,9 @@ namespace LinqToDB.Async
 			Func<IDbTransaction, CancellationToken, Task>? commitAsync,
 			Func<IDbTransaction, CancellationToken, Task>? rollbackAsync,
 #if NATIVE_ASYNC
-			Func<IDbConnection, ValueTask>?                disposeAsync)
+			Func<IDbTransaction, ValueTask>?               disposeAsync)
 #else
-			Func<IDbConnection, Task>?                     disposeAsync)
+			Func<IDbTransaction, Task>?                    disposeAsync)
 #endif
 			: base(transaction)
 		{
@@ -49,12 +49,12 @@ namespace LinqToDB.Async
 #if !NATIVE_ASYNC
 		public override Task DisposeAsync()
 		{
-			return _disposeAsync?.Invoke(Connection) ?? base.DisposeAsync();
+			return _disposeAsync?.Invoke(Transaction) ?? base.DisposeAsync();
 		}
 #else
 		public override ValueTask DisposeAsync()
 		{
-			return _disposeAsync != null ? _disposeAsync.Invoke(Connection) : base.DisposeAsync();
+			return _disposeAsync != null ? _disposeAsync.Invoke(Transaction) : base.DisposeAsync();
 		}
 #endif
 	}

--- a/Source/LinqToDB/Data/DataConnection.Async.cs
+++ b/Source/LinqToDB/Data/DataConnection.Async.cs
@@ -52,7 +52,7 @@ namespace LinqToDB.Data
 
 			// If transaction is open, we dispose it, it will rollback all changes.
 			//
-			TransactionAsync?.Dispose();
+			if (TransactionAsync != null) await TransactionAsync.DisposeAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 			// Create new transaction object.
 			//
@@ -139,7 +139,7 @@ namespace LinqToDB.Data
 
 				if (_closeTransaction)
 				{
-					TransactionAsync.Dispose();
+					await TransactionAsync.DisposeAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 					TransactionAsync = null;
 
 					if (_command != null)
@@ -162,7 +162,7 @@ namespace LinqToDB.Data
 
 				if (_closeTransaction)
 				{
-					TransactionAsync.Dispose();
+					await TransactionAsync.DisposeAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 					TransactionAsync = null;
 
 					if (_command != null)
@@ -184,7 +184,7 @@ namespace LinqToDB.Data
 
 			if (TransactionAsync != null && _closeTransaction)
 			{
-				TransactionAsync.Dispose();
+				await TransactionAsync.DisposeAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 				TransactionAsync = null;
 			}
 

--- a/Tests/Linq/Data/TransactionTests.cs
+++ b/Tests/Linq/Data/TransactionTests.cs
@@ -112,6 +112,24 @@ namespace Tests.Data
 		}
 
 		[Test]
+		public async Task DataConnectionDisposeAsyncTransaction([DataSources(false)] string context)
+		{
+			var tid = Thread.CurrentThread.ManagedThreadId;
+
+			using (var db = new DataConnection(context))
+			{
+				await using (db.BeginTransaction())
+				{
+					// perform synchonously to not mess with DisposeAsync testing
+					db.Insert(new Parent { ParentID = 1010, Value1 = 1010 });
+
+					if (tid == Thread.CurrentThread.ManagedThreadId)
+						Assert.Inconclusive("Executed synchronously due to lack of async support or there were no underlying async operations");
+				}
+			}
+		}
+
+		[Test]
 		public async Task DataConnectionCommitTransactionAsync([DataSources(false)] string context)
 		{
 			using (var db = new DataConnection(context))


### PR DESCRIPTION
Fix #2901

- fix incorrect DisposeAsync reflection for transaction
- replace calls to Dispose to DisposeAsync for transaction in async contexts (that's why this issue didn't surface before as DisposeAsync was called in quite specific case only)