### PR TITLE
Add operation type to trace events, more async disposable support

### DIFF
--- a/Source/LinqToDB/Async/AsyncDbConnection.cs
+++ b/Source/LinqToDB/Async/AsyncDbConnection.cs
@@ -42,7 +42,7 @@ namespace LinqToDB.Async
 			=> Task.FromResult(AsyncFactory.Create(BeginTransaction()));
 #elif !NETSTANDARD2_1PLUS
 		public virtual ValueTask<IAsyncDbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
-			=> new ValueTask<IAsyncDbTransaction>(AsyncFactory.Create(BeginTransaction()));
+			=> new (AsyncFactory.Create(BeginTransaction()));
 #else
 		public virtual async ValueTask<IAsyncDbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
 		{
@@ -69,7 +69,7 @@ namespace LinqToDB.Async
 		}
 #elif NATIVE_ASYNC
 		public virtual ValueTask<IAsyncDbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
-			=> new ValueTask<IAsyncDbTransaction>(AsyncFactory.Create(BeginTransaction(isolationLevel)));
+			=> new (AsyncFactory.Create(BeginTransaction(isolationLevel)));
 #else
 		public virtual Task<IAsyncDbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
 			=> Task.FromResult(AsyncFactory.Create(BeginTransaction(isolationLevel)));

--- a/Source/LinqToDB/Async/AsyncDbTransaction.cs
+++ b/Source/LinqToDB/Async/AsyncDbTransaction.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Data;
-using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
+#if NETSTANDARD2_1PLUS
+using System.Data.Common;
+#endif
 
 using JetBrains.Annotations;
 

--- a/Source/LinqToDB/Async/AsyncFactory.cs
+++ b/Source/LinqToDB/Async/AsyncFactory.cs
@@ -25,11 +25,9 @@ namespace LinqToDB.Async
 		private static readonly Type[] _tokenParams            = new Type[] { typeof(CancellationToken) };
 		private static readonly Type[] _beginTransactionParams = new Type[] { typeof(IsolationLevel)   , typeof(CancellationToken) };
 
-		private static readonly ConcurrentDictionary<Type, Func<IDbConnection, IAsyncDbConnection>> _connectionFactories
-			= new ConcurrentDictionary<Type, Func<IDbConnection, IAsyncDbConnection>>();
+		private static readonly ConcurrentDictionary<Type, Func<IDbConnection, IAsyncDbConnection>> _connectionFactories = new ();
 
-		private static readonly ConcurrentDictionary<Type, Func<IDbTransaction, IAsyncDbTransaction>> _transactionFactories
-			= new ConcurrentDictionary<Type, Func<IDbTransaction, IAsyncDbTransaction>>();
+		private static readonly ConcurrentDictionary<Type, Func<IDbTransaction, IAsyncDbTransaction>> _transactionFactories = new ();
 
 #if !NATIVE_ASYNC
 		private static readonly MethodInfo _transactionWrap      = MemberHelper.MethodOf(() => Wrap<IDbTransaction>(default!)).GetGenericMethodDefinition();

--- a/Source/LinqToDB/Async/ReflectedAsyncDbConnection.cs
+++ b/Source/LinqToDB/Async/ReflectedAsyncDbConnection.cs
@@ -78,14 +78,11 @@ namespace LinqToDB.Async
 
 #if !NATIVE_ASYNC
 		public override Task DisposeAsync()
+#else
+		public override ValueTask DisposeAsync()
+#endif
 		{
 			return _disposeAsync?.Invoke(Connection) ?? base.DisposeAsync();
 		}
-#else
-		public override ValueTask DisposeAsync()
-		{
-			return _disposeAsync != null ? _disposeAsync.Invoke(Connection) : base.DisposeAsync();
-		}
-#endif
 	}
 }

--- a/Source/LinqToDB/Async/ReflectedAsyncDbTransaction.cs
+++ b/Source/LinqToDB/Async/ReflectedAsyncDbTransaction.cs
@@ -48,14 +48,11 @@ namespace LinqToDB.Async
 
 #if !NATIVE_ASYNC
 		public override Task DisposeAsync()
+#else
+		public override ValueTask DisposeAsync()
+#endif
 		{
 			return _disposeAsync?.Invoke(Connection) ?? base.DisposeAsync();
 		}
-#else
-		public override ValueTask DisposeAsync()
-		{
-			return _disposeAsync != null ? _disposeAsync.Invoke(Connection) : base.DisposeAsync();
-		}
-#endif
 	}
 }

--- a/Source/LinqToDB/Common/EnumerableHelper.cs
+++ b/Source/LinqToDB/Common/EnumerableHelper.cs
@@ -186,7 +186,7 @@ namespace LinqToDB.Common
 			{
 				if (_finished) return false;
 
-				_isCurrent = await _source.MoveNextAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+				_isCurrent = await _source.MoveNextAsync().ConfigureAwait(Configuration.ContinueOnCapturedContext);
 				_current   = _isCurrent ? GetNewEnumerable() : null;
 				_finished  = !_isCurrent;
 
@@ -199,7 +199,7 @@ namespace LinqToDB.Common
 				yield return _source.Current;
 				while (++returned < _batchSize)
 				{
-					if (_finished || !await _source.MoveNextAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
+					if (_finished || !await _source.MoveNextAsync().ConfigureAwait(Configuration.ContinueOnCapturedContext))
 					{
 						_finished = true;
 						yield break;

--- a/Source/LinqToDB/Data/CommandInfo.cs
+++ b/Source/LinqToDB/Data/CommandInfo.cs
@@ -1747,7 +1747,7 @@ namespace LinqToDB.Data
 				var converterKey  = Tuple.Create(readerType, dataConnection.DataProvider.DataReaderType);
 				converterExpr = _dataReaderConverter.GetOrCreate(converterKey, o =>
 				{
-					o.SlidingExpiration = Common.Configuration.Linq.CacheSlidingExpiration;
+					o.SlidingExpiration = Configuration.Linq.CacheSlidingExpiration;
 
 					var expr = dataConnection.MappingSchema.GetConvertExpression(readerType, typeof(IDataReader), false, false);
 					if (expr != null)

--- a/Source/LinqToDB/Data/DataConnection.Async.cs
+++ b/Source/LinqToDB/Data/DataConnection.Async.cs
@@ -111,7 +111,7 @@ namespace LinqToDB.Data
 				{
 					if (TraceSwitchConnection.TraceError)
 					{
-						OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error)
+						OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.OpenAsync)
 						{
 							TraceLevel     = TraceLevel.Error,
 							StartTime      = DateTime.UtcNow,
@@ -230,7 +230,7 @@ namespace LinqToDB.Data
 
 			if (TraceSwitchConnection.TraceInfo)
 			{
-				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute)
+				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute, TraceOperation.ExecuteNonQueryAsync)
 				{
 					TraceLevel     = TraceLevel.Info,
 					StartTime      = now,
@@ -247,7 +247,7 @@ namespace LinqToDB.Data
 
 				if (TraceSwitchConnection.TraceInfo)
 				{
-					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute)
+					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute, TraceOperation.ExecuteNonQueryAsync)
 					{
 						TraceLevel      = TraceLevel.Info,
 						Command         = GetCurrentCommand(),
@@ -264,7 +264,7 @@ namespace LinqToDB.Data
 			{
 				if (TraceSwitchConnection.TraceError)
 				{
-					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error)
+					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.ExecuteNonQueryAsync)
 					{
 						TraceLevel     = TraceLevel.Error,
 						Command        = GetCurrentCommand(),
@@ -299,7 +299,7 @@ namespace LinqToDB.Data
 
 			if (TraceSwitchConnection.TraceInfo)
 			{
-				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute)
+				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute, TraceOperation.ExecuteScalarAsync)
 				{
 					TraceLevel     = TraceLevel.Info,
 					Command        = GetCurrentCommand(),
@@ -316,7 +316,7 @@ namespace LinqToDB.Data
 
 				if (TraceSwitchConnection.TraceInfo)
 				{
-					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute)
+					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute, TraceOperation.ExecuteScalarAsync)
 					{
 						TraceLevel      = TraceLevel.Info,
 						Command         = GetCurrentCommand(),
@@ -332,7 +332,7 @@ namespace LinqToDB.Data
 			{
 				if (TraceSwitchConnection.TraceError)
 				{
-					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error)
+					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.ExecuteScalarAsync)
 					{
 						TraceLevel     = TraceLevel.Error,
 						Command        = GetCurrentCommand(),
@@ -373,7 +373,7 @@ namespace LinqToDB.Data
 
 			if (TraceSwitchConnection.TraceInfo)
 			{
-				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute)
+				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute, TraceOperation.ExecuteReaderAsync)
 				{
 					TraceLevel     = TraceLevel.Info,
 					Command        = GetCurrentCommand(),
@@ -392,7 +392,7 @@ namespace LinqToDB.Data
 
 				if (TraceSwitchConnection.TraceInfo)
 				{
-					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute)
+					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute, TraceOperation.ExecuteReaderAsync)
 					{
 						TraceLevel     = TraceLevel.Info,
 						Command        = GetCurrentCommand(),
@@ -408,7 +408,7 @@ namespace LinqToDB.Data
 			{
 				if (TraceSwitchConnection.TraceError)
 				{
-					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error)
+					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.ExecuteReaderAsync)
 					{
 						TraceLevel     = TraceLevel.Error,
 						Command        = GetCurrentCommand(),

--- a/Source/LinqToDB/Data/DataConnection.Async.cs
+++ b/Source/LinqToDB/Data/DataConnection.Async.cs
@@ -111,12 +111,11 @@ namespace LinqToDB.Data
 				{
 					if (TraceSwitchConnection.TraceError)
 					{
-						OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.OpenAsync)
+						OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.Open, true)
 						{
-							TraceLevel     = TraceLevel.Error,
-							StartTime      = DateTime.UtcNow,
-							Exception      = ex,
-							IsAsync        = true,
+							TraceLevel = TraceLevel.Error,
+							StartTime  = DateTime.UtcNow,
+							Exception  = ex,
 						});
 					}
 
@@ -171,12 +170,17 @@ namespace LinqToDB.Data
 			}
 		}
 
+		[Obsolete("Use parameter-less CloseAsync() call")]
+		public Task CloseAsync(CancellationToken cancellationToken)
+		{
+			return CloseAsync();
+		}
+
 		/// <summary>
 		/// Closes and dispose associated underlying database transaction/connection asynchronously.
 		/// </summary>
-		/// <param name="cancellationToken">Asynchronous operation cancellation token.</param>
 		/// <returns>Asynchronous operation completion task.</returns>
-		public virtual async Task CloseAsync(CancellationToken cancellationToken = default)
+		public virtual async Task CloseAsync()
 		{
 			OnClosing?.Invoke(this, EventArgs.Empty);
 
@@ -202,17 +206,31 @@ namespace LinqToDB.Data
 			OnClosed?.Invoke(this, EventArgs.Empty);
 		}
 
+		[Obsolete("Use parameter-less DisposeAsync() call")]
+		public Task DisposeAsync(CancellationToken cancellationToken)
+		{
+#if NATIVE_ASYNC
+			return DisposeAsync().AsTask();
+#else
+			return DisposeAsync();
+#endif
+		}
+
 		/// <summary>
 		/// Disposes connection asynchronously.
 		/// </summary>
 		/// <returns>Asynchronous operation completion task.</returns>
-		public async Task DisposeAsync(CancellationToken cancellationToken = default)
+#if NATIVE_ASYNC
+		public async ValueTask DisposeAsync()
+#else
+		public async Task DisposeAsync()
+#endif
 		{
 			Disposed = true;
-			await CloseAsync(cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+			await CloseAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
-		#region ExecuteNonQueryAsync
+#region ExecuteNonQueryAsync
 
 		protected virtual Task<int> ExecuteNonQueryAsync(IDbCommand command, CancellationToken cancellationToken)
 		{
@@ -230,12 +248,11 @@ namespace LinqToDB.Data
 
 			if (TraceSwitchConnection.TraceInfo)
 			{
-				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute, TraceOperation.ExecuteNonQueryAsync)
+				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute, TraceOperation.ExecuteNonQuery, true)
 				{
 					TraceLevel     = TraceLevel.Info,
 					StartTime      = now,
 					Command        = GetCurrentCommand(),
-					IsAsync        = true,
 				});
 			}
 
@@ -247,14 +264,13 @@ namespace LinqToDB.Data
 
 				if (TraceSwitchConnection.TraceInfo)
 				{
-					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute, TraceOperation.ExecuteNonQueryAsync)
+					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute, TraceOperation.ExecuteNonQuery, true)
 					{
 						TraceLevel      = TraceLevel.Info,
 						Command         = GetCurrentCommand(),
 						StartTime       = now,
 						ExecutionTime   = sw.Elapsed,
 						RecordsAffected = ret,
-						IsAsync         = true,
 					});
 				}
 
@@ -264,14 +280,13 @@ namespace LinqToDB.Data
 			{
 				if (TraceSwitchConnection.TraceError)
 				{
-					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.ExecuteNonQueryAsync)
+					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.ExecuteNonQuery, true)
 					{
 						TraceLevel     = TraceLevel.Error,
 						Command        = GetCurrentCommand(),
 						StartTime      = now,
 						ExecutionTime  = sw.Elapsed,
 						Exception      = ex,
-						IsAsync        = true,
 					});
 				}
 
@@ -279,9 +294,9 @@ namespace LinqToDB.Data
 			}
 		}
 
-		#endregion
+#endregion
 
-		#region ExecuteScalarAsync
+#region ExecuteScalarAsync
 
 		protected virtual Task<object?> ExecuteScalarAsync(IDbCommand command, CancellationToken cancellationToken)
 		{
@@ -299,12 +314,11 @@ namespace LinqToDB.Data
 
 			if (TraceSwitchConnection.TraceInfo)
 			{
-				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute, TraceOperation.ExecuteScalarAsync)
+				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute, TraceOperation.ExecuteScalar, true)
 				{
 					TraceLevel     = TraceLevel.Info,
 					Command        = GetCurrentCommand(),
 					StartTime      = now,
-					IsAsync        = true,
 				});
 			}
 
@@ -316,13 +330,12 @@ namespace LinqToDB.Data
 
 				if (TraceSwitchConnection.TraceInfo)
 				{
-					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute, TraceOperation.ExecuteScalarAsync)
+					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute, TraceOperation.ExecuteScalar, true)
 					{
 						TraceLevel      = TraceLevel.Info,
 						Command         = GetCurrentCommand(),
 						StartTime       = now,
 						ExecutionTime   = sw.Elapsed,
-						IsAsync         = true,
 					});
 				}
 
@@ -332,14 +345,13 @@ namespace LinqToDB.Data
 			{
 				if (TraceSwitchConnection.TraceError)
 				{
-					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.ExecuteScalarAsync)
+					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.ExecuteScalar, true)
 					{
 						TraceLevel     = TraceLevel.Error,
 						Command        = GetCurrentCommand(),
 						StartTime      = now,
 						ExecutionTime  = sw.Elapsed,
 						Exception      = ex,
-						IsAsync        = true,
 					});
 				}
 
@@ -347,9 +359,9 @@ namespace LinqToDB.Data
 			}
 		}
 
-		#endregion
+#endregion
 
-		#region ExecuteReaderAsync
+#region ExecuteReaderAsync
 
 		protected virtual Task<DbDataReader> ExecuteReaderAsync(
 			IDbCommand        command,
@@ -373,12 +385,11 @@ namespace LinqToDB.Data
 
 			if (TraceSwitchConnection.TraceInfo)
 			{
-				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute, TraceOperation.ExecuteReaderAsync)
+				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute, TraceOperation.ExecuteReader, true)
 				{
 					TraceLevel     = TraceLevel.Info,
 					Command        = GetCurrentCommand(),
 					StartTime      = now,
-					IsAsync        = true,
 				});
 			}
 
@@ -392,13 +403,12 @@ namespace LinqToDB.Data
 
 				if (TraceSwitchConnection.TraceInfo)
 				{
-					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute, TraceOperation.ExecuteReaderAsync)
+					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute, TraceOperation.ExecuteReader, true)
 					{
 						TraceLevel     = TraceLevel.Info,
 						Command        = GetCurrentCommand(),
 						StartTime      = now,
 						ExecutionTime  = sw.Elapsed,
-						IsAsync        = true,
 					});
 				}
 
@@ -408,14 +418,13 @@ namespace LinqToDB.Data
 			{
 				if (TraceSwitchConnection.TraceError)
 				{
-					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.ExecuteReaderAsync)
+					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.ExecuteReader, true)
 					{
 						TraceLevel     = TraceLevel.Error,
 						Command        = GetCurrentCommand(),
 						StartTime      = now,
 						ExecutionTime  = sw.Elapsed,
 						Exception      = ex,
-						IsAsync        = true,
 					});
 				}
 
@@ -423,6 +432,6 @@ namespace LinqToDB.Data
 			}
 		}
 
-		#endregion
+#endregion
 	}
 }

--- a/Source/LinqToDB/Data/DataConnection.Linq.cs
+++ b/Source/LinqToDB/Data/DataConnection.Linq.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Linq.Expressions;
@@ -9,10 +8,10 @@ namespace LinqToDB.Data
 {
 	using DataProvider;
 	using Linq;
-	using SqlQuery;
 	using SqlProvider;
+	using SqlQuery;
 
-	public partial class DataConnection : IDataContext
+	public partial class DataConnection
 	{
 		/// <summary>
 		/// Returns queryable source for specified mapping class for current connection, mapped to database table or view.
@@ -31,7 +30,7 @@ namespace LinqToDB.Data
 		/// </summary>
 		/// <typeparam name="T">Mapping class type.</typeparam>
 		/// <param name="instance">Instance object for <paramref name="methodInfo"/> method or null for static method.</param>
-		/// <param name="methodInfo">Method, decorated with expression attribute, based on <see cref="LinqToDB.Sql.TableFunctionAttribute"/>.</param>
+		/// <param name="methodInfo">Method, decorated with expression attribute, based on <see cref="Sql.TableFunctionAttribute"/>.</param>
 		/// <param name="parameters">Parameters for <paramref name="methodInfo"/> method.</param>
 		/// <returns>Queryable source.</returns>
 		public ITable<T> GetTable<T>(object instance, MethodInfo methodInfo, params object?[] parameters)

--- a/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
+++ b/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
@@ -52,13 +52,12 @@ namespace LinqToDB.Data
 					if (value != null && Configuration.Linq.TraceMapperExpression &&
 					    _dataConnection.TraceSwitchConnection.TraceInfo)
 					{
-						_dataConnection.OnTraceConnection(new TraceInfo(_dataConnection, TraceInfoStep.MapperCreated, TraceOperation.ExecuteReader)
+						_dataConnection.OnTraceConnection(new TraceInfo(_dataConnection, TraceInfoStep.MapperCreated, TraceOperation.BuildMapping, _isAsync)
 						{
 							TraceLevel       = TraceLevel.Info,
 							MapperExpression = MapperExpression,
 							StartTime        = _startedOn,
-							ExecutionTime    = _stopwatch.Elapsed,
-							IsAsync          = _isAsync,
+							ExecutionTime    = _stopwatch.Elapsed
 						});
 					}
 				}
@@ -124,19 +123,43 @@ namespace LinqToDB.Data
 
 				if (_dataConnection.TraceSwitchConnection.TraceInfo)
 				{
-					_dataConnection.OnTraceConnection(new TraceInfo(_dataConnection, TraceInfoStep.Completed, TraceOperation.ExecuteReader)
+					_dataConnection.OnTraceConnection(new TraceInfo(_dataConnection, TraceInfoStep.Completed, TraceOperation.DisposeQuery, _isAsync)
 					{
 						TraceLevel       = TraceLevel.Info,
 						Command          = _dataConnection.GetCurrentCommand(),
 						MapperExpression = MapperExpression,
 						StartTime        = _startedOn,
 						ExecutionTime    = _stopwatch.Elapsed,
-						RecordsAffected  = RowsCount,
-						IsAsync          = _isAsync,
+						RecordsAffected  = RowsCount
 					});
 				}
 
 				base.Dispose();
+			}
+
+#if !NATIVE_ASYNC
+			public override Task DisposeAsync()
+#else
+			public override ValueTask DisposeAsync()
+#endif
+			{
+				if (_executionScope != null)
+					_executionScope.Dispose();
+
+				if (_dataConnection.TraceSwitchConnection.TraceInfo)
+				{
+					_dataConnection.OnTraceConnection(new TraceInfo(_dataConnection, TraceInfoStep.Completed, TraceOperation.DisposeQuery, _isAsync)
+					{
+						TraceLevel       = TraceLevel.Info,
+						Command          = _dataConnection.GetCurrentCommand(),
+						MapperExpression = MapperExpression,
+						StartTime        = _startedOn,
+						ExecutionTime    = _stopwatch.Elapsed,
+						RecordsAffected  = RowsCount
+					});
+				}
+
+				return base.DisposeAsync();
 			}
 
 			public class CommandWithParameters

--- a/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
+++ b/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
@@ -52,7 +52,7 @@ namespace LinqToDB.Data
 					if (value != null && Configuration.Linq.TraceMapperExpression &&
 					    _dataConnection.TraceSwitchConnection.TraceInfo)
 					{
-						_dataConnection.OnTraceConnection(new TraceInfo(_dataConnection, TraceInfoStep.MapperCreated)
+						_dataConnection.OnTraceConnection(new TraceInfo(_dataConnection, TraceInfoStep.MapperCreated, TraceOperation.ExecuteReader)
 						{
 							TraceLevel       = TraceLevel.Info,
 							MapperExpression = MapperExpression,
@@ -124,7 +124,7 @@ namespace LinqToDB.Data
 
 				if (_dataConnection.TraceSwitchConnection.TraceInfo)
 				{
-					_dataConnection.OnTraceConnection(new TraceInfo(_dataConnection, TraceInfoStep.Completed)
+					_dataConnection.OnTraceConnection(new TraceInfo(_dataConnection, TraceInfoStep.Completed, TraceOperation.ExecuteReader)
 					{
 						TraceLevel       = TraceLevel.Info,
 						Command          = _dataConnection.GetCurrentCommand(),

--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -30,7 +30,7 @@ namespace LinqToDB.Data
 	/// or attached to existing connection or transaction.
 	/// </summary>
 	[PublicAPI]
-	public partial class DataConnection : ICloneable
+	public partial class DataConnection : IDataContext, ICloneable
 	{
 		#region .ctor
 
@@ -1281,7 +1281,7 @@ namespace LinqToDB.Data
 
 			if (TraceSwitchConnection.TraceInfo)
 			{
-				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute, TraceOperation.ExecuteNonQuery)
+				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute, TraceOperation.ExecuteNonQuery, false)
 				{
 					TraceLevel     = TraceLevel.Info,
 					Command        = GetCurrentCommand(),
@@ -1297,7 +1297,7 @@ namespace LinqToDB.Data
 
 				if (TraceSwitchConnection.TraceInfo)
 				{
-					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute, TraceOperation.ExecuteNonQuery)
+					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute, TraceOperation.ExecuteNonQuery, false)
 					{
 						TraceLevel      = TraceLevel.Info,
 						Command         = GetCurrentCommand(),
@@ -1313,7 +1313,7 @@ namespace LinqToDB.Data
 			{
 				if (TraceSwitchConnection.TraceError)
 				{
-					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.ExecuteNonQuery)
+					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.ExecuteNonQuery, false)
 					{
 						TraceLevel     = TraceLevel.Error,
 						Command        = GetCurrentCommand(),
@@ -1347,7 +1347,7 @@ namespace LinqToDB.Data
 
 			if (TraceSwitchConnection.TraceInfo)
 			{
-				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute, TraceOperation.ExecuteScalar)
+				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute, TraceOperation.ExecuteScalar, false)
 				{
 					TraceLevel     = TraceLevel.Info,
 					Command        = GetCurrentCommand(),
@@ -1363,7 +1363,7 @@ namespace LinqToDB.Data
 
 				if (TraceSwitchConnection.TraceInfo)
 				{
-					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute, TraceOperation.ExecuteScalar)
+					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute, TraceOperation.ExecuteScalar, false)
 					{
 						TraceLevel     = TraceLevel.Info,
 						Command        = GetCurrentCommand(),
@@ -1378,7 +1378,7 @@ namespace LinqToDB.Data
 			{
 				if (TraceSwitchConnection.TraceError)
 				{
-					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.ExecuteScalar)
+					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.ExecuteScalar, false)
 					{
 						TraceLevel     = TraceLevel.Error,
 						Command        = GetCurrentCommand(),
@@ -1417,7 +1417,7 @@ namespace LinqToDB.Data
 
 			if (TraceSwitchConnection.TraceInfo)
 			{
-				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute, TraceOperation.ExecuteReader)
+				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute, TraceOperation.ExecuteReader, false)
 				{
 					TraceLevel     = TraceLevel.Info,
 					Command        = GetCurrentCommand(),
@@ -1434,7 +1434,7 @@ namespace LinqToDB.Data
 
 				if (TraceSwitchConnection.TraceInfo)
 				{
-					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute, TraceOperation.ExecuteReader)
+					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute, TraceOperation.ExecuteReader, false)
 					{
 						TraceLevel     = TraceLevel.Info,
 						Command        = GetCurrentCommand(),
@@ -1449,7 +1449,7 @@ namespace LinqToDB.Data
 			{
 				if (TraceSwitchConnection.TraceError)
 				{
-					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.ExecuteReader)
+					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.ExecuteReader, false)
 					{
 						TraceLevel     = TraceLevel.Error,
 						Command        = GetCurrentCommand(),

--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -471,7 +471,7 @@ namespace LinqToDB.Data
 
 		/// <summary>
 		/// Gets or sets trace handler, used for current connection instance.
-		/// Configured on the connection builder using <see cref="LinqToDbConnectionOptionsBuilder.WithTracing(System.Action{LinqToDB.Data.TraceInfo})"/>.
+		/// Configured on the connection builder using <see cref="LinqToDbConnectionOptionsBuilder.WithTracing(Action{TraceInfo})"/>.
 		/// defaults to <see cref="OnTrace"/>.
 		/// </summary>
 		public Action<TraceInfo> OnTraceConnection { get; set; } = _onTrace;
@@ -566,7 +566,7 @@ namespace LinqToDB.Data
 			}
 		}
 
-		private static TraceSwitch _traceSwitch = new TraceSwitch("DataConnection",
+		private static TraceSwitch _traceSwitch = new ("DataConnection",
 			"DataConnection trace switch",
 #if DEBUG
 			"Warning"
@@ -708,8 +708,7 @@ namespace LinqToDB.Data
 			}
 		}
 
-		static readonly List<Func<IConnectionStringSettings,string,IDataProvider?>> _providerDetectors =
-			new List<Func<IConnectionStringSettings,string,IDataProvider?>>();
+		static readonly List<Func<IConnectionStringSettings,string,IDataProvider?>> _providerDetectors = new();
 
 		/// <summary>
 		/// Registers database provider factory method.
@@ -738,7 +737,7 @@ namespace LinqToDB.Data
 			}
 		}
 
-		static readonly object _initSyncRoot = new object();
+		static readonly object _initSyncRoot = new ();
 		static          bool   _initialized;
 
 		static void InitConfig()
@@ -753,8 +752,7 @@ namespace LinqToDB.Data
 			}
 		}
 
-		static readonly ConcurrentDictionary<string,IDataProvider> _dataProviders =
-			new ConcurrentDictionary<string,IDataProvider>();
+		static readonly ConcurrentDictionary<string,IDataProvider> _dataProviders = new ();
 
 		/// <summary>
 		/// Registers database provider implementation by provided unique name.
@@ -960,8 +958,7 @@ namespace LinqToDB.Data
 			}
 		}
 
-		static readonly ConcurrentDictionary<string,ConfigurationInfo> _configurations =
-			new ConcurrentDictionary<string, ConfigurationInfo>();
+		static readonly ConcurrentDictionary<string,ConfigurationInfo> _configurations = new ();
 
 		/// <summary>
 		/// Register connection configuration with specified connection string and database provider implementation.
@@ -1284,7 +1281,7 @@ namespace LinqToDB.Data
 
 			if (TraceSwitchConnection.TraceInfo)
 			{
-				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute)
+				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute, TraceOperation.ExecuteNonQuery)
 				{
 					TraceLevel     = TraceLevel.Info,
 					Command        = GetCurrentCommand(),
@@ -1300,7 +1297,7 @@ namespace LinqToDB.Data
 
 				if (TraceSwitchConnection.TraceInfo)
 				{
-					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute)
+					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute, TraceOperation.ExecuteNonQuery)
 					{
 						TraceLevel      = TraceLevel.Info,
 						Command         = GetCurrentCommand(),
@@ -1316,7 +1313,7 @@ namespace LinqToDB.Data
 			{
 				if (TraceSwitchConnection.TraceError)
 				{
-					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error)
+					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.ExecuteNonQuery)
 					{
 						TraceLevel     = TraceLevel.Error,
 						Command        = GetCurrentCommand(),
@@ -1350,7 +1347,7 @@ namespace LinqToDB.Data
 
 			if (TraceSwitchConnection.TraceInfo)
 			{
-				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute)
+				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute, TraceOperation.ExecuteScalar)
 				{
 					TraceLevel     = TraceLevel.Info,
 					Command        = GetCurrentCommand(),
@@ -1366,7 +1363,7 @@ namespace LinqToDB.Data
 
 				if (TraceSwitchConnection.TraceInfo)
 				{
-					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute)
+					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute, TraceOperation.ExecuteScalar)
 					{
 						TraceLevel     = TraceLevel.Info,
 						Command        = GetCurrentCommand(),
@@ -1381,7 +1378,7 @@ namespace LinqToDB.Data
 			{
 				if (TraceSwitchConnection.TraceError)
 				{
-					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error)
+					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.ExecuteScalar)
 					{
 						TraceLevel     = TraceLevel.Error,
 						Command        = GetCurrentCommand(),
@@ -1420,7 +1417,7 @@ namespace LinqToDB.Data
 
 			if (TraceSwitchConnection.TraceInfo)
 			{
-				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute)
+				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute, TraceOperation.ExecuteReader)
 				{
 					TraceLevel     = TraceLevel.Info,
 					Command        = GetCurrentCommand(),
@@ -1437,7 +1434,7 @@ namespace LinqToDB.Data
 
 				if (TraceSwitchConnection.TraceInfo)
 				{
-					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute)
+					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute, TraceOperation.ExecuteReader)
 					{
 						TraceLevel     = TraceLevel.Info,
 						Command        = GetCurrentCommand(),
@@ -1452,7 +1449,7 @@ namespace LinqToDB.Data
 			{
 				if (TraceSwitchConnection.TraceError)
 				{
-					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error)
+					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.ExecuteReader)
 					{
 						TraceLevel     = TraceLevel.Error,
 						Command        = GetCurrentCommand(),
@@ -1605,12 +1602,12 @@ namespace LinqToDB.Data
 		/// </summary>
 		public  List<string>  NextQueryHints => _nextQueryHints ??= new List<string>();
 		
-		private static readonly MemoryCache _combinedSchemas = new MemoryCache(new MemoryCacheOptions());
+		private static readonly MemoryCache _combinedSchemas = new (new MemoryCacheOptions());
 
 		/// <summary>
 		/// Adds additional mapping schema to current connection.
 		/// </summary>
-		/// <remarks><see cref="DataConnection"/> will share <see cref="LinqToDB.Mapping.MappingSchema"/> instances that were created by combining same mapping schemas.</remarks>
+		/// <remarks><see cref="DataConnection"/> will share <see cref="Mapping.MappingSchema"/> instances that were created by combining same mapping schemas.</remarks>
 		/// <param name="mappingSchema">Mapping schema.</param>
 		/// <returns>Current connection object.</returns>
 		public DataConnection AddMappingSchema(MappingSchema mappingSchema)
@@ -1621,7 +1618,7 @@ namespace LinqToDB.Data
 				new { BaseSchema = MappingSchema, AddedSchema = mappingSchema },
 				static (entry, key, context) => 
 				{
-					entry.SlidingExpiration = Common.Configuration.Linq.CacheSlidingExpiration;
+					entry.SlidingExpiration = Configuration.Linq.CacheSlidingExpiration;
 					return new MappingSchema(context.AddedSchema, context.BaseSchema);
 				});
 			_id            = null;

--- a/Source/LinqToDB/Data/DataReader.cs
+++ b/Source/LinqToDB/Data/DataReader.cs
@@ -24,7 +24,7 @@ namespace LinqToDB.Data
 
 				if (CommandInfo?.DataConnection.TraceSwitchConnection.TraceInfo == true)
 				{
-					CommandInfo.DataConnection.OnTraceConnection(new TraceInfo(CommandInfo.DataConnection, TraceInfoStep.Completed, TraceOperation.ExecuteReader)
+					CommandInfo.DataConnection.OnTraceConnection(new TraceInfo(CommandInfo.DataConnection, TraceInfoStep.Completed, TraceOperation.ExecuteReader, false)
 					{
 						TraceLevel      = TraceLevel.Info,
 						Command         = CommandInfo.DataConnection.GetCurrentCommand(),

--- a/Source/LinqToDB/Data/DataReader.cs
+++ b/Source/LinqToDB/Data/DataReader.cs
@@ -24,7 +24,7 @@ namespace LinqToDB.Data
 
 				if (CommandInfo?.DataConnection.TraceSwitchConnection.TraceInfo == true)
 				{
-					CommandInfo.DataConnection.OnTraceConnection(new TraceInfo(CommandInfo.DataConnection, TraceInfoStep.Completed)
+					CommandInfo.DataConnection.OnTraceConnection(new TraceInfo(CommandInfo.DataConnection, TraceInfoStep.Completed, TraceOperation.ExecuteReader)
 					{
 						TraceLevel      = TraceLevel.Info,
 						Command         = CommandInfo.DataConnection.GetCurrentCommand(),

--- a/Source/LinqToDB/Data/DataReaderAsync.cs
+++ b/Source/LinqToDB/Data/DataReaderAsync.cs
@@ -30,7 +30,7 @@ namespace LinqToDB.Data
 
 				if (CommandInfo?.DataConnection.TraceSwitchConnection.TraceInfo == true)
 				{
-					CommandInfo.DataConnection.OnTraceConnection(new TraceInfo(CommandInfo.DataConnection, TraceInfoStep.Completed)
+					CommandInfo.DataConnection.OnTraceConnection(new TraceInfo(CommandInfo.DataConnection, TraceInfoStep.Completed, TraceOperation.ExecuteReader)
 					{
 						TraceLevel      = TraceLevel.Info,
 						Command         = CommandInfo.DataConnection.GetCurrentCommand(),
@@ -53,7 +53,7 @@ namespace LinqToDB.Data
 
 				if (CommandInfo?.DataConnection.TraceSwitchConnection.TraceInfo == true)
 				{
-					CommandInfo.DataConnection.OnTraceConnection(new TraceInfo(CommandInfo.DataConnection, TraceInfoStep.Completed)
+					CommandInfo.DataConnection.OnTraceConnection(new TraceInfo(CommandInfo.DataConnection, TraceInfoStep.Completed, TraceOperation.ExecuteReaderAsync)
 					{
 						TraceLevel      = TraceLevel.Info,
 						Command         = CommandInfo.DataConnection.GetCurrentCommand(),

--- a/Source/LinqToDB/Data/DataReaderAsync.cs
+++ b/Source/LinqToDB/Data/DataReaderAsync.cs
@@ -30,7 +30,7 @@ namespace LinqToDB.Data
 
 				if (CommandInfo?.DataConnection.TraceSwitchConnection.TraceInfo == true)
 				{
-					CommandInfo.DataConnection.OnTraceConnection(new TraceInfo(CommandInfo.DataConnection, TraceInfoStep.Completed, TraceOperation.ExecuteReader)
+					CommandInfo.DataConnection.OnTraceConnection(new TraceInfo(CommandInfo.DataConnection, TraceInfoStep.Completed, TraceOperation.ExecuteReaderAsync)
 					{
 						TraceLevel      = TraceLevel.Info,
 						Command         = CommandInfo.DataConnection.GetCurrentCommand(),

--- a/Source/LinqToDB/Data/DataReaderAsync.cs
+++ b/Source/LinqToDB/Data/DataReaderAsync.cs
@@ -30,7 +30,7 @@ namespace LinqToDB.Data
 
 				if (CommandInfo?.DataConnection.TraceSwitchConnection.TraceInfo == true)
 				{
-					CommandInfo.DataConnection.OnTraceConnection(new TraceInfo(CommandInfo.DataConnection, TraceInfoStep.Completed, TraceOperation.ExecuteReaderAsync)
+					CommandInfo.DataConnection.OnTraceConnection(new TraceInfo(CommandInfo.DataConnection, TraceInfoStep.Completed, TraceOperation.ExecuteReader, false)
 					{
 						TraceLevel      = TraceLevel.Info,
 						Command         = CommandInfo.DataConnection.GetCurrentCommand(),
@@ -53,7 +53,7 @@ namespace LinqToDB.Data
 
 				if (CommandInfo?.DataConnection.TraceSwitchConnection.TraceInfo == true)
 				{
-					CommandInfo.DataConnection.OnTraceConnection(new TraceInfo(CommandInfo.DataConnection, TraceInfoStep.Completed, TraceOperation.ExecuteReaderAsync)
+					CommandInfo.DataConnection.OnTraceConnection(new TraceInfo(CommandInfo.DataConnection, TraceInfoStep.Completed, TraceOperation.ExecuteReader, true)
 					{
 						TraceLevel      = TraceLevel.Info,
 						Command         = CommandInfo.DataConnection.GetCurrentCommand(),

--- a/Source/LinqToDB/Data/TraceInfo.cs
+++ b/Source/LinqToDB/Data/TraceInfo.cs
@@ -19,11 +19,13 @@ namespace LinqToDB.Data
 		/// <param name="dataConnection"><see cref="DataConnection"/> instance, generated this trace.</param>
 		/// <param name="traceInfoStep">Trace execution step.</param>
 		/// <param name="operation">Operation associated with trace event.</param>
-		public TraceInfo(DataConnection dataConnection, TraceInfoStep traceInfoStep, TraceOperation operation)
+		/// <param name="isAsync">Flag indicating whether operation was executed asynchronously.</param>
+		public TraceInfo(DataConnection dataConnection, TraceInfoStep traceInfoStep, TraceOperation operation, bool isAsync)
 		{
 			DataConnection = dataConnection;
 			TraceInfoStep  = traceInfoStep;
 			Operation      = operation;
+			IsAsync        = isAsync;
 		}
 
 		/// <summary>
@@ -84,9 +86,9 @@ namespace LinqToDB.Data
 		public Expression? MapperExpression { get; set; }
 
 		/// <summary>
-		/// Gets or sets a flag indicating whether the command was executed asynchronously.
+		/// Gets a flag indicating whether operation was executed asynchronously.
 		/// </summary>
-		public bool IsAsync { get; set; }
+		public bool IsAsync { get; }
 
 		private string? _sqlText;
 

--- a/Source/LinqToDB/Data/TraceInfo.cs
+++ b/Source/LinqToDB/Data/TraceInfo.cs
@@ -18,16 +18,23 @@ namespace LinqToDB.Data
 		/// </summary>
 		/// <param name="dataConnection"><see cref="DataConnection"/> instance, generated this trace.</param>
 		/// <param name="traceInfoStep">Trace execution step.</param>
-		public TraceInfo(DataConnection dataConnection, TraceInfoStep traceInfoStep)
+		/// <param name="operation">Operation associated with trace event.</param>
+		public TraceInfo(DataConnection dataConnection, TraceInfoStep traceInfoStep, TraceOperation operation)
 		{
 			DataConnection = dataConnection;
 			TraceInfoStep  = traceInfoStep;
+			Operation      = operation;
 		}
 
 		/// <summary>
 		/// Gets the tracing execution step, <see cref="TraceInfoStep"/>.
 		/// </summary>
 		public TraceInfoStep TraceInfoStep { get; }
+
+		/// <summary>
+		/// Gets the operation, for which tracing event generated, <see cref="TraceOperation"/>.
+		/// </summary>
+		public TraceOperation Operation { get; }
 
 		/// <summary>
 		/// Gets or sets the tracing detail level, <see cref="TraceLevel"/>.

--- a/Source/LinqToDB/Data/TraceInfoStep.cs
+++ b/Source/LinqToDB/Data/TraceInfoStep.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace LinqToDB.Data
+﻿namespace LinqToDB.Data
 {
 	/// <summary>
 	/// Tracing steps for the <see cref="DataConnection"/> trace events.

--- a/Source/LinqToDB/Data/TraceOperation.cs
+++ b/Source/LinqToDB/Data/TraceOperation.cs
@@ -9,53 +9,45 @@ namespace LinqToDB.Data
 	public enum TraceOperation
 	{
 		/// <summary>
-		/// Synchronous <see cref="DbCommand.ExecuteNonQuery"/> operation.
+		/// <see cref="DbCommand.ExecuteNonQuery"/> or <see cref="DbCommand.ExecuteNonQueryAsync(System.Threading.CancellationToken)"/> operation.
+		/// See also <seealso cref="TraceInfo.IsAsync"/>.
 		/// </summary>
 		ExecuteNonQuery,
 
 		/// <summary>
-		/// Asynchronous <see cref="DbCommand.ExecuteNonQueryAsync(System.Threading.CancellationToken)"/> operation.
-		/// </summary>
-		ExecuteNonQueryAsync,
-
-		/// <summary>
-		/// Synchronous <see cref="DbCommand.ExecuteReader(System.Data.CommandBehavior)"/> operation.
+		/// <see cref="DbCommand.ExecuteReader(System.Data.CommandBehavior)"/> or <see cref="DbCommand.ExecuteReaderAsync(System.Data.CommandBehavior, System.Threading.CancellationToken)"/> operation.
+		/// See also <seealso cref="TraceInfo.IsAsync"/>.
 		/// </summary>
 		ExecuteReader,
 
 		/// <summary>
-		/// Asynchronous <see cref="DbCommand.ExecuteReaderAsync(System.Data.CommandBehavior, System.Threading.CancellationToken)"/> operation.
-		/// </summary>
-		ExecuteReaderAsync,
-
-		/// <summary>
-		/// Synchronous <see cref="DbCommand.ExecuteScalar"/> operation.
+		/// <see cref="DbCommand.ExecuteScalar"/> or <see cref="DbCommand.ExecuteScalarAsync(System.Threading.CancellationToken)"/> operation.
+		/// See also <seealso cref="TraceInfo.IsAsync"/>.
 		/// </summary>
 		ExecuteScalar,
 
 		/// <summary>
-		/// Asynchronous <see cref="DbCommand.ExecuteScalarAsync(System.Threading.CancellationToken)"/> operation.
-		/// </summary>
-		ExecuteScalarAsync,
-
-		/// <summary>
-		/// Synchronous <see cref="DataConnectionExtensions.BulkCopy{T}(ITable{T}, System.Collections.Generic.IEnumerable{T})"/> operation.
+		/// <see cref="DataConnectionExtensions.BulkCopy{T}(ITable{T}, System.Collections.Generic.IEnumerable{T})"/> or <see cref="DataConnectionExtensions.BulkCopyAsync{T}(DataConnection, int, System.Collections.Generic.IEnumerable{T}, System.Threading.CancellationToken)"/> operation.
+		/// See also <seealso cref="TraceInfo.IsAsync"/>.
 		/// </summary>
 		BulkCopy,
 
 		/// <summary>
-		/// Asynchronous <see cref="DataConnectionExtensions.BulkCopyAsync{T}(DataConnection, int, System.Collections.Generic.IEnumerable{T}, System.Threading.CancellationToken)"/> operation.
-		/// </summary>
-		BulkCopyAsync,
-
-		/// <summary>
-		/// Synchronous <see cref="DbConnection.Open"/> operation.
+		/// <see cref="DbConnection.Open"/> or <see cref="DbConnection.OpenAsync(System.Threading.CancellationToken)"/> operation.
+		/// See also <seealso cref="TraceInfo.IsAsync"/>.
 		/// </summary>
 		Open,
 
 		/// <summary>
-		/// Asynchronous <see cref="DbConnection.OpenAsync(System.Threading.CancellationToken)"/> operation.
+		/// Mapper build operation.
+		/// See also <seealso cref="TraceInfo.IsAsync"/>.
 		/// </summary>
-		OpenAsync,
+		BuildMapping,
+
+		/// <summary>
+		/// Query runner disposal operation.
+		/// See also <seealso cref="TraceInfo.IsAsync"/>.
+		/// </summary>
+		DisposeQuery,
 	}
 }

--- a/Source/LinqToDB/Data/TraceOperation.cs
+++ b/Source/LinqToDB/Data/TraceOperation.cs
@@ -1,0 +1,61 @@
+﻿using System.Data.Common;
+
+namespace LinqToDB.Data
+{
+	/// <summary>
+	/// Type of operation associated with specific trace event.
+	/// </summary>
+	/// <seealso cref="TraceInfo"/>
+	public enum TraceOperation
+	{
+		/// <summary>
+		/// Synchronous <see cref="DbCommand.ExecuteNonQuery"/> operation.
+		/// </summary>
+		ExecuteNonQuery,
+
+		/// <summary>
+		/// Asynchronous <see cref="DbCommand.ExecuteNonQueryAsync(System.Threading.CancellationToken)"/> operation.
+		/// </summary>
+		ExecuteNonQueryAsync,
+
+		/// <summary>
+		/// Synchronous <see cref="DbCommand.ExecuteReader(System.Data.CommandBehavior)"/> operation.
+		/// </summary>
+		ExecuteReader,
+
+		/// <summary>
+		/// Asynchronous <see cref="DbCommand.ExecuteReaderAsync(System.Data.CommandBehavior, System.Threading.CancellationToken)"/> operation.
+		/// </summary>
+		ExecuteReaderAsync,
+
+		/// <summary>
+		/// Synchronous <see cref="DbCommand.ExecuteScalar"/> operation.
+		/// </summary>
+		ExecuteScalar,
+
+		/// <summary>
+		/// Asynchronous <see cref="DbCommand.ExecuteScalarAsync(System.Threading.CancellationToken)"/> operation.
+		/// </summary>
+		ExecuteScalarAsync,
+
+		/// <summary>
+		/// Synchronous <see cref="DataConnectionExtensions.BulkCopy{T}(ITable{T}, System.Collections.Generic.IEnumerable{T})"/> operation.
+		/// </summary>
+		BulkCopy,
+
+		/// <summary>
+		/// Asynchronous <see cref="DataConnectionExtensions.BulkCopyAsync{T}(DataConnection, int, System.Collections.Generic.IEnumerable{T}, System.Threading.CancellationToken)"/> operation.
+		/// </summary>
+		BulkCopyAsync,
+
+		/// <summary>
+		/// Synchronous <see cref="DbConnection.Open"/> operation.
+		/// </summary>
+		Open,
+
+		/// <summary>
+		/// Asynchronous <see cref="DbConnection.OpenAsync(System.Threading.CancellationToken)"/> operation.
+		/// </summary>
+		OpenAsync,
+	}
+}

--- a/Source/LinqToDB/DataContext.cs
+++ b/Source/LinqToDB/DataContext.cs
@@ -556,11 +556,8 @@ namespace LinqToDB
 			public async Task DisposeAsync()
 #endif
 			{
-				if (_queryRunner != null)
-					await _queryRunner.DisposeAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
-
-				if (_dataContext != null) 
-					await ((IDataContext)_dataContext).DisposeAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+				await _queryRunner!.DisposeAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+				_dataContext!.ReleaseQuery();
 
 				_queryRunner = null;
 				_dataContext = null;

--- a/Source/LinqToDB/DataProvider/BasicBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/BasicBulkCopy.cs
@@ -249,7 +249,7 @@ namespace LinqToDB.DataProvider
 
 			if (dataConnection.TraceSwitchConnection.TraceInfo)
 			{
-				dataConnection.OnTraceConnection(new TraceInfo(dataConnection, TraceInfoStep.BeforeExecute, async ? TraceOperation.BulkCopyAsync : TraceOperation.BulkCopy)
+				dataConnection.OnTraceConnection(new TraceInfo(dataConnection, TraceInfoStep.BeforeExecute, TraceOperation.BulkCopy, async)
 				{
 					TraceLevel     = TraceLevel.Info,
 					CommandText    = commandText(),
@@ -263,7 +263,7 @@ namespace LinqToDB.DataProvider
 
 				if (dataConnection.TraceSwitchConnection.TraceInfo)
 				{
-					dataConnection.OnTraceConnection(new TraceInfo(dataConnection, TraceInfoStep.AfterExecute, async ? TraceOperation.BulkCopyAsync : TraceOperation.BulkCopy)
+					dataConnection.OnTraceConnection(new TraceInfo(dataConnection, TraceInfoStep.AfterExecute, TraceOperation.BulkCopy, async)
 					{
 						TraceLevel      = TraceLevel.Info,
 						CommandText     = commandText(),
@@ -277,7 +277,7 @@ namespace LinqToDB.DataProvider
 			{
 				if (dataConnection.TraceSwitchConnection.TraceError)
 				{
-					dataConnection.OnTraceConnection(new TraceInfo(dataConnection, TraceInfoStep.Error, async ? TraceOperation.BulkCopyAsync : TraceOperation.BulkCopy)
+					dataConnection.OnTraceConnection(new TraceInfo(dataConnection, TraceInfoStep.Error, TraceOperation.BulkCopy, async)
 					{
 						TraceLevel     = TraceLevel.Error,
 						CommandText    = commandText(),

--- a/Source/LinqToDB/DataProvider/BasicBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/BasicBulkCopy.cs
@@ -237,19 +237,19 @@ namespace LinqToDB.DataProvider
 
 		protected void TraceAction(DataConnection dataConnection, Func<string> commandText, Func<int> action)
 		{
-			var task = TraceActionAsync(dataConnection, commandText, () => Task.FromResult(action()));
+			var task = TraceActionAsync(dataConnection, commandText, () => Task.FromResult(action()), false);
 			// the following line of code should be completely redundant, as exceptions should bubble up, since there are no awaited tasks
 			if (task.Status != TaskStatus.RanToCompletion) task.GetAwaiter().GetResult();
 		}
 
-		protected async Task TraceActionAsync(DataConnection dataConnection, Func<string> commandText, Func<Task<int>> action)
+		protected async Task TraceActionAsync(DataConnection dataConnection, Func<string> commandText, Func<Task<int>> action, bool async)
 		{
 			var now = DateTime.UtcNow;
 			var sw  = Stopwatch.StartNew();
 
 			if (dataConnection.TraceSwitchConnection.TraceInfo)
 			{
-				dataConnection.OnTraceConnection(new TraceInfo(dataConnection, TraceInfoStep.BeforeExecute)
+				dataConnection.OnTraceConnection(new TraceInfo(dataConnection, TraceInfoStep.BeforeExecute, async ? TraceOperation.BulkCopyAsync : TraceOperation.BulkCopy)
 				{
 					TraceLevel     = TraceLevel.Info,
 					CommandText    = commandText(),
@@ -263,7 +263,7 @@ namespace LinqToDB.DataProvider
 
 				if (dataConnection.TraceSwitchConnection.TraceInfo)
 				{
-					dataConnection.OnTraceConnection(new TraceInfo(dataConnection, TraceInfoStep.AfterExecute)
+					dataConnection.OnTraceConnection(new TraceInfo(dataConnection, TraceInfoStep.AfterExecute, async ? TraceOperation.BulkCopyAsync : TraceOperation.BulkCopy)
 					{
 						TraceLevel      = TraceLevel.Info,
 						CommandText     = commandText(),
@@ -277,7 +277,7 @@ namespace LinqToDB.DataProvider
 			{
 				if (dataConnection.TraceSwitchConnection.TraceError)
 				{
-					dataConnection.OnTraceConnection(new TraceInfo(dataConnection, TraceInfoStep.Error)
+					dataConnection.OnTraceConnection(new TraceInfo(dataConnection, TraceInfoStep.Error, async ? TraceOperation.BulkCopyAsync : TraceOperation.BulkCopy)
 					{
 						TraceLevel     = TraceLevel.Error,
 						CommandText    = commandText(),

--- a/Source/LinqToDB/DataProvider/BulkCopyReader.cs
+++ b/Source/LinqToDB/DataProvider/BulkCopyReader.cs
@@ -6,8 +6,7 @@ using System.Data.Common;
 using System.Globalization;
 using System.Linq;
 #if NATIVE_ASYNC
-	using System.Threading;
-	using System.Threading.Tasks;
+using System.Threading;
 #endif
 
 namespace LinqToDB.DataProvider
@@ -294,7 +293,7 @@ namespace LinqToDB.DataProvider
 #if NATIVE_ASYNC
 		public override async Task<bool> ReadAsync(CancellationToken cancellationToken)
 		{
-			var b = await MoveNextAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+			var b = await MoveNextAsync().ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 			if (b)
 				Count++;

--- a/Source/LinqToDB/DataProvider/MySql/MySqlBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlBulkCopy.cs
@@ -179,7 +179,7 @@ namespace LinqToDB.DataProvider.MySql
 						else
 							bc.WriteToServer(rd);
 						return rd.Count;
-					}).ConfigureAwait(Configuration.ContinueOnCapturedContext);
+					}, runAsync).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 				rc.RowsCopied += rd.Count;
 			}
@@ -239,7 +239,7 @@ namespace LinqToDB.DataProvider.MySql
 
 				await TraceActionAsync(
 					dataConnection,
-					() => "INSERT BULK " + tableName + "(" + string.Join(", ", columns.Select(x => x.ColumnName)) + Environment.NewLine,
+					() => (bc.CanWriteToServerAsync2 || bc.CanWriteToServerAsync ? "INSERT ASYNC BULK " : "INSERT BULK ") + tableName + "(" + string.Join(", ", columns.Select(x => x.ColumnName)) + Environment.NewLine,
 					async () => {
 						if (bc.CanWriteToServerAsync2)
 							await bc.WriteToServerAsync2(rd, cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
@@ -249,7 +249,7 @@ namespace LinqToDB.DataProvider.MySql
 							else
 								bc.WriteToServer(rd);
 						return rd.Count;
-					}).ConfigureAwait(Configuration.ContinueOnCapturedContext);
+					}, true).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 				rc.RowsCopied += rd.Count;
 			}

--- a/Source/LinqToDB/DataProvider/PostgreSQL/NpgsqlProviderAdapter.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/NpgsqlProviderAdapter.cs
@@ -19,7 +19,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 
 	public class NpgsqlProviderAdapter : IDynamicProviderAdapter
 	{
-		private static readonly object _syncRoot = new object();
+		private static readonly object _syncRoot = new ();
 		private static NpgsqlProviderAdapter? _instance;
 
 		public const string AssemblyName    = "Npgsql";

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
@@ -290,7 +290,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 							var ret = await writer.CompleteAsync(cancellationToken)
 								.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 							return (int)rowsCopied.RowsCopied;
-						}).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+						}, true).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 				}
 
 				if (options.NotifyAfter != 0 && options.RowsCopiedCallback != null)
@@ -408,7 +408,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 							var ret = await writer.CompleteAsync(cancellationToken)
 								.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 							return (int)rowsCopied.RowsCopied;
-						}).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+						}, true).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 				}
 
 				if (options.NotifyAfter != 0 && options.RowsCopiedCallback != null)

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaBulkCopy.cs
@@ -171,7 +171,7 @@ namespace LinqToDB.DataProvider.SapHana
 						else
 							bc.WriteToServer(rd);
 						return rd.Count;
-					}).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+					}, true).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 				if (rc.RowsCopied != rd.Count)
 				{

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerBulkCopy.cs
@@ -172,7 +172,7 @@ namespace LinqToDB.DataProvider.SqlServer
 						else
 							bc.WriteToServer(rd);
 						return rd.Count;
-					}).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
+					}, true).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			}
 
 			if (rc.RowsCopied != rd.Count)

--- a/Source/LinqToDB/IDataContext.cs
+++ b/Source/LinqToDB/IDataContext.cs
@@ -7,6 +7,7 @@ using JetBrains.Annotations;
 
 namespace LinqToDB
 {
+	using System.Threading.Tasks;
 	using Linq;
 	using Mapping;
 	using SqlProvider;
@@ -16,6 +17,11 @@ namespace LinqToDB
 	/// </summary>
 	[PublicAPI]
 	public interface IDataContext : IEntityServices, IDisposable
+#if NATIVE_ASYNC
+		, IAsyncDisposable
+#else
+		, Async.IAsyncDisposable
+#endif
 	{
 		/// <summary>
 		/// Provider identifier.
@@ -90,6 +96,11 @@ namespace LinqToDB
 		/// Closes context connection and disposes underlying resources.
 		/// </summary>
 		void                Close              ();
+
+		/// <summary>
+		/// Closes context connection and disposes underlying resources.
+		/// </summary>
+		Task                CloseAsync         ();
 
 		/// <summary>
 		/// Event, triggered before context connection closed using <see cref="Close"/> method.

--- a/Source/LinqToDB/Linq/IQueryRunner.cs
+++ b/Source/LinqToDB/Linq/IQueryRunner.cs
@@ -7,6 +7,11 @@ using System.Threading.Tasks;
 namespace LinqToDB.Linq
 {
 	public interface IQueryRunner: IDisposable
+#if NATIVE_ASYNC
+		, IAsyncDisposable
+#else
+		, Async.IAsyncDisposable
+#endif
 	{
 		/// <summary>
 		/// Executes query and returns number of affected records.

--- a/Source/LinqToDB/Linq/QueryRunnerBase.cs
+++ b/Source/LinqToDB/Linq/QueryRunnerBase.cs
@@ -46,6 +46,25 @@ namespace LinqToDB.Linq
 				DataContext.Close();
 		}
 
+#if !NATIVE_ASYNC
+		public virtual Task DisposeAsync()
+		{
+			if (DataContext.CloseAfterUse)
+				return DataContext.CloseAsync();
+
+			return TaskEx.CompletedTask;
+		}
+#else
+		public virtual ValueTask DisposeAsync()
+		{
+			if (DataContext.CloseAfterUse)
+				return new ValueTask(DataContext.CloseAsync());
+
+			return default;
+		}
+#endif
+
+
 		protected virtual void SetCommand(bool clearQueryHints)
 		{
 			if (QueryNumber == 0 && (DataContext.QueryHints.Count > 0 || DataContext.NextQueryHints.Count > 0))

--- a/Source/LinqToDB/ServiceModel/RemoteDataContextBase.QueryRunner.cs
+++ b/Source/LinqToDB/ServiceModel/RemoteDataContextBase.QueryRunner.cs
@@ -9,11 +9,13 @@ using System.Threading.Tasks;
 
 namespace LinqToDB.ServiceModel
 {
-	using Linq;
 	using Common.Internal;
-	using SqlQuery;
+	using Linq;
 	using SqlProvider;
+	using SqlQuery;
+#if !NATIVE_ASYNC
 	using Tools;
+#endif
 
 	public abstract partial class RemoteDataContextBase
 	{

--- a/Tests/Linq/Data/TraceTests.cs
+++ b/Tests/Linq/Data/TraceTests.cs
@@ -171,7 +171,7 @@ namespace Tests.Data
 
 			using (var db = new DataConnection())
 			{
-				db.OnTraceConnection(new TraceInfo(db, TraceInfoStep.BeforeExecute));
+				db.OnTraceConnection(new TraceInfo(db, TraceInfoStep.BeforeExecute, TraceOperation.BuildMapping, false));
 			}
 			Assert.True(traceCalled);
 		}
@@ -187,7 +187,7 @@ namespace Tests.Data
 
 			using (var db = new DataConnection(builder.Build()))
 			{
-				db.OnTraceConnection(new TraceInfo(db, TraceInfoStep.BeforeExecute));
+				db.OnTraceConnection(new TraceInfo(db, TraceInfoStep.BeforeExecute, TraceOperation.BuildMapping, false));
 			}
 
 			Assert.True(builderTraceCalled, "because the builder trace should have been called");

--- a/Tests/Linq/Samples/DataContextDecoratorTests.cs
+++ b/Tests/Linq/Samples/DataContextDecoratorTests.cs
@@ -13,6 +13,7 @@ using NUnit.Framework;
 
 namespace Tests.Samples
 {
+	using System.Threading.Tasks;
 	using Model;
 	/// <summary>
 	/// This sample demonstrates how can we use <see cref="IDataContext"/> decoration
@@ -65,9 +66,19 @@ namespace Tests.Samples
 				_context.Close();
 			}
 
+			public Task CloseAsync()
+			{
+				return _context.CloseAsync();
+			}
+
 			public void Dispose()
 			{
 				_context.Dispose();
+			}
+
+			public ValueTask DisposeAsync()
+			{
+				return _context.DisposeAsync();
 			}
 
 			public IQueryRunner GetQueryRunner(Query query, int queryNumber, Expression expression, object?[]? parameters, object?[]? preambles)


### PR DESCRIPTION
Fix #2898

Also:
- set `IsAsync` flag for all trace events
- add `CloseAsync` to `IDataContext`
- add `IAsyncDisposable` to `IDataContext` and `IQueryRunner`
- obsolete `DataConnection`'s `DisposeAsync` and `CloseAsync` methods with `CancellationToken` parameter

