### PR TITLE
Fix for #2919. Corrected support for internal members in explicit projection.

### DIFF
--- a/Source/LinqToDB/Linq/Builder/SelectBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/SelectBuilder.cs
@@ -267,7 +267,7 @@ namespace LinqToDB.Linq.Builder
 							.Select((m,i) => new { m, i })
 							.ToDictionary(_ => _.m.MemberInfo.Name, _ => _.i);
 
-						foreach (var binding in expr.Bindings.Cast<MemberAssignment>().OrderBy(b => dic[b.Member.Name]))
+						foreach (var binding in expr.Bindings.Cast<MemberAssignment>().OrderBy(b => dic.TryGetValue(b.Member.Name, out var idx) ? idx : int.MaxValue))
 						{
 							var q = GetExpressions(param, Expression.MakeMemberAccess(path, binding.Member), level + 1, binding.Expression);
 							foreach (var e in q)

--- a/Source/LinqToDB/Reflection/TypeAccessor.cs
+++ b/Source/LinqToDB/Reflection/TypeAccessor.cs
@@ -45,9 +45,9 @@ namespace LinqToDB.Reflection
 
 		#region Items
 
-		public List<MemberAccessor>    Members       { get; } = new List<MemberAccessor>();
+		public List<MemberAccessor>    Members       { get; } = new();
 
-		readonly ConcurrentDictionary<string,MemberAccessor> _membersByName = new ConcurrentDictionary<string,MemberAccessor>();
+		readonly ConcurrentDictionary<string,MemberAccessor> _membersByName = new();
 
 		public MemberAccessor this[string memberName] =>
 			_membersByName.GetOrAdd(memberName, name =>
@@ -63,7 +63,7 @@ namespace LinqToDB.Reflection
 
 		#region Static Members
 
-		static readonly ConcurrentDictionary<Type,TypeAccessor> _accessors = new ConcurrentDictionary<Type,TypeAccessor>();
+		static readonly ConcurrentDictionary<Type,TypeAccessor> _accessors = new();
 
 		public static TypeAccessor GetAccessor(Type type)
 		{

--- a/Source/LinqToDB/Reflection/TypeAccessorT.cs
+++ b/Source/LinqToDB/Reflection/TypeAccessorT.cs
@@ -89,7 +89,7 @@ namespace LinqToDB.Reflection
 			throw new LinqToDBException($"Cant create an instance of abstract class '{typeof(T).FullName}'.");
 		}
 
-		static readonly List<MemberInfo> _members = new List<MemberInfo>();
+		static readonly List<MemberInfo> _members = new();
 		static readonly IObjectFactory?  _objectFactory;
 
 		internal TypeAccessor()

--- a/Tests/Linq/Linq/SelectTests.cs
+++ b/Tests/Linq/Linq/SelectTests.cs
@@ -903,6 +903,29 @@ namespace Tests.Linq
 			}
 		}
 
+		public class ClassWithInternal
+		{
+			public int? Int { get; set; }
+			internal string? InternalStr { get; set; }
+		}
+
+
+		[Test]
+		public void InternalFieldProjection([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var query = db.Types.Select(t => new ClassWithInternal
+				{
+					Int = t.ID,
+					InternalStr = t.StringValue
+				});
+
+				var result = query.Where(x => x.InternalStr != "").ToArray();
+				Assert.That(result[0].InternalStr, Is.EqualTo(Types.First().StringValue));
+			}
+		}
+
 		class LocalClass
 		{
 		}

--- a/Tests/Tests.Playground/TestTemplate.cs
+++ b/Tests/Tests.Playground/TestTemplate.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using FluentAssertions;
 using LinqToDB.Mapping;
 
@@ -13,12 +12,12 @@ namespace Tests.Playground
 		[Table]
 		class SampleClass
 		{
-			[Column] public int Id    { get; set; }
-			[Column] public int Value { get; set; }
+			[Column]              public int     Id    { get; set; }
+			[Column(Length = 50)] public string? Value { get; set; }
 		}
 
 		[Test]
-		public void SampleSelectTest([DataSources] string context)
+		public void SampleSelectTest([IncludeDataSources(TestProvName. AllSQLite)] string context)
 		{
 			using (var db = GetDataContext(context))
 			using (var table = db.CreateLocalTable<SampleClass>())


### PR DESCRIPTION
Fixes #2919