### PR TITLE
Remove obsoleted members

### DIFF
--- a/Source/LinqToDB/Common/Configuration.cs
+++ b/Source/LinqToDB/Common/Configuration.cs
@@ -136,16 +136,6 @@ namespace LinqToDB.Common
 			public static bool IgnoreEmptyUpdate;
 
 			/// <summary>
-			/// Controls behavior of linq2db when multiple queries required to load requested data:
-			/// - if <c>true</c> - multiple queries allowed;
-			/// - if <c>false</c> - <see cref="LinqException"/> will be thrown.
-			/// This option required, if you want to select related collections, e.g. using <see cref="LinqExtensions.LoadWith{TEntity,TProperty}(System.Linq.IQueryable{TEntity},System.Linq.Expressions.Expression{System.Func{TEntity,TProperty}})"/> method.
-			/// Default value: <c>false</c>.
-			/// </summary>
-			[Obsolete("AllowMultipleQuery flag has no effect and will be removed in future.")]
-			public static bool AllowMultipleQuery;
-
-			/// <summary>
 			/// Enables generation of test class for each LINQ query, executed while this option is enabled.
 			/// This option could be useful for issue reporting, when you need to provide reproducible case.
 			/// Test file will be placed to <c>linq2db</c> subfolder of temp folder and exact file path will be logged

--- a/Source/LinqToDB/Data/DataConnection.Async.cs
+++ b/Source/LinqToDB/Data/DataConnection.Async.cs
@@ -172,12 +172,6 @@ namespace LinqToDB.Data
 			}
 		}
 
-		[Obsolete("Use parameter-less CloseAsync() call")]
-		public Task CloseAsync(CancellationToken cancellationToken)
-		{
-			return CloseAsync();
-		}
-
 		/// <summary>
 		/// Closes and dispose associated underlying database transaction/connection asynchronously.
 		/// </summary>
@@ -206,16 +200,6 @@ namespace LinqToDB.Data
 			}
 
 			OnClosed?.Invoke(this, EventArgs.Empty);
-		}
-
-		[Obsolete("Use parameter-less DisposeAsync() call")]
-		public Task DisposeAsync(CancellationToken cancellationToken)
-		{
-#if NATIVE_ASYNC
-			return DisposeAsync().AsTask();
-#else
-			return DisposeAsync();
-#endif
 		}
 
 		/// <summary>

--- a/Source/LinqToDB/DataProvider/Access/AccessTools.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessTools.cs
@@ -166,25 +166,6 @@ namespace LinqToDB.DataProvider.Access
 		/// Default value: <see cref="BulkCopyType.MultipleRows"/>.
 		/// </summary>
 		public static BulkCopyType  DefaultBulkCopyType { get; set; } = BulkCopyType.MultipleRows;
-
-		// If user has DataConnection - he can call BulkCopy directly and Tools methods only provide some
-		// defaults for parameters
-		[Obsolete("Please use the BulkCopy extension methods within DataConnectionExtensions")]
-		public static BulkCopyRowsCopied MultipleRowsCopy<T>(
-			DataConnection              dataConnection,
-			IEnumerable<T>              source,
-			int                         maxBatchSize       = 1000,
-			Action<BulkCopyRowsCopied>? rowsCopiedCallback = null)
-			where T : class
-		{
-			return dataConnection.BulkCopy(
-				new BulkCopyOptions
-				{
-					BulkCopyType       = BulkCopyType.MultipleRows,
-					MaxBatchSize       = maxBatchSize,
-					RowsCopiedCallback = rowsCopiedCallback,
-				}, source);
-		}
 		#endregion
 	}
 }

--- a/Source/LinqToDB/DataProvider/DB2/DB2Tools.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2Tools.cs
@@ -151,44 +151,6 @@ namespace LinqToDB.DataProvider.DB2
 		/// </summary>
 		public static BulkCopyType  DefaultBulkCopyType { get; set; } = BulkCopyType.MultipleRows;
 
-		[Obsolete("Please use the BulkCopy extension methods within DataConnectionExtensions")]
-		public static BulkCopyRowsCopied MultipleRowsCopy<T>(
-			DataConnection              dataConnection,
-			IEnumerable<T>              source,
-			int                         maxBatchSize       = 1000,
-			Action<BulkCopyRowsCopied>? rowsCopiedCallback = null)
-			where T : class
-		{
-			return dataConnection.BulkCopy(
-				new BulkCopyOptions
-				{
-					BulkCopyType       = BulkCopyType.ProviderSpecific,
-					MaxBatchSize       = maxBatchSize,
-					RowsCopiedCallback = rowsCopiedCallback,
-				}, source);
-		}
-
-		[Obsolete("Please use the BulkCopy extension methods within DataConnectionExtensions")]
-		public static BulkCopyRowsCopied ProviderSpecificBulkCopy<T>(
-			DataConnection              dataConnection,
-			IEnumerable<T>              source,
-			int?                        bulkCopyTimeout    = null,
-			bool                        keepIdentity       = false,
-			int                         notifyAfter        = 0,
-			Action<BulkCopyRowsCopied>? rowsCopiedCallback = null)
-			where T : class
-		{
-			return dataConnection.BulkCopy(
-				new BulkCopyOptions
-				{
-					BulkCopyType       = BulkCopyType.ProviderSpecific,
-					BulkCopyTimeout    = bulkCopyTimeout,
-					KeepIdentity       = keepIdentity,
-					NotifyAfter        = notifyAfter,
-					RowsCopiedCallback = rowsCopiedCallback,
-				}, source);
-		}
-
 		#endregion
 	}
 }

--- a/Source/LinqToDB/DataProvider/DataTools.cs
+++ b/Source/LinqToDB/DataProvider/DataTools.cs
@@ -193,17 +193,6 @@ namespace LinqToDB.DataProvider
 			}
 		}
 
-		[Obsolete("Use expression-based " + nameof(GetCharExpression) + " for mapping")]
-		public static Func<DbDataReader, int, string> GetChar = (dr, i) =>
-		{
-			var str = dr.GetString(i);
-
-			if (str.Length > 0)
-				return str[0].ToString();
-
-			return string.Empty;
-		};
-
 		public static Expression<Func<DbDataReader, int, string>> GetCharExpression = (dr, i) => GetCharFromString(dr.GetString(i));
 
 		private static string GetCharFromString(string str)

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdTools.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdTools.cs
@@ -75,23 +75,6 @@ namespace LinqToDB.DataProvider.Firebird
 
 		public  static BulkCopyType  DefaultBulkCopyType { get; set; } = BulkCopyType.MultipleRows;
 
-		[Obsolete("Please use the BulkCopy extension methods within DataConnectionExtensions")]
-		public static BulkCopyRowsCopied MultipleRowsCopy<T>(
-			DataConnection              dataConnection,
-			IEnumerable<T>              source,
-			int                         maxBatchSize       = 1000,
-			Action<BulkCopyRowsCopied>? rowsCopiedCallback = null)
-			where T : class
-		{
-			return dataConnection.BulkCopy(
-				new BulkCopyOptions
-				{
-					BulkCopyType       = BulkCopyType.MultipleRows,
-					MaxBatchSize       = maxBatchSize,
-					RowsCopiedCallback = rowsCopiedCallback,
-				}, source);
-		}
-
 		#endregion
 
 		#region ClearAllPools

--- a/Source/LinqToDB/DataProvider/Informix/InformixTools.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixTools.cs
@@ -122,23 +122,6 @@ namespace LinqToDB.DataProvider.Informix
 
 		public  static BulkCopyType  DefaultBulkCopyType { get; set; } = BulkCopyType.ProviderSpecific;
 
-		[Obsolete("Please use the BulkCopy extension methods within DataConnectionExtensions")]
-		public static BulkCopyRowsCopied MultipleRowsCopy<T>(
-			DataConnection              dataConnection,
-			IEnumerable<T>              source,
-			int                         maxBatchSize       = 1000,
-			Action<BulkCopyRowsCopied>? rowsCopiedCallback = null)
-			where T : class
-		{
-			return dataConnection.BulkCopy(
-				new BulkCopyOptions
-				{
-					BulkCopyType       = BulkCopyType.ProviderSpecific,
-					MaxBatchSize       = maxBatchSize,
-					RowsCopiedCallback = rowsCopiedCallback,
-				}, source);
-		}
-
 #endregion
 	}
 }

--- a/Source/LinqToDB/DataProvider/MySql/MySqlTools.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlTools.cs
@@ -143,23 +143,6 @@ namespace LinqToDB.DataProvider.MySql
 
 		public  static BulkCopyType  DefaultBulkCopyType { get; set; } = BulkCopyType.MultipleRows;
 
-		[Obsolete("Please use the BulkCopy extension methods within DataConnectionExtensions")]
-		public static BulkCopyRowsCopied MultipleRowsCopy<T>(
-			DataConnection               dataConnection,
-			IEnumerable<T>               source,
-			int                          maxBatchSize       = 1000,
-			Action<BulkCopyRowsCopied>?  rowsCopiedCallback = null)
-			where T : class
-		{
-			return dataConnection.BulkCopy(
-				new BulkCopyOptions
-				{
-					BulkCopyType       = BulkCopyType.MultipleRows,
-					MaxBatchSize       = maxBatchSize,
-					RowsCopiedCallback = rowsCopiedCallback,
-				}, source);
-		}
-
 		#endregion
 	}
 }

--- a/Source/LinqToDB/DataProvider/Oracle/OracleTools.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleTools.cs
@@ -264,50 +264,9 @@ namespace LinqToDB.DataProvider.Oracle
 
 		public  static BulkCopyType  DefaultBulkCopyType { get; set; } = BulkCopyType.MultipleRows;
 
-		[Obsolete("Please use the BulkCopy extension methods within DataConnectionExtensions")]
-		public static BulkCopyRowsCopied MultipleRowsCopy<T>(
-			this DataConnection          dataConnection,
-			IEnumerable<T>               source,
-			int                          maxBatchSize       = 1000,
-			Action<BulkCopyRowsCopied>?  rowsCopiedCallback = null)
-			where T : class
-		{
-			return dataConnection.BulkCopy(
-				new BulkCopyOptions
-				{
-					BulkCopyType       = BulkCopyType.MultipleRows,
-					MaxBatchSize       = maxBatchSize,
-					RowsCopiedCallback = rowsCopiedCallback,
-				}, source);
-		}
-
-		[Obsolete("Please use the BulkCopy extension methods within DataConnectionExtensions")]
-		public static BulkCopyRowsCopied ProviderSpecificBulkCopy<T>(
-			DataConnection               dataConnection,
-			IEnumerable<T>               source,
-			int?                         maxBatchSize       = null,
-			int?                         bulkCopyTimeout    = null,
-			int                          notifyAfter        = 0,
-			Action<BulkCopyRowsCopied>?  rowsCopiedCallback = null)
-			where T : class
-		{
-			return dataConnection.BulkCopy(
-				new BulkCopyOptions
-				{
-					BulkCopyType       = BulkCopyType.ProviderSpecific,
-					MaxBatchSize       = maxBatchSize,
-					BulkCopyTimeout    = bulkCopyTimeout,
-					NotifyAfter        = notifyAfter,
-					RowsCopiedCallback = rowsCopiedCallback,
-				}, source);
-		}
-
 #endregion
 
 		public static AlternativeBulkCopy UseAlternativeBulkCopy = AlternativeBulkCopy.InsertAll;
-
-		[Obsolete("This field is not used by linq2db. Configure reader expressions on DataProvider directly")]
-		public static Func<DbDataReader,int,decimal> DataReaderGetDecimal = (dr, i) => dr.GetDecimal(i);
 
 		/// <summary>
 		/// Gets or sets flag to tell LinqToDB to quote identifiers, if they contain lowercase letters.

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLTools.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLTools.cs
@@ -144,23 +144,6 @@ namespace LinqToDB.DataProvider.PostgreSQL
 
 		public  static BulkCopyType  DefaultBulkCopyType { get; set; } = BulkCopyType.MultipleRows;
 
-		[Obsolete("Please use the BulkCopy extension methods within DataConnectionExtensions")]
-		public static BulkCopyRowsCopied MultipleRowsCopy<T>(
-			DataConnection              dataConnection,
-			IEnumerable<T>              source,
-			int                         maxBatchSize       = 1000,
-			Action<BulkCopyRowsCopied>? rowsCopiedCallback = null)
-			where T : class
-		{
-			return dataConnection.BulkCopy(
-				new BulkCopyOptions
-				{
-					BulkCopyType       = BulkCopyType.MultipleRows,
-					MaxBatchSize       = maxBatchSize,
-					RowsCopiedCallback = rowsCopiedCallback,
-				}, source);
-		}
-
 		#endregion
 	}
 }

--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteTools.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteTools.cs
@@ -164,23 +164,6 @@ namespace LinqToDB.DataProvider.SQLite
 
 		public  static BulkCopyType  DefaultBulkCopyType { get; set; } = BulkCopyType.MultipleRows;
 
-		[Obsolete("Please use the BulkCopy extension methods within DataConnectionExtensions")]
-		public static BulkCopyRowsCopied MultipleRowsCopy<T>(
-			DataConnection               dataConnection,
-			IEnumerable<T>               source,
-			int                          maxBatchSize       = 1000,
-			Action<BulkCopyRowsCopied>?  rowsCopiedCallback = null)
-			where T : class
-		{
-			return dataConnection.BulkCopy(
-				new BulkCopyOptions
-				{
-					BulkCopyType       = BulkCopyType.MultipleRows,
-					MaxBatchSize       = maxBatchSize,
-					RowsCopiedCallback = rowsCopiedCallback,
-				}, source);
-		}
-
 		#endregion
 	}
 }

--- a/Source/LinqToDB/DataProvider/SqlCe/SqlCeTools.cs
+++ b/Source/LinqToDB/DataProvider/SqlCe/SqlCeTools.cs
@@ -86,23 +86,6 @@ namespace LinqToDB.DataProvider.SqlCe
 
 		public  static BulkCopyType  DefaultBulkCopyType { get; set; } = BulkCopyType.MultipleRows;
 
-		[Obsolete("Please use the BulkCopy extension methods within DataConnectionExtensions")]
-		public static BulkCopyRowsCopied MultipleRowsCopy<T>(
-			DataConnection               dataConnection,
-			IEnumerable<T>               source,
-			int                          maxBatchSize       = 1000,
-			Action<BulkCopyRowsCopied>?  rowsCopiedCallback = null)
-			where T : class
-		{
-			return dataConnection.BulkCopy(
-				new BulkCopyOptions
-				{
-					BulkCopyType       = BulkCopyType.MultipleRows,
-					MaxBatchSize       = maxBatchSize,
-					RowsCopiedCallback = rowsCopiedCallback,
-				}, source);
-		}
-
 		#endregion
 	}
 }

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerTools.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerTools.cs
@@ -361,41 +361,11 @@ namespace LinqToDB.DataProvider.SqlServer
 
 		public  static BulkCopyType  DefaultBulkCopyType { get; set; } = BulkCopyType.ProviderSpecific;
 
-		[Obsolete("Please use the BulkCopy extension methods within DataConnectionExtensions")]
-		public static BulkCopyRowsCopied ProviderSpecificBulkCopy<T>(
-			DataConnection              dataConnection,
-			IEnumerable<T>              source,
-			int?                        maxBatchSize       = null,
-			int?                        bulkCopyTimeout    = null,
-			bool                        keepIdentity       = false,
-			bool                        checkConstraints   = false,
-			int                         notifyAfter        = 0,
-			Action<BulkCopyRowsCopied>? rowsCopiedCallback = null)
-			where T : class
-		{
-			return dataConnection.BulkCopy(
-				new BulkCopyOptions
-				{
-					BulkCopyType       = BulkCopyType.ProviderSpecific,
-					MaxBatchSize       = maxBatchSize,
-					BulkCopyTimeout    = bulkCopyTimeout,
-					KeepIdentity       = keepIdentity,
-					CheckConstraints   = checkConstraints,
-					NotifyAfter        = notifyAfter,
-					RowsCopiedCallback = rowsCopiedCallback,
-				}, source);
-		}
-
 #endregion
 
 		public static class Sql
 		{
 			public const string OptionRecompile = "OPTION(RECOMPILE)";
 		}
-
-		[Obsolete("This field is not used by linq2db. Configure reader expressions on DataProvider directly")]
-		public static Func<DbDataReader,int,decimal> DataReaderGetMoney   = (dr, i) => dr.GetDecimal(i);
-		[Obsolete("This field is not used by linq2db. Configure reader expressions on DataProvider directly")]
-		public static Func<DbDataReader,int,decimal> DataReaderGetDecimal = (dr, i) => dr.GetDecimal(i);
 	}
 }

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseTools.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseTools.cs
@@ -138,23 +138,6 @@ namespace LinqToDB.DataProvider.Sybase
 		/// </summary>
 		public static BulkCopyType DefaultBulkCopyType { get; set; } = BulkCopyType.MultipleRows;
 
-		[Obsolete("Please use the BulkCopy extension methods within DataConnectionExtensions")]
-		public static BulkCopyRowsCopied MultipleRowsCopy<T>(
-			DataConnection              dataConnection,
-			IEnumerable<T>              source,
-			int                         maxBatchSize       = 1000,
-			Action<BulkCopyRowsCopied>? rowsCopiedCallback = null)
-			where T : class
-		{
-			return dataConnection.BulkCopy(
-				new BulkCopyOptions
-				{
-					BulkCopyType       = BulkCopyType.MultipleRows,
-					MaxBatchSize       = maxBatchSize,
-					RowsCopiedCallback = rowsCopiedCallback,
-				}, source);
-		}
-
 		#endregion
 	}
 }


### PR DESCRIPTION
Remove code, marked with `[Obsolete]` attribute, except legacy merge API (guess why)