### PR TITLE
Fix for #2925. TempTable DisposeAsync improvements.

### DIFF
--- a/Source/LinqToDB/TempTable.cs
+++ b/Source/LinqToDB/TempTable.cs
@@ -624,7 +624,7 @@ namespace LinqToDB
 			return new ValueTask(_table.DropTableAsync(throwExceptionIfNotExists: false));
 		}
 #else
-		public Task DisposeAsync()
+		public virtual Task DisposeAsync()
 		{
 			return _table.DropTableAsync();
 		}

--- a/Source/LinqToDB/TempTable.cs
+++ b/Source/LinqToDB/TempTable.cs
@@ -626,7 +626,7 @@ namespace LinqToDB
 #else
 		public virtual Task DisposeAsync()
 		{
-			return _table.DropTableAsync();
+			return _table.DropTableAsync(throwExceptionIfNotExists: true);
 		}
 #endif
 	}


### PR DESCRIPTION
Fix #2925

- Mark `Task DisposeAsync` as virtual.
- Pass throwExceptionIfNotExists as true if NATIVE_ASYNC is false.