### PR TITLE
Cut down array copies

### DIFF
--- a/Source/LinqToDB/Common/ConvertBuilder.cs
+++ b/Source/LinqToDB/Common/ConvertBuilder.cs
@@ -246,7 +246,7 @@ namespace LinqToDB.Common
 
 					if (ambiguityMapping != null)
 					{
-						var enums = ambiguityMapping.ToArray();
+						var enums = ambiguityMapping.ToList();
 
 						return Expression.Convert(
 							Expression.Call(

--- a/Source/LinqToDB/Data/TraceInfo.cs
+++ b/Source/LinqToDB/Data/TraceInfo.cs
@@ -123,7 +123,7 @@ namespace LinqToDB.Data
 
 					sb.AppendLine();
 
-					sqlProvider.PrintParameters(sb, Command.Parameters.Cast<IDbDataParameter>().ToArray());
+					sqlProvider.PrintParameters(sb, Command.Parameters.Cast<IDbDataParameter>());
 
 					sb.AppendLine(Command.CommandText);
 

--- a/Source/LinqToDB/DataProvider/DB2/DB2LUWSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2LUWSchemaProvider.cs
@@ -287,8 +287,7 @@ WHERE
 							var format = string.Join(",",
 								type.CreateParameters
 									.Split(',')
-									.Select((p,i) => "{" + i + "}")
-									.ToArray());
+									.Select((p,i) => "{" + i + "}"));
 
 							type.CreateFormat = type.TypeName + "(" + format + ")";
 						}

--- a/Source/LinqToDB/Linq/Builder/EagerLoading.cs
+++ b/Source/LinqToDB/Linq/Builder/EagerLoading.cs
@@ -750,7 +750,7 @@ namespace LinqToDB.Linq.Builder
 				var prevKeys       = ExtractKeys(context, keyExpression).ToArray();
 				var subMasterKeys  = ExtractKeys(context, detailExpression).ToArray();
 
-				var prevKeysByParameter = ExtractTupleValues(keyExpression, ExpressionHelper.Property(masterParam, nameof(KeyDetailEnvelope<object, object>.Key))).ToArray();
+				var prevKeysByParameter = ExtractTupleValues(keyExpression, ExpressionHelper.Property(masterParam, nameof(KeyDetailEnvelope<object, object>.Key)));
 
 				var correctLookup = prevKeysByParameter.ToLookup(tv => tv.Item1, tv => tv.Item2, ExpressionEqualityComparer.Instance);
 				foreach (var key in prevKeys)
@@ -1015,8 +1015,8 @@ namespace LinqToDB.Linq.Builder
 						var mi1 = (MemberInitExpression)expr1;
 						var mi2 = (MemberInitExpression)expr2;
 
-						var b1 = mi1.Bindings.OfType<MemberAssignment>().ToArray();
-						var b2 = mi2.Bindings.OfType<MemberAssignment>().ToArray();
+						var b1 = mi1.Bindings.OfType<MemberAssignment>();
+						var b2 = mi2.Bindings.OfType<MemberAssignment>();
 
 						var found = b1.Join(b2, _ => _.Member, _ => _.Member, Tuple.Create);
 
@@ -1602,7 +1602,8 @@ namespace LinqToDB.Linq.Builder
 				{
 					var lambda = (LambdaExpression)e;
 					var newParameters = lambda.Parameters
-						.Select(p => Expression.Parameter(p.Type, "_" + p.Name)).ToArray();
+						.Select(p => Expression.Parameter(p.Type, "_" + p.Name))
+						.ToArray();
 					var newBody = lambda.Body.Transform(b =>
 					{
 						if (b.NodeType == ExpressionType.Parameter)

--- a/Source/LinqToDB/Linq/Builder/ExpressionTestGenerator.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionTestGenerator.cs
@@ -552,8 +552,8 @@ namespace LinqToDB.Linq.Builder
 			var ctors = type.GetConstructors().Select(c =>
 			{
 				var attrs = c.GetCustomAttributesData();
-				var attr  = string.Join(string.Empty, attrs.Select(a => "\r\n\t\t" + a.ToString()));
-				var ps    = c.GetParameters().Select(p => GetTypeName(p.ParameterType) + " " + MangleName(p.Name, "p")).ToArray();
+				var attr  = string.Concat(attrs.Select(a => "\r\n\t\t" + a.ToString()));
+				var ps    = c.GetParameters().Select(p => GetTypeName(p.ParameterType) + " " + MangleName(p.Name, "p"));
 
 				return string.Format(@"{0}
 		public {1}({2})
@@ -626,13 +626,13 @@ namespace LinqToDB.Linq.Builder
 				type.GetMethods().Intersect(_usedMembers.OfType<MethodInfo>()).Select(m =>
 				{
 					var attrs = m.GetCustomAttributesData();
-					var ps    = m.GetParameters().Select(p => GetTypeName(p.ParameterType) + " " + MangleName(p.Name, "p")).ToArray();
+					var ps    = m.GetParameters().Select(p => GetTypeName(p.ParameterType) + " " + MangleName(p.Name, "p"));
 					return string.Format(@"{0}
 		{5}{4}{1} {2}({3})
 		{{
 			throw new NotImplementedException();
 		}}",
-						string.Join(string.Empty, attrs.Select(a => "\r\n\t\t" + a.ToString())),
+						string.Concat(attrs.Select(a => "\r\n\t\t" + a.ToString())),
 						GetTypeName(m.ReturnType),
 						MangleName(isUserName, m.Name, "M"),
 						string.Join(", ", ps),

--- a/Source/LinqToDB/Linq/Builder/SelectContext.cs
+++ b/Source/LinqToDB/Linq/Builder/SelectContext.cs
@@ -464,8 +464,7 @@ namespace LinqToDB.Linq.Builder
 
 		SqlInfo[] ConvertExpressions(Expression expression, ConvertFlags flags, ColumnDescriptor? columnDescriptor)
 		{
-			return Builder.ConvertExpressions(this, expression, flags, columnDescriptor)
-				.ToArray();
+			return Builder.ConvertExpressions(this, expression, flags, columnDescriptor);
 		}
 
 		#endregion

--- a/Source/LinqToDB/Metadata/MetadataReader.cs
+++ b/Source/LinqToDB/Metadata/MetadataReader.cs
@@ -22,7 +22,7 @@ namespace LinqToDB.Metadata
 		{
 			if (readers == null)
 				throw new ArgumentNullException(nameof(readers));
-			_readers = readers.ToArray();
+			_readers = readers.ToList();
 		}
 
 		IList<IMetadataReader> _readers;
@@ -30,7 +30,9 @@ namespace LinqToDB.Metadata
 		internal void AddReader(IMetadataReader reader)
 		{
 			// creation of new list is cheaper than lock on each method call
-			_readers = new[] { reader }.Concat(_readers).ToArray();
+			var newReaders = new List<IMetadataReader>(_readers.Count + 1) { reader };
+			newReaders.AddRange(_readers);
+			_readers = newReaders;
 		}
 
 		public T[] GetAttributes<T>(Type type, bool inherit)

--- a/Source/LinqToDB/Metadata/SystemDataSqlServerAttributeReader.cs
+++ b/Source/LinqToDB/Metadata/SystemDataSqlServerAttributeReader.cs
@@ -78,11 +78,11 @@ namespace LinqToDB.Metadata
 											? memberInfo.DeclaringType.Name.ToLower().Substring(3)
 											: memberInfo.DeclaringType.Name.ToLower(),
 											((dynamic)ma[0]).Name ?? memberInfo.Name,
-										string.Join(", ", ps.Select((_, i) => '{' + i.ToString() + '}').ToArray()))
+										string.Join(", ", ps.Select((_, i) => '{' + i.ToString() + '}')))
 									:
 									string.Format("{{0}}.{0}({1})",
 											((dynamic)ma[0]).Name ?? memberInfo.Name,
-										string.Join(", ", ps.Select((_, i) => '{' + (i + 1).ToString() + '}').ToArray()));
+										string.Join(", ", ps.Select((_, i) => '{' + (i + 1).ToString() + '}')));
 
 								attrs = new[] { (T)(Attribute)new Sql.ExpressionAttribute(ex) { ServerSideOnly = true } };
 							}

--- a/Source/LinqToDB/SchemaProvider/SchemaProviderBase.cs
+++ b/Source/LinqToDB/SchemaProvider/SchemaProviderBase.cs
@@ -640,7 +640,7 @@ namespace LinqToDB.SchemaProvider
 				var ss = name.Split(new [] {' ', '\t'}, StringSplitOptions.RemoveEmptyEntries)
 					.Select(s => char.ToUpper(s[0]) + s.Substring(1));
 
-				name = string.Join("", ss.ToArray());
+				name = string.Concat(ss);
 			}
 
 			if (name.Length > 0 && char.IsDigit(name[0]))
@@ -787,12 +787,11 @@ namespace LinqToDB.SchemaProvider
 					if (name.EndsWith("_BackReference"))
 						name = name.Substring(0, name.Length - "_BackReference".Length);
 
-					name = string.Join("", name
+					name = string.Concat(name
 						.Split('_')
 						.Where(_ =>
 							_.Length > 0 && _ != table.TableName &&
-							(table.SchemaName == null || table.IsDefaultSchema || _ != table.SchemaName))
-						.ToArray());
+							(table.SchemaName == null || table.IsDefaultSchema || _ != table.SchemaName)));
 
 					var digitEnd = 0;
 					for (var i = name.Length - 1; i >= 0; i--)

--- a/Source/LinqToDB/SqlProvider/BasicSqlOptimizer.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlOptimizer.cs
@@ -2879,11 +2879,11 @@ namespace LinqToDB.SqlProvider
 				(q, _) => (q.Select.IsDistinct && !q.Select.OrderBy.IsEmpty && queryFilter(q)) /*|| q.Select.TakeValue != null || q.Select.SkipValue != null*/,
 				(p, q) =>
 				{
-					var columnItems  = q.Select.Columns.Select(c => c.Expression).ToArray();
-					var orderItems   = q.Select.OrderBy.Items.Select(o => o.Expression).ToArray();
+					var columnItems  = q.Select.Columns.Select(c => c.Expression).ToList();
+					var orderItems   = q.Select.OrderBy.Items.Select(o => o.Expression).ToList();
 
-					var projectionItems = columnItems.Union(orderItems).ToArray();
-					if (projectionItems.Length < columnItems.Length)
+					var projectionItemsCount = columnItems.Union(orderItems).Count();
+					if (projectionItemsCount < columnItems.Count)
 					{
 						// Sort columns not in projection, transforming to 
 						/*
@@ -2901,8 +2901,8 @@ namespace LinqToDB.SqlProvider
 						var orderBy = string.Join(", ",
 							orderByItems.Select((oi, i) =>
 								oi.IsDescending
-									? $"{{{i + columnItems.Length}}} DESC"
-									: $"{{{i + columnItems.Length}}}"));
+									? $"{{{i + columnItems.Count}}} DESC"
+									: $"{{{i + columnItems.Count}}}"));
 
 						var parameters = columnItems.Concat(orderByItems.Select(oi => oi.Expression)).ToArray();
 
@@ -2910,7 +2910,7 @@ namespace LinqToDB.SqlProvider
 							$"ROW_NUMBER() OVER (PARTITION BY {partitionBy} ORDER BY {orderBy})", Precedence.Primary,
 							SqlFlags.IsWindowFunction, parameters);
 
-						var additionalProjection = orderItems.Except(columnItems).ToArray();
+						var additionalProjection = orderItems.Except(columnItems);
 						foreach (var expr in additionalProjection)
 						{
 							q.Select.AddNew(expr);

--- a/Source/LinqToDB/SqlQuery/ConvertVisitor.cs
+++ b/Source/LinqToDB/SqlQuery/ConvertVisitor.cs
@@ -1475,7 +1475,7 @@ namespace LinqToDB.SqlQuery
 						list2 = new List<T[]>(list1.Count);
 
 						for (var j = 0; j < i; j++)
-							list2.Add(clone == null ? list1[j] : list1[j].Select(e => clone(e)).ToArray() );
+							list2.Add(clone == null ? list1[j] : list1[j].Select(e => clone(e)).ToArray());
 					}
 
 					list2.Add(elem2);


### PR DESCRIPTION
As I was reading parts of the codebase, I noticed some array copies that are not required and cut them down.

The codebase makes a heavy use of LINQ and array copies, this won't make a big change but it's a small improvement anyway.