### PR TITLE
Improve thread-safety

### DIFF
--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -581,11 +581,11 @@ namespace LinqToDB.Data
 		/// defaults to off unless library was built in debug mode.
 		/// <remarks>Should only be used when <see cref="TraceSwitchConnection"/> can not be used!</remarks>
 		/// </summary>
-		public  static TraceSwitch  TraceSwitch
+		public static TraceSwitch TraceSwitch
 		{
 			// used by LoggingExtensions
 			get => _traceSwitch;
-			set => _traceSwitch = value;
+			set => Volatile.Write(ref _traceSwitch, value);
 		}
 
 		/// <summary>

--- a/Source/LinqToDB/Metadata/MetadataReader.cs
+++ b/Source/LinqToDB/Metadata/MetadataReader.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 
 namespace LinqToDB.Metadata
 {
@@ -32,7 +33,7 @@ namespace LinqToDB.Metadata
 			// creation of new list is cheaper than lock on each method call
 			var newReaders = new List<IMetadataReader>(_readers.Count + 1) { reader };
 			newReaders.AddRange(_readers);
-			_readers = newReaders;
+			Volatile.Write(ref _readers, newReaders);
 		}
 
 		public T[] GetAttributes<T>(Type type, bool inherit)


### PR DESCRIPTION
The "Publish a ref atomically" pattern is safe only with a memory half-fence that prevents writes to be reordered after the publishing write (aka _Release Write_).

Otherwise compiler and hardware are free to reorder writes as long as it isn't noticeable on a single thread, which can lead to other threads seeing the published reference pointing to a partially initialized object.

Fixes #2940