### PR TITLE
Better nulls handling in Contains

### DIFF
--- a/Source/LinqToDB/Common/Configuration.cs
+++ b/Source/LinqToDB/Common/Configuration.cs
@@ -242,7 +242,7 @@ namespace LinqToDB.Common
 			/// SELECT * FROM MyEntity WHERE Value NOT IN (1, 2) AND Value IS NOT NULL
 			/// </code>
 			/// </example>
-			public static bool CheckNullInContains = true;
+			public static bool CheckNullsInContains = true;
 
 			/// <summary>
 			/// Controls behavior of LINQ query, which ends with GroupBy call.

--- a/Source/LinqToDB/Common/Configuration.cs
+++ b/Source/LinqToDB/Common/Configuration.cs
@@ -216,6 +216,32 @@ namespace LinqToDB.Common
 			public static bool CompareNullsAsValues = true;
 
 			/// <summary>
+			/// If set to true, expressions are checked for IS [NOT] NULL in conditions [NOT] IN (..)
+			/// when the list of values includes a null constant.
+			/// Default value: <c>true</c>.
+			/// </summary>
+			/// <example>
+			/// <code>
+			/// public class MyEntity
+			/// {
+			///		public int? Value;
+			///	}
+			///	
+			/// db.MyEntity.Where(e => e.Value.In(1, 2, null));
+			/// 
+			/// db.MyEntity.Where(e => e.Value.NotIn(1, 2, null));
+			/// </code>
+			/// 
+			/// Would be converted to next queries: 
+			/// <code>
+			/// SELECT * FROM MyEntity WHERE Value IN (1, 2) OR Value IS NULL
+			/// 
+			/// SELECT * FROM MyEntity WHERE Value NOT IN (1, 2) AND Value IS NOT NULL
+			/// </code>
+			/// </example>
+			public static bool CheckNullInContains = true;
+
+			/// <summary>
 			/// Controls behavior of LINQ query, which ends with GroupBy call.
 			/// - if <c>true</c> - <seealso cref="LinqToDBException"/> will be thrown for such queries;
 			/// - if <c>false</c> - behavior is controlled by <see cref="PreloadGroups"/> option.

--- a/Source/LinqToDB/Common/Configuration.cs
+++ b/Source/LinqToDB/Common/Configuration.cs
@@ -220,6 +220,9 @@ namespace LinqToDB.Common
 			/// when the list of values includes a null constant.
 			/// Default value: <c>true</c>.
 			/// </summary>
+			/// <remarks>
+			/// This behavior is implicitly <c>true</c> when <see cref="CompareNullsAsValues" /> is <c>true</c>.
+			/// </remarks>
 			/// <example>
 			/// <code>
 			/// public class MyEntity

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -2135,7 +2135,7 @@ namespace LinqToDB.SqlProvider
 		{
 			var firstValue      = true;
 			var len             = StringBuilder.Length;
-			var checkNull       = Configuration.Linq.CheckNullInContains || Configuration.Linq.CompareNullsAsValues;
+			var checkNull       = Configuration.Linq.CheckNullsInContains || Configuration.Linq.CompareNullsAsValues;
 			var hasNull         = false;
 			var count           = 0;
 			var multipleClauses = false;

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -2135,7 +2135,7 @@ namespace LinqToDB.SqlProvider
 		{
 			var firstValue      = true;
 			var len             = StringBuilder.Length;
-			var checkNull       = Configuration.Linq.CheckNullInContains;
+			var checkNull       = Configuration.Linq.CheckNullInContains || Configuration.Linq.CompareNullsAsValues;
 			var hasNull         = false;
 			var count           = 0;
 			var multipleClauses = false;

--- a/Source/LinqToDB/Tools/SqlExtensions.cs
+++ b/Source/LinqToDB/Tools/SqlExtensions.cs
@@ -12,10 +12,29 @@ namespace LinqToDB.Tools
 	{
 		#region In/NotIn
 
+		private static bool InNullCheck<T>(T value)
+		{
+			// When CheckNullInContains option is not set, evaluating `Sql.In(null, ...)` should always
+			// return false. Otherwise a regular C# comparison can be used.
+			// Note that we can't control the behavior of `Array.Contains` so when it is used client-side, C# behavior always applies.
+			return Common.Configuration.Linq.CheckNullInContains
+				|| value != null;
+		}
+
+		private static bool NotInNullCheck<T>(T value)
+		{
+			// When CompareNullsAsValues is not set, evaluating `Sql.NotIn(null, ...)` should always be false,
+			// except when CheckNullInContains is set and `null` is amongst the list of values.
+			// Note that we can't control the behavior of `Array.Contains` so when it is used client-side, C# behavior always applies.
+			return Common.Configuration.Linq.CompareNullsAsValues
+				|| Common.Configuration.Linq.CheckNullInContains
+				|| value != null;
+		}
+
 		[ExpressionMethod(nameof(InImpl1))]
 		public static bool In<T>(this T value, IEnumerable<T> sequence)
 		{
-			return sequence.Contains(value);
+			return InNullCheck(value) && sequence.Contains(value);
 		}
 
 		static Expression<Func<T,IEnumerable<T>,bool>> InImpl1<T>()
@@ -26,7 +45,7 @@ namespace LinqToDB.Tools
 		[ExpressionMethod(nameof(InImpl2))]
 		public static bool In<T>(this T value, IQueryable<T> sequence)
 		{
-			return sequence.Contains(value);
+			return InNullCheck(value) && sequence.Contains(value);
 		}
 
 		static Expression<Func<T,IQueryable<T>,bool>> InImpl2<T>()
@@ -37,7 +56,7 @@ namespace LinqToDB.Tools
 		[ExpressionMethod(nameof(InImpl3))]
 		public static bool In<T>(this T value, params T[] sequence)
 		{
-			return sequence.Contains(value);
+			return InNullCheck(value) && sequence.Contains(value);
 		}
 
 		static Expression<Func<T,T[],bool>> InImpl3<T>()
@@ -48,7 +67,9 @@ namespace LinqToDB.Tools
 		[ExpressionMethod(nameof(InImpl4))]
 		public static bool In<T>(this T value, T cmp1, T cmp2)
 		{
-			return object.Equals(value, cmp1) || object.Equals(value, cmp2);
+			var comparer = EqualityComparer<T>.Default;
+			return InNullCheck(value) && 
+				(comparer.Equals(value, cmp1) || comparer.Equals(value, cmp2));
 		}
 
 		static Expression<Func<T,T,T,bool>> InImpl4<T>()
@@ -59,7 +80,9 @@ namespace LinqToDB.Tools
 		[ExpressionMethod(nameof(InImpl5))]
 		public static bool In<T>(this T value, T cmp1, T cmp2, T cmp3)
 		{
-			return object.Equals(value, cmp1) || object.Equals(value, cmp2) || object.Equals(value, cmp3);
+			var comparer = EqualityComparer<T>.Default;
+			return InNullCheck(value) &&
+				(comparer.Equals(value, cmp1) || comparer.Equals(value, cmp2) || comparer.Equals(value, cmp3));
 		}
 
 		static Expression<Func<T,T,T,T,bool>> InImpl5<T>()
@@ -70,7 +93,7 @@ namespace LinqToDB.Tools
 		[ExpressionMethod(nameof(NotInImpl1))]
 		public static bool NotIn<T>(this T value, IEnumerable<T> sequence)
 		{
-			return !sequence.Contains(value);
+			return NotInNullCheck(value) && !sequence.Contains(value);
 		}
 
 		static Expression<Func<T,IEnumerable<T>,bool>> NotInImpl1<T>()
@@ -81,7 +104,7 @@ namespace LinqToDB.Tools
 		[ExpressionMethod(nameof(NotInImpl2))]
 		public static bool NotIn<T>(this T value, IQueryable<T> sequence)
 		{
-			return !sequence.Contains(value);
+			return NotInNullCheck(value) && !sequence.Contains(value);
 		}
 
 		static Expression<Func<T,IQueryable<T>,bool>> NotInImpl2<T>()
@@ -92,7 +115,7 @@ namespace LinqToDB.Tools
 		[ExpressionMethod(nameof(NotInImpl3))]
 		public static bool NotIn<T>(this T value, params T[] sequence)
 		{
-			return !sequence.Contains(value);
+			return NotInNullCheck(value) && !sequence.Contains(value);
 		}
 
 		static Expression<Func<T,T[],bool>> NotInImpl3<T>()
@@ -103,7 +126,9 @@ namespace LinqToDB.Tools
 		[ExpressionMethod(nameof(NotInImpl4))]
 		public static bool NotIn<T>(this T value, T cmp1, T cmp2)
 		{
-			return !object.Equals(value, cmp1) && !object.Equals(value, cmp2);
+			var comparer = EqualityComparer<T>.Default;
+			return NotInNullCheck(value) &&
+				(!comparer.Equals(value, cmp1) && !comparer.Equals(value, cmp2));
 		}
 
 		static Expression<Func<T,T,T,bool>> NotInImpl4<T>()
@@ -114,7 +139,9 @@ namespace LinqToDB.Tools
 		[ExpressionMethod(nameof(NotInImpl5))]
 		public static bool NotIn<T>(this T value, T cmp1, T cmp2, T cmp3)
 		{
-			return !object.Equals(value, cmp1) && !object.Equals(value, cmp2) && !object.Equals(value, cmp3);
+			var comparer = EqualityComparer<T>.Default;
+			return NotInNullCheck(value) &&
+				(!comparer.Equals(value, cmp1) && !comparer.Equals(value, cmp2) && !comparer.Equals(value, cmp3));
 		}
 
 		static Expression<Func<T,T,T,T,bool>> NotInImpl5<T>()

--- a/Source/LinqToDB/Tools/SqlExtensions.cs
+++ b/Source/LinqToDB/Tools/SqlExtensions.cs
@@ -14,20 +14,12 @@ namespace LinqToDB.Tools
 
 		private static bool InNullCheck<T>(T value)
 		{
-			// When CheckNullInContains option is not set, evaluating `Sql.In(null, ...)` should always
-			// return false. Otherwise a regular C# comparison can be used.
+			// When CheckNullInContains (or CompareNullsAsValues) option is not set,
+			// evaluating `Sql.In(null, ...)` and `Sql.NotIn(null, ...)` should always return false.
+			// Otherwise a regular C# comparison can be used.
 			// Note that we can't control the behavior of `Array.Contains` so when it is used client-side, C# behavior always applies.
 			return Common.Configuration.Linq.CheckNullInContains
-				|| value != null;
-		}
-
-		private static bool NotInNullCheck<T>(T value)
-		{
-			// When CompareNullsAsValues is not set, evaluating `Sql.NotIn(null, ...)` should always be false,
-			// except when CheckNullInContains is set and `null` is amongst the list of values.
-			// Note that we can't control the behavior of `Array.Contains` so when it is used client-side, C# behavior always applies.
-			return Common.Configuration.Linq.CompareNullsAsValues
-				|| Common.Configuration.Linq.CheckNullInContains
+				|| Common.Configuration.Linq.CompareNullsAsValues
 				|| value != null;
 		}
 
@@ -93,7 +85,7 @@ namespace LinqToDB.Tools
 		[ExpressionMethod(nameof(NotInImpl1))]
 		public static bool NotIn<T>(this T value, IEnumerable<T> sequence)
 		{
-			return NotInNullCheck(value) && !sequence.Contains(value);
+			return InNullCheck(value) && !sequence.Contains(value);
 		}
 
 		static Expression<Func<T,IEnumerable<T>,bool>> NotInImpl1<T>()
@@ -104,7 +96,7 @@ namespace LinqToDB.Tools
 		[ExpressionMethod(nameof(NotInImpl2))]
 		public static bool NotIn<T>(this T value, IQueryable<T> sequence)
 		{
-			return NotInNullCheck(value) && !sequence.Contains(value);
+			return InNullCheck(value) && !sequence.Contains(value);
 		}
 
 		static Expression<Func<T,IQueryable<T>,bool>> NotInImpl2<T>()
@@ -115,7 +107,7 @@ namespace LinqToDB.Tools
 		[ExpressionMethod(nameof(NotInImpl3))]
 		public static bool NotIn<T>(this T value, params T[] sequence)
 		{
-			return NotInNullCheck(value) && !sequence.Contains(value);
+			return InNullCheck(value) && !sequence.Contains(value);
 		}
 
 		static Expression<Func<T,T[],bool>> NotInImpl3<T>()
@@ -127,7 +119,7 @@ namespace LinqToDB.Tools
 		public static bool NotIn<T>(this T value, T cmp1, T cmp2)
 		{
 			var comparer = EqualityComparer<T>.Default;
-			return NotInNullCheck(value) &&
+			return InNullCheck(value) &&
 				(!comparer.Equals(value, cmp1) && !comparer.Equals(value, cmp2));
 		}
 
@@ -140,7 +132,7 @@ namespace LinqToDB.Tools
 		public static bool NotIn<T>(this T value, T cmp1, T cmp2, T cmp3)
 		{
 			var comparer = EqualityComparer<T>.Default;
-			return NotInNullCheck(value) &&
+			return InNullCheck(value) &&
 				(!comparer.Equals(value, cmp1) && !comparer.Equals(value, cmp2) && !comparer.Equals(value, cmp3));
 		}
 

--- a/Source/LinqToDB/Tools/SqlExtensions.cs
+++ b/Source/LinqToDB/Tools/SqlExtensions.cs
@@ -18,7 +18,7 @@ namespace LinqToDB.Tools
 			// evaluating `Sql.In(null, ...)` and `Sql.NotIn(null, ...)` should always return false.
 			// Otherwise a regular C# comparison can be used.
 			// Note that we can't control the behavior of `Array.Contains` so when it is used client-side, C# behavior always applies.
-			return Common.Configuration.Linq.CheckNullInContains
+			return Common.Configuration.Linq.CheckNullsInContains
 				|| Common.Configuration.Linq.CompareNullsAsValues
 				|| value != null;
 		}

--- a/Tests/Base/TestBase.cs
+++ b/Tests/Base/TestBase.cs
@@ -60,7 +60,7 @@ namespace Tests
 				return value;
 			}
 
-			public static Guid SequentialGuid(int n)  => new ($"233bf399-9710-4e79-873d-2ec7bf1e{n:x4}");
+			public static Guid SequentialGuid(int n) => new($"233bf399-9710-4e79-873d-2ec7bf1e{n:x4}");
 		}
 
 		private const int TRACES_LIMIT = 50000;
@@ -1071,7 +1071,7 @@ namespace Tests
 			AreEqual(t => t, expected, result, ComparerBuilder.GetEqualityComparer<T>());
 		}
 
-		protected void AreEqualWithComparer<T>(IEnumerable<T> expected, IEnumerable<T> result, Func<MemberAccessor,bool> memberPredicate)
+		protected void AreEqualWithComparer<T>(IEnumerable<T> expected, IEnumerable<T> result, Func<MemberAccessor, bool> memberPredicate)
 		{
 			AreEqual(t => t, expected, result, ComparerBuilder.GetEqualityComparer<T>(memberPredicate));
 		}
@@ -1126,7 +1126,7 @@ namespace Tests
 
 			if (exceptResult != 0 || exceptExpected != 0)
 			{
-				Debug.WriteLine(resultList.  ToDiagnosticString());
+				Debug.WriteLine(resultList  .ToDiagnosticString());
 				Debug.WriteLine(expectedList.ToDiagnosticString());
 
 				for (var i = 0; i < resultList.Count; i++)
@@ -1521,7 +1521,7 @@ namespace Tests
 
 		public DisableLogging()
 		{
-			_ctx   = CustomTestContext.Get();
+			_ctx      = CustomTestContext.Get();
 			_oldState = _ctx.Get<bool>(CustomTestContext.TRACE_DISABLED);
 			_ctx.Set(CustomTestContext.TRACE_DISABLED, true);
 		}
@@ -1609,6 +1609,20 @@ namespace Tests
 		public void Dispose()
 		{
 			Configuration.Linq.CompareNullsAsValues = true;
+			Query.ClearCaches();
+		}
+	}
+
+	public class WithoutContainsNullCheck : IDisposable
+	{
+		public WithoutContainsNullCheck()
+		{
+			Configuration.Linq.CheckNullInContains = false;
+		}
+
+		public void Dispose()
+		{
+			Configuration.Linq.CheckNullInContains = true;
 			Query.ClearCaches();
 		}
 	}

--- a/Tests/Base/TestBase.cs
+++ b/Tests/Base/TestBase.cs
@@ -1617,12 +1617,12 @@ namespace Tests
 	{
 		public WithoutContainsNullCheck()
 		{
-			Configuration.Linq.CheckNullInContains = false;
+			Configuration.Linq.CheckNullsInContains = false;
 		}
 
 		public void Dispose()
 		{
-			Configuration.Linq.CheckNullInContains = true;
+			Configuration.Linq.CheckNullsInContains = true;
 			Query.ClearCaches();
 		}
 	}

--- a/Tests/Linq/Linq/ContainsTests.cs
+++ b/Tests/Linq/Linq/ContainsTests.cs
@@ -44,7 +44,7 @@ namespace Tests.Linq
 			result.Should().Be(2);
 
 			result = FetchId(s => s.Int.NotIn(2, null));
-			result.Should().Be(withNullContains ? 0 : 1);
+			result.Should().Be(0);
 
 			result = FetchId(s => s.Int.NotIn(-1, 2));
 			result.Should().Be(withNullCompares ? 1 : 0);

--- a/Tests/Linq/Linq/ContainsTests.cs
+++ b/Tests/Linq/Linq/ContainsTests.cs
@@ -38,18 +38,18 @@ namespace Tests.Linq
 			int? result;
 
 			result = FetchId(s => s.Int.In(-1, null));
-			result.Should().Be(withNullContains ? 1 : null);
+			result.Should().Be(withNullContains ? 1 : 0);
 
 			result = FetchId(s => s.Int.In(-1, 2));
 			result.Should().Be(2);
 
 			result = FetchId(s => s.Int.NotIn(2, null));
-			result.Should().Be(withNullContains ? null : 1);
+			result.Should().Be(withNullContains ? 0 : 1);
 
 			result = FetchId(s => s.Int.NotIn(-1, 2));
-			result.Should().Be(withNullCompares ? 1 : null);
+			result.Should().Be(withNullCompares ? 1 : 0);
 
-			int? FetchId(Expression<Func<Src, bool>> predicate)
+			int FetchId(Expression<Func<Src, bool>> predicate)
 				=> src.Where(predicate).Select(x => x.Id).FirstOrDefault();
 		}
 
@@ -68,7 +68,7 @@ namespace Tests.Linq
 			count.Should().Be(0);
 
 			count = src.Count(s => s.Int.NotIn(Array.Empty<int?>()));
-			count.Should().Be(withNullCompares ? 2 : 1);
+			count.Should().Be(2);
 		}
 
 		private static (bool withNullCompares, bool withNullContains, int? x, int? y, bool @in, bool notIn)[] ClientSideValues = new[]

--- a/Tests/Linq/Linq/ContainsTests.cs
+++ b/Tests/Linq/Linq/ContainsTests.cs
@@ -85,30 +85,21 @@ namespace Tests.Linq
 			(false, false, (int?)null, (int?)null, false, false),
 		};
 
-		[Test, Sequential]
-		public void ClientSide(
-			[DataSources]                           string                               context,
-			[ValueSource(nameof(ClientSideValues))] (bool, bool, int?, int?, bool, bool) values)
+		[Test]
+		public void ClientSide([ValueSource(nameof(ClientSideValues))] (bool, bool, int?, int?, bool, bool) values)
 		{
 			var (withNullCompares, withNullContains, x, y, @in, notIn) = values;
 
 			using var null1 = withNullContains ? null : new WithoutContainsNullCheck();
 			using var nulls = withNullCompares ? null : new WithoutComparisonNullCheck();
-			using var db    = GetDataContext(context);
 
-			var src = db.SelectQuery(() => new { ID = 1 });
-			
 			bool result;
 
-			result = src.Any(s => x.In(-1, y));
+			result = x.In(-1, y);
 			result.Should().Be(@in);
-			if (db is DataConnection c1)
-				c1.LastQuery.Should().NotContain(" IN ");
 
-			result = src.Any(s => x.NotIn(-1, y));
+			result = x.NotIn(-1, y);
 			result.Should().Be(notIn);
-			if (db is DataConnection c2)
-				c2.LastQuery.Should().NotContain(" IN ");
 		}
 
 		class Src

--- a/Tests/Linq/Linq/ContainsTests.cs
+++ b/Tests/Linq/Linq/ContainsTests.cs
@@ -1,5 +1,4 @@
 ﻿using LinqToDB;
-using LinqToDB.Data;
 using LinqToDB.Tools;
 using NUnit.Framework;
 using System.Linq;
@@ -34,6 +33,9 @@ namespace Tests.Linq
 			using var null2 = withNullCompares ? null : new WithoutComparisonNullCheck();
 			using var db    = GetDataContext(context);
 			using var src   = SetupSrcTable(db);
+
+			// withNullContains is implicitely true when withNullCompares is true
+			withNullContains |= withNullCompares;
 
 			int? result;
 
@@ -80,7 +82,7 @@ namespace Tests.Linq
 			(true,  true,  1,          (int?)null, false, true ),
 			(true,  false, 1,          (int?)null, false, true ),
 			(true,  true,  (int?)null, (int?)null, true,  false),
-			(true,  false, (int?)null, (int?)null, false, true ),
+			(true,  false, (int?)null, (int?)null, true,  false),
 			(false, true,  (int?)null, (int?)null, true,  false),
 			(false, false, (int?)null, (int?)null, false, false),
 		};

--- a/Tests/Linq/Linq/ContainsTests.cs
+++ b/Tests/Linq/Linq/ContainsTests.cs
@@ -1,0 +1,120 @@
+﻿using LinqToDB;
+using LinqToDB.Data;
+using LinqToDB.Tools;
+using NUnit.Framework;
+using System.Linq;
+using FluentAssertions;
+using System.Linq.Expressions;
+using System;
+
+namespace Tests.Linq
+{
+	[TestFixture]
+	public class ContainsTests : TestBase
+	{
+		private TempTable<Src> SetupSrcTable(IDataContext db)
+		{
+			var data = new[]
+			{
+				new Src { Id = 1, Int = null },
+				new Src { Id = 2, Int = 2 },
+			};
+
+			var src  = db.CreateLocalTable(data);
+			return src;
+		}
+
+		[Test]
+		public void Functional(
+			[DataSources]         string context, 
+			[Values(true, false)] bool   withNullContains,
+			[Values(true, false)] bool   withNullCompares)
+		{
+			using var null1 = withNullContains ? null : new WithoutContainsNullCheck();
+			using var null2 = withNullCompares ? null : new WithoutComparisonNullCheck();
+			using var db    = GetDataContext(context);
+			using var src   = SetupSrcTable(db);
+
+			int? result;
+
+			result = FetchId(s => s.Int.In(-1, null));
+			result.Should().Be(withNullContains ? 1 : null);
+
+			result = FetchId(s => s.Int.In(-1, 2));
+			result.Should().Be(2);
+
+			result = FetchId(s => s.Int.NotIn(2, null));
+			result.Should().Be(withNullContains ? null : 1);
+
+			result = FetchId(s => s.Int.NotIn(-1, 2));
+			result.Should().Be(withNullCompares ? 1 : null);
+
+			int? FetchId(Expression<Func<Src, bool>> predicate)
+				=> src.Where(predicate).Select(x => x.Id).FirstOrDefault();
+		}
+
+		[Test]
+		public void Empty(
+			[DataSources]         string context,
+			[Values(true, false)] bool   withNullCompares)
+		{
+			using var nulls = withNullCompares ? null : new WithoutComparisonNullCheck();
+			using var db    = GetDataContext(context);
+			using var src   = SetupSrcTable(db);
+
+			int count; 
+			
+			count = src.Count(s => s.Int.In(Array.Empty<int?>()));
+			count.Should().Be(0);
+
+			count = src.Count(s => s.Int.NotIn(Array.Empty<int?>()));
+			count.Should().Be(withNullCompares ? 2 : 1);
+		}
+
+		private static (bool withNullCompares, bool withNullContains, int? x, int? y, bool @in, bool notIn)[] ClientSideValues = new[]
+		{
+			(true,  true,  1,          1,          true,  false),
+			(true,  true,  2,          1,          false, true ),
+			(true,  true,  (int?)null, 1,          false, true ),
+			(false, true,  (int?)null, 1,          false, false),
+			(true,  true,  1,          (int?)null, false, true ),
+			(true,  false, 1,          (int?)null, false, true ),
+			(true,  true,  (int?)null, (int?)null, true,  false),
+			(true,  false, (int?)null, (int?)null, false, true ),
+			(false, true,  (int?)null, (int?)null, true,  false),
+			(false, false, (int?)null, (int?)null, false, false),
+		};
+
+		[Test, Sequential]
+		public void ClientSide(
+			[DataSources]                           string                               context,
+			[ValueSource(nameof(ClientSideValues))] (bool, bool, int?, int?, bool, bool) values)
+		{
+			var (withNullCompares, withNullContains, x, y, @in, notIn) = values;
+
+			using var null1 = withNullContains ? null : new WithoutContainsNullCheck();
+			using var nulls = withNullCompares ? null : new WithoutComparisonNullCheck();
+			using var db    = GetDataContext(context);
+
+			var src = db.SelectQuery(() => new { ID = 1 });
+			
+			bool result;
+
+			result = src.Any(s => x.In(-1, y));
+			result.Should().Be(@in);
+			if (db is DataConnection c1)
+				c1.LastQuery.Should().NotContain(" IN ");
+
+			result = src.Any(s => x.NotIn(-1, y));
+			result.Should().Be(notIn);
+			if (db is DataConnection c2)
+				c2.LastQuery.Should().NotContain(" IN ");
+		}
+
+		class Src
+		{
+			public int  Id  { get; set; }
+			public int? Int { get; set; }
+		}
+	}
+}


### PR DESCRIPTION
1. LinqToDb attempts to sniff `null` constants in `Sql.In` arguments and include them in a comparison (with `x IN (1,2) or x IS NULL` and `x NOT IN (1, 2) and x IS NOT NULL`). 
This is a non-standard SQL behavior that really should have been behind `CompareNullsAsValues`, but it is not. To not break backwards compatiblity, I created a new configuration to disable it: `CheckNullsInContains`.
The case `null not in (null)` can become just too confusing, so implicitly if `CompareNullsAsValues` is true, then `CheckNullsInContains` is implicitly true as well.

I did include client-side support to keep things coherent. This applies to `Sql.In`, but not to `Array.Contains` of course, whose client-side behavior is defined by C#.

I noticed regular LinqToDb code makes use of `Sql.In` internally as a helper method, which isn't great esp. if its exact behaviour depends on user configuration. I did a review of all usages and none passes `null` as a list value, so that's ok.

 2. I fixed a bug in SQL builder where negated IN translated `a not in (1, null)` into `a not in (1) or a is not null` which is incorrect because it's true for `1`. The correct version is `a not in (1) and a is not null`.

3. Removed a case of double parens `(())`

4. Added a bunch of tests for those cases.