### PR TITLE
Add Sql.Default<T>()

### DIFF
--- a/Source/LinqToDB/Sql/Sql.cs
+++ b/Source/LinqToDB/Sql/Sql.cs
@@ -37,7 +37,7 @@ namespace LinqToDB
 		/// Generates 'DEFAULT' keyword, usable in inserts.
 		/// </summary>
 		[Expression("DEFAULT", ServerSideOnly = true)]
-		public static T Default<T>() => throw new NotImplementedException();
+		public static T Default<T>() => throw new LinqException($"{nameof(Default<int>)} is only server-side method.");
 
 		/// <summary>
 		/// Enforces generating SQL even if an expression can be calculated locally.

--- a/Source/LinqToDB/Sql/Sql.cs
+++ b/Source/LinqToDB/Sql/Sql.cs
@@ -37,7 +37,7 @@ namespace LinqToDB
 		/// Generates 'DEFAULT' keyword, usable in inserts.
 		/// </summary>
 		[Expression("DEFAULT", ServerSideOnly = true)]
-		public static T Default<T>() => throw new LinqException($"{nameof(Default<int>)} is only server-side method.");
+		public static T Default<T>() => throw new LinqException($"Default is only server-side method.");
 
 		/// <summary>
 		/// Enforces generating SQL even if an expression can be calculated locally.

--- a/Source/LinqToDB/Sql/Sql.cs
+++ b/Source/LinqToDB/Sql/Sql.cs
@@ -34,6 +34,12 @@ namespace LinqToDB
 		}
 
 		/// <summary>
+		/// Generates 'DEFAULT' keyword, usable in inserts.
+		/// </summary>
+		[Expression("DEFAULT", ServerSideOnly = true)]
+		public static T Default<T>() => throw new NotImplementedException();
+
+		/// <summary>
 		/// Enforces generating SQL even if an expression can be calculated locally.
 		/// </summary>
 		/// <typeparam name="T"></typeparam>

--- a/Tests/Base/TestProvName.cs
+++ b/Tests/Base/TestProvName.cs
@@ -71,6 +71,7 @@ namespace Tests
 		public const string AllOracle11            = "Oracle.11.Native,Oracle.11.Managed";
 		public const string AllOracle12            = "Oracle.Native,Oracle.Managed";
 		public const string AllFirebird            = ProviderName.Firebird + "," + Firebird3 +"," + Firebird4;
+		public const string AllFirebirdLess4       = ProviderName.Firebird + "," + Firebird3;
 		public const string AllSQLite              = "SQLite.Classic,SQLite.MS,SQLite.Classic.MPU,SQLite.Classic.MPM";
 		public const string AllSQLiteClassic       = "SQLite.Classic,SQLite.Classic.MPU,SQLite.Classic.MPM";
 		public const string AllSybase              = "Sybase,Sybase.Managed";

--- a/Tests/Linq/Update/InsertTests.cs
+++ b/Tests/Linq/Update/InsertTests.cs
@@ -1609,11 +1609,11 @@ namespace Tests.xUpdate
 		// see https://github.com/linq2db/linq2db/pull/2954#issuecomment-821798021
 		[Test]
 		public void InsertDefault([DataSources(
-			TestProvName.AllMySql, 
-			TestProvName.AllPostgreSQL, 
-			TestProvName.AllOracle, 
-			TestProvName.Sybase, 
-			TestProvName.AllSqlServer)] string context)
+			TestProvName.AllAccess, 
+			TestProvName.AllFirebird, 
+			TestProvName.AllInformix, 
+			TestProvName.AllSapHana, 
+			TestProvName.AllSQLite)] string context)
 		{
 			using var db = GetDataContext(context);
 			try

--- a/Tests/Linq/Update/InsertTests.cs
+++ b/Tests/Linq/Update/InsertTests.cs
@@ -1606,6 +1606,26 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
+		public void InsertDefault([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+			try
+			{
+				db.Person.Insert(() => new Person
+				{
+					FirstName = "InsertDefault",
+					MiddleName = Sql.Default<string>(),
+					LastName = "InsertDefault",
+					Gender = Gender.Male,
+				});
+			}
+			finally
+			{
+				db.Person.Delete(p => p.FirstName == "InsertDefault");
+			}
+		}
+
+		[Test]
 		public void InsertSingleIdentity([DataSources(
 			TestProvName.AllInformix, ProviderName.SqlCe, TestProvName.AllSapHana)]
 			string context)

--- a/Tests/Linq/Update/InsertTests.cs
+++ b/Tests/Linq/Update/InsertTests.cs
@@ -1613,10 +1613,10 @@ namespace Tests.xUpdate
 			{
 				db.Person.Insert(() => new Person
 				{
-					FirstName = "InsertDefault",
+					FirstName  = "InsertDefault",
 					MiddleName = Sql.Default<string>(),
-					LastName = "InsertDefault",
-					Gender = Gender.Male,
+					LastName   = "InsertDefault",
+					Gender     = Gender.Male,
 				});
 			}
 			finally

--- a/Tests/Linq/Update/InsertTests.cs
+++ b/Tests/Linq/Update/InsertTests.cs
@@ -1609,10 +1609,10 @@ namespace Tests.xUpdate
 		// see https://github.com/linq2db/linq2db/pull/2954#issuecomment-821798021
 		[Test]
 		public void InsertDefault([DataSources(
-			TestProvName.AllAccess, 
-			TestProvName.AllFirebird, 
-			TestProvName.AllInformix, 
-			TestProvName.AllSapHana, 
+			TestProvName.AllAccess,
+			TestProvName.AllFirebirdLess4,
+			TestProvName.AllInformix,
+			TestProvName.AllSapHana,
 			TestProvName.AllSQLite)] string context)
 		{
 			using var db = GetDataContext(context);

--- a/Tests/Linq/Update/InsertTests.cs
+++ b/Tests/Linq/Update/InsertTests.cs
@@ -1605,8 +1605,15 @@ namespace Tests.xUpdate
 			}
 		}
 
+		// Access, SQLite, Firebird before v4, Informix and SAP Hana do not support DEFAULT in inserted values, 
+		// see https://github.com/linq2db/linq2db/pull/2954#issuecomment-821798021
 		[Test]
-		public void InsertDefault([DataSources] string context)
+		public void InsertDefault([DataSources(
+			TestProvName.AllMySql, 
+			TestProvName.AllPostgreSQL, 
+			TestProvName.AllOracle, 
+			TestProvName.Sybase, 
+			TestProvName.AllSqlServer)] string context)
 		{
 			using var db = GetDataContext(context);
 			try


### PR DESCRIPTION
This PR adds an extension to use the SQL `DEFAULT` keyword.
This keyword can be used as an insert value, for example:
```csharp
db.T.Insert(() => new T 
{
  Id = Sql.Default<int>(),
  Name = "Joe",
});
```
Generates:
```sql
insert into T (id, name)
values (default, "Joe")
```
Default is useful when you need to explicitly insert a non-null value but the DB decides what the value actually is, e.g.:
- Identities, sequences;
- Default constraints;
- Triggers.
