### PR TITLE
Add missing Blob datatype mapping

### DIFF
--- a/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
@@ -250,6 +250,7 @@ namespace LinqToDB.DataProvider.Oracle
 				case DataType.NText    : type = OracleProviderAdapter.OracleDbType.NClob       ; break;
 				case DataType.Image    :
 				case DataType.Binary   :
+				case DataType.Blob     :
 				case DataType.VarBinary: type = OracleProviderAdapter.OracleDbType.Blob        ; break;
 				case DataType.Cursor   : type = OracleProviderAdapter.OracleDbType.RefCursor   ; break;
 				case DataType.NVarChar : type = OracleProviderAdapter.OracleDbType.NVarchar2   ; break;

--- a/Tests/Linq/DataProvider/OracleTests.cs
+++ b/Tests/Linq/DataProvider/OracleTests.cs
@@ -3824,7 +3824,7 @@ CREATE TABLE ""TABLE_A""(
 			// Implicit OracleBlob support, no attribute
 			public OracleBlob? BinaryValue { get; set; }
 			// Explicit attribute with DataType = Blob
-			[Column("BINARYVALUE", DataType = DataType.Blob)]
+			[Column("BinaryValue", DataType = DataType.Blob)]
 			public OracleBlob? Blob { get; set; }
 		}
 		

--- a/Tests/Linq/DataProvider/OracleTests.cs
+++ b/Tests/Linq/DataProvider/OracleTests.cs
@@ -3845,7 +3845,7 @@ CREATE TABLE ""TABLE_A""(
 			var inserted = db
 				.GetTable<LinqDataTypesBlobs>()
 				.Where(x => x.ID.In(-10, -20))
-				.Select(x => Sql.Expr<int>("LENGTH(BINARYVALUE)"))
+				.Select(x => Sql.Expr<int>("LENGTH(\"BinaryValue\")"))
 				.ToList();
 
 			tx.Rollback();

--- a/Tests/Linq/DataProvider/OracleTests.cs
+++ b/Tests/Linq/DataProvider/OracleTests.cs
@@ -3817,7 +3817,7 @@ CREATE TABLE ""TABLE_A""(
 			}
 		}
 	
-		[Table("LINQDATATYPES", IsColumnAttributeRequired = false)]
+		[Table("LinqDataTypes", IsColumnAttributeRequired = false)]
 		class LinqDataTypesBlobs
 		{
 			public int ID { get; set; }

--- a/Tests/Linq/DataProvider/OracleTests.cs
+++ b/Tests/Linq/DataProvider/OracleTests.cs
@@ -3850,7 +3850,7 @@ CREATE TABLE ""TABLE_A""(
 
 			tx.Rollback();
 
-			inserted.Should().BeSameAs(new[] { 1, 1 });
+			inserted.Should().Equal(1, 1);
 		}
 	}
 }


### PR DESCRIPTION
Just a forgotten mapping that prevents `OracleBlob` from working smoothly.