### PR TITLE
Use Oracle date/timestamp literals instead of functions

### DIFF
--- a/Source/LinqToDB/DataProvider/Oracle/OracleMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleMappingSchema.cs
@@ -110,22 +110,22 @@ namespace LinqToDB.DataProvider.Oracle
 			switch (dataType.Type.DataType)
 			{
 				case DataType.Date:
-					format = "TO_DATE('{0:yyyy-MM-dd}', 'YYYY-MM-DD')";
+					format = "DATE '{0:yyyy-MM-dd}'";
 					break;
 				case DataType.DateTime2:
 					switch (dataType.Type.Precision)
 					{
-						case 0: format = "TO_TIMESTAMP('{0:yyyy-MM-dd HH:mm:ss}', 'YYYY-MM-DD HH24:MI:SS')"              ; break;
-						case 1: format = "TO_TIMESTAMP('{0:yyyy-MM-dd HH:mm:ss.f}', 'YYYY-MM-DD HH24:MI:SS.FF1')"        ; break;
-						case 2: format = "TO_TIMESTAMP('{0:yyyy-MM-dd HH:mm:ss.ff}', 'YYYY-MM-DD HH24:MI:SS.FF2')"       ; break;
-						case 3: format = "TO_TIMESTAMP('{0:yyyy-MM-dd HH:mm:ss.fff}', 'YYYY-MM-DD HH24:MI:SS.FF3')"      ; break;
-						case 4: format = "TO_TIMESTAMP('{0:yyyy-MM-dd HH:mm:ss.ffff}', 'YYYY-MM-DD HH24:MI:SS.FF4')"     ; break;
-						case 5: format = "TO_TIMESTAMP('{0:yyyy-MM-dd HH:mm:ss.fffff}', 'YYYY-MM-DD HH24:MI:SS.FF5')"    ; break;
+						case 0: format = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss}'"          ; break;
+						case 1: format = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.f}'"        ; break;
+						case 2: format = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.ff}'"       ; break;
+						case 3: format = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.fff}'"      ; break;
+						case 4: format = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.ffff}'"     ; break;
+						case 5: format = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.fffff}'"    ; break;
 						default:
-						case 6: format = "TO_TIMESTAMP('{0:yyyy-MM-dd HH:mm:ss.ffffff}', 'YYYY-MM-DD HH24:MI:SS.FF6')"   ; break;
+						case 6: format = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.ffffff}'"   ; break;
 						case 7: // .net types doesn't support more than 7 digits, so it doesn't make sense to generate 8/9
 						case 8:
-						case 9: format = "TO_TIMESTAMP('{0:yyyy-MM-dd HH:mm:ss.fffffff}', 'YYYY-MM-DD HH24:MI:SS.FF7')"  ; break;
+						case 9: format = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.fffffff}'"  ; break;
 					}
 					break;
 				case DataType.DateTimeOffset:
@@ -133,17 +133,17 @@ namespace LinqToDB.DataProvider.Oracle
 					value = value.ToUniversalTime();
 					switch (dataType.Type.Precision)
 					{
-						case 0: format = "TO_TIMESTAMP_TZ('{0:yyyy-MM-dd HH:mm:ss} 00:00', 'YYYY-MM-DD HH24:MI:SS TZH:TZM')"            ; break;
-						case 1: format = "TO_TIMESTAMP_TZ('{0:yyyy-MM-dd HH:mm:ss.f} 00:00', 'YYYY-MM-DD HH24:MI:SS.FF1 TZH:TZM')"      ; break;
-						case 2: format = "TO_TIMESTAMP_TZ('{0:yyyy-MM-dd HH:mm:ss.ff} 00:00', 'YYYY-MM-DD HH24:MI:SS.FF2 TZH:TZM')"     ; break;
-						case 3: format = "TO_TIMESTAMP_TZ('{0:yyyy-MM-dd HH:mm:ss.fff} 00:00', 'YYYY-MM-DD HH24:MI:SS.FF3 TZH:TZM')"    ; break;
-						case 4: format = "TO_TIMESTAMP_TZ('{0:yyyy-MM-dd HH:mm:ss.ffff} 00:00', 'YYYY-MM-DD HH24:MI:SS.FF4 TZH:TZM')"   ; break;
-						case 5: format = "TO_TIMESTAMP_TZ('{0:yyyy-MM-dd HH:mm:ss.fffff} 00:00', 'YYYY-MM-DD HH24:MI:SS.FF5 TZH:TZM')"  ; break;
+						case 0: format = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss} +00:00'"        ; break;
+						case 1: format = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.f} +00:00'"      ; break;
+						case 2: format = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.ff} +00:00'"     ; break;
+						case 3: format = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.fff} +00:00'"    ; break;
+						case 4: format = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.ffff} +00:00'"   ; break;
+						case 5: format = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.fffff} +00:00'"  ; break;
 						default:
-						case 6: format = "TO_TIMESTAMP_TZ('{0:yyyy-MM-dd HH:mm:ss.ffffff} 00:00', 'YYYY-MM-DD HH24:MI:SS.FF6 TZH:TZM')" ; break;
+						case 6: format = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.ffffff} +00:00'" ; break;
 						case 7:
 						case 8:
-						case 9: format = "TO_TIMESTAMP_TZ('{0:yyyy-MM-dd HH:mm:ss.fffffff} 00:00', 'YYYY-MM-DD HH24:MI:SS.FF7 TZH:TZM')"; break;
+						case 9: format = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.fffffff} +00:00'"; break;
 					}
 					break;
 				case DataType.DateTime:

--- a/Tests/Linq/DataProvider/OracleTests.cs
+++ b/Tests/Linq/DataProvider/OracleTests.cs
@@ -3386,37 +3386,37 @@ namespace Tests.DataProvider
 				var pDateTimeOffset = new DateTimeOffset(2020, 1, 3, 4, 5, 6, 789, TimeSpan.FromMinutes(45)).AddTicks(1234);
 
 				var results = table.Where(r => r.Date == pDate).ToArray();
-				assert("TO_DATE('2020-01-03', 'YYYY-MM-DD')");
+				assert("DATE '2020-01-03'");
 
 				results = table.Where(r => r.DateTime == pDateTime).ToArray();
-				assert("TO_TIMESTAMP('2020-01-03 04:05:06.789123', 'YYYY-MM-DD HH24:MI:SS.FF6')");
+				assert("TIMESTAMP '2020-01-03 04:05:06.789123'");
 
 				results = table.Where(r => r.DateTime_ == pDateTime).ToArray();
 				assert("TO_DATE('2020-01-03 04:05:06', 'YYYY-MM-DD HH24:MI:SS')");
 
 				results = table.Where(r => r.DateTime2 == pDateTime).ToArray();
-				assert("TO_TIMESTAMP('2020-01-03 04:05:06.789123', 'YYYY-MM-DD HH24:MI:SS.FF6')");
+				assert("TIMESTAMP '2020-01-03 04:05:06.789123'");
 
 				results = table.Where(r => r.DateTime2_0 == pDateTime).ToArray();
-				assert("TO_TIMESTAMP('2020-01-03 04:05:06', 'YYYY-MM-DD HH24:MI:SS')");
+				assert("TIMESTAMP '2020-01-03 04:05:06'");
 
 				results = table.Where(r => r.DateTime2_1 == pDateTime).ToArray();
-				assert("TO_TIMESTAMP('2020-01-03 04:05:06.7', 'YYYY-MM-DD HH24:MI:SS.FF1')");
+				assert("TIMESTAMP '2020-01-03 04:05:06.7'");
 
 				results = table.Where(r => r.DateTime2_9 == pDateTime).ToArray();
-				assert("TO_TIMESTAMP('2020-01-03 04:05:06.7891234', 'YYYY-MM-DD HH24:MI:SS.FF7')");
+				assert("TIMESTAMP '2020-01-03 04:05:06.7891234'");
 
 				results = table.Where(r => r.DateTimeOffset_ == pDateTimeOffset).ToArray();
-				assert("TO_TIMESTAMP_TZ('2020-01-03 03:20:06.789123 00:00', 'YYYY-MM-DD HH24:MI:SS.FF6 TZH:TZM')");
+				assert("TIMESTAMP '2020-01-03 03:20:06.789123 +00:00'");
 
 				results = table.Where(r => r.DateTimeOffset_0 == pDateTimeOffset).ToArray();
-				assert("TO_TIMESTAMP_TZ('2020-01-03 03:20:06 00:00', 'YYYY-MM-DD HH24:MI:SS TZH:TZM')");
+				assert("TIMESTAMP '2020-01-03 03:20:06 +00:00'");
 
 				results = table.Where(r => r.DateTimeOffset_1 == pDateTimeOffset).ToArray();
-				assert("TO_TIMESTAMP_TZ('2020-01-03 03:20:06.7 00:00', 'YYYY-MM-DD HH24:MI:SS.FF1 TZH:TZM')");
+				assert("TIMESTAMP '2020-01-03 03:20:06.7 +00:00'");
 
 				results = table.Where(r => r.DateTimeOffset_9 == pDateTimeOffset).ToArray();
-				assert("TO_TIMESTAMP_TZ('2020-01-03 03:20:06.7891234 00:00', 'YYYY-MM-DD HH24:MI:SS.FF7 TZH:TZM')");
+				assert("TIMESTAMP '2020-01-03 03:20:06.7891234 +00:00'");
 
 				void assert(string function)
 				{


### PR DESCRIPTION
Oracle supports ANSI SQL dates literal, as well as timestamp literals, which are shorter and more readable then calling parsing functions:
- `DATE '2020-01-01'`
- `TIMESTAMP '2020-01-01 10:30:00.1234567 +00:00'`

Sadly, there's no such literal for dates with times, so this has to stay as `TO_DATE('2020-01-01 10:00:00', 'YYYY-MON-DD HH24:MIN-SS')`