### PR TITLE
Update dependencies

### DIFF
--- a/Build/Azure/README.md
+++ b/Build/Azure/README.md
@@ -93,10 +93,10 @@ Legend:
 |MS SQL Server 2019<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.2<br>with FTS Tests|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|
 |Azure SQL<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.2|:x:|:x:|:x:|:x:|
 |Azure SQL<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.2|:x:|:x:|:x:|:x:|
-|MySQL 5.6<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.21|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|MySQL 8<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.21|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|MySQL 5.6<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.24|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|MySQL 8<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.24|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |MySQL 8<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 1.3.3|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|MariaDB 10<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.21|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+|MariaDB 10<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.24|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |PostgreSQL 9.2<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.4 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |PostgreSQL 9.3<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.4 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |PostgreSQL 9.5<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.4 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|

--- a/Build/Azure/README.md
+++ b/Build/Azure/README.md
@@ -95,7 +95,7 @@ Legend:
 |Azure SQL<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.2|:x:|:x:|:x:|:x:|
 |MySQL 5.6<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.24|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |MySQL 8<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.24|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|MySQL 8<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 1.3.3|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|MySQL 8<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 1.3.4|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |MariaDB 10<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.24|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |PostgreSQL 9.2<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.4 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |PostgreSQL 9.3<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.4 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|

--- a/Build/linq2db.Tests.Providers.props
+++ b/Build/linq2db.Tests.Providers.props
@@ -25,4 +25,24 @@
 		</None>
 	</ItemGroup>
 
+	<!--https://github.com/microsoft/vstest/issues/2814-->
+	<Target Name="TestFxIssue790Workaround" AfterTargets="ResolvePackageAssets">
+		<ItemGroup>
+			<_AssetListForConflictResolution
+					Include="@(RuntimeCopyLocalItems);
+					   @(Reference);
+					   @(NativeCopyLocalItems);
+					   @(ResourceCopyLocalItems);
+					   @(RuntimeTargetsCopyLocalItems);
+					   @(ReferenceCopyLocalPaths)" />
+
+			<AssetsToRemove Include="@(_AssetListForConflictResolution->WithMetadataValue('NuGetPackageId', 'Microsoft.TestPlatform.ObjectModel'))"
+							Condition="'%(FileName)' == 'Microsoft.TestPlatform.PlatformAbstractions'" />
+
+			<Reference Remove="@(AssetsToRemove)" />
+			<RuntimeCopyLocalItems Remove="@(AssetsToRemove)" />
+			<ResolvedCompileFileDefinitions Remove="@(AssetsToRemove)" />
+		</ItemGroup>
+	</Target>
+
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,7 +28,7 @@
 		<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
 
 		<!--data providers-->
-		<PackageVersion Include="MySql.Data" Version="8.0.21" />
+		<PackageVersion Include="MySql.Data" Version="8.0.24" />
 		<PackageVersion Include="System.Data.SQLite.Core" Version="1.0.113.7" />
 		<PackageVersion Include="MySqlConnector" Version="1.3.3" />
 		<PackageVersion Include="AdoNetCore.AseClient" Version="0.19.2" />
@@ -46,8 +46,8 @@
 		<PackageVersion Include="MiniProfiler.Shared" Version="4.2.22" />
 		<PackageVersion Include="NUnit" Version="3.13.1" />
 		<PackageVersion Include="NUnit3TestAdapter" Version="4.0.0-beta.2" />
-		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-		<PackageVersion Include="FastExpressionCompiler" Version="3.0.4" />
+		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+		<PackageVersion Include="FastExpressionCompiler" Version="3.0.5" />
 		<PackageVersion Include="BenchmarkDotNet" Version="0.12.1" />
 		<PackageVersion Include="JetBrains.Profiler.Api" Version="1.1.7" />
 		<PackageVersion Include="Humanizer.Core" Version="2.8.26" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,7 @@
 		<!--data providers-->
 		<PackageVersion Include="MySql.Data" Version="8.0.24" />
 		<PackageVersion Include="System.Data.SQLite.Core" Version="1.0.113.7" />
-		<PackageVersion Include="MySqlConnector" Version="1.3.3" />
+		<PackageVersion Include="MySqlConnector" Version="1.3.4" />
 		<PackageVersion Include="AdoNetCore.AseClient" Version="0.19.2" />
 		<PackageVersion Include="System.Data.SqlClient" Version="4.8.2" />
 		<PackageVersion Include="Microsoft.Data.SqlClient" Version="2.1.2" />

--- a/NuGet/linq2db.MySql.nuspec
+++ b/NuGet/linq2db.MySql.nuspec
@@ -13,7 +13,7 @@
 		<tags>linq linq2db MySql LinqToDB ORM database DB SQL</tags>
 		<dependencies>
 			<dependency id="linq2db"    version="3.0.0"  />
-			<dependency id="MySql.Data" version="8.0.21" />
+			<dependency id="MySql.Data" version="8.0.24" />
 		</dependencies>
 		<contentFiles>
 			<files include="**\*" buildAction="None" />

--- a/NuGet/linq2db.MySqlConnector.nuspec
+++ b/NuGet/linq2db.MySqlConnector.nuspec
@@ -13,7 +13,7 @@
 		<tags>linq linq2db MySql LinqToDB ORM database DB SQL</tags>
 		<dependencies>
 			<dependency id="linq2db"        version="3.0.0" />
-			<dependency id="MySqlConnector" version="1.3.3" />
+			<dependency id="MySqlConnector" version="1.3.4" />
 		</dependencies>
 		<contentFiles>
 			<files include="**\*" buildAction="None" />

--- a/Tests/Linq/DataProvider/MySqlTests.cs
+++ b/Tests/Linq/DataProvider/MySqlTests.cs
@@ -1908,9 +1908,7 @@ namespace Tests.DataProvider
 	{
 		public static int TestOutputParametersWithoutTableProcedure(this DataConnection dataConnection, string aInParam, out sbyte? aOutParam)
 		{
-			// WORKAROUND: db name needed for MySql.Data 8.0.21, as they managed to break already escaped procedure name handling
-			var dbName = dataConnection.DataProvider.CreateSqlBuilder(dataConnection.MappingSchema).ConvertInline(TestUtils.GetDatabaseName(dataConnection), ConvertType.NameToDatabase);
-			var ret = dataConnection.ExecuteProc($"{dbName}.`TestOutputParametersWithoutTableProcedure`",
+			var ret = dataConnection.ExecuteProc("`TestOutputParametersWithoutTableProcedure`",
 				new DataParameter("aInParam", aInParam, DataType.VarChar),
 				new DataParameter("aOutParam", null, DataType.SByte) { Direction = ParameterDirection.Output });
 
@@ -1921,9 +1919,7 @@ namespace Tests.DataProvider
 
 		public static IEnumerable<Person> TestProcedure(this DataConnection dataConnection, int? param3, ref int? param2, out int? param1)
 		{
-			// WORKAROUND: db name needed for MySql.Data 8.0.21, as they managed to break already escaped procedure name handling
-			var dbName = dataConnection.DataProvider.CreateSqlBuilder(dataConnection.MappingSchema).ConvertInline(TestUtils.GetDatabaseName(dataConnection), ConvertType.NameToDatabase);
-			var ret = dataConnection.QueryProc<Person>($"{dbName}.`TestProcedure`",
+			var ret = dataConnection.QueryProc<Person>("`TestProcedure`",
 				new DataParameter("param3", param3, DataType.Int32),
 				new DataParameter("param2", param2, DataType.Int32) { Direction = ParameterDirection.InputOutput },
 				new DataParameter("param1", null, DataType.Int32) { Direction = ParameterDirection.Output }).ToList();


### PR DESCRIPTION
- [FastExpressionCompiler](https://www.nuget.org/packages/FastExpressionCompiler) 3.0.4 -> 3.0.5
- [Microsoft.NET.Test.Sdk](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk) 16.8.3 -> 16.9.4
- [MySql.Data](https://www.nuget.org/packages/MySql.Data) 8.0.21 -> 8.0.24
- [MySqlConnector](https://www.nuget.org/packages/MySqlConnector) 1.3.3 -> 1.3.4

Let's see if test sdk and mysql.data fixed...