### PR TITLE
Add sql server support to RetrieveIdentity

### DIFF
--- a/Source/LinqToDB/Sql/Sql.cs
+++ b/Source/LinqToDB/Sql/Sql.cs
@@ -1324,5 +1324,27 @@ namespace LinqToDB
 		}
 
 		#endregion
+
+		#region Identity Functions
+		// identity APIs are nternal as:
+		// - there is plans to make them public for now
+		// - support for more providers required
+
+		/// <summary>
+		/// Returns last identity value (current value) for specific table.
+		/// </summary>
+		[Function  (PN.SqlServer    , "IDENT_CURRENT", ServerSideOnly = true)]
+		[Expression(PN.SqlServer2000, "NULL"         , ServerSideOnly = true)]
+		[Expression(                  "NULL"         , ServerSideOnly = true)]
+		internal static object? CurrentIdentity(string tableName) => throw new LinqException($"'{nameof(CurrentIdentity)}' is server side only property.");
+
+		/// <summary>
+		/// Returns identity step for specific table.
+		/// </summary>
+		[Function  (PN.SqlServer    , "IDENT_INCR", ServerSideOnly = true)]
+		[Expression(PN.SqlServer2000, "NULL"      , ServerSideOnly = true)]
+		[Expression(                  "NULL"      , ServerSideOnly = true)]
+		internal static object? IdentityStep(string tableName) => throw new LinqException($"'{nameof(IdentityStep)}' is server side only property.");
+		#endregion
 	}
 }

--- a/Source/LinqToDB/Sql/Sql.cs
+++ b/Source/LinqToDB/Sql/Sql.cs
@@ -1326,8 +1326,8 @@ namespace LinqToDB
 		#endregion
 
 		#region Identity Functions
-		// identity APIs are nternal as:
-		// - there is plans to make them public for now
+		// identity APIs are internal as:
+		// - there is no plans to make them public for now
 		// - support for more providers required
 
 		/// <summary>

--- a/Source/LinqToDB/Tools/DataExtensions.cs
+++ b/Source/LinqToDB/Tools/DataExtensions.cs
@@ -4,26 +4,34 @@ using System.Linq;
 
 namespace LinqToDB.Tools
 {
+	using System.Text;
 	using Common;
 	using Data;
 	using LinqToDB.Mapping;
+	using LinqToDB.SqlProvider;
 
 	public static class DataExtensions
 	{
 		/// <summary>
-		/// Initializes source columns, marked with <see cref="ColumnAttribute.IsIdentity"/> with values.
-		/// If column had sequence name set using <see cref="SequenceNameAttribute"/> and <paramref name="useSequenceName"/> set to <c>true</c>, values from sequence used.
-		/// Otherwise column initialized with values, incremented by 1 starting with max value from database for this column plus 1.
+		/// Initializes source columns, marked with <see cref="ColumnAttribute.IsIdentity"/> or <see cref="IdentityAttribute" /> with identity values:
+		/// <list type="bullet">
+		/// <item>if column had sequence name set using <see cref="SequenceNameAttribute"/> and <paramref name="useSequenceName"/> set to <c>true</c>, values from sequence used. Implemented for: Oracle, PostgreSQL</item>
+		/// <item>if table has identity configured and <paramref name="useIdentity"/> set to <c>true</c>, values from sequence used. Implemented for: SQL Server 2005+</item>
+		/// <item>Otherwise column initialized with values, incremented by 1 starting with max value from database for this column plus 1.</item>
+		/// </list>
 		/// </summary>
 		/// <typeparam name="T">Entity type.</typeparam>
 		/// <param name="source">Ordered list of entities to initialize.</param>
 		/// <param name="context">Data connection to use to retrieve sequence values of max used value for column.</param>
-		/// <param name="useSequenceName">Enables identity values retrieval from sequence for columns with sequence name specified in mapping using <see cref="SequenceNameAttribute"/>.</param>
+		/// <param name="useSequenceName">Enables identity values retrieval from sequence for columns with sequence name specified in mapping using <see cref="SequenceNameAttribute"/>. Implemented for Oracle and PostgreSQL.</param>
+		/// <param name="useIdentity">Enables identity values retrieval from table with identity column. Implemented for SQL Server 2005+.</param>
 		/// <returns>Returns new collection of identity fields initialized or <paramref name="source"/> if entity had no identity columns.</returns>
 		public static IEnumerable<T> RetrieveIdentity<T>(
 			this IEnumerable<T> source,
 			DataConnection      context,
-			bool                useSequenceName = true)
+			bool                useSequenceName = true,
+			bool                useIdentity     = false)
+			where T: notnull
 		{
 			if (source  == null) throw new ArgumentNullException(nameof(source));
 			if (context == null) throw new ArgumentNullException(nameof(context));
@@ -41,54 +49,107 @@ namespace LinqToDB.Tools
 					if (sourceList.Count == 0)
 						return sourceList;
 
+					var sqlBuilder = context.DataProvider.CreateSqlBuilder(context.MappingSchema);
+
 					var sequenceName = useSequenceName && column.SequenceName != null ? column.SequenceName.SequenceName : null;
 
 					if (sequenceName != null)
-					{
-						var sql       = context.DataProvider.CreateSqlBuilder(context.MappingSchema).GetReserveSequenceValuesSql(sourceList.Count, sequenceName);
-						var sequences = context.Query<object>(sql).ToList();
-
-						for (var i = 0; i < sourceList.Count; i++)
-						{
-							var item  = sourceList[i];
-							var value = Converter.ChangeType(sequences[i], column.MemberType);
-							column.MemberAccessor.SetValue(item!, value);
-						}
-					}
+						GetColumnSequenceValues(context, sourceList, column, sqlBuilder, sequenceName);
 					else
 					{
-						var sql      = context.DataProvider.CreateSqlBuilder(context.MappingSchema).GetMaxValueSql(entityDescriptor, column);
-						var maxValue = context.Execute<object?>(sql);
-
-						if (maxValue == null || maxValue == DBNull.Value)
-							maxValue = 0;
-
-						var type = Type.GetTypeCode(maxValue.GetType());
-
-						foreach (var item in sourceList)
+						if (useIdentity)
 						{
-							maxValue = type switch
+							var sb = new StringBuilder();
+							sqlBuilder.BuildTableName(sb, entityDescriptor.ServerName, entityDescriptor.DatabaseName, entityDescriptor.SchemaName, entityDescriptor.TableName, entityDescriptor.TableOptions);
+							var tableName = sb.ToString();
+
+							var identity = context.Select(() => new { last = Sql.CurrentIdentity(tableName), step = Sql.IdentityStep(tableName) });
+
+							if (identity.last != null && identity.step != null)
 							{
-								TypeCode.Byte	 => (byte)maxValue + 1,
-								TypeCode.SByte	 => (sbyte)maxValue + 1,
-								TypeCode.Int16	 => (short)maxValue + 1,
-								TypeCode.Int32	 => (int)maxValue + 1,
-								TypeCode.Int64	 => (long)maxValue + 1,
-								TypeCode.UInt16  => (ushort)maxValue + 1,
-								TypeCode.UInt32  => (uint)maxValue + 1,
-								TypeCode.UInt64  => (ulong)maxValue + 1,
-								TypeCode.Single  => (float)maxValue + 1,
-								TypeCode.Decimal => (decimal)maxValue + 1,
-								_                => throw new NotImplementedException(),
-							};
-							var value = Converter.ChangeType(maxValue, column.MemberType);
-							column.MemberAccessor.SetValue(item!, value);
+								GetIdentityValues(sourceList, column, identity.last, identity.step);
+								// current implementations (sql server) support single identity per table
+								return sourceList;
+							}
 						}
+
+						GetDefaultIdentityImpl(context, sourceList, entityDescriptor, column, sqlBuilder);
 					}
 				}
 			}
 
 			return sourceList ?? source;
+		}
+
+		private static void GetDefaultIdentityImpl<T>(DataConnection context, IList<T> sourceList, EntityDescriptor entityDescriptor, ColumnDescriptor column, ISqlBuilder sqlBuilder) where T : notnull
+		{
+			var sql      = sqlBuilder.GetMaxValueSql(entityDescriptor, column);
+			var maxValue = context.Execute<object?>(sql);
+
+			if (maxValue == null || maxValue == DBNull.Value)
+				maxValue = 0;
+
+			var type = Type.GetTypeCode(maxValue.GetType());
+
+			foreach (var item in sourceList)
+			{
+				maxValue = type switch
+				{
+					TypeCode.Byte    => (byte   )maxValue + 1,
+					TypeCode.SByte   => (sbyte  )maxValue + 1,
+					TypeCode.Int16   => (short  )maxValue + 1,
+					TypeCode.Int32   => (int    )maxValue + 1,
+					TypeCode.Int64   => (long   )maxValue + 1,
+					TypeCode.UInt16  => (ushort )maxValue + 1,
+					TypeCode.UInt32  => (uint   )maxValue + 1,
+					TypeCode.UInt64  => (ulong  )maxValue + 1,
+					TypeCode.Single  => (float  )maxValue + 1,
+					TypeCode.Decimal => (decimal)maxValue + 1,
+					_                => throw new NotImplementedException(),
+				};
+				var value = Converter.ChangeType(maxValue, column.MemberType);
+				column.MemberAccessor.SetValue(item!, value);
+			}
+		}
+
+		private static void GetIdentityValues<T>(IList<T> sourceList, ColumnDescriptor column, object last, object step)
+			where T: notnull
+		{
+			var type = Type.GetTypeCode(last.GetType());
+
+			for (var i = 0; i < sourceList.Count; i++)
+			{
+				object nextValue = type switch
+				{
+					TypeCode.Byte    => (byte   )last + (i + 1) * (byte   )step,
+					TypeCode.SByte   => (sbyte  )last + (i + 1) * (sbyte  )step,
+					TypeCode.Int16   => (short  )last + (i + 1) * (short  )step,
+					TypeCode.Int32   => (int    )last + (i + 1) * (int    )step,
+					TypeCode.Int64   => (long   )last + (i + 1) * (long   )step,
+					TypeCode.UInt16  => (ushort )last + (i + 1) * (ushort )step,
+					TypeCode.UInt32  => (uint   )last + (i + 1) * (uint   )step,
+					TypeCode.UInt64  => (ulong  )last + (ulong)(i + 1) * (ulong)step,
+					TypeCode.Single  => (float  )last + (i + 1) * (float  )step,
+					TypeCode.Decimal => (decimal)last + (i + 1) * (decimal)step,
+					_                => throw new NotImplementedException(),
+				};
+
+				var value = Converter.ChangeType(nextValue, column.MemberType);
+				column.MemberAccessor.SetValue(sourceList[i], value);
+			}
+		}
+
+		private static void GetColumnSequenceValues<T>(DataConnection context, IList<T> sourceList, ColumnDescriptor column, ISqlBuilder sqlBuilder, string sequenceName) where T : notnull
+		{
+			var sql       = sqlBuilder.GetReserveSequenceValuesSql(sourceList.Count, sequenceName);
+			var sequences = context.Query<object>(sql).ToList();
+
+			for (var i = 0; i < sourceList.Count; i++)
+			{
+				var item  = sourceList[i];
+				var value = Converter.ChangeType(sequences[i], column.MemberType);
+				column.MemberAccessor.SetValue(item!, value);
+			}
 		}
 	}
 }

--- a/Tests/Linq/DataProvider/SqlServerTests.cs
+++ b/Tests/Linq/DataProvider/SqlServerTests.cs
@@ -19,6 +19,7 @@ using LinqToDB.DataProvider.SqlServer;
 using LinqToDB.Linq.Internal;
 using LinqToDB.Mapping;
 using LinqToDB.SchemaProvider;
+using LinqToDB.Tools;
 using Microsoft.SqlServer.Types;
 using NUnit.Framework;
 using Tests.Model;
@@ -1911,6 +1912,31 @@ AS
 				param = func.Parameters.FirstOrDefault(p => p.ParameterName == "@value")!;
 				Assert.NotNull(param);
 				Assert.AreEqual("This is <test> scalar function parameter!", param.Description);
+			}
+		}
+
+		[Test]
+		public void TestRetrieveIdentity([IncludeDataSources(false, TestProvName.AllSqlServer2005Plus)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			{
+				using (db.BeginTransaction())
+				{
+					// advance identity forward
+					db.Insert(new Person() { FirstName = "", LastName = "" });
+					db.Insert(new Person() { FirstName = "", LastName = "" });
+					db.Insert(new Person() { FirstName = "", LastName = "" });
+				}
+
+				var lastIdentity = db.Execute<int>("SELECT IDENT_CURRENT('Person')");
+				var step         = db.Execute<int>("SELECT IDENT_INCR('Person')");
+
+				var persons  = Enumerable.Range(1, 10).Select(_ => new Person()).ToArray();
+
+				persons.RetrieveIdentity(db);
+
+				for (var i = 0; i < 10; i++)
+					Assert.AreEqual(lastIdentity + (i + 1) * step, persons[i].ID);
 			}
 		}
 	}


### PR DESCRIPTION
Fix #2983

feature hidden behind `useIdentity` parameter to preserve backward compatibility.