### PR TITLE
NaN/Infinity literals for PostgreSQL

### DIFF
--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
@@ -39,6 +39,24 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			SetValueToSqlConverter(typeof(Binary),   (sb,dt,v) => ConvertBinaryToSql(sb, ((Binary)v).ToArray()));
 			SetValueToSqlConverter(typeof(DateTime), (sb,dt,v) => BuildDateTime(sb, dt, (DateTime)v));
 
+			// adds floating point special values support
+			SetValueToSqlConverter(typeof(float) , (sb, dt, v) =>
+			{
+				var f = (float)v;
+				var quote = float.IsNaN(f) || float.IsInfinity(f);
+				if (quote) sb.Append('\'');
+				sb.AppendFormat(CultureInfo.InvariantCulture, "{0:G9}", f);
+				if (quote) sb.Append('\'');
+			});
+			SetValueToSqlConverter(typeof(double), (sb, dt, v) =>
+			{
+				var d = (double)v;
+				var quote = double.IsNaN(d) || double.IsInfinity(d);
+				if (quote) sb.Append('\'');
+				sb.AppendFormat(CultureInfo.InvariantCulture, "{0:G17}", d);
+				if (quote) sb.Append('\'');
+			});
+
 			AddScalarType(typeof(string),          DataType.Text);
 			AddScalarType(typeof(TimeSpan),        DataType.Interval);
 			AddScalarType(typeof(TimeSpan?),       DataType.Interval);

--- a/Source/LinqToDB/SqlProvider/ValueToSqlConverter.cs
+++ b/Source/LinqToDB/SqlProvider/ValueToSqlConverter.cs
@@ -50,7 +50,7 @@ namespace LinqToDB.SqlProvider
 			SetConverter(typeof(uint),       (sb,dt,v) => sb.Append((uint)      v));
 			SetConverter(typeof(long),       (sb,dt,v) => sb.Append((long)      v));
 			SetConverter(typeof(ulong),      (sb,dt,v) => sb.Append((ulong)     v));
-			SetConverter(typeof(float),      (sb,dt,v) => sb.Append(((float)    v). ToString(_numberFormatInfo)));
+			SetConverter(typeof(float),      (sb,dt,v) => sb.Append(((float)    v). ToString("G9", _numberFormatInfo)));
 			SetConverter(typeof(double),     (sb,dt,v) => sb.Append(((double)   v). ToString("G17", _numberFormatInfo)));
 			SetConverter(typeof(decimal),    (sb,dt,v) => sb.Append(((decimal)v).   ToString(_numberFormatInfo)));
 			SetConverter(typeof(DateTime),   (sb,dt,v) => BuildDateTime(sb, (DateTime)v));


### PR DESCRIPTION
Fix #2978

- add special value literal support for floating point values for postgresql
- bonus: use roundtrip format for float literals