### PR TITLE
update dependencies

### DIFF
--- a/Build/Azure/README.md
+++ b/Build/Azure/README.md
@@ -66,7 +66,7 @@ Legend:
 |:---|:---:|:---:|:---:|:---:|
 |TestNoopProvider<sup>[1](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |SQLite [3.13.0](https://www.sqlite.org/releaselog/3_13_0.html)<sup>[2](#notes)</sup><br>[Microsoft.Data.SQLite](https://www.nuget.org/packages/Microsoft.Data.SQLite/) 1.1.1<br>with NorthwindDB Tests|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
-|SQLite [3.33.0](https://www.sqlite.org/releaselog/3_33_0.html)<br>[Microsoft.Data.SQLite](https://www.nuget.org/packages/Microsoft.Data.SQLite/) 5.0.5<br>with NorthwindDB Tests|:heavy_minus_sign:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+|SQLite [3.33.0](https://www.sqlite.org/releaselog/3_33_0.html)<br>[Microsoft.Data.SQLite](https://www.nuget.org/packages/Microsoft.Data.SQLite/) 5.0.6<br>with NorthwindDB Tests|:heavy_minus_sign:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |SQLite [3.32.1](https://www.sqlite.org/releaselog/3_32_1.html)(win)<br>[3.31.1](https://www.sqlite.org/releaselog/3_31_1.html)<br>[System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite.Core/) 1.0.113.7<br>with NorthwindDB Tests|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |SQLite [3.32.1](https://www.sqlite.org/releaselog/3_32_1.html)(win)<br>[3.31.1](https://www.sqlite.org/releaselog/3_31_1.html)<br>[System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite.Core/) 1.0.113.7<br>with [MiniProfiler](https://www.nuget.org/packages/MiniProfiler.Shared/) 4.2.22 (core)<br>[MiniProfiler](https://www.nuget.org/packages/MiniProfiler/) 3.2.0.157 (netfx)<br>without mappings to underlying provider|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |SQLite [3.32.1](https://www.sqlite.org/releaselog/3_32_1.html)(win)<br>[3.31.1](https://www.sqlite.org/releaselog/3_31_1.html)<br>[System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite.Core/) 1.0.113.7<br>with [MiniProfiler](https://www.nuget.org/packages/MiniProfiler.Shared/) 4.2.22 (core)<br>[MiniProfiler](https://www.nuget.org/packages/MiniProfiler/) 3.2.0.157 (netfx)<br>with mappings to underlying provider|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
@@ -93,17 +93,17 @@ Legend:
 |MS SQL Server 2019<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.2<br>with FTS Tests|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|
 |Azure SQL<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.2|:x:|:x:|:x:|:x:|
 |Azure SQL<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.2|:x:|:x:|:x:|:x:|
-|MySQL 5.6<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.24|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|MySQL 8<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.24|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|MySQL 8<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 1.3.5|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|MariaDB 10<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.24|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 9.2<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.4 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 9.3<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.4 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 9.5<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.4 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 10<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.4 (core)|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 11<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.4 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 12<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.4 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 13<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.4 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|MySQL 5.6<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.25|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|MySQL 8<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.25|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|MySQL 8<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 1.3.8|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|MariaDB 10<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.25|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 9.2<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.5 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 9.3<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.5 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 9.5<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.5 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 10<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.5 (core)|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 11<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.5 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 12<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.5 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 13<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.5 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |DB2 LUW 11.5.0.0a<br>[IBM.Data.DB2](https://www.nuget.org/packages/IBM.Data.DB.Provider/) 11.5.4000.4861 (netfx)<br>[IBM.Data.DB2.Core](https://www.nuget.org/packages/IBM.Data.DB2.Core/) 2.2.0.100 ([osx](https://www.nuget.org/packages/IBM.Data.DB2.Core-osx/) 2.0.0.100, [lin](https://www.nuget.org/packages/IBM.Data.DB2.Core-lnx/) 2.2.0.100) (core)|:x:|:x:|:heavy_check_mark:<sup>[6](#notes)</sup>|:heavy_check_mark:|
 |Informix 12.10.FC12W1DE<br>IBM.Data.Informix (SQLI) 4.0.410.10|:x:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
 |Informix 14.10<br>IBM.Data.Informix (SQLI) 4.0.410.10|:x:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,9 +28,9 @@
 		<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
 
 		<!--data providers-->
-		<PackageVersion Include="MySql.Data" Version="8.0.24" />
+		<PackageVersion Include="MySql.Data" Version="8.0.25" />
 		<PackageVersion Include="System.Data.SQLite.Core" Version="1.0.113.7" />
-		<PackageVersion Include="MySqlConnector" Version="1.3.5" />
+		<PackageVersion Include="MySqlConnector" Version="1.3.8" />
 		<PackageVersion Include="AdoNetCore.AseClient" Version="0.19.2" />
 		<PackageVersion Include="System.Data.SqlClient" Version="4.8.2" />
 		<PackageVersion Include="Microsoft.Data.SqlClient" Version="2.1.2" />
@@ -44,16 +44,16 @@
 		<!--test infrastructure-->
 		<PackageVersion Include="MiniProfiler" Version="3.2.0.157" />
 		<PackageVersion Include="MiniProfiler.Shared" Version="4.2.22" />
-		<PackageVersion Include="NUnit" Version="3.13.1" />
+		<PackageVersion Include="NUnit" Version="3.13.2" />
 		<PackageVersion Include="NUnit3TestAdapter" Version="4.0.0-beta.2" />
 		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-		<PackageVersion Include="FastExpressionCompiler" Version="3.0.5" />
+		<PackageVersion Include="FastExpressionCompiler" Version="3.1.0" />
 		<PackageVersion Include="BenchmarkDotNet" Version="0.12.1" />
 		<!--<PackageVersion Include="BenchmarkDotNet" Version="0.12.1.1533" />-->
 		<PackageVersion Include="JetBrains.Profiler.Api" Version="1.1.7" />
-		<PackageVersion Include="Humanizer.Core" Version="2.8.26" />
+		<PackageVersion Include="Humanizer.Core" Version="2.10.1" />
 		<PackageVersion Include="FSharp.Core" Version="5.0.1" />
-		<PackageVersion Include="Microsoft.AspNet.OData" Version="7.5.7" />
+		<PackageVersion Include="Microsoft.AspNet.OData" Version="7.5.8" />
 		<PackageVersion Include="NodaTime" Version="3.0.5" />
 
 		<!--nuget doesn't have strong name, so we use local self-signed copy-->
@@ -62,8 +62,8 @@
 
 	<ItemGroup Condition=" '$(TargetFramework)' != 'net472' ">
 		<!--main version-->
-		<PackageVersion Include="Microsoft.Data.SQLite" Version="5.0.5" />
-		<PackageVersion Include="Npgsql" Version="5.0.4" />
+		<PackageVersion Include="Microsoft.Data.SQLite" Version="5.0.6" />
+		<PackageVersion Include="Npgsql" Version="5.0.5" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
 		<!--specify here or it will conflict with Reference-include in netcore targets-->
@@ -75,7 +75,7 @@
 	
 	<ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">
 		<!--main version-->
-		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="3.1.14" />
+		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="3.1.15" />
 		<PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/NuGet/linq2db.AspNet.nuspec
+++ b/NuGet/linq2db.AspNet.nuspec
@@ -16,7 +16,7 @@
 			</group>
 			<group targetFramework=".NETStandard2.0">
 				<dependency id="linq2db"                                   version="3.0.0"  />
-				<dependency id="Microsoft.Extensions.DependencyInjection"  version="3.1.14" />
+				<dependency id="Microsoft.Extensions.DependencyInjection"  version="3.1.15" />
 				<dependency id="Microsoft.Extensions.Logging.Abstractions" version="5.0.0"  />
 			</group>
 		</dependencies>

--- a/NuGet/linq2db.MySql.nuspec
+++ b/NuGet/linq2db.MySql.nuspec
@@ -13,7 +13,7 @@
 		<tags>linq linq2db MySql LinqToDB ORM database DB SQL</tags>
 		<dependencies>
 			<dependency id="linq2db"    version="3.0.0"  />
-			<dependency id="MySql.Data" version="8.0.24" />
+			<dependency id="MySql.Data" version="8.0.25" />
 		</dependencies>
 		<contentFiles>
 			<files include="**\*" buildAction="None" />

--- a/NuGet/linq2db.MySqlConnector.nuspec
+++ b/NuGet/linq2db.MySqlConnector.nuspec
@@ -13,7 +13,7 @@
 		<tags>linq linq2db MySql LinqToDB ORM database DB SQL</tags>
 		<dependencies>
 			<dependency id="linq2db"        version="3.0.0" />
-			<dependency id="MySqlConnector" version="1.3.5" />
+			<dependency id="MySqlConnector" version="1.3.8" />
 		</dependencies>
 		<contentFiles>
 			<files include="**\*" buildAction="None" />

--- a/NuGet/linq2db.PostgreSQL.nuspec
+++ b/NuGet/linq2db.PostgreSQL.nuspec
@@ -22,11 +22,11 @@
 			</group>
 			<group targetFramework=".NETStandard2.0">
 				<dependency id="linq2db" version="3.0.0"  />
-				<dependency id="Npgsql"  version="5.0.4"  />
+				<dependency id="Npgsql"  version="5.0.5"  />
 			</group>
 			<group targetFramework=".NETCoreApp2.1">
 				<dependency id="linq2db" version="3.0.0"  />
-				<dependency id="Npgsql"  version="5.0.4"  />
+				<dependency id="Npgsql"  version="5.0.5"  />
 			</group>
 		</dependencies>
 		<contentFiles>

--- a/NuGet/linq2db.SQLite.MS.nuspec
+++ b/NuGet/linq2db.SQLite.MS.nuspec
@@ -13,7 +13,7 @@
 		<tags>linq linq2db SQLite LinqToDB ORM database DB SQL</tags>
 		<dependencies>
 			<dependency id="linq2db"                version="3.0.0" />
-			<dependency id="Microsoft.Data.Sqlite"  version="5.0.5" />
+			<dependency id="Microsoft.Data.Sqlite"  version="5.0.6" />
 		</dependencies>
 		<contentFiles>
 			<files include="**\*" buildAction="None" />

--- a/Tests/FSharp/Tests.FSharp.fsproj
+++ b/Tests/FSharp/Tests.FSharp.fsproj
@@ -31,7 +31,7 @@
 		<!--workaround for Directory.Packages.props issue-->
 		<PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
 		<PackageReference Update="System.Collections.Immutable" Version="5.0.0" />
-		<PackageReference Update="NUnit" Version="3.13.1" />
+		<PackageReference Update="NUnit" Version="3.13.2" />
 		<PackageReference Update="FluentAssertions " Version="5.10.3" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Updated dependencies:
 - [FastExpressionCompiler](https://www.nuget.org/packages/FastExpressionCompiler) 3.0.5 -> 3.1.0
 - [Humanizer.Core](https://www.nuget.org/packages/Humanizer.Core): 2.8.26 -> 2.10.1
 - [Microsoft.AspNet.OData](https://www.nuget.org/packages/Microsoft.AspNet.OData): 7.5.7 -> 7.5.8
 - [Microsoft.Data.Sqlite](https://www.nuget.org/packages/Microsoft.Data.Sqlite): 5.0.5 -> 5.0.6
 - [Microsoft.Extensions.DependencyInjection](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection): 3.1.14 -> 3.1.15
 - [MySql.Data](https://www.nuget.org/packages/MySql.Data): 8.0.24 -> 8.0.25
 - [MySqlConnector](https://www.nuget.org/packages/MySqlConnector): 1.3.5 -> 1.3.8
 - [Npgsql](https://www.nuget.org/packages/Npgsql): 5.0.4 -> 5.0.5
 - [NUnit](https://www.nuget.org/packages/NUnit): 3.13.1 -> 3.13.2