### PR TITLE
An attempt to work around the DataContext grouping issue #2937

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ linq2db.sln.ide/
 /.vs/*
 *.lock.json
 /.idea/
+/.temp

--- a/Source/LinqToDB/DataContext.cs
+++ b/Source/LinqToDB/DataContext.cs
@@ -598,7 +598,7 @@ namespace LinqToDB
 				return _queryRunner!.GetSqlText();
 			}
 
-			public IDataContext DataContext      { get => _queryRunner!.DataContext;      set => _queryRunner!.DataContext      = value; }
+			public IDataContext DataContext      { get => _dataContext!;                  set => _queryRunner!.DataContext      = value; }
 			public Expression   Expression       { get => _queryRunner!.Expression;       set => _queryRunner!.Expression       = value; }
 			public object?[]?   Parameters       { get => _queryRunner!.Parameters;       set => _queryRunner!.Parameters       = value; }
 			public object?[]?   Preambles        { get => _queryRunner!.Preambles;        set => _queryRunner!.Preambles        = value; }

--- a/Source/LinqToDB/Linq/Builder/GroupByBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/GroupByBuilder.cs
@@ -109,7 +109,7 @@ namespace LinqToDB.Linq.Builder
 						{
 							sequenceExpr = sequenceExpr.Replace(groupingMethod, groupingKey.Body.Unwrap());
 						}
-						
+
 					}
 				}
 			}
@@ -122,7 +122,7 @@ namespace LinqToDB.Linq.Builder
 			var elementSelector = (LambdaExpression)methodCall.Arguments[2].Unwrap()!;
 
 			if (wrapSequence)
-			{ 
+			{
 				sequence = new SubQueryContext(sequence);
 			}
 
@@ -259,6 +259,7 @@ namespace LinqToDB.Linq.Builder
 					Key = key;
 
 					_queryRunner = queryRunner;
+					_dataContext = queryRunner.DataContext;
 					_parameters   = parameters;
 					_itemReader   = itemReader;
 
@@ -270,6 +271,7 @@ namespace LinqToDB.Linq.Builder
 
 				private  IList<TElement>?                                        _items;
 				readonly IQueryRunner                                            _queryRunner;
+				readonly IDataContext                                            _dataContext;
 				readonly List<ParameterAccessor>                                 _parameters;
 				readonly Func<IDataContext,TKey,object?[]?,IQueryable<TElement>> _itemReader;
 
@@ -277,12 +279,12 @@ namespace LinqToDB.Linq.Builder
 
 				List<TElement> GetItems()
 				{
-					using (var db = _queryRunner.DataContext.Clone(true))
+					using (var db = _dataContext.Clone(true))
 					{
 						var ps = new object?[_parameters.Count];
 
 						for (var i = 0; i < ps.Length; i++)
-							ps[i] = _parameters[i].OriginalAccessor(_queryRunner.Expression, _queryRunner.DataContext, _queryRunner.Parameters);
+							ps[i] = _parameters[i].OriginalAccessor(_queryRunner.Expression, db, _queryRunner.Parameters);
 
 						return _itemReader(db, Key, ps).ToList();
 					}

--- a/Source/LinqToDB/Linq/Builder/GroupByBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/GroupByBuilder.cs
@@ -258,10 +258,11 @@ namespace LinqToDB.Linq.Builder
 				{
 					Key = key;
 
-					_queryRunner = queryRunner;
-					_dataContext = queryRunner.DataContext;
-					_parameters   = parameters;
-					_itemReader   = itemReader;
+					_queryExpression = queryRunner.Expression;
+					_queryParameters = queryRunner.Parameters;
+					_dataContext     = queryRunner.DataContext;
+					_parameters      = parameters;
+					_itemReader      = itemReader;
 
 					if (Configuration.Linq.PreloadGroups)
 					{
@@ -270,8 +271,9 @@ namespace LinqToDB.Linq.Builder
 				}
 
 				private  IList<TElement>?                                        _items;
-				readonly IQueryRunner                                            _queryRunner;
 				readonly IDataContext                                            _dataContext;
+				readonly Expression                                              _queryExpression;
+				readonly object?[]?                                              _queryParameters;
 				readonly List<ParameterAccessor>                                 _parameters;
 				readonly Func<IDataContext,TKey,object?[]?,IQueryable<TElement>> _itemReader;
 
@@ -284,7 +286,7 @@ namespace LinqToDB.Linq.Builder
 						var ps = new object?[_parameters.Count];
 
 						for (var i = 0; i < ps.Length; i++)
-							ps[i] = _parameters[i].OriginalAccessor(_queryRunner.Expression, db, _queryRunner.Parameters);
+							ps[i] = _parameters[i].OriginalAccessor(_queryExpression, db, _queryParameters);
 
 						return _itemReader(db, Key, ps).ToList();
 					}

--- a/Tests/Linq/Data/DataExtensionsTests.cs
+++ b/Tests/Linq/Data/DataExtensionsTests.cs
@@ -175,11 +175,8 @@ namespace Tests.Data
 		[Test]
 		public void TestGrouping1([IncludeDataSources(TestProvName.AllSQLite)] string context)
 		{
-			var old = (Configuration.Linq.GuardGrouping, Configuration.Linq.PreloadGroups);
-			Configuration.Linq.GuardGrouping = false;
-			Configuration.Linq.PreloadGroups = false;
-
-			try
+			using (new GuardGrouping(false))
+			using (new PreloadGroups(false))
 			{
 				using (var dc = new DataContext(context))
 				{
@@ -190,21 +187,13 @@ namespace Tests.Data
 					var tables = dictionary.ToDictionary(p => p.Key, p => p.Value.ToList());
 				}
 			}
-			finally
-			{
-				Configuration.Linq.GuardGrouping = old.GuardGrouping;
-				Configuration.Linq.PreloadGroups = old.PreloadGroups;
-			}
 		}
 
 		[Test]
 		public void TestGrouping2([IncludeDataSources(TestProvName.AllSQLite)] string context)
 		{
-			var old = (Configuration.Linq.GuardGrouping, Configuration.Linq.PreloadGroups);
-			Configuration.Linq.GuardGrouping = false;
-			Configuration.Linq.PreloadGroups = false;
-
-			try
+			using (new GuardGrouping(false))
+			using (new PreloadGroups(false))
 			{
 				using (var dc = new DataContext(context))
 				{
@@ -226,11 +215,6 @@ namespace Tests.Data
 						Assert.IsTrue(ids.Length > 0);
 					}
 				}
-			}
-			finally
-			{
-				Configuration.Linq.GuardGrouping = old.GuardGrouping;
-				Configuration.Linq.PreloadGroups = old.PreloadGroups;
 			}
 		}
 


### PR DESCRIPTION
Fix #2937

Hi, this pull request has two unit tests that demonstrate the NullReferenceException
when a query with a grouping is executed by `DataContext`, see issue #2937.

I tried to work around the NRE, but now I'm getting an `ObjectDisposedException` instead:

```csharp
using (var dc = new DataContext(context))
{
    // part1: this part works fine
	var dictionary = dc.GetTable<Person>()
		.GroupBy(p => p.FirstName)
		.ToDictionary(p => p.Key);

    // part2: this part throws an ObjectDisposedException 
	var tables = dictionary.ToDictionary(p => p.Key, p => p.Value.ToList());
}
```

That's because the DataContext's query runner redirects all its calls to the
internal DataConnection's query runner, and the data connection is released 
when the first part is executed and DataContext.ReleaseQuery is called.

Any thoughts how this can be addressed?