### PR TITLE
Recognize more values as empty update in InsertOrUpdate

### DIFF
--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaSqlBuilder.cs
@@ -76,11 +76,6 @@ namespace LinqToDB.DataProvider.SapHana
 			}
 		}
 
-		protected override void BuildInsertOrUpdateQuery(SqlInsertOrUpdateStatement insertOrUpdate)
-		{
-			BuildInsertOrUpdateQueryAsUpdateInsert(insertOrUpdate);
-		}
-
 		protected override void BuildDataTypeFromDataType(SqlDataType type, bool forCreateTable)
 		{
 			switch (type.Type.DataType)

--- a/Source/LinqToDB/Linq/Builder/ExpressionContext.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionContext.cs
@@ -4,6 +4,7 @@ using System.Linq.Expressions;
 
 namespace LinqToDB.Linq.Builder
 {
+	using LinqToDB.Common;
 	using LinqToDB.Expressions;
 	using SqlQuery;
 
@@ -63,6 +64,16 @@ namespace LinqToDB.Linq.Builder
 										Sequence.ConvertToSql(null,       0,         flags) :
 										Sequence.ConvertToSql(expression, level + 1, flags);
 								}
+							}
+							else if (root.NodeType == ExpressionType.Constant)
+							{
+								if (((ConstantExpression)root).Value == null)
+									return Array<SqlInfo>.Empty;
+							}
+							else if (root.NodeType == ExpressionType.New)
+							{
+								if (((NewExpression)root).Arguments.Count == 0)
+									return Array<SqlInfo>.Empty;
 							}
 
 							break;

--- a/Source/LinqToDB/Linq/Builder/InsertOrUpdateBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/InsertOrUpdateBuilder.cs
@@ -31,13 +31,15 @@ namespace LinqToDB.Linq.Builder
 				insertOrUpdateStatement.Insert.Items,
 				sequence);
 
-			UpdateBuilder.BuildSetter(
-				builder,
-				buildInfo,
-				(LambdaExpression)methodCall.Arguments[2].Unwrap(),
-				sequence,
-				insertOrUpdateStatement.Update.Items,
-				sequence);
+			var updateExpr = methodCall.Arguments[2].Unwrap();
+			if (!(updateExpr is ConstantExpression constant && constant.Value == null))
+				UpdateBuilder.BuildSetter(
+					builder,
+					buildInfo,
+					(LambdaExpression)updateExpr,
+					sequence,
+					insertOrUpdateStatement.Update.Items,
+					sequence);
 
 			insertOrUpdateStatement.Insert.Into  = ((TableBuilder.TableContext)sequence).SqlTable;
 			insertOrUpdateStatement.Update.Table = ((TableBuilder.TableContext)sequence).SqlTable;

--- a/Source/LinqToDB/LinqExtensions.cs
+++ b/Source/LinqToDB/LinqExtensions.cs
@@ -2111,6 +2111,8 @@ namespace LinqToDB
 
 		/// <summary>
 		/// Inserts new record into target table or updates existing record if record with the same primary key value already exists in target table.
+		/// When <c>null</c> value or expression without field setters passed to <paramref name="onDuplicateKeyUpdateSetter"/>, this method
+		/// implements <c>INSERT IF NOT EXISTS</c> logic.
 		/// </summary>
 		/// <typeparam name="T">Table record type.</typeparam>
 		/// <param name="target">Target table.</param>
@@ -2121,14 +2123,13 @@ namespace LinqToDB
 		/// Accepts updated record as parameter.</param>
 		/// <returns>Number of affected records.</returns>
 		public static int InsertOrUpdate<T>(
-			                this ITable<T>        target,
-			[InstantHandle] Expression<Func<T>>   insertSetter,
-			[InstantHandle] Expression<Func<T,T>> onDuplicateKeyUpdateSetter)
+			                this ITable<T>          target,
+			[InstantHandle] Expression<Func<T>>     insertSetter,
+			[InstantHandle] Expression<Func<T,T?>>? onDuplicateKeyUpdateSetter)
 			where T : notnull
 		{
 			if (target                     == null) throw new ArgumentNullException(nameof(target));
 			if (insertSetter               == null) throw new ArgumentNullException(nameof(insertSetter));
-			if (onDuplicateKeyUpdateSetter == null) throw new ArgumentNullException(nameof(onDuplicateKeyUpdateSetter));
 
 			IQueryable<T> query = target;
 
@@ -2138,11 +2139,13 @@ namespace LinqToDB
 				Expression.Call(
 					null,
 					_insertOrUpdateMethodInfo.MakeGenericMethod(typeof(T)),
-					currentQuery.Expression, Expression.Quote(insertSetter), Expression.Quote(onDuplicateKeyUpdateSetter)));
+					currentQuery.Expression, Expression.Quote(insertSetter), onDuplicateKeyUpdateSetter != null ? Expression.Quote(onDuplicateKeyUpdateSetter) : Expression.Constant(null, typeof(Expression<Func<T, T>>))));
 		}
 
 		/// <summary>
 		/// Asynchronously inserts new record into target table or updates existing record if record with the same primary key value already exists in target table.
+		/// When <c>null</c> value or expression without field setters passed to <paramref name="onDuplicateKeyUpdateSetter"/>, this method
+		/// implements <c>INSERT IF NOT EXISTS</c> logic.
 		/// </summary>
 		/// <typeparam name="T">Table record type.</typeparam>
 		/// <param name="target">Target table.</param>
@@ -2154,15 +2157,14 @@ namespace LinqToDB
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Number of affected records.</returns>
 		public static async Task<int> InsertOrUpdateAsync<T>(
-			                this ITable<T>        target,
-			[InstantHandle] Expression<Func<T>>   insertSetter,
-			[InstantHandle] Expression<Func<T,T>> onDuplicateKeyUpdateSetter,
-			CancellationToken                     token = default)
+			                this ITable<T>          target,
+			[InstantHandle] Expression<Func<T>>     insertSetter,
+			[InstantHandle] Expression<Func<T,T?>>? onDuplicateKeyUpdateSetter,
+			CancellationToken                       token = default)
 			where T : notnull
 		{
 			if (target                     == null) throw new ArgumentNullException(nameof(target));
 			if (insertSetter               == null) throw new ArgumentNullException(nameof(insertSetter));
-			if (onDuplicateKeyUpdateSetter == null) throw new ArgumentNullException(nameof(onDuplicateKeyUpdateSetter));
 
 			IQueryable<T> source = target;
 
@@ -2171,7 +2173,7 @@ namespace LinqToDB
 			var expr = Expression.Call(
 				null,
 				_insertOrUpdateMethodInfo.MakeGenericMethod(typeof(T)),
-				currentSource.Expression, Expression.Quote(insertSetter), Expression.Quote(onDuplicateKeyUpdateSetter));
+				currentSource.Expression, Expression.Quote(insertSetter), onDuplicateKeyUpdateSetter != null ? Expression.Quote(onDuplicateKeyUpdateSetter) : Expression.Constant(null, typeof(Expression<Func<T, T>>)));
 
 			if (currentSource is IQueryProviderAsync query)
 				return await query.ExecuteAsync<int>(expr, token).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
@@ -2184,6 +2186,8 @@ namespace LinqToDB
 
 		/// <summary>
 		/// Inserts new record into target table or updates existing record if record with the same key value already exists in target table.
+		/// When <c>null</c> value or expression without field setters passed to <paramref name="onDuplicateKeyUpdateSetter"/>, this method
+		/// implements <c>INSERT IF NOT EXISTS</c> logic.
 		/// </summary>
 		/// <typeparam name="T">Table record type.</typeparam>
 		/// <param name="target">Target table.</param>
@@ -2196,15 +2200,14 @@ namespace LinqToDB
 		/// Expression supports only target table record new expression with field initializers for each key field. Assigned key field value will be used as key value by operation type selector.</param>
 		/// <returns>Number of affected records.</returns>
 		public static int InsertOrUpdate<T>(
-			                this ITable<T>        target,
-			[InstantHandle] Expression<Func<T>>   insertSetter,
-			[InstantHandle] Expression<Func<T,T>> onDuplicateKeyUpdateSetter,
-			[InstantHandle] Expression<Func<T>>   keySelector)
+			                this ITable<T>          target,
+			[InstantHandle] Expression<Func<T>>     insertSetter,
+			[InstantHandle] Expression<Func<T,T?>>? onDuplicateKeyUpdateSetter,
+			[InstantHandle] Expression<Func<T>>     keySelector)
 			where T : notnull
 		{
 			if (target                     == null) throw new ArgumentNullException(nameof(target));
 			if (insertSetter               == null) throw new ArgumentNullException(nameof(insertSetter));
-			if (onDuplicateKeyUpdateSetter == null) throw new ArgumentNullException(nameof(onDuplicateKeyUpdateSetter));
 			if (keySelector                == null) throw new ArgumentNullException(nameof(keySelector));
 
 			IQueryable<T> query = target;
@@ -2217,12 +2220,14 @@ namespace LinqToDB
 					_insertOrUpdateMethodInfo2.MakeGenericMethod(typeof(T)),
 					currentQuery.Expression,
 					Expression.Quote(insertSetter),
-					Expression.Quote(onDuplicateKeyUpdateSetter),
+					onDuplicateKeyUpdateSetter != null ? Expression.Quote(onDuplicateKeyUpdateSetter) : Expression.Constant(null, typeof(Expression<Func<T, T>>)),
 					Expression.Quote(keySelector)));
 		}
 
 		/// <summary>
 		/// Asynchronously inserts new record into target table or updates existing record if record with the same key value already exists in target table.
+		/// When <c>null</c> value or expression without field setters passed to <paramref name="onDuplicateKeyUpdateSetter"/>, this method
+		/// implements <c>INSERT IF NOT EXISTS</c> logic.
 		/// </summary>
 		/// <typeparam name="T">Table record type.</typeparam>
 		/// <param name="target">Target table.</param>
@@ -2236,16 +2241,15 @@ namespace LinqToDB
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Number of affected records.</returns>
 		public static async Task<int> InsertOrUpdateAsync<T>(
-			                this ITable<T>        target,
-			[InstantHandle] Expression<Func<T>>   insertSetter,
-			[InstantHandle] Expression<Func<T,T>> onDuplicateKeyUpdateSetter,
-			[InstantHandle] Expression<Func<T>>   keySelector,
-			CancellationToken                     token = default)
+			                this ITable<T>          target,
+			[InstantHandle] Expression<Func<T>>     insertSetter,
+			[InstantHandle] Expression<Func<T,T?>>? onDuplicateKeyUpdateSetter,
+			[InstantHandle] Expression<Func<T>>     keySelector,
+			CancellationToken                       token = default)
 			where T : notnull
 		{
 			if (target                     == null) throw new ArgumentNullException(nameof(target));
 			if (insertSetter               == null) throw new ArgumentNullException(nameof(insertSetter));
-			if (onDuplicateKeyUpdateSetter == null) throw new ArgumentNullException(nameof(onDuplicateKeyUpdateSetter));
 			if (keySelector                == null) throw new ArgumentNullException(nameof(keySelector));
 
 			IQueryable<T> source = target;
@@ -2257,7 +2261,7 @@ namespace LinqToDB
 				_insertOrUpdateMethodInfo2.MakeGenericMethod(typeof(T)),
 				currentSource.Expression,
 				Expression.Quote(insertSetter),
-				Expression.Quote(onDuplicateKeyUpdateSetter),
+				onDuplicateKeyUpdateSetter != null ? Expression.Quote(onDuplicateKeyUpdateSetter) : Expression.Constant(null, typeof(Expression<Func<T, T>>)),
 				Expression.Quote(keySelector));
 
 			if (currentSource is IQueryProviderAsync query)

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -930,7 +930,6 @@ namespace LinqToDB.SqlProvider
 		protected void BuildInsertOrUpdateQueryAsUpdateInsert(SqlInsertOrUpdateStatement insertOrUpdate)
 		{
 			BuildTag(insertOrUpdate);
-			AppendIndent().AppendLine("BEGIN TRAN").AppendLine();
 
 			var buildUpdate = insertOrUpdate.Update.Items.Count > 0;
 			if (buildUpdate)
@@ -1006,7 +1005,6 @@ namespace LinqToDB.SqlProvider
 			AppendIndent().AppendLine("END");
 
 			StringBuilder.AppendLine();
-			AppendIndent().AppendLine("COMMIT");
 		}
 
 		#endregion

--- a/Tests/Linq/Update/InsertTests.cs
+++ b/Tests/Linq/Update/InsertTests.cs
@@ -2056,6 +2056,19 @@ namespace Tests.xUpdate
 		}
 
 		#region InsertIfNotExists (https://github.com/linq2db/linq2db/issues/3005)
+		private int GetEmptyRowCount(string context)
+		{
+			var provider = GetProviderName(context, out _);
+
+			// those providers generate IF (), which doesn't return rowcount if not entered
+			// for some reason it doesn't affect managed sybase provider (provider bug?)
+			return provider == ProviderName.Sybase
+				|| provider == ProviderName.SqlServer2000
+				|| provider == ProviderName.SqlServer2005
+				? -1
+				: 0;
+		}
+
 		[Test]
 		public void InsertIfNotExists_EmptyInit1([InsertOrUpdateDataSources] string context)
 		{
@@ -2078,7 +2091,7 @@ namespace Tests.xUpdate
 					p => new TestInsertOrReplaceInfo() { });
 
 				Assert.AreEqual(1, cnt1);
-				Assert.AreEqual(0, cnt2);
+				Assert.AreEqual(GetEmptyRowCount(context), cnt2);
 			}
 		}
 
@@ -2106,7 +2119,7 @@ namespace Tests.xUpdate
 					() => new TestInsertOrReplaceInfo() { Id = 1 });
 
 				Assert.AreEqual(1, cnt1);
-				Assert.AreEqual(0, cnt2);
+				Assert.AreEqual(GetEmptyRowCount(context), cnt2);
 			}
 		}
 
@@ -2132,7 +2145,7 @@ namespace Tests.xUpdate
 					p => new TestInsertOrReplaceInfo());
 
 				Assert.AreEqual(1, cnt1);
-				Assert.AreEqual(0, cnt2);
+				Assert.AreEqual(GetEmptyRowCount(context), cnt2);
 			}
 		}
 
@@ -2160,7 +2173,7 @@ namespace Tests.xUpdate
 					() => new TestInsertOrReplaceInfo() { Id = 1 });
 
 				Assert.AreEqual(1, cnt1);
-				Assert.AreEqual(0, cnt2);
+				Assert.AreEqual(GetEmptyRowCount(context), cnt2);
 			}
 		}
 
@@ -2186,7 +2199,7 @@ namespace Tests.xUpdate
 					p => null);
 
 				Assert.AreEqual(1, cnt1);
-				Assert.AreEqual(0, cnt2);
+				Assert.AreEqual(GetEmptyRowCount(context), cnt2);
 			}
 		}
 
@@ -2214,7 +2227,7 @@ namespace Tests.xUpdate
 					() => new TestInsertOrReplaceInfo() { Id = 1 });
 
 				Assert.AreEqual(1, cnt1);
-				Assert.AreEqual(0, cnt2);
+				Assert.AreEqual(GetEmptyRowCount(context), cnt2);
 			}
 		}
 
@@ -2240,7 +2253,7 @@ namespace Tests.xUpdate
 					null);
 
 				Assert.AreEqual(1, cnt1);
-				Assert.AreEqual(0, cnt2);
+				Assert.AreEqual(GetEmptyRowCount(context), cnt2);
 			}
 		}
 
@@ -2268,7 +2281,7 @@ namespace Tests.xUpdate
 					() => new TestInsertOrReplaceInfo() { Id = 1 });
 
 				Assert.AreEqual(1, cnt1);
-				Assert.AreEqual(0, cnt2);
+				Assert.AreEqual(GetEmptyRowCount(context), cnt2);
 			}
 		}
 		#endregion

--- a/Tests/Linq/Update/InsertTests.cs
+++ b/Tests/Linq/Update/InsertTests.cs
@@ -2055,14 +2055,231 @@ namespace Tests.xUpdate
 			}
 		}
 
+		#region InsertIfNotExists (https://github.com/linq2db/linq2db/issues/3005)
+		[Test]
+		public void InsertIfNotExists_EmptyInit1([InsertOrUpdateDataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var table = db.CreateLocalTable<TestInsertOrReplaceInfo>())
+			{
+				var cnt1 = table.InsertOrUpdate(
+					() => new TestInsertOrReplaceInfo()
+					{
+						Id   = 1,
+						Name = "test"
+					},
+					p => new TestInsertOrReplaceInfo() { });
+				var cnt2 = table.InsertOrUpdate(
+					() => new TestInsertOrReplaceInfo()
+					{
+						Id   = 1,
+						Name = "test"
+					},
+					p => new TestInsertOrReplaceInfo() { });
 
-#region issue 2243
+				Assert.AreEqual(1, cnt1);
+				Assert.AreEqual(0, cnt2);
+			}
+		}
+
+		[Test]
+		public void InsertIfNotExists_EmptyInit2([InsertOrUpdateDataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var table = db.CreateLocalTable<TestInsertOrReplaceInfo>())
+			{
+				var cnt1 = table.InsertOrUpdate(
+					() => new TestInsertOrReplaceInfo()
+					{
+						Id   = 1,
+						Name = "test"
+					},
+					p => new TestInsertOrReplaceInfo() { },
+					() => new TestInsertOrReplaceInfo() { Id = 1 });
+				var cnt2 = table.InsertOrUpdate(
+					() => new TestInsertOrReplaceInfo()
+					{
+						Id   = 1,
+						Name = "test"
+					},
+					p => new TestInsertOrReplaceInfo() { },
+					() => new TestInsertOrReplaceInfo() { Id = 1 });
+
+				Assert.AreEqual(1, cnt1);
+				Assert.AreEqual(0, cnt2);
+			}
+		}
+
+		[Test]
+		public void InsertIfNotExists_EmptyNew1([InsertOrUpdateDataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var table = db.CreateLocalTable<TestInsertOrReplaceInfo>())
+			{
+				var cnt1 = table.InsertOrUpdate(
+					() => new TestInsertOrReplaceInfo()
+					{
+						Id   = 1,
+						Name = "test"
+					},
+					p => new TestInsertOrReplaceInfo());
+				var cnt2 = table.InsertOrUpdate(
+					() => new TestInsertOrReplaceInfo()
+					{
+						Id   = 1,
+						Name = "test"
+					},
+					p => new TestInsertOrReplaceInfo());
+
+				Assert.AreEqual(1, cnt1);
+				Assert.AreEqual(0, cnt2);
+			}
+		}
+
+		[Test]
+		public void InsertIfNotExists_EmptyNew2([InsertOrUpdateDataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var table = db.CreateLocalTable<TestInsertOrReplaceInfo>())
+			{
+				var cnt1 = table.InsertOrUpdate(
+					() => new TestInsertOrReplaceInfo()
+					{
+						Id   = 1,
+						Name = "test"
+					},
+					p => new TestInsertOrReplaceInfo(),
+					() => new TestInsertOrReplaceInfo() { Id = 1 });
+				var cnt2 = table.InsertOrUpdate(
+					() => new TestInsertOrReplaceInfo()
+					{
+						Id   = 1,
+						Name = "test"
+					},
+					p => new TestInsertOrReplaceInfo(),
+					() => new TestInsertOrReplaceInfo() { Id = 1 });
+
+				Assert.AreEqual(1, cnt1);
+				Assert.AreEqual(0, cnt2);
+			}
+		}
+
+		[Test]
+		public void InsertIfNotExists_NullExpr1([InsertOrUpdateDataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var table = db.CreateLocalTable<TestInsertOrReplaceInfo>())
+			{
+				var cnt1 = table.InsertOrUpdate(
+					() => new TestInsertOrReplaceInfo()
+					{
+						Id   = 1,
+						Name = "test"
+					},
+					p => null);
+				var cnt2 = table.InsertOrUpdate(
+					() => new TestInsertOrReplaceInfo()
+					{
+						Id   = 1,
+						Name = "test"
+					},
+					p => null);
+
+				Assert.AreEqual(1, cnt1);
+				Assert.AreEqual(0, cnt2);
+			}
+		}
+
+		[Test]
+		public void InsertIfNotExists_NullExpr2([InsertOrUpdateDataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var table = db.CreateLocalTable<TestInsertOrReplaceInfo>())
+			{
+				var cnt1 = table.InsertOrUpdate(
+					() => new TestInsertOrReplaceInfo()
+					{
+						Id   = 1,
+						Name = "test"
+					},
+					p => null,
+					() => new TestInsertOrReplaceInfo() { Id = 1 });
+				var cnt2 = table.InsertOrUpdate(
+					() => new TestInsertOrReplaceInfo()
+					{
+						Id   = 1,
+						Name = "test"
+					},
+					p => null,
+					() => new TestInsertOrReplaceInfo() { Id = 1 });
+
+				Assert.AreEqual(1, cnt1);
+				Assert.AreEqual(0, cnt2);
+			}
+		}
+
+		[Test]
+		public void InsertIfNotExists_Null1([InsertOrUpdateDataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var table = db.CreateLocalTable<TestInsertOrReplaceInfo>())
+			{
+				var cnt1 = table.InsertOrUpdate(
+					() => new TestInsertOrReplaceInfo()
+					{
+						Id   = 1,
+						Name = "test"
+					},
+					null);
+				var cnt2 = table.InsertOrUpdate(
+					() => new TestInsertOrReplaceInfo()
+					{
+						Id   = 1,
+						Name = "test"
+					},
+					null);
+
+				Assert.AreEqual(1, cnt1);
+				Assert.AreEqual(0, cnt2);
+			}
+		}
+
+		[Test]
+		public void InsertIfNotExists_Null2([InsertOrUpdateDataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var table = db.CreateLocalTable<TestInsertOrReplaceInfo>())
+			{
+				var cnt1 = table.InsertOrUpdate(
+					() => new TestInsertOrReplaceInfo()
+					{
+						Id   = 1,
+						Name = "test"
+					},
+					null,
+					() => new TestInsertOrReplaceInfo() { Id = 1 });
+				var cnt2 = table.InsertOrUpdate(
+					() => new TestInsertOrReplaceInfo()
+					{
+						Id   = 1,
+						Name = "test"
+					},
+					null,
+					() => new TestInsertOrReplaceInfo() { Id = 1 });
+
+				Assert.AreEqual(1, cnt1);
+				Assert.AreEqual(0, cnt2);
+			}
+		}
+		#endregion
+
+		#region issue 2243
 		[Table("test_insert_or_replace")]
 		public partial class TestInsertOrReplaceInfo
 		{
 			[Column("id"), PrimaryKey, NotNull]                   public int       Id        { get; set; } // bigint
 			[Column("name"), Nullable]                            public string?   Name      { get; set; } // character varying(100)
-			[Column("created_by", SkipOnUpdate = true), NotNull]  public string?   CreatedBy { get; set; } // character varying(100)
+			[Column("created_by", SkipOnUpdate = true), Nullable] public string?   CreatedBy { get; set; } // character varying(100)
 			[Column("updated_by", SkipOnInsert = true), Nullable] public string?   UpdatedBy { get; set; } // character varying(100)
 		}
 


### PR DESCRIPTION
Fix #3005

alongsize with `r => new Table() { }` empty init statement following values also now recognized:
- `null`
- `record => null`
- `record => new Table()`