### PR TITLE
Distinct+OrderBy + Take/Skip fixes

### DIFF
--- a/Source/LinqToDB/Linq/Builder/OrderByBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/OrderByBuilder.cs
@@ -42,8 +42,7 @@ namespace LinqToDB.Linq.Builder
 
 			var wrapped = false;
 
-			if (sequence.SelectQuery.Select.TakeValue != null ||
-				sequence.SelectQuery.Select.SkipValue != null)
+			if (sequence.SelectQuery.Select.HasModifier)
 			{
 				sequence = new SubQueryContext(sequence);
 				wrapped = true;

--- a/Source/LinqToDB/SqlProvider/BasicSqlOptimizer.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlOptimizer.cs
@@ -2977,10 +2977,10 @@ namespace LinqToDB.SqlProvider
 				(p, q) =>
 				{
 					var columnItems  = q.Select.Columns.Select(c => c.Expression).ToList();
-					var orderItems   = q.Select.OrderBy.Items.Select(o => o.Expression).ToList();
+					var orderItems   = q.Select.OrderBy.Items.Select(o => o.Expression);
 
-					var projectionItemsCount = columnItems.Union(orderItems).Count();
-					if (projectionItemsCount < columnItems.Count)
+					var additionalProjection = orderItems.Except(columnItems).ToList();
+					if (additionalProjection.Count > 0)
 					{
 						// Sort columns not in projection, transforming to 
 						/*
@@ -3007,7 +3007,6 @@ namespace LinqToDB.SqlProvider
 							$"ROW_NUMBER() OVER (PARTITION BY {partitionBy} ORDER BY {orderBy})", Precedence.Primary,
 							SqlFlags.IsWindowFunction, parameters);
 
-						var additionalProjection = orderItems.Except(columnItems);
 						foreach (var expr in additionalProjection)
 						{
 							q.Select.AddNew(expr);

--- a/Source/LinqToDB/SqlQuery/QueryHelper.cs
+++ b/Source/LinqToDB/SqlQuery/QueryHelper.cs
@@ -621,7 +621,7 @@ namespace LinqToDB.SqlQuery
 						!nonProjecting.Contains(oi.Expression)
 							? oi
 							: new SqlOrderByItem(
-								new SqlFunction(oi.Expression.SystemType!, oi.IsDescending ? "Min" : "Max", true, oi.Expression),
+								new SqlFunction(oi.Expression.SystemType!, !oi.IsDescending ? "Min" : "Max", true, oi.Expression),
 								oi.IsDescending))
 					.ToList();
 

--- a/Tests/Linq/Linq/DistinctTests.cs
+++ b/Tests/Linq/Linq/DistinctTests.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 
 namespace Tests.Linq
 {
+	using LinqToDB.Mapping;
 	using Model;
 
 	[TestFixture]
@@ -147,6 +148,86 @@ namespace Tests.Linq
 					from p in q2.Where(_ => _.ID == e.ID).DefaultIfEmpty()
 					select new { e.ID, p.SmallIntValue }
 					);
+			}
+		}
+
+		[Table]
+		public class DistinctOrderByTable
+		{
+			[PrimaryKey] public int    Id { get; set; }
+			[Column]     public int    F1 { get; set; }
+			[Column]     public string F2 { get; set; } = null!;
+
+			public static readonly DistinctOrderByTable[] Data = new[]
+			{
+				new DistinctOrderByTable() { Id = 8, F1 = 8, F2 = "8" },
+				new DistinctOrderByTable() { Id = 3, F1 = 3, F2 = "3" },
+				new DistinctOrderByTable() { Id = 2, F1 = 2, F2 = "2" },
+				new DistinctOrderByTable() { Id = 6, F1 = 3, F2 = "3" },
+				new DistinctOrderByTable() { Id = 1, F1 = 3, F2 = "3" },
+				new DistinctOrderByTable() { Id = 5, F1 = 5, F2 = "5" },
+				new DistinctOrderByTable() { Id = 7, F1 = 2, F2 = "2" },
+				new DistinctOrderByTable() { Id = 4, F1 = 4, F2 = "4" },
+			};
+		}
+
+		[Test]
+		public void DistinctOrderBy2([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var t = db.CreateLocalTable(DistinctOrderByTable.Data))
+			{
+				var res = t.Select(_ => new { _.F1, _.F2 }).Distinct().OrderByDescending(_ => _.F1).Select(_ => _.F2).ToArray();
+
+				Assert.AreEqual(5, res.Length);
+				Assert.AreEqual("8", res[0]);
+				Assert.AreEqual("5", res[1]);
+				Assert.AreEqual("4", res[2]);
+				Assert.AreEqual("3", res[3]);
+				Assert.AreEqual("2", res[4]);
+			}
+		}
+
+		[Test]
+		public void DistinctOrderBySkipTake([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var t = db.CreateLocalTable(DistinctOrderByTable.Data))
+			{
+				var res = t.Select(_ => new { _.F1, _.F2 }).Distinct().OrderByDescending(_ => _.F1).Select(_ => _.F2).Skip(1).Take(2).ToArray();
+
+				Assert.AreEqual(2, res.Length);
+				Assert.AreEqual("5", res[0]);
+				Assert.AreEqual("4", res[1]);
+			}
+		}
+
+		[Test]
+		public void DistinctOrderByTake([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var t = db.CreateLocalTable(DistinctOrderByTable.Data))
+			{
+				var res = t.Select(_ => new { _.F1, _.F2 }).Distinct().OrderByDescending(_ => _.F1).Select(_ => _.F2).Take(2).ToArray();
+
+				Assert.AreEqual(2, res.Length);
+				Assert.AreEqual("8", res[0]);
+				Assert.AreEqual("5", res[1]);
+			}
+		}
+
+		[Test]
+		public void DistinctOrderBySkip([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var t = db.CreateLocalTable(DistinctOrderByTable.Data))
+			{
+				var res = t.Select(_ => new { _.F1, _.F2 }).Distinct().OrderByDescending(_ => _.F1).Select(_ => _.F2).Skip(2).ToArray();
+
+				Assert.AreEqual(3, res.Length);
+				Assert.AreEqual("4", res[0]);
+				Assert.AreEqual("3", res[1]);
+				Assert.AreEqual("2", res[2]);
 			}
 		}
 	}

--- a/Tests/Linq/Linq/DistinctTests.cs
+++ b/Tests/Linq/Linq/DistinctTests.cs
@@ -157,17 +157,18 @@ namespace Tests.Linq
 			[PrimaryKey] public int    Id { get; set; }
 			[Column]     public int    F1 { get; set; }
 			[Column]     public string F2 { get; set; } = null!;
+			[Column]     public int    F3 { get; set; }
 
 			public static readonly DistinctOrderByTable[] Data = new[]
 			{
-				new DistinctOrderByTable() { Id = 8, F1 = 8, F2 = "8" },
-				new DistinctOrderByTable() { Id = 3, F1 = 3, F2 = "3" },
-				new DistinctOrderByTable() { Id = 2, F1 = 2, F2 = "2" },
-				new DistinctOrderByTable() { Id = 6, F1 = 3, F2 = "3" },
-				new DistinctOrderByTable() { Id = 1, F1 = 3, F2 = "3" },
-				new DistinctOrderByTable() { Id = 5, F1 = 5, F2 = "5" },
-				new DistinctOrderByTable() { Id = 7, F1 = 2, F2 = "2" },
-				new DistinctOrderByTable() { Id = 4, F1 = 4, F2 = "4" },
+				new DistinctOrderByTable() { Id = 8, F1 = 8, F2 = "8", F3 = 5 },
+				new DistinctOrderByTable() { Id = 3, F1 = 3, F2 = "3", F3 = 3 },
+				new DistinctOrderByTable() { Id = 2, F1 = 2, F2 = "2", F3 = 1 },
+				new DistinctOrderByTable() { Id = 6, F1 = 3, F2 = "3", F3 = 4 },
+				new DistinctOrderByTable() { Id = 1, F1 = 3, F2 = "3", F3 = 7 },
+				new DistinctOrderByTable() { Id = 5, F1 = 5, F2 = "5", F3 = 2 },
+				new DistinctOrderByTable() { Id = 7, F1 = 2, F2 = "2", F3 = 8 },
+				new DistinctOrderByTable() { Id = 4, F1 = 4, F2 = "4", F3 = 6 },
 			};
 		}
 
@@ -228,6 +229,114 @@ namespace Tests.Linq
 				Assert.AreEqual("4", res[0]);
 				Assert.AreEqual("3", res[1]);
 				Assert.AreEqual("2", res[2]);
+			}
+		}
+
+		[Test]
+		public void OrderByDistinct([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var t = db.CreateLocalTable(DistinctOrderByTable.Data))
+			{
+				var res = t.OrderByDescending(_ => _.F3).Select(_ => new { _.F1, _.F2 }).Distinct().Select(_ => _.F2).ToArray();
+
+				Assert.AreEqual(5, res.Length);
+				Assert.AreEqual("2", res[0]);
+				Assert.AreEqual("3", res[1]);
+				Assert.AreEqual("4", res[2]);
+				Assert.AreEqual("8", res[3]);
+				Assert.AreEqual("5", res[4]);
+			}
+		}
+
+		[Test]
+		public void OrderByDistinctSkipTake([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var t = db.CreateLocalTable(DistinctOrderByTable.Data))
+			{
+				var res = t.OrderByDescending(_ => _.F3).Select(_ => new { _.F1, _.F2 }).Distinct().Select(_ => _.F2).Skip(1).Take(2).ToArray();
+
+				Assert.AreEqual(2, res.Length);
+				Assert.AreEqual("3", res[0]);
+				Assert.AreEqual("4", res[1]);
+			}
+		}
+
+		[Test]
+		public void OrderByDistinctTake([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var t = db.CreateLocalTable(DistinctOrderByTable.Data))
+			{
+				var res = t.OrderByDescending(_ => _.F3).Select(_ => new { _.F1, _.F2 }).Distinct().Select(_ => _.F2).Take(2).ToArray();
+
+				Assert.AreEqual(2, res.Length);
+				Assert.AreEqual("2", res[0]);
+				Assert.AreEqual("3", res[1]);
+			}
+		}
+
+		[Test]
+		public void OrderByDistinctSkip([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var t = db.CreateLocalTable(DistinctOrderByTable.Data))
+			{
+				var res = t.OrderByDescending(_ => _.F3).Select(_ => new { _.F1, _.F2 }).Distinct().Select(_ => _.F2).Skip(2).ToArray();
+
+				Assert.AreEqual(3, res.Length);
+				Assert.AreEqual("4", res[0]);
+				Assert.AreEqual("8", res[1]);
+				Assert.AreEqual("5", res[2]);
+			}
+		}
+
+		[Test]
+		public void OrderByDistinctSkipTakeFirst([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var t = db.CreateLocalTable(DistinctOrderByTable.Data))
+			{
+				var res = t.OrderByDescending(_ => _.F3).Skip(1).Take(4).Select(_ => new { _.F1, _.F2 }).Distinct().Select(_ => _.F2).ToArray();
+
+				Assert.AreEqual(3, res.Length);
+				Assert.AreEqual("3", res[0]);
+				Assert.AreEqual("4", res[1]);
+				Assert.AreEqual("8", res[2]);
+			}
+		}
+
+		[Test]
+		public void OrderByDistinctTakeFirst([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var t = db.CreateLocalTable(DistinctOrderByTable.Data))
+			{
+				var res = t.OrderByDescending(_ => _.F3).Take(5).Select(_ => new { _.F1, _.F2 }).Distinct().Select(_ => _.F2).ToArray();
+
+				Assert.AreEqual(4, res.Length);
+				Assert.AreEqual("2", res[0]);
+				Assert.AreEqual("3", res[1]);
+				Assert.AreEqual("4", res[2]);
+				Assert.AreEqual("8", res[3]);
+			}
+		}
+
+		[Test]
+		public void OrderByDistinctSkipFirst([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (var t = db.CreateLocalTable(DistinctOrderByTable.Data))
+			{
+				var res = t.OrderByDescending(_ => _.F3).Skip(2).Select(_ => new { _.F1, _.F2 }).Distinct().Select(_ => _.F2).ToArray();
+
+				Assert.AreEqual(5, res.Length);
+				Assert.AreEqual("4", res[0]);
+				Assert.AreEqual("8", res[1]);
+				Assert.AreEqual("3", res[2]);
+				Assert.AreEqual("5", res[3]);
+				Assert.AreEqual("2", res[4]);
 			}
 		}
 	}


### PR DESCRIPTION
Fix #2943 (part 1)

First reported issue is about unreachable code in `ReplaceDistinctOrderByWithRowNumber` method. This method used only for SQL Server 2005 but when I tried to create test for this code, I found out that tests doesn't work for other databases (at least SQL Server 2008+), e.g. order by clause is not correct.