### PR TITLE
Fix issues around LinqToDbConnectionOptions

### DIFF
--- a/Source/LinqToDB.AspNet/ServiceConfigurationExtensions.cs
+++ b/Source/LinqToDB.AspNet/ServiceConfigurationExtensions.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace LinqToDB.AspNet
 {
+	using System.Reflection;
 	using Configuration;
 	using Data;
 
@@ -102,7 +102,7 @@ namespace LinqToDB.AspNet
 		public static IServiceCollection AddLinqToDbContext<TContext>(
 			this IServiceCollection serviceCollection,
 			Action<IServiceProvider, LinqToDbConnectionOptionsBuilder> configure,
-			ServiceLifetime lifetime = ServiceLifetime.Scoped) where TContext : IDataContext
+			ServiceLifetime lifetime  = ServiceLifetime.Scoped) where TContext : IDataContext
 		{
 			return AddLinqToDbContext<TContext, TContext>(serviceCollection, configure, lifetime);
 		}
@@ -157,9 +157,9 @@ namespace LinqToDB.AspNet
 		public static IServiceCollection AddLinqToDbContext<TContext, TContextImplementation>(
 			this IServiceCollection serviceCollection,
 			Action<IServiceProvider, LinqToDbConnectionOptionsBuilder> configure,
-			ServiceLifetime lifetime = ServiceLifetime.Scoped) where TContextImplementation : TContext, IDataContext
+			ServiceLifetime lifetime  = ServiceLifetime.Scoped) where TContextImplementation : TContext, IDataContext
 		{
-			CheckContextConstructor<TContextImplementation>();
+			var hasTypedConstructor = HasTypedContextConstructor<TContextImplementation>();
 			serviceCollection.Add(new ServiceDescriptor(typeof(TContext), typeof(TContextImplementation), lifetime));
 			serviceCollection.Add(new ServiceDescriptor(typeof(LinqToDbConnectionOptions<TContextImplementation>),
 				provider =>
@@ -169,21 +169,31 @@ namespace LinqToDB.AspNet
 					return builder.Build<TContextImplementation>();
 				},
 				lifetime));
-			//serviceCollection.Add(new ServiceDescriptor(typeof(LinqToDbConnectionOptions),
-			//	provider => provider.GetService(typeof(LinqToDbConnectionOptions<TContextImplementation>)), lifetime));
+
+			if (!hasTypedConstructor)
+				serviceCollection.Add(new ServiceDescriptor(typeof(LinqToDbConnectionOptions),
+					provider => provider.GetService(typeof(LinqToDbConnectionOptions<TContextImplementation>)), lifetime));
+
 			return serviceCollection;
 		}
 
-		private static void CheckContextConstructor<TContext>()
+		private static bool HasTypedContextConstructor<TContext>()
 		{
-			var constructorInfo =
-				typeof(TContext).GetConstructor(new[] {typeof(LinqToDbConnectionOptions<TContext>)}) ??
-				typeof(TContext).GetConstructor(new[] {typeof(LinqToDbConnectionOptions)});
-			if (constructorInfo == null)
-			{
+			var typedConstructorInfo   = typeof(TContext).GetConstructor(
+				BindingFlags.Public | BindingFlags.Instance | BindingFlags.ExactBinding,
+				null,
+				new[] {typeof(LinqToDbConnectionOptions<TContext>)},
+				null);
+
+			var untypedConstructorInfo = typedConstructorInfo == null
+				? typeof(TContext).GetConstructor(new[] {typeof(LinqToDbConnectionOptions)})
+				: null;
+
+			if (typedConstructorInfo == null && untypedConstructorInfo == null)
 				throw new ArgumentException("Missing constructor accepting 'LinqToDbContextOptions' on type "
 				                            + typeof(TContext).Name);
-			}
+
+			return typedConstructorInfo != null;
 		}
 	}
 }

--- a/Source/LinqToDB.AspNet/ServiceConfigurationExtensions.cs
+++ b/Source/LinqToDB.AspNet/ServiceConfigurationExtensions.cs
@@ -160,8 +160,8 @@ namespace LinqToDB.AspNet
 			ServiceLifetime lifetime = ServiceLifetime.Scoped) where TContextImplementation : TContext, IDataContext
 		{
 			CheckContextConstructor<TContextImplementation>();
-			serviceCollection.TryAdd(new ServiceDescriptor(typeof(TContext), typeof(TContextImplementation), lifetime));
-			serviceCollection.TryAdd(new ServiceDescriptor(typeof(LinqToDbConnectionOptions<TContextImplementation>),
+			serviceCollection.Add(new ServiceDescriptor(typeof(TContext), typeof(TContextImplementation), lifetime));
+			serviceCollection.Add(new ServiceDescriptor(typeof(LinqToDbConnectionOptions<TContextImplementation>),
 				provider =>
 				{
 					var builder = new LinqToDbConnectionOptionsBuilder();
@@ -169,8 +169,8 @@ namespace LinqToDB.AspNet
 					return builder.Build<TContextImplementation>();
 				},
 				lifetime));
-			serviceCollection.TryAdd(new ServiceDescriptor(typeof(LinqToDbConnectionOptions),
-				provider => provider.GetService(typeof(LinqToDbConnectionOptions<TContextImplementation>)), lifetime));
+			//serviceCollection.Add(new ServiceDescriptor(typeof(LinqToDbConnectionOptions),
+			//	provider => provider.GetService(typeof(LinqToDbConnectionOptions<TContextImplementation>)), lifetime));
 			return serviceCollection;
 		}
 

--- a/Source/LinqToDB.AspNet/ServiceConfigurationExtensions.cs
+++ b/Source/LinqToDB.AspNet/ServiceConfigurationExtensions.cs
@@ -6,6 +6,7 @@ namespace LinqToDB.AspNet
 	using System.Reflection;
 	using Configuration;
 	using Data;
+	using Microsoft.Extensions.DependencyInjection.Extensions;
 
 	public static class ServiceConfigurationExtensions
 	{
@@ -160,8 +161,8 @@ namespace LinqToDB.AspNet
 			ServiceLifetime lifetime  = ServiceLifetime.Scoped) where TContextImplementation : TContext, IDataContext
 		{
 			var hasTypedConstructor = HasTypedContextConstructor<TContextImplementation>();
-			serviceCollection.Add(new ServiceDescriptor(typeof(TContext), typeof(TContextImplementation), lifetime));
-			serviceCollection.Add(new ServiceDescriptor(typeof(LinqToDbConnectionOptions<TContextImplementation>),
+			serviceCollection.TryAdd(new ServiceDescriptor(typeof(TContext), typeof(TContextImplementation), lifetime));
+			serviceCollection.TryAdd(new ServiceDescriptor(typeof(LinqToDbConnectionOptions<TContextImplementation>),
 				provider =>
 				{
 					var builder = new LinqToDbConnectionOptionsBuilder();
@@ -171,7 +172,7 @@ namespace LinqToDB.AspNet
 				lifetime));
 
 			if (!hasTypedConstructor)
-				serviceCollection.Add(new ServiceDescriptor(typeof(LinqToDbConnectionOptions),
+				serviceCollection.TryAdd(new ServiceDescriptor(typeof(LinqToDbConnectionOptions),
 					provider => provider.GetService(typeof(LinqToDbConnectionOptions<TContextImplementation>)), lifetime));
 
 			return serviceCollection;

--- a/Source/LinqToDB.Templates/LinqToDB.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.ttinclude
@@ -44,7 +44,7 @@ private static IEnumerable<Method> GetConstructorsImpl(string defaultConfigurati
 	else
 		yield return new Method(null, name) { AfterSignature = { ": base(\"" + defaultConfiguration + "\")" } };
 	yield return new Method(null, name, new Func<string>[] { () => "string configuration" }) { AfterSignature = { ": base(configuration)" } };
-	yield return new Method(null, name, new Func<string>[] { () => "LinqToDbConnectionOptions options" }) { AfterSignature = { ": base(options)" } };
+	yield return new Method(null, name, new Func<string>[] { () => string.Format("LinqToDbConnectionOptions<{0}> options", name) }) { AfterSignature = { ": base(options)" } };
 }
 
 void GenerateTypesFromMetadata()

--- a/Source/LinqToDB.Templates/LinqToDB.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.ttinclude
@@ -44,6 +44,7 @@ private static IEnumerable<Method> GetConstructorsImpl(string defaultConfigurati
 	else
 		yield return new Method(null, name) { AfterSignature = { ": base(\"" + defaultConfiguration + "\")" } };
 	yield return new Method(null, name, new Func<string>[] { () => "string configuration" }) { AfterSignature = { ": base(configuration)" } };
+	yield return new Method(null, name, new Func<string>[] { () => "LinqToDbConnectionOptions options" }) { AfterSignature = { ": base(options)" } };
 	yield return new Method(null, name, new Func<string>[] { () => string.Format("LinqToDbConnectionOptions<{0}> options", name) }) { AfterSignature = { ": base(options)" } };
 }
 

--- a/Tests/Tests.T4/Databases/Access.generated.cs
+++ b/Tests/Tests.T4/Databases/Access.generated.cs
@@ -58,7 +58,7 @@ namespace AccessDataContext
 			InitMappingSchema();
 		}
 
-		public TestDataDB(LinqToDbConnectionOptions options)
+		public TestDataDB(LinqToDbConnectionOptions<TestDataDB> options)
 			: base(options)
 		{
 			InitDataContext();

--- a/Tests/Tests.T4/Databases/Access.generated.cs
+++ b/Tests/Tests.T4/Databases/Access.generated.cs
@@ -58,6 +58,13 @@ namespace AccessDataContext
 			InitMappingSchema();
 		}
 
+		public TestDataDB(LinqToDbConnectionOptions options)
+			: base(options)
+		{
+			InitDataContext();
+			InitMappingSchema();
+		}
+
 		public TestDataDB(LinqToDbConnectionOptions<TestDataDB> options)
 			: base(options)
 		{


### PR DESCRIPTION
Fix #2998

- generate typed options constructor in T4
- register untyped options only for context without typed options constructor