### PR TITLE
Fix for #3056

### DIFF
--- a/Source/LinqToDB/Metadata/MetadataReader.cs
+++ b/Source/LinqToDB/Metadata/MetadataReader.cs
@@ -120,9 +120,9 @@ namespace LinqToDB.Metadata
 				cols[i] = readers[i].GetDynamicColumns(type);
 				length  += cols[i].Length;
 			}
-
-			length = 0;
+			
 			var columns = new MemberInfo[length];
+			length = 0;
 			for (var i = 0; i < cols.Length; i++)
 			{
 				if (cols[i].Length > 0)

--- a/Tests/Linq/UserTests/Issue3056Tests.cs
+++ b/Tests/Linq/UserTests/Issue3056Tests.cs
@@ -55,7 +55,7 @@ namespace Tests.UserTests
 			[Column(DataType = DataType.VarChar, Length = 100)]
 			public string? Name;
 
-			[Column(DataType = DataType.VarChar, Length = 500)]
+			[Column(DataType = DataType.VarChar, Length = 200)]
 			public string? Description;
 
 		}

--- a/Tests/Linq/UserTests/Issue3056Tests.cs
+++ b/Tests/Linq/UserTests/Issue3056Tests.cs
@@ -1,0 +1,70 @@
+﻿using System.Collections.Generic;
+using LinqToDB;
+using LinqToDB.Data;
+using LinqToDB.Mapping;
+using NUnit.Framework;
+using Tests.Model;
+
+namespace Tests.UserTests
+{
+	[TestFixture]
+	public class Issue3056Tests : TestBase
+	{
+		[Test]
+		public void DataModelDynamicTableTest2([DataSources(false)] string context)
+		{
+			using (var db = new TestDataConnection(context))
+			using (db.CreateLocalTable<TestRow>())
+			{
+				var fm = MappingSchema.Default.GetFluentMappingBuilder();
+
+				fm.Entity<DynamicTableRow>()
+					//.HasIdentity(x => Sql.Property<int>(x, "Id"))
+					.Property(x => Sql.Property<string>(x, "Name"))
+					.Property(x => Sql.Property<string>(x, "Description"));
+
+				var rows = new List<DynamicTableRow>();
+				var drow = new DynamicTableRow();
+				drow.Properties.Add("Id", 1);
+				drow.Properties.Add("Name", "n1");
+				drow.Properties.Add("Description", "d0");
+				rows.Add(drow);
+				drow = new DynamicTableRow();
+				drow.Properties.Add("Id", 2);
+				drow.Properties.Add("Name", "n2");
+				drow.Properties.Add("Description", "d00");
+				rows.Add(drow);
+
+				db.BulkCopy(new BulkCopyOptions
+					{
+						TableName    = TestTableName,
+						SchemaName   = "dbo",
+						MaxBatchSize = 100
+					},
+					rows);
+			}
+		}
+
+		private const string TestTableName = "Table_3056";
+		[Table(TestTableName, Schema = "dbo")]
+		class TestRow
+		{
+			[PrimaryKey, Identity]
+			public int Id;
+
+			[Column(DataType = DataType.VarChar, Length = 100)]
+			public string? Name;
+
+			[Column(DataType = DataType.VarChar, Length = 500)]
+			public string? Description;
+
+		}
+
+		[Table]
+		public class DynamicTableRow
+		{
+			[DynamicColumnsStore]
+			public Dictionary<string, object> Properties = new Dictionary<string, object>();
+		}
+	}
+}

--- a/Tests/Linq/UserTests/Issue3056Tests.cs
+++ b/Tests/Linq/UserTests/Issue3056Tests.cs
@@ -11,29 +11,31 @@ namespace Tests.UserTests
 	public class Issue3056Tests : TestBase
 	{
 		[Test]
-		public void DataModelDynamicTableTest2([DataSources(false)] string context)
+		public void DataModelDynamicTableTest2([IncludeDataSources(false, TestProvName.AllSQLite)] string context)
 		{
-			using (var db = new TestDataConnection(context))
+			var mappingSchema =  new MappingSchema();
+			var fm            =mappingSchema.GetFluentMappingBuilder();
+
+			fm.Entity<DynamicTableRow>()
+				//.HasIdentity(x => Sql.Property<int>(x, "Id"))
+				.Property(x => Sql.Property<string>(x, "Name"))
+				.Property(x => Sql.Property<string>(x, "Description"));
+
+			var rows = new List<DynamicTableRow>();
+			var drow = new DynamicTableRow();
+			drow.Properties.Add("Id", 1);
+			drow.Properties.Add("Name", "n1");
+			drow.Properties.Add("Description", "d0");
+			rows.Add(drow);
+			drow = new DynamicTableRow();
+			drow.Properties.Add("Id", 2);
+			drow.Properties.Add("Name", "n2");
+			drow.Properties.Add("Description", "d00");
+			rows.Add(drow);
+			using (var db = new TestDataConnection(context, mappingSchema))
 			using (db.CreateLocalTable<TestRow>())
 			{
-				var fm = MappingSchema.Default.GetFluentMappingBuilder();
-
-				fm.Entity<DynamicTableRow>()
-					//.HasIdentity(x => Sql.Property<int>(x, "Id"))
-					.Property(x => Sql.Property<string>(x, "Name"))
-					.Property(x => Sql.Property<string>(x, "Description"));
-
-				var rows = new List<DynamicTableRow>();
-				var drow = new DynamicTableRow();
-				drow.Properties.Add("Id", 1);
-				drow.Properties.Add("Name", "n1");
-				drow.Properties.Add("Description", "d0");
-				rows.Add(drow);
-				drow = new DynamicTableRow();
-				drow.Properties.Add("Id", 2);
-				drow.Properties.Add("Name", "n2");
-				drow.Properties.Add("Description", "d00");
-				rows.Add(drow);
+				
 
 				db.BulkCopy(new BulkCopyOptions
 					{

--- a/Tests/Model/TestDataConnection.cs
+++ b/Tests/Model/TestDataConnection.cs
@@ -5,6 +5,7 @@ using System.Text;
 
 using LinqToDB;
 using LinqToDB.Data;
+using LinqToDB.Mapping;
 using LinqToDB.SqlProvider;
 using LinqToDB.SqlQuery;
 
@@ -19,6 +20,12 @@ namespace Tests.Model
 		{
 //			if (configString == ProviderName.SqlServer2008 && ++_counter > 1000)
 //				OnClosing += TestDataConnection_OnClosing;
+		}
+		
+		public TestDataConnection(string configString, MappingSchema mappingSchema)
+			: base(configString, mappingSchema)
+		{
+
 		}
 
 		public TestDataConnection()


### PR DESCRIPTION
Simple change, fix MetadataReader.GetDynamicColumns to not reset length variable until we have made array.

Fixes #3056