### PR TITLE
update dependencies

### DIFF
--- a/Build/Azure/README.md
+++ b/Build/Azure/README.md
@@ -66,44 +66,44 @@ Legend:
 |:---|:---:|:---:|:---:|:---:|
 |TestNoopProvider<sup>[1](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |SQLite [3.13.0](https://www.sqlite.org/releaselog/3_13_0.html)<sup>[2](#notes)</sup><br>[Microsoft.Data.SQLite](https://www.nuget.org/packages/Microsoft.Data.SQLite/) 1.1.1<br>with NorthwindDB Tests|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
-|SQLite [3.33.0](https://www.sqlite.org/releaselog/3_33_0.html)<br>[Microsoft.Data.SQLite](https://www.nuget.org/packages/Microsoft.Data.SQLite/) 5.0.6<br>with NorthwindDB Tests|:heavy_minus_sign:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-|SQLite [3.35.5](https://www.sqlite.org/releaselog/3_32_1.html)(win)<br>[3.31.1](https://www.sqlite.org/releaselog/3_35_5.html)<br>[System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite.Core/) 1.0.114.2<br>with NorthwindDB Tests|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-|SQLite [3.35.5](https://www.sqlite.org/releaselog/3_32_1.html)(win)<br>[3.31.1](https://www.sqlite.org/releaselog/3_35_5.html)<br>[System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite.Core/) 1.0.114.2<br>with [MiniProfiler](https://www.nuget.org/packages/MiniProfiler.Shared/) 4.2.22 (core)<br>[MiniProfiler](https://www.nuget.org/packages/MiniProfiler/) 3.2.0.157 (netfx)<br>without mappings to underlying provider|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-|SQLite [3.35.5](https://www.sqlite.org/releaselog/3_32_1.html)(win)<br>[3.31.1](https://www.sqlite.org/releaselog/3_35_5.html)<br>[System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite.Core/) 1.0.114.2<br>with [MiniProfiler](https://www.nuget.org/packages/MiniProfiler.Shared/) 4.2.22 (core)<br>[MiniProfiler](https://www.nuget.org/packages/MiniProfiler/) 3.2.0.157 (netfx)<br>with mappings to underlying provider|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+|SQLite [3.33.0](https://www.sqlite.org/releaselog/3_33_0.html)<br>[Microsoft.Data.SQLite](https://www.nuget.org/packages/Microsoft.Data.SQLite/) 5.0.7<br>with NorthwindDB Tests|:heavy_minus_sign:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+|SQLite [3.35.5](https://www.sqlite.org/releaselog/3_32_1.html)(win)<br>[3.31.1](https://www.sqlite.org/releaselog/3_35_5.html)<br>[System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite.Core/) 1.0.114.3<br>with NorthwindDB Tests|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+|SQLite [3.35.5](https://www.sqlite.org/releaselog/3_32_1.html)(win)<br>[3.31.1](https://www.sqlite.org/releaselog/3_35_5.html)<br>[System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite.Core/) 1.0.114.3<br>with [MiniProfiler](https://www.nuget.org/packages/MiniProfiler.Shared/) 4.2.22 (core)<br>[MiniProfiler](https://www.nuget.org/packages/MiniProfiler/) 3.2.0.157 (netfx)<br>without mappings to underlying provider|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+|SQLite [3.35.5](https://www.sqlite.org/releaselog/3_32_1.html)(win)<br>[3.31.1](https://www.sqlite.org/releaselog/3_35_5.html)<br>[System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite.Core/) 1.0.114.3<br>with [MiniProfiler](https://www.nuget.org/packages/MiniProfiler.Shared/) 4.2.22 (core)<br>[MiniProfiler](https://www.nuget.org/packages/MiniProfiler/) 3.2.0.157 (netfx)<br>with mappings to underlying provider|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |Access<sup>[3](#notes)</sup><br>Jet 4.0 OLE DB|:heavy_check_mark:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
 |Access<sup>[3](#notes)</sup><br>ACE 12 OLE DB|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
 |Access<br>MDB ODBC|:heavy_check_mark:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
 |Access<br>MDB+ACCDB ODBC|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL CE<sup>[4](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL Server 2000<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.2|:x:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
-|MS SQL Server 2000<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.3|:x:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
+|MS SQL Server 2000<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 3.0.0|:x:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL Server 2005<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.2|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
-|MS SQL Server 2005<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.3|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
+|MS SQL Server 2005<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 3.0.0|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL Server 2008<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.2|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
-|MS SQL Server 2008<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.3|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
+|MS SQL Server 2008<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 3.0.0|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL Server 2012<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.2|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
-|MS SQL Server 2012<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.3|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
+|MS SQL Server 2012<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 3.0.0|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL Server 2014<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.2|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
-|MS SQL Server 2014<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.3|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
+|MS SQL Server 2014<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 3.0.0|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL Server 2016<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.2|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
-|MS SQL Server 2016<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.3|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
+|MS SQL Server 2016<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 3.0.0|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL Server 2017<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.2<br>with FTS Tests|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|
-|MS SQL Server 2017<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.3<br>with FTS Tests|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|
+|MS SQL Server 2017<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 3.0.0<br>with FTS Tests|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|
 |MS SQL Server 2019<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.2<br>with FTS Tests|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|
-|MS SQL Server 2019<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.3<br>with FTS Tests|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|
+|MS SQL Server 2019<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 3.0.0<br>with FTS Tests|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:<sup>[5](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|
 |Azure SQL<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.2|:x:|:x:|:x:|:x:|
-|Azure SQL<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 2.1.3|:x:|:x:|:x:|:x:|
+|Azure SQL<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 3.0.0|:x:|:x:|:x:|:x:|
 |MySQL 5.6<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.25|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |MySQL 8<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.25|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|MySQL 8<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 1.3.9|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|MySQL 8<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 1.3.11|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |MariaDB 10<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.25|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 9.2<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.5 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 9.3<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.5 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 9.5<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.5 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 10<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.5 (core)|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 11<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.5 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 12<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.5 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 13<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.5 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 9.2<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.7 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 9.3<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.7 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 9.5<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.7 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 10<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.7 (core)|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 11<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.7 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 12<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.7 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 13<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.7 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |DB2 LUW 11.5.0.0a<br>[IBM.Data.DB2](https://www.nuget.org/packages/IBM.Data.DB.Provider/) 11.5.4000.4861 (netfx)<br>[IBM.Data.DB2.Core](https://www.nuget.org/packages/IBM.Data.DB2.Core/) 2.2.0.100 ([osx](https://www.nuget.org/packages/IBM.Data.DB2.Core-osx/) 2.0.0.100, [lin](https://www.nuget.org/packages/IBM.Data.DB2.Core-lnx/) 2.2.0.100) (core)|:x:|:x:|:heavy_check_mark:<sup>[6](#notes)</sup>|:heavy_check_mark:|
 |Informix 12.10.FC12W1DE<br>IBM.Data.Informix (SQLI) 4.0.410.10|:x:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
 |Informix 14.10<br>IBM.Data.Informix (SQLI) 4.0.410.10|:x:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|

--- a/Build/linq2db.Providers.props
+++ b/Build/linq2db.Providers.props
@@ -20,11 +20,6 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
-		<!--workaround for VS 16.10 breaking change
-		https://sqlite.org/forum/info/e4c09bad740332eadb7141b31e6e6a941360a7a1ec6454881d3ff9cd975e3b1d
-		-->
-		<SQLiteInteropFiles Include="$(USERPROFILE)\.nuget\packages\stub.system.data.sqlite.core.netframework\1.0.114\build\net46\**\SQLite.Interop.*" />
-		
 		<Reference Include="System.Data.Services" />
 		<Reference Include="System.Windows.Forms" />
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,15 +29,15 @@
 
 		<!--data providers-->
 		<PackageVersion Include="MySql.Data" Version="8.0.25" />
-		<PackageVersion Include="MySqlConnector" Version="1.3.9" />
+		<PackageVersion Include="MySqlConnector" Version="1.3.11" />
 		<PackageVersion Include="AdoNetCore.AseClient" Version="0.19.2" />
 		<PackageVersion Include="System.Data.SqlClient" Version="4.8.2" />
-		<PackageVersion Include="Microsoft.Data.SqlClient" Version="2.1.3" />
+		<PackageVersion Include="Microsoft.Data.SqlClient" Version="3.0.0" />
 		<PackageVersion Include="System.Data.Odbc" Version="5.0.0" />
 		<PackageVersion Include="System.Data.OleDb" Version="5.0.0" />
 		<PackageVersion Include="Oracle.ManagedDataAccess" Version="19.11.0" />
 		<PackageVersion Include="FirebirdSql.Data.FirebirdClient" Version="8.0.1" />
-		<PackageVersion Include="System.Data.SQLite.Core" Version="1.0.114.2" />
+		<PackageVersion Include="System.Data.SQLite.Core" Version="1.0.114.3" />
 
 		<PackageVersion Include="IBM.Data.DB.Provider" Version="11.5.4000.4861" />
 
@@ -45,13 +45,13 @@
 		<PackageVersion Include="MiniProfiler" Version="3.2.0.157" />
 		<PackageVersion Include="MiniProfiler.Shared" Version="4.2.22" />
 		<PackageVersion Include="NUnit" Version="3.13.2" />
-		<PackageVersion Include="NUnit3TestAdapter" Version="4.0.0-beta.2" />
+		<PackageVersion Include="NUnit3TestAdapter" Version="4.0.0" />
 		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-		<PackageVersion Include="FastExpressionCompiler" Version="3.1.0" />
+		<PackageVersion Include="FastExpressionCompiler" Version="3.2.0" />
 		<PackageVersion Include="BenchmarkDotNet" Version="0.13.0" />
 		<PackageVersion Include="JetBrains.Profiler.Api" Version="1.1.7" />
-		<PackageVersion Include="Humanizer.Core" Version="2.10.1" />
-		<PackageVersion Include="FSharp.Core" Version="5.0.1" />
+		<PackageVersion Include="Humanizer.Core" Version="2.11.10" />
+		<PackageVersion Include="FSharp.Core" Version="5.0.2" />
 		<PackageVersion Include="Microsoft.AspNet.OData" Version="7.5.8" />
 		<PackageVersion Include="NodaTime" Version="3.0.5" />
 
@@ -61,8 +61,8 @@
 
 	<ItemGroup Condition=" '$(TargetFramework)' != 'net472' ">
 		<!--main version-->
-		<PackageVersion Include="Microsoft.Data.SQLite" Version="5.0.6" />
-		<PackageVersion Include="Npgsql" Version="5.0.5" />
+		<PackageVersion Include="Microsoft.Data.SQLite" Version="5.0.7" />
+		<PackageVersion Include="Npgsql" Version="5.0.7" />
 	
 	</ItemGroup>
 	

--- a/NuGet/linq2db.MySqlConnector.nuspec
+++ b/NuGet/linq2db.MySqlConnector.nuspec
@@ -12,8 +12,8 @@
 		</summary>
 		<tags>linq linq2db MySql LinqToDB ORM database DB SQL</tags>
 		<dependencies>
-			<dependency id="linq2db"        version="3.0.0" />
-			<dependency id="MySqlConnector" version="1.3.9" />
+			<dependency id="linq2db"        version="3.0.0"  />
+			<dependency id="MySqlConnector" version="1.3.11" />
 		</dependencies>
 		<contentFiles>
 			<files include="**\*" buildAction="None" />

--- a/NuGet/linq2db.PostgreSQL.nuspec
+++ b/NuGet/linq2db.PostgreSQL.nuspec
@@ -22,11 +22,11 @@
 			</group>
 			<group targetFramework=".NETStandard2.0">
 				<dependency id="linq2db" version="3.0.0"  />
-				<dependency id="Npgsql"  version="5.0.5"  />
+				<dependency id="Npgsql"  version="5.0.7"  />
 			</group>
 			<group targetFramework=".NETCoreApp2.1">
 				<dependency id="linq2db" version="3.0.0"  />
-				<dependency id="Npgsql"  version="5.0.5"  />
+				<dependency id="Npgsql"  version="5.0.7"  />
 			</group>
 		</dependencies>
 		<contentFiles>

--- a/NuGet/linq2db.SQLite.MS.nuspec
+++ b/NuGet/linq2db.SQLite.MS.nuspec
@@ -13,7 +13,7 @@
 		<tags>linq linq2db SQLite LinqToDB ORM database DB SQL</tags>
 		<dependencies>
 			<dependency id="linq2db"                version="3.0.0" />
-			<dependency id="Microsoft.Data.Sqlite"  version="5.0.6" />
+			<dependency id="Microsoft.Data.Sqlite"  version="5.0.7" />
 		</dependencies>
 		<contentFiles>
 			<files include="**\*" buildAction="None" />

--- a/NuGet/linq2db.SQLite.nuspec
+++ b/NuGet/linq2db.SQLite.nuspec
@@ -13,7 +13,7 @@
 		<tags>linq linq2db SQLite LinqToDB ORM database DB SQL</tags>
 		<dependencies>
 			<dependency id="linq2db"                 version="3.0.0"     />
-			<dependency id="System.Data.SQLite.Core" version="1.0.114.2" />
+			<dependency id="System.Data.SQLite.Core" version="1.0.114.3" />
 		</dependencies>
 		<contentFiles>
 			<files include="**\*" buildAction="None" />

--- a/NuGet/linq2db.SqlServer.MS.nuspec
+++ b/NuGet/linq2db.SqlServer.MS.nuspec
@@ -13,7 +13,7 @@
 		<tags>linq linq2db SqlServer LinqToDB ORM database DB SQL</tags>
 		<dependencies>
 			<dependency id="linq2db"                  version="3.0.0" />
-			<dependency id="Microsoft.Data.SqlClient" version="2.1.3" />
+			<dependency id="Microsoft.Data.SqlClient" version="3.0.0" />
 		</dependencies>
 		<contentFiles>
 			<files include="**\*" buildAction="None" />

--- a/Tests/FSharp/Tests.FSharp.fsproj
+++ b/Tests/FSharp/Tests.FSharp.fsproj
@@ -25,7 +25,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FSharp.Core" Version="5.0.1" />
+		<PackageReference Include="FSharp.Core" Version="5.0.2" />
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 
 		<!--workaround for Directory.Packages.props issue-->


### PR DESCRIPTION
- Updated dependencies:
  - [FastExpressionCompiler](https://www.nuget.org/packages/FastExpressionCompiler): 3.1.0 -> 3.2.0
  - [FSharp.Core](https://www.nuget.org/packages/FSharp.Core): 5.0.1 -> 5.0.2
  - [Humanizer.Core](https://www.nuget.org/packages/Humanizer.Core): 2.10.1 -> 2.11.10
  - [Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient): 2.1.3 -> 3.0.0
  - [Microsoft.Data.Sqlite](https://www.nuget.org/packages/Microsoft.Data.Sqlite): 5.0.6 -> 5.0.7
  - [Microsoft.Extensions.DependencyInjection](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection): 3.1.15 -> 3.1.16
  - [MySqlConnector](https://www.nuget.org/packages/MySqlConnector): 1.3.9 -> 1.3.11
  - [Npgsql](https://www.nuget.org/packages/Npgsql): 5.0.5 -> 5.0.7
  - [NUnit3TestAdapter](https://www.nuget.org/packages/NUnit3TestAdapter): 4.0.0-beta.2 -> 4.0.0
  - [System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite): 1.0.114.2 -> 1.0.114.3
- Removed msbuild bug workaround for sqlite nuget
