### PR TITLE
Make `TableAttributeBuilder` and `WithTableExpressionBuilder` working with `LoadWithContext`

### DIFF
--- a/Source/LinqToDB/Linq/Builder/LoadWithBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/LoadWithBuilder.cs
@@ -299,7 +299,7 @@ namespace LinqToDB.Linq.Builder
 			return null;
 		}
 
-		class LoadWithContext : PassThroughContext
+		internal class LoadWithContext : PassThroughContext
 		{
 			private readonly TableBuilder.TableContext _tableContext;
 

--- a/Source/LinqToDB/Linq/Builder/SequenceHelper.cs
+++ b/Source/LinqToDB/Linq/Builder/SequenceHelper.cs
@@ -23,6 +23,30 @@ namespace LinqToDB.Linq.Builder
 
 			return expression;
 		}
-		
+
+		public static TableBuilder.TableContext? GetTableContext(IBuildContext context)
+		{
+			var table = context as TableBuilder.TableContext;
+
+			if (table != null)
+				return table;
+			
+			if (context is LoadWithBuilder.LoadWithContext lwCtx)
+				return lwCtx.TableContext;
+			
+			if (table == null)
+			{
+				var isTableResult = context.IsExpression(null, 0, RequestFor.Table);
+				if (isTableResult.Result)
+				{
+					table = isTableResult.Context as TableBuilder.TableContext;
+					if (table != null)
+						return table;
+				}
+			}
+
+			return null;
+		}
+
 	}
 }

--- a/Source/LinqToDB/Linq/Builder/TableAttributeBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/TableAttributeBuilder.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq.Expressions;
+﻿using System.Linq.Expressions;
 
 namespace LinqToDB.Linq.Builder
 {
@@ -25,14 +24,14 @@ namespace LinqToDB.Linq.Builder
 		protected override IBuildContext BuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo)
 		{
 			var sequence = builder.BuildSequence(new BuildInfo(buildInfo, methodCall.Arguments[0]));
-			var table    = (TableBuilder.TableContext)sequence;
+			var table    = sequence is LoadWithBuilder.LoadWithContext lwc ? lwc.TableContext : (TableBuilder.TableContext)sequence;
 			var value    = methodCall.Arguments.Count == 1 && methodCall.Method.Name == nameof(TableExtensions.IsTemporary) ?
 				true :
 				methodCall.Arguments[1].EvaluateExpression();
 
 			switch (methodCall.Method.Name)
 			{
-				case nameof(LinqExtensions.TableName)     : table.SqlTable.PhysicalName  = (string?)     value!; break;
+				case nameof(LinqExtensions.TableName)     : table.SqlTable.PhysicalName  = (string)      value!; break;
 				case nameof(LinqExtensions.ServerName)    : table.SqlTable.Server        = (string?)     value;  break;
 				case nameof(LinqExtensions.DatabaseName)  : table.SqlTable.Database      = (string?)     value;  break;
 				case nameof(LinqExtensions.SchemaName)    : table.SqlTable.Schema        = (string?)     value;  break;

--- a/Source/LinqToDB/Linq/Builder/TableAttributeBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/TableAttributeBuilder.cs
@@ -24,7 +24,7 @@ namespace LinqToDB.Linq.Builder
 		protected override IBuildContext BuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo)
 		{
 			var sequence = builder.BuildSequence(new BuildInfo(buildInfo, methodCall.Arguments[0]));
-			var table    = sequence is LoadWithBuilder.LoadWithContext lwc ? lwc.TableContext : (TableBuilder.TableContext)sequence;
+			var table    = SequenceHelper.GetTableContext(sequence) ?? throw new LinqToDBException($"Cannot get table context from {sequence.GetType()}");
 			var value    = methodCall.Arguments.Count == 1 && methodCall.Method.Name == nameof(TableExtensions.IsTemporary) ?
 				true :
 				methodCall.Arguments[1].EvaluateExpression();

--- a/Source/LinqToDB/Linq/Builder/WithTableExpressionBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/WithTableExpressionBuilder.cs
@@ -18,7 +18,7 @@ namespace LinqToDB.Linq.Builder
 		protected override IBuildContext BuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo)
 		{
 			var sequence = builder.BuildSequence(new BuildInfo(buildInfo, methodCall.Arguments[0]));
-			var table    = (TableBuilder.TableContext)sequence;
+			var table    = sequence is LoadWithBuilder.LoadWithContext lwc ? lwc.TableContext : (TableBuilder.TableContext)sequence;
 			var value    = (string)methodCall.Arguments[1].EvaluateExpression()!;
 
 			table.SqlTable.SqlTableType   = SqlTableType.Expression;

--- a/Source/LinqToDB/Linq/Builder/WithTableExpressionBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/WithTableExpressionBuilder.cs
@@ -18,7 +18,7 @@ namespace LinqToDB.Linq.Builder
 		protected override IBuildContext BuildMethodCall(ExpressionBuilder builder, MethodCallExpression methodCall, BuildInfo buildInfo)
 		{
 			var sequence = builder.BuildSequence(new BuildInfo(buildInfo, methodCall.Arguments[0]));
-			var table    = sequence is LoadWithBuilder.LoadWithContext lwc ? lwc.TableContext : (TableBuilder.TableContext)sequence;
+			var table    = SequenceHelper.GetTableContext(sequence) ?? throw new LinqToDBException($"Cannot get table context from {sequence.GetType()}");
 			var value    = (string)methodCall.Arguments[1].EvaluateExpression()!;
 
 			table.SqlTable.SqlTableType   = SqlTableType.Expression;

--- a/Source/LinqToDB/LinqExtensions.cs
+++ b/Source/LinqToDB/LinqExtensions.cs
@@ -55,11 +55,10 @@ namespace LinqToDB
 		/// <returns>Table-like query source with new database name.</returns>
 		[LinqTunnel]
 		[Pure]
-		public static ITable<T> DatabaseName<T>(this ITable<T> table, [SqlQueryDependent] string name)
+		public static ITable<T> DatabaseName<T>(this ITable<T> table, [SqlQueryDependent] string? name)
 			where T : notnull
 		{
 			if (table == null) throw new ArgumentNullException(nameof(table));
-			if (name  == null) throw new ArgumentNullException(nameof(name));
 
 			var result = ((ITableMutable<T>)table).ChangeDatabaseName(name);
 			return result;
@@ -76,11 +75,10 @@ namespace LinqToDB
 		/// <returns>Table-like query source with new linked server name.</returns>
 		[LinqTunnel]
 		[Pure]
-		public static ITable<T> ServerName<T>(this ITable<T> table, [SqlQueryDependent] string name)
+		public static ITable<T> ServerName<T>(this ITable<T> table, [SqlQueryDependent] string? name)
 			where T : notnull
 		{
 			if (table == null) throw new ArgumentNullException(nameof(table));
-			if (name  == null) throw new ArgumentNullException(nameof(name));
 
 			var result = ((ITableMutable<T>)table).ChangeServerName(name);
 			return result;
@@ -97,7 +95,7 @@ namespace LinqToDB
 		/// <returns>Table-like query source with new owner/schema name.</returns>
 		[LinqTunnel]
 		[Pure]
-		public static ITable<T> SchemaName<T>(this ITable<T> table, [SqlQueryDependent] string name)
+		public static ITable<T> SchemaName<T>(this ITable<T> table, [SqlQueryDependent] string? name)
 			where T : notnull
 		{
 			var result = ((ITableMutable<T>)table).ChangeSchemaName(name);

--- a/Tests/Linq/Linq/EagerLoadingTests.cs
+++ b/Tests/Linq/Linq/EagerLoadingTests.cs
@@ -1412,6 +1412,81 @@ FROM
 				query.ToList();
 			}
 		}
-#endregion
+		#endregion
+
+		#region issue 3128
+
+		[Table]
+		class UserIssue3128
+		{
+			[PrimaryKey]
+			public int Id { get; set; }
+
+			[Association(ThisKey = nameof(Id), OtherKey = nameof(UserDetailsIssue3128.UserId), CanBeNull = true)]
+			public UserDetailsIssue3128? Details { get; set; }
+		}
+
+		[Table]
+		class UserDetailsIssue3128
+		{
+			[PrimaryKey] public int UserId { get; set; }
+			[Column] public int Age { get; set; }
+		}
+
+		[Test]
+		public void TableExpressionAfterLoadWithTable([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (db.CreateLocalTable<UserIssue3128>())
+			using (db.CreateLocalTable<UserDetailsIssue3128>())
+			{
+				db.InsertWithIdentity(new UserIssue3128 { Id = 10 });
+				db.InsertWithIdentity(new UserDetailsIssue3128 { UserId = 10, Age = 18 });
+
+				var result = db.GetTable<UserIssue3128>()
+					.LoadWithAsTable( _ => _.Details)
+					.WithTableExpression($"{{0}} {{1}}")
+					.ToList();
+
+				Assert.AreEqual(result.Count, 1);
+			}
+		}
+
+		[Test]
+		public void TableExpressionFirst([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (db.CreateLocalTable<UserIssue3128>())
+			using (db.CreateLocalTable<UserDetailsIssue3128>())
+			{
+				db.InsertWithIdentity(new UserIssue3128 { Id = 10 });
+				db.InsertWithIdentity(new UserDetailsIssue3128 { UserId = 10, Age = 18 });
+
+				var result = db.GetTable<UserIssue3128>()
+					.WithTableExpression($"{{0}} {{1}}")
+					.LoadWithAsTable( _ => _.Details)
+					.ToList();
+
+				Assert.AreEqual(result.Count, 1);
+			}
+		}
+
+		[Test]
+		public void WithTableAttributeMethods([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			using (db.CreateLocalTable<UserIssue3128>())
+			using (db.CreateLocalTable<UserDetailsIssue3128>())
+			{
+				db.InsertWithIdentity(new UserIssue3128 { Id = 10 });
+				db.InsertWithIdentity(new UserDetailsIssue3128 { UserId = 10, Age = 18 });
+
+				db.Person.Where(p => db.GetTable<UserIssue3128>()
+					.LoadWithAsTable(_ => _.Details)
+					.SchemaName(null).Count() > 0).ToList();
+			}
+		}
+		#endregion
+
 	}
 }


### PR DESCRIPTION
Fix #3128
