### PR TITLE
Various PostgreSQL type mapping issues

### DIFF
--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
@@ -10,7 +10,6 @@ namespace LinqToDB.DataProvider.PostgreSQL
 	using Mapping;
 	using System.Data.Linq;
 	using System.Globalization;
-	using System.Linq.Expressions;
 
 	public class PostgreSQLMappingSchema : MappingSchema
 	{

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
@@ -73,16 +73,8 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			AddScalarType(typeof(ulong ), ulongType);
 			AddScalarType(typeof(ulong?), ulongType);
 
-			var ulongDbType = new DbDataType(typeof(ulong), DataType.Decimal);
-
-			SetConvertExpression(
-				ulongDbType,
-				new DbDataType(typeof(DataParameter)),
-				(Expression<Func<ulong, DataParameter>>)((ulong value) => new DataParameter(null, (decimal)value, DataType.Decimal) /*{ Precision = 20, Scale = 0 }*/));
-			SetConvertExpression(
-				ulongDbType.WithSystemType(typeof(ulong?)),
-				new DbDataType(typeof(DataParameter)),
-				(Expression<Func<ulong?, DataParameter>>)((ulong? value) => new DataParameter(null, (decimal?)value, DataType.Decimal) /*{ Precision = 20, Scale = 0 }*/), addNullCheck: false);
+			SetConvertExpression<ulong , DataParameter>(value => new DataParameter(null, (decimal)value , DataType.Decimal) /*{ Precision = 20, Scale = 0 }*/);
+			SetConvertExpression<ulong?, DataParameter>(value => new DataParameter(null, (decimal?)value, DataType.Decimal) /*{ Precision = 20, Scale = 0 }*/, addNullCheck: false);
 		}
 
 		static void BuildDateTime(StringBuilder stringBuilder, SqlDataType dt, DateTime value)

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLSqlBuilder.cs
@@ -105,6 +105,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 				case DataType.Json           : StringBuilder.Append("json");           break;
 				case DataType.BinaryJson     : StringBuilder.Append("jsonb");          break;
 				case DataType.Guid           : StringBuilder.Append("uuid");           break;
+				case DataType.Binary         :
 				case DataType.VarBinary      : StringBuilder.Append("bytea");          break;
 				case DataType.BitArray       :
 					if (type.Type.Length == 1)

--- a/Tests/Linq/DataProvider/PostgreSQLTests.cs
+++ b/Tests/Linq/DataProvider/PostgreSQLTests.cs
@@ -1708,15 +1708,23 @@ namespace Tests.DataProvider
 
 		class ExtraBulkCopyTypesTable
 		{
-			[Column] public int     Id     { get; set; }
-			[Column] public byte?   Byte   { get; set; }
-			[Column] public sbyte?  SByte  { get; set; }
-			[Column] public short?  Int16  { get; set; }
-			[Column] public ushort? UInt16 { get; set; }
-			[Column] public int?    Int32  { get; set; }
-			[Column] public uint?   UInt32 { get; set; }
-			[Column] public long?   Int64  { get; set; }
-			[Column] public ulong?  UInt64 { get; set; }
+			[Column                            ] public int     Id      { get; set; }
+			[Column                            ] public byte?   Byte    { get; set; }
+			[Column                            ] public sbyte?  SByte   { get; set; }
+			[Column                            ] public short?  Int16   { get; set; }
+			[Column                            ] public ushort? UInt16  { get; set; }
+			[Column                            ] public int?    Int32   { get; set; }
+			[Column                            ] public uint?   UInt32  { get; set; }
+			[Column                            ] public long?   Int64   { get; set; }
+			[Column                            ] public ulong?  UInt64  { get; set; }
+			[Column(DataType = DataType.Byte)  ] public byte?   ByteT   { get; set; }
+			[Column(DataType = DataType.SByte) ] public sbyte?  SByteT  { get; set; }
+			[Column(DataType = DataType.Int16) ] public short?  Int16T  { get; set; }
+			[Column(DataType = DataType.UInt16)] public ushort? UInt16T { get; set; }
+			[Column(DataType = DataType.Int32) ] public int?    Int32T  { get; set; }
+			[Column(DataType = DataType.UInt32)] public uint?   UInt32T { get; set; }
+			[Column(DataType = DataType.Int64) ] public long?   Int64T  { get; set; }
+			[Column(DataType = DataType.UInt64)] public ulong?  UInt64T { get; set; }
 		}
 
 		[Test]
@@ -1730,15 +1738,24 @@ namespace Tests.DataProvider
 					new ExtraBulkCopyTypesTable() { Id = 1 },
 					new ExtraBulkCopyTypesTable()
 					{
-						Id     = 2,
-						Byte   = byte.MaxValue,
-						SByte  = sbyte.MaxValue,
-						Int16  = short.MaxValue,
-						UInt16 = ushort.MaxValue,
-						Int32  = int.MaxValue,
-						UInt32 = uint.MaxValue,
-						Int64  = long.MaxValue,
-						UInt64 = ulong.MaxValue,
+						Id          = 2,
+
+						Byte        = byte.MaxValue,
+						SByte       = sbyte.MaxValue,
+						Int16       = short.MaxValue,
+						UInt16      = ushort.MaxValue,
+						Int32       = int.MaxValue,
+						UInt32      = uint.MaxValue,
+						Int64       = long.MaxValue,
+						UInt64      = ulong.MaxValue,
+						ByteT       = byte.MaxValue,
+						SByteT      = sbyte.MaxValue,
+						Int16T      = short.MaxValue,
+						UInt16T     = ushort.MaxValue,
+						Int32T      = int.MaxValue,
+						UInt32T     = uint.MaxValue,
+						Int64T      = long.MaxValue,
+						UInt64T     = ulong.MaxValue,
 					}
 				};
 
@@ -1757,6 +1774,14 @@ namespace Tests.DataProvider
 				Assert.IsNull(result[0].UInt32);
 				Assert.IsNull(result[0].Int64);
 				Assert.IsNull(result[0].UInt64);
+				Assert.IsNull(result[0].ByteT);
+				Assert.IsNull(result[0].SByteT);
+				Assert.IsNull(result[0].Int16T);
+				Assert.IsNull(result[0].UInt16T);
+				Assert.IsNull(result[0].Int32T);
+				Assert.IsNull(result[0].UInt32T);
+				Assert.IsNull(result[0].Int64T);
+				Assert.IsNull(result[0].UInt64T);
 
 				Assert.AreEqual(2              , result[1].Id);
 				Assert.AreEqual(byte.MaxValue  , result[1].Byte);
@@ -1767,6 +1792,14 @@ namespace Tests.DataProvider
 				Assert.AreEqual(uint.MaxValue  , result[1].UInt32);
 				Assert.AreEqual(long.MaxValue  , result[1].Int64);
 				Assert.AreEqual(ulong.MaxValue , result[1].UInt64);
+				Assert.AreEqual(byte.MaxValue  , result[1].ByteT);
+				Assert.AreEqual(sbyte.MaxValue , result[1].SByteT);
+				Assert.AreEqual(short.MaxValue , result[1].Int16T);
+				Assert.AreEqual(ushort.MaxValue, result[1].UInt16T);
+				Assert.AreEqual(int.MaxValue   , result[1].Int32T);
+				Assert.AreEqual(uint.MaxValue  , result[1].UInt32T);
+				Assert.AreEqual(long.MaxValue  , result[1].Int64T);
+				Assert.AreEqual(ulong.MaxValue , result[1].UInt64T);
 			}
 		}
 
@@ -1781,15 +1814,23 @@ namespace Tests.DataProvider
 					new ExtraBulkCopyTypesTable() { Id = 1 },
 					new ExtraBulkCopyTypesTable()
 					{
-						Id     = 2,
-						Byte   = byte.MaxValue,
-						SByte  = sbyte.MaxValue,
-						Int16  = short.MaxValue,
-						UInt16 = ushort.MaxValue,
-						Int32  = int.MaxValue,
-						UInt32 = uint.MaxValue,
-						Int64  = long.MaxValue,
-						UInt64 = ulong.MaxValue,
+						Id      = 2,
+						Byte    = byte.MaxValue,
+						SByte   = sbyte.MaxValue,
+						Int16   = short.MaxValue,
+						UInt16  = ushort.MaxValue,
+						Int32   = int.MaxValue,
+						UInt32  = uint.MaxValue,
+						Int64   = long.MaxValue,
+						UInt64  = ulong.MaxValue,
+						ByteT   = byte.MaxValue,
+						SByteT  = sbyte.MaxValue,
+						Int16T  = short.MaxValue,
+						UInt16T = ushort.MaxValue,
+						Int32T  = int.MaxValue,
+						UInt32T = uint.MaxValue,
+						Int64T  = long.MaxValue,
+						UInt64T = ulong.MaxValue,
 					}
 				};
 
@@ -1808,6 +1849,14 @@ namespace Tests.DataProvider
 				Assert.IsNull(result[0].UInt32);
 				Assert.IsNull(result[0].Int64);
 				Assert.IsNull(result[0].UInt64);
+				Assert.IsNull(result[0].ByteT);
+				Assert.IsNull(result[0].SByteT);
+				Assert.IsNull(result[0].Int16T);
+				Assert.IsNull(result[0].UInt16T);
+				Assert.IsNull(result[0].Int32T);
+				Assert.IsNull(result[0].UInt32T);
+				Assert.IsNull(result[0].Int64T);
+				Assert.IsNull(result[0].UInt64T);
 
 				Assert.AreEqual(2              , result[1].Id);
 				Assert.AreEqual(byte.MaxValue  , result[1].Byte);
@@ -1818,6 +1867,14 @@ namespace Tests.DataProvider
 				Assert.AreEqual(uint.MaxValue  , result[1].UInt32);
 				Assert.AreEqual(long.MaxValue  , result[1].Int64);
 				Assert.AreEqual(ulong.MaxValue , result[1].UInt64);
+				Assert.AreEqual(byte.MaxValue  , result[1].ByteT);
+				Assert.AreEqual(sbyte.MaxValue , result[1].SByteT);
+				Assert.AreEqual(short.MaxValue , result[1].Int16T);
+				Assert.AreEqual(ushort.MaxValue, result[1].UInt16T);
+				Assert.AreEqual(int.MaxValue   , result[1].Int32T);
+				Assert.AreEqual(uint.MaxValue  , result[1].UInt32T);
+				Assert.AreEqual(long.MaxValue  , result[1].Int64T);
+				Assert.AreEqual(ulong.MaxValue , result[1].UInt64T);
 			}
 		}
 

--- a/Tests/Linq/DataProvider/PostgreSQLTests.cs
+++ b/Tests/Linq/DataProvider/PostgreSQLTests.cs
@@ -2275,9 +2275,6 @@ namespace Tests.DataProvider
 		}
 
 		// see https://github.com/linq2db/linq2db/issues/3130
-		// tests:
-		// - DataType.Binary support
-		// - fluent mapping override by configuration name
 		[Test]
 		public void DataTypeBinaryMappingTest([IncludeDataSources(TestProvName.AllPostgreSQL)] string context)
 		{
@@ -2285,8 +2282,6 @@ namespace Tests.DataProvider
 
 			ms.GetFluentMappingBuilder()
 				.Entity<DataTypeBinaryMapping>()
-					.Property(p => p.Binary).HasDataType(DataType.Int128).IsNullable(false)
-				.Entity<DataTypeBinaryMapping>(context)//(ProviderName.PostgreSQL)
 					.Property(p => p.Binary).HasDataType(DataType.Binary).IsNullable(false);
 
 			using (var db = (DataConnection)GetDataContext(context, ms))

--- a/Tests/Linq/Mapping/FluentMappingTests.cs
+++ b/Tests/Linq/Mapping/FluentMappingTests.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 
 namespace Tests.Mapping
 {
+	using LinqToDB.Data;
 	using Model;
 
 	[TestFixture]
@@ -692,6 +693,5 @@ namespace Tests.Mapping
 					Assert.That(sql2, Does.Not.Contain("[Money]"));
 			}
 		}
-
 	}
 }


### PR DESCRIPTION
- fix ulong handling in bulk copy when mapped to UInt64
- fix `DataType.Binary` mapping to `bytea`. Fix #3130

TODO:
- [ ] #3131 (needs repro first)