### PR TITLE
Don't generate options constructors for context based on DataContext

### DIFF
--- a/Source/LinqToDB.Templates/DataModel.ttinclude
+++ b/Source/LinqToDB.Templates/DataModel.ttinclude
@@ -21,7 +21,7 @@ string   NamespaceName
 public string   ServerName;
 public string   DatabaseName;
 public string   DataContextName;
-public string   BaseDataContextClass;
+public static string BaseDataContextClass;
 public string   BaseEntityClass;
 public string   OneToManyAssociationType      = "IEnumerable<{0}>";
 

--- a/Source/LinqToDB.Templates/DataModel.ttinclude
+++ b/Source/LinqToDB.Templates/DataModel.ttinclude
@@ -18,10 +18,12 @@ string   NamespaceName
 	set { Model.Namespace.Name = value; }
 }
 
+public static string BaseDataContextClass;
+public static bool   EnforceModelNullability = true;
+
 public string   ServerName;
 public string   DatabaseName;
 public string   DataContextName;
-public static string BaseDataContextClass;
 public string   BaseEntityClass;
 public string   OneToManyAssociationType      = "IEnumerable<{0}>";
 
@@ -44,7 +46,6 @@ public bool SingularizeDataContextPropertyNames;
 
 public bool NormalizeNames                      = true;
 public bool NormalizeNamesWithoutUnderscores;
-public static bool EnforceModelNullability      = true;
 
 private Func<string, bool, string> _toValidName;
 public Func<string, bool, string> ToValidName

--- a/Source/LinqToDB.Templates/LinqToDB.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.ttinclude
@@ -13,23 +13,24 @@ Action AfterGenerateLinqToDBModel  = () => {};
 public Func<Table,MemberBase> GenerateProviderSpecificTable = _ => null;
 public Func<Parameter, bool>  GenerateProcedureDbType       = _ => false;
 
-bool   GenerateObsoleteAttributeForAliases = false;
-bool   GenerateFindExtensions              = true;
-bool   IsCompactColumns                    = true;
-bool   IsCompactColumnAliases              = true;
-bool   GenerateDataTypes                   = false;
-bool?  GenerateLengthProperty              = null;
-bool?  GeneratePrecisionProperty           = null;
-bool?  GenerateScaleProperty               = null;
-bool   GenerateDbTypes                     = false;
-bool   GenerateSchemaAsType                = false;
-bool   GenerateViews                       = true;
-bool   GenerateProcedureResultAsList       = false;
-bool   GenerateProceduresOnTypedContext    = true;
-bool   PrefixTableMappingWithSchema        = true;
-bool   PrefixTableMappingForDefaultSchema  = false;
-string SchemaNameSuffix                    = "Schema";
-string SchemaDataContextTypeName           = "DataContext";
+static bool GenerateLinqToDbConnectionOptionsConstructors = true;
+bool   GenerateObsoleteAttributeForAliases                = false;
+bool   GenerateFindExtensions                             = true;
+bool   IsCompactColumns                                   = true;
+bool   IsCompactColumnAliases                             = true;
+bool   GenerateDataTypes                                  = false;
+bool?  GenerateLengthProperty                             = null;
+bool?  GeneratePrecisionProperty                          = null;
+bool?  GenerateScaleProperty                              = null;
+bool   GenerateDbTypes                                    = false;
+bool   GenerateSchemaAsType                               = false;
+bool   GenerateViews                                      = true;
+bool   GenerateProcedureResultAsList                      = false;
+bool   GenerateProceduresOnTypedContext                   = true;
+bool   PrefixTableMappingWithSchema                       = true;
+bool   PrefixTableMappingForDefaultSchema                 = false;
+string SchemaNameSuffix                                   = "Schema";
+string SchemaDataContextTypeName                          = "DataContext";
 
 public Dictionary<string,string> SchemaNameMapping = new Dictionary<string,string>();
 
@@ -44,8 +45,12 @@ private static IEnumerable<Method> GetConstructorsImpl(string defaultConfigurati
 	else
 		yield return new Method(null, name) { AfterSignature = { ": base(\"" + defaultConfiguration + "\")" } };
 	yield return new Method(null, name, new Func<string>[] { () => "string configuration" }) { AfterSignature = { ": base(configuration)" } };
-	yield return new Method(null, name, new Func<string>[] { () => "LinqToDbConnectionOptions options" }) { AfterSignature = { ": base(options)" } };
-	yield return new Method(null, name, new Func<string>[] { () => string.Format("LinqToDbConnectionOptions<{0}> options", name) }) { AfterSignature = { ": base(options)" } };
+	// TODO: v4: remove BaseDataContextClass check against DataContext
+	if (BaseDataContextClass != "LinqToDB.DataContext" && GenerateLinqToDbConnectionOptionsConstructors)
+	{
+		yield return new Method(null, name, new Func<string>[] { () => "LinqToDbConnectionOptions options" }) { AfterSignature = { ": base(options)" } };
+		yield return new Method(null, name, new Func<string>[] { () => string.Format("LinqToDbConnectionOptions<{0}> options", name) }) { AfterSignature = { ": base(options)" } };
+	}
 }
 
 void GenerateTypesFromMetadata()

--- a/Tests/Tests.T4/Databases/SQLite.generated.cs
+++ b/Tests/Tests.T4/Databases/SQLite.generated.cs
@@ -18,7 +18,7 @@ using LinqToDB.Mapping;
 
 namespace SQLiteDataContext
 {
-	public partial class TestDataDB : LinqToDB.Data.DataConnection
+	public partial class TestDataDB : LinqToDB.DataContext
 	{
 		public ITable<AllType>           AllTypes            { get { return this.GetTable<AllType>(); } }
 		public ITable<Child>             Children            { get { return this.GetTable<Child>(); } }
@@ -47,13 +47,6 @@ namespace SQLiteDataContext
 
 		public TestDataDB(string configuration)
 			: base(configuration)
-		{
-			InitDataContext();
-			InitMappingSchema();
-		}
-
-		public TestDataDB(LinqToDbConnectionOptions options)
-			: base(options)
 		{
 			InitDataContext();
 			InitMappingSchema();

--- a/Tests/Tests.T4/Databases/SQLite.tt
+++ b/Tests/Tests.T4/Databases/SQLite.tt
@@ -5,6 +5,7 @@
 <#@ include file="..\..\..\Source\LinqToDB.Templates\LinqToDB.SQLite.ttinclude" once="true"  #>
 <#
 	NamespaceName = "SQLiteDataContext";
+	BaseDataContextClass = "LinqToDB.DataContext";
 
 	GenerateAssociationExtensions = true;
 

--- a/Tests/Tests.T4/Databases/SqlCe.generated.cs
+++ b/Tests/Tests.T4/Databases/SqlCe.generated.cs
@@ -50,13 +50,6 @@ namespace SqlCeDataContext
 			InitMappingSchema();
 		}
 
-		public TestDataDB(LinqToDbConnectionOptions options)
-			: base(options)
-		{
-			InitDataContext();
-			InitMappingSchema();
-		}
-
 		partial void InitDataContext  ();
 		partial void InitMappingSchema();
 	}

--- a/Tests/Tests.T4/Databases/SqlCe.tt
+++ b/Tests/Tests.T4/Databases/SqlCe.tt
@@ -7,6 +7,7 @@
 	NamespaceName = "SqlCeDataContext";
 
 	GenerateAssociationExtensions = true;
+	GenerateLinqToDbConnectionOptionsConstructors = false;
 
 	var solutionsPath = Host.ResolveAssemblyReference("$(SolutionDir)");
 	LoadSqlCeMetadata(solutionsPath + @"\Data\", "TestData.sdf");


### PR DESCRIPTION
fix #3138

- check that base class is not DataContext (will be removed after merge to v4 as there we support such constructors)
- add explicit option to disable options constructors (`GenerateLinqToDbConnectionOptionsConstructors = true`)