### PR TITLE
Fix concurrency issues with hints

### DIFF
--- a/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
+++ b/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
@@ -457,7 +457,7 @@ namespace LinqToDB.Data
 			[MethodImpl(MethodImplOptions.AggressiveInlining)]
 			static void InitCommand(DataConnection dataConnection, ExecutionPreparedQuery executionQuery, int index)
 			{
-				InitCommand(dataConnection, 
+				InitCommand(dataConnection,
 					executionQuery.PreparedQuery.Commands[index],
 					executionQuery.CommandsParameters[index],
 					index == 0 ? executionQuery.PreparedQuery.QueryHints : null);

--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -1178,17 +1178,16 @@ namespace LinqToDB.Data
 		/// </summary>
 		public IDataParameterCollection? LastParameters;
 
-		internal void InitCommand(CommandType commandType, string sql, DataParameter[]? parameters, List<string>? queryHints, bool withParameters)
+		internal void InitCommand(CommandType commandType, string sql, DataParameter[]? parameters, IReadOnlyCollection<string>? queryHints, bool withParameters)
 		{
 			if (queryHints?.Count > 0)
 			{
 				var sqlProvider = DataProvider.CreateSqlBuilder(MappingSchema);
-				sql = sqlProvider.ApplyQueryHints(sql, queryHints);
-				queryHints.Clear();
+				sql             = sqlProvider.ApplyQueryHints(sql, queryHints);
 			}
 
 			DataProvider.InitCommand(this, commandType, sql, parameters, withParameters);
-			LastQuery = Command.CommandText;
+			LastQuery      = Command.CommandText;
 			LastParameters = Command.Parameters;
 		}
 

--- a/Source/LinqToDB/DataContext.cs
+++ b/Source/LinqToDB/DataContext.cs
@@ -250,13 +250,13 @@ namespace LinqToDB
 				if (_commandTimeout != null)
 					_dataConnection.CommandTimeout = CommandTimeout;
 
-				if (_queryHints != null && _queryHints.Count > 0)
+				if (_queryHints?.Count > 0)
 				{
 					_dataConnection.QueryHints.AddRange(_queryHints);
 					_queryHints = null;
 				}
 
-				if (_nextQueryHints != null && _nextQueryHints.Count > 0)
+				if (_nextQueryHints?.Count > 0)
 				{
 					_dataConnection.NextQueryHints.AddRange(_nextQueryHints);
 					_nextQueryHints = null;
@@ -291,8 +291,8 @@ namespace LinqToDB
 
 				if (LockDbManagerCounter == 0 && KeepConnectionAlive == false)
 				{
-					if (_dataConnection.QueryHints.    Count > 0) QueryHints.    AddRange(_queryHints!);
-					if (_dataConnection.NextQueryHints.Count > 0) NextQueryHints.AddRange(_nextQueryHints!);
+					if (_dataConnection.QueryHints.    Count > 0) (_queryHints     ??= new List<string>()).AddRange(_dataConnection.QueryHints);
+					if (_dataConnection.NextQueryHints.Count > 0) (_nextQueryHints ??= new List<string>()).AddRange(_dataConnection.NextQueryHints);
 
 					_dataConnection.Dispose();
 					_dataConnection = null;
@@ -437,8 +437,8 @@ namespace LinqToDB
 			{
 				OnClosing?.Invoke(this, EventArgs.Empty);
 
-				if (_dataConnection.QueryHints.    Count > 0) QueryHints.    AddRange(_queryHints!);
-				if (_dataConnection.NextQueryHints.Count > 0) NextQueryHints.AddRange(_nextQueryHints!);
+				if (_dataConnection.QueryHints.    Count > 0) (_queryHints     ??= new List<string>()).AddRange(_dataConnection.QueryHints);
+				if (_dataConnection.NextQueryHints.Count > 0) (_nextQueryHints ??= new List<string>()).AddRange(_dataConnection.NextQueryHints);
 
 				_dataConnection.Dispose();
 				_dataConnection = null;
@@ -456,8 +456,8 @@ namespace LinqToDB
 			{
 				OnClosing?.Invoke(this, EventArgs.Empty);
 
-				if (_dataConnection.QueryHints.    Count > 0) QueryHints.AddRange(_queryHints!);
-				if (_dataConnection.NextQueryHints.Count > 0) NextQueryHints.AddRange(_nextQueryHints!);
+				if (_dataConnection.QueryHints.    Count > 0) (_queryHints     ??= new List<string>()).AddRange(_dataConnection.QueryHints);
+				if (_dataConnection.NextQueryHints.Count > 0) (_nextQueryHints ??= new List<string>()).AddRange(_dataConnection.NextQueryHints);
 
 				await _dataConnection.DisposeAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 				_dataConnection = null;

--- a/Source/LinqToDB/Extensions/DataContextExtensions.cs
+++ b/Source/LinqToDB/Extensions/DataContextExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+
+namespace LinqToDB
+{
+	/// <summary>
+	/// Internal data context helpers.
+	/// </summary>
+	internal static class DataContextExtensions
+	{
+		public static IReadOnlyCollection<string>? GetNextCommandHints(this IDataContext context, bool clearNextHints)
+		{
+			if (context.QueryHints.Count > 0 || context.NextQueryHints.Count > 0)
+			{
+				// it is safe to use existing collection as optimization as we don't save and/or use returned collection
+				// after command execution
+				if (context.NextQueryHints.Count == 0)
+					return context.QueryHints;
+
+				var queryHints = new List<string>(context.QueryHints.Count + context.NextQueryHints.Count);
+				queryHints.AddRange(context.QueryHints);
+				queryHints.AddRange(context.NextQueryHints);
+
+				if (clearNextHints)
+					context.NextQueryHints.Clear();
+
+				return queryHints;
+			}
+
+			return null;
+		}
+	}
+}

--- a/Source/LinqToDB/Linq/IQueryContext.cs
+++ b/Source/LinqToDB/Linq/IQueryContext.cs
@@ -1,14 +1,11 @@
-﻿using System.Collections.Generic;
-
-namespace LinqToDB.Linq
+﻿namespace LinqToDB.Linq
 {
 	using SqlQuery;
 
 	public interface IQueryContext
 	{
-		SqlStatement    Statement   { get; }
-		object?         Context     { get; set; }
-		List<string>?   QueryHints  { get; set; }
+		SqlStatement                 Statement   { get; }
+		object?                      Context     { get; set; }
 
 		SqlParameter[]? Parameters  { get; set; }
 		AliasesContext? Aliases     { get; set; }

--- a/Source/LinqToDB/Linq/Query.cs
+++ b/Source/LinqToDB/Linq/Query.cs
@@ -549,7 +549,6 @@ namespace LinqToDB.Linq
 	{
 		public SqlStatement    Statement   { get; set; } = null!;
 		public object?         Context     { get; set; }
-		public List<string>?   QueryHints  { get; set; }
 		public SqlParameter[]? Parameters  { get; set; }
 		public AliasesContext? Aliases     { get; set; }
 

--- a/Source/LinqToDB/Linq/QueryRunnerBase.cs
+++ b/Source/LinqToDB/Linq/QueryRunnerBase.cs
@@ -22,8 +22,6 @@ namespace LinqToDB.Linq
 
 		protected readonly Query    Query;
 
-		protected List<string>?     QueryHints;
-
 		public IDataContext         DataContext      { get; set; }
 		public Expression           Expression       { get; set; }
 		public object?[]?           Parameters       { get; set; }
@@ -65,32 +63,16 @@ namespace LinqToDB.Linq
 #endif
 
 
-		protected virtual void SetCommand(bool clearQueryHints)
+		protected virtual void SetCommand(bool forGetSqlText)
 		{
-			if (QueryNumber == 0 && (DataContext.QueryHints.Count > 0 || DataContext.NextQueryHints.Count > 0))
-			{
-				var queryContext = Query.Queries[QueryNumber];
-
-				queryContext.QueryHints = new List<string>(DataContext.QueryHints);
-				queryContext.QueryHints.AddRange(DataContext.NextQueryHints);
-
-				if (QueryHints == null)
-					QueryHints = new List<string>(DataContext.QueryHints.Count + DataContext.NextQueryHints.Count);
-
-				QueryHints.AddRange(DataContext.QueryHints);
-				QueryHints.AddRange(DataContext.NextQueryHints);
-
-				if (clearQueryHints)
-					DataContext.NextQueryHints.Clear();
-			}
-
 			var parameterValues = new SqlParameterValues();
+
 			QueryRunner.SetParameters(Query, Expression, DataContext, Parameters, QueryNumber, parameterValues);
 
-			SetQuery(parameterValues);
+			SetQuery(parameterValues, forGetSqlText);
 		}
 
-		protected abstract void SetQuery(IReadOnlyParameterValues parameterValues);
+		protected abstract void SetQuery(IReadOnlyParameterValues parameterValues, bool forGetSqlText);
 
 		public    abstract string GetSqlText();
 	}

--- a/Source/LinqToDB/ServiceModel/LinqService.cs
+++ b/Source/LinqToDB/ServiceModel/LinqService.cs
@@ -86,7 +86,6 @@ namespace LinqToDB.ServiceModel
 			public object?         Context     { get; set; }
 			public SqlParameter[]? Parameters  { get; set; }
 			public AliasesContext? Aliases     { get; set; }
-			public List<string>?   QueryHints  { get; set; }
 		}
 
 		[WebMethod]
@@ -101,10 +100,11 @@ namespace LinqToDB.ServiceModel
 				using var db = CreateDataContext(configuration);
 				using var _  = db.DataProvider.ExecuteScope(db);
 
+				if (query.QueryHints?.Count > 0) db.NextQueryHints.AddRange(query.QueryHints);
+
 				return DataConnection.QueryRunner.ExecuteNonQuery(db, new QueryContext
 				{
-					Statement  = query.Statement,
-					QueryHints = query.QueryHints
+					Statement  = query.Statement
 				}, new SqlParameterValues());
 			}
 			catch (Exception exception)
@@ -126,10 +126,11 @@ namespace LinqToDB.ServiceModel
 				using var db = CreateDataContext(configuration);
 				using var _  = db.DataProvider.ExecuteScope(db);
 
+				if (query.QueryHints?.Count > 0) db.NextQueryHints.AddRange(query.QueryHints);
+
 				return DataConnection.QueryRunner.ExecuteScalar(db, new QueryContext
 				{
-					Statement  = query.Statement,
-					QueryHints = query.QueryHints
+					Statement  = query.Statement
 				}, null);
 			}
 			catch (Exception exception)
@@ -150,10 +151,12 @@ namespace LinqToDB.ServiceModel
 
 				using var db = CreateDataContext(configuration);
 				using var _  = db.DataProvider.ExecuteScope(db);
+
+				if (query.QueryHints?.Count > 0) db.NextQueryHints.AddRange(query.QueryHints);
+
 				using var rd = DataConnection.QueryRunner.ExecuteReader(db, new QueryContext
 				{
-					Statement  = query.Statement,
-					QueryHints = query.QueryHints,
+					Statement  = query.Statement
 				}, SqlParameterValues.Empty);
 
 				var reader = DataReaderWrapCache.TryUnwrapDataReader(db.MappingSchema, rd);
@@ -273,10 +276,11 @@ namespace LinqToDB.ServiceModel
 
 				foreach (var query in queries)
 				{
+					if (query.QueryHints?.Count > 0) db.NextQueryHints.AddRange(query.QueryHints);
+
 					DataConnection.QueryRunner.ExecuteNonQuery(db, new QueryContext
 					{
-						Statement  = query.Statement,
-						QueryHints = query.QueryHints
+						Statement  = query.Statement
 					}, null);
 				}
 

--- a/Source/LinqToDB/ServiceModel/LinqServiceQuery.cs
+++ b/Source/LinqToDB/ServiceModel/LinqServiceQuery.cs
@@ -7,8 +7,8 @@ namespace LinqToDB.ServiceModel
 
 	public class LinqServiceQuery
 	{
-		public SqlStatement   Statement  { get; set; } = null!;
-		public List<string>?  QueryHints { get; set; }
+		public SqlStatement                 Statement  { get; set; } = null!;
+		public IReadOnlyCollection<string>? QueryHints { get; set; }
 	}
 }
 #endif

--- a/Source/LinqToDB/ServiceModel/LinqServiceSerializer.cs
+++ b/Source/LinqToDB/ServiceModel/LinqServiceSerializer.cs
@@ -19,7 +19,7 @@ namespace LinqToDB.ServiceModel
 	{
 		#region Public Members
 
-		public static string Serialize(MappingSchema serializationSchema, SqlStatement statement, IReadOnlyParameterValues? parameterValues, List<string>? queryHints)
+		public static string Serialize(MappingSchema serializationSchema, SqlStatement statement, IReadOnlyParameterValues? parameterValues, IReadOnlyCollection<string>? queryHints)
 		{
 			return new QuerySerializer(serializationSchema).Serialize(statement, parameterValues, queryHints);
 		}
@@ -629,7 +629,7 @@ namespace LinqToDB.ServiceModel
 			{
 			}
 
-			public string Serialize(SqlStatement statement, IReadOnlyParameterValues? parameterValues, List<string>? queryHints)
+			public string Serialize(SqlStatement statement, IReadOnlyParameterValues? parameterValues, IReadOnlyCollection<string>? queryHints)
 			{
 				var queryHintCount = queryHints?.Count ?? 0;
 

--- a/Source/LinqToDB/ServiceModel/RemoteDataContextBase.QueryRunner.cs
+++ b/Source/LinqToDB/ServiceModel/RemoteDataContextBase.QueryRunner.cs
@@ -40,7 +40,7 @@ namespace LinqToDB.ServiceModel
 
 			public override Expression? MapperExpression { get; set; }
 
-			protected override void SetQuery(IReadOnlyParameterValues parameterValues)
+			protected override void SetQuery(IReadOnlyParameterValues parameterValues, bool forGetSqlText)
 			{
 				_evaluationContext = new EvaluationContext(parameterValues);
 			}
@@ -49,14 +49,14 @@ namespace LinqToDB.ServiceModel
 
 			public override string GetSqlText()
 			{
-				SetCommand(false);
+				SetCommand(true);
 
-				var sb = new StringBuilder();
-				var query = Query.Queries[QueryNumber];
-				var sqlBuilder   = DataContext.CreateSqlProvider();
-				var sqlOptimizer = DataContext.GetSqlOptimizer();
+				var sb               = new StringBuilder();
+				var query            = Query.Queries[QueryNumber];
+				var sqlBuilder       = DataContext.CreateSqlProvider();
+				var sqlOptimizer     = DataContext.GetSqlOptimizer();
 				var sqlStringBuilder = new StringBuilder();
-				var cc = sqlBuilder.CommandCount(query.Statement);
+				var cc               = sqlBuilder.CommandCount(query.Statement);
 
 				var optimizationContext = new OptimizationContext(_evaluationContext, query.Aliases!, false);
 
@@ -65,13 +65,17 @@ namespace LinqToDB.ServiceModel
 					var statement = sqlOptimizer.PrepareStatementForSql(query.Statement, DataContext.MappingSchema, optimizationContext);
 					sqlBuilder.BuildSql(i, statement, sqlStringBuilder, optimizationContext);
 
-					if (i == 0 && query.QueryHints != null && query.QueryHints.Count > 0)
+					if (i == 0)
 					{
-						var sql = sqlStringBuilder.ToString();
+						var queryHints = DataContext.GetNextCommandHints(false);
+						if (queryHints != null)
+						{
+							var sql = sqlStringBuilder.ToString();
 
-						sql = sqlBuilder.ApplyQueryHints(sql, query.QueryHints);
+							sql = sqlBuilder.ApplyQueryHints(sql, queryHints);
 
-						sqlStringBuilder.Append(sql);
+							sqlStringBuilder.Append(sql);
+						}
 					}
 
 					sb
@@ -144,7 +148,7 @@ namespace LinqToDB.ServiceModel
 			{
 				string data;
 
-				SetCommand(true);
+				SetCommand(false);
 
 				var queryContext = Query.Queries[QueryNumber];
 
@@ -155,7 +159,7 @@ namespace LinqToDB.ServiceModel
 					_dataContext.SerializationMappingSchema,
 					q,
 					_evaluationContext.ParameterValues,
-					QueryHints);
+					_dataContext.GetNextCommandHints(true));
 
 				if (_dataContext._batchCounter > 0)
 				{
@@ -175,7 +179,7 @@ namespace LinqToDB.ServiceModel
 
 				string data;
 
-				SetCommand(true);
+				SetCommand(false);
 
 				var queryContext = Query.Queries[QueryNumber];
 
@@ -185,7 +189,8 @@ namespace LinqToDB.ServiceModel
 				data = LinqServiceSerializer.Serialize(
 					_dataContext.SerializationMappingSchema,
 					q,
-					_evaluationContext.ParameterValues, QueryHints);
+					_evaluationContext.ParameterValues,
+					_dataContext.GetNextCommandHints(true));
 
 				_client = _dataContext.GetClient();
 
@@ -201,7 +206,7 @@ namespace LinqToDB.ServiceModel
 
 				string data;
 
-				SetCommand(true);
+				SetCommand(false);
 
 				var queryContext = Query.Queries[QueryNumber];
 
@@ -211,7 +216,7 @@ namespace LinqToDB.ServiceModel
 					_dataContext.SerializationMappingSchema,
 					q,
 					_evaluationContext.ParameterValues,
-					QueryHints);
+					_dataContext.GetNextCommandHints(true));
 
 				_client = _dataContext.GetClient();
 
@@ -279,7 +284,7 @@ namespace LinqToDB.ServiceModel
 
 				string data;
 
-				SetCommand(true);
+				SetCommand(false);
 
 				var queryContext = Query.Queries[QueryNumber];
 
@@ -289,7 +294,7 @@ namespace LinqToDB.ServiceModel
 					_dataContext.SerializationMappingSchema,
 					q,
 					_evaluationContext.ParameterValues,
-					QueryHints);
+					_dataContext.GetNextCommandHints(true));
 
 				_client = _dataContext.GetClient();
 
@@ -308,7 +313,7 @@ namespace LinqToDB.ServiceModel
 
 				string data;
 
-				SetCommand(true);
+				SetCommand(false);
 
 				var queryContext = Query.Queries[QueryNumber];
 
@@ -318,7 +323,7 @@ namespace LinqToDB.ServiceModel
 					_dataContext.SerializationMappingSchema,
 					q,
 					_evaluationContext.ParameterValues,
-					QueryHints);
+					_dataContext.GetNextCommandHints(true));
 
 				_client = _dataContext.GetClient();
 
@@ -329,7 +334,7 @@ namespace LinqToDB.ServiceModel
 			{
 				string data;
 
-				SetCommand(true);
+				SetCommand(false);
 
 				var queryContext = Query.Queries[QueryNumber];
 
@@ -339,7 +344,7 @@ namespace LinqToDB.ServiceModel
 					_dataContext.SerializationMappingSchema,
 					q,
 					_evaluationContext.ParameterValues,
-					QueryHints);
+					_dataContext.GetNextCommandHints(true));
 
 				if (_dataContext._batchCounter > 0)
 				{

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -3273,7 +3273,7 @@ namespace LinqToDB.SqlProvider
 				sb.Append(value);
 		}
 
-		public string ApplyQueryHints(string sqlText, List<string> queryHints)
+		public string ApplyQueryHints(string sqlText, IReadOnlyCollection<string> queryHints)
 		{
 			var sb = new StringBuilder();
 

--- a/Source/LinqToDB/SqlProvider/ISqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/ISqlBuilder.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Data;
 using System.Text;
 
@@ -25,7 +24,7 @@ namespace LinqToDB.SqlProvider
 		ISqlExpression?  GetIdentityExpression(SqlTable table);
 
 		StringBuilder    PrintParameters      (StringBuilder sb, IEnumerable<IDbDataParameter>? parameters);
-		string           ApplyQueryHints      (string sqlText, List<string> queryHints);
+		string           ApplyQueryHints      (string sqlText, IReadOnlyCollection<string> queryHints);
 
 		string           GetReserveSequenceValuesSql(int count, string sequenceName);
 		string           GetMaxValueSql       (EntityDescriptor entity, ColumnDescriptor column);

--- a/Tests/Linq/Linq/QueryHintsTests.cs
+++ b/Tests/Linq/Linq/QueryHintsTests.cs
@@ -1,11 +1,11 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using LinqToDB;
 using LinqToDB.Data;
 using LinqToDB.DataProvider.SqlServer;
 
 using NUnit.Framework;
-using Tests.Model;
 
 namespace Tests.Linq
 {
@@ -112,9 +112,10 @@ namespace Tests.Linq
 
 		[Repeat(100)]
 		[Test]
-		public async Task Issue3137([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		public async Task Issue3137([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
 			using var _ = new DisableBaseline("multi-threading");
+			var rnd = new Random();
 
 			const int runs = 10;
 
@@ -127,22 +128,31 @@ namespace Tests.Linq
 
 			async Task execute()
 			{
-				using (var db = new TestDataConnection(context))
+				// add uniqueness to hints to ensure no hints spilling between contexts through query cache
+				using (var db = GetDataContext(context))
 				{
-					db.QueryHints.Add("-- many");
-					db.NextQueryHints.Add("-- once");
+					var corr = rnd.Next();
+					var sharedHint  = $"-- many {corr}!";
+					var oneTimeHint = $"-- once {corr}!";
+					db.QueryHints.Add(sharedHint);
+					db.NextQueryHints.Add(oneTimeHint);
 
-					await db.Parent.Where(r => r.ParentID == 11).SingleOrDefaultAsync();
-					var sql = db.LastQuery!;
+					var query = db.Parent.Where(r => r.ParentID == 11);
+					var sql = db is DataConnection ? null : query.ToString();
+					await query.ToListAsync();
+					if (db is DataConnection dc) sql = dc.LastQuery!;
 
-					Assert.True(sql.Contains("-- many"));
-					Assert.True(sql.Contains("-- once"));
+					Assert.True(sql!.Contains(sharedHint), $"(1) expected {sharedHint}. Has alien hint: {sql.Contains("many")}");
+					Assert.True(sql.Contains(oneTimeHint), $"(1) expected {oneTimeHint}. Has alien hint: {sql.Contains("once")}");
 
-					await db.Parent.Where(r => r.ParentID == 11).SingleOrDefaultAsync();
-					sql = db.LastQuery!;
+					query = db.Parent.Where(r => r.ParentID == 11);
+					sql = db is DataConnection ? null : query.ToString();
+					await query.ToListAsync();
+					if (db is DataConnection dc2) sql = dc2.LastQuery!;
 
-					Assert.True(sql.Contains("-- many"));
-					Assert.False(sql.Contains("-- once"));
+					Assert.True(sql!.Contains(sharedHint), $"(2) expected {sharedHint}. Has alien hint: {sql.Contains("many")}");
+					Assert.False(sql.Contains(oneTimeHint), $"(2) expected no {oneTimeHint}");
+					Assert.False(sql.Contains("once"), $"(2) alien one-time hint found");
 				}
 			}
 		}


### PR DESCRIPTION
Fix #3137

Issue was caused by storing hints in query cache so it was shared between context which is not correct as our current hint API is per-connection (new hints API should be query-bound!).
So:
- hints from one connection appeared for same query on other connections
- hints cleanup in execution logic lead to concurrency exceptions as this shared hints collection were enumerated in another thread by sql builder

Fix:
- moves hints population to execution phase where there is no way for hints to escape to cache
- implemented safe optimization case where hints collection could be used without copying it
- switched to `IReadOnlyCollection<string>` to pass hints internally to avoid invalid use in future
- also found and fixed incorrect hints copy logic in `DataContext`