### PR TITLE
Allow to use private and protected parameterized constructor for mapping

### DIFF
--- a/Source/LinqToDB/Linq/Builder/TableBuilder.TableContext.cs
+++ b/Source/LinqToDB/Linq/Builder/TableBuilder.TableContext.cs
@@ -527,19 +527,28 @@ namespace LinqToDB.Linq.Builder
 				}
 			}
 
-
-			Expression BuildFromParametrizedConstructor(Type objectType,
-				IList<(string Name, Expression? Expr)> expressions)
+			ConstructorInfo SelectParametrizedConstructor(Type objectType)
 			{
-				var constructors = objectType.GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+				var constructors = objectType.GetConstructors();
 
 				if (constructors.Length == 0)
-					throw new InvalidOperationException($"Type '{objectType.Name}' has no constructors.");
+				{
+					constructors = objectType.GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic);
+
+					if (constructors.Length == 0)
+						throw new InvalidOperationException($"Type '{objectType.Name}' has no constructors.");
+				}
 
 				if (constructors.Length > 1)
 					throw new InvalidOperationException($"Type '{objectType.Name}' has ambiguous constructors.");
 
-				var ctor = constructors[0];
+				return constructors[0];
+			}
+
+			Expression BuildFromParametrizedConstructor(Type objectType,
+				IList<(string Name, Expression? Expr)> expressions)
+			{
+				var ctor = SelectParametrizedConstructor(objectType);
 
 				var parameters = ctor.GetParameters();
 				var argFound   = false;

--- a/Source/LinqToDB/Linq/Builder/TableBuilder.TableContext.cs
+++ b/Source/LinqToDB/Linq/Builder/TableBuilder.TableContext.cs
@@ -531,13 +531,13 @@ namespace LinqToDB.Linq.Builder
 			Expression BuildFromParametrizedConstructor(Type objectType,
 				IList<(string Name, Expression? Expr)> expressions)
 			{
-				var constructors = objectType.GetConstructors();
+				var constructors = objectType.GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
 
 				if (constructors.Length == 0)
-					throw new InvalidOperationException($"Type '{objectType.Namespace}' has no constructors.");
+					throw new InvalidOperationException($"Type '{objectType.Name}' has no constructors.");
 
 				if (constructors.Length > 1)
-					throw new InvalidOperationException($"Type '{objectType.Namespace}' has ambiguous constructors.");
+					throw new InvalidOperationException($"Type '{objectType.Name}' has ambiguous constructors.");
 
 				var ctor = constructors[0];
 

--- a/Tests/Linq/Linq/ConstructorTests.cs
+++ b/Tests/Linq/Linq/ConstructorTests.cs
@@ -120,6 +120,29 @@ namespace Tests.Linq
 			public static WithOnlyProtectedConstructor Create(int id) => new(id, "Some");
 		}
 
+		[Table("ConstructorTestTable")]
+		public class WithPublicAndProtectedConstructor
+		{
+			[Column(IsPrimaryKey = true)]
+			public int Id { get; }
+
+			[Column]
+			public string? Value { get; }
+
+			protected WithPublicAndProtectedConstructor(int id)
+			{
+				Id    = id;
+			}
+			
+			public WithPublicAndProtectedConstructor(int id, string value)
+			{
+				Id    = id;
+				Value = value;
+			}
+
+			public static WithPublicAndProtectedConstructor Create(int id) => new(id, "Some");
+		}
+
 		[Test]
 		public void TestPublicConstructor([IncludeDataSources(TestProvName.AllSQLite)] string context)
 		{
@@ -194,6 +217,17 @@ namespace Tests.Linq
 		{
 			using var db = GetDataContext(context);
 			using var table = db.CreateLocalTable(new []{ WithOnlyProtectedConstructor.Create(5)});
+
+			var obj = table.First();
+			obj.Id.Should().Be(5);
+			obj.Value.Should().Be("Some");
+		}
+
+		[Test]
+		public void TestPublicAndProtectedParameterizedConstructors([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataContext(context);
+			using var table = db.CreateLocalTable(new []{ WithPublicAndProtectedConstructor.Create(5)});
 
 			var obj = table.First();
 			obj.Id.Should().Be(5);

--- a/Tests/Linq/Linq/ConstructorTests.cs
+++ b/Tests/Linq/Linq/ConstructorTests.cs
@@ -84,6 +84,42 @@ namespace Tests.Linq
 			}
 		}
 
+		[Table("ConstructorTestTable")]
+		public class WithOnlyPrivateConstructor
+		{
+			[Column(IsPrimaryKey = true)]
+			public int Id { get; }
+
+			[Column]
+			public string? Value { get; }
+
+			private WithOnlyPrivateConstructor(int id, string value)
+			{
+				Id    = id;
+				Value = value;
+			}
+
+			public static WithOnlyPrivateConstructor Create(int id) => new(id, "Some");
+		}
+
+		[Table("ConstructorTestTable")]
+		public class WithOnlyProtectedConstructor
+		{
+			[Column(IsPrimaryKey = true)]
+			public int Id { get; }
+
+			[Column]
+			public string? Value { get; }
+
+			protected WithOnlyProtectedConstructor(int id, string value)
+			{
+				Id    = id;
+				Value = value;
+			}
+
+			public static WithOnlyProtectedConstructor Create(int id) => new(id, "Some");
+		}
+
 		[Test]
 		public void TestPublicConstructor([IncludeDataSources(TestProvName.AllSQLite)] string context)
 		{
@@ -142,5 +178,26 @@ namespace Tests.Linq
 			}
 		}
 
+		[Test]
+		public void TestPrivateParameterizedConstructor([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataContext(context);
+			using var table = db.CreateLocalTable(new []{ WithOnlyPrivateConstructor.Create(5)});
+
+			var obj = table.First();
+			obj.Id.Should().Be(5);
+			obj.Value.Should().Be("Some");
+		}
+
+		[Test]
+		public void TestProtectedParameterizedConstructor([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataContext(context);
+			using var table = db.CreateLocalTable(new []{ WithOnlyProtectedConstructor.Create(5)});
+
+			var obj = table.First();
+			obj.Id.Should().Be(5);
+			obj.Value.Should().Be("Some");
+		}
 	}
 }


### PR DESCRIPTION
This PR adds an ability for linq2db to map data to classes with only private or protected constructors. Before this PR only public ones were supported. 

This case is useful when you want to map data to encapsulated rich models, which often have closed constructors.

We can also consider smartly selecting which constructor to use (most suitable based on field names). Right now it will only work for classes with single constructor.