### PR TITLE
LATERAL support for SAP HANA/MySQL

### DIFF
--- a/Build/Azure/scripts/hana2.sh
+++ b/Build/Azure/scripts/hana2.sh
@@ -51,6 +51,7 @@ cat <<-EOJSON > UserDataProviders.json
         "TraceLevel": "Info",
         "Connections": {
             "SapHana.Odbc": {
+                "Provider": "SapHana.2sps04.Odbc",
                 "ConnectionString": "Driver=$HOME/linq2db_ci/providers/saphana/linux/ODBC/libodbcHDB.so;SERVERNODE=localhost:39017;databaseName=HXE;CS=TESTDB;UID=SYSTEM;PWD=Passw0rd;"
             }
         }

--- a/Build/Azure/scripts/hana2.sh
+++ b/Build/Azure/scripts/hana2.sh
@@ -51,7 +51,6 @@ cat <<-EOJSON > UserDataProviders.json
         "TraceLevel": "Info",
         "Connections": {
             "SapHana.Odbc": {
-                "Provider": "SapHana.2sps04.Odbc",
                 "ConnectionString": "Driver=$HOME/linq2db_ci/providers/saphana/linux/ODBC/libodbcHDB.so;SERVERNODE=localhost:39017;databaseName=HXE;CS=TESTDB;UID=SYSTEM;PWD=Passw0rd;"
             }
         }

--- a/Build/Azure/scripts/mac.hana2.sh
+++ b/Build/Azure/scripts/mac.hana2.sh
@@ -46,6 +46,7 @@ cat <<-EOJSON > UserDataProviders.json
         "TraceLevel": "Info",
         "Connections": {
             "SapHana.Odbc": {
+                "Provider": "SapHana.2sps04.Odbc",
                 "ConnectionString": "Driver=$HOME/linq2db_ci/providers/saphana/macos/ODBC/libSQLDBCHDB.dylib;SERVERNODE=localhost:39017;databaseName=HXE;CS=TESTDB;UID=SYSTEM;PWD=Passw0rd;"
             }
         }

--- a/Build/Azure/scripts/mac.hana2.sh
+++ b/Build/Azure/scripts/mac.hana2.sh
@@ -46,7 +46,6 @@ cat <<-EOJSON > UserDataProviders.json
         "TraceLevel": "Info",
         "Connections": {
             "SapHana.Odbc": {
-                "Provider": "SapHana.2sps04.Odbc",
                 "ConnectionString": "Driver=$HOME/linq2db_ci/providers/saphana/macos/ODBC/libSQLDBCHDB.dylib;SERVERNODE=localhost:39017;databaseName=HXE;CS=TESTDB;UID=SYSTEM;PWD=Passw0rd;"
             }
         }

--- a/Source/LinqToDB/Configuration/LinqToDbConnectionOptionsBuilderExtensions.cs
+++ b/Source/LinqToDB/Configuration/LinqToDbConnectionOptionsBuilderExtensions.cs
@@ -374,31 +374,31 @@
 			return builder.UseConnectionString(ProviderName.SapHana, connectionString);
 		}
 
-#if NETFRAMEWORK || NETCOREAPP
 		/// <summary>
 		/// Configure connection to use native SAP HANA provider and connection string.
 		/// </summary>
 		/// <param name="builder">Instance of <see cref="LinqToDbConnectionOptionsBuilder"/>.</param>
 		/// <param name="connectionString">SAP HANA connection string.</param>
+		/// <param name="version">SAP HANA SQL dialect version.</param>
 		/// <returns>The builder instance so calls can be chained.</returns>
-		public static LinqToDbConnectionOptionsBuilder UseSapHanaNative(this LinqToDbConnectionOptionsBuilder builder, string connectionString)
+		public static LinqToDbConnectionOptionsBuilder UseSapHanaNative(this LinqToDbConnectionOptionsBuilder builder, string connectionString, SapHanaVersion version = SapHanaVersion.SapHana1)
 		{
 			return builder.UseConnectionString(
-				SapHanaTools.GetDataProvider(ProviderName.SapHanaNative),
+				SapHanaTools.GetDataProvider(version: version, provider: SapHanaProvider.Native),
 				connectionString);
 		}
-#endif
 
 		/// <summary>
 		/// Configure connection to use SAP HANA ODBC provider and connection string.
 		/// </summary>
 		/// <param name="builder">Instance of <see cref="LinqToDbConnectionOptionsBuilder"/>.</param>
 		/// <param name="connectionString">SAP HANA connection string.</param>
+		/// <param name="version">SAP HANA SQL dialect version.</param>
 		/// <returns>The builder instance so calls can be chained.</returns>
-		public static LinqToDbConnectionOptionsBuilder UseSapHanaODBC(this LinqToDbConnectionOptionsBuilder builder, string connectionString)
+		public static LinqToDbConnectionOptionsBuilder UseSapHanaODBC(this LinqToDbConnectionOptionsBuilder builder, string connectionString, SapHanaVersion version = SapHanaVersion.SapHana1)
 		{
 			return builder.UseConnectionString(
-				SapHanaTools.GetDataProvider(ProviderName.SapHanaOdbc),
+				SapHanaTools.GetDataProvider(version: version, provider: SapHanaProvider.Odbc),
 				connectionString);
 		}
 		#endregion

--- a/Source/LinqToDB/DataProvider/MySql/MySqlSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlSqlBuilder.cs
@@ -631,5 +631,16 @@ namespace LinqToDB.DataProvider.MySql
 			if (table.TableOptions.HasCreateIfNotExists())
 				StringBuilder.Append("IF NOT EXISTS ");
 		}
+
+		protected override bool BuildJoinType(JoinType joinType, SqlSearchCondition condition)
+		{
+			switch (joinType)
+			{
+				case JoinType.CrossApply : StringBuilder.Append("INNER JOIN LATERAL ");       return true;
+				case JoinType.OuterApply : StringBuilder.Append("LEFT OUTER JOIN LATERAL ");  return true;
+			}
+
+			return base.BuildJoinType(joinType, condition);
+		}
 	}
 }

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaBulkCopy.cs
@@ -1,5 +1,4 @@
-﻿#if NETFRAMEWORK || NETCOREAPP
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
@@ -20,9 +19,9 @@ namespace LinqToDB.DataProvider.SapHana
 		}
 
 		protected override BulkCopyRowsCopied ProviderSpecificCopy<T>(
-			ITable<T> table,
+			ITable<T>       table,
 			BulkCopyOptions options,
-			IEnumerable<T> source)
+			IEnumerable<T>  source)
 		{
 			var connections = TryGetProviderConnections(table);
 			if (connections.HasValue)
@@ -38,9 +37,9 @@ namespace LinqToDB.DataProvider.SapHana
 		}
 
 		protected override Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
-			ITable<T> table,
-			BulkCopyOptions options,
-			IEnumerable<T> source,
+			ITable<T>         table,
+			BulkCopyOptions   options,
+			IEnumerable<T>    source,
 			CancellationToken cancellationToken)
 		{
 			var connections = TryGetProviderConnections(table);
@@ -59,10 +58,10 @@ namespace LinqToDB.DataProvider.SapHana
 
 #if NATIVE_ASYNC
 		protected override Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
-			ITable<T> table,
-			BulkCopyOptions options,
+			ITable<T>           table,
+			BulkCopyOptions     options,
 			IAsyncEnumerable<T> source,
-			CancellationToken cancellationToken)
+			CancellationToken   cancellationToken)
 		{
 			var connections = TryGetProviderConnections(table);
 			if (connections.HasValue)
@@ -253,4 +252,3 @@ namespace LinqToDB.DataProvider.SapHana
 		}
 	}
 }
-#endif

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaDataProvider.cs
@@ -1,5 +1,4 @@
-﻿#if NETFRAMEWORK || NETCOREAPP
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Threading;
@@ -15,16 +14,17 @@ namespace LinqToDB.DataProvider.SapHana
 
 	public class SapHanaDataProvider : DynamicDataProviderBase<SapHanaProviderAdapter>
 	{
-		public SapHanaDataProvider()
-			: this(ProviderName.SapHanaNative)
+		public SapHanaDataProvider(SapHanaVersion version = SapHanaVersion.SapHana1)
+			: this(GetProviderName(version), version)
 		{
 		}
 
-		public SapHanaDataProvider(string name)
-			: this(name, MappingSchemaInstance)
+		public SapHanaDataProvider(string name, SapHanaVersion version = SapHanaVersion.SapHana1)
+			: this(name, GetMappingSchema(version), version)
 		{
 		}
-		protected SapHanaDataProvider(string name, MappingSchema mappingSchema)
+
+		protected SapHanaDataProvider(string name, MappingSchema mappingSchema, SapHanaVersion version)
 			: base(name, mappingSchema, SapHanaProviderAdapter.GetInstance())
 		{
 			SqlProviderFlags.IsParameterOrderDependent = true;
@@ -41,10 +41,10 @@ namespace LinqToDB.DataProvider.SapHana
 
 			SqlProviderFlags.IsTakeSupported            = true;
 			SqlProviderFlags.IsDistinctOrderBySupported = false;
+			SqlProviderFlags.IsApplyJoinSupported       = version != SapHanaVersion.SapHana1;
 
 			//not supported flags
 			SqlProviderFlags.IsSubQueryTakeSupported   = false;
-			SqlProviderFlags.IsApplyJoinSupported      = false;
 			SqlProviderFlags.IsInsertOrUpdateSupported = false;
 			SqlProviderFlags.IsUpdateFromSupported     = false;
 
@@ -187,7 +187,22 @@ namespace LinqToDB.DataProvider.SapHana
 			return true;
 		}
 
-		private static readonly MappingSchema MappingSchemaInstance = new SapHanaMappingSchema.NativeMappingSchema();
+		private static string GetProviderName(SapHanaVersion version)
+		{
+			return version switch
+			{
+				SapHanaVersion.SapHana2sps04 => ProviderName.SapHana2SPS04Native,
+				_                            => ProviderName.SapHanaNative,
+			};
+		}
+
+		private static MappingSchema GetMappingSchema(SapHanaVersion version)
+		{
+			return version switch
+			{
+				SapHanaVersion.SapHana2sps04 => SapHanaMappingSchema.Native2SPS04MappingSchema.Instance,
+				_                            => SapHanaMappingSchema.NativeMappingSchema.Instance,
+			};
+		}
 	}
 }
-#endif

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaFactory.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaFactory.cs
@@ -11,8 +11,15 @@ namespace LinqToDB.DataProvider.SapHana
 	{
 		IDataProvider IDataProviderFactory.GetDataProvider(IEnumerable<NamedValue> attributes)
 		{
-			var assemblyName = attributes.FirstOrDefault(_ => _.Name == "assemblyName");
-			return SapHanaTools.GetDataProvider(null, assemblyName?.Value);
+			var version      = attributes.FirstOrDefault(_ => _.Name == "version")?.Value;
+			var assemblyName = attributes.FirstOrDefault(_ => _.Name == "assemblyName")?.Value;
+
+			return version switch
+			{
+				"1"      => SapHanaTools.GetDataProvider(assemblyName: assemblyName, version: SapHanaVersion.SapHana1),
+				"2SPS04" => SapHanaTools.GetDataProvider(assemblyName: assemblyName, version: SapHanaVersion.SapHana2sps04),
+				_        => SapHanaTools.GetDataProvider(assemblyName: assemblyName),
+			};
 		}
 	}
 }

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaMappingSchema.cs
@@ -1,13 +1,12 @@
-﻿
+﻿using System;
+using System.Data.Linq;
+using System.Text;
 
 namespace LinqToDB.DataProvider.SapHana
 {
 	using Common;
 	using Mapping;
 	using SqlQuery;
-	using System;
-	using System.Data.Linq;
-	using System.Text;
 
 	public class SapHanaMappingSchema : MappingSchema
 	{
@@ -58,22 +57,44 @@ namespace LinqToDB.DataProvider.SapHana
 
 		internal static readonly SapHanaMappingSchema Instance = new ();
 
-#if NETFRAMEWORK || NETCOREAPP
 		public class NativeMappingSchema : MappingSchema
 		{
 			public NativeMappingSchema()
-				: base(ProviderName.SapHanaNative, Instance)
+				: base(ProviderName.SapHanaNative, SapHanaMappingSchema.Instance)
 			{
 			}
+
+			public static NativeMappingSchema Instance { get; } = new();
 		}
-#endif
 
 		public class OdbcMappingSchema : MappingSchema
 		{
 			public OdbcMappingSchema()
-				: base(ProviderName.SapHanaOdbc, Instance)
+				: base(ProviderName.SapHanaOdbc, SapHanaMappingSchema.Instance)
 			{
 			}
+
+			public static OdbcMappingSchema Instance { get; } = new();
+		}
+
+		public class Native2SPS04MappingSchema : MappingSchema
+		{
+			public Native2SPS04MappingSchema()
+				: base(ProviderName.SapHana2SPS04Native, SapHanaMappingSchema.Instance)
+			{
+			}
+
+			public static Native2SPS04MappingSchema Instance { get; } = new();
+		}
+
+		public class Odbc2SPS04MappingSchema : MappingSchema
+		{
+			public Odbc2SPS04MappingSchema()
+				: base(ProviderName.SapHana2SPS04Odbc, SapHanaMappingSchema.Instance)
+			{
+			}
+
+			public static Odbc2SPS04MappingSchema Instance { get; } = new();
 		}
 	}
 }

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaProvider.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaProvider.cs
@@ -1,0 +1,8 @@
+﻿namespace LinqToDB.DataProvider.SapHana
+{
+	public enum SapHanaProvider
+	{
+		Native,
+		Odbc
+	}
+}

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaSqlBuilder.cs
@@ -239,5 +239,16 @@ namespace LinqToDB.DataProvider.SapHana
 		}
 
 		protected override void BuildIsDistinctPredicate(SqlPredicate.IsDistinct expr) => BuildIsDistinctPredicateFallback(expr);
+
+		protected override bool BuildJoinType(JoinType joinType, SqlSearchCondition condition)
+		{
+			switch (joinType)
+			{
+				case JoinType.CrossApply : StringBuilder.Append("INNER JOIN LATERAL ");       return true;
+				case JoinType.OuterApply : StringBuilder.Append("LEFT OUTER JOIN LATERAL ");  return true;
+			}
+
+			return base.BuildJoinType(joinType, condition);
+		}
 	}
 }

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaSqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaSqlOptimizer.cs
@@ -10,7 +10,6 @@ namespace LinqToDB.DataProvider.SapHana
 	{
 		public SapHanaSqlOptimizer(SqlProviderFlags sqlProviderFlags) : base(sqlProviderFlags)
 		{
-
 		}
 
 		public override SqlStatement TransformStatement(SqlStatement statement)

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaTools.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaTools.cs
@@ -6,38 +6,59 @@ namespace LinqToDB.DataProvider.SapHana
 	using Data;
 	using Configuration;
 	using System;
+	using LinqToDB.Common;
 
 	public static class SapHanaTools
 	{
-#if NETFRAMEWORK || NETCOREAPP
-		private static readonly Lazy<IDataProvider> _hanaDataProvider = new Lazy<IDataProvider>(() =>
+		/// <summary>
+		/// Default provider to use for SAP HANA connection.
+		/// Default value: not set (<c>null</c>).
+		/// </summary>
+		public static SapHanaProvider? Provider { get; set; }
+
+		private static readonly Lazy<IDataProvider> _hana1DataProvider = new (() =>
 		{
-			var provider = new SapHanaDataProvider(ProviderName.SapHanaNative);
+			var provider = new SapHanaDataProvider(ProviderName.SapHanaNative, SapHanaVersion.SapHana1);
 
 			DataConnection.AddDataProvider(provider);
 
 			return provider;
 		}, true);
-#endif
 
-		private static readonly Lazy<IDataProvider> _hanaOdbcDataProvider = new Lazy<IDataProvider>(() =>
+		private static readonly Lazy<IDataProvider> _hana2sps04DataProvider = new (() =>
 		{
-			var provider = new SapHanaOdbcDataProvider();
+			var provider = new SapHanaDataProvider(ProviderName.SapHanaNative, SapHanaVersion.SapHana2sps04);
 
 			DataConnection.AddDataProvider(provider);
 
 			return provider;
 		}, true);
+
+		private static readonly Lazy<IDataProvider> _hana1OdbcDataProvider = new (() =>
+		{
+			var provider = new SapHanaOdbcDataProvider(SapHanaVersion.SapHana1);
+
+			DataConnection.AddDataProvider(provider);
+
+			return provider;
+		}, true);
+
+		private static readonly Lazy<IDataProvider> _hana2sps04OdbcDataProvider = new (() =>
+		{
+			var provider = new SapHanaOdbcDataProvider(SapHanaVersion.SapHana2sps04);
+
+			DataConnection.AddDataProvider(provider);
+
+			return provider;
+		}, true);
+
+		public static bool AutoDetectProvider { get; set; } = true;
 
 		public static void ResolveSapHana(string path)
 		{
 			new AssemblyResolver(
 				path,
-#if NETFRAMEWORK || NETCOREAPP
-			DetectedProviderName == ProviderName.SapHanaNative
-						? SapHanaProviderAdapter.AssemblyName :
-#endif
-						OdbcProviderAdapter.AssemblyName);
+				(Provider ?? SapHanaProvider.Odbc) == SapHanaProvider.Native ? SapHanaProviderAdapter.AssemblyName : OdbcProviderAdapter.AssemblyName);
 		}
 
 		public static void ResolveSapHana(Assembly assembly)
@@ -45,52 +66,56 @@ namespace LinqToDB.DataProvider.SapHana
 			new AssemblyResolver(assembly, assembly.FullName!);
 		}
 
-		public static IDataProvider GetDataProvider(string? providerName = null, string? assemblyName = null)
+		public static IDataProvider GetDataProvider(string? providerName = null, string? assemblyName = null, SapHanaProvider? provider = null, SapHanaVersion? version = null)
 		{
-#if NETFRAMEWORK || NETCOREAPP
-			if (assemblyName == SapHanaProviderAdapter.AssemblyName) return _hanaDataProvider.Value;
-#endif
-			if (assemblyName == OdbcProviderAdapter.AssemblyName)    return _hanaOdbcDataProvider.Value;
+			var dataProvider = providerName != null ? getDataProvider(providerName) : null;
 
+			if (dataProvider != null)
+				return dataProvider;
 
-			switch (providerName)
+			if (provider == SapHanaProvider.Native || assemblyName == SapHanaProviderAdapter.AssemblyName)
+				return version == SapHanaVersion.SapHana2sps04 ? _hana2sps04DataProvider.Value : _hana1DataProvider.Value;
+
+			return version == SapHanaVersion.SapHana2sps04 ? _hana2sps04OdbcDataProvider.Value : _hana1OdbcDataProvider.Value;
+
+			static IDataProvider? getDataProvider(string providerName)
 			{
-				case ProviderName.SapHanaOdbc  : return _hanaOdbcDataProvider.Value;
-#if NETFRAMEWORK || NETCOREAPP
-				case ProviderName.SapHanaNative: return _hanaDataProvider.Value;
-#endif
+				// resolve explicit provider version
+				switch (providerName)
+				{
+					case ProviderName.SapHanaOdbc        : return _hana1OdbcDataProvider.Value;
+					case ProviderName.SapHana2SPS04Odbc  : return _hana2sps04OdbcDataProvider.Value;
+					case ProviderName.SapHanaNative      : return _hana1DataProvider.Value;
+					case ProviderName.SapHana2SPS04Native: return _hana2sps04DataProvider.Value;
+				}
+
+				return null;
 			}
-
-#if NETFRAMEWORK || NETCOREAPP
-			if (DetectedProviderName == ProviderName.SapHanaNative)
-				return _hanaDataProvider.Value;
-#endif
-
-			return _hanaOdbcDataProvider.Value;
 		}
 
 		#region CreateDataConnection
 
-		public static DataConnection CreateDataConnection(string connectionString, string? providerName = null)
+		public static DataConnection CreateDataConnection(string connectionString, string? providerName = null, SapHanaProvider? provider = null, SapHanaVersion? version = null)
 		{
-			return new DataConnection(GetDataProvider(providerName), connectionString);
+			return new DataConnection(GetDataProvider(providerName: providerName, provider: provider, version: version), connectionString);
 		}
 
-		public static DataConnection CreateDataConnection(IDbConnection connection, string? providerName = null)
+		public static DataConnection CreateDataConnection(IDbConnection connection, string? providerName = null, SapHanaProvider? provider = null, SapHanaVersion? version = null)
 		{
-			return new DataConnection(GetDataProvider(providerName), connection);
+			return new DataConnection(GetDataProvider(providerName: providerName, provider: provider, version: version), connection);
 		}
 
-		public static DataConnection CreateDataConnection(IDbTransaction transaction, string? providerName = null)
+		public static DataConnection CreateDataConnection(IDbTransaction transaction, string? providerName = null, SapHanaProvider? provider = null, SapHanaVersion? version = null)
 		{
-			return new DataConnection(GetDataProvider(providerName), transaction);
+			return new DataConnection(GetDataProvider(providerName: providerName, provider: provider, version: version), transaction);
 		}
 
 #endregion
 
+		// TODO: v4: remove
 		private static string? _detectedProviderName;
-		public  static string  DetectedProviderName =>
-			_detectedProviderName ??= DetectProviderName();
+		[Obsolete("Property is obsoleted and could return wrong value")]
+		public  static string  DetectedProviderName => _detectedProviderName ??= DetectProviderName();
 
 		static string DetectProviderName()
 		{
@@ -103,29 +128,92 @@ namespace LinqToDB.DataProvider.SapHana
 
 		internal static IDataProvider? ProviderDetector(IConnectionStringSettings css, string connectionString)
 		{
+			var provider = Provider ?? SapHanaProvider.Native;
+
 			if (connectionString.IndexOf("HDBODBC", StringComparison.InvariantCultureIgnoreCase) >= 0)
-				return _hanaOdbcDataProvider.Value;
+				provider = SapHanaProvider.Odbc;
+			if (css.Name.IndexOf("ODBC", StringComparison.InvariantCultureIgnoreCase) >= 0)
+				provider = SapHanaProvider.Odbc;
+
+			var version = SapHanaVersion.SapHana1;
 
 			switch (css.ProviderName)
 			{
-#if NETFRAMEWORK || NETCOREAPP
 				case SapHanaProviderAdapter.ClientNamespace:
 				case "Sap.Data.Hana.v4.5"                  :
 				case "Sap.Data.Hana.Core"                  :
 				case "Sap.Data.Hana.Core.v2.1"             :
-				case ProviderName.SapHanaNative            : return _hanaDataProvider.Value;
-#endif
-				case ProviderName.SapHanaOdbc              : return _hanaOdbcDataProvider.Value;
+				case ProviderName.SapHanaNative            :
+					provider = SapHanaProvider.Native;
+					goto case ProviderName.SapHana;
+				case ProviderName.SapHanaOdbc              :
+					provider = SapHanaProvider.Odbc;
+					goto case ProviderName.SapHana;
 				case ""                                    :
 				case null                                  :
 					if (css.Name.Contains("Hana"))
 						goto case ProviderName.SapHana;
 					break;
 				case ProviderName.SapHana                  :
-					if (css.Name.IndexOf("ODBC", StringComparison.InvariantCultureIgnoreCase) >= 0)
-						return _hanaOdbcDataProvider.Value;
+					version = GetAutoDetectedVersion(css, connectionString, provider, version) ?? version;
 
-					return GetDataProvider();
+					return GetDataProvider(providerName: css.ProviderName, provider: provider, version: version);
+			}
+
+			return null;
+		}
+
+		private static SapHanaVersion? GetAutoDetectedVersion(IConnectionStringSettings css, string connectionString, SapHanaProvider provider, SapHanaVersion version)
+		{
+			if (AutoDetectProvider)
+			{
+				// try native provider
+				try
+				{
+					var cs = string.IsNullOrWhiteSpace(connectionString) ? css.ConnectionString : connectionString;
+					string hanaVersion;
+
+					if (provider == SapHanaProvider.Native)
+					{
+						using (var conn = SapHanaProviderAdapter.GetInstance().CreateConnection(cs))
+						{
+							conn.Open();
+
+							using (var cmd = conn.CreateCommand())
+							{
+								cmd.CommandText = "SELECT VERSION FROM SYS.M_DATABASE";
+								hanaVersion = Converter.ChangeTypeTo<string>(cmd.ExecuteScalar());
+							}
+						}
+					}
+					else
+					{
+						using (var conn = OdbcProviderAdapter.GetInstance().CreateConnection(cs))
+						{
+							conn.Open();
+
+							using (var cmd = conn.CreateCommand())
+							{
+								cmd.CommandText = "SELECT VERSION FROM SYS.M_DATABASE";
+								hanaVersion = Converter.ChangeTypeTo<string>(cmd.ExecuteScalar());
+							}
+						}
+					}
+
+					// https://www.blue.works/en/hana-version-numbering-explained/
+					var parts    = hanaVersion.Split('.');
+					var major    = int.Parse(parts[0]);
+					var minor    = int.Parse(parts[1]);
+					var revision = int.Parse(parts[2]);
+					if (major == 2
+						|| (major == 2 && minor > 0)
+						|| (major == 2 && minor == 0 && revision >= 40))
+						return SapHanaVersion.SapHana2sps04;
+					return SapHanaVersion.SapHana1;
+				}
+				catch
+				{
+				}
 			}
 
 			return null;

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaVersion.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaVersion.cs
@@ -1,0 +1,17 @@
+﻿namespace LinqToDB.DataProvider.SapHana
+{
+	/// <summary>
+	/// SQL Dialect version.
+	/// </summary>
+	public enum SapHanaVersion
+	{
+		/// <summary>
+		/// Base SQL dialect, matching SAP HANA 1.
+		/// </summary>
+		SapHana1,
+		/// <summary>
+		/// SQL dialect with new features from SAP HANA 2 SPS 04.
+		/// </summary>
+		SapHana2sps04,
+	}
+}

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerTools.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerTools.cs
@@ -16,12 +16,12 @@ namespace LinqToDB.DataProvider.SqlServer
 		#region Init
 
 		public static SqlServerProvider Provider = SqlServerProvider.SystemDataSqlClient;
-		private static readonly ConcurrentQueue<SqlServerDataProvider> _providers = new ConcurrentQueue<SqlServerDataProvider>();
+		private static readonly ConcurrentQueue<SqlServerDataProvider> _providers = new ();
 
 		// System.Data
 		// and/or
 		// System.Data.SqlClient
-		private static readonly Lazy<IDataProvider> _sqlServerDataProvider2000sdc = new Lazy<IDataProvider>(() =>
+		private static readonly Lazy<IDataProvider> _sqlServerDataProvider2000sdc = new (() =>
 		{
 			var provider = new SqlServerDataProvider(ProviderName.SqlServer2000, SqlServerVersion.v2000, SqlServerProvider.SystemDataSqlClient);
 
@@ -31,7 +31,7 @@ namespace LinqToDB.DataProvider.SqlServer
 			_providers.Enqueue(provider);
 			return provider;
 		}, true);
-		private static readonly Lazy<IDataProvider> _sqlServerDataProvider2005sdc = new Lazy<IDataProvider>(() =>
+		private static readonly Lazy<IDataProvider> _sqlServerDataProvider2005sdc = new (() =>
 		{
 			var provider = new SqlServerDataProvider(ProviderName.SqlServer2005, SqlServerVersion.v2005, SqlServerProvider.SystemDataSqlClient);
 
@@ -41,7 +41,7 @@ namespace LinqToDB.DataProvider.SqlServer
 			_providers.Enqueue(provider);
 			return provider;
 		}, true);
-		private static readonly Lazy<IDataProvider> _sqlServerDataProvider2008sdc = new Lazy<IDataProvider>(() =>
+		private static readonly Lazy<IDataProvider> _sqlServerDataProvider2008sdc = new (() =>
 		{
 			var provider = new SqlServerDataProvider(ProviderName.SqlServer2008, SqlServerVersion.v2008, SqlServerProvider.SystemDataSqlClient);
 
@@ -53,7 +53,7 @@ namespace LinqToDB.DataProvider.SqlServer
 			_providers.Enqueue(provider);
 			return provider;
 		}, true);
-		private static readonly Lazy<IDataProvider> _sqlServerDataProvider2012sdc = new Lazy<IDataProvider>(() =>
+		private static readonly Lazy<IDataProvider> _sqlServerDataProvider2012sdc = new (() =>
 		{
 			var provider = new SqlServerDataProvider(ProviderName.SqlServer2012, SqlServerVersion.v2012, SqlServerProvider.SystemDataSqlClient);
 
@@ -66,7 +66,7 @@ namespace LinqToDB.DataProvider.SqlServer
 			_providers.Enqueue(provider);
 			return provider;
 		}, true);
-		private static readonly Lazy<IDataProvider> _sqlServerDataProvider2016sdc = new Lazy<IDataProvider>(() =>
+		private static readonly Lazy<IDataProvider> _sqlServerDataProvider2016sdc = new (() =>
 		{
 			var provider = new SqlServerDataProvider(ProviderName.SqlServer2016, SqlServerVersion.v2016, SqlServerProvider.SystemDataSqlClient);
 
@@ -76,7 +76,7 @@ namespace LinqToDB.DataProvider.SqlServer
 			_providers.Enqueue(provider);
 			return provider;
 		}, true);
-		private static readonly Lazy<IDataProvider> _sqlServerDataProvider2017sdc = new Lazy<IDataProvider>(() =>
+		private static readonly Lazy<IDataProvider> _sqlServerDataProvider2017sdc = new (() =>
 		{
 			var provider = new SqlServerDataProvider(ProviderName.SqlServer2017, SqlServerVersion.v2017, SqlServerProvider.SystemDataSqlClient);
 
@@ -88,7 +88,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		}, true);
 
 		// Microsoft.Data.SqlClient
-		private static readonly Lazy<IDataProvider> _sqlServerDataProvider2000mdc = new Lazy<IDataProvider>(() =>
+		private static readonly Lazy<IDataProvider> _sqlServerDataProvider2000mdc = new (() =>
 		{
 			var provider = new SqlServerDataProvider(ProviderName.SqlServer2000, SqlServerVersion.v2000, SqlServerProvider.MicrosoftDataSqlClient);
 
@@ -98,7 +98,7 @@ namespace LinqToDB.DataProvider.SqlServer
 			_providers.Enqueue(provider);
 			return provider;
 		}, true);
-		private static readonly Lazy<IDataProvider> _sqlServerDataProvider2005mdc = new Lazy<IDataProvider>(() =>
+		private static readonly Lazy<IDataProvider> _sqlServerDataProvider2005mdc = new (() =>
 		{
 			var provider = new SqlServerDataProvider(ProviderName.SqlServer2005, SqlServerVersion.v2005, SqlServerProvider.MicrosoftDataSqlClient);
 
@@ -108,7 +108,7 @@ namespace LinqToDB.DataProvider.SqlServer
 			_providers.Enqueue(provider);
 			return provider;
 		}, true);
-		private static readonly Lazy<IDataProvider> _sqlServerDataProvider2008mdc = new Lazy<IDataProvider>(() =>
+		private static readonly Lazy<IDataProvider> _sqlServerDataProvider2008mdc = new (() =>
 		{
 			var provider = new SqlServerDataProvider(ProviderName.SqlServer2008, SqlServerVersion.v2008, SqlServerProvider.MicrosoftDataSqlClient);
 
@@ -120,7 +120,7 @@ namespace LinqToDB.DataProvider.SqlServer
 			_providers.Enqueue(provider);
 			return provider;
 		}, true);
-		private static readonly Lazy<IDataProvider> _sqlServerDataProvider2012mdc = new Lazy<IDataProvider>(() =>
+		private static readonly Lazy<IDataProvider> _sqlServerDataProvider2012mdc = new (() =>
 		{
 			var provider = new SqlServerDataProvider(ProviderName.SqlServer2012, SqlServerVersion.v2012, SqlServerProvider.MicrosoftDataSqlClient);
 
@@ -133,7 +133,7 @@ namespace LinqToDB.DataProvider.SqlServer
 			_providers.Enqueue(provider);
 			return provider;
 		}, true);
-		private static readonly Lazy<IDataProvider> _sqlServerDataProvider2016mdc = new Lazy<IDataProvider>(() =>
+		private static readonly Lazy<IDataProvider> _sqlServerDataProvider2016mdc = new (() =>
 		{
 			var provider = new SqlServerDataProvider(ProviderName.SqlServer2016, SqlServerVersion.v2016, SqlServerProvider.MicrosoftDataSqlClient);
 
@@ -143,7 +143,7 @@ namespace LinqToDB.DataProvider.SqlServer
 			_providers.Enqueue(provider);
 			return provider;
 		}, true);
-		private static readonly Lazy<IDataProvider> _sqlServerDataProvider2017mdc = new Lazy<IDataProvider>(() =>
+		private static readonly Lazy<IDataProvider> _sqlServerDataProvider2017mdc = new (() =>
 		{
 			var provider = new SqlServerDataProvider(ProviderName.SqlServer2017, SqlServerVersion.v2017, SqlServerProvider.MicrosoftDataSqlClient);
 

--- a/Source/LinqToDB/ProviderName.cs
+++ b/Source/LinqToDB/ProviderName.cs
@@ -169,17 +169,29 @@ namespace LinqToDB
 		/// Used as configuration name for SAP HANA mapping schema <see cref="DataProvider.SapHana.SapHanaMappingSchema"/>.
 		/// </summary>
 		public const string SapHana       = "SapHana";
-#if NETFRAMEWORK || NETCOREAPP
+
 		/// <summary>
 		/// SAP HANA provider.
 		/// Used as configuration name for SAP HANA mapping schema <see cref="DataProvider.SapHana.SapHanaMappingSchema.NativeMappingSchema"/>.
 		/// </summary>
 		public const string SapHanaNative = "SapHana.Native";
-#endif
+
+		/// <summary>
+		/// SAP HANA2 SPS04 provider.
+		/// Used as configuration name for SAP HANA mapping schema <see cref="DataProvider.SapHana.SapHanaMappingSchema.NativeMappingSchema"/>.
+		/// </summary>
+		public const string SapHana2SPS04Native = "SapHana.2sps04.Native";
+
 		/// <summary>
 		/// SAP HANA ODBC provider.
 		/// Used as configuration name for SAP HANA mapping schema <see cref="DataProvider.SapHana.SapHanaMappingSchema.OdbcMappingSchema"/>.
 		/// </summary>
 		public const string SapHanaOdbc = "SapHana.Odbc";
+
+		/// <summary>
+		/// SAP HANA2 SPS04 ODBC provider.
+		/// Used as configuration name for SAP HANA mapping schema <see cref="DataProvider.SapHana.SapHanaMappingSchema.OdbcMappingSchema"/>.
+		/// </summary>
+		public const string SapHana2SPS04Odbc = "SapHana.2sps04.Odbc";
 	}
 }

--- a/Tests/DataProviders.json
+++ b/Tests/DataProviders.json
@@ -195,7 +195,7 @@
 			"Informix"            : { "Provider": "Informix",                        "ConnectionString": "Server=localhost:9089;Database=testdb;userid=informix;password=in4mix"                                                                                    },
 			"Informix.DB2"        : {                                                "ConnectionString": "Server=localhost:9089;Database=testdb;userid=informix;password=in4mix"                                                                                    },
 			"DB2"                 : { "Provider": "IBM.Data.DB2.Core",               "ConnectionString": "Server=localhost:50000;Database=testdb;UID=db2inst1;PWD=Password12!"                                                                                      },
-			"SapHana.Odbc"        : { "Provider": "SapHana.Odbc",                    "ConnectionString": "<SET BY SCRIPT>"                                                                                                                                          },
+			"SapHana.Odbc"        : { "Provider": "SapHana.2sps04.Odbc",             "ConnectionString": "<SET BY SCRIPT>"                                                                                                                                          },
 		}
 	},
 

--- a/Tests/DataProviders.json
+++ b/Tests/DataProviders.json
@@ -195,7 +195,7 @@
 			"Informix"            : { "Provider": "Informix",                        "ConnectionString": "Server=localhost:9089;Database=testdb;userid=informix;password=in4mix"                                                                                    },
 			"Informix.DB2"        : {                                                "ConnectionString": "Server=localhost:9089;Database=testdb;userid=informix;password=in4mix"                                                                                    },
 			"DB2"                 : { "Provider": "IBM.Data.DB2.Core",               "ConnectionString": "Server=localhost:50000;Database=testdb;UID=db2inst1;PWD=Password12!"                                                                                      },
-			"SapHana.Odbc"        : { "Provider": "SapHana.2sps04.Odbc",             "ConnectionString": "<SET BY SCRIPT>"                                                                                                                                          },
+			"SapHana.Odbc"        : {                                                "ConnectionString": "<SET BY SCRIPT>"                                                                                                                                          },
 		}
 	},
 

--- a/Tests/Linq/Linq/ArrayTableTests.cs
+++ b/Tests/Linq/Linq/ArrayTableTests.cs
@@ -11,7 +11,7 @@ namespace Tests.Linq
 	{
 		[Test]
 		public void ApplyJoinArray(
-			[IncludeDataSources(TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL93Plus, TestProvName.AllOracle12)]
+			[IncludeDataSources(TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL93Plus, TestProvName.AllOracle12, TestProvName.AllMySql, TestProvName.AllSapHana)]
 			string context)
 		{
 			var doe = "Doe";

--- a/Tests/Linq/Linq/AssociationTests.cs
+++ b/Tests/Linq/Linq/AssociationTests.cs
@@ -495,7 +495,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void MultipleUse([IncludeDataSources(TestProvName.AllSqlServer2005Plus, TestProvName.AllPostgreSQL93Plus, TestProvName.AllOracle12)] string context)
+		public void MultipleUse([IncludeDataSources(TestProvName.AllSqlServer2005Plus, TestProvName.AllPostgreSQL93Plus, TestProvName.AllOracle12, TestProvName.AllMySql, TestProvName.AllSapHana)] string context)
 		{
 			using (var db = new TestDataConnection(context))
 			{

--- a/Tests/Linq/Linq/ConvertExpressionTests.cs
+++ b/Tests/Linq/Linq/ConvertExpressionTests.cs
@@ -215,7 +215,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void LetTest1([DataSources(ProviderName.SqlCe, TestProvName.AllInformix, TestProvName.AllSybase, TestProvName.AllSapHana)] string context)
+		public void LetTest1([DataSources(ProviderName.SqlCe, TestProvName.AllInformix, TestProvName.AllSybase)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -251,7 +251,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void LetTest3([DataSources(TestProvName.AllInformix, TestProvName.AllSybase, TestProvName.AllSapHana)] string context)
+		public void LetTest3([DataSources(TestProvName.AllInformix, TestProvName.AllSybase)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -267,7 +267,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void LetTest4([DataSources(TestProvName.AllInformix, TestProvName.AllSapHana)] string context)
+		public void LetTest4([DataSources(TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -297,7 +297,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void LetTest41([DataSources(TestProvName.AllInformix, TestProvName.AllSapHana)] string context)
+		public void LetTest41([DataSources(TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -327,7 +327,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void LetTest5([DataSources(TestProvName.AllOracle11, TestProvName.AllInformix, TestProvName.AllSybase, TestProvName.AllSapHana)] string context)
+		public void LetTest5([DataSources(TestProvName.AllOracle11, TestProvName.AllInformix, TestProvName.AllSybase)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -357,7 +357,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void LetTest6([DataSources(TestProvName.AllOracle11, TestProvName.AllInformix, TestProvName.AllSybase, TestProvName.AllSapHana)] string context)
+		public void LetTest6([DataSources(TestProvName.AllOracle11, TestProvName.AllInformix, TestProvName.AllSybase)] string context)
 		{
 			//LinqToDB.Common.Configuration.Linq.GenerateExpressionTest = true;
 
@@ -400,7 +400,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void LetTest61([DataSources(TestProvName.AllOracle11, TestProvName.AllInformix, TestProvName.AllSybase, TestProvName.AllSapHana)] string context)
+		public void LetTest61([DataSources(TestProvName.AllOracle11, TestProvName.AllInformix, TestProvName.AllSybase)] string context)
 		{
 			//LinqToDB.Common.Configuration.Linq.GenerateExpressionTest = true;
 
@@ -444,7 +444,7 @@ namespace Tests.Linq
 
 		// PostgreSQL92 Uses 3 queries and we join results in wrong order. See LetTest71 with explicit sort
 		[Test]
-		public void LetTest7([DataSources(TestProvName.AllInformix, ProviderName.PostgreSQL92, TestProvName.AllSybase, TestProvName.AllSapHana, TestProvName.AllAccess)] string context)
+		public void LetTest7([DataSources(TestProvName.AllInformix, ProviderName.PostgreSQL92, TestProvName.AllSybase, TestProvName.AllAccess)] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -478,7 +478,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void LetTest71([DataSources(TestProvName.AllOracle11, TestProvName.AllInformix, TestProvName.AllSybase, TestProvName.AllSapHana, ProviderName.Access)] string context)
+		public void LetTest71([DataSources(TestProvName.AllOracle11, TestProvName.AllInformix, TestProvName.AllSybase, ProviderName.Access)] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(

--- a/Tests/Linq/Linq/ElementOperationTests.cs
+++ b/Tests/Linq/Linq/ElementOperationTests.cs
@@ -80,7 +80,7 @@ namespace Tests.Linq
 
 		[Test]
 		public void NestedFirstOrDefaultScalar1([DataSources(
-			TestProvName.AllInformix, ProviderName.Sybase, ProviderName.SybaseManaged, TestProvName.AllSapHana)]
+			TestProvName.AllInformix, TestProvName.AllSybase, TestProvName.AllSapHana)]
 			string context)
 		{
 			using (var db = GetDataContext(context))
@@ -92,7 +92,7 @@ namespace Tests.Linq
 		[Test]
 		public void NestedFirstOrDefaultScalar2([DataSources(
 			TestProvName.AllInformix, TestProvName.AllOracle,
-			ProviderName.Sybase, ProviderName.SybaseManaged, TestProvName.AllSapHana)]
+			TestProvName.AllSybase)]
 			string context)
 		{
 			using (var db = GetDataContext(context))
@@ -144,7 +144,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void NestedFirstOrDefault3([DataSources(TestProvName.AllInformix, TestProvName.AllSapHana, TestProvName.AllOracle)]
+		public void NestedFirstOrDefault3([DataSources(TestProvName.AllInformix, TestProvName.AllOracle)]
 			string context)
 		{
 			using (var db = GetDataContext(context))

--- a/Tests/Linq/Linq/JoinTests.cs
+++ b/Tests/Linq/Linq/JoinTests.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 
 namespace Tests.Linq
 {
+	using System.Linq.Expressions;
 	using LinqToDB.Common;
 	using Model;
 
@@ -118,7 +119,7 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 				TestJohn(
 					from p1 in db.Person
-						join p2 in db.Person on p1.ID equals p2.ID
+					join p2 in db.Person on p1.ID equals p2.ID
 					where p1.ID == 1
 					select new Person { ID = p1.ID, FirstName = p2.FirstName });
 		}
@@ -129,7 +130,7 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 				TestJohn(
 					from p1 in db.Person
-						join p2 in db.Person on new { p1.ID, p1.FirstName } equals new { p2.ID, p2.FirstName }
+					join p2 in db.Person on new { p1.ID, p1.FirstName } equals new { p2.ID, p2.FirstName }
 					where p1.ID == 1
 					select new Person { ID = p1.ID, FirstName = p2.FirstName });
 		}
@@ -140,9 +141,9 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 				TestJohn(
 					from p1 in db.Person
-						join p2 in
-							from p2 in db.Person join p3 in db.Person on new { p2.ID, p2.LastName } equals new { p3.ID, p3.LastName } select new { p2, p3 }
-						on new { p1.ID, p1.FirstName } equals new { p2.p2.ID, p2.p2.FirstName }
+					join p2 in
+						from p2 in db.Person join p3 in db.Person on new { p2.ID, p2.LastName } equals new { p3.ID, p3.LastName } select new { p2, p3 }
+					on new { p1.ID, p1.FirstName } equals new { p2.p2.ID, p2.p2.FirstName }
 					where p1.ID == 1
 					select new Person { ID = p1.ID, FirstName = p2.p2.FirstName, LastName = p2.p3.LastName });
 		}
@@ -153,8 +154,8 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 				TestJohn(
 					from p1 in db.Person
-						join p2 in db.Person on new { p1.ID, p1.FirstName } equals new { p2.ID, p2.FirstName }
-							join p3 in db.Person on new { p2.ID, p2.LastName } equals new { p3.ID, p3.LastName }
+					join p2 in db.Person on new { p1.ID, p1.FirstName } equals new { p2.ID, p2.FirstName }
+					join p3 in db.Person on new { p2.ID, p2.LastName } equals new { p3.ID, p3.LastName }
 					where p1.ID == 1
 					select new Person { ID = p1.ID, FirstName = p2.FirstName, LastName = p3.LastName });
 		}
@@ -166,7 +167,7 @@ namespace Tests.Linq
 				TestJohn(
 					from p1 in db.Person
 					join p2 in db.Person on new { p1.ID, p1.FirstName } equals new { p2.ID, p2.FirstName }
-					join p3 in db.Person on new { p1.ID, p2.LastName  } equals new { p3.ID, p3.LastName  }
+					join p3 in db.Person on new { p1.ID, p2.LastName } equals new { p3.ID, p3.LastName }
 					where p1.ID == 1
 					select new Person { ID = p1.ID, FirstName = p2.FirstName, LastName = p3.LastName });
 		}
@@ -177,7 +178,7 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 				TestJohn(
 					from p1 in db.Person
-						join p2 in from p3 in db.Person select new { ID = p3.ID + 1, p3.FirstName } on p1.ID equals p2.ID - 1
+					join p2 in from p3 in db.Person select new { ID = p3.ID + 1, p3.FirstName } on p1.ID equals p2.ID - 1
 					where p1.ID == 1
 					select new Person { ID = p1.ID, FirstName = p2.FirstName });
 		}
@@ -189,14 +190,14 @@ namespace Tests.Linq
 				AreEqual(
 					from t in
 						from ch in Child
-							join p in Parent on ch.ParentID equals p.ParentID
+						join p in Parent on ch.ParentID equals p.ParentID
 						select ch.ParentID + p.ParentID
 					where t > 2
 					select t
 					,
 					from t in
 						from ch in db.Child
-							join p in db.Parent on ch.ParentID equals p.ParentID
+						join p in db.Parent on ch.ParentID equals p.ParentID
 						select ch.ParentID + p.ParentID
 					where t > 2
 					select t);
@@ -209,13 +210,13 @@ namespace Tests.Linq
 				AreEqual(
 					from t in
 						from ch in Child
-							join p in Parent on ch.ParentID equals p.ParentID
+						join p in Parent on ch.ParentID equals p.ParentID
 						select new { ID = ch.ParentID + p.ParentID }
 					where t.ID > 2
 					select t,
 					from t in
 						from ch in db.Child
-							join p in db.Parent on ch.ParentID equals p.ParentID
+						join p in db.Parent on ch.ParentID equals p.ParentID
 						select new { ID = ch.ParentID + p.ParentID }
 					where t.ID > 2
 					select t);
@@ -241,8 +242,8 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
-					from p in    Parent
-					join g in    GrandChild on p.ParentID equals g.ParentID into q
+					from p in Parent
+					join g in GrandChild on p.ParentID equals g.ParentID into q
 					from q1 in q
 					select new { p.ParentID, q1.GrandChildID },
 					from p in db.Parent
@@ -257,11 +258,11 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 				AreEqual(
 					from p in Parent
-						join ch in Child on p.ParentID equals ch.ParentID into lj1
+					join ch in Child on p.ParentID equals ch.ParentID into lj1
 					where p.ParentID == 1
 					select p,
 					from p in db.Parent
-						join ch in db.Child on p.ParentID equals ch.ParentID into lj1
+					join ch in db.Child on p.ParentID equals ch.ParentID into lj1
 					where p.ParentID == 1
 					select p);
 		}
@@ -273,7 +274,7 @@ namespace Tests.Linq
 			{
 				var q =
 					from p in db.Parent
-						join c in db.Child on p.ParentID equals c.ParentID into lj
+					join c in db.Child on p.ParentID equals c.ParentID into lj
 					where p.ParentID == 1
 					select new { p, lj };
 
@@ -285,7 +286,7 @@ namespace Tests.Linq
 
 				var ch = list[0].lj.ToList();
 
-				Assert.AreEqual( 1, ch[0].ParentID);
+				Assert.AreEqual(1, ch[0].ParentID);
 				Assert.AreEqual(11, ch[0].ChildID);
 			}
 		}
@@ -319,8 +320,8 @@ namespace Tests.Linq
 
 				var list2 = q2.ToList();
 
-				Assert.AreEqual(list1.Count,              list2.Count);
-				Assert.AreEqual(list1[0].p.ParentID,      list2[0].p.ParentID);
+				Assert.AreEqual(list1.Count, list2.Count);
+				Assert.AreEqual(list1[0].p.ParentID, list2[0].p.ParentID);
 				Assert.AreEqual(list1[0].lj1.lj1.Count(), list2[0].lj1.lj1.Count());
 			}
 		}
@@ -332,7 +333,7 @@ namespace Tests.Linq
 			{
 				var q1 =
 					from p in Parent
-						join ch in
+					join ch in
 							from c in Child select new { c.ParentID, c.ChildID }
 						on p.ParentID equals ch.ParentID into lj1
 					where p.ParentID == 3
@@ -342,7 +343,7 @@ namespace Tests.Linq
 
 				var q2 =
 					from p in db.Parent
-						join ch in
+					join ch in
 							from c in db.Child select new { c.ParentID, c.ChildID }
 						on p.ParentID equals ch.ParentID into lj1
 					where p.ParentID == 3
@@ -350,8 +351,8 @@ namespace Tests.Linq
 
 				var list2 = q2.ToList();
 
-				Assert.AreEqual(list1.Count,          list2.Count);
-				Assert.AreEqual(list1[0].p.ParentID,  list2[0].p.ParentID);
+				Assert.AreEqual(list1.Count, list2.Count);
+				Assert.AreEqual(list1[0].p.ParentID, list2[0].p.ParentID);
 				Assert.AreEqual(list1[0].lj1.Count(), list2[0].lj1.Count());
 			}
 		}
@@ -362,16 +363,16 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 			{
 				var expectedQuery = from p in Parent
-					join ch in Child on p.ParentID equals ch.ParentID into lj1
-					orderby p.ParentID
-					where p.ParentID >= 1
-					select lj1.OrderBy(c => c.ChildID).FirstOrDefault();
+									join ch in Child on p.ParentID equals ch.ParentID into lj1
+									orderby p.ParentID
+									where p.ParentID >= 1
+									select lj1.OrderBy(c => c.ChildID).FirstOrDefault();
 
 				var actualQuery = from p in db.Parent
-					join ch in db.Child on p.ParentID equals ch.ParentID into lj1
-					orderby p.ParentID
-					where p.ParentID >= 1
-					select lj1.OrderBy(c => c.ChildID).FirstOrDefault();
+								  join ch in db.Child on p.ParentID equals ch.ParentID into lj1
+								  orderby p.ParentID
+								  where p.ParentID >= 1
+								  select lj1.OrderBy(c => c.ChildID).FirstOrDefault();
 
 				var expected = expectedQuery.ToArray();
 				var actual   = actualQuery.ToArray();
@@ -388,7 +389,7 @@ namespace Tests.Linq
 				var result =
 				(
 					from p in db.Parent
-						join ch in db.Child on p.ParentID equals ch.ParentID into lj1
+					join ch in db.Child on p.ParentID equals ch.ParentID into lj1
 					where p.ParentID == 1
 					select new { p1 = lj1, p2 = lj1.OrderByDescending(e => e.ChildID).First() }
 				).ToList();
@@ -396,7 +397,7 @@ namespace Tests.Linq
 				var expected =
 				(
 					from p in Parent
-						join ch in Child on p.ParentID equals ch.ParentID into lj1
+					join ch in Child on p.ParentID equals ch.ParentID into lj1
 					where p.ParentID == 1
 					select new { p1 = lj1, p2 = lj1.OrderByDescending(e => e.ChildID).First() }
 				).ToList();
@@ -412,12 +413,12 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 				AreEqual(
 					from p in Parent
-						join ch in Child on p.ParentID equals ch.ParentID into lj1
+					join ch in Child on p.ParentID equals ch.ParentID into lj1
 					where p.ParentID == 1
 					select lj1.First().ParentID
 					,
 					from p in db.Parent
-						join ch in db.Child on p.ParentID equals ch.ParentID into lj1
+					join ch in db.Child on p.ParentID equals ch.ParentID into lj1
 					where p.ParentID == 1
 					select lj1.First().ParentID);
 		}
@@ -428,12 +429,12 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 				AreEqual(
 					from p in Parent
-						join ch in Child on p.ParentID equals ch.ParentID into lj1
+					join ch in Child on p.ParentID equals ch.ParentID into lj1
 					where p.ParentID == 1
 					select lj1.Select(_ => _.ParentID).First()
 					,
 					from p in db.Parent
-						join ch in db.Child on p.ParentID equals ch.ParentID into lj1
+					join ch in db.Child on p.ParentID equals ch.ParentID into lj1
 					where p.ParentID == 1
 					select lj1.Select(_ => _.ParentID).First());
 		}
@@ -444,12 +445,12 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 				AreEqual(
 					from p in Parent
-						join ch in Child on p.ParentID equals ch.ParentID into lj1
+					join ch in Child on p.ParentID equals ch.ParentID into lj1
 					where p.ParentID == 1
 					select new { p1 = lj1.Count(), p2 = lj1.First() }
 					,
 					from p in db.Parent
-						join ch in db.Child on p.ParentID equals ch.ParentID into lj1
+					join ch in db.Child on p.ParentID equals ch.ParentID into lj1
 					where p.ParentID == 1
 					select new { p1 = lj1.Count(), p2 = lj1.First() });
 		}
@@ -463,7 +464,7 @@ namespace Tests.Linq
 			{
 				var q1 =
 					from p in Parent
-						join c in Child on p.ParentID + n equals c.ParentID into lj
+					join c in Child on p.ParentID + n equals c.ParentID into lj
 					where p.ParentID == 1
 					select new { p, lj };
 
@@ -472,20 +473,20 @@ namespace Tests.Linq
 
 				var q2 =
 					from p in db.Parent
-						join c in db.Child on p.ParentID + n equals c.ParentID into lj
+					join c in db.Child on p.ParentID + n equals c.ParentID into lj
 					where p.ParentID == 1
 					select new { p, lj };
 
 				var list2 = q2.ToList();
 
-				Assert.AreEqual(list1.Count,         list2.Count);
+				Assert.AreEqual(list1.Count, list2.Count);
 				Assert.AreEqual(list1[0].p.ParentID, list2[0].p.ParentID);
 				Assert.AreEqual(list1[0].lj.Count(), list2[0].lj.Count());
 
 				var ch2 = list2[0].lj.ToList();
 
 				Assert.AreEqual(ch1[0].ParentID, ch2[0].ParentID);
-				Assert.AreEqual(ch1[0].ChildID,  ch2[0].ChildID);
+				Assert.AreEqual(ch1[0].ChildID, ch2[0].ChildID);
 			}
 		}
 
@@ -498,7 +499,7 @@ namespace Tests.Linq
 			{
 				var q1 =
 					from p in Parent
-						join c in Child on new { id = p.ParentID } equals new { id = c.ParentID - n } into j
+					join c in Child on new { id = p.ParentID } equals new { id = c.ParentID - n } into j
 					where p.ParentID == 1
 					select new { p, j };
 
@@ -507,20 +508,20 @@ namespace Tests.Linq
 
 				var q2 =
 					from p in db.Parent
-						join c in db.Child on new { id = p.ParentID } equals new { id = c.ParentID - n } into j
+					join c in db.Child on new { id = p.ParentID } equals new { id = c.ParentID - n } into j
 					where p.ParentID == 1
 					select new { p, j };
 
 				var list2 = q2.ToList();
 
-				Assert.AreEqual(list1.Count,         list2.Count);
+				Assert.AreEqual(list1.Count, list2.Count);
 				Assert.AreEqual(list1[0].p.ParentID, list2[0].p.ParentID);
-				Assert.AreEqual(list1[0].j.Count(),  list2[0].j.Count());
+				Assert.AreEqual(list1[0].j.Count(), list2[0].j.Count());
 
 				var ch2 = list2[0].j.OrderBy(_ => _.ChildID).ThenBy(_ => _.ParentID).ToList();
 
 				Assert.AreEqual(ch1[0].ParentID, ch2[0].ParentID);
-				Assert.AreEqual(ch1[0].ChildID,  ch2[0].ChildID);
+				Assert.AreEqual(ch1[0].ChildID, ch2[0].ChildID);
 			}
 		}
 
@@ -559,7 +560,7 @@ namespace Tests.Linq
 						.GroupJoin(
 							Parent,
 							x => new { Id = x.xid.ParentID },
-							y => new { Id = y.ParentID     },
+							y => new { Id = y.ParentID },
 							(x2, y) => new { x2.xid, x2.y, h = y }
 						)
 						.SelectMany(
@@ -569,7 +570,7 @@ namespace Tests.Linq
 						.GroupJoin(
 							Parent,
 							x => new { Id = x.xid.ParentID },
-							y => new { Id = y.ParentID     },
+							y => new { Id = y.ParentID },
 							(x4, y) => new { x4.xid, x4.y, x4.a, p = y }
 						)
 						.SelectMany(
@@ -589,7 +590,7 @@ namespace Tests.Linq
 						.GroupJoin(
 							Parent,
 							x => new { Id = x.xid.ParentID },
-							y => new { Id = y.ParentID     },
+							y => new { Id = y.ParentID },
 							(x8, y) => new { x8.xid, x8.z, x8.xy, x8.a, x8.xz, y }
 						)
 						.SelectMany(
@@ -610,7 +611,7 @@ namespace Tests.Linq
 						.GroupJoin(
 							db.Parent,
 							x => new { Id = x.xid.ParentID },
-							y => new { Id = y.ParentID     },
+							y => new { Id = y.ParentID },
 							(x2, y) => new { x2.xid, x2.y, h = y }
 						)
 						.SelectMany(
@@ -620,7 +621,7 @@ namespace Tests.Linq
 						.GroupJoin(
 							db.Parent,
 							x => new { Id = x.xid.ParentID },
-							y => new { Id = y.ParentID     },
+							y => new { Id = y.ParentID },
 							(x4, y) => new { x4.xid, x4.y, x4.a, p = y }
 						)
 						.SelectMany(
@@ -640,7 +641,7 @@ namespace Tests.Linq
 						.GroupJoin(
 							db.Parent,
 							x => new { Id = x.xid.ParentID },
-							y => new { Id = y.ParentID     },
+							y => new { Id = y.ParentID },
 							(x8, y) => new { x8.xid, x8.z, x8.xy, x8.a, x8.xz, y }
 						)
 						.SelectMany(
@@ -655,8 +656,8 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
-					from p in    Parent
-					join c in    Child on p.ParentID equals c.ParentID into t
+					from p in Parent
+					join c in Child on p.ParentID equals c.ParentID into t
 					select new { p.ParentID, n = t.Any() },
 					from p in db.Parent
 					join c in db.Child on p.ParentID equals c.ParentID into t
@@ -668,8 +669,8 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
-					from p in    Parent
-					join c in    Child on p.ParentID equals c.ParentID into t
+					from p in Parent
+					join c in Child on p.ParentID equals c.ParentID into t
 					select new { p.ParentID, n = t.Select(t1 => t1.ChildID > 0).Any() },
 					from p in db.Parent
 					join c in db.Child on p.ParentID equals c.ParentID into t
@@ -681,8 +682,8 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
-					from p in    Parent
-					let c = from c in    Child where p.ParentID == c.ParentID select c
+					from p in Parent
+					let c = from c in Child where p.ParentID == c.ParentID select c
 					select new { p.ParentID, n = c.Any() },
 					from p in db.Parent
 					let c = from c in db.Child where p.ParentID == c.ParentID select c
@@ -694,8 +695,8 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
-					from p in    Parent
-					select new { p.ParentID, n = (from c in    Child where p.ParentID == c.ParentID select c).Any() },
+					from p in Parent
+					select new { p.ParentID, n = (from c in Child where p.ParentID == c.ParentID select c).Any() },
 					from p in db.Parent
 					select new { p.ParentID, n = (from c in db.Child where p.ParentID == c.ParentID select c).Any() });
 		}
@@ -705,8 +706,8 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
-					from p in    Parent
-					join c in    Child on p.ParentID equals c.ParentID into t
+					from p in Parent
+					join c in Child on p.ParentID equals c.ParentID into t
 					select new { n = t.Any() },
 					from p in db.Parent
 					join c in db.Child on p.ParentID equals c.ParentID into t
@@ -720,14 +721,14 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 				AreEqual(
 					from p in Parent
-						join ch in Child on p.ParentID equals ch.ParentID into lj1
-						from ch in lj1.DefaultIfEmpty()
+					join ch in Child on p.ParentID equals ch.ParentID into lj1
+					from ch in lj1.DefaultIfEmpty()
 					where p.ParentID >= 4
 					select new { p, ch }
 					,
 					from p in db.Parent
-						join ch in db.Child on p.ParentID equals ch.ParentID into lj1
-						from ch in lj1.DefaultIfEmpty()
+					join ch in db.Child on p.ParentID equals ch.ParentID into lj1
+					from ch in lj1.DefaultIfEmpty()
 					where p.ParentID >= 4
 					select new { p, ch });
 		}
@@ -738,13 +739,13 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 				AreEqual(
 					from p in Parent
-						join ch in Child on p.ParentID equals ch.ParentID into lj1
-						from ch in lj1.DefaultIfEmpty()
+					join ch in Child on p.ParentID equals ch.ParentID into lj1
+					from ch in lj1.DefaultIfEmpty()
 					select new { p, ch }
 					,
 					from p in db.Parent
-						join ch in db.Child on p.ParentID equals ch.ParentID into lj1
-						from ch in lj1.DefaultIfEmpty()
+					join ch in db.Child on p.ParentID equals ch.ParentID into lj1
+					from ch in lj1.DefaultIfEmpty()
 					select new { p, ch });
 		}
 
@@ -753,7 +754,7 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
-					from c in    Child select c.Parent,
+					from c in Child select c.Parent,
 					from c in db.Child select c.Parent);
 		}
 
@@ -806,8 +807,8 @@ namespace Tests.Linq
 			{
 				var q =
 					from p in db.Parent
-						join ch in db.GetTable<CountedChild>() on p.ParentID equals ch.ParentID into lj1
-						from ch in lj1.DefaultIfEmpty()
+					join ch in db.GetTable<CountedChild>() on p.ParentID equals ch.ParentID into lj1
+					from ch in lj1.DefaultIfEmpty()
 					where ch == null
 					select new { p, ch, ch1 = ch };
 
@@ -866,21 +867,21 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 				AreEqual(
 					from p in Parent
-						join ch in
-							from c in Child
-							where c.ParentID > 0
-							select new { c.ParentID, c.ChildID }
-						on p.ParentID equals ch.ParentID into lj1
-						from ch in lj1.DefaultIfEmpty()
+					join ch in
+						from c in Child
+						where c.ParentID > 0
+						select new { c.ParentID, c.ChildID }
+					on p.ParentID equals ch.ParentID into lj1
+					from ch in lj1.DefaultIfEmpty()
 					select p
 					,
 					from p in db.Parent
-						join ch in
-							from c in db.Child
-							where c.ParentID > 0
-							select new { c.ParentID, c.ChildID }
-						on p.ParentID equals ch.ParentID into lj1
-						from ch in lj1.DefaultIfEmpty()
+					join ch in
+						from c in db.Child
+						where c.ParentID > 0
+						select new { c.ParentID, c.ChildID }
+					on p.ParentID equals ch.ParentID into lj1
+					from ch in lj1.DefaultIfEmpty()
 					select p);
 		}
 
@@ -889,7 +890,7 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
-					from c in    Child join g in    GrandChild on c equals g.Child select new { c.ParentID, g.GrandChildID },
+					from c in Child join g in GrandChild on c equals g.Child select new { c.ParentID, g.GrandChildID },
 					from c in db.Child join g in db.GrandChild on c equals g.Child select new { c.ParentID, g.GrandChildID });
 		}
 
@@ -898,11 +899,11 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
-					from g in    GrandChild
-						join c in    Child on g.Child equals c
+					from g in GrandChild
+					join c in Child on g.Child equals c
 					select new { c.ParentID, g.GrandChildID },
 					from g in db.GrandChild
-						join c in db.Child on g.Child equals c
+					join c in db.Child on g.Child equals c
 					select new { c.ParentID, g.GrandChildID });
 		}
 
@@ -911,8 +912,8 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
-					from p in    Parent
-					join c in    Child on new { Parent = p, p.ParentID } equals new { c.Parent, c.ParentID }
+					from p in Parent
+					join c in Child on new { Parent = p, p.ParentID } equals new { c.Parent, c.ParentID }
 					select new { p.ParentID, c.ChildID },
 					from p in db.Parent
 					join c in db.Child on new { Parent = p, p.ParentID } equals new { c.Parent, c.ParentID }
@@ -925,13 +926,13 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 				AreEqual(
 					from p in Parent
-					join c1 in Child      on p.ParentID  equals c1.ParentID
+					join c1 in Child on p.ParentID equals c1.ParentID
 					join c2 in GrandChild on c1.ParentID equals c2.ParentID
 					join c3 in GrandChild on c2.ParentID equals c3.ParentID
 					select new { p, c1Key = c1.ChildID, c2Key = c2.GrandChildID, c3Key = c3.GrandChildID }
 					,
 					from p in db.Parent
-					join c1 in db.Child      on p.ParentID  equals c1.ParentID
+					join c1 in db.Child on p.ParentID equals c1.ParentID
 					join c2 in db.GrandChild on c1.ParentID equals c2.ParentID
 					join c3 in db.GrandChild on c2.ParentID equals c3.ParentID
 					select new { p, c1Key = c1.ChildID, c2Key = c2.GrandChildID, c3Key = c3.GrandChildID });
@@ -1016,7 +1017,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void ApplyJoin([IncludeDataSources(TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL93Plus)] string context)
+		public void ApplyJoin([IncludeDataSources(TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL93Plus, TestProvName.AllMySql, TestProvName.AllSapHana)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -1036,7 +1037,7 @@ namespace Tests.Linq
 			{
 				var q =
 					from m in db.Types
-						join p in db.Parent on m.ID equals p.ParentID
+					join p in db.Parent on m.ID equals p.ParentID
 					group m by new
 					{
 						m.DateTimeValue.Date
@@ -1057,8 +1058,8 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
-					from p1 in    Parent
-					join p2 in    Parent on new { p1.ParentID, p1.Value1 } equals new { p2.ParentID, p2.Value1 }
+					from p1 in Parent
+					join p2 in Parent on new { p1.ParentID, p1.Value1 } equals new { p2.ParentID, p2.Value1 }
 					select p2
 					,
 					from p1 in db.Parent
@@ -1071,15 +1072,15 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
-					from p1 in    Parent
-					join p2 in    Parent
-						on     new { a = new { p1.ParentID, p1.Value1 } }
+					from p1 in Parent
+					join p2 in Parent
+						on new { a = new { p1.ParentID, p1.Value1 } }
 						equals new { a = new { p2.ParentID, p2.Value1 } }
 					select p2
 					,
 					from p1 in db.Parent
 					join p2 in db.Parent
-						on     new { a = new { p1.ParentID, p1.Value1 } }
+						on new { a = new { p1.ParentID, p1.Value1 } }
 						equals new { a = new { p2.ParentID, p2.Value1 } }
 					select p2);
 		}
@@ -1089,8 +1090,8 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
-					from p1 in    Parent
-					from p2 in    Parent.Where(p => p1.ParentID == p.ParentID && p1.Value1 == p.Value1)
+					from p1 in Parent
+					from p2 in Parent.Where(p => p1.ParentID == p.ParentID && p1.Value1 == p.Value1)
 					select p2
 					,
 					from p1 in db.Parent
@@ -1107,7 +1108,7 @@ namespace Tests.Linq
 
 			using (var db = GetDataContext(context))
 				AreEqual(
-					from p in    Parent
+					from p in Parent
 					where p.ParentID > 0
 					join c in Child on p.ParentID equals c.ParentID into t
 					//select new { p.ParentID, count = t.Count() }
@@ -1126,7 +1127,7 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
-					from p in    Parent
+					from p in Parent
 					where p.ParentID > 0
 					join c in Child on p.ParentID equals c.ParentID into t
 					//select new { p.ParentID, count = t.Count() }
@@ -1179,11 +1180,11 @@ namespace Tests.Linq
 			{
 				var expected = from p in Parent
 						.SqlJoinInternal(Child, joinType, (p, c) => p.ParentID == c.ParentID, (p, c) => new {p, c})
-					select new { ParentID = p.p == null ? (int?) null : p.p.ParentID, ChildID = p.c == null ? (int?) null : p.c.ChildID};
+							   select new { ParentID = p.p == null ? (int?) null : p.p.ParentID, ChildID = p.c == null ? (int?) null : p.c.ChildID};
 
 				var actual = from p in db.Parent
-					from c in db.Child.Join(joinType, r => p.ParentID == r.ParentID)
-					select new {ParentID = (int?) p.ParentID, ChildID = (int?) c.ChildID};
+							 from c in db.Child.Join(joinType, r => p.ParentID == r.ParentID)
+							 select new {ParentID = (int?) p.ParentID, ChildID = (int?) c.ChildID};
 
 				AreEqual(expected.ToList().OrderBy(r => r.ParentID).ThenBy(r => r.ChildID),
 					actual.ToList().OrderBy(r => r.ParentID).ThenBy(r => r.ChildID));
@@ -1235,11 +1236,11 @@ namespace Tests.Linq
 			{
 				var expected = from p in Parent.Where(p => p.ParentID > 0).Take(10)
 						.SqlJoinInternal(Child, joinType, (p, c) => p.ParentID == c.ParentID, (p, c) => new { p, c })
-					select new { ParentID = p.p == null ? (int?)null : p.p.ParentID, ChildID = p.c == null ? (int?)null : p.c.ChildID };
+							   select new { ParentID = p.p == null ? (int?)null : p.p.ParentID, ChildID = p.c == null ? (int?)null : p.c.ChildID };
 
 				var actual = from p in db.Parent.Where(p => p.ParentID > 0).Take(10)
-					from c in db.Child.Join(joinType, r => p.ParentID == r.ParentID)
-					select new { ParentID = (int?)p.ParentID, ChildID = (int?)c.ChildID };
+							 from c in db.Child.Join(joinType, r => p.ParentID == r.ParentID)
+							 select new { ParentID = (int?)p.ParentID, ChildID = (int?)c.ChildID };
 
 				AreEqual(expected.ToList().OrderBy(r => r.ParentID).ThenBy(r => r.ChildID),
 					actual.ToList().OrderBy(r => r.ParentID).ThenBy(r => r.ChildID));
@@ -1287,7 +1288,7 @@ namespace Tests.Linq
 			{
 				var expected = from p in Parent
 						.SqlJoinInternal(Child, joinType, (p, c) => p.ParentID == c.ParentID, (p, c) => new {p, c})
-					select new { ParentID = p.p == null ? (int?) null : p.p.ParentID, ChildID = p.c == null ? (int?) null : p.c.ChildID};
+							   select new { ParentID = p.p == null ? (int?) null : p.p.ParentID, ChildID = p.c == null ? (int?) null : p.c.ChildID};
 
 				var actual = db.Parent.Join(db.Child, joinType, (p, c) => p.ParentID == c.ParentID,
 					(p, c) => new {ParentID = (int?)p.ParentID, ChildID = (int?)c.ChildID});
@@ -1338,7 +1339,7 @@ namespace Tests.Linq
 			{
 				var expected = from p in Parent.Where(p => p.ParentID > 0).Take(10)
 						.SqlJoinInternal(Child, joinType, (p, c) => p.ParentID == c.ParentID, (p, c) => new { p, c })
-					select new { ParentID = p.p == null ? (int?)null : p.p.ParentID, ChildID = p.c == null ? (int?)null : p.c.ChildID };
+							   select new { ParentID = p.p == null ? (int?)null : p.p.ParentID, ChildID = p.c == null ? (int?)null : p.c.ChildID };
 
 				var actual = db.Parent.Where(p => p.ParentID > 0).Take(10)
 					.Join(db.Child, joinType, (p, c) => p.ParentID == c.ParentID,
@@ -1383,7 +1384,7 @@ namespace Tests.Linq
 		// https://imgflip.com/i/2a6oc8
 		[ActiveIssue(
 			Configuration = TestProvName.AllSybase,
-			Details       = "Cross-join doesn't work in Sybase")]
+			Details = "Cross-join doesn't work in Sybase")]
 		[Test]
 		public void SqlLinqCrossJoinSubQuery([DataSources] string context)
 		{
@@ -1391,7 +1392,7 @@ namespace Tests.Linq
 			{
 				var expected = from p in Parent.Where(p => p.ParentID > 0).Take(10)
 						.SqlJoinInternal(Child.Take(10), SqlJoinType.Inner, (p, c) => true, (p, c) => new { p, c })
-					select new { ParentID = p.p == null ? (int?)null : p.p.ParentID, ChildID = p.c == null ? (int?)null : p.c.ChildID };
+							   select new { ParentID = p.p == null ? (int?)null : p.p.ParentID, ChildID = p.c == null ? (int?)null : p.c.ChildID };
 
 				var actual = db.Parent.Where(p => p.ParentID > 0).Take(10)
 					.CrossJoin(db.Child.Take(10), (p, c) => new { ParentID = (int?)p.ParentID, ChildID = (int?)c.ChildID });
@@ -1413,8 +1414,8 @@ namespace Tests.Linq
 			{
 				var areEqual =
 					(from left in db.Parent
-					from right in db.Parent.FullJoin(p => p.ParentID == left.ParentID)
-					select Sql.Ext.Count(left.ParentID, Sql.AggregateModifier.None).ToValue() == Sql.Ext.Count(right.ParentID, Sql.AggregateModifier.None).ToValue()
+					 from right in db.Parent.FullJoin(p => p.ParentID == left.ParentID)
+					 select Sql.Ext.Count(left.ParentID, Sql.AggregateModifier.None).ToValue() == Sql.Ext.Count(right.ParentID, Sql.AggregateModifier.None).ToValue()
 					&& Sql.Ext.Count(left.ParentID, Sql.AggregateModifier.None).ToValue() == Sql.Ext.Count().ToValue())
 					.Single();
 
@@ -2119,12 +2120,12 @@ namespace Tests.Linq
 				var result1 = query1.ToArray();
 
 				var query2 = from p in db.Parent
-					join c in db.Child on p.ParentID equals c.ChildID
-					select new
-					{
-						p,
-						c
-					};
+							 join c in db.Child on p.ParentID equals c.ChildID
+							 select new
+							 {
+								 p,
+								 c
+							 };
 
 				var result2 = query2.ToArray();
 			}
@@ -2149,9 +2150,9 @@ namespace Tests.Linq
 		[Table]
 		public partial class Tag
 		{
-			[PrimaryKey]      public int    Id     { get; set; }
-			[Column]          public int    FactId { get; set; }
-			[Column, NotNull] public string Name   { get; set; } = null!;
+			[PrimaryKey] public int Id { get; set; }
+			[Column] public int FactId { get; set; }
+			[Column, NotNull] public string Name { get; set; } = null!;
 
 			public static readonly Tag[] Data = new[]
 			{
@@ -2174,9 +2175,9 @@ namespace Tests.Linq
 		[Test]
 		public void LeftJoinWithRecordSelection1([DataSources] string context)
 		{
-			using (var db        = GetDataContext(context))
+			using (var db = GetDataContext(context))
 			using (var factTable = db.CreateLocalTable(Fact.Data))
-			using (var tagTable  = db.CreateLocalTable(Tag.Data))
+			using (var tagTable = db.CreateLocalTable(Tag.Data))
 			{
 				var t =
 					from fact in factTable
@@ -2198,9 +2199,9 @@ namespace Tests.Linq
 		[Test]
 		public void LeftJoinWithRecordSelection2([DataSources] string context)
 		{
-			using (var db        = GetDataContext(context))
+			using (var db = GetDataContext(context))
 			using (var factTable = db.CreateLocalTable(Fact.Data))
-			using (var tagTable  = db.CreateLocalTable(Tag.Data))
+			using (var tagTable = db.CreateLocalTable(Tag.Data))
 			{
 				var t =
 					from fact in factTable
@@ -2221,9 +2222,9 @@ namespace Tests.Linq
 		[Test]
 		public void LeftJoinWithRecordSelection3([DataSources] string context)
 		{
-			using (var db        = GetDataContext(context))
+			using (var db = GetDataContext(context))
 			using (var factTable = db.CreateLocalTable(Fact.Data))
-			using (var tagTable  = db.CreateLocalTable(Tag.Data))
+			using (var tagTable = db.CreateLocalTable(Tag.Data))
 			{
 				var t =
 					from fact in factTable
@@ -2244,9 +2245,9 @@ namespace Tests.Linq
 		[Test]
 		public void LeftJoinWithRecordSelection4([DataSources] string context)
 		{
-			using (var db        = GetDataContext(context))
+			using (var db = GetDataContext(context))
 			using (var factTable = db.CreateLocalTable(Fact.Data))
-			using (var tagTable  = db.CreateLocalTable(Tag.Data))
+			using (var tagTable = db.CreateLocalTable(Tag.Data))
 			{
 				var t =
 					from fact in factTable
@@ -2530,9 +2531,9 @@ namespace Tests.Linq
 		[Table]
 		public class StLink
 		{
-			[PrimaryKey] public int     InId          { get; set; }
-			[Column]     public double? InMaxQuantity { get; set; }
-			[Column]     public double? InMinQuantity { get; set; }
+			[PrimaryKey] public int InId { get; set; }
+			[Column] public double? InMaxQuantity { get; set; }
+			[Column] public double? InMinQuantity { get; set; }
 
 			public static StLink[] Data = new[]
 			{
@@ -2544,9 +2545,9 @@ namespace Tests.Linq
 		[Table]
 		public class EdtLink
 		{
-			[PrimaryKey] public int     InId          { get; set; }
-			[Column]     public double? InMaxQuantity { get; set; }
-			[Column]     public double? InMinQuantity { get; set; }
+			[PrimaryKey] public int InId { get; set; }
+			[Column] public double? InMaxQuantity { get; set; }
+			[Column] public double? InMinQuantity { get; set; }
 
 			public static EdtLink[] Data = new[]
 			{
@@ -2558,7 +2559,7 @@ namespace Tests.Linq
 		public void Issue1815([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
-			using (var stLinks  = db.CreateLocalTable(StLink.Data))
+			using (var stLinks = db.CreateLocalTable(StLink.Data))
 			using (var edtLinks = db.CreateLocalTable(EdtLink.Data))
 			{
 				var query1 = from l in stLinks
@@ -2666,7 +2667,7 @@ namespace Tests.Linq
 		public class StVersion
 		{
 			[Column("inId"), PrimaryKey] public int InId { get; set; }
-			[Column("inIdMain")]         public int InIdMain { get; set; }
+			[Column("inIdMain")] public int InIdMain { get; set; }
 
 			[Association(ThisKey = "InIdMain", OtherKey = "InId", CanBeNull = false, Relationship = Relationship.ManyToOne)]
 			public StMain Main { get; set; } = null!;
@@ -2678,7 +2679,7 @@ namespace Tests.Linq
 		public class RlStatesTypesAndUserGroup
 		{
 			[Column("inIdState"), PrimaryKey(1)] public int InIdState { get; set; }
-			[Column("inIdType"),  PrimaryKey(2)] public int InIdType { get; set; }
+			[Column("inIdType"), PrimaryKey(2)] public int InIdType { get; set; }
 
 			public static RlStatesTypesAndUserGroup[] Data = Array<RlStatesTypesAndUserGroup>.Empty;
 		}
@@ -2686,8 +2687,8 @@ namespace Tests.Linq
 		[Table("stMain")]
 		public class StMain
 		{
-			[Column("inId"), PrimaryKey]  public int InId { get; set; }
-			[Column("inIdType")]          public int InIdType { get; set; }
+			[Column("inId"), PrimaryKey] public int InId { get; set; }
+			[Column("inIdType")] public int InIdType { get; set; }
 
 			public static StMain[] Data = Array<StMain>.Empty;
 		}
@@ -2695,10 +2696,10 @@ namespace Tests.Linq
 		[Test]
 		public void Issue1816v1([DataSources] string context)
 		{
-			using (var db                        = GetDataContext(context))
-			using (var stVersion                 = db.CreateLocalTable(StVersion.Data))
+			using (var db = GetDataContext(context))
+			using (var stVersion = db.CreateLocalTable(StVersion.Data))
 			using (var rlStatesTypesAndUserGroup = db.CreateLocalTable(RlStatesTypesAndUserGroup.Data))
-			using (var stMain                    = db.CreateLocalTable(StMain.Data))
+			using (var stMain = db.CreateLocalTable(StMain.Data))
 			{
 				var q = from v in stVersion
 						from t in rlStatesTypesAndUserGroup.Where(r => r.InIdType == v.Main.InIdType).DefaultIfEmpty()
@@ -2715,10 +2716,10 @@ namespace Tests.Linq
 		[Test]
 		public void Issue1816v2([DataSources] string context)
 		{
-			using (var db                        = GetDataContext(context))
-			using (var stVersion                 = db.CreateLocalTable(StVersion.Data))
+			using (var db = GetDataContext(context))
+			using (var stVersion = db.CreateLocalTable(StVersion.Data))
 			using (var rlStatesTypesAndUserGroup = db.CreateLocalTable(RlStatesTypesAndUserGroup.Data))
-			using (var stMain                    = db.CreateLocalTable(StMain.Data))
+			using (var stMain = db.CreateLocalTable(StMain.Data))
 			{
 				var q = from v in stVersion
 						from t in rlStatesTypesAndUserGroup.Where(r => r.InIdType == v.Main.InIdType).DefaultIfEmpty()
@@ -2736,8 +2737,8 @@ namespace Tests.Linq
 		#region issue 1455
 		public class Alert
 		{
-			public string?   AlertKey     { get; set; }
-			public string?   AlertCode    { get; set; }
+			public string? AlertKey { get; set; }
+			public string? AlertCode { get; set; }
 			public DateTime? CreationDate { get { return DateTime.Today; } }
 		}
 		public class AuditAlert : Alert
@@ -2746,27 +2747,27 @@ namespace Tests.Linq
 		}
 		public class Trade
 		{
-			public int     DealId       { get; set; }
-			public int     ParcelId     { get; set; }
+			public int DealId { get; set; }
+			public int ParcelId { get; set; }
 			public string? CounterParty { get; set; }
 		}
 		public class Nomin
 		{
-			public int     CargoId              { get; set; }
-			public int     DeliveryId           { get; set; }
+			public int CargoId { get; set; }
+			public int DeliveryId { get; set; }
 			public string? DeliveryCounterParty { get; set; }
 		}
 		public class Flat
 		{
-			public string?   AlertKey             { get; set; }
-			public string?   AlertCode            { get; set; }
-			public int?      CargoId              { get; set; }
-			public int?      DeliveryId           { get; set; }
-			public string?   DeliveryCounterParty { get; set; }
-			public int?      DealId               { get; set; }
-			public int?      ParcelId             { get; set; }
-			public string?   CounterParty         { get; set; }
-			public DateTime? TransactionDate      { get; set; }
+			public string? AlertKey { get; set; }
+			public string? AlertCode { get; set; }
+			public int? CargoId { get; set; }
+			public int? DeliveryId { get; set; }
+			public string? DeliveryCounterParty { get; set; }
+			public int? DealId { get; set; }
+			public int? ParcelId { get; set; }
+			public string? CounterParty { get; set; }
+			public DateTime? TransactionDate { get; set; }
 		}
 
 		[Test]
@@ -2814,15 +2815,15 @@ namespace Tests.Linq
 				extract
 					.Select(sql => new Flat()
 					{
-						AlertCode            = sql.alert.AlertCode,
-						AlertKey             = sql.alert.AlertKey,
-						TransactionDate      = sql.first?.LastUpdate,
-						CargoId              = sql.first?.nomin?.CargoId,
-						DeliveryId           = sql.first?.nomin?.DeliveryId,
+						AlertCode = sql.alert.AlertCode,
+						AlertKey = sql.alert.AlertKey,
+						TransactionDate = sql.first?.LastUpdate,
+						CargoId = sql.first?.nomin?.CargoId,
+						DeliveryId = sql.first?.nomin?.DeliveryId,
 						DeliveryCounterParty = sql.first?.nomin?.DeliveryCounterParty,
-						DealId               = sql.first?.trade?.DealId,
-						ParcelId             = sql.first?.trade?.ParcelId,
-						CounterParty         = sql.first?.trade?.CounterParty
+						DealId = sql.first?.trade?.DealId,
+						ParcelId = sql.first?.trade?.ParcelId,
+						CounterParty = sql.first?.trade?.CounterParty
 					}).ToArray();
 			}
 		}
@@ -2872,22 +2873,21 @@ namespace Tests.Linq
 				extract
 					.Select(sql => new Flat()
 					{
-						AlertCode            = sql.alert.AlertCode,
-						AlertKey             = sql.alert.AlertKey,
-						TransactionDate      = sql.first?.LastUpdate,
-						CargoId              = sql.first?.nomin?.CargoId,
-						DeliveryId           = sql.first?.nomin?.DeliveryId,
+						AlertCode = sql.alert.AlertCode,
+						AlertKey = sql.alert.AlertKey,
+						TransactionDate = sql.first?.LastUpdate,
+						CargoId = sql.first?.nomin?.CargoId,
+						DeliveryId = sql.first?.nomin?.DeliveryId,
 						DeliveryCounterParty = sql.first?.nomin?.DeliveryCounterParty,
-						DealId               = sql.first?.trade?.DealId,
-						ParcelId             = sql.first?.trade?.ParcelId,
-						CounterParty         = sql.first?.trade?.CounterParty
+						DealId = sql.first?.trade?.DealId,
+						ParcelId = sql.first?.trade?.ParcelId,
+						CounterParty = sql.first?.trade?.CounterParty
 					}).ToArray();
 			}
 		}
 		#endregion
 
-
-		[ActiveIssue(1224, Configurations = new[] 
+		[ActiveIssue(1224, Configurations = new[]
 		{
 			TestProvName.AllSQLite,
 			TestProvName.AllAccess,
@@ -2913,6 +2913,5 @@ namespace Tests.Linq
 				Assert.AreNotEqual(0, count);
 			}
 		}
-
 	}
 }

--- a/Tests/Linq/Linq/SelectTests.cs
+++ b/Tests/Linq/Linq/SelectTests.cs
@@ -1446,7 +1446,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void OuterApplyTest([IncludeDataSources(TestProvName.AllPostgreSQL95Plus, TestProvName.AllSqlServer2008Plus, TestProvName.AllOracle12)] string context)
+		public void OuterApplyTest([IncludeDataSources(TestProvName.AllPostgreSQL95Plus, TestProvName.AllSqlServer2008Plus, TestProvName.AllOracle12, TestProvName.AllMySql, TestProvName.AllSapHana)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{

--- a/Tests/Linq/Linq/SubQueryTests.cs
+++ b/Tests/Linq/Linq/SubQueryTests.cs
@@ -296,11 +296,9 @@ namespace Tests.Linq
 			TestProvName.AllAccess,
 			ProviderName.DB2,
 			TestProvName.AllOracle,
-			TestProvName.AllMySql,
 			ProviderName.SqlServer2000,
 			TestProvName.AllSybase,
-			TestProvName.AllInformix,
-			TestProvName.AllSapHana)]
+			TestProvName.AllInformix)]
 			string context)
 		{
 			using (var db = GetDataContext(context))

--- a/Tests/Linq/UserTests/Issue1298Tests.cs
+++ b/Tests/Linq/UserTests/Issue1298Tests.cs
@@ -56,14 +56,13 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void Issue1298Test([IncludeDataSources(TestProvName.AllPostgreSQL)] string context)
+		public void Issue1298Test([IncludeDataSources(TestProvName.AllPostgreSQL, TestProvName.AllMySql, TestProvName.AllSapHana)] string context)
 		{
 			using (var db = new DataConnection(context))
 			using (db.BeginTransaction())
+			using (db.CreateLocalTable<mega_composites>())
+			using (db.CreateLocalTable<qwerty>())
 			{
-				db.CreateTable<mega_composites>();
-				db.CreateTable<qwerty>();
-
 				db.Insert(new qwerty() { Id = 1, asdfgh = "res1" });
 				db.Insert(new qwerty() { Id = 100500, asdfgh = "res100500" });
 

--- a/Tests/Linq/UserTests/Issue461Tests.cs
+++ b/Tests/Linq/UserTests/Issue461Tests.cs
@@ -209,7 +209,7 @@ namespace Tests.UserTests
 
 		// Sybase do not supports limiting subqueries
 		[Test]
-		public void SelectPlainTest1([DataSources(TestProvName.AllSybase, TestProvName.AllInformix, TestProvName.AllSapHana)] string context)
+		public void SelectPlainTest1([DataSources(TestProvName.AllSybase, TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -222,7 +222,7 @@ namespace Tests.UserTests
 
 		// Sybase do not supports limiting subqueries
 		[Test]
-		public void SelectPlainTest2([DataSources(TestProvName.AllSybase, TestProvName.AllInformix, TestProvName.AllSapHana)] string context)
+		public void SelectPlainTest2([DataSources(TestProvName.AllSybase, TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -256,6 +256,5 @@ namespace Tests.UserTests
 				);
 			}
 		}
-
 	}
 }


### PR DESCRIPTION
Fix #3154

- added SQL dialect versioning for SAP HANA provider (`default` version and `HANA 2 SPS 04+` version)
- added lateral join generation to mysql and sap hana providers
- enabled lateral-related tests for mysql and sap hana. Some of them were working already, some were fixed with proper join generation, some should be disabled later as they are not supported by database and some require SQL generation fixes

TODO:
- [ ] add mysql provider versioning (maria db dialect support)
- [ ] disable unsupported tests
- [ ] fix sql generation
- [ ] setup pre-sps4 testing in azure (check for docker image names for older versions e.g. [here](https://github.com/SAPDocuments/Tutorials/issues/3065) as it is not visible on docherhub...)