### PR TITLE
Extended readme with more details about mapping and transaction scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,15 +187,15 @@ public class Product
 }
 ```
 
-There is two other ways to configure POCOs: no configuration at all and using Fluent configuration (also known as Code First).
+There is two other ways to configure POCOs: no configuration at all and using Fluent configuration.
 
 The first one involves no attributes. In this case Linq2Db will use POCO's name as table name and property names as column names. This might seem to be convenient, but there some moments: Linq2Db will not infer primary key even if class has property called "ID", and it will not infer nullability of string properties as there is no way to do so. Also, there will be no associations configured. In most cases the approach is pretty useless.
 
 The second way lets you configure your mapping dynamically, at runtime. Furthermore, it lets you to have several different configurations if you need so. This kind of configuration is done through class `MappingSchema`. There is static property `LinqToDB.Mapping.MappingSchema.Default` which might be used to one-time, global configuration. This mapping is used by default if no mapping schema provided explicitly. The other way is to pass instance of `MappingSchema` into constructor alongside with connection string. 
 
-Code First approach lets you to use all configuration abilities available with attributes. These two approaches are interchangeable in its abilities.
+Fluent approach lets you to use all configuration abilities available with attributes. These two approaches are interchangeable in its abilities.
 
-There one thing which differs these approaches. If you add at least one attribute into POCO, all other properties should also have attributes, otherwise they will be ignored. With Code First approach you can configure only thing that require it explicitly. All other properties will be inferred by Linq2Db:
+There one thing which differs these approaches. If you add at least one attribute into POCO, all other properties should also have attributes, otherwise they will be ignored. With Fluent approach you can configure only thing that require it explicitly. All other properties will be inferred by Linq2Db:
 
 ```c#
 var builder = MappingSchema.Default.GetFluentMappingBuilder();

--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ From **NuGet**:
 You can simply pass provider name and connection string into `DataConnection` constructor:
 
 ```cs
-var db = new LinqToDB.Data.DataConnection(LinqToDB.ProviderName.SqlServer2012,
-   "Server=.\;Database=Northwind;Trusted_Connection=True;Enlist=False;");
+var db = new LinqToDB.Data.DataConnection(
+  LinqToDB.ProviderName.SqlServer2012,
+  "Server=.\;Database=Northwind;Trusted_Connection=True;Enlist=False;");
 ```
 
 ### Using Connection Options Builder
@@ -168,35 +169,9 @@ See [article](https://linq2db.github.io/articles/get-started/asp-dotnet-core/ind
 
 ## Now let's create a **POCO** class
 
-You can generate those classes from your database using [T4 templates](https://linq2db.github.io/articles/T4.html). Demonstration video could be found [here](https://linq2db.github.io/articles/general/Video.html). Or you can write them manually, using `Fluent configuration`, `Attribute configuration`, or inferring.
+You can generate POCO classes from your database using [T4 templates](https://linq2db.github.io/articles/T4.html).  These classes will be generated using the `Attribute configuration`. Demonstration video could be found [here](https://linq2db.github.io/articles/general/Video.html). 
 
-### Fluent Configuration
-
-This method lets you configure your mapping dynamically at runtime. Furthermore, it lets you to have several different configurations if you need so. This kind of configuration is done through the class `MappingSchema`. 
-
-With Fluent approach you can configure only thing that require it explicitly. All other properties will be inferred by linq2db:
-
-```c#
-var builder = MappingSchema.Default.GetFluentMappingBuilder();
-
-builder.Entity<Product>()
-    .HasTableName("Products")
-    .HasSchemaName("dbo")
-    .HasIdentity(x => x.ProductID)
-    .HasPrimaryKey(x => x.ProductID)
-    .Ignore(x => x.SomeNonDbProperty)
-    .Property(x => x.TimeStamp)
-        .HasSkipOnInsert()
-        .HasSkipOnUpdate()
-    .Association(x => x.Vendor, x => x.VendorID, x => x.VendorID, canBeNull: false)
-    ;
-
-//... other mapping configurations
-```
-
-In this example we configured only three properties and one association. We let linq2db to infer all other properties which have to match with column names. However, other associations will not get configured automatically.
-
-There is a static property `LinqToDB.Mapping.MappingSchema.Default` which may be used to define a global configuration. This mapping is used by default if no mapping schema provided explicitly. The other way is to pass instance of `MappingSchema` into constructor alongside with connection string. 
+Alternatively, you can write them manually, using `Attribute configuration`, `Fluent configuration`, or inferring.
 
 ### Attribute configuration
 
@@ -223,7 +198,7 @@ public class Product
 }
 ```
 
-This approach involves attributes on all properties that should be mapped. This way lets you to configure all possible things linq2db ever supports. You will get all configuration abilities available with fluent configuration. These two approaches are interchangeable in its abilities. There one thing to mention: if you add at least one attribute into POCO, all other properties should also have attributes, otherwise they will be ignored:
+This approach involves attributes on all properties that should be mapped. This way lets you to configure all possible things linq2db ever supports. There one thing to mention: if you add at least one attribute into POCO, all other properties should also have attributes, otherwise they will be ignored:
 
 ```c#
 using System;
@@ -240,6 +215,34 @@ public class Product
 ```
 
 Property `Name` will be ignored as it lacks `Column` attibute. 
+
+### Fluent Configuration
+
+This method lets you configure your mapping dynamically at runtime. Furthermore, it lets you to have several different configurations if you need so. You will get all configuration abilities available with attribute configuration. These two approaches are interchangeable in its abilities. This kind of configuration is done through the class `MappingSchema`. 
+
+With Fluent approach you can configure only things that require it explicitly. All other properties will be inferred by linq2db:
+
+```c#
+var builder = MappingSchema.Default.GetFluentMappingBuilder();
+
+builder.Entity<Product>()
+    .HasTableName("Products")
+    .HasSchemaName("dbo")
+    .HasIdentity(x => x.ProductID)
+    .HasPrimaryKey(x => x.ProductID)
+    .Ignore(x => x.SomeNonDbProperty)
+    .Property(x => x.TimeStamp)
+        .HasSkipOnInsert()
+        .HasSkipOnUpdate()
+    .Association(x => x.Vendor, x => x.VendorID, x => x.VendorID, canBeNull: false)
+    ;
+
+//... other mapping configurations
+```
+
+In this example we configured only three properties and one association. We let linq2db to infer all other properties which have to match with column names. However, other associations will not get configured automatically.
+
+There is a static property `LinqToDB.Mapping.MappingSchema.Default` which may be used to define a global configuration. This mapping is used by default if no mapping schema provided explicitly. The other way is to pass instance of `MappingSchema` into constructor alongside with connection string.
 
 ### Inferred Configuration
 
@@ -263,7 +266,7 @@ public class Product
 }
 ```
 
-This way linq2db will auto-configure `Product` class to map to `Product` table with fields `ProductID`, `Name`, and `VendorID`. This POCO will have not treat `ProductID` property as primary key. And there will be no association with `Vendor`.
+This way linq2db will auto-configure `Product` class to map to `Product` table with fields `ProductID`, `Name`, and `VendorID`. POCO will not get `ProductID` property treated as primary key. And there will be no association with `Vendor`.
 
 This approach is not generally recommended.
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ There is a static property `LinqToDB.Mapping.MappingSchema.Default` which may be
 
 ### Inferred Configuration
 
-This approach involves no attributes at all. In this case linq2db will use POCO's name as table name and property names as column names (with exact same casing, which could be important for case-sensitive databases). This might seem to be convenient, but there are some moments: linq2db will not infer primary key even if class has property called "ID"; it will not infer nullability of string properties as there is no way to do so; and associations will not be automatically configured.
+This approach involves no attributes at all. In this case linq2db will use POCO's name as table name and property names as column names (with exact same casing, which could be important for case-sensitive databases). This might seem to be convenient, but there are some restrictions: linq2db will not infer primary key even if class has property called "ID"; it will not infer nullability of string properties as there is no way to do so; and associations will not be automatically configured.
 
 ```c#
 using System;


### PR DESCRIPTION
Extended readme with more details about mapping and transaction scope. Changed "Code First" with more appropriate "Fluent".