### PR TITLE
Fixed regression with query cache.

### DIFF
--- a/Source/LinqToDB/Linq/Builder/ExpressionTreeOptimizationContext.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionTreeOptimizationContext.cs
@@ -181,6 +181,10 @@ namespace LinqToDB.Linq.Builder
 
 		private TransformVisitor<ExpressionTreeOptimizationContext> _expandExpressionTransformer;
 
+		private bool _expressionDependsOnParameters;
+
+		public bool IsDependsOnParameters() => _expressionDependsOnParameters;
+
 		public Expression ExpandExpressionTransformer(Expression expr)
 		{
 			switch (expr.NodeType)
@@ -271,7 +275,10 @@ namespace LinqToDB.Linq.Builder
 					{
 						var testValue = conditional.Test.EvaluateExpression();
 						if (testValue is bool test)
+						{
+							_expressionDependsOnParameters = true;
 							return test ? ExpandExpression(conditional.IfTrue) : ExpandExpression(conditional.IfFalse);
+						}
 					}
 					break;
 				}

--- a/Source/LinqToDB/Linq/Query.cs
+++ b/Source/LinqToDB/Linq/Query.cs
@@ -470,10 +470,13 @@ namespace LinqToDB.Linq
 
 		public static long CacheMissCount => _queryCache.CacheMissCount;
 
-		public static Query<T> GetQuery(IDataContext dataContext, ref Expression expr)
+		public static Query<T> GetQuery(IDataContext dataContext, ref Expression expr, out bool dependsOnParameters)
 		{
 			var optimizationContext = new ExpressionTreeOptimizationContext(dataContext);
+
 			expr = optimizationContext.ExpandExpression(expr);
+
+			dependsOnParameters = optimizationContext.IsDependsOnParameters();
 
 			if (dataContext is IExpressionPreprocessor preprocessor)
 				expr = preprocessor.ProcessExpression(expr);

--- a/Tests/Base/QueryUtils.cs
+++ b/Tests/Base/QueryUtils.cs
@@ -13,7 +13,7 @@ namespace Tests
 		{
 			var eq = (IExpressionQuery)query;
 			var expression = eq.Expression;
-			var info = Query<T>.GetQuery(eq.DataContext, ref expression);
+			var info = Query<T>.GetQuery(eq.DataContext, ref expression, out _);
 
 			InitParameters(eq, info, expression);
 
@@ -29,7 +29,7 @@ namespace Tests
 		{
 			var eq = (IExpressionQuery)query;
 			var expression = eq.Expression;
-			var info = Query<T>.GetQuery(eq.DataContext, ref expression);
+			var info = Query<T>.GetQuery(eq.DataContext, ref expression, out _);
 
 			return info.PreamblesCount();
 		}

--- a/Tests/Linq/Linq/FromSqlTests.cs
+++ b/Tests/Linq/Linq/FromSqlTests.cs
@@ -479,8 +479,8 @@ namespace Tests.Linq
 				var expr1 = qry1.Expression;
 				var expr2 = qry2.Expression;
 
-				var query1 = Query<SampleClass>.GetQuery(db, ref expr1);
-				var query2 = Query<SampleClass>.GetQuery(db, ref expr2);
+				var query1 = Query<SampleClass>.GetQuery(db, ref expr1, out _);
+				var query2 = Query<SampleClass>.GetQuery(db, ref expr2, out _);
 
 				Assert.True(ReferenceEquals(query1, query2));
 
@@ -505,8 +505,8 @@ namespace Tests.Linq
 				var expr1 = qry1.Expression;
 				var expr2 = qry2.Expression;
 
-				var query1 = Query<SampleClass>.GetQuery(db, ref expr1);
-				var query2 = Query<SampleClass>.GetQuery(db, ref expr2);
+				var query1 = Query<SampleClass>.GetQuery(db, ref expr1, out _);
+				var query2 = Query<SampleClass>.GetQuery(db, ref expr2, out _);
 
 				Assert.False(ReferenceEquals(query1, query2));
 
@@ -531,8 +531,8 @@ namespace Tests.Linq
 				var expr1 = qry1.Expression;
 				var expr2 = qry2.Expression;
 
-				var query1 = Query<SampleClass>.GetQuery(db, ref expr1);
-				var query2 = Query<SampleClass>.GetQuery(db, ref expr2);
+				var query1 = Query<SampleClass>.GetQuery(db, ref expr1, out _);
+				var query2 = Query<SampleClass>.GetQuery(db, ref expr2, out _);
 
 				Assert.False(ReferenceEquals(query1, query2));
 
@@ -557,8 +557,8 @@ namespace Tests.Linq
 				var expr1 = qry1.Expression;
 				var expr2 = qry2.Expression;
 
-				var query1 = Query<SampleClass>.GetQuery(db, ref expr1);
-				var query2 = Query<SampleClass>.GetQuery(db, ref expr2);
+				var query1 = Query<SampleClass>.GetQuery(db, ref expr1, out _);
+				var query2 = Query<SampleClass>.GetQuery(db, ref expr2, out _);
 
 				Assert.True(ReferenceEquals(query1, query2));
 
@@ -585,8 +585,8 @@ namespace Tests.Linq
 				var expr1 = qry1.Expression;
 				var expr2 = qry2.Expression;
 
-				var query1 = Query<SampleClass>.GetQuery(db, ref expr1);
-				var query2 = Query<SampleClass>.GetQuery(db, ref expr2);
+				var query1 = Query<SampleClass>.GetQuery(db, ref expr1, out _);
+				var query2 = Query<SampleClass>.GetQuery(db, ref expr2, out _);
 
 				Assert.False(ReferenceEquals(query1, query2));
 
@@ -614,8 +614,8 @@ namespace Tests.Linq
 				var expr1 = qry1.Expression;
 				var expr2 = qry2.Expression;
 
-				var query1 = Query<SampleClass>.GetQuery(db, ref expr1);
-				var query2 = Query<SampleClass>.GetQuery(db, ref expr2);
+				var query1 = Query<SampleClass>.GetQuery(db, ref expr1, out _);
+				var query2 = Query<SampleClass>.GetQuery(db, ref expr2, out _);
 
 				Assert.False(ReferenceEquals(query1, query2));
 

--- a/Tests/Linq/Linq/SelectTests.cs
+++ b/Tests/Linq/Linq/SelectTests.cs
@@ -1072,18 +1072,29 @@ namespace Tests.Linq
 
 			var cacheMissCount = Query<IntermediateChildResult>.CacheMissCount;
 
-			var result = query.First();
+			var result = query.ToArray().First();
 
-			if (includeChild)
+			void CheckResult()
 			{
-				result.Child.Should().NotBeNull();
-			}
-			else
-			{
-				result.Child.Should().BeNull();
+				if (includeChild)
+				{
+					result.Child.Should().NotBeNull();
+				}
+				else
+				{
+					result.Child.Should().BeNull();
 
-				((DataConnection)db).LastQuery.Should().NotContain("ChildID");
+					((DataConnection)db).LastQuery.Should().NotContain("ChildID");
+				}
 			}
+
+			CheckResult();
+
+			includeChild = !includeChild;
+
+			result = query.ToArray().First();
+
+			CheckResult();
 
 			if (iteration > 1)
 			{


### PR DESCRIPTION
`IQueryable` instances has it's own cache and we have to do not cache queries which are dependent on parameters.