### PR TITLE
Replace SingleOrDefault with Any

### DIFF
--- a/Source/LinqToDB.Templates/LinqToDB.Tools.ttinclude
+++ b/Source/LinqToDB.Templates/LinqToDB.Tools.ttinclude
@@ -35,8 +35,9 @@ public static string GetProviderToolsPath(string assemblyName, string fullName)
 public static void LoadAssembly(string assemblyName, string toolsPath)
 {
 	// check if already loaded
-	if (AppDomain.CurrentDomain.GetAssemblies().SingleOrDefault(a => a.GetName().Name == assemblyName) != null)
+	if (AppDomain.CurrentDomain.GetAssemblies().Any(a => a.GetName().Name == assemblyName))
 		return;
+	
 	try
 	{
 		// try to load using VS (host) lookup paths


### PR DESCRIPTION
I've encountered a case when SingleOrDefault() (at line 38) throws `InvalidOperationException` due to finding more than one assembly item in the collection.

Changing the **tt** file this way eliminated the issue and otherwise didn't affect my project anyhow.