### PR TITLE
[WIP] Fix issue with null assigment to list property

### DIFF
--- a/Source/LinqToDB/Linq/Builder/EnumerableBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/EnumerableBuilder.cs
@@ -38,6 +38,9 @@ namespace LinqToDB.Linq.Builder
 					break;
 				}
 				case ExpressionType.Constant:
+					var ce = (ConstantExpression)expr;
+					if (ce.Value == null)
+						return false;
 					break;
 				default:
 					return false;


### PR DESCRIPTION
Such syntax in expressions worked in the version 3.2.3 but in the verson 3.5.0 its behaviour changed:
```c#
// case 1
var personWithArray = await db.GetTable<Person>()
	.OrderBy(p => p.ID)
	.Select(p =>
		new PersonArrayProjection
		{
			Id = p.ID,
			Name = p.Name,
			SomeArray = null  // ok
		}
	).ToListAsync();

Assert.IsNotEmpty(personWithArray);
Assert.True(personWithArray.All(p => p.SomeArray == null));

// case 2
var personWithList = await db.GetTable<Person>()
	.OrderBy(p => p.ID)
	.Select(p =>
		new PersonListProjection
		{
			Id        = p.ID,
			Name      = p.Name,
			SomeList  = null // worked in 3.2.3 but throws LinqToDB.LinqToDBException: Source must be enumerable: LinqToDB.SqlQuery.SqlValue in 3.5.0
		}
	).ToListAsync();

Assert.IsNotEmpty(personWithList);
Assert.True(personWithList.All(p => p.SomeList == null));
```
It seems that in the second case linq2db tries to build SqlValuesTable even though it doesn't make sense.