### PR TITLE
Fix for #3276. Handling special case when constant expression is null when detecting enumerable source.

### DIFF
--- a/Source/LinqToDB/Linq/Builder/EnumerableBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/EnumerableBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using LinqToDB.Extensions;
@@ -38,6 +39,8 @@ namespace LinqToDB.Linq.Builder
 					break;
 				}
 				case ExpressionType.Constant:
+					if (((ConstantExpression)expr).Value is not IEnumerable)
+						return false;
 					break;
 				default:
 					return false;

--- a/Tests/Linq/Linq/EnumerableSourceTests.cs
+++ b/Tests/Linq/Linq/EnumerableSourceTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using LinqToDB;
@@ -795,6 +796,59 @@ namespace Tests.Linq
 			}
 		}
 
+		class PersonListProjection
+		{
+			public int        Id      { get; set; }
+			public string?    Name    { get; set; }
+			public List<int>? SomeList { get; set; }
+		}
 
+		[Test]
+		public void NullConstantProjection(
+			[DataSources(ProviderName.SQLiteMS, TestProvName.AllAccess, ProviderName.DB2, TestProvName.AllSybase,
+				TestProvName.AllSybase, TestProvName.AllInformix)]
+			string context, [Values(1, 2)] int iteration)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var personWithList = db.GetTable<Person>()
+					.OrderBy(p => p.ID)
+					.Select(p =>
+						new PersonListProjection
+						{
+							Id   = p.ID,
+							Name = p.Name,
+							SomeList = null						}
+					).ToList();
+
+				personWithList.Should().HaveCountGreaterThan(0);
+				personWithList.All(p => p.SomeList == null).Should().BeTrue();
+			}
+
+		}
+
+		[Test]
+		public void ConstantProjection(
+			[DataSources(ProviderName.SQLiteMS, TestProvName.AllAccess, ProviderName.DB2, TestProvName.AllSybase,
+				TestProvName.AllSybase, TestProvName.AllInformix)]
+			string context, [Values(1, 2)] int iteration)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var personWithList = db.GetTable<Person>()
+					.OrderBy(p => p.ID)
+					.Select(p =>
+						new PersonListProjection
+						{
+							Id       = p.ID,
+							Name     = p.Name,
+							SomeList = new List<int>()						}
+					).ToList();
+
+				personWithList.Should().HaveCountGreaterThan(0);
+				personWithList.All(p => p.SomeList.Count == 0).Should().BeTrue();
+			}
+
+		}
 	}
 }


### PR DESCRIPTION
Fixes #3276