### PR TITLE
Fix race condition in mapping schema

### DIFF
--- a/Source/LinqToDB/Expressions/ExpressionVisitors/TransformVisitor.cs
+++ b/Source/LinqToDB/Expressions/ExpressionVisitors/TransformVisitor.cs
@@ -233,7 +233,7 @@ namespace LinqToDB.Expressions
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		private Expression TransformX(ChangeTypeExpression e)
 		{
-			var ex = Transform(e.Expression)!;
+			var ex = Transform(e.Expression);
 
 			if (ex == e.Expression)
 				return e;
@@ -264,7 +264,7 @@ namespace LinqToDB.Expressions
 		private Expression TransformX(MemberInitExpression e)
 		{
 			return e.Update(
-				(NewExpression)Transform(e.NewExpression)!,
+				(NewExpression)Transform(e.NewExpression),
 				Transform(e.Bindings, Modify));
 		}
 
@@ -279,7 +279,7 @@ namespace LinqToDB.Expressions
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		private Expression TransformX(ListInitExpression e)
 		{
-			var n = Transform(e.NewExpression)!;
+			var n = Transform(e.NewExpression);
 			var i = Transform(e.Initializers, TransformElementInit);
 
 			return n != e.NewExpression || i != e.Initializers ? Expression.ListInit((NewExpression)n, i) : e;
@@ -358,7 +358,7 @@ namespace LinqToDB.Expressions
 			for (var i = 0; i < source.Count; i++)
 			{
 				var item = source[i];
-				var e    = (T)Transform(item)!;
+				var e    = (T)Transform(item);
 
 				if (e != item)
 				{

--- a/Source/LinqToDB/Mapping/MappingSchema.cs
+++ b/Source/LinqToDB/Mapping/MappingSchema.cs
@@ -90,6 +90,8 @@ namespace LinqToDB.Mapping
 		/// mappings for same type.</remarks>
 		public MappingSchema(string? configuration, params MappingSchema[]? schemas)
 		{
+			_reduceDefaultValueTransformer = TransformVisitor<MappingSchema>.Create(this, static (ctx, e) => ctx.ReduceDefaultValueTransformer(e));
+
 			// always generate "unique" configuration name, if name not provided to avoid duplicate names
 			// e.g. see https://github.com/linq2db/linq2db/issues/3251
 			if (configuration.IsNullOrEmpty())
@@ -805,11 +807,10 @@ namespace LinqToDB.Mapping
 
 		Expression ReduceDefaultValue(Expression expr)
 		{
-			return (_reduceDefaultValueTransformer ??= TransformVisitor<MappingSchema>.Create(this, static (ctx, e) => ctx.ReduceDefaultValueTransformer(e)))
-				.Transform(expr);
+			return _reduceDefaultValueTransformer.Transform(expr);
 		}
 
-		private TransformVisitor<MappingSchema>? _reduceDefaultValueTransformer;
+		private readonly TransformVisitor<MappingSchema> _reduceDefaultValueTransformer;
 		private Expression ReduceDefaultValueTransformer(Expression e)
 		{
 			return Converter.IsDefaultValuePlaceHolder(e) ?

--- a/Source/LinqToDB/Mapping/MappingSchema.cs
+++ b/Source/LinqToDB/Mapping/MappingSchema.cs
@@ -1264,6 +1264,8 @@ namespace LinqToDB.Mapping
 
 		internal MappingSchema(MappingSchemaInfo mappingSchemaInfo)
 		{
+			_reduceDefaultValueTransformer = TransformVisitor<MappingSchema>.Create(this, static (ctx, e) => ctx.ReduceDefaultValueTransformer(e));
+
 			Schemas = new[] { mappingSchemaInfo };
 
 			ValueToSqlConverter = new ValueToSqlConverter();

--- a/Tests/Linq/Mapping/MappingSchemaTests.cs
+++ b/Tests/Linq/Mapping/MappingSchemaTests.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Linq;
+using System.Threading.Tasks;
 
 using LinqToDB;
 using LinqToDB.Common;
@@ -409,7 +410,20 @@ namespace Tests.Mapping
 			Assert.False(c.IsPrimaryKey);
 			Assert.False(c.IsIdentity);
 			Assert.AreEqual(DataType.DateTime, c.DataType);
+		}
 
+		[Repeat(100)]
+		[Test]
+		public void TestIssue3312()
+		{
+			var ms = new MappingSchema();
+
+			var tasks = new Task[10];
+
+			for (var i = 0; i < tasks.Length; i++)
+				tasks[i] = Task.Run(() => ms.GetConvertExpression(typeof(string), typeof(int)));
+
+			Task.WaitAll(tasks);
 		}
 	}
 }


### PR DESCRIPTION
Fix #3312

TIL that `(x =?? new T())` code is not thread-safe and parallel thread could get uninitialized `x` instance.