### PR TITLE
Optimize UPDATE SET queries

### DIFF
--- a/Source/LinqToDB/SqlQuery/SqlUpdateStatement.cs
+++ b/Source/LinqToDB/SqlQuery/SqlUpdateStatement.cs
@@ -49,6 +49,17 @@ namespace LinqToDB.SqlQuery
 			return null;
 		}
 
+		public override void WalkQueries<TContext>(TContext context, Func<TContext, SelectQuery, SelectQuery> func)
+		{
+			base.WalkQueries(context, func);
+
+			foreach (var setItem in Update.Items) {
+				if (setItem.Expression is SelectQuery q) {
+					setItem.Expression = func(context, q);
+				}
+			}
+		}
+
 		public override ISqlTableSource? GetTableSource(ISqlTableSource table)
 		{
 			var result = SelectQuery.GetTableSource(table);


### PR DESCRIPTION
I encountered a blocker while working on my SqlRow branch: I noticed that queries inside UPDATE SET expressions are not visited.

I traced that to the fact that `SqlUpdateStatement.WalkQueries` doesn't visit them, which I fixed in this PR.

Notice that I only visit "full query" statements, which is enough to unlock me. In reality an expression could be:
`SET x = 1 + (select 2)`
and I'm not visiting those queries (not sure how it would be done).

⚠ More tests from me showed that there's a problem with this PR, though -- and I'm not sure how to fix it:

When the query refers to the outer table being updated, linq2db can't find that table source.

I debugged a bit and it seems that it searches the SqlUpdateStatement alright, but instead of looking for the plain Table that is found in that statement, it looks for a weird sub-select expression instead... I'm not sure how that's supposed to be fixed.