### PR TITLE
ActiveIssue tests review

### DIFF
--- a/Data/Create Scripts/Sybase.sql
+++ b/Data/Create Scripts/Sybase.sql
@@ -271,8 +271,8 @@ SELECT * FROM Person
 GO
 
 CREATE TABLE KeepIdentityTest (
-	ID    NUMERIC(12, 0) IDENTITY,
-	Value INT            NULL
+	ID    INT IDENTITY,
+	Value INT NULL
 )
 GO
 

--- a/Source/LinqToDB/Sql/Sql.cs
+++ b/Source/LinqToDB/Sql/Sql.cs
@@ -518,6 +518,7 @@ namespace LinqToDB
 		[Function  (PN.SqlCe,     "Len",                               PreferServerSide = true)]
 		[Function  (PN.Sybase,    "Len",                               PreferServerSide = true)]
 		[Function  (PN.MySql,     "Char_Length",                       PreferServerSide = true)]
+		[Function  (PN.Informix,  "CHAR_LENGTH",                       PreferServerSide = true)]
 		[Expression(PN.DB2LUW,    "CHARACTER_LENGTH({0},CODEUNITS32)", PreferServerSide = true)]
 		public static int? Length(string str)
 		{

--- a/Tests/Linq/Data/DataConnectionTests.cs
+++ b/Tests/Linq/Data/DataConnectionTests.cs
@@ -1000,7 +1000,7 @@ namespace Tests.Data
 		// also some providers remove credentials from connection string in non-design mode
 		[ActiveIssue(Configurations = new[]
 		{
-			ProviderName.MySqlConnector,
+			//ProviderName.MySqlConnector,
 			ProviderName.SapHanaNative, // HanaException: error while parsing protocol
 			// Providers remove credentials in non-design mode:
 			TestProvName.AllPostgreSQL,

--- a/Tests/Linq/Infrastructure/ActiveIssueConfigurationTests.cs
+++ b/Tests/Linq/Infrastructure/ActiveIssueConfigurationTests.cs
@@ -69,8 +69,8 @@ namespace Tests.Infrastructure
 			{
 				case ProviderName.Access:
 				case ProviderName.Access + ".LinqService":
-				case TestProvName.NoopProvider + ".LinqService":
 					return;
+				case TestProvName.NoopProvider + ".LinqService":
 				case TestProvName.NoopProvider:
 				case ProviderName.SQLiteClassic:
 				case ProviderName.SQLiteClassic + ".LinqService":
@@ -93,8 +93,8 @@ namespace Tests.Infrastructure
 				case ProviderName.Access + ".LinqService":
 				case ProviderName.SQLiteClassic:
 				case ProviderName.SQLiteClassic + ".LinqService":
-				case TestProvName.NoopProvider + ".LinqService":
 					return;
+				case TestProvName.NoopProvider + ".LinqService":
 				case TestProvName.NoopProvider:
 					Assert.Fail("This test should be available only for explicit run");
 					break;

--- a/Tests/Linq/Linq/AnalyticTests.cs
+++ b/Tests/Linq/Linq/AnalyticTests.cs
@@ -1314,7 +1314,9 @@ namespace Tests.Linq
 			};
 		}
 
+#if NETFRAMEWORK
 		[ActiveIssue("Old SQLite version", Configuration = ProviderName.SQLiteMS)]
+#endif
 		[Test]
 		public void Issue1732Lag([DataSources(
 			TestProvName.AllSqlServer2008Minus,
@@ -1358,7 +1360,9 @@ namespace Tests.Linq
 			}
 		}
 
+#if NETFRAMEWORK
 		[ActiveIssue("Old SQLite version", Configuration = ProviderName.SQLiteMS)]
+#endif
 		[Test]
 		public void Issue1732Lead([DataSources(
 			TestProvName.AllSqlServer2008Minus,
@@ -1400,7 +1404,9 @@ namespace Tests.Linq
 			}
 		}
 
+#if NETFRAMEWORK
 		[ActiveIssue("Old SQLite version", Configuration = ProviderName.SQLiteMS)]
+#endif
 		[Test]
 		public void Issue1732FirstValue([DataSources(
 			TestProvName.AllSqlServer2008Minus,
@@ -1440,7 +1446,9 @@ namespace Tests.Linq
 			}
 		}
 
+#if NETFRAMEWORK
 		[ActiveIssue("Old SQLite version", Configuration = ProviderName.SQLiteMS)]
+#endif
 		[Test]
 		public void Issue1732LastValue([DataSources(
 			TestProvName.AllSqlServer2008Minus,
@@ -1546,7 +1554,9 @@ namespace Tests.Linq
 			[Column] public string? ProcessName { get; set; }
 		}
 
+#if NETFRAMEWORK
 		[ActiveIssue("Old SQLite version", Configuration = ProviderName.SQLiteMS)]
+#endif
 		[Test]
 		public void Issue1799Test1([DataSources(
 			TestProvName.AllSqlServer2008Minus,
@@ -1601,7 +1611,9 @@ namespace Tests.Linq
 			}
 		}
 
+#if NETFRAMEWORK
 		[ActiveIssue("Old SQLite version", Configuration = ProviderName.SQLiteMS)]
+#endif
 		[Test]
 		public void Issue1799Test2([DataSources(
 			TestProvName.AllSqlServer2008Minus,

--- a/Tests/Linq/Linq/CommonTests.cs
+++ b/Tests/Linq/Linq/CommonTests.cs
@@ -162,7 +162,6 @@ namespace Tests.Linq
 					select p);
 		}
 
-		[ActiveIssue("Incorrect length returned for Jürgen: 7 instead of 6", Configuration = TestProvName.AllInformix)]
 		[Test]
 		public void PreferServerFunc1([DataSources] string context)
 		{
@@ -172,7 +171,6 @@ namespace Tests.Linq
 					from p in db.Person select p.FirstName.Length);
 		}
 
-		[ActiveIssue("Incorrect length returned for Jürgen: 7 instead of 6", Configuration = TestProvName.AllInformix)]
 		[Test]
 		public void PreferServerFunc2([DataSources] string context)
 		{

--- a/Tests/Linq/Linq/ConcatUnionTests.cs
+++ b/Tests/Linq/Linq/ConcatUnionTests.cs
@@ -669,7 +669,7 @@ namespace Tests.Linq
 			}
 		}
 
-		[ActiveIssue("Not supported")]
+		[ActiveIssue("Associations with Concat/Union or other Set operations are not supported.")]
 		[Test]
 		public void AssociationUnion1([DataSources] string context)
 		{
@@ -683,7 +683,7 @@ namespace Tests.Linq
 					select p.ParentID);
 		}
 
-		[ActiveIssue("Not supported")]
+		[ActiveIssue("Associations with Concat/Union or other Set operations are not supported.")]
 		[Test]
 		public void AssociationUnion2([DataSources] string context)
 		{
@@ -695,7 +695,7 @@ namespace Tests.Linq
 					select c.Parent!.ParentID);
 		}
 
-		[ActiveIssue("Not supported")]
+		[ActiveIssue("Associations with Concat/Union or other Set operations are not supported.")]
 		[Test]
 		public void AssociationConcat2([DataSources] string context)
 		{

--- a/Tests/Linq/Linq/CountTests.cs
+++ b/Tests/Linq/Linq/CountTests.cs
@@ -172,7 +172,7 @@ namespace Tests.Linq
 					select g.Count(ch => ch.ChildID > 20));
 		}
 
-		[ActiveIssue(Configuration = TestProvName.AllInformix)]
+		[ActiveIssue("The column ((expression)) must be in the GROUP BY list.", Configuration = TestProvName.AllInformix)]
 		[Test]
 		public void GroupBy21([DataSources] string context)
 		{
@@ -192,7 +192,7 @@ namespace Tests.Linq
 					select g.Count(p => p.ParentID < 3));
 		}
 
-		[ActiveIssue(Configuration = TestProvName.AllInformix)]
+		[ActiveIssue("The column ((expression)) must be in the GROUP BY list.", Configuration = TestProvName.AllInformix)]
 		[Test]
 		public void GroupBy22([DataSources] string context)
 		{
@@ -229,7 +229,7 @@ namespace Tests.Linq
 					select g.Count(p => p.ParentID < 3));
 		}
 
-		[ActiveIssue("Unsupported by Informix?", Configuration = TestProvName.AllInformix)]
+		[ActiveIssue("The column ((expression)) must be in the GROUP BY list.", Configuration = TestProvName.AllInformix)]
 		[Test]
 		public void GroupBy3([DataSources] string context)
 		{

--- a/Tests/Linq/Linq/CteTests.cs
+++ b/Tests/Linq/Linq/CteTests.cs
@@ -989,7 +989,7 @@ namespace Tests.Linq
 			}
 		}
 
-		[ActiveIssue("Scalar recursive CTE are not working")]
+		[ActiveIssue("Scalar recursive CTE are not working: SQL logic error near *: syntax error")]
 		[Test]
 		public void TestRecursiveScalar([IncludeDataSources(TestProvName.AllSQLite)] string context)
 		{
@@ -1026,7 +1026,7 @@ namespace Tests.Linq
 			public string? GroupName { get; set; }
 		}
 
-		[ActiveIssue(1644)]
+		[ActiveIssue(1644, Details = "Expression 'parent.OrgGroup' is not a Field.")]
 		[Test]
 		public void TestRecursiveObjects([CteContextSource] string context)
 		{

--- a/Tests/Linq/Linq/DataContextTests.cs
+++ b/Tests/Linq/Linq/DataContextTests.cs
@@ -88,7 +88,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[ActiveIssue("Unstable issue with Sybase vs Sybase.Managed DataProvider.Name", Configuration = TestProvName.AllSybase)]
+		[ActiveIssue("Provider detector picks managed provider as we don't have separate provider name for native Sybase provider", Configuration = ProviderName.Sybase)]
 		public void ProviderConnectionStringConstructorTest3([DataSources(false)] string context)
 		{
 			using (var db  = (TestDataConnection)GetDataContext(context))

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -1477,7 +1477,7 @@ namespace Tests.Linq
 
 #endregion
 
-		[ActiveIssue("SQL0418N", Configuration = ProviderName.DB2)]
+		[ActiveIssue("SQL0418N  The statement was not processed because the statement contains an invalid use of one of the following: an untyped parameter marker, the DEFAULT keyword, or a null value.", Configuration = ProviderName.DB2)]
 		[Test]
 		public void GetDateTest1([DataSources] string context)
 		{

--- a/Tests/Linq/Linq/DynamicColumnsTests.cs
+++ b/Tests/Linq/Linq/DynamicColumnsTests.cs
@@ -569,8 +569,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[ActiveIssue(Details = "https://stackoverflow.com/questions/61081571")]
-		public void DynamicGoesBanana1([IncludeDataSources(true, TestProvName.AllSQLiteClassic)] string context)
+		[ActiveIssue("https://stackoverflow.com/questions/61081571", Details = "Expression 't.Id' is not a Field.")]
+		public void DynamicGoesBanana1([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
 
 			using (var db = GetDataContext(context))

--- a/Tests/Linq/Linq/EnumerableSourceTests.cs
+++ b/Tests/Linq/Linq/EnumerableSourceTests.cs
@@ -235,7 +235,6 @@ namespace Tests.Linq
 			}
 		}
 
-		[ActiveIssue("PosgreSql needs type for literals. We have to rewise literals generation.")]
 		[Test]
 		public void InnerJoinArray6Postgres([IncludeDataSources(TestProvName.AllPostgreSQLLess10)] string context, [Values(1, 2)] int iteration)
 		{

--- a/Tests/Linq/Linq/InheritanceTests.cs
+++ b/Tests/Linq/Linq/InheritanceTests.cs
@@ -742,7 +742,7 @@ namespace Tests.Linq
 			}
 		}
 
-		[ActiveIssue(Details = "Invalid mappings?")]
+		[ActiveIssue(Details = "Expression 'x.BaseValue' is not a Field. (Invalid mappings?)")]
 		[Test]
 		public void Issue2429PropertiesTest2([DataSources] string context)
 		{
@@ -761,7 +761,7 @@ namespace Tests.Linq
 			}
 		}
 
-		[ActiveIssue(Details = "Invalid mappings?")]
+		[ActiveIssue(Details = "Expression 'x.BaseValue' is not a Field. (Invalid mappings?)")]
 		[Test]
 		public void Issue2429MethodsTest2([DataSources] string context)
 		{

--- a/Tests/Linq/Linq/IssueTests.cs
+++ b/Tests/Linq/Linq/IssueTests.cs
@@ -400,9 +400,8 @@ namespace Tests.Linq
 			Client
 		}
 
-		[ActiveIssue(535)]
 		[Test]
-		public void Issue535Test2([DataSources] string context)
+		public void Issue535Test2([DataSources(TestProvName.AllSybase)] string context)
 		{
 			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable<CustomerBase>())

--- a/Tests/Linq/Linq/VisualBasicTests.cs
+++ b/Tests/Linq/Linq/VisualBasicTests.cs
@@ -109,6 +109,7 @@ namespace Tests.Linq
 			}
 		}
 
+		//Instance property or field with name Key not found on type System.Collections.Generic.IEnumerable`1[Tests.VisualBasic.VBTests+Activity649]
 		[ActiveIssue(649)]
 		[Test]
 		public void Issue649Test1([DataSources] string context)
@@ -143,6 +144,7 @@ namespace Tests.Linq
 			}
 		}
 
+		// Instance property or field with name Key not found on type System.Collections.Generic.IEnumerable`1[Tests.Model.Child]
 		[ActiveIssue(649)]
 		[Test]
 		public void Issue649Test4([DataSources] string context)

--- a/Tests/Linq/OrmBattle/OrmBattleTests.cs
+++ b/Tests/Linq/OrmBattle/OrmBattleTests.cs
@@ -1205,10 +1205,9 @@ namespace Tests.OrmBattle
 			Assert.AreEqual(10, result.ToList().Count);
 		}
 
-		[Test, ActiveIssue(573)]
+		[Test]
 		public void AnyParameterizedTest([NorthwindDataContext] string context)
 		{
-			//TODO: sdanyliv: It may take many efforts to implement. And I don't see any benefits.
 			Setup(context);
 			var ids = new[] {"ABCDE", "ALFKI"};
 			var result = db.Customer.Where(c => ids.Any(id => c.CustomerID == id));
@@ -1426,7 +1425,7 @@ namespace Tests.OrmBattle
 			}
 		}
 
-		[Test, ActiveIssue(573)]
+		[Test, ActiveIssue(573, Details = "'k.CompanyName' cannot be converted to SQL.")]
 		public void ComplexTest2([NorthwindDataContext] string context)
 		{
 			Setup(context);

--- a/Tests/Linq/Update/BulkCopyTests.cs
+++ b/Tests/Linq/Update/BulkCopyTests.cs
@@ -47,7 +47,6 @@ namespace Tests.xUpdate
 			public int Value { get; set; }
 		}
 
-		[ActiveIssue("Sybase: Bulk insert failed. Null value is not allowed in not null column.", Configuration = ProviderName.Sybase)]
 		[Test]
 		public async Task KeepIdentity_SkipOnInsertTrue(
 			[DataSources(false)]string context,
@@ -55,6 +54,9 @@ namespace Tests.xUpdate
 			[Values] BulkCopyType copyType,
 			[Values(0, 1, 2)] int asyncMode) // 0 == sync, 1 == async, 2 == async with IAsyncEnumerable
 		{
+			if ((context == ProviderName.Sybase) && copyType == BulkCopyType.ProviderSpecific && keepIdentity != true)
+				Assert.Inconclusive("Sybase native bulk copy doesn't support identity insert (despite documentation)");
+
 			ResetAllTypesIdentity(context);
 
 			if ((context == ProviderName.OracleNative || context == TestProvName.Oracle11Native) && copyType == BulkCopyType.ProviderSpecific)
@@ -131,7 +133,6 @@ namespace Tests.xUpdate
 			}
 		}
 
-		[ActiveIssue("Unsupported column datatype for BulkCopyType.ProviderSpecific", Configurations = new[] { TestProvName.AllOracleNative , ProviderName.Sybase } )]
 		[Test]
 		public async Task KeepIdentity_SkipOnInsertFalse(
 			[DataSources(false)]        string       context,
@@ -139,6 +140,9 @@ namespace Tests.xUpdate
 			[Values]                    BulkCopyType copyType,
 			[Values(0, 1, 2)]           int          asyncMode) // 0 == sync, 1 == async, 2 == async with IAsyncEnumerable
 		{
+			if ((context == ProviderName.Sybase) && copyType == BulkCopyType.ProviderSpecific && keepIdentity != true)
+				Assert.Inconclusive("Sybase native bulk copy doesn't support identity insert (despite documentation)");
+
 			ResetAllTypesIdentity(context);
 
 			// don't use transactions as some providers will fallback to non-provider-specific implementation then

--- a/Tests/Linq/UserTests/Issue1298Tests.cs
+++ b/Tests/Linq/UserTests/Issue1298Tests.cs
@@ -113,7 +113,7 @@ namespace Tests.UserTests
 
 		}
 
-		[Test, ActiveIssue(1298)]
+		[Test, ActiveIssue(1298, Details = "Expression 'x.y1' is not a Field.")]
 		public void Issue1298Test1([IncludeDataSources(TestProvName.AllPostgreSQL)] string context)
 		{
 			using (var db = new DataConnection(context))

--- a/Tests/Linq/UserTests/Issue1441Tests.cs
+++ b/Tests/Linq/UserTests/Issue1441Tests.cs
@@ -32,8 +32,6 @@ namespace Tests.UserTests
 			public string Title { get; set; } = null!;
 		}
 
-		[ActiveIssue(1441, Details = "Causes StackOverflowException")]
-		[Test]
 		public void SampleSelectTest1([DataSources] string context)
 		{
 			using (var db           = GetDataContext(context))
@@ -46,7 +44,8 @@ namespace Tests.UserTests
 
 				if (onlyWithBooks)
 				{
-					// This causes StackOverflowException
+					// referencing authors variable causes StackOverflowException
+					// due to circular dependency
 					authors =
 						from book in booksTable
 						from author in authors.InnerJoin(author => author.Id == book.AuthorId)

--- a/Tests/Linq/UserTests/Issue2478Tests.cs
+++ b/Tests/Linq/UserTests/Issue2478Tests.cs
@@ -116,7 +116,7 @@ namespace Tests.UserTests
 			}
 		}
 
-		[ActiveIssue]
+		[ActiveIssue(Details = "Converted FuncLikePredicate expression is not a Predicate expression.")]
 		[Test]
 		public void ExistsRemoval([IncludeDataSources(TestProvName.AllSqlServer2005Plus)] string context, [Values] bool shouldFilter, [Values] bool isPositive)
 		{

--- a/Tests/Linq/UserTests/Issue2800Tests.cs
+++ b/Tests/Linq/UserTests/Issue2800Tests.cs
@@ -30,7 +30,7 @@ namespace Tests.UserTests
 			}
 		}
 
-		[ActiveIssue(2839, Configuration = TestProvName.AllFirebird)]
+		[ActiveIssue(2839, Configuration = TestProvName.AllFirebird, SkipForLinqService = true)]
 		[Test]
 		public void TestExpressionMethod([DataSources] string context)
 		{

--- a/Tests/Linq/UserTests/Issue3148Tests.cs
+++ b/Tests/Linq/UserTests/Issue3148Tests.cs
@@ -294,9 +294,25 @@ namespace Tests.UserTests
 			}
 		}
 
-		// generates bad sql (EXISTS missing in subquery condition)
-		[Test, ActiveIssue]
-		public void TestDefaultExpression_09([IncludeDataSources(true, TestProvName.AllSQLite)] string context, [Values] bool withDefault)
+		// some databases require EXISTS
+		[Test, ActiveIssue(
+			Configurations = new[]
+			{
+				TestProvName.AllAccess,
+				ProviderName.DB2,
+				TestProvName.AllFirebird,
+				TestProvName.AllInformix,
+				TestProvName.AllOracle,
+				TestProvName.AllPostgreSQL,
+				TestProvName.AllSapHana,
+				ProviderName.SqlCe,
+#if NETFRAMEWORK // old sqlite
+				ProviderName.SQLiteMS,
+#endif
+				TestProvName.AllSqlServer,
+				TestProvName.AllSybase
+			})]
+		public void TestDefaultExpression_09([DataSources] string context, [Values] bool withDefault)
 		{
 			using (var db = GetDataContext(context))
 			{


### PR DESCRIPTION
Another run over ActiveIssue tests:
- `InnerJoinArray6Postgres` now works probably due to recent enumerable context improvements
- [FIX][Informix] use `CHAR_LENGTH` function instead of `LENGTH` for text (`Sql.Length(str)`, `string.Length` mappings)
- fixed SQL script for Sybase
- issue #1078 seems fixed in current release or earlier (except Access/SQL CE)
- removed test for #1441 as it is not actionable
- issue #535 seems fixed in current release or earlier
- andother ORM Battle test works now (`AnyParameterizedTest`)
