### PR TITLE
Update dependencies

### DIFF
--- a/Build/Azure/README.md
+++ b/Build/Azure/README.md
@@ -97,13 +97,13 @@ Legend:
 |MySQL 8<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.27|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |MySQL 8<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 0.69.10/1.3.14/2.0.0|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |MariaDB 10<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.27|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 9.2<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.10 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 9.3<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.10 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 9.5<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.10 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 10<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.10 (core)|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 11<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.10 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 12<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.10 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|PostgreSQL 13<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.9 (netfx) / 5.0.10 (core)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 9.2<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.10 (netfx) / 5.0.11 (core2.1) / 6.0.0 (core3.1+)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 9.3<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.10 (netfx) / 5.0.11 (core2.1) / 6.0.0 (core3.1+)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 9.5<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.10 (netfx) / 5.0.11 (core2.1) / 6.0.0 (core3.1+)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 10<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.10 (netfx) / 5.0.11 (core2.1) / 6.0.0 (core3.1+)|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 11<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.10 (netfx) / 5.0.11 (core2.1) / 6.0.0 (core3.1+)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 12<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.10 (netfx) / 5.0.11 (core2.1) / 6.0.0 (core3.1+)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|PostgreSQL 13<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 4.1.10 (netfx) / 5.0.11 (core2.1) / 6.0.0 (core3.1+)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |DB2 LUW 11.5.0.0a<br>[IBM.Data.DB2](https://www.nuget.org/packages/IBM.Data.DB.Provider/) 11.5.5010.4 (netfx)<br>[IBM.Data.DB2.Core](https://www.nuget.org/packages/IBM.Data.DB2.Core/) 2.2.0.100 ([osx](https://www.nuget.org/packages/IBM.Data.DB2.Core-osx/) 2.0.0.100, [lin](https://www.nuget.org/packages/IBM.Data.DB2.Core-lnx/) 2.2.0.100) (core)|:x:|:x:|:heavy_check_mark:<sup>[6](#notes)</sup>|:heavy_check_mark:|
 |Informix 12.10.FC12W1DE<br>IBM.Data.Informix (SQLI) 4.0.410.10|:x:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|
 |Informix 14.10<br>IBM.Data.Informix (SQLI) 4.0.410.10|:x:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,123 +13,114 @@
 	As both issues occur only in MSBUILD, it could be transitional issue fixed in future as feature is still not finalized
 	-->
 	<ItemGroup>
-		<!--generic packages-->
-		<PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageVersion Include="System.Memory" Version="4.5.4" />
-		<PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-		<PackageVersion Include="System.ValueTuple" Version="4.5.0" />
-		<PackageVersion Include="System.Collections.Immutable" Version="5.0.0" />
-		<PackageVersion Include="System.Data.DataSetExtensions" Version="4.5.0" />
-		<PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
-		<PackageVersion Include="FluentAssertions" Version="6.2.0" />
-
-		<!--infrastructure-->
-		<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-
+		<!--as stated in issue 1 -  packages in this item group shouldn't be duplicated in other groups-->
+		
+		<!--generic code packages-->
+		<PackageVersion Include="Newtonsoft.Json"                           Version="13.0.1"      />
+		<PackageVersion Include="System.Memory"                             Version="4.5.4"       />
+		<PackageVersion Include="System.Threading.Tasks.Extensions"         Version="4.5.4"       />
+		<PackageVersion Include="System.ValueTuple"                         Version="4.5.0"       />
+		<PackageVersion Include="System.Collections.Immutable"              Version="5.0.0"       />
+		<PackageVersion Include="System.Data.DataSetExtensions"             Version="4.5.0"       />
+		<PackageVersion Include="Microsoft.CSharp"                          Version="4.7.0"       />
+		<PackageVersion Include="Microsoft.Bcl.AsyncInterfaces"             Version="5.0.0"       />
+		<PackageVersion Include="FluentAssertions"                          Version="6.2.0"       />
 		<!--data providers-->
-		<PackageVersion Include="MySql.Data" Version="8.0.27" />
-		<PackageVersion Include="AdoNetCore.AseClient" Version="0.19.2" />
-		<PackageVersion Include="System.Data.SqlClient" Version="4.8.3" />
-		<PackageVersion Include="Microsoft.Data.SqlClient" Version="3.0.1" />
-		<PackageVersion Include="System.Data.Odbc" Version="5.0.0" />
-		<PackageVersion Include="System.Data.OleDb" Version="5.0.0" />
-		<PackageVersion Include="Oracle.ManagedDataAccess" Version="21.4.0" />
-		<PackageVersion Include="FirebirdSql.Data.FirebirdClient" Version="8.5.4" />
-		<PackageVersion Include="System.Data.SQLite.Core" Version="1.0.115.5" />
-
-		<PackageVersion Include="IBM.Data.DB.Provider" Version="11.5.5010.4" />
-
-		<!--test infrastructure-->
-		<PackageVersion Include="MiniProfiler" Version="3.2.0.157" />
-		<PackageVersion Include="MiniProfiler.Shared" Version="4.2.22" />
-		<PackageVersion Include="NUnit" Version="3.13.2" />
-		<PackageVersion Include="NUnit3TestAdapter" Version="4.1.0" />
-		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-		<PackageVersion Include="FastExpressionCompiler" Version="3.2.1" />
-		<PackageVersion Include="BenchmarkDotNet" Version="0.13.1" />
-		<PackageVersion Include="JetBrains.Profiler.Api" Version="1.1.7" />
-		<PackageVersion Include="Humanizer.Core" Version="2.11.10" />
-		<PackageVersion Include="FSharp.Core" Version="6.0.1" />
-		<PackageVersion Include="Microsoft.AspNet.OData" Version="7.5.12" />
-		<PackageVersion Include="NodaTime" Version="3.0.9" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.3" />
-
+		<PackageVersion Include="MySql.Data"                                Version="8.0.27"      />
+		<PackageVersion Include="AdoNetCore.AseClient"                      Version="0.19.2"      />
+		<PackageVersion Include="System.Data.SqlClient"                     Version="4.8.3"       />
+		<PackageVersion Include="Microsoft.Data.SqlClient"                  Version="3.0.1"       />
+		<PackageVersion Include="System.Data.Odbc"                          Version="5.0.0"       />
+		<PackageVersion Include="System.Data.OleDb"                         Version="5.0.0"       />
+		<PackageVersion Include="Oracle.ManagedDataAccess"                  Version="21.4.0"      />
+		<PackageVersion Include="FirebirdSql.Data.FirebirdClient"           Version="8.5.4"       />
+		<PackageVersion Include="System.Data.SQLite.Core"                   Version="1.0.115.5"   />
+		<PackageVersion Include="IBM.Data.DB.Provider"                      Version="11.5.5010.4" />
+		<!--infrastructure/testing-->
+		<PackageVersion Include="MiniProfiler"                              Version="3.2.0.157"   />
+		<PackageVersion Include="MiniProfiler.Shared"                       Version="4.2.22"      />
+		<PackageVersion Include="NUnit"                                     Version="3.13.2"      />
+		<PackageVersion Include="NUnit3TestAdapter"                         Version="4.1.0"       />
+		<PackageVersion Include="Microsoft.NET.Test.Sdk"                    Version="17.0.0"      />
+		<PackageVersion Include="FastExpressionCompiler"                    Version="3.2.1"       />
+		<PackageVersion Include="BenchmarkDotNet"                           Version="0.13.1"      />
+		<PackageVersion Include="JetBrains.Profiler.Api"                    Version="1.1.7"       />
+		<PackageVersion Include="Humanizer.Core"                            Version="2.11.10"     />
+		<PackageVersion Include="FSharp.Core"                               Version="6.0.1"       />
+		<PackageVersion Include="Microsoft.AspNet.OData"                    Version="7.5.12"      />
+		<PackageVersion Include="NodaTime"                                  Version="3.0.9"       />
+		<PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.3"       />
+		<PackageVersion Include="Microsoft.SourceLink.GitHub"               Version="1.1.1"       />
 		<!--nuget doesn't have strong name, so we use local self-signed copy-->
-		<!--<PackageVersion Include="dotMorten.Microsoft.SqlServer.Types" Version="1.3.0" />-->
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' != 'net472' ">
-		<!--main version-->
-		<PackageVersion Include="Microsoft.Data.Sqlite" Version="5.0.12" />
+		<!--<PackageVersion Include="dotMorten.Microsoft.SqlServer.Types"   Version="1.3.0"       />-->
 	</ItemGroup>
 	
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
-		<!--specify here or it will conflict with Reference-include in netcore targets-->
-		<PackageVersion Include="Microsoft.SqlServer.Types" Version="14.0.1016.290" />
-		<!--downgrade-->
-		<PackageVersion Include="Microsoft.Data.Sqlite" Version="1.1.1" />
-		<PackageVersion Include="Npgsql" Version="4.1.9" />
-		<PackageVersion Include="MySqlConnector" Version="2.0.0" />
-	</ItemGroup>
-	
-	<ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">
-		<!--main version-->
-		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="3.1.20" />
-		<PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-	</ItemGroup>
+	<!--linq2db targets-->
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
 		<!--downgrade-->
-		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
-		<PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2" />
+		<PackageVersion Include="Microsoft.Extensions.DependencyInjection"  Version="1.1.1"  />
+		<PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2"  />
 	</ItemGroup>
-	
-	<ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp2.1' ">
+	<ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">
 		<!--main version-->
-		<PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="3.21.4" />
-		<PackageVersion Include="IBM.Data.DB2.Core" Version="3.1.0.500" />
-		<PackageVersion Include="IBM.Data.DB2.Core-lnx" Version="3.1.0.500" />
-		<PackageVersion Include="IBM.Data.DB2.Core-osx" Version="3.1.0.500" />
+		<PackageVersion Include="Microsoft.Extensions.DependencyInjection"  Version="3.1.20" />
+		<PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0"  />
 	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-		<!--downgrade-->
-		<PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="2.19.130" />
-		<PackageVersion Include="IBM.Data.DB2.Core" Version="2.2.0.100" />
-		<PackageVersion Include="IBM.Data.DB2.Core-lnx" Version="2.2.0.100" />
-		<PackageVersion Include="IBM.Data.DB2.Core-osx" Version="2.0.0.100" />
-		<PackageVersion Include="Microsoft.AspNetCore.OData" Version="7.5.12" />
-
-		<PackageVersion Include="MySqlConnector" Version="0.69.10" />
-		<PackageVersion Include="Npgsql" Version="5.0.10" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp2.1' AND '$(TargetFramework)' != 'net472' ">
-		<PackageVersion Include="Microsoft.AspNetCore.OData" Version="8.0.3" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.1' ">
-		<PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
-	</ItemGroup>
-
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-		<!-- explicitly reference specific version of transient dependency to avoid MSB3277 -->
-		<PackageVersion Include="System.Security.Cryptography.Cng" Version="5.0.0" />
-		<PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
-
 		<!--
-		downgraded temporary to make linq2db work with Azure Function v3:
+		downgrade to make linq2db work with Azure Function v3:
 		https://github.com/linq2db/linq2db/issues/2868
 		https://github.com/Azure/azure-functions-host/issues/6893
 		-->
-		<PackageVersion Include="System.ComponentModel.Annotations" Version="4.7.0" />
-
-		<PackageVersion Include="MySqlConnector" Version="1.3.14" />
-		<PackageVersion Include="Npgsql" Version="5.0.10" />
+		<PackageVersion Include="System.ComponentModel.Annotations"         Version="4.7.0"  />
+	</ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.1' ">
+		<PackageVersion Include="System.ComponentModel.Annotations"         Version="5.0.0"  />
 	</ItemGroup>
 
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-		<PackageVersion Include="MySqlConnector" Version="2.0.0" />
-		<PackageVersion Include="Npgsql" Version="5.0.10" />
+	<!--test targets-->
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+		<!--used only for netfx, but adding it to main group produce conflicts-->
+		<PackageVersion Include="Microsoft.SqlServer.Types"                             Version="14.0.1016.290" />
+		<!--old versions of providers with netfx support-->
+		<PackageVersion Include="Microsoft.Data.Sqlite"                                 Version="1.1.1"         />
+		<PackageVersion Include="Npgsql"                                                Version="4.1.10"        />
 	</ItemGroup>
-
+	<ItemGroup Condition=" '$(TargetFramework)' != 'net472' ">
+		<!--main version-->
+		<PackageVersion Include="Microsoft.Data.Sqlite"                                 Version="5.0.12"        />
+	</ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
+		<!--old versions of providers with netcoreapp2.1 support-->
+		<PackageVersion Include="Oracle.ManagedDataAccess.Core"                         Version="2.19.130"      />
+		<PackageVersion Include="IBM.Data.DB2.Core"                                     Version="2.2.0.100"     />
+		<PackageVersion Include="IBM.Data.DB2.Core-lnx"                                 Version="2.2.0.100"     />
+		<PackageVersion Include="IBM.Data.DB2.Core-osx"                                 Version="2.0.0.100"     />
+		<PackageVersion Include="Npgsql"                                                Version="5.0.11"        />
+		<!--test м0.x compatibility, required for old Pomelo EF.Core provider-->
+		<PackageVersion Include="MySqlConnector"                                        Version="0.69.10"       />
+		<!--legacy odata library for netcoreapp2.1-->
+		<PackageVersion Include="Microsoft.AspNetCore.OData"                            Version="7.5.12"        />
+	</ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp2.1' ">
+		<!--main version-->
+		<PackageVersion Include="Oracle.ManagedDataAccess.Core"                         Version="3.21.4"        />
+		<PackageVersion Include="IBM.Data.DB2.Core"                                     Version="3.1.0.500"     />
+		<PackageVersion Include="IBM.Data.DB2.Core-lnx"                                 Version="3.1.0.500"     />
+		<PackageVersion Include="IBM.Data.DB2.Core-osx"                                 Version="3.1.0.500"     />
+		<PackageVersion Include="Microsoft.AspNetCore.OData"                            Version="8.0.3"         />
+	</ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+		<!-- explicitly reference specific version of transient dependency to avoid MSB3277 -->
+		<PackageVersion Include="System.Security.Cryptography.Cng"                      Version="5.0.0"         />
+		<PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0"         />
+		<!--test v1.x compatibility, required for old Pomelo EF.Core provider-->
+		<PackageVersion Include="MySqlConnector"                                        Version="1.3.14"        />
+	</ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp2.1' AND '$(TargetFramework)' != 'netcoreapp3.1' ">
+		<PackageVersion Include="MySqlConnector"                                        Version="2.0.0"         />
+	</ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' != 'net472' AND '$(TargetFramework)' != 'netcoreapp2.1' ">
+		<PackageVersion Include="Npgsql"                                                Version="6.0.0"         />
+	</ItemGroup>
 </Project>

--- a/NuGet/PostgreSQL/LinqToDB.PostgreSQL.Tools.ttinclude
+++ b/NuGet/PostgreSQL/LinqToDB.PostgreSQL.Tools.ttinclude
@@ -3,7 +3,7 @@
 <#@ include  file="LinqToDB.PostgreSQL.ttinclude" once="true" #>
 <#
 
-var toolsPath = GetProviderToolsPath("Npgsql", "Npgsql, Version=4.1.9.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7");
+var toolsPath = GetProviderToolsPath("Npgsql", "Npgsql, Version=4.1.10.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7");
 
 LoadAssembly("System.Threading.Tasks.Extensions", toolsPath);
 LoadAssembly("System.Text.Json"                 , toolsPath);

--- a/NuGet/linq2db.PostgreSQL.nuspec
+++ b/NuGet/linq2db.PostgreSQL.nuspec
@@ -18,15 +18,15 @@
 			</group>
 			<group targetFramework=".NETFramework4.6.1">
 				<dependency id="linq2db" version="3.0.0"  />
-				<dependency id="Npgsql"  version="4.1.9"  />
+				<dependency id="Npgsql"  version="4.1.10" />
 			</group>
 			<group targetFramework=".NETStandard2.0">
 				<dependency id="linq2db" version="3.0.0"  />
-				<dependency id="Npgsql"  version="5.0.10" />
+				<dependency id="Npgsql"  version="6.0.0"  />
 			</group>
 			<group targetFramework=".NETCoreApp2.1">
 				<dependency id="linq2db" version="3.0.0"  />
-				<dependency id="Npgsql"  version="5.0.10" />
+				<dependency id="Npgsql"  version="5.0.11" />
 			</group>
 		</dependencies>
 		<contentFiles>

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
@@ -89,15 +89,15 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			var columns    = ed.Columns.Where(c => !c.SkipOnInsert || options.KeepIdentity == true && c.IsIdentity).ToArray();
 
 			var npgsqlTypes = new NpgsqlProviderAdapter.NpgsqlDbType[columns.Length];
+			var columnTypes = new DbDataType[columns.Length];
 			for (var i = 0; i < columns.Length; i++)
 			{
+				columnTypes[i] = columns[i].GetDbDataType(true);
 				var npgsqlType = _provider.GetNativeType(columns[i].DbType, true);
 				if (npgsqlType == null)
 				{
-					var columnType = columns[i].GetDbDataType(true);
-
 					var sb = new System.Text.StringBuilder();
-					sqlBuilder.BuildTypeName(sb, new SqlQuery.SqlDataType(columnType));
+					sqlBuilder.BuildTypeName(sb, new SqlQuery.SqlDataType(columnTypes[i]));
 					npgsqlType = _provider.GetNativeType(sb.ToString(), true);
 				}
 
@@ -115,7 +115,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 
 			var writer      = _provider.Adapter.BeginBinaryImport(connection, copyCommand);
 
-			return ProviderSpecificCopySyncImpl(dataConnection, options, source, connection, tableName, columns, npgsqlTypes, copyCommand, batchSize, writer);
+			return ProviderSpecificCopySyncImpl(dataConnection, options, source, connection, tableName, columns, columnTypes, npgsqlTypes, copyCommand, batchSize, writer);
 		}
 
 		private BulkCopyRowsCopied ProviderSpecificCopySyncImpl<T>(
@@ -125,6 +125,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			IDbConnection                              connection,
 			string                                     tableName,
 			ColumnDescriptor[]                         columns,
+			DbDataType[]                               columnTypes,
 			NpgsqlProviderAdapter.NpgsqlDbType[]       npgsqlTypes,
 			string                                     copyCommand,
 			int                                        batchSize,
@@ -138,9 +139,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 				{
 					writer.StartRow();
 					for (var i = 0; i < columns.Length; i++)
-					{
-						writer.Write(columns[i].GetValue(item!), npgsqlTypes[i]);
-					}
+						writer.Write(_provider.NormalizeTimeStamp(columns[i].GetValue(item!), columnTypes[i]), npgsqlTypes[i]);
 
 					currentCount++;
 					rowsCopied.RowsCopied++;
@@ -210,10 +209,11 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			if (connection == null)
 				return await MultipleRowsCopyAsync(table, options, source, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			var sqlBuilder = (BasicSqlBuilder)_provider.CreateSqlBuilder(table.DataContext.MappingSchema);
-			var ed         = table.DataContext.MappingSchema.GetEntityDescriptor(typeof(T));
-			var tableName  = GetTableName(sqlBuilder, options, table);
-			var columns    = ed.Columns.Where(c => !c.SkipOnInsert || options.KeepIdentity == true && c.IsIdentity).ToArray();
+			var sqlBuilder  = (BasicSqlBuilder)_provider.CreateSqlBuilder(table.DataContext.MappingSchema);
+			var ed          = table.DataContext.MappingSchema.GetEntityDescriptor(typeof(T));
+			var tableName   = GetTableName(sqlBuilder, options, table);
+			var columns     = ed.Columns.Where(c => !c.SkipOnInsert || options.KeepIdentity == true && c.IsIdentity).ToArray();
+			var columnTypes = new DbDataType[columns.Length];
 
 			var fields      = string.Join(", ", columns.Select(column => sqlBuilder.ConvertInline(column.ColumnName, ConvertType.NameToQueryField)));
 			var copyCommand = $"COPY {tableName} ({fields}) FROM STDIN (FORMAT BINARY)";
@@ -224,16 +224,12 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			var npgsqlTypes = new NpgsqlProviderAdapter.NpgsqlDbType[columns.Length];
 			for (var i = 0; i < columns.Length; i++)
 			{
+				columnTypes[i] = columns[i].GetDbDataType(true);
 				var npgsqlType = _provider.GetNativeType(columns[i].DbType, true);
 				if (npgsqlType == null)
 				{
-					var columnType = columns[i].DataType != DataType.Undefined ? new SqlQuery.SqlDataType(columns[i]) : null;
-
-					if (columnType == null || columnType.Type.DataType == DataType.Undefined)
-						columnType = columns[i].MappingSchema.GetDataType(columns[i].StorageType);
-
 					var sb = new System.Text.StringBuilder();
-					sqlBuilder.BuildTypeName(sb, columnType);
+					sqlBuilder.BuildTypeName(sb, new SqlQuery.SqlDataType(columnTypes[i]));
 					npgsqlType = _provider.GetNativeType(sb.ToString(), true);
 				}
 
@@ -248,7 +244,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			if (!writer.SupportsAsync)
 			{
 				// seems to be missing one of the required async methods; fallback to sync importer
-				return ProviderSpecificCopySyncImpl(dataConnection, options, source, connection, tableName, columns, npgsqlTypes, copyCommand, batchSize, writer);
+				return ProviderSpecificCopySyncImpl(dataConnection, options, source, connection, tableName, columns, columnTypes, npgsqlTypes, copyCommand, batchSize, writer);
 			}
 
 			var rowsCopied = new BulkCopyRowsCopied();
@@ -261,7 +257,10 @@ namespace LinqToDB.DataProvider.PostgreSQL
 					await writer.StartRowAsync(cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 					for (var i = 0; i < columns.Length; i++)
 					{
-						await writer.WriteAsync(columns[i].GetValue(item!), npgsqlTypes[i], cancellationToken)
+						await writer.WriteAsync(
+								_provider.NormalizeTimeStamp(columns[i].GetValue(item!), columnTypes[i]),
+								npgsqlTypes[i],
+								cancellationToken)
 							.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 					}
 
@@ -324,11 +323,11 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			if (connection == null)
 				return await MultipleRowsCopyAsync(table, options, source, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			var sqlBuilder = (BasicSqlBuilder)_provider.CreateSqlBuilder(table.DataContext.MappingSchema);
-			var ed         = table.DataContext.MappingSchema.GetEntityDescriptor(typeof(T));
-			var tableName  = GetTableName(sqlBuilder, options, table);
-			var columns    = ed.Columns.Where(c => !c.SkipOnInsert || options.KeepIdentity == true && c.IsIdentity).ToArray();
-
+			var sqlBuilder  = (BasicSqlBuilder)_provider.CreateSqlBuilder(table.DataContext.MappingSchema);
+			var ed          = table.DataContext.MappingSchema.GetEntityDescriptor(typeof(T));
+			var tableName   = GetTableName(sqlBuilder, options, table);
+			var columns     = ed.Columns.Where(c => !c.SkipOnInsert || options.KeepIdentity == true && c.IsIdentity).ToArray();
+			var columnTypes = new DbDataType[columns.Length];
 			var fields      = string.Join(", ", columns.Select(column => sqlBuilder.ConvertInline(column.ColumnName, ConvertType.NameToQueryField)));
 			var copyCommand = $"COPY {tableName} ({fields}) FROM STDIN (FORMAT BINARY)";
 
@@ -338,16 +337,12 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			var npgsqlTypes = new NpgsqlProviderAdapter.NpgsqlDbType[columns.Length];
 			for (var i = 0; i < columns.Length; i++)
 			{
+				columnTypes[i] = columns[i].GetDbDataType(true);
 				var npgsqlType = _provider.GetNativeType(columns[i].DbType, true);
 				if (npgsqlType == null)
 				{
-					var columnType = columns[i].DataType != DataType.Undefined ? new SqlQuery.SqlDataType(columns[i]) : null;
-
-					if (columnType == null || columnType.Type.DataType == DataType.Undefined)
-						columnType = columns[i].MappingSchema.GetDataType(columns[i].StorageType);
-
 					var sb = new System.Text.StringBuilder();
-					sqlBuilder.BuildTypeName(sb, columnType);
+					sqlBuilder.BuildTypeName(sb, new SqlQuery.SqlDataType(columnTypes[i]));
 					npgsqlType = _provider.GetNativeType(sb.ToString(), true);
 				}
 
@@ -365,7 +360,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 				var enumerator = source.GetAsyncEnumerator(cancellationToken);
 				await using (enumerator.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
 				{
-					return ProviderSpecificCopySyncImpl(dataConnection, options, EnumerableHelper.AsyncToSyncEnumerable(enumerator), connection, tableName, columns, npgsqlTypes, copyCommand, batchSize, writer);
+					return ProviderSpecificCopySyncImpl(dataConnection, options, EnumerableHelper.AsyncToSyncEnumerable(enumerator), connection, tableName, columns, columnTypes, npgsqlTypes, copyCommand, batchSize, writer);
 				}
 			}
 
@@ -379,7 +374,10 @@ namespace LinqToDB.DataProvider.PostgreSQL
 					await writer.StartRowAsync(cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 					for (var i = 0; i < columns.Length; i++)
 					{
-						await writer.WriteAsync(columns[i].GetValue(item!), npgsqlTypes[i], cancellationToken)
+						await writer.WriteAsync(
+								_provider.NormalizeTimeStamp(columns[i].GetValue(item!), columnTypes[i]),
+								npgsqlTypes[i],
+								cancellationToken)
 							.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 					}
 

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLTools.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLTools.cs
@@ -7,6 +7,7 @@ using JetBrains.Annotations;
 
 namespace LinqToDB.DataProvider.PostgreSQL
 {
+	using System.Runtime.CompilerServices;
 	using Configuration;
 	using Data;
 
@@ -40,7 +41,21 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			return provider;
 		}, true);
 
-		public static bool AutoDetectProvider { get; set; } = true;
+		public static bool AutoDetectProvider     { get; set; } = true;
+
+		/// <summary>
+		/// Enables normalization of <see cref="DateTime"/> and <see cref="DateTimeOffset"/> data, passed to query
+		/// as parameter or passed to <see cref="DataConnectionExtensions.BulkCopy{T}(ITable{T}, IEnumerable{T})"/> APIs,
+		/// to comform with Npgsql 6 requerements:
+		/// <list type="bullet">
+		/// <item>convert <see cref="DateTimeOffset"/> value to UTC value with zero <see cref="DateTimeOffset.Offset"/></item>
+		/// <item>Use <see cref="DateTimeKind.Utc"/> for <see cref="DateTime"/> timestamptz values</item>
+		/// <item>Use <see cref="DateTimeKind.Unspecified"/> for <see cref="DateTime"/> timestamp values with <see cref="DateTimeKind.Utc"/> kind</item>
+		/// </list>
+		/// - 
+		/// Default value: <c>true</c>.
+		/// </summary>
+		public static bool NormalizeTimestampData { get; set; } = true;
 
 		internal static IDataProvider? ProviderDetector(IConnectionStringSettings css, string connectionString)
 		{

--- a/Tests/Linq/Data/MiniProfilerTests.cs
+++ b/Tests/Linq/Data/MiniProfilerTests.cs
@@ -1458,7 +1458,9 @@ namespace Tests.Data
 
 				// provider-specific type classes and readers
 				var dateValue = new DateTime(1234, 11, 22);
+#pragma warning disable CS0618 // Type or member is obsolete
 				var ndateValue = db.Execute<NpgsqlTypes.NpgsqlDate>("SELECT @p", new DataParameter("@p", dateValue, DataType.Date));
+#pragma warning restore CS0618 // Type or member is obsolete
 				Assert.AreEqual(dateValue, (DateTime)ndateValue);
 				var rawValue = db.Execute<object>("SELECT @p", new DataParameter("@p", dateValue, DataType.Date));
 				Assert.True    (rawValue is DateTime);

--- a/Tests/Linq/DataProvider/PostgreSQLTests.cs
+++ b/Tests/Linq/DataProvider/PostgreSQLTests.cs
@@ -138,7 +138,9 @@ namespace Tests.DataProvider
 
 						new TypeTestData("timestampDataType",   (n,t,c) => t.TestTypeEx<DateTime?>         (c, n, DataType.DateTime2),      new DateTime(2012, 12, 12, 12, 12, 12)),
 						new TypeTestData("timestampTZDataType", (n,t,c) => t.TestTypeEx<DateTimeOffset?>   (c, n, DataType.DateTimeOffset), new DateTimeOffset(2012, 12, 12, 11, 12, 12, new TimeSpan(-5, 0, 0))),
+#pragma warning disable CS0618 // Type or member is obsolete
 						new TypeTestData("dateDataType",    0,  (n,t,c) => t.TestTypeEx<NpgsqlDate?>       (c, n, skipDefaultNull:true),    new NpgsqlDate(2012, 12, 12)),
+#pragma warning restore CS0618 // Type or member is obsolete
 						new TypeTestData("dateDataType",    1,  (n,t,c) => t.TestTypeEx<DateTime?>         (c, n, DataType.Date),           new DateTime(2012, 12, 12)),
 
 						new TypeTestData("charDataType",    0,  (n,t,c) => t.TestTypeEx<char?>             (c, n, DataType.Char),                           '1'),
@@ -826,10 +828,16 @@ namespace Tests.DataProvider
 		{
 			PostgreSQLTools.GetDataProvider().CreateConnection(DataConnection.GetConnectionString(context));
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var d = new NpgsqlDateTime(TestData.Date);
+#pragma warning restore CS0618 // Type or member is obsolete
 			var o = new DateTimeOffset(TestData.Date);
+#pragma warning disable CS0618 // Type or member is obsolete
 			var c1 = PostgreSQLTools.GetDataProvider().MappingSchema.GetConvertExpression<NpgsqlDateTime, DateTimeOffset>();
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			var c2 = PostgreSQLTools.GetDataProvider().MappingSchema.GetConvertExpression<NpgsqlDateTime, DateTimeOffset?>();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			Assert.IsNotNull(c1);
 			Assert.IsNotNull(c2);
@@ -851,12 +859,18 @@ namespace Tests.DataProvider
 			[Column]                                   public double?  doubleDataType                   { get; set; }
 			[Column]                                   public float?   realDataType                     { get; set; }
 			// time/date/intertval
+#pragma warning disable CS0618 // Type or member is obsolete
 			[Column]                                   public NpgsqlDateTime? timestampDataType         { get; set; }
+#pragma warning restore CS0618 // Type or member is obsolete
 			[Column]                                   public DateTimeOffset? timestampTZDataType       { get; set; }
+#pragma warning disable CS0618 // Type or member is obsolete
 			[Column]                                   public NpgsqlDate?     dateDataType              { get; set; }
+#pragma warning restore CS0618 // Type or member is obsolete
 			[Column(DbType = "time")]                  public TimeSpan?       timeDataType              { get; set; }
 			[Column  (DbType = "time with time zone")] public DateTimeOffset? timeTZDataType            { get; set; }
+#pragma warning disable CS0618 // Type or member is obsolete
 			[Column]                                   public NpgsqlTimeSpan? intervalDataType          { get; set; }
+#pragma warning restore CS0618 // Type or member is obsolete
 			[Column(DataType = DataType.Interval)]     public TimeSpan?       intervalDataType2         { get; set; }
 			// text
 			[Column]                                   public char?   charDataType                      { get; set; }
@@ -937,9 +951,13 @@ namespace Tests.DataProvider
 					doubleDataType      = double.MaxValue,
 					realDataType        = float.MaxValue,
 
+#pragma warning disable CS0618 // Type or member is obsolete
 					timestampDataType   = new NpgsqlDateTime(2010, 5, 30, 1, 2, 3, 4),
+#pragma warning restore CS0618 // Type or member is obsolete
 					timestampTZDataType = new DateTimeOffset(2011, 3, 22, 10, 11, 12, 13, TimeSpan.FromMinutes(30)),
+#pragma warning disable CS0618 // Type or member is obsolete
 					dateDataType        = new NpgsqlDate(2010, 5, 30),
+#pragma warning restore CS0618 // Type or member is obsolete
 					timeDataType        = new TimeSpan(0, 1, 2, 3, 4),
 					// npgsql4 uses 2/1/1 instead of 1/1/1 as date part in npgsql3
 					timeTZDataType      = new DateTimeOffset(1, 1, 2, 10, 11, 12, 13, TimeSpan.FromMinutes(30)),
@@ -1087,9 +1105,13 @@ namespace Tests.DataProvider
 					doubleDataType      = double.MaxValue,
 					realDataType        = float.MaxValue,
 
+#pragma warning disable CS0618 // Type or member is obsolete
 					timestampDataType   = new NpgsqlDateTime(2010, 5, 30, 1, 2, 3, 4),
+#pragma warning restore CS0618 // Type or member is obsolete
 					timestampTZDataType = new DateTimeOffset(2011, 3, 22, 10, 11, 12, 13, TimeSpan.FromMinutes(30)),
+#pragma warning disable CS0618 // Type or member is obsolete
 					dateDataType        = new NpgsqlDate(2010, 5, 30),
+#pragma warning restore CS0618 // Type or member is obsolete
 					timeDataType        = new TimeSpan(0, 1, 2, 3, 4),
 					// npgsql4 uses 2/1/1 instead of 1/1/1 as date part in npgsql3
 					timeTZDataType      = new DateTimeOffset(1, 1, 2, 10, 11, 12, 13, TimeSpan.FromMinutes(30)),
@@ -1471,12 +1493,13 @@ namespace Tests.DataProvider
 
 		private static MappingSchema CreateRangesMapping()
 		{
-			NpgsqlRange<DateTime> ConvertToNpgSqlRange(SomeRange<DateTime> r)
+			NpgsqlRange<DateTime> ConvertToNpgSqlRange(SomeRange<DateTime> r, bool withTimeZone)
 			{
+				// specify proper kind for npgsql 6
 				var range = NpgsqlRange<DateTime>.Empty;
 					range = new NpgsqlRange<DateTime>(
-						r.Start ?? default, true,  r.Start == null,
-						r.End   ?? default, false, r.End == null);
+						DateTime.SpecifyKind(r.Start ?? default, withTimeZone ? DateTimeKind.Utc : DateTimeKind.Unspecified), true,  r.Start == null,
+						DateTime.SpecifyKind(r.End   ?? default, withTimeZone ? DateTimeKind.Utc : DateTimeKind.Unspecified), false, r.End == null);
 
 				return range;
 			}
@@ -1500,13 +1523,13 @@ namespace Tests.DataProvider
 
 			mapping.SetConverter<SomeRange<DateTime>, DataParameter>(r =>
 			{
-				var range = ConvertToNpgSqlRange(r);
+				var range = ConvertToNpgSqlRange(r, true);
 				return new DataParameter("", range, "tstzrange");
 			}, new DbDataType(typeof(SomeRange<DateTime>)), new DbDataType(typeof(DataParameter), "tstzrange"));
 
 			mapping.SetConverter<SomeRange<DateTime>, DataParameter>(r =>
 			{
-				var range = ConvertToNpgSqlRange(r);
+				var range = ConvertToNpgSqlRange(r, false);
 				return new DataParameter("", range, "tsrange");
 			}, new DbDataType(typeof(SomeRange<DateTime>)), new DbDataType(typeof(DataParameter), "tsrange"));
 
@@ -1907,7 +1930,7 @@ namespace Tests.DataProvider
 				var range1 = new NpgsqlRange<DateTime>(new DateTime(2000, 2, 3), true, new DateTime(2000, 3, 3), true);
 				var range2 = new NpgsqlRange<DateTime>(new DateTime(2000, 2, 3), false, new DateTime(2000, 3, 3), false);
 				var range3 = new NpgsqlRange<DateTime>(new DateTime(2000, 2, 3, 4, 5, 6), new DateTime(2000, 4, 3, 4, 5, 6));
-				var range4 = new NpgsqlRange<DateTime>(new DateTime(2000, 4, 3, 4, 5, 6, DateTimeKind.Local), new DateTime(2000, 5, 3, 4, 5, 6, DateTimeKind.Local));
+				var range4 = new NpgsqlRange<DateTime>(new DateTime(2000, 4, 3, 4, 5, 6, DateTimeKind.Utc), new DateTime(2000, 5, 3, 4, 5, 6, DateTimeKind.Utc));
 				db.Insert(new NpgsqlTableWithDateRanges
 				{
 					DateRangeInclusive = range1,
@@ -1921,7 +1944,15 @@ namespace Tests.DataProvider
 				Assert.AreEqual(new NpgsqlRange<DateTime>(new DateTime(2000, 2, 3), true, new DateTime(2000, 3, 4), false), record.DateRangeInclusive);
 				Assert.AreEqual(new NpgsqlRange<DateTime>(new DateTime(2000, 2, 4), true, new DateTime(2000, 3, 3), false), record.DateRangeExclusive);
 				Assert.AreEqual(range3, record.TSRange);
+
+#if NETCOREAPP3_1 || NET5_0
+				// npgsql 6+
 				Assert.AreEqual(range4, record.TSTZRange);
+#else
+				// pre-v6 returned data with Local kind
+				range4 = new NpgsqlRange<DateTime>(range4.LowerBound.ToLocalTime(), range4.UpperBound.ToLocalTime());
+				Assert.AreEqual(range4, record.TSTZRange);
+#endif
 			}
 		}
 
@@ -1941,9 +1972,7 @@ namespace Tests.DataProvider
 							DateRangeInclusive = new NpgsqlRange<DateTime>(new DateTime(2000, 2, 3), true, new DateTime(2000, 3, 3), true),
 							DateRangeExclusive = new NpgsqlRange<DateTime>(new DateTime(2000, 2, 3), false, new DateTime(2000, 3, 3), false),
 							TSRange            = new NpgsqlRange<DateTime>(new DateTime(2000 + i, 2, 3, 4, 5, 6), true, new DateTime(2000 + i, 4, 3, 4, 5, 6), true),
-							// DateTimeKind.Local used, because npgsql will return values with DateTimeKind.Local kind
-							// passing DateTimeKind.Utc values will require offset calculations in assert, as DateTime.Equals ignore kind in comparison
-							TSTZRange          = new NpgsqlRange<DateTime>(new DateTime(2000 + i, 4, 3, 4, 5, 6, DateTimeKind.Local), true, new DateTime(2000 + i, 5, 3, 4, 5, 6, DateTimeKind.Local), true),
+							TSTZRange          = new NpgsqlRange<DateTime>(new DateTime(2000 + i, 4, 3, 4, 5, 6, DateTimeKind.Utc), true, new DateTime(2000 + i, 5, 3, 4, 5, 6, DateTimeKind.Utc), true),
 						};
 					})
 					.ToArray();
@@ -1953,6 +1982,12 @@ namespace Tests.DataProvider
 				var records = table.OrderBy(_ => _.Id).ToArray();
 
 				Assert.AreEqual(100, records.Length);
+
+#if !NETCOREAPP3_1 && !NET5_0
+				// pre-v6 returned data with Local kind
+				foreach (var item in items)
+					item.TSTZRange = new NpgsqlRange<DateTime>(item.TSTZRange.LowerBound.ToLocalTime(), true, item.TSTZRange.UpperBound.ToLocalTime(), true);
+#endif
 
 				AreEqual(
 					items.Select(t => new
@@ -1987,9 +2022,7 @@ namespace Tests.DataProvider
 							DateRangeInclusive = new NpgsqlRange<DateTime>(new DateTime(2000, 2, 3), true, new DateTime(2000, 3, 3), true),
 							DateRangeExclusive = new NpgsqlRange<DateTime>(new DateTime(2000, 2, 3), false, new DateTime(2000, 3, 3), false),
 							TSRange            = new NpgsqlRange<DateTime>(new DateTime(2000 + i, 2, 3, 4, 5, 6), true, new DateTime(2000 + i, 4, 3, 4, 5, 6), true),
-							// DateTimeKind.Local used, because npgsql will return values with DateTimeKind.Local kind
-							// passing DateTimeKind.Utc values will require offset calculations in assert, as DateTime.Equals ignore kind in comparison
-							TSTZRange          = new NpgsqlRange<DateTime>(new DateTime(2000 + i, 4, 3, 4, 5, 6, DateTimeKind.Local), true, new DateTime(2000 + i, 5, 3, 4, 5, 6, DateTimeKind.Local), true),
+							TSTZRange          = new NpgsqlRange<DateTime>(new DateTime(2000 + i, 4, 3, 4, 5, 6, DateTimeKind.Utc), true, new DateTime(2000 + i, 5, 3, 4, 5, 6, DateTimeKind.Utc), true),
 						};
 					})
 					.ToArray();
@@ -1999,6 +2032,12 @@ namespace Tests.DataProvider
 				var records = await table.OrderBy(_ => _.Id).ToArrayAsync();
 
 				Assert.AreEqual(100, records.Length);
+
+#if !NETCOREAPP3_1 && !NET5_0
+				// pre-v6 returned data with Local kind
+				foreach (var item in items)
+					item.TSTZRange = new NpgsqlRange<DateTime>(item.TSTZRange.LowerBound.ToLocalTime(), true, item.TSTZRange.UpperBound.ToLocalTime(), true);
+#endif
 
 				AreEqual(
 					items.Select(t => new
@@ -2131,7 +2170,9 @@ namespace Tests.DataProvider
 		{
 			[Column, PrimaryKey, Identity]         public int             ID                { get; set; }
 			[Column]                               public TimeSpan?       timeDataType      { get; set; }
+#pragma warning disable CS0618 // Type or member is obsolete
 			[Column]                               public NpgsqlTimeSpan? intervalDataType  { get; set; }
+#pragma warning restore CS0618 // Type or member is obsolete
 			[Column(DataType = DataType.Interval)] public TimeSpan?       intervalDataType2 { get; set; }
 		}
 
@@ -2173,7 +2214,9 @@ namespace Tests.DataProvider
 		public class DateProviderSpecific
 		{
 			[Column, PrimaryKey, Identity] public int         ID { get; set; }
+#pragma warning disable CS0618 // Type or member is obsolete
 			[Column]                       public NpgsqlDate? dateDataType { get; set; }
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		[Table("AllTypes")]
@@ -2195,7 +2238,9 @@ namespace Tests.DataProvider
 					var date2 = TestData.Date.AddDays(5);
 					db.GetTable<DateProviderSpecific>().Insert(() => new DateProviderSpecific()
 					{
+#pragma warning disable CS0618 // Type or member is obsolete
 						dateDataType = (NpgsqlDate)date1
+#pragma warning restore CS0618 // Type or member is obsolete
 					});
 
 					db.GetTable<DateCommon>().Insert(() => new DateCommon()

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -655,7 +655,7 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 				AreEqual(
 					from t in    Types select           Sql.DateAdd(Sql.DateParts.Hour, 1, t.DateTimeValue)!. Value.Hour,
-					from t in db.Types select Sql.AsSql(Sql.DateAdd(Sql.DateParts.Hour, 1, t.DateTimeValue))!.Value.Hour);
+					from t in db.Types select Sql.AsSql(Sql.DateAdd(Sql.DateParts.Hour, 1, t.DateTimeValue)!.Value.Hour));
 		}
 
 		[Test]
@@ -719,7 +719,7 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 				AreEqual(
 					from t in    Types select           t.DateTimeValue.AddHours(22). Hour,
-					from t in db.Types select Sql.AsSql(t.DateTimeValue.AddHours(22)).Hour);
+					from t in db.Types select Sql.AsSql(t.DateTimeValue.AddHours(22).Hour));
 		}
 
 		[Test]
@@ -963,7 +963,7 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 				AreEqual(
 					from t in Types select Sql.DateAdd(Sql.DateParts.Hour, 1, t.DateTimeValue)!.Value.Hour,
-					from t in db.Types select Sql.AsSql(Sql.DateAdd(Sql.DateParts.Hour, part2 - part1, t.DateTimeValue))!.Value.Hour);
+					from t in db.Types select Sql.AsSql(Sql.DateAdd(Sql.DateParts.Hour, part2 - part1, t.DateTimeValue)!.Value.Hour));
 		}
 
 		[Test]
@@ -1048,7 +1048,7 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 				AreEqual(
 					from t in Types select t.DateTimeValue.AddHours(22).Hour,
-					from t in db.Types select Sql.AsSql(t.DateTimeValue.AddHours(part1 + part2)).Hour);
+					from t in db.Types select Sql.AsSql(t.DateTimeValue.AddHours(part1 + part2).Hour));
 		}
 
 		[Test]

--- a/Tests/Linq/Linq/DateTimeOffsetTests.cs
+++ b/Tests/Linq/Linq/DateTimeOffsetTests.cs
@@ -62,7 +62,7 @@ namespace Tests.Linq
 
 			/* Currently, only SQL Server properly handles DateTimeOffset with full fidelity in both directions.
 			 * Other Server behaviors:
-			 *  - PostgreSQL: 
+			 *  - PostgreSQL:
 			 *     - Translates to UTC before transmitting to server. Original TZ lost in translation.
 			 *     - Does not keep precision to the Tick level, only to the 100ns level.
 			 */
@@ -568,7 +568,7 @@ namespace Tests.Linq
 			using (db.CreateLocalTable(Transaction.GetDbDataForContext(context)))
 				AreEqual(
 					from t in Transaction.GetTestDataForContext(context) select           Sql.DateAdd(Sql.DateParts.Hour, 1, t.TransactionDate)!. Value.Hour,
-					from t in db.GetTable<Transaction>()                 select Sql.AsSql(Sql.DateAdd(Sql.DateParts.Hour, 1, t.TransactionDate))!.Value.Hour);
+					from t in db.GetTable<Transaction>()                 select Sql.AsSql(Sql.DateAdd(Sql.DateParts.Hour, 1, t.TransactionDate)!.Value.Hour));
 		}
 
 		[Test]
@@ -628,7 +628,7 @@ namespace Tests.Linq
 			using (db.CreateLocalTable(Transaction.GetDbDataForContext(context)))
 				AreEqual(
 					from t in Transaction.GetTestDataForContext(context) select           t.TransactionDate.AddHours(22). Hour,
-					from t in db.GetTable<Transaction>()                 select Sql.AsSql(t.TransactionDate.AddHours(22)).Hour);
+					from t in db.GetTable<Transaction>()                 select Sql.AsSql(t.TransactionDate.AddHours(22).Hour));
 		}
 
 		[Test]
@@ -756,7 +756,7 @@ namespace Tests.Linq
 			using (db.CreateLocalTable(Transaction.GetDbDataForContext(context)))
 				AreEqual(
 					from t in Transaction.GetTestDataForContext(context) select           Sql.DateAdd(Sql.DateParts.Hour, 1, t.TransactionDate)!.             Value.Hour,
-					from t in db.GetTable<Transaction>()                 select Sql.AsSql(Sql.DateAdd(Sql.DateParts.Hour, part2 - part1, t.TransactionDate))!.Value.Hour);
+					from t in db.GetTable<Transaction>()                 select Sql.AsSql(Sql.DateAdd(Sql.DateParts.Hour, part2 - part1, t.TransactionDate)!.Value.Hour));
 		}
 
 		[Test]
@@ -834,7 +834,7 @@ namespace Tests.Linq
 			using (db.CreateLocalTable(Transaction.GetDbDataForContext(context)))
 				AreEqual(
 					from t in Transaction.GetTestDataForContext(context) select           t.TransactionDate.AddHours(22)            .Hour,
-					from t in db.GetTable<Transaction>()                 select Sql.AsSql(t.TransactionDate.AddHours(part1 + part2)).Hour);
+					from t in db.GetTable<Transaction>()                 select Sql.AsSql(t.TransactionDate.AddHours(part1 + part2).Hour));
 		}
 
 		[Test]


### PR DESCRIPTION
- Update [Npgsql](https://www.nuget.org/packages/Npgsql): 4.1.9 -> 4.1.10, 5.0.10 -> 5.0.11+6.0.0
- Npgsql 6.0.0 support changes:
  - Explicitly set parameter type for `DataType.DateTime` and `DataType.DateTime2` (used by default for `DateTime`) to `timestamp` to prevent `Npgsql` from treating it as `timestamptz`, when it is not, and fail
  - automatically `Offset`/`Kind` for `DateTime`/`DateTimeOffset` values , used to pass `timestamp`/`timestamptz` values, to simplify migration to `npgsql` 6 for users. If user wants to fix his data himself and receive errrors when he pass invalid data, he can disable those fixes using `PostgreSQLTools.NormalizeTimestampData = false;` setting
    - Reset offset to zero for `DateTimeOffset` values, passed to native `BulkCopy` or as query parameter to prevent `Nnpgsql` complains about non-zero offset
    - Update `Kind` for `DateTime` parameters of `timestamp` type from `UTC` to `Unspecified` to prevent `Nnpgsql` complains about it
    - Update `Kind` for `DateTime` parameters of `timestamptz` type from non-`UTC` to `UTC` to prevent `Nnpgsql` complains about it
    - for other .net types, used to pass `timestamp`/`timestamptz` values (e.g. `NpgsqlRange<T>`), user will need to fix their data manually to comply with `npgsql` 6 requrements
- updated `PostgreSQL` range tests to use `DateTime` values with proper `Kind`
- converted "add/get Hour(s)" tests for `DateTime` and `DateTimeOffset` to evaluate completely on server side to avoid inconsistent results due to UTC <-> local conversions


Remaining tasks:
- support new npgsql 6 APIs
- try to update to M.D.Sqlite 6 once more