### PR TITLE
`Contains` as IN support improvements

### DIFF
--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -1458,7 +1458,7 @@ namespace LinqToDB.Linq.Builder
 					{
 						if (e.Method.DeclaringType == typeof(Enumerable) ||
 							typeof(IList).IsSameOrParentOf(e.Method.DeclaringType!) ||
-							typeof(ICollection<>).IsSameOrParentOf(e.Method.DeclaringType!)) ||
+							typeof(ICollection<>).IsSameOrParentOf(e.Method.DeclaringType!) ||
 							typeof(IReadOnlyCollection<>).IsSameOrParentOf(e.Method.DeclaringType!))
 						{
 							predicate = ConvertInPredicate(context!, e);

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -1458,7 +1458,8 @@ namespace LinqToDB.Linq.Builder
 					{
 						if (e.Method.DeclaringType == typeof(Enumerable) ||
 							typeof(IList).IsSameOrParentOf(e.Method.DeclaringType!) ||
-							typeof(ICollection<>).IsSameOrParentOf(e.Method.DeclaringType!))
+							typeof(ICollection<>).IsSameOrParentOf(e.Method.DeclaringType!)) ||
+							typeof(IReadOnlyCollection<>).IsSameOrParentOf(e.Method.DeclaringType!))
 						{
 							predicate = ConvertInPredicate(context!, e);
 						}

--- a/Tests/Linq/Linq/FunctionTests.cs
+++ b/Tests/Linq/Linq/FunctionTests.cs
@@ -190,6 +190,19 @@ namespace Tests.Linq
 					from p in db.Parent where arr.Contains(p.ParentID) select p);
 		}
 
+#if NET5_0_OR_GREATER
+		[Test]
+		public void ContainsReadOnlySet([DataSources] string context)
+		{
+			IReadOnlySet<int> arr = new HashSet<int> { 1, 2 };
+
+			using (var db = GetDataContext(context))
+				AreEqual(
+					from p in    Parent where arr.Contains(p.ParentID) select p,
+					from p in db.Parent where arr.Contains(p.ParentID) select p);
+		}
+#endif
+
 		[Test]
 		public void EmptyContains1([DataSources] string context)
 		{


### PR DESCRIPTION
Fix #3375

Translate `Contains` calls over `IReadOnlyCollection<T>` instances (e.g. `IReadOnlySet<T>.Contains`)