### PR TITLE
Fix #3423 LEAD and LAG default parameter type

### DIFF
--- a/Source/LinqToDB/Sql/Sql.Analytic.cs
+++ b/Source/LinqToDB/Sql/Sql.Analytic.cs
@@ -720,8 +720,26 @@ namespace LinqToDB
 			throw new LinqException($"'{nameof(Lag)}' is server-side method.");
 		}
 
+		[Sql.Extension("LAG({expr})", TokenName = FunctionToken, ChainPrecedence = 1, IsWindowFunction = true)]
+		public static IAnalyticFunctionWithoutWindow<T> Lag<T>(this Sql.ISqlExtension? ext, [ExprParameter] T expr)
+		{
+			throw new LinqException($"'{nameof(Lag)}' is server-side method.");
+		}
+
+		[Sql.Extension("LAG({expr}, {offset})", TokenName = FunctionToken, ChainPrecedence = 1, IsWindowFunction = true)]
+		public static IAnalyticFunctionWithoutWindow<T> Lag<T>(this Sql.ISqlExtension? ext, [ExprParameter] T expr, [ExprParameter] int offset)
+		{
+			throw new LinqException($"'{nameof(Lag)}' is server-side method.");
+		}
+
+		[Sql.Extension("LAG({expr}, {offset}, {default})", TokenName = FunctionToken, ChainPrecedence = 1, IsWindowFunction = true)]
+		public static IAnalyticFunctionWithoutWindow<T> Lag<T>(this Sql.ISqlExtension? ext, [ExprParameter] T expr, [ExprParameter] int offset, [ExprParameter] T @default)
+		{
+			throw new LinqException($"'{nameof(Lag)}' is server-side method.");
+		}		
+
 		[Sql.Extension("LAG({expr}{_}{modifier?}, {offset}, {default})", TokenName = FunctionToken, BuilderType = typeof(ApplyNullsModifier), ChainPrecedence = 1, IsWindowFunction = true)]
-		public static IAnalyticFunctionWithoutWindow<T> Lag<T>(this Sql.ISqlExtension? ext, [ExprParameter] T expr, [SqlQueryDependent] Sql.Nulls nulls, [ExprParameter] int offset, [ExprParameter] int? @default)
+		public static IAnalyticFunctionWithoutWindow<T> Lag<T>(this Sql.ISqlExtension? ext, [ExprParameter] T expr, [SqlQueryDependent] Sql.Nulls nulls, [ExprParameter] int offset, [ExprParameter] T @default)
 		{
 			throw new LinqException($"'{nameof(Lag)}' is server-side method.");
 		}
@@ -738,8 +756,26 @@ namespace LinqToDB
 			throw new LinqException($"'{nameof(Lead)}' is server-side method.");
 		}
 
+		[Sql.Extension("LEAD({expr})", TokenName = FunctionToken, ChainPrecedence = 1, IsWindowFunction = true)]
+		public static IAnalyticFunctionWithoutWindow<T> Lead<T>(this Sql.ISqlExtension? ext, [ExprParameter] T expr)
+		{
+			throw new LinqException($"'{nameof(Lead)}' is server-side method.");
+		}
+
+		[Sql.Extension("LEAD({expr}, {offset})", TokenName = FunctionToken, ChainPrecedence = 1, IsWindowFunction = true)]
+		public static IAnalyticFunctionWithoutWindow<T> Lead<T>(this Sql.ISqlExtension? ext, [ExprParameter] T expr, [ExprParameter] int offset)
+		{
+			throw new LinqException($"'{nameof(Lead)}' is server-side method.");
+		}
+
+		[Sql.Extension("LEAD({expr}, {offset}, {default})", TokenName = FunctionToken, ChainPrecedence = 1, IsWindowFunction = true)]
+		public static IAnalyticFunctionWithoutWindow<T> Lead<T>(this Sql.ISqlExtension? ext, [ExprParameter] T expr, [ExprParameter] int offset, [ExprParameter] T @default)
+		{
+			throw new LinqException($"'{nameof(Lead)}' is server-side method.");
+		}
+
 		[Sql.Extension("LEAD({expr}{_}{modifier?}, {offset}, {default})", TokenName = FunctionToken, BuilderType = typeof(ApplyNullsModifier), ChainPrecedence = 1, IsWindowFunction = true)]
-		public static IAnalyticFunctionWithoutWindow<T> Lead<T>(this Sql.ISqlExtension? ext, [ExprParameter] T expr, [SqlQueryDependent] Sql.Nulls nulls, [ExprParameter] int offset, [ExprParameter] int? @default)
+		public static IAnalyticFunctionWithoutWindow<T> Lead<T>(this Sql.ISqlExtension? ext, [ExprParameter] T expr, [SqlQueryDependent] Sql.Nulls nulls, [ExprParameter] int offset, [ExprParameter] T @default)
 		{
 			throw new LinqException($"'{nameof(Lead)}' is server-side method.");
 		}

--- a/Tests/Linq/Linq/AnalyticTests.cs
+++ b/Tests/Linq/Linq/AnalyticTests.cs
@@ -1710,8 +1710,8 @@ namespace Tests.Linq
 			TestProvName.AllSybase,
 			ProviderName.SqlCe,
 			TestProvName.AllAccess,
-			// Firebird excluded because of #2839, the test data is inserted with padding and then expectations fail
-			// ProviderName.Firebird,
+			// All Firebird excluded because of #2839, test data is inserted with padding and then expectations fail
+			TestProvName.AllFirebird,
 			TestProvName.MySql55)] string context)
 		{
 			var data = new Issue1799Table3[] 

--- a/Tests/Linq/Linq/AnalyticTests.cs
+++ b/Tests/Linq/Linq/AnalyticTests.cs
@@ -1700,7 +1700,7 @@ namespace Tests.Linq
 												 	.Over().OrderBy(p.ProcessID).ToValue())
 								.ToArray();
 
-				CollectionAssert.AreEqual(new[] { "None", "One" }, leads);
+				CollectionAssert.AreEqual(new[] { "None", "One" }, lags);
 			}
 		}
 	}

--- a/Tests/Linq/Linq/AnalyticTests.cs
+++ b/Tests/Linq/Linq/AnalyticTests.cs
@@ -1710,7 +1710,8 @@ namespace Tests.Linq
 			TestProvName.AllSybase,
 			ProviderName.SqlCe,
 			TestProvName.AllAccess,
-			ProviderName.Firebird,
+			// Firebird excluded because of #2839, the test data is inserted with padding and then expectations fail
+			// ProviderName.Firebird,
 			TestProvName.MySql55)] string context)
 		{
 			var data = new Issue1799Table3[] 

--- a/Tests/Linq/Linq/AnalyticTests.cs
+++ b/Tests/Linq/Linq/AnalyticTests.cs
@@ -1684,7 +1684,7 @@ namespace Tests.Linq
 			var data = new Issue1799Table3[] 
 			{
 				new() { ProcessID = 1, ProcessName = "One" },
-				new() { ProcessID = 2, ProcesSName = "Two" },
+				new() { ProcessID = 2, ProcessName = "Two" },
 			};
 			using (var db    = GetDataContext(context))
 			using (var table = db.CreateLocalTable(data))

--- a/Tests/Linq/Linq/AnalyticTests.cs
+++ b/Tests/Linq/Linq/AnalyticTests.cs
@@ -1670,7 +1670,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void Issue3423LeadLagDefault([DataSources(
+		public void LeadLagWithStringDefault([DataSources(
 			TestProvName.AllSqlServer2008Minus,
 			TestProvName.AllSybase,
 			ProviderName.SqlCe,

--- a/Tests/Linq/Linq/AnalyticTests.cs
+++ b/Tests/Linq/Linq/AnalyticTests.cs
@@ -1727,25 +1727,25 @@ namespace Tests.Linq
 												 	 .Over().OrderBy(p.ProcessID).ToValue())
 								 .ToArray();
 
-				CollectionAssert.AreEqual(new string[] { "Three", "Four", null, null }, leads);
+				CollectionAssert.AreEqual(new string?[] { "Three", "Four", null, null }, leads);
 
 				leads = table.Select(p => Sql.Ext.Lead(p.ProcessName)
 											 	 .Over().OrderBy(p.ProcessID).ToValue())
 							 .ToArray();
 
-				CollectionAssert.AreEqual(new string[] { "Two", "Three", "Four", null }, leads);
+				CollectionAssert.AreEqual(new string?[] { "Two", "Three", "Four", null }, leads);
 
 				var lags = table.Select(p => Sql.Ext.Lag(p.ProcessName, 2)
 												 	.Over().OrderBy(p.ProcessID).ToValue())
 								.ToArray();
 
-				CollectionAssert.AreEqual(new string[] { null, null, "One", "Two" }, lags);
+				CollectionAssert.AreEqual(new string?[] { null, null, "One", "Two" }, lags);
 				
 				lags = table.Select(p => Sql.Ext.Lag(p.ProcessName)
 										 	.Over().OrderBy(p.ProcessID).ToValue())
 							.ToArray();
 
-				CollectionAssert.AreEqual(new string[] { null, "One", "Two", "Three" }, lags);
+				CollectionAssert.AreEqual(new string?[] { null, "One", "Two", "Three" }, lags);
 			}
 		}
 	}


### PR DESCRIPTION
Fix #3423 
This PR fixes the type of `default` in `LEAD` and `LAG`.

It comes with a unit test that uses string as `default` in addition to existing tests that used `int`.

I've also added more `LEAD` and `LAG` convenience overloads because it's pretty uncommon to specify the null modifier.
Now all these are possible: `Lag(expr)`, `Lag(expr, 3)`, `Lag(expr, 3, "default")`, which mirrors the native SQL function specs.