### PR TITLE
Added .NET 6.0+ Hot Reload compatibility

### DIFF
--- a/Source/LinqToDB/Common/Configuration.cs
+++ b/Source/LinqToDB/Common/Configuration.cs
@@ -237,7 +237,7 @@ namespace LinqToDB.Common
 			/// Default value: <c>false</c>.
 			/// <para />
 			/// It is not recommended to enable this option as it could lead to severe slowdown. Better approach will be
-			/// to call <see cref="Query{T}.ClearCache"/> method to cleanup cache after queries, that produce severe memory leaks you need to fix.
+			/// to call <see cref="Query{T}.ClearCache()"/> method to cleanup cache after queries, that produce severe memory leaks you need to fix.
 			/// <para />
 			/// <a href="https://github.com/linq2db/linq2db/issues/256">More details</a>.
 			/// </summary>

--- a/Source/LinqToDB/Common/ConvertBuilder.cs
+++ b/Source/LinqToDB/Common/ConvertBuilder.cs
@@ -6,6 +6,10 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading;
 
+#if NET6_0_OR_GREATER
+[assembly: System.Reflection.Metadata.MetadataUpdateHandler(typeof(LinqToDB.Common.ConvertBuilder))]
+#endif
+
 namespace LinqToDB.Common
 {
 	using Expressions;
@@ -15,7 +19,7 @@ namespace LinqToDB.Common
 
 	static class ConvertBuilder
 	{
-		static readonly MethodInfo _defaultConverter = MemberHelper.MethodOf(() => ConvertDefault(null!, typeof(int)));
+		static MethodInfo _defaultConverter = MemberHelper.MethodOf(() => ConvertDefault(null!, typeof(int)));
 
 		static object ConvertDefault(object value, Type conversionType)
 		{
@@ -678,5 +682,13 @@ namespace LinqToDB.Common
 		}
 
 		#endregion
+
+		#region Hot reload compatibility
+		private static void ClearCache(Type[]? updatedTypes)
+		{
+			_defaultConverter = MemberHelper.MethodOf(() => ConvertDefault(null!, typeof(int)));
+		}
+		#endregion
+
 	}
 }

--- a/Source/LinqToDB/Data/RecordReaderBuilder.cs
+++ b/Source/LinqToDB/Data/RecordReaderBuilder.cs
@@ -5,6 +5,10 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
+#if NET6_0_OR_GREATER
+[assembly: System.Reflection.Metadata.MetadataUpdateHandler(typeof(LinqToDB.Data.RecordReaderBuilder))]
+#endif
+
 namespace LinqToDB.Data
 {
 	using Expressions;
@@ -16,8 +20,8 @@ namespace LinqToDB.Data
 
 	class RecordReaderBuilder
 	{
-		public static readonly ParameterExpression DataReaderParam  = Expression.Parameter(typeof(IDataReader),  "rd");
-		public        readonly ParameterExpression DataReaderLocal;
+		public static   ParameterExpression DataReaderParam  = Expression.Parameter(typeof(IDataReader),  "rd");
+		public readonly ParameterExpression DataReaderLocal;
 
 		public readonly List<ParameterExpression>  BlockVariables   = new ();
 		public readonly List<Expression>           BlockExpressions = new ();
@@ -410,5 +414,11 @@ namespace LinqToDB.Data
 			return expression;
 		}
 
+		#region Hot reload compatibility
+		private static void ClearCache(Type[]? updatedTypes) // Hot reload compatibility
+		{
+			DataReaderParam = Expression.Parameter(typeof(IDataReader),  "rd");
+		}
+		#endregion
 	}
 }

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
@@ -9,6 +9,10 @@ using System.Reflection;
 
 using JetBrains.Annotations;
 
+#if NET6_0_OR_GREATER
+[assembly: System.Reflection.Metadata.MetadataUpdateHandler(typeof(LinqToDB.Linq.Builder.ExpressionBuilder))]
+#endif
+
 namespace LinqToDB.Linq.Builder
 {
 	using Common;
@@ -148,13 +152,13 @@ namespace LinqToDB.Linq.Builder
 		public readonly Expression             Expression;
 		public readonly ParameterExpression[]? CompiledParameters;
 		public readonly List<IBuildContext>    Contexts = new ();
+		public readonly ParameterExpression    DataReaderLocal;
 
-		public static readonly ParameterExpression QueryRunnerParam = Expression.Parameter(typeof(IQueryRunner), "qr");
-		public static readonly ParameterExpression DataContextParam = Expression.Parameter(typeof(IDataContext), "dctx");
-		public static readonly ParameterExpression DataReaderParam  = Expression.Parameter(typeof(IDataReader),  "rd");
-		public        readonly ParameterExpression DataReaderLocal;
-		public static readonly ParameterExpression ParametersParam  = Expression.Parameter(typeof(object[]),     "ps");
-		public static readonly ParameterExpression ExpressionParam  = Expression.Parameter(typeof(Expression),   "expr");
+		public static ParameterExpression QueryRunnerParam = Expression.Parameter(typeof(IQueryRunner), "qr");
+		public static ParameterExpression DataContextParam = Expression.Parameter(typeof(IDataContext), "dctx");
+		public static ParameterExpression DataReaderParam  = Expression.Parameter(typeof(IDataReader),  "rd");
+		public static ParameterExpression ParametersParam  = Expression.Parameter(typeof(object[]),     "ps");
+		public static ParameterExpression ExpressionParam  = Expression.Parameter(typeof(Expression),   "expr");
 
 		public MappingSchema MappingSchema => DataContext.MappingSchema;
 
@@ -1604,6 +1608,17 @@ namespace LinqToDB.Linq.Builder
 			return root;
 		}
 
+		#endregion
+
+		#region Hot Reload Compatibility
+		private static void ClearCache(Type[]? updatedTypes)
+		{
+			QueryRunnerParam = Expression.Parameter(typeof(IQueryRunner), "qr");
+			DataContextParam = Expression.Parameter(typeof(IDataContext), "dctx");
+			DataReaderParam = Expression.Parameter(typeof(IDataReader), "rd");
+			ParametersParam = Expression.Parameter(typeof(object[]), "ps");
+			ExpressionParam = Expression.Parameter(typeof(Expression), "expr");
+		}
 		#endregion
 	}
 }

--- a/Source/LinqToDB/Linq/Builder/ParametersContext.cs
+++ b/Source/LinqToDB/Linq/Builder/ParametersContext.cs
@@ -10,6 +10,10 @@ using LinqToDB.Mapping;
 using LinqToDB.Reflection;
 using LinqToDB.SqlQuery;
 
+#if NET6_0_OR_GREATER
+[assembly: System.Reflection.Metadata.MetadataUpdateHandler(typeof(LinqToDB.Linq.Builder.ParametersContext))]
+#endif
+
 namespace LinqToDB.Linq.Builder
 {
 	class ParametersContext
@@ -516,5 +520,11 @@ namespace LinqToDB.Linq.Builder
 			return p.SqlParameter;
 		}
 
+		#region Hot reload compatibility
+		private static void ClearCache(Type[]? updatedTypes)
+		{
+			AccessorParameters = new ParameterExpression[] { ExpressionBuilder.ExpressionParam, ExpressionBuilder.DataContextParam, ExpressionBuilder.ParametersParam };
+		}
+		#endregion
 	}
 }

--- a/Source/LinqToDB/Linq/ExpressionQuery.cs
+++ b/Source/LinqToDB/Linq/ExpressionQuery.cs
@@ -38,6 +38,7 @@ namespace LinqToDB.Linq
 		// This property is helpful in Debug Mode.
 		//
 		[JetBrains.Annotations.UsedImplicitly]
+		[CLSCompliant(false)]
 		// ReSharper disable once InconsistentNaming
 		public string _sqlText => SqlText;
 #endif

--- a/Source/LinqToDB/Linq/Query.cs
+++ b/Source/LinqToDB/Linq/Query.cs
@@ -10,6 +10,10 @@ using System.Threading.Tasks;
 
 // ReSharper disable StaticMemberInGenericType
 
+#if NET6_0_OR_GREATER
+[assembly: System.Reflection.Metadata.MetadataUpdateHandler(typeof(LinqToDB.Linq.Query<>))]
+#endif
+
 namespace LinqToDB.Linq
 {
 #if !NATIVE_ASYNC
@@ -232,7 +236,8 @@ namespace LinqToDB.Linq
 			return preambles;
 		}
 
-#endregion
+		#endregion
+		
 	}
 
 	class Query<T> : Query
@@ -552,8 +557,15 @@ namespace LinqToDB.Linq
 
 			return query;
 		}
+		#endregion
 
-#endregion
+		#region Hot reload compatibility
+		private static void ClearCache(Type[]? updatedTypes)
+		{
+			ClearCaches();
+			ClearCache();
+		}
+		#endregion
 	}
 
 	class QueryInfo : IQueryContext

--- a/Source/LinqToDB/Linq/ReflectionHelper.cs
+++ b/Source/LinqToDB/Linq/ReflectionHelper.cs
@@ -5,6 +5,11 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
+#if NET6_0_OR_GREATER
+[assembly: System.Reflection.Metadata.MetadataUpdateHandler(typeof(LinqToDB.Linq.ReflectionHelper))]
+[assembly: System.Reflection.Metadata.MetadataUpdateHandler(typeof(LinqToDB.Linq.ReflectionHelper.IndexExpressor<>))]
+#endif
+
 namespace LinqToDB.Linq
 {
 	using LinqToDB.Expressions;
@@ -121,6 +126,11 @@ namespace LinqToDB.Linq
 			}
 
 			public static MethodInfo Item = IndexerExpressor(c => c[0]!);
+
+			private static void ClearCache(Type[]? updatedTypes) // Hot Reload Compatibility
+			{
+				Item = IndexerExpressor(c => c[0]!);
+			}
 		}
 
 		public class MemberAssignmentBind : Expressor<MemberAssignment>
@@ -174,5 +184,72 @@ namespace LinqToDB.Linq
 			}
 #endif
 		}
+
+		#region Hot Reload Compatibility
+		private static void ClearCache(Type[]? updatedTypes) // Hot Reload Compatibility
+		{
+			Binary.Conversion				= Binary.PropertyOf(e => e.Conversion);
+			Binary.Left						= Binary.PropertyOf(e => e.Left);
+			Binary.Right					= Binary.PropertyOf(e => e.Right);
+
+			Unary.Operand					= Unary.PropertyOf(e => e.Operand);
+
+			LambdaExpr.Body					= LambdaExpr.PropertyOf(e => e.Body);
+			LambdaExpr.Parameters			= LambdaExpr.PropertyOf(e => e.Parameters);
+
+			Constant.Value					= Constant.PropertyOf(e => e.Value);
+
+			QueryableInt.Expression			= QueryableInt.PropertyOf(e => e.Expression);
+
+			MethodCall.Object				= MethodCall.PropertyOf(e => e.Object);
+			MethodCall.Arguments			= MethodCall.PropertyOf(e => e.Arguments);
+
+			Conditional.Test				= Conditional.PropertyOf(e => e.Test);
+			Conditional.IfTrue				= Conditional.PropertyOf(e => e.IfTrue);
+			Conditional.IfFalse				= Conditional.PropertyOf(e => e.IfFalse);
+
+			Invocation.Expression			= Invocation.PropertyOf(e => e.Expression);
+			Invocation.Arguments			= Invocation.PropertyOf(e => e.Arguments);
+
+			ListInit.NewExpression			= ListInit.PropertyOf(e => e.NewExpression);
+			ListInit.Initializers			= ListInit.PropertyOf(e => e.Initializers);
+
+			ElementInit.Arguments			= ElementInit.PropertyOf(e => e.Arguments);
+
+			Member.Expression				= Member.PropertyOf(e => e.Expression);
+
+			MemberInit.NewExpression		= MemberInit.PropertyOf(e => e.NewExpression);
+			MemberInit.Bindings				= MemberInit.PropertyOf(e => e.Bindings);
+
+			New.Arguments					= New.PropertyOf(e => e.Arguments);
+
+			NewArray.Expressions			= NewArray.PropertyOf(e => e.Expressions);
+
+			TypeBinary.Expression			= TypeBinary.PropertyOf(e => e.Expression);
+
+			MemberAssignmentBind.Expression	= MemberAssignmentBind.PropertyOf(e => e.Expression);
+
+			MemberListBind.Initializers		= MemberListBind.PropertyOf(e => e.Initializers);
+
+			MemberMemberBind.Bindings		= MemberMemberBind.PropertyOf(e => e.Bindings);
+
+			Block.Expressions				= Block.PropertyOf(e => e.Expressions);
+			Block.Variables					= Block.PropertyOf(e => e.Variables);
+
+			ExprItem						= IndexExpressor<Expression>.Item;
+			ParamItem						= IndexExpressor<ParameterExpression>.Item;
+			ElemItem						= IndexExpressor<ElementInit>.Item;
+
+			DataReader.GetValue				= DataReader.MethodOf(rd => rd.GetValue(0));
+			DataReader.IsDBNull				= DataReader.MethodOf(rd => rd.IsDBNull(0));
+
+			Functions.String.Like21			= Functions.String.MethodOf(s => Sql.Like(s, ""));
+			Functions.String.Like22			= Functions.String.MethodOf(s => Sql.Like(s, "", ' '));
+#if !NET45
+			Functions.FormattableString.GetArguments 
+											= Functions.FormattableString.MethodOf(s => s.GetArgument(0));
+#endif
+		}
+		#endregion
 	}
 }


### PR DESCRIPTION
Due to the heavy use of Reflection in static (global) variables in linq2db, running queries after a Hot Reload may issue exceptions due to mismatch metadata info. This pull request re-reads and updates reflection data in such variables every time a hot reload is triggered, avoiding such exceptions.

More info: https://github.com/dotnet/sdk/issues/23736