### PR TITLE
Fix tests execution on win2022 for netfx targets

### DIFF
--- a/Build/Azure/pipelines/templates/test-workflow-windows.yml
+++ b/Build/Azure/pipelines/templates/test-workflow-windows.yml
@@ -72,7 +72,7 @@ steps:
 
 - script: dotnet test linq2db.Tests.dll /TestCaseFilter:"TestCategory != SkipCI" /Framework:${{ parameters.framework }} /logger:trx
   displayName: 'Execute tests: $(title)'
-  condition: and(ne('${{ parameters.framework }}', 'net472'), variables.title, succeeded())
+  condition: and(ne('${{ parameters.useVsTest }}', True), variables.title, succeeded())
 
 - task: PublishTestResults@2
   condition: and(ne('${{ parameters.useVsTest }}', True), variables.title, succeededOrFailed())

--- a/Tests/Linq/Linq/AnalyticTests.cs
+++ b/Tests/Linq/Linq/AnalyticTests.cs
@@ -1677,6 +1677,9 @@ namespace Tests.Linq
 			TestProvName.AllAccess,
 			ProviderName.Firebird,
 			TestProvName.MySql55,
+#if NETFRAMEWORK
+			ProviderName.SQLiteMS, // TODO: time to switch to modern sqlite.ms version for netfx
+#endif
 			// doesn't support 3-rd parameter for LEAD
 			TestProvName.MariaDB)] string context)
 		{
@@ -1710,6 +1713,9 @@ namespace Tests.Linq
 			TestProvName.AllSybase,
 			ProviderName.SqlCe,
 			TestProvName.AllAccess,
+#if NETFRAMEWORK
+			ProviderName.SQLiteMS, // TODO: time to switch to modern sqlite.ms version for netfx
+#endif
 			// All Firebird excluded because of #2839, test data is inserted with padding and then expectations fail
 			TestProvName.AllFirebird,
 			TestProvName.MySql55)] string context)


### PR DESCRIPTION
Looks like after migration to win2022 test image, NETFX tests stopped to run.