### PR TITLE
Remove use of win2016 image on CI

### DIFF
--- a/Build/Azure/pipelines/templates/test-jobs.yml
+++ b/Build/Azure/pipelines/templates/test-jobs.yml
@@ -190,39 +190,6 @@ jobs:
       titleFramework: 'NET472'
       with_baselines: ${{ parameters.with_baselines }}
 
-#############################################
-#  Tests: Windows (NETFX 4.7.2)             #
-#  Windows 2016 (for Win2016 docker images) #
-#############################################
-- job: test_win_netfx472_job_2016
-  pool:
-    vmImage: 'vs2017-win2016'
-  displayName: 'Tests: Win / NETFX 4.7.2 / '
-  dependsOn: create_baselines_branch
-  condition: ${{ parameters.enabled }}
-  variables:
-    baselines_branch: $[ dependencies.create_baselines_branch.outputs['baselines_init.baselines_branch'] ]
-
-  strategy:
-    matrix:
-      ${{ each test_config in parameters.test_matrix }}:
-        ${{ if and(eq(test_config.enabled, 'true'), eq(test_config.enable_os_win2016, 'true'), eq(test_config.enable_fw_net472, 'true'), eq(test_config.is_experimental, parameters.experimental)) }}:
-          ${{ test_config.name }}:
-            title: ${{ test_config.title }}
-            config: ${{ test_config.config_win }}
-            script: ${{ test_config.script_win }}
-            psscript: ${{ test_config.psscript_win }}
-
-  steps:
-  - template: test-workflow-windows.yml
-    parameters:
-      isCore: true
-      artifacts: $(netfx472_tests)
-      framework: 'net472'
-      titleFramework: 'NET472'
-      with_baselines: ${{ parameters.with_baselines }}
-      useVsTest: true
-
 ###################################
 #  Tests: Windows (NETCOREAPP2_1) #
 #  Windows 2022                   #
@@ -256,38 +223,6 @@ jobs:
       with_baselines: ${{ parameters.with_baselines }}
 
 ###################################
-#  Tests: Windows (NETCOREAPP2_1) #
-#  Windows 2016                   #
-###################################
-- job: test_win2016_netcoreapp21_job
-  pool:
-    vmImage: 'vs2017-win2016'
-  displayName: 'Tests: Win / NETCOREAPP2.1 / '
-  dependsOn: create_baselines_branch
-  condition: ${{ parameters.enabled }}
-  variables:
-    baselines_branch: $[ dependencies.create_baselines_branch.outputs['baselines_init.baselines_branch'] ]
-
-  strategy:
-    matrix:
-      ${{ each test_config in parameters.test_matrix }}:
-        ${{ if and(eq(test_config.enabled, 'true'), eq(test_config.enable_os_win2016, 'true'), eq(test_config.enable_fw_netcore21, 'true'), eq(test_config.is_experimental, parameters.experimental)) }}:
-          ${{ test_config.name }}:
-            title: ${{ test_config.title }}
-            config: ${{ test_config.config_win }}
-            script: ${{ test_config.script_win }}
-            psscript: ${{ test_config.psscript_win }}
-
-  steps:
-  - template: test-workflow-windows.yml
-    parameters:
-      isCore: true
-      artifacts: $(netcore21_tests)
-      framework: 'netcoreapp2.1'
-      titleFramework: 'NETCOREAPP2.1'
-      with_baselines: ${{ parameters.with_baselines }}
-
-###################################
 #  Tests: Windows (NETCOREAPP3_1) #
 #  Windows 2022                   #
 ###################################
@@ -304,38 +239,6 @@ jobs:
     matrix:
       ${{ each test_config in parameters.test_matrix }}:
         ${{ if and(eq(test_config.enabled, 'true'), eq(test_config.enable_os_win2022, 'true'), eq(test_config.enable_fw_netcore31, 'true'), eq(test_config.is_experimental, parameters.experimental)) }}:
-          ${{ test_config.name }}:
-            title: ${{ test_config.title }}
-            config: ${{ test_config.config_win }}
-            script: ${{ test_config.script_win }}
-            psscript: ${{ test_config.psscript_win }}
-
-  steps:
-  - template: test-workflow-windows.yml
-    parameters:
-      isCore: true
-      artifacts: $(netcore31_tests)
-      framework: 'netcoreapp3.1'
-      titleFramework: 'NETCOREAPP3.1'
-      with_baselines: ${{ parameters.with_baselines }}
-
-###################################
-#  Tests: Windows (NETCOREAPP3_1) #
-#  Windows 2016                   #
-###################################
-- job: test_win2016_netcoreapp31_job
-  pool:
-    vmImage: 'vs2017-win2016'
-  displayName: 'Tests: Win / NETCOREAPP3.1 / '
-  dependsOn: create_baselines_branch
-  condition: ${{ parameters.enabled }}
-  variables:
-    baselines_branch: $[ dependencies.create_baselines_branch.outputs['baselines_init.baselines_branch'] ]
-
-  strategy:
-    matrix:
-      ${{ each test_config in parameters.test_matrix }}:
-        ${{ if and(eq(test_config.enabled, 'true'), eq(test_config.enable_os_win2016, 'true'), eq(test_config.enable_fw_netcore31, 'true'), eq(test_config.is_experimental, parameters.experimental)) }}:
           ${{ test_config.name }}:
             title: ${{ test_config.title }}
             config: ${{ test_config.config_win }}
@@ -415,71 +318,6 @@ jobs:
       titleFramework: 'NET6.0'
       with_baselines: ${{ parameters.with_baselines }}
       installnet6: true
-
-############################
-#  Tests: Windows (NET6.0) #
-#  Windows 2016            #
-############################
-- job: test_win2016_net60_job
-  pool:
-    vmImage: 'vs2017-win2016'
-  displayName: 'Tests: Win / NET 6.0 / '
-  dependsOn: create_baselines_branch
-  condition: ${{ parameters.enabled }}
-  variables:
-    baselines_branch: $[ dependencies.create_baselines_branch.outputs['baselines_init.baselines_branch'] ]
-
-  strategy:
-    matrix:
-      ${{ each test_config in parameters.test_matrix }}:
-        ${{ if and(eq(test_config.enabled, 'true'), eq(test_config.enable_os_win2016, 'true'), eq(test_config.enable_fw_net60, 'true'), eq(test_config.is_experimental, parameters.experimental)) }}:
-          ${{ test_config.name }}:
-            title: ${{ test_config.title }}
-            config: ${{ test_config.config_win }}
-            script: ${{ test_config.script_win }}
-            psscript: ${{ test_config.psscript_win }}
-
-  steps:
-  - template: test-workflow-windows.yml
-    parameters:
-      isCore: true
-      artifacts: $(net60_tests)
-      framework: 'net6.0'
-      titleFramework: 'NET6.0'
-      with_baselines: ${{ parameters.with_baselines }}
-      installnet6: true
-
-############################
-#  Tests: Windows (NET5.0) #
-#  Windows 2016            #
-############################
-- job: test_win2016_net50_job
-  pool:
-    vmImage: 'vs2017-win2016'
-  displayName: 'Tests: Win / NET 5.0 / '
-  dependsOn: create_baselines_branch
-  condition: ${{ parameters.enabled }}
-  variables:
-    baselines_branch: $[ dependencies.create_baselines_branch.outputs['baselines_init.baselines_branch'] ]
-
-  strategy:
-    matrix:
-      ${{ each test_config in parameters.test_matrix }}:
-        ${{ if and(eq(test_config.enabled, 'true'), eq(test_config.enable_os_win2016, 'true'), eq(test_config.enable_fw_net50, 'true'), eq(test_config.is_experimental, parameters.experimental)) }}:
-          ${{ test_config.name }}:
-            title: ${{ test_config.title }}
-            config: ${{ test_config.config_win }}
-            script: ${{ test_config.script_win }}
-            psscript: ${{ test_config.psscript_win }}
-
-  steps:
-  - template: test-workflow-windows.yml
-    parameters:
-      isCore: true
-      artifacts: $(net50_tests)
-      framework: 'net5.0'
-      titleFramework: 'NET5.0'
-      with_baselines: ${{ parameters.with_baselines }}
 
 ###################################
 #  Tests: Windows (NETCOREAPP2_1) #
@@ -875,11 +713,6 @@ jobs:
   - create_baselines_branch # for variables flow
   - test_win_netfx472_job_2022
   - test_win_netfx472_job_2019
-  - test_win_netfx472_job_2016
-  - test_win2016_netcoreapp21_job
-  - test_win2016_netcoreapp31_job
-  - test_win2016_net50_job
-  - test_win2016_net60_job
   - test_win2019_netcoreapp21_job
   - test_win2019_netcoreapp31_job
   - test_win2019_net50_job

--- a/Build/Azure/pipelines/templates/test-matrix.yml
+++ b/Build/Azure/pipelines/templates/test-matrix.yml
@@ -41,7 +41,6 @@ parameters:
 # OPERATION SYSTEM SELECTORS
 # - enable_os_win2022  (true/false string) : enables testrun for windows 2019 image (windows-2022)
 # - enable_os_win2019  (true/false string) : enables testrun for windows 2019 image (windows-2019)
-# - enable_os_win2016  (true/false string) : enables testrun for windows 2016 image (vs2017-win2016)
 # - enable_os_ubuntu   (true/false string) : enables testrun for Ubuntu 20.04 image (ubuntu-20.04)
 # - enable_os_macos    (true/false string) : enables testrun for Mac OS image (macOS-10.15)
 
@@ -86,7 +85,6 @@ jobs:
           config_win: sqlite
           config_linux: sqlite
           config_macos: sqlite
-          enable_os_win2016: false
           enable_os_win2019: false
           enable_os_win2022: true
           enable_os_ubuntu: true
@@ -107,7 +105,6 @@ jobs:
           config_win: sqlite.ms
           config_linux: sqlite.ms
           config_macos: sqlite.ms
-          enable_os_win2016: false
           enable_os_win2019: false
           enable_os_win2022: true
           enable_os_ubuntu: true
@@ -127,7 +124,6 @@ jobs:
         - name: Access_OLEDB_JET
           title: Access Jet
           config_win: access
-          enable_os_win2016: false
           enable_os_win2019: true
           enable_os_win2022: false
           enable_os_ubuntu: false
@@ -147,7 +143,6 @@ jobs:
           title: Access ACE
           config_win: access.ace
           script_win: access.ace.cmd
-          enable_os_win2016: false
           enable_os_win2019: true
           enable_os_win2022: false
           enable_os_ubuntu: false
@@ -166,7 +161,6 @@ jobs:
         - name: Access_ODBC_MDB
           title: Access ODBC MDB
           config_win: access.odbc.mdb
-          enable_os_win2016: false
           enable_os_win2019: true
           enable_os_win2022: false
           enable_os_ubuntu: false
@@ -186,7 +180,6 @@ jobs:
           title: Access ODBC ACE
           config_win: access.odbc.ace
           script_win: access.ace.cmd
-          enable_os_win2016: false
           enable_os_win2019: true
           enable_os_win2022: false
           enable_os_ubuntu: false
@@ -206,9 +199,8 @@ jobs:
           title: Access ODBC ACE x64
           config_win: access.odbc.ace
           script_win: access.ace.x64.cmd
-          enable_os_win2016: true
           enable_os_win2019: false
-          enable_os_win2022: false
+          enable_os_win2022: true
           enable_os_ubuntu: false
           enable_os_macos: false
           enable_fw_net472: false
@@ -226,7 +218,6 @@ jobs:
           title: Access OleDb ACE x64
           config_win: access.ace
           script_win: access.ace.x64.cmd
-          enable_os_win2016: false # true (disabled due to a lot of random crashes https://github.com/dotnet/runtime/issues/36954)
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: false
@@ -247,9 +238,8 @@ jobs:
           title: SQL CE
           config_win: sqlce
           psscript_win: sqlce.ps1
-          enable_os_win2016: true
           enable_os_win2019: false
-          enable_os_win2022: false
+          enable_os_win2022: true
           enable_os_ubuntu: false
           enable_os_macos: false
           enable_fw_net472: true
@@ -271,7 +261,6 @@ jobs:
           script_linux: mysql.sh
           script_macos: mac.mysql.sh
           install_docker_macos: true
-          enable_os_win2016: false
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: true
@@ -294,7 +283,6 @@ jobs:
           script_linux: mysql55.sh
           script_macos: mac.mysql55.sh
           install_docker_macos: true
-          enable_os_win2016: false
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: true
@@ -319,7 +307,6 @@ jobs:
           script_linux: mariadb.sh
           script_macos: mac.mariadb.sh
           install_docker_macos: true
-          enable_os_win2016: false # true (needs working docker image)
           enable_os_win2019: false # true (needs working docker image)
           enable_os_win2022: false
           enable_os_ubuntu: true
@@ -343,7 +330,6 @@ jobs:
           script_linux: pgsql.sh
           script_macos: mac.pgsql.sh
           install_docker_macos: true
-          enable_os_win2016: false
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: true
@@ -366,7 +352,6 @@ jobs:
           script_linux: pgsql92.sh
           script_macos: mac.pgsql92.sh
           install_docker_macos: true
-          enable_os_win2016: false
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: true
@@ -389,7 +374,6 @@ jobs:
           script_linux: pgsql93.sh
           script_macos: mac.pgsql93.sh
           install_docker_macos: true
-          enable_os_win2016: false
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: true
@@ -412,7 +396,6 @@ jobs:
           script_linux: pgsql95.sh
           script_macos: mac.pgsql95.sh
           install_docker_macos: true
-          enable_os_win2016: false
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: true
@@ -437,7 +420,6 @@ jobs:
           script_linux: pgsql10.sh
           script_macos: mac.pgsql10.sh
           install_docker_macos: true
-          enable_os_win2016: false # true (needs working docker image)
           enable_os_win2019: false # true (needs working docker image)
           enable_os_win2022: false
           enable_os_ubuntu: true
@@ -461,7 +443,6 @@ jobs:
           script_linux: pgsql11.sh
           script_macos: mac.pgsql11.sh
           install_docker_macos: true
-          enable_os_win2016: false
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: true
@@ -485,7 +466,6 @@ jobs:
           script_linux: pgsql12.sh
           script_macos: mac.pgsql12.sh
           install_docker_macos: true
-          enable_os_win2016: false
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: true
@@ -509,7 +489,6 @@ jobs:
           script_linux: pgsql13.sh
           script_macos: mac.pgsql13.sh
           install_docker_macos: true
-          enable_os_win2016: false
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: true
@@ -533,7 +512,6 @@ jobs:
           script_linux: pgsql14.sh
           script_macos: mac.pgsql14.sh
           install_docker_macos: true
-          enable_os_win2016: false
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: true
@@ -554,9 +532,8 @@ jobs:
           title: SQL Server 2005 (System.Data.SqlClient)
           config_win: sqlserver.2005
           script_win: sqlserver.2005.cmd
-          enable_os_win2016: true
           enable_os_win2019: false
-          enable_os_win2022: false
+          enable_os_win2022: true
           enable_os_ubuntu: false
           enable_os_macos: false
           enable_fw_net472: true
@@ -574,7 +551,6 @@ jobs:
           title: SQL Server 2005 (Microsoft.Data.SqlClient)
           config_win: sqlserver.2005.ms
           script_win: sqlserver.2005.cmd
-          enable_os_win2016: false # true (too many sqlserver tests)
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: false
@@ -594,9 +570,8 @@ jobs:
           title: SQL Server 2008 (System.Data.SqlClient)
           config_win: sqlserver.2008
           script_win: sqlserver.2008.cmd
-          enable_os_win2016: true
           enable_os_win2019: false
-          enable_os_win2022: false
+          enable_os_win2022: true
           enable_os_ubuntu: false
           enable_os_macos: false
           enable_fw_net472: true
@@ -614,7 +589,6 @@ jobs:
           title: SQL Server 2008 (Microsoft.Data.SqlClient)
           config_win: sqlserver.2008.ms
           script_win: sqlserver.2008.cmd
-          enable_os_win2016: false # true (too many sqlserver tests)
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: false
@@ -634,9 +608,8 @@ jobs:
           title: SQL Server 2012 (System.Data.SqlClient)
           config_win: sqlserver.2012
           script_win: sqlserver.2012.cmd
-          enable_os_win2016: true
           enable_os_win2019: false
-          enable_os_win2022: false
+          enable_os_win2022: true
           enable_os_ubuntu: false
           enable_os_macos: false
           enable_fw_net472: true
@@ -654,7 +627,6 @@ jobs:
           title: SQL Server 2012 (Microsoft.Data.SqlClient)
           config_win: sqlserver.2012.ms
           script_win: sqlserver.2012.cmd
-          enable_os_win2016: false # true (too many sqlserver tests)
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: false
@@ -674,9 +646,8 @@ jobs:
           title: SQL Server 2014 (System.Data.SqlClient)
           config_win: sqlserver.2014
           script_win: sqlserver.2014.cmd
-          enable_os_win2016: true
           enable_os_win2019: false
-          enable_os_win2022: false
+          enable_os_win2022: true
           enable_os_ubuntu: false
           enable_os_macos: false
           enable_fw_net472: true
@@ -694,7 +665,6 @@ jobs:
           title: SQL Server 2014 (Microsoft.Data.SqlClient)
           config_win: sqlserver.2014.ms
           script_win: sqlserver.2014.cmd
-          enable_os_win2016: false # true (too many sqlserver tests)
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: false
@@ -714,9 +684,8 @@ jobs:
           title: SQL Server 2016 (System.Data.SqlClient)
           config_win: sqlserver.2016
           script_win: sqlserver.2016.cmd
-          enable_os_win2016: true
           enable_os_win2019: false
-          enable_os_win2022: false
+          enable_os_win2022: true
           enable_os_ubuntu: false
           enable_os_macos: false
           enable_fw_net472: true
@@ -734,7 +703,6 @@ jobs:
           title: SQL Server 2016 (Microsoft.Data.SqlClient)
           config_win: sqlserver.2016.ms
           script_win: sqlserver.2016.cmd
-          enable_os_win2016: false # true (too many sqlserver tests)
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: false
@@ -759,7 +727,6 @@ jobs:
           script_linux: sqlserver.2017.sh
           script_macos: mac.sqlserver.2017.sh
           install_docker_macos: true
-          enable_os_win2016: false # disabled as MS removed docker images for sql server for no good reason
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: true
@@ -784,7 +751,6 @@ jobs:
           script_linux: sqlserver.2017.sh
           script_macos: mac.sqlserver.2017.sh
           install_docker_macos: true
-          enable_os_win2016: false # too many sqlserver tests
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: true
@@ -809,7 +775,6 @@ jobs:
           script_linux: sqlserver.2019.sh
           script_macos: mac.sqlserver.2019.sh
           install_docker_macos: true
-          enable_os_win2016: false
           enable_os_win2019: true
           enable_os_win2022: false
           enable_os_ubuntu: true
@@ -834,7 +799,6 @@ jobs:
           script_linux: sqlserver.2019.sh
           script_macos: mac.sqlserver.2019.sh
           install_docker_macos: true
-          enable_os_win2016: false
           enable_os_win2019: true
           enable_os_win2022: false
           enable_os_ubuntu: true
@@ -858,7 +822,6 @@ jobs:
           script_linux: sybase.sh
           script_macos: sybase.sh
           install_docker_macos: true
-          enable_os_win2016: false
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: true
@@ -882,7 +845,6 @@ jobs:
           script_linux: oracle11.sh
           script_macos: oracle11.sh
           install_docker_macos: true
-          enable_os_win2016: false
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: true
@@ -905,7 +867,6 @@ jobs:
           script_linux: oracle12.sh
           script_macos: oracle12.sh
           install_docker_macos: true
-          enable_os_win2016: false
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: true
@@ -929,7 +890,6 @@ jobs:
           script_linux: firebird25.sh
           script_macos: firebird25.sh
           install_docker_macos: true
-          enable_os_win2016: false
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: true
@@ -952,7 +912,6 @@ jobs:
           script_linux: firebird3.sh
           script_macos: firebird3.sh
           install_docker_macos: true
-          enable_os_win2016: false
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: true
@@ -975,7 +934,6 @@ jobs:
           script_linux: firebird4.sh
           script_macos: firebird4.sh
           install_docker_macos: true
-          enable_os_win2016: false
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: true
@@ -1001,7 +959,6 @@ jobs:
           nuget_linux: IBM.Data.DB2.Core-lnx -Version 3.1.0.500
           nuget_macos: IBM.Data.DB2.Core-osx -Version 3.1.0.500
           install_docker_macos: true
-          enable_os_win2016: false
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: true
@@ -1027,7 +984,6 @@ jobs:
           nuget_linux: IBM.Data.DB2.Core-lnx -Version 3.1.0.500
           nuget_macos: IBM.Data.DB2.Core-osx -Version 3.1.0.500
           install_docker_macos: true
-          enable_os_win2016: false
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: false # true (needs working docker image)
@@ -1052,7 +1008,6 @@ jobs:
           nuget_linux: IBM.Data.DB2.Core-lnx -Version 3.1.0.500
           nuget_macos: IBM.Data.DB2.Core-osx -Version 3.1.0.500
           install_docker_macos: true
-          enable_os_win2016: false
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: true
@@ -1076,7 +1031,6 @@ jobs:
           script_linux: hana2.sh
           script_macos: mac.hana2.sh
           install_docker_macos: true
-          enable_os_win2016: false
           enable_os_win2019: false
           enable_os_win2022: false
           enable_os_ubuntu: true

--- a/Build/Azure/pipelines/templates/test-matrix.yml
+++ b/Build/Azure/pipelines/templates/test-matrix.yml
@@ -775,8 +775,8 @@ jobs:
           script_linux: sqlserver.2019.sh
           script_macos: mac.sqlserver.2019.sh
           install_docker_macos: true
-          enable_os_win2019: true
-          enable_os_win2022: false
+          enable_os_win2019: false
+          enable_os_win2022: true
           enable_os_ubuntu: true
           enable_os_macos:  true
           enable_fw_net472: true
@@ -799,8 +799,8 @@ jobs:
           script_linux: sqlserver.2019.sh
           script_macos: mac.sqlserver.2019.sh
           install_docker_macos: true
-          enable_os_win2019: true
-          enable_os_win2022: false
+          enable_os_win2019: false
+          enable_os_win2022: true
           enable_os_ubuntu: true
           enable_os_macos:  true
           enable_fw_net472: true

--- a/Build/Azure/pipelines/templates/test-workflow-windows.yml
+++ b/Build/Azure/pipelines/templates/test-workflow-windows.yml
@@ -69,7 +69,7 @@ steps:
   inputs:
     filePath: '$(System.DefaultWorkingDirectory)\scripts\$(psscript)'
     workingDirectory: '$(System.DefaultWorkingDirectory)'
-  condition: and(variables.title, variables.psscript, ne(${{ parameters.isCore }}, False))
+  condition: and(variables.title, variables.psscript)
   displayName: Setup tests
 
 - task: VSTest@2

--- a/Build/Azure/scripts/sqlserver.2005.cmd
+++ b/Build/Azure/scripts/sqlserver.2005.cmd
@@ -1,5 +1,5 @@
 rem without real 2005 image we use 2012 in compatibility mode
-docker run -d -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Password12!" -p 1433:1433 -h mssql --name=mssql dbafromthecold/sqlserver2012express:rtm
+docker run -d -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Password12!" -p 1433:1433 -h mssql --name=mssql cagrin/mssql-server-ltsc2022:2012-latest
 docker ps -a
 
 echo "Waiting for SQL Server to accept connections"

--- a/Build/Azure/scripts/sqlserver.2008.cmd
+++ b/Build/Azure/scripts/sqlserver.2008.cmd
@@ -1,5 +1,5 @@
 rem without real 2008 image we use 2012 in compatibility mode
-docker run -d -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Password12!" -p 1433:1433 -h mssql --name=mssql dbafromthecold/sqlserver2012express:rtm
+docker run -d -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Password12!" -p 1433:1433 -h mssql --name=mssql cagrin/mssql-server-ltsc2022:2012-latest
 docker ps -a
 
 echo "Waiting for SQL Server to accept connections"

--- a/Build/Azure/scripts/sqlserver.2012.cmd
+++ b/Build/Azure/scripts/sqlserver.2012.cmd
@@ -1,6 +1,6 @@
 rem also this SP4 image works too
 rem docker run -d -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Password12!" -p 1433:1433 -h mssql --name=mssql dbafromthecold/sqlserver2012dev:sp4
-docker run -d -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Password12!" -p 1433:1433 -h mssql --name=mssql dbafromthecold/sqlserver2012express:rtm
+docker run -d -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Password12!" -p 1433:1433 -h mssql --name=mssql cagrin/mssql-server-ltsc2022:2012-latest
 docker ps -a
 
 echo "Waiting for SQL Server to accept connections"

--- a/Build/Azure/scripts/sqlserver.2014.cmd
+++ b/Build/Azure/scripts/sqlserver.2014.cmd
@@ -1,6 +1,6 @@
 rem this SP2 also works
 rem docker run -d -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Password12!" -p 1433:1433 -h mssql --name=mssql dbafromthecold/sqlserver2014dev:sp2
-docker run -d -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Password12!" -p 1433:1433 -h mssql --name=mssql dbafromthecold/sqlserver2014express:rtm
+docker run -d -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Password12!" -p 1433:1433 -h mssql --name=mssql cagrin/mssql-server-ltsc2022:2014-latest
 docker ps -a
 
 echo "Waiting for SQL Server to accept connections"

--- a/Build/Azure/scripts/sqlserver.2016.cmd
+++ b/Build/Azure/scripts/sqlserver.2016.cmd
@@ -1,6 +1,6 @@
 rem use much smaller image instead of one from MS
 rem docker run -d -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Password12!" -p 1433:1433 -h mssql --name=mssql microsoft/mssql-server-windows-express:2016-sp1
-docker run -d -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Password12!" -p 1433:1433 -h mssql --name=mssql cortside/sqlserver:2016-developer
+docker run -d -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Password12!" -p 1433:1433 -h mssql --name=mssql cagrin/mssql-server-ltsc2022:2016-latest
 docker ps -a
 
 echo "Waiting for SQL Server to accept connections"

--- a/Build/Azure/scripts/sqlserver.2017.cmd
+++ b/Build/Azure/scripts/sqlserver.2017.cmd
@@ -1,5 +1,5 @@
 rem docker pull microsoft/mssql-server-windows-developer:2017-latest
-docker run -d -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Password12!" -p 1433:1433 -h mssql --name=mssql microsoft/mssql-server-windows-express:2017-latest
+docker run -d -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Password12!" -p 1433:1433 -h mssql --name=mssql cagrin/mssql-server-ltsc2022:2017-latest
 docker ps -a
 
 echo "Waiting for SQL Server to accept connections"

--- a/Build/Azure/scripts/sqlserver.2019.cmd
+++ b/Build/Azure/scripts/sqlserver.2019.cmd
@@ -1,4 +1,4 @@
-docker run -d -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Password12!" -p 1433:1433 -h mssql --name=mssql iamrjindal/sqlserverexpress:latest
+docker run -d -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Password12!" -p 1433:1433 -h mssql --name=mssql cagrin/mssql-server-ltsc2022:2019-latest
 docker ps -a
 
 echo "Waiting for SQL Server to accept connections"


### PR DESCRIPTION
It will be removed 15/03, so we better stop using it now