### PR TITLE
Reduce number of `IQueryable` parameter evaluations

### DIFF
--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
@@ -16,6 +16,7 @@ namespace LinqToDB.Linq.Builder
 	using Mapping;
 	using SqlQuery;
 	using LinqToDB.Expressions;
+	using LinqToDB.Reflection;
 
 	partial class ExpressionBuilder
 	{
@@ -1405,7 +1406,7 @@ namespace LinqToDB.Linq.Builder
 				var path =
 					Expression.Call(
 						Expression.Constant(_query),
-						MemberHelper.MethodOf<Query>(a => a.GetIQueryable(0, null!)),
+						Methods.Query.GetIQueryable,
 						ExpressionInstances.Int32(n), accessor ?? Expression.Constant(null, typeof(Expression)));
 
 				var qex = _query.GetIQueryable(n, expression);

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
@@ -1409,7 +1409,7 @@ namespace LinqToDB.Linq.Builder
 						Methods.Query.GetIQueryable,
 						ExpressionInstances.Int32(n), accessor ?? Expression.Constant(null, typeof(Expression)), Expression.Constant(true));
 
-				var qex = _query.GetIQueryable(n, expression, false);
+				var qex = _query.GetIQueryable(n, expression, force: false);
 
 				if (expression.NodeType == ExpressionType.Call && qex.NodeType == ExpressionType.Call)
 				{

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
@@ -1407,9 +1407,9 @@ namespace LinqToDB.Linq.Builder
 					Expression.Call(
 						Expression.Constant(_query),
 						Methods.Query.GetIQueryable,
-						ExpressionInstances.Int32(n), accessor ?? Expression.Constant(null, typeof(Expression)));
+						ExpressionInstances.Int32(n), accessor ?? Expression.Constant(null, typeof(Expression)), Expression.Constant(true));
 
-				var qex = _query.GetIQueryable(n, expression);
+				var qex = _query.GetIQueryable(n, expression, false);
 
 				if (expression.NodeType == ExpressionType.Call && qex.NodeType == ExpressionType.Call)
 				{

--- a/Source/LinqToDB/Linq/Query.cs
+++ b/Source/LinqToDB/Linq/Query.cs
@@ -116,9 +116,18 @@ namespace LinqToDB.Linq
 			}
 		}
 
-		internal Expression GetIQueryable(int n, Expression expr)
+		internal Expression GetIQueryable(int n, Expression expr, bool force)
 		{
-			return _queryableAccessorList[n].Queryable.Expression;
+			var accessor = _queryableAccessorList[n];
+			if (force)
+			{
+				if (accessor.SkipForce)
+					accessor.SkipForce = false;
+				else
+					return (accessor.Queryable = accessor.Accessor(expr)).Expression;
+			}
+
+			return accessor.Queryable.Expression;
 		}
 
 		public void ClearMemberQueryableInfo()

--- a/Source/LinqToDB/Linq/Query.cs
+++ b/Source/LinqToDB/Linq/Query.cs
@@ -83,8 +83,7 @@ namespace LinqToDB.Linq
 			if (_queryableAccessorDic.TryGetValue(expr, out var e))
 				return _queryableAccessorList.IndexOf(e);
 
-			e = new QueryableAccessor { Accessor = qe.CompileExpression() };
-			e.Queryable = e.Accessor(expr);
+			e = new QueryableAccessor(qe.CompileExpression(), expr);
 
 			_queryableAccessorDic. Add(expr, e);
 			_queryableAccessorList.Add(e);
@@ -119,7 +118,7 @@ namespace LinqToDB.Linq
 
 		internal Expression GetIQueryable(int n, Expression expr)
 		{
-			return _queryableAccessorList[n].Accessor(expr).Expression;
+			return _queryableAccessorList[n].Queryable.Expression;
 		}
 
 		public void ClearMemberQueryableInfo()

--- a/Source/LinqToDB/Linq/QueryableAccessor.cs
+++ b/Source/LinqToDB/Linq/QueryableAccessor.cs
@@ -6,7 +6,13 @@ namespace LinqToDB.Linq
 {
 	class QueryableAccessor
 	{
-		public IQueryable                  Queryable = null!;
-		public Func<Expression,IQueryable> Accessor  = null!;
+		public QueryableAccessor(Func<Expression, IQueryable> accessor, Expression expr)
+		{
+			Accessor  = accessor;
+			Queryable = accessor(expr);
+		}
+
+		public readonly IQueryable                  Queryable;
+		public readonly Func<Expression,IQueryable> Accessor;
 	}
 }

--- a/Source/LinqToDB/Linq/QueryableAccessor.cs
+++ b/Source/LinqToDB/Linq/QueryableAccessor.cs
@@ -10,9 +10,12 @@ namespace LinqToDB.Linq
 		{
 			Accessor  = accessor;
 			Queryable = accessor(expr);
+			// skip first re-evaluation by parameter setter
+			SkipForce = true;
 		}
 
-		public readonly IQueryable                  Queryable;
+		public          bool                        SkipForce;
+		public          IQueryable                  Queryable;
 		public readonly Func<Expression,IQueryable> Accessor;
 	}
 }

--- a/Source/LinqToDB/Reflection/Methods.cs
+++ b/Source/LinqToDB/Reflection/Methods.cs
@@ -19,6 +19,11 @@ namespace LinqToDB.Reflection
 	/// </summary>
 	public static class Methods
 	{
+		internal static class Query
+		{
+			public static readonly MethodInfo GetIQueryable = MemberHelper.MethodOf<Linq.Query>(a => a.GetIQueryable(default, default!));
+		}
+
 		public static class ADONet
 		{
 			public static readonly MethodInfo IsDBNull      = MemberHelper.MethodOf<IDataRecord> (r => r.IsDBNull(0));

--- a/Source/LinqToDB/Reflection/Methods.cs
+++ b/Source/LinqToDB/Reflection/Methods.cs
@@ -21,7 +21,7 @@ namespace LinqToDB.Reflection
 	{
 		internal static class Query
 		{
-			public static readonly MethodInfo GetIQueryable = MemberHelper.MethodOf<Linq.Query>(a => a.GetIQueryable(default, default!));
+			public static readonly MethodInfo GetIQueryable = MemberHelper.MethodOf<Linq.Query>(a => a.GetIQueryable(default, default!, default));
 		}
 
 		public static class ADONet

--- a/Tests/Linq/Linq/ParameterTests.cs
+++ b/Tests/Linq/Linq/ParameterTests.cs
@@ -1228,6 +1228,9 @@ namespace Tests.Linq
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/3450")]
 		public void TestIQueryableParameterEvaluation([DataSources] string context)
 		{
+			// cached queries affect cnt values due to extra comparisons in cache
+			LinqToDB.Linq.Query.ClearCaches();
+
 			using (var db = GetDataContext(context))
 			{
 				_cnt1       = 0;

--- a/Tests/Linq/Linq/ParameterTests.cs
+++ b/Tests/Linq/Linq/ParameterTests.cs
@@ -2,11 +2,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading.Tasks;
 using FluentAssertions;
 using LinqToDB;
 using LinqToDB.Data;
 using LinqToDB.Linq;
 using LinqToDB.Mapping;
+using Tests.Model;
 
 using NUnit.Framework;
 
@@ -1215,6 +1217,277 @@ namespace Tests.Linq
 				res[1].String2.Should().Be("str2");
 				res[1].String3.Should().Be("str3");
 			}
+		}
+
+		private int _cnt;
+		private int _cnt1;
+		private int _cnt2;
+		private int _cnt3;
+		private int _param;
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/3450")]
+		public void TestIQueryableParameterEvaluation([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				_cnt1       = 0;
+				_cnt2       = 0;
+				_cnt3       = 0;
+				_param      = 1;
+				var persons = Query(db);
+
+				Assert.AreEqual(1, persons.Count);
+				Assert.AreEqual(1, persons[0].ID);
+				Assert.AreEqual(1, _cnt1);
+				Assert.AreEqual(1, _cnt2);
+				Assert.AreEqual(1, _cnt3);
+
+				_cnt1   = 0;
+				_cnt2   = 0;
+				_cnt3   = 0;
+				_param  = 2;
+				persons = Query(db);
+
+				Assert.AreEqual(3, persons.Count);
+				Assert.AreEqual(1, persons.Count(_ => _.ID == 1));
+				Assert.AreEqual(1, persons.Count(_ => _.ID == 2));
+				Assert.AreEqual(1, persons.Count(_ => _.ID == 4));
+				Assert.AreEqual(3, _cnt1);
+				Assert.AreEqual(1, _cnt2);
+				Assert.AreEqual(1, _cnt3);
+
+				_cnt1   = 0;
+				_cnt2   = 0;
+				_cnt3   = 0;
+				_param  = 3;
+				persons = Query(db);
+
+				Assert.AreEqual(2, persons.Count);
+				Assert.AreEqual(1, persons.Count(_ => _.ID == 2));
+				Assert.AreEqual(1, persons.Count(_ => _.ID == 3));
+				Assert.AreEqual(5, _cnt1);
+				Assert.AreEqual(3, _cnt2);
+				Assert.AreEqual(1, _cnt3);
+
+				_cnt1   = 0;
+				_cnt2   = 0;
+				_cnt3   = 0;
+				_param  = 1;
+				persons = Query(db);
+
+				Assert.AreEqual(1, persons.Count);
+				Assert.AreEqual(1, persons[0].ID);
+				Assert.AreEqual(3, _cnt1);
+				Assert.AreEqual(1, _cnt2);
+				Assert.AreEqual(1, _cnt3);
+
+				_cnt1   = 0;
+				_cnt2   = 0;
+				_cnt3   = 0;
+				_param  = 3;
+				persons = Query(db);
+
+				Assert.AreEqual(2, persons.Count);
+				Assert.AreEqual(1, persons.Count(_ => _.ID == 2));
+				Assert.AreEqual(1, persons.Count(_ => _.ID == 3));
+				Assert.AreEqual(1, _cnt1);
+				Assert.AreEqual(1, _cnt2);
+				Assert.AreEqual(1, _cnt3);
+
+				_cnt1   = 0;
+				_cnt2   = 0;
+				_cnt3   = 0;
+				_param  = 2;
+				persons = Query(db);
+
+				Assert.AreEqual(3, persons.Count);
+				Assert.AreEqual(1, persons.Count(_ => _.ID == 1));
+				Assert.AreEqual(1, persons.Count(_ => _.ID == 2));
+				Assert.AreEqual(1, persons.Count(_ => _.ID == 4));
+				Assert.AreEqual(3, _cnt1);
+				Assert.AreEqual(2, _cnt2);
+				Assert.AreEqual(1, _cnt3);
+			}
+
+			List<Person> Query(ITestDataContext db)
+			{
+				return db.Person
+					.Where(_ => 
+					 GetQuery1(db).Select(p => p.ID).Contains(_.ID) &&
+					(GetQuery2(db).Select(p => p.ID).Contains(_.ID) ||
+					 GetQuery3(db).Select(p => p.ID).Contains(_.ID)))
+					.ToList();
+			}
+		}
+
+		private IQueryable<Person> GetQuery1(ITestDataContext db)
+		{
+			_cnt1++;
+			var paramCopy = _param;
+			if (paramCopy == 1)
+				return db.Person.Where(p => p.ID == paramCopy);
+
+			return db.Person.Where(p => paramCopy + 1 != p.ID);
+		}
+
+		private IQueryable<Person> GetQuery2(ITestDataContext db)
+		{
+			_cnt2++;
+			var paramCopy = _param;
+			if (paramCopy == 2)
+				return db.Person.Where(p => paramCopy == p.ID);
+
+			return db.Person.Where(p => p.ID == paramCopy - 1);
+		}
+
+		private IQueryable<Person> GetQuery3(ITestDataContext db)
+		{
+			_cnt3++;
+			var paramCopy = _param;
+			if (paramCopy == 3)
+				return db.Person.Where(p => p.ID == paramCopy);
+
+			return db.Person.Where(p => paramCopy + 1 != p.ID);
+		}
+
+		private int[] _params = new int[30];
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/3450")]
+		public void TestIQueryableParameterEvaluationMultiThreaded([IncludeDataSources(true, TestProvName.AllSqlServer)] string context)
+		{
+			using var _ = new DisableBaseline("multi-threading");
+
+			var tasks = new Task[30];
+
+			for (var i = 0; i < tasks.Length; i++)
+			{
+				var thread = i;
+				tasks[i] = Task.Run(() => TestRunner(context, thread));
+			}
+
+			Task.WaitAll(tasks);
+		}
+
+		public void TestRunner(string context, int thread)
+		{
+			using (var db = GetDataContext(context))
+			{
+				_params[thread] = 1;
+				var persons = Query(db, thread);
+
+				Assert.AreEqual(1, persons.Count);
+				Assert.AreEqual(1, persons[0].ID);
+
+				_params[thread] = 2;
+				persons = Query(db, thread);
+
+				Assert.AreEqual(3, persons.Count);
+				Assert.AreEqual(1, persons.Count(_ => _.ID == 1));
+				Assert.AreEqual(1, persons.Count(_ => _.ID == 2));
+				Assert.AreEqual(1, persons.Count(_ => _.ID == 4));
+
+				_params[thread] = 3;
+				persons = Query(db, thread);
+
+				Assert.AreEqual(2, persons.Count);
+				Assert.AreEqual(1, persons.Count(_ => _.ID == 2));
+				Assert.AreEqual(1, persons.Count(_ => _.ID == 3));
+
+				_params[thread] = 1;
+				persons = Query(db, thread);
+
+				Assert.AreEqual(1, persons.Count);
+				Assert.AreEqual(1, persons[0].ID);
+
+				_params[thread] = 3;
+				persons = Query(db, thread);
+
+				Assert.AreEqual(2, persons.Count);
+				Assert.AreEqual(1, persons.Count(_ => _.ID == 2));
+				Assert.AreEqual(1, persons.Count(_ => _.ID == 3));
+
+				_params[thread] = 2;
+				persons = Query(db, thread);
+
+				Assert.AreEqual(3, persons.Count);
+				Assert.AreEqual(1, persons.Count(_ => _.ID == 1));
+				Assert.AreEqual(1, persons.Count(_ => _.ID == 2));
+				Assert.AreEqual(1, persons.Count(_ => _.ID == 4));
+			}
+
+			List<Person> Query(ITestDataContext db, int thread)
+			{
+				return db.Person
+					.Where(_ => 
+					 GetQueryT1(db, thread).Select(p => p.ID).Contains(_.ID) &&
+					(GetQueryT2(db, thread).Select(p => p.ID).Contains(_.ID) ||
+					 GetQueryT3(db, thread).Select(p => p.ID).Contains(_.ID)))
+					.ToList();
+			}
+		}
+
+		private IQueryable<Person> GetQueryT1(ITestDataContext db, int thread)
+		{
+			_cnt1++;
+			var paramCopy = _params[thread];
+			if (paramCopy == 1)
+				return db.Person.Where(p => p.ID == paramCopy);
+
+			return db.Person.Where(p => paramCopy + 1 != p.ID);
+		}
+
+		private IQueryable<Person> GetQueryT2(ITestDataContext db, int thread)
+		{
+			_cnt2++;
+			var paramCopy = _params[thread];
+			if (paramCopy == 2)
+				return db.Person.Where(p => paramCopy == p.ID);
+
+			return db.Person.Where(p => p.ID == paramCopy - 1);
+		}
+
+		private IQueryable<Person> GetQueryT3(ITestDataContext db, int thread)
+		{
+			_cnt3++;
+			var paramCopy = _params[thread];
+			if (paramCopy == 3)
+				return db.Person.Where(p => p.ID == paramCopy);
+
+			return db.Person.Where(p => paramCopy + 1 != p.ID);
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/3450")]
+		public void TestSimpleParameterEvaluation([DataSources] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				_cnt        = 0;
+				_param      = 1;
+				var persons = Query(db);
+
+				Assert.AreEqual(3, persons.Count);
+				Assert.True(persons.All(p => p.ID != _param));
+				Assert.AreEqual(1, _cnt);
+
+				_cnt    = 0;
+				_param  = 2;
+				persons = Query(db);
+
+				Assert.AreEqual(3, persons.Count);
+				Assert.True(persons.All(p => p.ID != _param));
+				Assert.AreEqual(1, _cnt);
+			}
+
+			List<Person> Query(ITestDataContext db)
+			{
+				return db.Person.Where(_ => GetPersonsEnumerable().Contains(_.ID)).ToList();
+			}
+		}
+
+		private IEnumerable<int> GetPersonsEnumerable()
+		{
+			_cnt++;
+			return new[] { 1, 2, 3, 4 }.Where(_ => _ != _param);
 		}
 	}
 }


### PR DESCRIPTION
Partial fix #3450

Partial, because extra parameter evaluation still performed by query cache comparer.