### PR TITLE
Fix Sql.Property use in expression methods

### DIFF
--- a/Source/LinqToDB/Extensions/ReflectionExtensions.cs
+++ b/Source/LinqToDB/Extensions/ReflectionExtensions.cs
@@ -17,6 +17,7 @@ namespace LinqToDB.Extensions
 	using System.Diagnostics.CodeAnalysis;
 	using Expressions;
 	using LinqToDB.Common;
+	using LinqToDB.Reflection;
 
 	[PublicAPI]
 	public static class ReflectionExtensions
@@ -209,8 +210,6 @@ namespace LinqToDB.Extensions
 			return memberInfo.MemberType == MemberTypes.Method;
 		}
 
-		private static readonly MemberInfo SQLPropertyMethod = MemberHelper.MethodOf(() => Sql.Property<string>(null!, null!)).GetGenericMethodDefinition();
-
 		/// <summary>
 		/// Determines whether member info represent a Sql.Property method.
 		/// </summary>
@@ -221,7 +220,7 @@ namespace LinqToDB.Extensions
 		public static bool IsSqlPropertyMethodEx(this MemberInfo memberInfo)
 		{
 			return memberInfo is MethodInfo methodCall && methodCall.IsGenericMethod &&
-			       methodCall.GetGenericMethodDefinition() == SQLPropertyMethod;
+			       methodCall.GetGenericMethodDefinition() == Methods.LinqToDB.SqlExt.Property;
 		}
 
 		/// <summary>

--- a/Source/LinqToDB/Reflection/Methods.cs
+++ b/Source/LinqToDB/Reflection/Methods.cs
@@ -160,7 +160,7 @@ namespace LinqToDB.Reflection
 				public static readonly MethodInfo ToNotNull     = MemberHelper.MethodOfGeneric<int?>(i => global::LinqToDB.Sql.ToNotNull(i));
 				public static readonly MethodInfo ToNotNullable = MemberHelper.MethodOfGeneric<int?>(i => global::LinqToDB.Sql.ToNotNullable(i));
 				public static readonly MethodInfo Alias         = MemberHelper.MethodOfGeneric<int?>(i => global::LinqToDB.Sql.Alias(i, ""));
-				// don't use MethodOfGeneric here (Sql.Property treatened in specifal way by it)
+				// don't use MethodOfGeneric here (Sql.Property treatened in special way by it)
 				public static readonly MethodInfo Property      = typeof(global::LinqToDB.Sql).GetMethodEx(nameof(global::LinqToDB.Sql.Property))!.GetGenericMethodDefinition();
 			}
 

--- a/Source/LinqToDB/Sql/Sql.Expressions.cs
+++ b/Source/LinqToDB/Sql/Sql.Expressions.cs
@@ -468,7 +468,7 @@ namespace LinqToDB
 		}
 
 		[Extension("", BuilderType = typeof(TableFieldBuilder))]
-		internal static TColumn TableField<TEntity, TColumn>([NoEnumeration] TEntity entity, string fieldName)
+		public static TColumn TableField<TEntity, TColumn>([NoEnumeration] TEntity entity, string fieldName)
 		{
 			throw new LinqToDBException("'Sql.TableField' is server side only method and used only for generating custom SQL parts");
 		}

--- a/Tests/Linq/Linq/CalculatedColumnTests.cs
+++ b/Tests/Linq/Linq/CalculatedColumnTests.cs
@@ -131,5 +131,47 @@ namespace Tests.Linq
 				Assert.That(l[0].AsSqlFullName, Is.EqualTo(l[0].LastName + ", " + l[0].FirstName));
 			}
 		}
+
+		[Table("Person")]
+		public class CustomPerson1
+		{
+			[ExpressionMethod(nameof(Expr), IsColumn = true)]
+			public string? MiddleNamePreview { get; set; }
+
+			private static Expression<Func<CustomPerson1, string?>> Expr()
+			{
+				return e => Sql.TableField<CustomPerson1, string>(e, "MiddleName").Substring(0, 200);
+			}
+		}
+
+		[Table("Person")]
+		public class CustomPerson2
+		{
+			[ExpressionMethod(nameof(Expr), IsColumn = true)]
+			public string? MiddleNamePreview { get; set; }
+
+			private static Expression<Func<CustomPerson2, string?>> Expr()
+			{
+				return e => Sql.Property<string>(e, "MiddleName").Substring(0, 200);
+			}
+		}
+
+		[Test]
+		public void CalculatedColumnExpression1([IncludeDataSources(true, TestProvName.AllFirebird)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				_ = db.GetTable<CustomPerson1>().ToArray();
+			}
+		}
+
+		[Test]
+		public void CalculatedColumnExpression2([IncludeDataSources(true, TestProvName.AllFirebird)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				_ = db.GetTable<CustomPerson2>().ToArray();
+			}
+		}
 	}
 }


### PR DESCRIPTION
Fix #3465

- mark `Sql.TableField` as public
- fix `Sql.Property` use in expressions