### PR TITLE
Improve types support by providers

### DIFF
--- a/Data/Create Scripts/Firebird.sql
+++ b/Data/Create Scripts/Firebird.sql
@@ -167,7 +167,7 @@ CREATE TABLE "DataTypeTest"
 	"DateTime_"       TIMESTAMP,
 	"Decimal_"        DECIMAL(10, 2),
 	"Double_"         DOUBLE PRECISION,
-	"Guid_"           CHAR(38),
+	"Guid_"           CHAR(16) CHARACTER SET OCTETS,
 	"Int16_"          SMALLINT,
 	"Int32_"          INTEGER,
 	"Int64_"          NUMERIC(11),
@@ -210,7 +210,7 @@ INSERT INTO "DataTypeTest"
 	 "Xml_")
 VALUES
 	('dddddddddddddddd', 1,  255,'dddddddddddddddd', 'B', 'NOW', 12345.67,
-	1234.567, 'dddddddddddddddddddddddddddddddd', 32767, 32768, 1000000, 12.3456, 127,
+	1234.567, X'dddddddddddddddddddddddddddddddd', 32767, 32768, 1000000, 12.3456, 127,
 	1234.123, 'dddddddddddddddd', 'string', 32767, 32768, 200000000,
 	'<root><element strattr="strvalue" intattr="12345"/></root>');
 COMMIT;
@@ -235,12 +235,12 @@ CREATE TABLE "LinqDataTypes"
 	"DateTimeValue"  timestamp,
 	"DateTimeValue2" timestamp,
 	"BoolValue"      char(1),
-	"GuidValue"      char(38),
+	"GuidValue"      CHAR(16) CHARACTER SET OCTETS,
 	"BinaryValue"    blob,
 	"SmallIntValue"  smallint,
 	"IntValue"       int,
 	"BigIntValue"    bigint,
-	"StringValue"    VARCHAR(50) CHARACTER SET UNICODE_FSS
+	"StringValue"    VARCHAR(50)
 );
 COMMIT;
 
@@ -775,7 +775,7 @@ CREATE TABLE "TestMerge1"
 	"FieldDouble"     DOUBLE PRECISION,
 	"FieldDateTime"   TIMESTAMP,
 	"FieldBinary"     BLOB(20),
-	"FieldGuid"       CHAR(38),
+	"FieldGuid"       CHAR(16) CHARACTER SET OCTETS,
 	"FieldDecimal"    DECIMAL(18, 10),
 	"FieldDate"       DATE,
 	"FieldTime"       TIMESTAMP,
@@ -803,7 +803,7 @@ CREATE TABLE "TestMerge2"
 	"FieldDouble"     DOUBLE PRECISION,
 	"FieldDateTime"   TIMESTAMP,
 	"FieldBinary"     BLOB(20),
-	"FieldGuid"       CHAR(38),
+	"FieldGuid"       CHAR(16) CHARACTER SET OCTETS,
 	"FieldDecimal"    DECIMAL(18, 10),
 	"FieldDate"       DATE,
 	"FieldTime"       TIMESTAMP,

--- a/Data/Create Scripts/Firebird.sql
+++ b/Data/Create Scripts/Firebird.sql
@@ -240,7 +240,7 @@ CREATE TABLE "LinqDataTypes"
 	"SmallIntValue"  smallint,
 	"IntValue"       int,
 	"BigIntValue"    bigint,
-	"StringValue"    VARCHAR(50)
+	"StringValue"    VARCHAR(50) CHARACTER SET UNICODE_FSS
 );
 COMMIT;
 

--- a/Source/LinqToDB/Common/DbDataType.cs
+++ b/Source/LinqToDB/Common/DbDataType.cs
@@ -63,7 +63,6 @@ namespace LinqToDB.Common
 		public int?     Precision  { get; }
 		public int?     Scale      { get; }
 
-
 		internal static MethodInfo WithSetValuesMethodInfo =
 			MemberHelper.MethodOf<DbDataType>(dt => dt.WithSetValues(dt));
 

--- a/Source/LinqToDB/DataProvider/BasicBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/BasicBulkCopy.cs
@@ -8,6 +8,7 @@ using LinqToDB.SqlQuery;
 namespace LinqToDB.DataProvider
 {
 	using Data;
+	using LinqToDB.Mapping;
 	using SqlProvider;
 	using System.Data;
 	using System.Threading;
@@ -16,10 +17,13 @@ namespace LinqToDB.DataProvider
 	public class BasicBulkCopy
 	{
 		protected virtual int MaxParameters => 999;
-		protected virtual int MaxSqlLength => 100000;
+		protected virtual int MaxSqlLength  => 100000;
 
-		protected virtual bool CastOnUnionAll         => false;
-		protected virtual bool TypeAllUnionParameters => false;
+		protected virtual bool CastFirstRowLiteralOnUnionAll    => false;
+		protected virtual bool CastFirstRowParametersOnUnionAll => false;
+		protected virtual bool CastAllRowsParametersOnUnionAll  => false;
+
+		protected virtual bool CastLiteral(ColumnDescriptor column) => false;
 
 		public virtual BulkCopyRowsCopied BulkCopy<T>(BulkCopyType bulkCopyType, ITable<T> table, BulkCopyOptions options, IEnumerable<T> source)
 			where T : notnull
@@ -616,7 +620,7 @@ namespace LinqToDB.DataProvider
 			helper.StringBuilder
 				.AppendLine()
 				.Append("SELECT ");
-			helper.BuildColumns(item, castParameters: CastOnUnionAll, castAllRows: TypeAllUnionParameters);
+			helper.BuildColumns(item, castParameters: CastFirstRowParametersOnUnionAll, castAllRows: CastAllRowsParametersOnUnionAll, castFirstRowLiteralOnUnionAll: CastFirstRowLiteralOnUnionAll, castLiteral: CastLiteral);
 			helper.StringBuilder.Append(from);
 			helper.StringBuilder.Append(" UNION ALL");
 
@@ -671,7 +675,7 @@ namespace LinqToDB.DataProvider
 			helper.StringBuilder
 				.AppendLine()
 				.Append("\tSELECT ");
-			helper.BuildColumns(item, castParameters: CastOnUnionAll, castAllRows : TypeAllUnionParameters);
+			helper.BuildColumns(item, castParameters: CastFirstRowParametersOnUnionAll, castAllRows : CastAllRowsParametersOnUnionAll, castFirstRowLiteralOnUnionAll: CastFirstRowLiteralOnUnionAll, castLiteral: CastLiteral);
 			helper.StringBuilder.Append(from);
 			helper.StringBuilder.Append(" UNION ALL");
 

--- a/Source/LinqToDB/DataProvider/BulkCopyReader.cs
+++ b/Source/LinqToDB/DataProvider/BulkCopyReader.cs
@@ -123,7 +123,7 @@ namespace LinqToDB.DataProvider
 		{
 			_dataConnection = dataConnection;
 			_columns        = columns;
-			_columnTypes    = _columns.Select(c => c.GetDbDataType(true)).ToArray();
+			_columnTypes    = _columns.Select(c => c.GetConvertedDbDataType()).ToArray();
 			_ordinals       = _columns.Select((c, i) => new { c, i }).ToDictionary(_ => _.c.ColumnName, _ => _.i);
 		}
 
@@ -256,10 +256,11 @@ namespace LinqToDB.DataProvider
 			for (var i = 0; i < _columns.Count; ++i)
 			{
 				var columnDescriptor = _columns[i];
+				var convertedType    = columnDescriptor.GetConvertedDbDataType();
 				var row              = table.NewRow();
 
 				row[SchemaTableColumn.ColumnName]              = columnDescriptor.ColumnName;
-				row[SchemaTableColumn.DataType]                = _dataConnection.DataProvider.ConvertParameterType(columnDescriptor.MemberType, _columnTypes[i]);
+				row[SchemaTableColumn.DataType]                = _dataConnection.DataProvider.ConvertParameterType(convertedType.SystemType, _columnTypes[i]);
 				row[SchemaTableColumn.IsKey]                   = columnDescriptor.IsPrimaryKey;
 				row[SchemaTableOptionalColumn.IsAutoIncrement] = columnDescriptor.IsIdentity;
 				row[SchemaTableColumn.AllowDBNull]             = columnDescriptor.CanBeNull;

--- a/Source/LinqToDB/DataProvider/DB2/DB2MappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2MappingSchema.cs
@@ -46,10 +46,11 @@ namespace LinqToDB.DataProvider.DB2
 
 		protected DB2MappingSchema(string configuration) : base(configuration)
 		{
-			SetValueToSqlConverter(typeof(Guid), (sb,dt,v) => ConvertGuidToSql(sb, (Guid)v));
-
 			SetDataType(typeof(string), new SqlDataType(DataType.NVarChar, typeof(string), 255));
+			SetDataType(typeof(byte), new SqlDataType(DataType.Int16, typeof(byte)));
+			SetDataType(typeof(byte?), new SqlDataType(DataType.Int16, typeof(byte)));
 
+			SetValueToSqlConverter(typeof(Guid),     (sb,dt,v) => ConvertBinaryToSql  (sb, ((Guid)v).ToByteArray()));
 			SetValueToSqlConverter(typeof(string),   (sb,dt,v) => ConvertStringToSql  (sb, v.ToString()!));
 			SetValueToSqlConverter(typeof(char),     (sb,dt,v) => ConvertCharToSql    (sb, (char)v));
 			SetValueToSqlConverter(typeof(byte[]),   (sb,dt,v) => ConvertBinaryToSql  (sb, (byte[])v));
@@ -147,25 +148,6 @@ namespace LinqToDB.DataProvider.DB2
 		}
 
 		internal static readonly DB2MappingSchema Instance = new ();
-
-		static void ConvertGuidToSql(StringBuilder stringBuilder, Guid value)
-		{
-			var s = value.ToString("N");
-
-			stringBuilder
-				.Append("Cast(x'")
-				.Append(s.Substring( 6,  2))
-				.Append(s.Substring( 4,  2))
-				.Append(s.Substring( 2,  2))
-				.Append(s.Substring( 0,  2))
-				.Append(s.Substring(10,  2))
-				.Append(s.Substring( 8,  2))
-				.Append(s.Substring(14,  2))
-				.Append(s.Substring(12,  2))
-				.Append(s.Substring(16, 16))
-				.Append("' as char(16) for bit data)")
-				;
-		}
 	}
 
 	public class DB2zOSMappingSchema : MappingSchema

--- a/Source/LinqToDB/DataProvider/DB2/DB2SqlBuilderBase.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2SqlBuilderBase.cs
@@ -143,7 +143,7 @@ namespace LinqToDB.DataProvider.DB2
 					return;
 				case DataType.Boolean   : StringBuilder.Append("smallint");              return;
 				case DataType.Guid      : StringBuilder.Append("char(16) for bit data"); return;
-				case DataType.NVarChar:
+				case DataType.NVarChar  :
 					if (type.Type.Length == null || type.Type.Length > 8168 || type.Type.Length < 1)
 					{
 						StringBuilder
@@ -156,6 +156,14 @@ namespace LinqToDB.DataProvider.DB2
 			}
 
 			base.BuildDataTypeFromDataType(type, forCreateTable);
+		}
+
+		protected override void BuildCreateTableNullAttribute(SqlField field, DefaultNullable defaultNullable)
+		{
+			if (field.CanBeNull && field.Type.DataType == DataType.Guid)
+				return;
+
+			base.BuildCreateTableNullAttribute(field, defaultNullable);
 		}
 
 		public static DB2IdentifierQuoteMode IdentifierQuoteMode = DB2IdentifierQuoteMode.Auto;

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdBulkCopy.cs
@@ -3,6 +3,7 @@
 namespace LinqToDB.DataProvider.Firebird
 {
 	using Data;
+	using LinqToDB.Mapping;
 	using System.Threading;
 	using System.Threading.Tasks;
 
@@ -21,8 +22,19 @@ namespace LinqToDB.DataProvider.Firebird
 		/// </remarks>
 		protected override int MaxParameters => 32767;
 
-		protected override bool CastOnUnionAll         => true;
-		protected override bool TypeAllUnionParameters => true;
+		protected override bool CastFirstRowLiteralOnUnionAll    => true;
+		protected override bool CastFirstRowParametersOnUnionAll => true;
+		protected override bool CastAllRowsParametersOnUnionAll  => true;
+
+		protected override bool CastLiteral(ColumnDescriptor column)
+		{
+			// if union column is not typed as varchar, it will use char(max_literal_length) type with values padded with spaces
+			var dataType = column.DataType;
+			if (dataType == DataType.Undefined)
+				dataType = column.GetConvertedDbDataType().DataType;
+
+			return dataType is DataType.VarChar or DataType.NVarChar;
+		}
 
 		protected override BulkCopyRowsCopied MultipleRowsCopy<T>(
 			ITable<T> table, BulkCopyOptions options, IEnumerable<T> source)

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdDataProvider.cs
@@ -96,7 +96,7 @@ namespace LinqToDB.DataProvider.Firebird
 			FirebirdProviderAdapter.FbDbType? type = null;
 			switch (dataType.DataType)
 			{
-				case DataType.DateTimeOffset     : type = FirebirdProviderAdapter.FbDbType.TimeStampTZ; break;
+				case DataType.DateTimeOffset : type = FirebirdProviderAdapter.FbDbType.TimeStampTZ; break;
 			}
 
 			if (type != null)

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdExtensions.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdExtensions.cs
@@ -1,0 +1,22 @@
+﻿using LinqToDB.Data;
+using LinqToDB.Linq;
+using LinqToDB.SqlProvider;
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace LinqToDB.DataProvider.Firebird
+{
+	public interface IFirebirdExtensions
+	{
+	}
+
+	public static class FirebirdExtensions
+	{
+		public static IFirebirdExtensions? Firebird(this Sql.ISqlExtension? ext) => null;
+
+		[Sql.Extension("UUID_TO_CHAR({guid})", PreferServerSide = true, IsNullable = Sql.IsNullableType.SameAsFirstParameter)]
+		public static string? UuidToChar(this IFirebirdExtensions? ext, [ExprParameter] Guid? guid) => guid?.ToString("D").ToUpperInvariant();
+	}
+}

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdMappingSchema.cs
@@ -29,6 +29,7 @@ namespace LinqToDB.DataProvider.Firebird
 			// firebird string literals can contain only limited set of characters, so we should encode them
 			SetValueToSqlConverter(typeof(string)  , (sb, dt, v) => ConvertStringToSql(sb, (string)v));
 			SetValueToSqlConverter(typeof(char)    , (sb, dt, v) => ConvertCharToSql  (sb, (char)v));
+			SetValueToSqlConverter(typeof(Guid)    , (sb, dt, v) => ConvertGuidToSql  (sb, (Guid)v));
 			SetValueToSqlConverter(typeof(byte[])  , (sb, dt, v) => ConvertBinaryToSql(sb, (byte[])v));
 			SetValueToSqlConverter(typeof(Binary)  , (sb, dt, v) => ConvertBinaryToSql(sb, ((Binary)v).ToArray()));
 			SetValueToSqlConverter(typeof(DateTime), (sb, dt, v) => BuildDateTime(sb, dt, (DateTime)v));
@@ -85,6 +86,19 @@ namespace LinqToDB.DataProvider.Firebird
 			stringBuilder.Append("X'");
 
 			stringBuilder.AppendByteArrayAsHexViaLookup32(value);
+
+			stringBuilder.Append('\'');
+		}
+
+		static void ConvertGuidToSql(StringBuilder stringBuilder, Guid value)
+		{
+			stringBuilder.Append("X'");
+
+			var bytes = value.ToByteArray();
+
+			(bytes[3], bytes[2], bytes[1], bytes[0], bytes[5], bytes[4], bytes[7], bytes[6]) = (bytes[0], bytes[1], bytes[2], bytes[3], bytes[4],bytes[5], bytes[6], bytes[7]);
+
+			stringBuilder.AppendByteArrayAsHexViaLookup32(bytes);
 
 			stringBuilder.Append('\'');
 		}

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdSqlBuilder.cs
@@ -119,6 +119,7 @@ namespace LinqToDB.DataProvider.Firebird
 				case DataType.DateTime2     :
 				case DataType.SmallDateTime :
 				case DataType.DateTime      : StringBuilder.Append("TimeStamp");                          break;
+				case DataType.VarChar       :
 				case DataType.NVarChar      :
 					StringBuilder.Append("VarChar");
 
@@ -136,6 +137,7 @@ namespace LinqToDB.DataProvider.Firebird
 				// BOOLEAN type available since FB 3.0, but FirebirdDataProvider.SetParameter converts boolean to '1'/'0'
 				// so for now we will use type, compatible with SetParameter by default
 				case DataType.Boolean       : StringBuilder.Append("CHAR");                               break;
+				case DataType.Guid          : StringBuilder.Append("CHAR(16) CHARACTER SET OCTETS");      break;
 				default: base.BuildDataTypeFromDataType(type, forCreateTable);                            break;
 			}
 		}

--- a/Source/LinqToDB/DataProvider/Informix/InformixDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixDataProvider.cs
@@ -22,16 +22,16 @@ namespace LinqToDB.DataProvider.Informix
 				InformixProviderAdapter.GetInstance(providerName))
 
 		{
-			SqlProviderFlags.IsParameterOrderDependent         = !Adapter.IsIDSProvider;
-			SqlProviderFlags.IsSubQueryTakeSupported           = false;
-			SqlProviderFlags.IsInsertOrUpdateSupported         = false;
+			SqlProviderFlags.IsParameterOrderDependent          = !Adapter.IsIDSProvider;
+			SqlProviderFlags.IsSubQueryTakeSupported            = false;
+			SqlProviderFlags.IsInsertOrUpdateSupported          = false;
 			SqlProviderFlags.IsGroupByExpressionSupported      = false;
-			SqlProviderFlags.IsCrossJoinSupported              = false;
-			SqlProviderFlags.IsCommonTableExpressionsSupported = true;
-			SqlProviderFlags.IsSubQueryOrderBySupported        = true;
-			SqlProviderFlags.IsDistinctOrderBySupported        = false;
-			SqlProviderFlags.IsUpdateFromSupported             = false;
-			SqlProviderFlags.IsGroupByColumnRequred            = true;
+			SqlProviderFlags.IsCrossJoinSupported               = false;
+			SqlProviderFlags.IsCommonTableExpressionsSupported  = true;
+			SqlProviderFlags.IsSubQueryOrderBySupported         = true;
+			SqlProviderFlags.IsDistinctOrderBySupported         = false;
+			SqlProviderFlags.IsUpdateFromSupported              = false;
+			SqlProviderFlags.IsGroupByColumnRequred             = true;
 
 			SetCharField("CHAR",  (r,i) => r.GetString(i).TrimEnd(' '));
 			SetCharField("NCHAR", (r,i) => r.GetString(i).TrimEnd(' '));
@@ -120,6 +120,10 @@ namespace LinqToDB.DataProvider.Informix
 			{
 				value    = value?.ToString();
 				dataType = dataType.WithDataType(DataType.Char);
+			}
+			else if (value is byte byteValue && dataType.DataType == DataType.Int16)
+			{
+				value = (short)byteValue;
 			}
 			else if (value is bool b)
 			{

--- a/Source/LinqToDB/DataProvider/Informix/InformixMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixMappingSchema.cs
@@ -29,6 +29,8 @@ namespace LinqToDB.DataProvider.Informix
 			SetValueToSqlConverter(typeof(bool), (sb,dt,v) => sb.Append('\'').Append((bool)v ? 't' : 'f').Append('\''));
 
 			SetDataType(typeof(string), new SqlDataType(DataType.NVarChar, typeof(string), 255));
+			SetDataType(typeof(byte), new SqlDataType(DataType.Int16, typeof(byte)));
+			SetDataType(typeof(byte?), new SqlDataType(DataType.Int16, typeof(byte)));
 
 			SetValueToSqlConverter(typeof(string),   (sb,dt,v)   => ConvertStringToSql  (sb, v.ToString()!));
 			SetValueToSqlConverter(typeof(char),     (sb,dt,v)   => ConvertCharToSql    (sb, (char)v));

--- a/Source/LinqToDB/DataProvider/Informix/InformixSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixSqlBuilder.cs
@@ -128,6 +128,7 @@ namespace LinqToDB.DataProvider.Informix
 		{
 			switch (type.Type.DataType)
 			{
+				case DataType.Guid       : StringBuilder.Append("VARCHAR(36)");               return;
 				case DataType.VarBinary  : StringBuilder.Append("BYTE");                      return;
 				case DataType.Boolean    : StringBuilder.Append("BOOLEAN");                   return;
 				case DataType.DateTime   : StringBuilder.Append("datetime year to second");   return;

--- a/Source/LinqToDB/DataProvider/Oracle/OracleMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleMappingSchema.cs
@@ -49,13 +49,13 @@ namespace LinqToDB.DataProvider.Oracle
 
 			SetConvertExpression<decimal,TimeSpan>(v => new TimeSpan((long)v));
 
-			SetValueToSqlConverter(typeof(Guid),     (sb,dt,v)         => ConvertGuidToSql    (sb,     (Guid)    v));
+			SetValueToSqlConverter(typeof(Guid),     (sb,dt,v)         => ConvertBinaryToSql  (sb,     ((Guid)   v).ToByteArray()));
 			SetValueToSqlConverter(typeof(DateTime), (sb,dt,v)         => ConvertDateTimeToSql(sb, dt, (DateTime)v));
 			SetValueToSqlConverter(typeof(DateTimeOffset), (sb, dt, v) => ConvertDateTimeToSql(sb, dt, ((DateTimeOffset)v).UtcDateTime));
 			SetValueToSqlConverter(typeof(string)        , (sb, dt, v) => ConvertStringToSql  (sb, v.ToString()!));
 			SetValueToSqlConverter(typeof(char)          , (sb, dt, v) => ConvertCharToSql    (sb, (char)v));
-			SetValueToSqlConverter(typeof(byte[]), (sb, dt, v)         => ConvertBinaryToSql(sb, (byte[])v));
-			SetValueToSqlConverter(typeof(Binary), (sb, dt, v)         => ConvertBinaryToSql(sb, ((Binary)v).ToArray()));
+			SetValueToSqlConverter(typeof(byte[]), (sb, dt, v)         => ConvertBinaryToSql  (sb, (byte[])v));
+			SetValueToSqlConverter(typeof(Binary), (sb, dt, v)         => ConvertBinaryToSql  (sb, ((Binary)v).ToArray()));
 
 			// adds floating point special values support
 			SetValueToSqlConverter(typeof(float), (sb, dt, v) =>
@@ -131,25 +131,6 @@ namespace LinqToDB.DataProvider.Oracle
 			}
 
 			return base.TryGetConvertExpression(from, to);
-		}
-
-		static void ConvertGuidToSql(StringBuilder stringBuilder, Guid value)
-		{
-			var s = value.ToString("N");
-
-			stringBuilder
-				.Append("Cast('")
-				.Append(s.Substring( 6,  2))
-				.Append(s.Substring( 4,  2))
-				.Append(s.Substring( 2,  2))
-				.Append(s.Substring( 0,  2))
-				.Append(s.Substring(10,  2))
-				.Append(s.Substring( 8,  2))
-				.Append(s.Substring(14,  2))
-				.Append(s.Substring(12,  2))
-				.Append(s.Substring(16, 16))
-				.Append("' as raw(16))")
-				;
 		}
 
 		static void ConvertDateTimeToSql(StringBuilder stringBuilder, SqlDataType dataType, DateTime value)

--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteMappingSchema.cs
@@ -26,7 +26,7 @@ namespace LinqToDB.DataProvider.SQLite
 		{
 			SetConvertExpression<string,TimeSpan>(s => DateTime.Parse(s, null, DateTimeStyles.NoCurrentDateDefault).TimeOfDay);
 
-			SetValueToSqlConverter(typeof(Guid),     (sb,dt,v) => ConvertGuidToSql    (sb, (Guid)    v));
+			SetValueToSqlConverter(typeof(Guid),     (sb,dt,v) => ConvertBinaryToSql  (sb, ((Guid)  v).ToByteArray()));
 			SetValueToSqlConverter(typeof(DateTime), (sb,dt,v) => ConvertDateTimeToSql(sb, (DateTime)v));
 			SetValueToSqlConverter(typeof(string),   (sb,dt,v) => ConvertStringToSql  (sb, v.ToString()!));
 			SetValueToSqlConverter(typeof(char),     (sb,dt,v) => ConvertCharToSql    (sb, (char)v));
@@ -43,25 +43,6 @@ namespace LinqToDB.DataProvider.SQLite
 			stringBuilder.AppendByteArrayAsHexViaLookup32(value);
 
 			stringBuilder.Append('\'');
-		}
-
-		static void ConvertGuidToSql(StringBuilder stringBuilder, Guid value)
-		{
-			var s = value.ToString("N");
-
-			stringBuilder
-				.Append("Cast(x'")
-				.Append(s.Substring( 6,  2))
-				.Append(s.Substring( 4,  2))
-				.Append(s.Substring( 2,  2))
-				.Append(s.Substring( 0,  2))
-				.Append(s.Substring(10,  2))
-				.Append(s.Substring( 8,  2))
-				.Append(s.Substring(14,  2))
-				.Append(s.Substring(12,  2))
-				.Append(s.Substring(16, 16))
-				.Append("' as blob)")
-				;
 		}
 
 		static void ConvertDateTimeToSql(StringBuilder stringBuilder, DateTime value)

--- a/Source/LinqToDB/DataProvider/SqlCe/SqlCeSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlCe/SqlCeSqlBuilder.cs
@@ -84,6 +84,7 @@ namespace LinqToDB.DataProvider.SqlCe
 		{
 			switch (type.Type.DataType)
 			{
+				case DataType.Guid          : StringBuilder.Append("UNIQUEIDENTIFIER");                                                             return;
 				case DataType.Char          : base.BuildDataTypeFromDataType(new SqlDataType(DataType.NChar,    type.Type.Length), forCreateTable); return;
 				case DataType.VarChar       : base.BuildDataTypeFromDataType(new SqlDataType(DataType.NVarChar, type.Type.Length), forCreateTable); return;
 				case DataType.SmallMoney    : StringBuilder.Append("Decimal(10, 4)");                                                               return;

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2005SqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2005SqlOptimizer.cs
@@ -1,6 +1,4 @@
-﻿using LinqToDB.Common;
-
-namespace LinqToDB.DataProvider.SqlServer
+﻿namespace LinqToDB.DataProvider.SqlServer
 {
 	using SqlProvider;
 	using SqlQuery;
@@ -28,6 +26,5 @@ namespace LinqToDB.DataProvider.SqlServer
 			func = ConvertFunctionParameters(func, false);
 			return base.ConvertFunction(func);
 		}
-
 	}
 }

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
@@ -51,6 +51,7 @@ namespace LinqToDB.DataProvider.SqlServer
 			{
 				SqlProviderFlags.IsApplyJoinSupported              = true;
 				SqlProviderFlags.TakeHintsSupported                = TakeHints.Percent | TakeHints.WithTies;
+				// TODO: move both options to SQL2005 level
 				SqlProviderFlags.IsCommonTableExpressionsSupported = version >= SqlServerVersion.v2008;
 			}
 

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlBuilder.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Linq;
 using System.Text;
 
 namespace LinqToDB.DataProvider.SqlServer
 {
-	using SqlQuery;
-	using SqlProvider;
 	using Mapping;
+	using SqlProvider;
+	using SqlQuery;
 
 	abstract class SqlServerSqlBuilder : BasicSqlBuilder
 	{

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseSqlBuilder.cs
@@ -79,8 +79,9 @@ namespace LinqToDB.DataProvider.Sybase
 		{
 			switch (type.Type.DataType)
 			{
-				case DataType.DateTime2 : StringBuilder.Append("DateTime");       return;
-				case DataType.NVarChar:
+				case DataType.Guid      : StringBuilder.Append("VARCHAR(36)"); return;
+				case DataType.DateTime2 : StringBuilder.Append("DateTime");    return;
+				case DataType.NVarChar  :
 					// yep, 5461...
 					if (type.Type.Length == null || type.Type.Length > 5461 || type.Type.Length < 1)
 					{
@@ -93,6 +94,15 @@ namespace LinqToDB.DataProvider.Sybase
 			}
 
 			base.BuildDataTypeFromDataType(type, forCreateTable);
+		}
+
+		protected override void BuildCreateTableNullAttribute(SqlField field, DefaultNullable defaultNullable)
+		{
+			// BIT cannot be nullable in ASE
+			if (field.CanBeNull && field.Type.DataType == DataType.Boolean)
+				return;
+
+			base.BuildCreateTableNullAttribute(field, defaultNullable);
 		}
 
 		protected override void BuildDeleteClause(SqlDeleteStatement deleteStatement)

--- a/Source/LinqToDB/Linq/Expressions.cs
+++ b/Source/LinqToDB/Linq/Expressions.cs
@@ -23,6 +23,7 @@ namespace LinqToDB.Linq
 	using Common;
 	using Extensions;
 	using LinqToDB.Common.Internal;
+	using LinqToDB.DataProvider.Firebird;
 	using LinqToDB.Expressions;
 	using Mapping;
 
@@ -1281,6 +1282,8 @@ namespace LinqToDB.Linq
 
 					{ M(() => Sql.RoundToEven(0.0)  ), N(() => L<double?,double?>     ((double? v)        => (double?)Sql.RoundToEven((decimal)v!)))    },
 					{ M(() => Sql.RoundToEven(0.0,0)), N(() => L<double?,int?,double?>((double? v,int? p) => (double?)Sql.RoundToEven((decimal)v!, p))) },
+
+					{ M(() => Sql.ConvertTo<string>.From(Guid.Empty)), N(() => L<Guid,string?>((Guid p) => Sql.Lower(Sql.Ext.Firebird().UuidToChar(p)))) },
 				}},
 
 				#endregion

--- a/Source/LinqToDB/Mapping/ColumnDescriptor.cs
+++ b/Source/LinqToDB/Mapping/ColumnDescriptor.cs
@@ -457,7 +457,9 @@ namespace LinqToDB.Mapping
 					systemType = typeof(object);
 				}
 				else
-					if (systemType.IsEnum)
+				{
+					var enumType = systemType.ToNullableUnderlying();
+					if (enumType.IsEnum)
 					{
 						var type = Converter.GetDefaultMappingFromEnumType(MappingSchema, dbDataType.SystemType);
 						if (type != null)
@@ -465,6 +467,7 @@ namespace LinqToDB.Mapping
 							systemType = type;
 						}
 					}
+				}
 			}
 
 			if (dbDataType.SystemType != systemType)

--- a/Source/LinqToDB/Reflection/Methods.cs
+++ b/Source/LinqToDB/Reflection/Methods.cs
@@ -12,6 +12,7 @@ namespace LinqToDB.Reflection
 	using Linq;
 	using LinqToDB.Common;
 	using LinqToDB.Extensions;
+	using LinqToDB.SqlQuery;
 
 	/// <summary>
 	/// This API supports the LinqToDB infrastructure and is not intended to be used  directly from your code.
@@ -142,21 +143,20 @@ namespace LinqToDB.Reflection
 
 			public static class GroupBy
 			{
-				public static readonly MethodInfo Rollup       = MemberHelper.MethodOfGeneric<Sql.IGroupBy>(g => g.Rollup<object>(null!));
-				public static readonly MethodInfo Cube         = MemberHelper.MethodOfGeneric<Sql.IGroupBy>(g => g.Cube<object>(null!));
-				public static readonly MethodInfo GroupingSets = MemberHelper.MethodOfGeneric<Sql.IGroupBy>(g => g.GroupingSets<object>(null!));
+				public static readonly MethodInfo Rollup       = MemberHelper.MethodOfGeneric<global::LinqToDB.Sql.IGroupBy>(g => g.Rollup<object>(null!));
+				public static readonly MethodInfo Cube         = MemberHelper.MethodOfGeneric<global::LinqToDB.Sql.IGroupBy>(g => g.Cube<object>(null!));
+				public static readonly MethodInfo GroupingSets = MemberHelper.MethodOfGeneric<global::LinqToDB.Sql.IGroupBy>(g => g.GroupingSets<object>(null!));
 
-				public static readonly MethodInfo Grouping     = MemberHelper.MethodOf(() => Sql.Grouping(null!));
-
+				public static readonly MethodInfo Grouping     = MemberHelper.MethodOf(() => global::LinqToDB.Sql.Grouping(null!));
 			}
 
 			public static class SqlExt
 			{
-				public static readonly MethodInfo ToNotNull     = MemberHelper.MethodOfGeneric<int?>(i => Sql.ToNotNull(i));
-				public static readonly MethodInfo ToNotNullable = MemberHelper.MethodOfGeneric<int?>(i => Sql.ToNotNullable(i));
-				public static readonly MethodInfo Alias         = MemberHelper.MethodOfGeneric<int?>(i => Sql.Alias(i, ""));
+				public static readonly MethodInfo ToNotNull     = MemberHelper.MethodOfGeneric<int?>(i => global::LinqToDB.Sql.ToNotNull(i));
+				public static readonly MethodInfo ToNotNullable = MemberHelper.MethodOfGeneric<int?>(i => global::LinqToDB.Sql.ToNotNullable(i));
+				public static readonly MethodInfo Alias         = MemberHelper.MethodOfGeneric<int?>(i => global::LinqToDB.Sql.Alias(i, ""));
 				// don't use MethodOfGeneric here (Sql.Property treatened in specifal way by it)
-				public static readonly MethodInfo Property      = typeof(Sql).GetMethodEx(nameof(Sql.Property))!.GetGenericMethodDefinition();
+				public static readonly MethodInfo Property      = typeof(global::LinqToDB.Sql).GetMethodEx(nameof(global::LinqToDB.Sql.Property))!.GetGenericMethodDefinition();
 			}
 
 			public static class Update
@@ -330,6 +330,12 @@ namespace LinqToDB.Reflection
 			{ 
 				public static readonly PropertyInfo DbDataType = MemberHelper.PropertyOf<Data.DataParameter>(dp => dp.DbDataType);
 				public static readonly PropertyInfo Value      = MemberHelper.PropertyOf<Data.DataParameter>(dp => dp.Value);
+			}
+
+			internal static class Sql
+			{
+				public static readonly ConstructorInfo SqlParameterConstructor = MemberHelper.ConstructorOf(() => new SqlParameter(default(DbDataType), default(string), null));
+				public static readonly ConstructorInfo SqlValueConstructor     = MemberHelper.ConstructorOf(() => new SqlValue    (default(DbDataType), null));
 			}
 		}
 

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -95,7 +95,7 @@ namespace LinqToDB.SqlProvider
 		public T? ConvertElement<T>(T? element)
 			where T : class, IQueryElement
 		{
-			return SqlOptimizer.ConvertElement(MappingSchema, element, OptimizationContext) as T;
+			return (T?)SqlOptimizer.ConvertElement(MappingSchema, element, OptimizationContext);
 		}
 
 		#endregion

--- a/Source/LinqToDB/SqlQuery/ISqlExpression.cs
+++ b/Source/LinqToDB/SqlQuery/ISqlExpression.cs
@@ -8,6 +8,7 @@ namespace LinqToDB.SqlQuery
 
 		bool  CanBeNull  { get; }
 		int   Precedence { get; }
+		// TODO: v4 refactoring: replace with DbDataType and eradicate nullability. Should remove need for GetExpressionType method
 		Type? SystemType { get; }
 	}
 }

--- a/Tests/Base/TestUtils.cs
+++ b/Tests/Base/TestUtils.cs
@@ -309,6 +309,17 @@ namespace Tests
 			}
 		}
 
+		public static Version GetSqliteVersion(DataConnection db)
+		{
+			using (var cmd = db.CreateCommand())
+			{
+				cmd.CommandText = "select sqlite_version();";
+				var version     = (string)cmd.ExecuteScalar()!;
+
+				return new Version(version);
+			}
+		}
+
 		public static TempTable<T> CreateLocalTable<T>(this IDataContext db, string? tableName = null, TableOptions tableOptions = TableOptions.NotSet)
 			where T : notnull
 		{

--- a/Tests/Linq/Linq/AnalyticTests.cs
+++ b/Tests/Linq/Linq/AnalyticTests.cs
@@ -1716,8 +1716,7 @@ namespace Tests.Linq
 #if NETFRAMEWORK
 			ProviderName.SQLiteMS, // TODO: time to switch to modern sqlite.ms version for netfx
 #endif
-			// All Firebird excluded because of #2839, test data is inserted with padding and then expectations fail
-			TestProvName.AllFirebird,
+			ProviderName.Firebird,
 			TestProvName.MySql55)] string context)
 		{
 			var data = new Issue1799Table3[] 

--- a/Tests/Linq/Linq/DataTypesTests.cs
+++ b/Tests/Linq/Linq/DataTypesTests.cs
@@ -1,0 +1,203 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Linq;
+using System.Globalization;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+
+using LinqToDB;
+using LinqToDB.Mapping;
+using LinqToDB.Extensions;
+
+using NUnit.Framework;
+
+namespace Tests.Linq
+{
+	using LinqToDB.Common;
+	using LinqToDB.Data;
+	using Model;
+
+	// TODO: add more base types tests
+	// TODO: and more type test cases
+	[TestFixture]
+	public class DataTypesTests : TestBase
+	{
+		public abstract class TypeTable<TType>
+			where TType : struct
+		{
+			[Column] public int    Id             { get; set; }
+			[Column] public TType  Column         { get; set; }
+			[Column] public TType? ColumnNullable { get; set; }
+		}
+
+		#region Guid
+		[Table]
+		public class GuidTable : TypeTable<Guid>
+		{
+			public static GuidTable[] Data = new[]
+			{
+				new GuidTable() { Id = 1, Column = TestData.Guid1, ColumnNullable = null },
+				new GuidTable() { Id = 2, Column = TestData.Guid2, ColumnNullable = TestData.Guid3 },
+			};
+		}
+
+		[Test]
+		public void TestGuid([DataSources(false)] string context)
+		{
+			using var db = (TestDataConnection)GetDataContext(context);
+
+			TestType<GuidTable, Guid>(db, GuidTable.Data);
+		}
+		#endregion
+
+		#region Byte
+		[Table]
+		public class ByteTable : TypeTable<byte>
+		{
+			public static ByteTable[] Data = new[]
+			{
+				new ByteTable() { Id = 1, Column = 1, ColumnNullable = null },
+				new ByteTable() { Id = 2, Column = 255, ColumnNullable = 2 },
+			};
+		}
+
+		[Test]
+		public void TestByte([DataSources(false)] string context)
+		{
+			using var db = (TestDataConnection)GetDataContext(context);
+
+			TestType<ByteTable, byte>(db, ByteTable.Data);
+		}
+		#endregion
+
+		#region Boolean
+		[Table]
+		public class BooleanTable : TypeTable<bool>
+		{
+			public static BooleanTable[] Data = new[]
+			{
+				new BooleanTable() { Id = 1, Column = true, ColumnNullable = null },
+				new BooleanTable() { Id = 2, Column = false, ColumnNullable = true },
+			};
+		}
+
+		[Test]
+		public void TestBoolean([DataSources(false)] string context)
+		{
+			using var db = (TestDataConnection)GetDataContext(context);
+
+			var data = BooleanTable.Data;
+			if (context.Contains("Access") || context.Contains("Sybase"))
+			{
+				// for both Access and ASE BIT type cannot be NULL
+				data = data.Select(r => new BooleanTable() { Id = r.Id, Column = r.Column, ColumnNullable = r.ColumnNullable ?? false }).ToArray();
+			}
+
+			TestType<BooleanTable, bool>(db, data);
+		}
+		#endregion
+
+		#region Enum (int)
+		public enum IntEnum
+		{
+			Value1 = 1,
+			Value2 = 2,
+			Value3 = 3,
+		}
+		[Table]
+		public class IntEnumTable : TypeTable<IntEnum>
+		{
+			public static IntEnumTable[] Data = new[]
+			{
+				new IntEnumTable() { Id = 1, Column = IntEnum.Value1, ColumnNullable = null },
+				new IntEnumTable() { Id = 2, Column = IntEnum.Value2, ColumnNullable = IntEnum.Value3 },
+			};
+		}
+
+		[Test]
+		public void TestIntEnum([DataSources(false)] string context)
+		{
+			using var db = (TestDataConnection)GetDataContext(context);
+
+			TestType<IntEnumTable, IntEnum>(db, IntEnumTable.Data);
+		}
+		#endregion
+
+		#region Enum (string)
+		public enum StringEnum
+		{
+			[MapValue("val=1")   ] Value1 = 1,
+			[MapValue("value=2") ] Value2 = 2,
+			[MapValue("value=33")] Value3 = 33,
+		}
+		[Table]
+		public class StringEnumTable : TypeTable<StringEnum>
+		{
+			public static StringEnumTable[] Data = new[]
+			{
+				new StringEnumTable() { Id = 1, Column = StringEnum.Value1, ColumnNullable = null },
+				new StringEnumTable() { Id = 2, Column = StringEnum.Value2, ColumnNullable = StringEnum.Value3 },
+			};
+		}
+
+		[Test]
+		public void TestStringEnum([DataSources(false)] string context)
+		{
+			using var db = (TestDataConnection)GetDataContext(context);
+
+			TestType<StringEnumTable, StringEnum>(db, StringEnumTable.Data);
+		}
+		#endregion
+
+		#region Test Implementation
+		[Sql.Expression("{0} = {1}", IsPredicate = true)]
+		private static bool Equality(object? x, object? y) => throw new NotImplementedException();
+
+		private void TestType<TTable, TType>(DataConnection db, TTable[] data)
+			where TTable: TypeTable<TType>
+			where TType: struct
+		{
+			using var table = db.CreateLocalTable(data);
+
+			// test parameter
+			db.InlineParameters = false;
+			var record = table.Where(r => Equality(r.Column, data[1].Column) && Equality(r.ColumnNullable, data[1].ColumnNullable)).ToArray()[0];
+			Assert.AreEqual(2, record.Id);
+			Assert.AreEqual(data[1].Column, record.Column);
+			Assert.AreEqual(data[1].ColumnNullable, record.ColumnNullable);
+			Assert.AreEqual(2, db.LastParameters?.Count);
+
+			// test literal
+			db.InlineParameters = true;
+			record = table.Where(r => Equality(r.Column, data[1].Column) && Equality(r.ColumnNullable, data[1].ColumnNullable)).ToArray()[0];
+			Assert.AreEqual(2, record.Id);
+			Assert.AreEqual(data[1].Column, record.Column);
+			Assert.AreEqual(data[1].ColumnNullable, record.ColumnNullable);
+			Assert.AreEqual(0, db.LastParameters?.Count);
+			db.InlineParameters = false;
+
+			// test bulk copy
+			TestBulkCopy<TTable, TType>(db, data, table, BulkCopyType.RowByRow);
+			TestBulkCopy<TTable, TType>(db, data, table, BulkCopyType.MultipleRows);
+			TestBulkCopy<TTable, TType>(db, data, table, BulkCopyType.ProviderSpecific);
+		}
+
+		private static void TestBulkCopy<TTable, TType>(DataConnection db, TTable[] data, TempTable<TTable> table, BulkCopyType bulkCopyType)
+			where TTable : TypeTable<TType>
+			where TType : struct
+		{
+			table.Delete();
+			db.BulkCopy(new BulkCopyOptions() { BulkCopyType = bulkCopyType }, data);
+			var records = table.OrderBy(r => r.Id).ToArray();
+			Assert.AreEqual(2, records.Length);
+			Assert.AreEqual(data[0].Id, records[0].Id);
+			Assert.AreEqual(data[0].Column, records[0].Column);
+			Assert.AreEqual(data[0].ColumnNullable, records[0].ColumnNullable);
+			Assert.AreEqual(data[1].Id, records[1].Id);
+			Assert.AreEqual(data[1].Column, records[1].Column);
+			Assert.AreEqual(data[1].ColumnNullable, records[1].ColumnNullable);
+		}
+		#endregion
+	}
+}

--- a/Tests/Linq/UserTests/Issue2800Tests.cs
+++ b/Tests/Linq/UserTests/Issue2800Tests.cs
@@ -30,7 +30,6 @@ namespace Tests.UserTests
 			}
 		}
 
-		[ActiveIssue(2839, Configuration = TestProvName.AllFirebird, SkipForLinqService = true)]
 		[Test]
 		public void TestExpressionMethod([DataSources] string context)
 		{

--- a/Tests/Linq/UserTests/Issue3402Tests.cs
+++ b/Tests/Linq/UserTests/Issue3402Tests.cs
@@ -43,7 +43,7 @@ namespace Tests.UserTests
 			using (db.CreateLocalTable<EmployeeScheduleSection>())
 			using (db.CreateLocalTable<EmployeeScheduleSectionAdditionalPermission>())
 			{
-				var fullAccess = false;				
+				var fullAccess = false;
 
 				var permissions = from ess in db.GetTable<EmployeeScheduleSection>()
 					let allowEdit = fullAccess || ess.AdditionalPermissions.Any(y => y.IsActive)
@@ -68,7 +68,6 @@ namespace Tests.UserTests
 				var data2 = permissions.ToList(); 
 			}
 		}
-
 
 		[Test]
 		public void SubQueryAny([DataSources] string context)

--- a/Tests/Model/LinqDataTypes.cs
+++ b/Tests/Model/LinqDataTypes.cs
@@ -91,6 +91,7 @@ namespace Tests.Model
 		[Column]                                        public short?    SmallIntValue;
 		[Column]                                        public int?      IntValue;
 		[Column]                                        public long?     BigIntValue;
+		[Column(DataType = DataType.NVarChar, Length = 50, Configuration = ProviderName.Firebird)]
 		[Column]                                        public string?   StringValue;
 
 		public override bool Equals(object? obj)


### PR DESCRIPTION
- fix #2839
- improve `Guid` type support:
  - [DB2] fixed table creation for entity with `Guid?` columns. Update literal generation to generate `BX'...'` literal instead of `CAST(x'...' as char(16) for bit data)`
  - [Firebird] add missing `CreateTable` support (`CHAR(16) CHARACTER SET OCTETS`) and add binary literal generation. Added `Sql.Ext.Firebird().UuidToChar(Guid)` extension to map `UUID_TO_CHAR` Firebird function
  - [Informix] add missing `CreateTable` support (`VARCHAR(36)`). Literal value example: `d8948d42-7b56-4dd3-b522-51a07c818e14`
  - [SQL CE] add missing `CreateTable` support (`UNIQUEIDENTIFIER`)
  - [Sybase ASE] add missing `CreateTable` support (`VARCHAR(36)`). Literal value example: `d8948d42-7b56-4dd3-b522-51a07c818e14`
  - [SQLite] remove `CAST(... as blob)` around binary literal for `Guid`
  - [Oracle] replace `CAST(... as raw(16))` with `HEXTORAW('...')` for `Guid` literal
- improve `Byte` type support:
  - [DB2] Byte type mapped to `SMALLINT`
  - [Informix] Byte type mapped to `SMALLINT`, fixed byte values support in parameters
- improve mapped and unmapped enums support:
  - [Sybase] Fix enums support in native provider bulk copy
- improve `bool` support:
  - [Sybase] Create non-nullable `bit` column (type doesn't support nullability in Sybase ASE) by `CreateTable`