### PR TITLE
Fix multiple `SET` issues, add tests for existing issues

### DIFF
--- a/Source/LinqToDB/Data/RecordReaderBuilder.cs
+++ b/Source/LinqToDB/Data/RecordReaderBuilder.cs
@@ -39,21 +39,10 @@ namespace LinqToDB.Data
 			OriginalType  = objectType;
 			ObjectType    = objectType;
 			Reader        = reader;
-			ReaderIndexes = Enumerable.Range(0, reader.FieldCount).ToDictionary(reader.GetName, i => i, MappingSchema.ColumnNameComparer);
+			ReaderIndexes = Enumerable.Range(0, reader.FieldCount).ToDictionary(reader.GetName, static i => i, MappingSchema.ColumnNameComparer);
 
 			var typedDataReader = Expression.Convert(DataReaderParam, reader.GetType());
 			DataReaderLocal     = BuildVariable(converterExpr?.GetBody(typedDataReader) ?? typedDataReader, "ldr");
-		}
-
-		static object DefaultInheritanceMappingException(object value, Type type)
-		{
-			throw new LinqException("Inheritance mapping is not defined for discriminator value '{0}' in the '{1}' hierarchy.", value, type);
-		}
-
-		static bool IsRecord(IEnumerable<Attribute> attrs)
-		{
-			return  attrs.Any(attr => attr.GetType().FullName == "Microsoft.FSharp.Core.CompilationMappingAttribute")
-				&& !attrs.Any(attr => attr.GetType().FullName == "Microsoft.FSharp.Core.CLIMutableAttribute");
 		}
 
 		Expression BuildReadExpression(bool buildBlock, Type objectType)
@@ -63,11 +52,10 @@ namespace LinqToDB.Data
 
 			var entityDescriptor = MappingSchema.GetEntityDescriptor(objectType);
 
-			bool isRecord = IsRecord(MappingSchema.GetAttributes<Attribute>(objectType));
-
-			var expr = isRecord == false
+			var recordType = RecordsHelper.GetRecordType(MappingSchema, objectType);
+			var expr = recordType == RecordType.NotRecord
 				? BuildDefaultConstructor(entityDescriptor, objectType)
-				: BuildRecordConstructor (entityDescriptor, objectType);
+				: BuildRecordConstructor (entityDescriptor, objectType, recordType);
 
 			expr = ProcessExpression(expr);
 
@@ -103,11 +91,13 @@ namespace LinqToDB.Data
 		{
 			if (!ReaderIndexes.TryGetValue(name, out var value))
 			{
-				var cd = entityDescriptor.Columns.Find(c =>
-					(objectType == null || c.MemberAccessor.TypeAccessor.Type == objectType) && c.MemberName == name);
-
-				if (cd != null)
-					return GetReaderIndex(cd.ColumnName);
+				foreach (var cd in entityDescriptor.Columns)
+				{
+					if ((objectType == null || cd.MemberAccessor.TypeAccessor.Type == objectType) && cd.MemberName == name)
+					{
+						return GetReaderIndex(cd.ColumnName);
+					}
+				}
 
 				return -1;
 			}
@@ -117,35 +107,40 @@ namespace LinqToDB.Data
 
 		IEnumerable<ReadColumnInfo> GetReadIndexes(EntityDescriptor entityDescriptor)
 		{
-			var result = from c in entityDescriptor.Columns
-				where c.MemberAccessor.TypeAccessor.Type == entityDescriptor.ObjectType
-				let   index = GetReaderIndex(c.ColumnName)
-				where index >= 0
-				select new ReadColumnInfo() { ReaderIndex = index, Column = c };
-			return result;
+			foreach (var c in entityDescriptor.Columns)
+			{
+				if (c.MemberAccessor.TypeAccessor.Type == entityDescriptor.ObjectType)
+				{
+					var index = GetReaderIndex(c.ColumnName);
+					if (index >= 0)
+					{
+						yield return new ReadColumnInfo() { ReaderIndex = index, Column = c };
+					}
+				}
+			}
 		}
 
 		Expression BuildDefaultConstructor(EntityDescriptor entityDescriptor, Type objectType)
 		{
-			var members =
-			(
-				from info in GetReadIndexes(entityDescriptor)
-				where info.Column.Storage != null ||
-				      info.Column.MemberAccessor.MemberInfo is not PropertyInfo pi ||
-				      pi.GetSetMethod(true) != null
-				select new
+			var members = new List<(ColumnDescriptor column, ConvertFromDataReaderExpression expr)>();
+			foreach (var info in GetReadIndexes(entityDescriptor))
+			{
+				if (info.Column.Storage != null ||
+					  info.Column.MemberAccessor.MemberInfo is not PropertyInfo pi ||
+					  pi.GetSetMethod(true) != null)
 				{
-					Column = info.Column,
-					Expr   = new ConvertFromDataReaderExpression(info.Column.StorageType, info.ReaderIndex, info.Column.ValueConverter, DataReaderLocal, DataContext)
+					members.Add((
+						info.Column,
+						new ConvertFromDataReaderExpression(info.Column.StorageType, info.ReaderIndex, info.Column.ValueConverter, DataReaderLocal, DataContext)));
 				}
-			).ToList();
+			}
 
 			var initExpr = Expression.MemberInit(
 				Expression.New(objectType),
 				members
 					// IMPORTANT: refactoring this condition will affect hasComplex variable calculation below
-					.Where (m => !m.Column.MemberAccessor.IsComplex)
-					.Select(m => (MemberBinding)Expression.Bind(m.Column.StorageInfo, m.Expr)));
+					.Where (static m => !m.column.MemberAccessor.IsComplex)
+					.Select(static m => (MemberBinding)Expression.Bind(m.column.StorageInfo, m.expr)));
 
 			Expression expr = initExpr;
 
@@ -157,9 +152,13 @@ namespace LinqToDB.Data
 				var obj   = Expression.Variable(expr.Type);
 				var exprs = new List<Expression> { Expression.Assign(obj, expr) };
 
-				exprs.AddRange(
-					members.Where(m => m.Column.MemberAccessor.IsComplex).Select(m =>
-						m.Column.MemberAccessor.SetterExpression.GetBody(obj, m.Expr)));
+				foreach (var m in members)
+				{
+					if (m.column.MemberAccessor.IsComplex)
+					{
+						exprs.Add(m.column.MemberAccessor.SetterExpression.GetBody(obj, m.expr));
+					}
+				}
 
 				exprs.Add(obj);
 
@@ -176,16 +175,30 @@ namespace LinqToDB.Data
 			public Expression Expression = null!;
 		}
 
-		IEnumerable<Expression?> GetExpressions(TypeAccessor typeAccessor, bool isRecordType, List<ColumnInfo> columns)
+		IEnumerable<Expression?> GetExpressions(TypeAccessor typeAccessor, RecordType recordType, List<ColumnInfo> columns)
 		{
-			var members = isRecordType ?
-				typeAccessor.Members.Where(m =>
-					IsRecord(MappingSchema.GetAttributes<Attribute>(typeAccessor.Type, m.MemberInfo))) :
-				typeAccessor.Members;
+			var members = typeAccessor.Members;
+			if (recordType == RecordType.FSharp)
+			{
+				members = new List<MemberAccessor>();
+				foreach (var member in typeAccessor.Members)
+				{
+					if (-1 != RecordsHelper.GetFSharpRecordMemberSequence(MappingSchema, typeAccessor.Type, member.MemberInfo))
+						members.Add(member);
+				}
+			}
 
 			foreach (var member in members)
 			{
-				var column = columns.FirstOrDefault(c => !c.IsComplex && c.Name == member.Name);
+				ColumnInfo? column = null;
+				foreach (var c in columns)
+				{
+					if (!c.IsComplex && c.Name == member.Name)
+					{
+						column = c;
+						break;
+					}
+				}
 
 				if (column != null)
 				{
@@ -196,7 +209,12 @@ namespace LinqToDB.Data
 					// HERE was removed associations and LoadWith
 
 					var name = member.Name + '.';
-					var cols = columns.Where(c => c.IsComplex && c.Name.StartsWith(name)).ToList();
+					var cols = new List<ColumnInfo>();
+					foreach (var c in columns)
+					{
+						if (c.IsComplex && c.Name.StartsWith(name))
+							cols.Add(c);
+					}
 
 					if (cols.Count == 0)
 					{
@@ -210,36 +228,39 @@ namespace LinqToDB.Data
 							col.IsComplex = col.Name.Contains(".");
 						}
 
-						var typeAcc  = TypeAccessor.GetAccessor(member.Type);
-						var isRecord = IsRecord(MappingSchema.GetAttributes<Attribute>(member.Type));
+						var typeAcc          = TypeAccessor.GetAccessor(member.Type);
+						var memberRecordType = RecordsHelper.GetRecordType(MappingSchema, member.Type);
 
-						var exprs = GetExpressions(typeAcc, isRecord, cols).ToList();
+						var exprs = GetExpressions(typeAcc, memberRecordType, cols).ToList();
 
-						if (isRecord)
+						if (memberRecordType != RecordType.NotRecord)
 						{
 							var ctor      = member.Type.GetConstructors().Single();
 							var ctorParms = ctor.GetParameters();
 
-							var parms =
-							(
-								from p in ctorParms.Select((p, i) => new {p, i})
-								join e in exprs.Select((e, i) => new {e, i}) on p.i equals e.i into j
-								from e in j.DefaultIfEmpty()
-								select
-									(e == null ? null : e.e) ??
-									Expression.Constant(p.p.DefaultValue ?? MappingSchema.GetDefaultValue(p.p.ParameterType),
-										p.p.ParameterType)
-							).ToList();
+							var parms = new List<Expression>();
+							for (var i = 0; i < ctorParms.Length; i++)
+							{
+								var p = ctorParms[i];
+								var e = (exprs.Count > i ? exprs[i] : null)
+									?? Expression.Constant(p.DefaultValue ?? MappingSchema.GetDefaultValue(p.ParameterType), p.ParameterType);
+								parms.Add(e);
+							}
 
 							yield return Expression.New(ctor, parms);
 						}
 						else
 						{
-							var expr = Expression.MemberInit(
-								Expression.New(member.Type),
-								from m in typeAcc.Members.Zip(exprs, (m, e) => new {m, e})
-								where m.e != null
-								select (MemberBinding) Expression.Bind(m.m.MemberInfo, m.e));
+							var bindings = new List<MemberBinding>();
+							for (var i = 0; i < typeAcc.Members.Count && i < exprs.Count; i++)
+							{
+								if (exprs[i] != null)
+								{
+									bindings.Add(Expression.Bind(typeAcc.Members[i].MemberInfo, exprs[i]!));
+								}
+							}
+
+							var expr = Expression.MemberInit(Expression.New(member.Type), bindings);
 
 							yield return expr;
 						}
@@ -248,29 +269,35 @@ namespace LinqToDB.Data
 			}
 		}
 
-		Expression BuildRecordConstructor(EntityDescriptor entityDescriptor, Type objectType)
+		Expression BuildRecordConstructor(EntityDescriptor entityDescriptor, Type objectType, RecordType recordType)
 		{
 			var ctor  = objectType.GetConstructors().Single();
 
-			var exprs = GetExpressions(entityDescriptor.TypeAccessor, true,
-				(
-					from info in GetReadIndexes(entityDescriptor)
-					select new ColumnInfo
-					{
-						IsComplex  = info.Column.MemberAccessor.IsComplex,
-						Name       = info.Column.MemberName,
-						Expression = new ConvertFromDataReaderExpression(info.Column.MemberType, info.ReaderIndex, info.Column.ValueConverter, DataReaderLocal, DataContext)
-					}
-				).ToList()).ToList();
+			var columns = new List<ColumnInfo>();
+			foreach (var info in GetReadIndexes(entityDescriptor))
+			{
+				columns.Add(new ColumnInfo
+				{
+					IsComplex  = info.Column.MemberAccessor.IsComplex,
+					Name       = info.Column.MemberName,
+					Expression = new ConvertFromDataReaderExpression(info.Column.MemberType, info.ReaderIndex, info.Column.ValueConverter, DataReaderLocal, DataContext)
+				});
+			}
 
-			var parms =
-			(
-				from p in ctor.GetParameters().Select((p,i) => new { p, i })
-				join e in exprs.Select((e,i) => new { e, i }) on p.i equals e.i into j
-				from e in j.DefaultIfEmpty()
-				select
-					(e == null ? null : e.e) ?? Expression.Constant(MappingSchema.GetDefaultValue(p.p.ParameterType), p.p.ParameterType)
-			).ToList();
+			var exprs = GetExpressions(entityDescriptor.TypeAccessor, recordType, columns);
+
+			var parameters       = ctor.GetParameters();
+			var parms            = new Expression[parameters.Length];
+			using var enumerator = exprs.GetEnumerator();
+
+			for (var i = 0; i < parameters.Length; i++)
+			{
+				Expression? e = null;
+				if (enumerator.MoveNext())
+					e = enumerator.Current;
+
+				parms[i] = e ?? Expression.Constant(MappingSchema.GetDefaultValue(parameters[i].ParameterType), parameters[i].ParameterType);
+			}
 
 			var expr = Expression.New(ctor, parms);
 
@@ -318,7 +345,7 @@ namespace LinqToDB.Data
 
 			Expression? expr = null;
 
-			var defaultMapping = inheritanceMapping.SingleOrDefault(m => m.IsDefault);
+			var defaultMapping = inheritanceMapping.SingleOrDefault(static m => m.IsDefault);
 
 			if (defaultMapping != null)
 			{
@@ -328,7 +355,6 @@ namespace LinqToDB.Data
 			}
 			else
 			{
-				var exceptionMethod = MemberHelper.MethodOf(() => DefaultInheritanceMappingException(null!, null!));
 				var dindex          = GetReaderIndex(entityDescriptor, null, inheritanceMapping[0].DiscriminatorName);
 
 				if (dindex >= 0)
@@ -336,7 +362,7 @@ namespace LinqToDB.Data
 					expr = Expression.Convert(
 						Expression.Call(
 							null,
-							exceptionMethod,
+							Methods.LinqToDB.Exceptions.DefaultInheritanceMappingException,
 							new ConvertFromDataReaderExpression(typeof(object), dindex, null, DataReaderLocal, DataContext),
 							Expression.Constant(ObjectType)),
 						ObjectType);
@@ -348,8 +374,11 @@ namespace LinqToDB.Data
 				return BuildReadExpression(true, ObjectType);
 			}
 
-			foreach (var mapping in inheritanceMapping.Select((m,i) => new { m, i }).Where(m => m.m != defaultMapping))
+			foreach (var mapping in inheritanceMapping.Select(static (m,i) => new { m, i }))
 			{
+				if (mapping.m == defaultMapping)
+					continue;
+
 				var ed     = MappingSchema.GetEntityDescriptor(mapping.m.Type);
 				var dindex = GetReaderIndex(ed, null, mapping.m.DiscriminatorName);
 

--- a/Source/LinqToDB/DataProvider/Access/AccessODBCSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessODBCSqlBuilder.cs
@@ -2,6 +2,7 @@
 {
 	using System.Data;
 	using System.Text;
+	using LinqToDB.SqlQuery;
 	using Mapping;
 	using SqlProvider;
 
@@ -56,6 +57,15 @@
 			}
 
 			return base.GetProviderTypeName(parameter);
+		}
+
+		protected override void BuildColumnExpression(SelectQuery? selectQuery, ISqlExpression expr, string? alias, ref bool addAlias)
+		{
+			// ODBC provider doesn't support NULL parameter as top-level select column value
+			if (expr is SqlParameter p && p.IsQueryParameter && p.Value == null)
+				expr = new SqlValue(p.Type, null);
+
+			base.BuildColumnExpression(selectQuery, expr, alias, ref addAlias);
 		}
 	}
 }

--- a/Source/LinqToDB/DataProvider/Access/AccessODBCSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessODBCSqlBuilder.cs
@@ -62,7 +62,7 @@
 		protected override void BuildColumnExpression(SelectQuery? selectQuery, ISqlExpression expr, string? alias, ref bool addAlias)
 		{
 			// ODBC provider doesn't support NULL parameter as top-level select column value
-			if (expr is SqlParameter p && p.IsQueryParameter && p.Value == null)
+			if (expr is SqlParameter p && p.IsQueryParameter && p.GetParameterValue(OptimizationContext.Context.ParameterValues).Value == null)
 				expr = new SqlValue(p.Type, null);
 
 			base.BuildColumnExpression(selectQuery, expr, alias, ref addAlias);

--- a/Source/LinqToDB/DataProvider/Access/AccessODBCSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessODBCSqlBuilder.cs
@@ -62,7 +62,12 @@
 		protected override void BuildColumnExpression(SelectQuery? selectQuery, ISqlExpression expr, string? alias, ref bool addAlias)
 		{
 			// ODBC provider doesn't support NULL parameter as top-level select column value
-			if (expr is SqlParameter p && p.IsQueryParameter && p.GetParameterValue(OptimizationContext.Context.ParameterValues).Value == null)
+			if (expr is SqlParameter p
+				&& p.IsQueryParameter
+				&& selectQuery != null
+				&& Statement.QueryType == QueryType.Select
+				&& Statement.SelectQuery == selectQuery
+				&& p.GetParameterValue(OptimizationContext.Context.ParameterValues).Value == null)
 				expr = new SqlValue(p.Type, null);
 
 			base.BuildColumnExpression(selectQuery, expr, alias, ref addAlias);

--- a/Source/LinqToDB/DataProvider/DataProviderBase.cs
+++ b/Source/LinqToDB/DataProvider/DataProviderBase.cs
@@ -40,7 +40,6 @@ namespace LinqToDB.DataProvider
 				IsInsertOrUpdateSupported            = true,
 				CanCombineParameters                 = true,
 				MaxInListValuesCount                 = int.MaxValue,
-				IsGroupByExpressionSupported         = true,
 				IsDistinctOrderBySupported           = true,
 				IsSubQueryOrderBySupported           = false,
 				IsUpdateSetTableAliasSupported       = true,

--- a/Source/LinqToDB/DataProvider/Informix/InformixDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixDataProvider.cs
@@ -11,7 +11,6 @@ namespace LinqToDB.DataProvider.Informix
 	using LinqToDB.Linq.Internal;
 	using Mapping;
 	using SqlProvider;
-	using SqlQuery;
 
 	public class InformixDataProvider : DynamicDataProviderBase<InformixProviderAdapter>
 	{
@@ -22,16 +21,15 @@ namespace LinqToDB.DataProvider.Informix
 				InformixProviderAdapter.GetInstance(providerName))
 
 		{
-			SqlProviderFlags.IsParameterOrderDependent          = !Adapter.IsIDSProvider;
-			SqlProviderFlags.IsSubQueryTakeSupported            = false;
-			SqlProviderFlags.IsInsertOrUpdateSupported          = false;
-			SqlProviderFlags.IsGroupByExpressionSupported      = false;
-			SqlProviderFlags.IsCrossJoinSupported               = false;
-			SqlProviderFlags.IsCommonTableExpressionsSupported  = true;
-			SqlProviderFlags.IsSubQueryOrderBySupported         = true;
-			SqlProviderFlags.IsDistinctOrderBySupported         = false;
-			SqlProviderFlags.IsUpdateFromSupported              = false;
-			SqlProviderFlags.IsGroupByColumnRequred             = true;
+			SqlProviderFlags.IsParameterOrderDependent         = !Adapter.IsIDSProvider;
+			SqlProviderFlags.IsSubQueryTakeSupported           = false;
+			SqlProviderFlags.IsInsertOrUpdateSupported         = false;
+			SqlProviderFlags.IsCrossJoinSupported              = false;
+			SqlProviderFlags.IsCommonTableExpressionsSupported = true;
+			SqlProviderFlags.IsSubQueryOrderBySupported        = true;
+			SqlProviderFlags.IsDistinctOrderBySupported        = false;
+			SqlProviderFlags.IsUpdateFromSupported             = false;
+			SqlProviderFlags.IsGroupByColumnRequred            = true;
 
 			SetCharField("CHAR",  (r,i) => r.GetString(i).TrimEnd(' '));
 			SetCharField("NCHAR", (r,i) => r.GetString(i).TrimEnd(' '));

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
@@ -35,7 +35,6 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			SqlProviderFlags.IsDistinctOrderBySupported        = false;
 			SqlProviderFlags.IsSubQueryOrderBySupported        = true;
 			SqlProviderFlags.IsAllSetOperationsSupported       = true;
-			SqlProviderFlags.IsGroupByExpressionSupported      = false;
 
 			SetCharFieldToType<char>("bpchar"   , DataTools.GetCharExpression);
 			SetCharFieldToType<char>("character", DataTools.GetCharExpression);

--- a/Source/LinqToDB/DataProvider/SqlCe/SqlCeDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlCe/SqlCeDataProvider.cs
@@ -28,12 +28,10 @@ namespace LinqToDB.DataProvider.SqlCe
 			SqlProviderFlags.IsCountSubQuerySupported             = false;
 			SqlProviderFlags.IsApplyJoinSupported                 = true;
 			SqlProviderFlags.IsInsertOrUpdateSupported            = false;
-			SqlProviderFlags.IsCrossJoinSupported                 = true;
 			SqlProviderFlags.IsDistinctOrderBySupported           = false;
 			SqlProviderFlags.IsOrderByAggregateFunctionsSupported = false;
 			SqlProviderFlags.IsDistinctSetOperationsSupported     = false;
 			SqlProviderFlags.IsUpdateFromSupported                = false;
-			SqlProviderFlags.IsGroupByExpressionSupported         = false;
 
 			SetCharFieldToType<char>("NChar", DataTools.GetCharExpression);
 

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerMappingSchema.cs
@@ -83,6 +83,7 @@ namespace LinqToDB.DataProvider.SqlServer
 			AddScalarType(typeof(DateTime),  DataType.DateTime);
 			AddScalarType(typeof(DateTime?), DataType.DateTime);
 
+
 			SqlServerTypes.Configure(this);
 
 			SetValueToSqlConverter(typeof(string),         (sb,dt,v) => ConvertStringToSql        (sb, dt, v.ToString()!));

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseDataProvider.cs
@@ -32,7 +32,6 @@ namespace LinqToDB.DataProvider.Sybase
 			SqlProviderFlags.IsSubQueryOrderBySupported       = false;
 			SqlProviderFlags.IsDistinctOrderBySupported       = false;
 			SqlProviderFlags.IsDistinctSetOperationsSupported = false;
-			SqlProviderFlags.IsGroupByExpressionSupported     = false;
 
 			SetCharField("char",  (r,i) => r.GetString(i).TrimEnd(' '));
 			SetCharField("nchar", (r,i) => r.GetString(i).TrimEnd(' '));

--- a/Source/LinqToDB/Extensions/ReflectionExtensions.cs
+++ b/Source/LinqToDB/Extensions/ReflectionExtensions.cs
@@ -1083,9 +1083,11 @@ namespace LinqToDB.Extensions
 			return
 				!type.IsPublic &&
 				 type.IsGenericType &&
+				// C# anonymous type name prefix
 				(type.Name.StartsWith("<>f__AnonymousType", StringComparison.Ordinal) ||
+				 // VB.NET anonymous type name prefix
 				 type.Name.StartsWith("VB$AnonymousType", StringComparison.Ordinal)) &&
-				type.GetCustomAttributes(typeof(CompilerGeneratedAttribute), true).Any();
+				type.GetCustomAttribute(typeof(CompilerGeneratedAttribute), false) != null;
 		}
 
 		internal static MemberInfo GetMemberOverride(this Type type, MemberInfo mi)

--- a/Source/LinqToDB/Linq/Builder/MergeBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/MergeBuilder.cs
@@ -32,7 +32,7 @@ namespace LinqToDB.Linq.Builder
 		{
 			var mergeContext = (MergeContext)builder.BuildSequence(new BuildInfo(buildInfo, methodCall.Arguments[0]));
 
-			var kind = MergeKind.Merge;
+			var kind = MergeKind.Merge; 
 
 			if (methodCall.IsSameGenericMethod(MergeWithOutputInto))
 				kind = MergeKind.MergeWithOutputInto;
@@ -216,8 +216,8 @@ namespace LinqToDB.Linq.Builder
 				//TODO: Why it is not handled by main optimizer
 				var sqlFlags = builder.DataContext.SqlProviderFlags;
 				new SelectQueryOptimizer(sqlFlags, query, query, 0, statement)
-					.FinalizeAndValidate(sqlFlags.IsApplyJoinSupported, sqlFlags.IsGroupByExpressionSupported);
-
+					.FinalizeAndValidate(sqlFlags.IsApplyJoinSupported);
+				
 				if (query.From.Tables.Count == 0)
 				{
 					result = query.Where.SearchCondition;

--- a/Source/LinqToDB/Linq/Builder/SelectContext.cs
+++ b/Source/LinqToDB/Linq/Builder/SelectContext.cs
@@ -459,7 +459,10 @@ namespace LinqToDB.Linq.Builder
 						newInfo[i] = si;
 					else
 					{
-						var index = SelectQuery.Select.Add(si.Query!.Select.Columns[si.Index]);
+						var index = SelectQuery.Select.Add(
+							si.Query != null
+								? si.Query.Select.Columns[si.Index]
+								: si.Sql);
 
 						newInfo[i] = new SqlInfo(si.MemberChain, SelectQuery.Select.Columns[index], SelectQuery, index);
 					}

--- a/Source/LinqToDB/Linq/Exceptions.cs
+++ b/Source/LinqToDB/Linq/Exceptions.cs
@@ -1,0 +1,18 @@
+﻿using System.Reflection;
+
+namespace LinqToDB.Linq
+{
+	using System;
+	using System.Linq;
+	using Common;
+	using LinqToDB.Linq.Builder;
+	using LinqToDB.Mapping;
+
+	internal static class Exceptions
+	{
+		internal static object DefaultInheritanceMappingException(object value, Type type)
+		{
+			throw new LinqException("Inheritance mapping is not defined for discriminator value '{0}' in the '{1}' hierarchy.", value, type);
+		}
+	}
+}

--- a/Source/LinqToDB/Linq/RecordsHelper.cs
+++ b/Source/LinqToDB/Linq/RecordsHelper.cs
@@ -1,0 +1,130 @@
+﻿using System.Reflection;
+
+namespace LinqToDB.Linq
+{
+	using System;
+	using System.Collections.Concurrent;
+	using System.Linq;
+	using System.Runtime.CompilerServices;
+	using LinqToDB.Extensions;
+	using LinqToDB.Mapping;
+
+	[Flags]
+	internal enum RecordType
+	{
+		/// <summary>
+		/// Type is not recognized as record type.
+		/// </summary>
+		NotRecord     = 0x00,
+		/// <summary>
+		/// Type is F# record type (has reflection information about members position).
+		/// </summary>
+		FSharp        = 0x01,
+		/// <summary>
+		/// Type is C# record class or any other class with constructor parameter mathing properties by name.
+		/// </summary>
+		RecordClass   = 0x02,
+		/// <summary>
+		/// Type is C# or VB.NET anonymous type.
+		/// </summary>
+		AnonymousType = 0x04,
+
+		/// <summary>
+		/// Mask for types that instantiated using record-like constructor.
+		/// </summary>
+		CallConstructorOnWrite = FSharp | RecordClass | AnonymousType,
+		/// <summary>
+		/// Mask for types that instantiated in expressions using record-like constructor.
+		/// </summary>
+		CallConstructorOnRead  = FSharp | RecordClass,
+	}
+
+	internal static class RecordsHelper
+	{
+		private static readonly ConcurrentDictionary<Type, RecordType> _recordCache = new ();
+		private static readonly ConcurrentDictionary<MemberInfo, int>  _fsharpRecordMemberCache = new ();
+
+		internal static RecordType GetRecordType(MappingSchema mappingSchema, Type objectType)
+		{
+#if NET45 || NET46 || NETSTANDARD2_0
+			return _recordCache.GetOrAdd(objectType, objectType =>
+#else
+			return _recordCache.GetOrAdd(objectType, static (objectType, mappingSchema) =>
+#endif
+			{
+				if (IsFSharpRecord(mappingSchema, objectType))
+					return RecordType.FSharp;
+
+				if (objectType.IsAnonymous())
+					return RecordType.AnonymousType;
+
+				if (!HasDefaultConstructor(objectType))
+					return RecordType.RecordClass;
+
+				return RecordType.NotRecord;
+#if NET45 || NET46 || NETSTANDARD2_0
+			});
+#else
+			}, mappingSchema);
+#endif
+		}
+
+		public static int GetFSharpRecordMemberSequence(MappingSchema mappingSchema, Type objectType, MemberInfo memberInfo)
+		{
+#if NET45 || NET46 || NETSTANDARD2_0
+			return _fsharpRecordMemberCache.GetOrAdd(memberInfo, memberInfo =>
+			{
+#else
+			return _fsharpRecordMemberCache.GetOrAdd(memberInfo, static (memberInfo, ctx) =>
+			{
+				var (mappingSchema, objectType) = ctx;
+#endif
+				var attrs                  = mappingSchema.GetAttributes<Attribute>(objectType, memberInfo);
+				var compilationMappingAttr = attrs.FirstOrDefault(attr => attr.GetType().FullName == "Microsoft.FSharp.Core.CompilationMappingAttribute");
+
+				if (compilationMappingAttr != null)
+				{
+					// https://github.com/dotnet/fsharp/blob/1fcb351bb98fe361c7e70172ea51b5e6a4b52ee0/src/fsharp/FSharp.Core/prim-types.fsi
+					// ObjectType = 3
+					if (Convert.ToInt32(((dynamic)compilationMappingAttr).SourceConstructFlags) != 3)
+						return ((dynamic)compilationMappingAttr).SequenceNumber;
+				}
+
+				return -1;
+#if NET45 || NET46 || NETSTANDARD2_0
+			});
+#else
+			}, (mappingSchema, objectType));
+#endif
+		}
+
+		private static bool IsFSharpRecord(MappingSchema mappingSchema, Type objectType)
+		{
+			var attrs = mappingSchema.GetAttributes<Attribute>(objectType);
+
+			var compilationMappingAttr = attrs.FirstOrDefault(attr => attr.GetType().FullName == "Microsoft.FSharp.Core.CompilationMappingAttribute");
+			if (compilationMappingAttr == null)
+				return false;
+
+			// https://github.com/dotnet/fsharp/blob/1fcb351bb98fe361c7e70172ea51b5e6a4b52ee0/src/fsharp/FSharp.Core/prim-types.fsi
+			// ObjectType = 3
+			if (Convert.ToInt32(((dynamic)compilationMappingAttr).SourceConstructFlags) == 3)
+				return false;
+
+			return !attrs.Any(attr => attr.GetType().FullName == "Microsoft.FSharp.Core.CLIMutableAttribute");
+		}
+
+		private static bool HasDefaultConstructor(Type objectType)
+		{
+			var constructors = objectType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+			foreach (var constructor in constructors)
+			{
+				if (constructor.GetParameters().Length == 0)
+					return true;
+			}
+
+			return constructors.Length == 0;
+		}
+	}
+}

--- a/Source/LinqToDB/Reflection/Methods.cs
+++ b/Source/LinqToDB/Reflection/Methods.cs
@@ -332,6 +332,11 @@ namespace LinqToDB.Reflection
 				public static readonly PropertyInfo Value      = MemberHelper.PropertyOf<Data.DataParameter>(dp => dp.Value);
 			}
 
+			internal static class Exceptions
+			{
+				public static readonly MethodInfo DefaultInheritanceMappingException = MemberHelper.MethodOf(() => Linq.Exceptions.DefaultInheritanceMappingException(null!, null!));
+			}
+
 			internal static class Sql
 			{
 				public static readonly ConstructorInfo SqlParameterConstructor = MemberHelper.ConstructorOf(() => new SqlParameter(default(DbDataType), default(string), null));

--- a/Source/LinqToDB/SqlProvider/BasicSqlOptimizer.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlOptimizer.cs
@@ -48,8 +48,7 @@ namespace LinqToDB.SqlProvider
 				static (context, selectQuery) =>
 				{
 					new SelectQueryOptimizer(context.SqlProviderFlags, context.statement, selectQuery, 0).FinalizeAndValidate(
-						context.SqlProviderFlags.IsApplyJoinSupported,
-						context.SqlProviderFlags.IsGroupByExpressionSupported);
+						context.SqlProviderFlags.IsApplyJoinSupported);
 
 					return selectQuery;
 				}
@@ -73,8 +72,7 @@ namespace LinqToDB.SqlProvider
 					static (context, selectQuery) =>
 					{
 						new SelectQueryOptimizer(context.SqlProviderFlags, context.statement, selectQuery, 0).FinalizeAndValidate(
-							context.SqlProviderFlags.IsApplyJoinSupported,
-							context.SqlProviderFlags.IsGroupByExpressionSupported);
+							context.SqlProviderFlags.IsApplyJoinSupported);
 
 						return selectQuery;
 					}
@@ -160,16 +158,16 @@ namespace LinqToDB.SqlProvider
 		}
 
 		protected virtual SqlStatement FixSetOperationNulls(SqlStatement statement)
-		{
+							{
 			statement.VisitParentFirst(static e =>
-			{
+								{
 				if (e.ElementType == QueryElementType.SqlQuery)
-				{
+		{
 					var query = (SelectQuery)e;
 					if (query.HasSetOperators)
-					{
+			{
 						for (int i = 0; i < query.Select.Columns.Count; i++)
-						{
+				{
 							var column     = query.Select.Columns[i];
 							var columnExpr = column.Expression;
 
@@ -182,7 +180,7 @@ namespace LinqToDB.SqlProvider
 								CorrelateNullValueTypes(ref otherExpr, columnExpr);
 
 								otherColumn.Expression = otherExpr;
-							}
+								}
 
 							column.Expression = columnExpr;
 						}
@@ -194,7 +192,6 @@ namespace LinqToDB.SqlProvider
 
 			return statement;
 		}
-
 
 		protected virtual void FixEmptySelect(SqlStatement statement)
 		{
@@ -1173,7 +1170,8 @@ namespace LinqToDB.SqlProvider
 					return predicate;
 			}
 
-			if (predicate.TryEvaluateExpression(context, out var value) && value != null)
+			if (predicate.ElementType != QueryElementType.SearchCondition
+				&& predicate.TryEvaluateExpression(context, out var value) && value != null)
 			{
 				return new SqlPredicate.Expr(new SqlValue(value));
 			}
@@ -1864,6 +1862,7 @@ namespace LinqToDB.SqlProvider
 					});
 
 			}
+
 			return newElement;
 		}
 

--- a/Source/LinqToDB/SqlProvider/SqlProviderFlags.cs
+++ b/Source/LinqToDB/SqlProvider/SqlProviderFlags.cs
@@ -11,24 +11,23 @@ namespace LinqToDB.SqlProvider
 	{
 		public bool        IsSybaseBuggyGroupBy              { get; set; }
 
-		public bool        IsParameterOrderDependent         { get; set; }
-		public bool        AcceptsTakeAsParameter            { get; set; }
-		public bool        AcceptsTakeAsParameterIfSkip      { get; set; }
-		public bool        IsTakeSupported                   { get; set; }
-		public bool        IsSkipSupported                   { get; set; }
-		public bool        IsSkipSupportedIfTake             { get; set; }
-		public bool        IsSubQueryTakeSupported           { get; set; }
-		public bool        IsSubQueryColumnSupported         { get; set; }
-		public bool        IsSubQueryOrderBySupported        { get; set; }
-		public bool        IsCountSubQuerySupported          { get; set; }
-		public bool        IsIdentityParameterRequired       { get; set; }
-		public bool        IsApplyJoinSupported              { get; set; }
-		public bool        IsInsertOrUpdateSupported         { get; set; }
-		public bool        CanCombineParameters              { get; set; }
-		public bool        IsGroupByExpressionSupported      { get; set; }
-		public int         MaxInListValuesCount              { get; set; }
-		public bool        IsUpdateSetTableAliasSupported    { get; set; }
-		public TakeHints?  TakeHintsSupported                { get; set; }
+		public bool        IsParameterOrderDependent          { get; set; }
+		public bool        AcceptsTakeAsParameter             { get; set; }
+		public bool        AcceptsTakeAsParameterIfSkip       { get; set; }
+		public bool        IsTakeSupported                    { get; set; }
+		public bool        IsSkipSupported                    { get; set; }
+		public bool        IsSkipSupportedIfTake              { get; set; }
+		public bool        IsSubQueryTakeSupported            { get; set; }
+		public bool        IsSubQueryColumnSupported          { get; set; }
+		public bool        IsSubQueryOrderBySupported         { get; set; }
+		public bool        IsCountSubQuerySupported           { get; set; }
+		public bool        IsIdentityParameterRequired        { get; set; }
+		public bool        IsApplyJoinSupported               { get; set; }
+		public bool        IsInsertOrUpdateSupported          { get; set; }
+		public bool        CanCombineParameters               { get; set; }
+		public int         MaxInListValuesCount               { get; set; }
+		public bool        IsUpdateSetTableAliasSupported     { get; set; }
+		public TakeHints?  TakeHintsSupported                 { get; set; }
 
 		/// <summary>
 		/// If <c>true</c>, removed record fields in OUTPUT clause of DELETE statement should be referenced using
@@ -181,7 +180,6 @@ namespace LinqToDB.SqlProvider
 				^ IsApplyJoinSupported                         .GetHashCode()
 				^ IsInsertOrUpdateSupported                    .GetHashCode()
 				^ CanCombineParameters                         .GetHashCode()
-				^ IsGroupByExpressionSupported                 .GetHashCode()
 				^ MaxInListValuesCount                         .GetHashCode()
 				^ IsUpdateSetTableAliasSupported               .GetHashCode()
 				^ (TakeHintsSupported?                         .GetHashCode() ?? 0)
@@ -221,7 +219,6 @@ namespace LinqToDB.SqlProvider
 				&& IsApplyJoinSupported                 == other.IsApplyJoinSupported
 				&& IsInsertOrUpdateSupported            == other.IsInsertOrUpdateSupported
 				&& CanCombineParameters                 == other.CanCombineParameters
-				&& IsGroupByExpressionSupported         == other.IsGroupByExpressionSupported
 				&& MaxInListValuesCount                 == other.MaxInListValuesCount
 				&& IsUpdateSetTableAliasSupported       == other.IsUpdateSetTableAliasSupported
 				&& TakeHintsSupported                   == other.TakeHintsSupported
@@ -243,7 +240,7 @@ namespace LinqToDB.SqlProvider
 				// CustomFlags as List wasn't best idea
 				&& CustomFlags.Count                    == other.CustomFlags.Count
 				&& (CustomFlags.Count                   == 0
-					|| CustomFlags.OrderBy(_ => _).SequenceEqual(other.CustomFlags.OrderBy(_ => _)));
+					|| CustomFlags.OrderBy(_            => _).SequenceEqual(other.CustomFlags.OrderBy(_ => _)));
 		}
 		#endregion
 	}

--- a/Source/LinqToDB/SqlQuery/QueryHelper.cs
+++ b/Source/LinqToDB/SqlQuery/QueryHelper.cs
@@ -1423,6 +1423,9 @@ namespace LinqToDB.SqlQuery
 			return false;
 		}
 
+		// TODO: IsAggregationOrWindowFunction use needs review - maybe we should call ContainsAggregationOrWindowFunction there
+		public static bool ContainsAggregationOrWindowFunction(IQueryElement expr) => null != expr.Find(IsAggregationOrWindowFunction);
+
 		/// <summary>
 		/// Collects unique keys from different sources.
 		/// </summary>
@@ -1719,11 +1722,9 @@ namespace LinqToDB.SqlQuery
 			return new DbDataType(expr.SystemType!);
 		}
 
-		public static bool HasOuterReferences(SelectQuery root, ISqlExpression expr)
+		public static bool HasOuterReferences(ISet<ISqlTableSource> sources, ISqlExpression expr)
 		{
-			var sources = new HashSet<ISqlTableSource>(EnumerateAccessibleSources(root));
-
-			var outerElementFound = null != expr.Find(e =>
+			var outerElementFound = null != expr.Find(sources, static (sources, e) =>
 			{
 				if (e.ElementType == QueryElementType.Column)
 				{

--- a/Source/LinqToDB/SqlQuery/SelectQuery.cs
+++ b/Source/LinqToDB/SqlQuery/SelectQuery.cs
@@ -80,14 +80,15 @@ namespace LinqToDB.SqlQuery
 		private List<object>? _properties;
 		public  List<object>   Properties => _properties ??= new ();
 
-		public SelectQuery?    ParentSelect         { get; set; }
-		public bool            IsSimple => !Select.HasModifier && Where.IsEmpty && GroupBy.IsEmpty && Having.IsEmpty && OrderBy.IsEmpty && !HasSetOperators;
-		public bool            IsParameterDependent { get; set; }
+		public SelectQuery?   ParentSelect         { get; set; }
+		public bool           IsSimple      => IsSimpleOrSet && !HasSetOperators;
+		public bool           IsSimpleOrSet => !Select.HasModifier && Where.IsEmpty && GroupBy.IsEmpty && Having.IsEmpty && OrderBy.IsEmpty;
+		public bool           IsParameterDependent { get; set; }
 
 		/// <summary>
 		/// Gets or sets flag when sub-query can be removed during optimization.
 		/// </summary>
-		public bool            DoNotRemove          { get; set; }
+		public bool               DoNotRemove         { get; set; }
 		public bool            DoNotSetAliases      { get; set; }
 
 		List<ISqlExpression[]>? _uniqueKeys;
@@ -97,7 +98,7 @@ namespace LinqToDB.SqlQuery
 		/// Used in JoinOptimizer for safely removing sub-query from resulting SQL.
 		/// </summary>
 		public  List<ISqlExpression[]> UniqueKeys    => _uniqueKeys ??= new ();
-		public  bool                   HasUniqueKeys => _uniqueKeys != null && _uniqueKeys.Count > 0;
+		public  bool                    HasUniqueKeys => _uniqueKeys != null && _uniqueKeys.Count > 0;
 
 		#endregion
 

--- a/Source/LinqToDB/SqlQuery/SelectQueryOptimizer.cs
+++ b/Source/LinqToDB/SqlQuery/SelectQueryOptimizer.cs
@@ -24,7 +24,7 @@ namespace LinqToDB.SqlQuery
 		readonly int              _level;
 		readonly IQueryElement[]  _dependencies;
 
-		public void FinalizeAndValidate(bool isApplySupported, bool optimizeColumns)
+		public void FinalizeAndValidate(bool isApplySupported)
 		{
 #if DEBUG
 			// ReSharper disable once NotAccessedVariable
@@ -45,7 +45,7 @@ namespace LinqToDB.SqlQuery
 #endif
 
 			OptimizeUnions();
-			FinalizeAndValidateInternal(isApplySupported, optimizeColumns);
+			FinalizeAndValidateInternal(isApplySupported);
 			ResolveFields();
 
 #if DEBUG
@@ -357,18 +357,25 @@ namespace LinqToDB.SqlQuery
 
 		void OptimizeUnions()
 		{
-			var isAllUnion = _selectQuery.Find(static ne => ne is SqlSetOperator nu && nu.Operation == SetOperation.UnionAll);
-
-			var isNotAllUnion = _selectQuery.Find(static ne => ne is SqlSetOperator nu && nu.Operation != SetOperation.UnionAll);
-
-			if (isNotAllUnion != null && isAllUnion != null)
+			if (null == _selectQuery.Find(QueryElementType.SetOperator))
 				return;
 
-			var exprs = new Dictionary<ISqlExpression,ISqlExpression>();
-
-			_selectQuery.Visit(exprs, static (exprs, e) =>
+			var parentSetType = new Dictionary<ISqlExpression, SetOperation>();
+			_selectQuery.Visit(parentSetType, static (parentSetType, e) =>
 			{
-				if (!(e is SelectQuery sql) || sql.From.Tables.Count != 1 || !sql.IsSimple)
+				if (e is SelectQuery sql && sql.HasSetOperators)
+				{
+					parentSetType.Add(sql.From.Tables[0].Source, sql.SetOperators[0].Operation);
+					foreach (var set in sql.SetOperators)
+						parentSetType.Add(set.SelectQuery, sql.SetOperators[0].Operation);
+				}
+			});
+
+			var exprs = new Dictionary<ISqlExpression, ISqlExpression>();
+
+			_selectQuery.Visit((exprs, parentSetType), static (ctx, e) =>
+			{
+				if (!(e is SelectQuery sql) || sql.From.Tables.Count != 1 || !sql.IsSimpleOrSet)
 					return;
 
 				var table = sql.From.Tables[0];
@@ -381,6 +388,12 @@ namespace LinqToDB.SqlQuery
 				if (!union.HasSetOperators || sql.Select.Columns.Count != union.Select.Columns.Count)
 					return;
 
+				var operation = union.SetOperators[0].Operation;
+				if (sql.HasSetOperators && operation != sql.SetOperators[0].Operation)
+					return;
+				if (ctx.parentSetType.TryGetValue(sql, out var parentOp) && parentOp != operation)
+					return;
+
 				for (var i = 0; i < sql.Select.Columns.Count; i++)
 				{
 					var scol = sql.  Select.Columns[i];
@@ -390,7 +403,7 @@ namespace LinqToDB.SqlQuery
 						return;
 				}
 
-				exprs.Add(union, sql);
+				ctx.exprs.Add(union, sql);
 
 				for (var i = 0; i < sql.Select.Columns.Count; i++)
 				{
@@ -400,8 +413,8 @@ namespace LinqToDB.SqlQuery
 					scol.Expression = ucol.Expression;
 					scol.RawAlias   = ucol.RawAlias;
 
-					if (!exprs.ContainsKey(ucol))
-						exprs.Add(ucol, scol);
+					if (!ctx.exprs.ContainsKey(ucol))
+						ctx.exprs.Add(ucol, scol);
 				}
 
 				for (var i = sql.Select.Columns.Count; i < union.Select.Columns.Count; i++)
@@ -426,15 +439,15 @@ namespace LinqToDB.SqlQuery
 			}
 		}
 
-		void FinalizeAndValidateInternal(bool isApplySupported, bool optimizeColumns)
+		void FinalizeAndValidateInternal(bool isApplySupported)
 		{
-			_selectQuery.Visit((optimizer: this, isApplySupported, optimizeColumns), static (context, e) =>
+			_selectQuery.Visit((optimizer: this, isApplySupported), static (context, e) =>
 			{
 				if (e is SelectQuery sql && sql != context.optimizer._selectQuery)
 				{
 					sql.ParentSelect = context.optimizer._selectQuery;
 					new SelectQueryOptimizer(context.optimizer._flags, context.optimizer._rootElement, sql, context.optimizer._level + 1, context.optimizer._dependencies)
-						.FinalizeAndValidateInternal(context.isApplySupported, context.optimizeColumns);
+						.FinalizeAndValidateInternal(context.isApplySupported);
 
 					if (sql.IsParameterDependent)
 						context.optimizer._selectQuery.IsParameterDependent = true;
@@ -445,9 +458,9 @@ namespace LinqToDB.SqlQuery
 			RemoveEmptyJoins();
 			OptimizeGroupBy();
 			OptimizeColumns();
-			OptimizeApplies   (isApplySupported, optimizeColumns);
-			OptimizeSubQueries(isApplySupported, optimizeColumns);
-			OptimizeApplies   (isApplySupported, optimizeColumns);
+			OptimizeApplies   (isApplySupported);
+			OptimizeSubQueries(isApplySupported);
+			OptimizeApplies   (isApplySupported);
 
 			OptimizeGroupBy();
 			OptimizeDistinct();
@@ -880,7 +893,6 @@ namespace LinqToDB.SqlQuery
 			bool allColumns,
 			bool isApplySupported,
 			bool optimizeValues,
-			bool optimizeColumns,
 			SqlJoinedTable? parentJoinedTable)
 		{
 			foreach (var jt in source.Joins)
@@ -892,7 +904,6 @@ namespace LinqToDB.SqlQuery
 					false,
 					isApplySupported,
 					jt.JoinType == JoinType.Inner || jt.JoinType == JoinType.CrossApply,
-					optimizeColumns,
 					jt);
 
 				if (table != jt.Table)
@@ -921,7 +932,7 @@ namespace LinqToDB.SqlQuery
 					}
 				}
 				if (canRemove)
-					return RemoveSubQuery(parentQuery, source, optimizeWhere, allColumns && !isApplySupported, optimizeValues, optimizeColumns, parentJoinedTable);
+					return RemoveSubQuery(parentQuery, source, optimizeWhere, allColumns && !isApplySupported, optimizeValues, parentJoinedTable);
 			}
 
 			return source;
@@ -930,7 +941,7 @@ namespace LinqToDB.SqlQuery
 		bool CorrectCrossJoinQuery(SelectQuery query)
 		{
 			var select = query.Select;
-			if (select.From.Tables.Count == 1)
+			if (select.From.Tables.Count < 2)
 				return false;
 
 			var joins = select.From.Tables.SelectMany(static _ => _.Joins).Distinct().ToArray();
@@ -990,7 +1001,7 @@ namespace LinqToDB.SqlQuery
 			return true;
 		}
 
-		bool CheckColumn(SelectQuery parentQuery, SqlColumn column, ISqlExpression expr, SelectQuery query, bool optimizeValues, bool optimizeColumns)
+		bool CheckColumn(SelectQuery parentQuery, SqlColumn column, ISqlExpression expr, SelectQuery query, bool optimizeValues, ISet<ISqlTableSource> sources)
 		{
 			expr = QueryHelper.UnwrapExpression(expr);
 
@@ -1008,11 +1019,11 @@ namespace LinqToDB.SqlQuery
 				if (e1.Operation == "*" && e1.Expr1 is SqlValue value)
 				{
 					if (value.Value is int i && i == -1)
-						return CheckColumn(parentQuery, column, e1.Expr2, query, optimizeValues, optimizeColumns);
+						return CheckColumn(parentQuery, column, e1.Expr2, query, optimizeValues, sources);
 				}
 			}
 
-			if (expr.Find(static ex => ex is SelectQuery || QueryHelper.IsAggregationOrWindowFunction(ex)) == null)
+			if (!QueryHelper.ContainsAggregationOrWindowFunction(expr))
 			{
 				var elementsToIgnore = new HashSet<IQueryElement> { query };
 
@@ -1022,7 +1033,7 @@ namespace LinqToDB.SqlQuery
 
 				if (!_flags.AcceptsOuterExpressionInAggregate && 
 				    column.Expression.ElementType != QueryElementType.Column &&
-				    QueryHelper.HasOuterReferences(parentQuery, column))
+				    QueryHelper.HasOuterReferences(sources, column))
 				{
 					// handle case when aggregate expression has outer references. SQL Server will fail.
 					return true;
@@ -1047,7 +1058,6 @@ namespace LinqToDB.SqlQuery
 			bool concatWhere,
 			bool allColumns,
 			bool optimizeValues,
-			bool optimizeColumns,
 			SqlJoinedTable? parentJoinedTable)
 		{
 			var query = (SelectQuery)childSource.Source;
@@ -1092,9 +1102,18 @@ namespace LinqToDB.SqlQuery
 			if (!isColumnsOK)
 			{
 				isColumnsOK = true;
+
+				var sources = new HashSet<ISqlTableSource>();
+				query.Visit(sources, static (sources, e) =>
+				{
+					if (e is ISqlTableSource src)
+						sources.Add(src);
+				});
+				sources.AddRange(QueryHelper.EnumerateAccessibleSources(parentQuery));
+
 				foreach (var column in query.Select.Columns)
 				{
-					if (CheckColumn(parentQuery, column, column.Expression, query, optimizeValues, optimizeColumns))
+					if (CheckColumn(parentQuery, column, column.Expression, query, optimizeValues, sources))
 					{
 						isColumnsOK = false;
 						break;
@@ -1232,13 +1251,13 @@ namespace LinqToDB.SqlQuery
 			return result;
 		}
 
-		void OptimizeApply(SelectQuery parentQuery, HashSet<ISqlTableSource> parentTableSources, SqlTableSource tableSource, SqlJoinedTable joinTable, bool isApplySupported, bool optimizeColumns)
+		void OptimizeApply(SelectQuery parentQuery, HashSet<ISqlTableSource> parentTableSources, SqlTableSource tableSource, SqlJoinedTable joinTable, bool isApplySupported)
 		{
 			var joinSource = joinTable.Table;
 
 			foreach (var join in joinSource.Joins)
 				if (join.JoinType == JoinType.CrossApply || join.JoinType == JoinType.OuterApply)
-					OptimizeApply(parentQuery, parentTableSources, joinSource, join, isApplySupported, optimizeColumns);
+					OptimizeApply(parentQuery, parentTableSources, joinSource, join, isApplySupported);
 
 			if (isApplySupported && !joinTable.CanConvertApply)
 				return;
@@ -1369,7 +1388,6 @@ namespace LinqToDB.SqlQuery
 						joinTable.JoinType == JoinType.CrossApply,
 						isApplySupported,
 						joinTable.JoinType == JoinType.Inner || joinTable.JoinType == JoinType.CrossApply,
-						optimizeColumns,
 						joinTable);
 
 					if (table != joinTable.Table)
@@ -1379,7 +1397,7 @@ namespace LinqToDB.SqlQuery
 
 						joinTable.Table = table;
 
-						OptimizeApply(parentQuery, parentTableSources, tableSource, joinTable, isApplySupported, optimizeColumns);
+						OptimizeApply(parentQuery, parentTableSources, tableSource, joinTable, isApplySupported);
 					}
 				}
 			}
@@ -1421,13 +1439,13 @@ namespace LinqToDB.SqlQuery
 			}
 		}
 
-		void OptimizeSubQueries(bool isApplySupported, bool optimizeColumns)
+		void OptimizeSubQueries(bool isApplySupported)
 		{
 			CorrectCrossJoinQuery(_selectQuery);
 
 			for (var i = 0; i < _selectQuery.From.Tables.Count; i++)
 			{
-				var table = OptimizeSubQuery(_selectQuery, _selectQuery.From.Tables[i], true, false, isApplySupported, true, optimizeColumns, null);
+				var table = OptimizeSubQuery(_selectQuery, _selectQuery.From.Tables[i], true, false, isApplySupported, true, null);
 
 				if (table != _selectQuery.From.Tables[i])
 				{
@@ -1440,39 +1458,6 @@ namespace LinqToDB.SqlQuery
 					_selectQuery.From.Tables[i] = table;
 				}
 			}
-
-			// Move up simple subqueries
-			//
-			/* TODO: Cause Stackoverflow in ConcatUnionTests.UnionWithObjects
-			for (int tableIndex = 0; tableIndex < _selectQuery.From.Tables.Count; tableIndex++)
-			{
-				var table = _selectQuery.From.Tables[tableIndex];
-				if (table.Source is SelectQuery subQuery && subQuery.IsSimple)
-				{
-					_selectQuery.From.Tables.RemoveAt(tableIndex);
-					_selectQuery.From.Tables.InsertRange(tableIndex, subQuery.Select.From.Tables);
-					if (table.Joins.Count > 0)
-					{
-						subQuery.Select.From.Tables.Last().Joins.AddRange(table.Joins);
-					}
-
-					var root = _selectQuery.ParentSelect ?? _selectQuery;
-
-					root.Walk(new WalkOptions(), static e =>
-					{
-						if (e is SqlColumn column && column.Parent == subQuery)
-						{
-							return column.Expression;
-						}
-					
-						return e;
-					});
-
-				}
-			}
-
-			*/
-
 
 			//TODO: Failed SelectQueryTests.JoinScalarTest
 			//Needs optimization refactor for 3.X
@@ -1499,7 +1484,7 @@ namespace LinqToDB.SqlQuery
 			*/
 		}
 
-		void OptimizeApplies(bool isApplySupported, bool optimizeColumns)
+		void OptimizeApplies(bool isApplySupported)
 		{
 			var tableSources = new HashSet<ISqlTableSource>();
 
@@ -1510,7 +1495,7 @@ namespace LinqToDB.SqlQuery
 				foreach (var join in table.Joins)
 				{
 					if (join.JoinType == JoinType.CrossApply || join.JoinType == JoinType.OuterApply)
-						OptimizeApply(_selectQuery, tableSources, table, join, isApplySupported, optimizeColumns);
+						OptimizeApply(_selectQuery, tableSources, table, join, isApplySupported);
 
 					join.Walk(WalkOptions.Default, tableSources, static (tableSources, e) =>
 					{

--- a/Source/LinqToDB/SqlQuery/SetOperation.cs
+++ b/Source/LinqToDB/SqlQuery/SetOperation.cs
@@ -1,15 +1,12 @@
-﻿using System;
-
-namespace LinqToDB.SqlQuery
+﻿namespace LinqToDB.SqlQuery
 {
-	[Flags]
 	public enum SetOperation
 	{
-		Union        = 0x1,
-		UnionAll     = 0x2,
-		Except       = 0x3,
-		ExceptAll    = 0x4,
-		Intersect    = 0x8,
-		IntersectAll = 0xA
+		Union,
+		UnionAll,
+		Except,
+		ExceptAll,
+		Intersect,
+		IntersectAll,
 	}
 }

--- a/Source/LinqToDB/SqlQuery/SqlColumn.cs
+++ b/Source/LinqToDB/SqlQuery/SqlColumn.cs
@@ -39,6 +39,8 @@ namespace LinqToDB.SqlQuery
 			{
 				if (_expression == value)
 					return;
+				if (value == this)
+					throw new InvalidOperationException();
 				_expression = value;
 				_hashCode   = null;
 			}

--- a/Tests/FSharp/Issue3357.fs
+++ b/Tests/FSharp/Issue3357.fs
@@ -1,0 +1,69 @@
+﻿module Tests.FSharp.Issue3357
+
+open System
+open System.Linq
+
+open Tests.FSharp.Models
+
+open LinqToDB
+open LinqToDB.Mapping
+open Tests.Tools
+
+type Record2 = {
+    Id: int
+    Name: string
+}
+
+let Union1(db : IDataContext) =
+    let persons = db.GetTable<Person>()
+    let query1 = query {
+        for p in persons do
+        where (p.ID = 1)
+        select (p.ID, p.FirstName)
+    }
+
+    let query2 = query {
+        for p in persons do
+        where (p.ID = 1)
+        select (p.ID, p.FirstName)
+    }
+
+    let result = query1.Concat(query2).ToArray()
+    
+    NUnitAssert.IsTrue(result[0] = (1, "John"));
+
+let Union2(db : IDataContext) =
+    let persons = db.GetTable<Person>()
+    let query1 = query {
+        for p in persons do
+        where (p.ID = 1)
+        select { Id = p.ID; Name = p.FirstName }
+    }
+
+    let query2 = query {
+        for p in persons do
+        where (p.ID = 1)
+        select { Id = p.ID; Name = p.FirstName }
+    }
+
+    let result = query1.Concat(query2).ToArray()
+    
+    NUnitAssert.IsTrue(result[0] = {Id = 1 ; Name = "John" });
+
+let Union3(db : IDataContext) =
+    let persons = db.GetTable<Person>()
+    let query1 = query {
+        for p in persons do
+        where (p.ID = 1)
+        select {| Id = p.ID; Name = p.FirstName |}
+    }
+
+    let query2 = query {
+        for p in persons do
+        where (p.ID = 1)
+        select {| Id = p.ID; Name = p.FirstName |}
+    }
+
+    let result = query1.Concat(query2).ToArray()
+    
+    NUnitAssert.IsTrue(result[0] = {| Id = 1 ; Name = "John" |});

--- a/Tests/FSharp/Tests.FSharp.fsproj
+++ b/Tests/FSharp/Tests.FSharp.fsproj
@@ -14,6 +14,7 @@
 		<Compile Include="AssemblyInfo.fs" />
 		<Compile Include="Issue2678.fs" />
 		<Compile Include="Models.fs" />
+		<Compile Include="Issue3357.fs" />
 		<Compile Include="WhereTest.fs" />
 		<Compile Include="SelectTest.fs" />
 		<Compile Include="InsertTest.fs" />

--- a/Tests/Linq/Linq/AssociationTests.cs
+++ b/Tests/Linq/Linq/AssociationTests.cs
@@ -1258,6 +1258,15 @@ namespace Tests.Linq
 		}
 
 		#endregion
+
+		[ActiveIssue(2966)]
+		[Test(Description = "association over set query")]
+		public void Issue2966([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			db.Patient.Concat(db.Patient).Select(r => new { r.Diagnosis, r.Person.FirstName }).ToArray();
+		}
 	}
 
 	public static class AssociationExtension

--- a/Tests/Linq/Linq/ConcatUnionTests.cs
+++ b/Tests/Linq/Linq/ConcatUnionTests.cs
@@ -8,6 +8,8 @@ using NUnit.Framework;
 
 namespace Tests.Linq
 {
+	using System;
+	using System.Linq.Expressions;
 	using Model;
 
 
@@ -1041,6 +1043,438 @@ namespace Tests.Linq
 			query.Invoking(q => q.ToList()).Should().NotThrow();
 		}		
 
+		[Test(Description = "Test that we generate plain UNION without sub-queries")]
+		public void Issue3359_MultipleSets([DataSources(false)] string context)
+		{
+			using var db = (TestDataConnection)GetDataContext(context);
 
+			var query1 = db.Person.Select(p => new { p.FirstName, p.LastName });
+			var query2 = db.Person.Select(p => new { p.FirstName, p.LastName });
+			var query3 = db.Person.Select(p => new { p.FirstName, p.LastName });
+
+			query1.Concat(query2).Concat(query3).ToArray();
+
+			db.LastQuery!.Should().Contain("SELECT", Exactly.Thrice());
+		}
+
+		[Test(Description = "Test that we generate plain UNION without sub-queries")]
+		public void Issue3359_MultipleSetsCombined([DataSources(false)] string context)
+		{
+			using var db = (TestDataConnection)GetDataContext(context);
+
+			var query1 = db.Person.Select(p => new { p.FirstName, p.LastName });
+			var query2 = db.Person.Select(p => new { p.FirstName, p.LastName });
+			var query3 = db.Person.Select(p => new { p.FirstName, p.LastName });
+			var query4 = db.Person.Select(p => new { p.FirstName, p.LastName });
+			var query5 = db.Person.Select(p => new { p.FirstName, p.LastName });
+			var query6 = db.Person.Select(p => new { p.FirstName, p.LastName });
+
+			query1.Concat(query2.Concat(query3)).Concat(query4.Concat(query5).Concat(query6)).ToArray();
+
+			db.LastQuery!.Should().Contain("SELECT", Exactly.Times(6));
+		}
+
+		// only pgsql supports all 6 operators right now
+		[Test(Description = "Test that we generate sub-queries for incompatible set operators and order queries properly")]
+		public void Issue3359_MultipleSetsCombined_DifferentOperators([IncludeDataSources(TestProvName.AllPostgreSQL)] string context)
+		{
+			using var db = (TestDataConnection)GetDataContext(context);
+
+			var query1 = db.Person.Select(p => new { FirstName = p.FirstName + "q1", p.LastName });
+			var query2 = db.Person.Select(p => new { FirstName = p.FirstName + "q2", p.LastName });
+			var query3 = db.Person.Select(p => new { FirstName = p.FirstName + "q3", p.LastName });
+			var query4 = db.Person.Select(p => new { FirstName = p.FirstName + "q4", p.LastName });
+			var query5 = db.Person.Select(p => new { FirstName = p.FirstName + "q5", p.LastName });
+			var query6 = db.Person.Select(p => new { FirstName = p.FirstName + "q6", p.LastName });
+
+			query1.Union(query2.UnionAll(query3)).Intersect(query4.IntersectAll(query5).Except(query6)).ToArray();
+
+			var sql = db.LastQuery!;
+			// 6 main queries and 4 subqueries for incompatible operators
+			sql.Should().Contain("SELECT", Exactly.Times(6 + 4));
+
+			// operators generated
+			sql.Should().Contain("UNION ALL", Exactly.Once());
+			sql.Should().Contain("UNION", Exactly.Twice());
+			sql.Should().Contain("INTERSECT", Exactly.Twice());
+			sql.Should().Contain("INTERSECT ALL", Exactly.Once());
+			sql.Should().Contain("EXCEPT", Exactly.Once());
+
+			// operators order correct
+			var i1 = sql.IndexOf("UNION");
+			var i2 = sql.IndexOf("UNION ALL");
+			var i3 = sql.IndexOf("INTERSECT");
+			var i4 = sql.IndexOf("INTERSECT ALL");
+			var i5 = sql.IndexOf("EXCEPT");
+			Assert.AreNotEqual(-1, i1);
+			Assert.Less(i1, i2);
+			Assert.Less(i2, i3);
+			Assert.Less(i3, i4);
+			Assert.Less(i4, i5);
+
+			// queries order correct
+			i1 = sql.IndexOf("q1");
+			i2 = sql.IndexOf("q2");
+			i3 = sql.IndexOf("q3");
+			i4 = sql.IndexOf("q4");
+			i5 = sql.IndexOf("q5");
+			Assert.AreNotEqual(-1, i1);
+			Assert.Less(i1, i2);
+			Assert.Less(i2, i3);
+			Assert.Less(i3, i4);
+			Assert.Less(i4, i5);
+		}
+
+		public record class  Issue3357RecordClass (int Id, string FirstName, string LastName);
+		public class Issue3357RecordLike
+		{
+			public Issue3357RecordLike(int Id, string FirstName, string LastName)
+			{
+				this.Id        = Id;
+				this.FirstName = FirstName;
+				this.LastName  = LastName;
+			}
+
+			public int    Id        { get; }
+			public string FirstName { get; }
+			public string LastName  { get; }
+		}
+
+		[Test(Description = "record type support")]
+		public void Issue3357_RecordClass([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			AreEqual(
+				Person.Select(p => new Issue3357RecordClass(p.ID, p.FirstName, p.LastName))
+				.Concat(Person.Select(p => new Issue3357RecordClass(p.ID, p.FirstName, p.LastName))),
+
+				db.Person.Select(p => new Issue3357RecordClass(p.ID, p.FirstName, p.LastName))
+				.Concat(db.Person.Select(p => new Issue3357RecordClass(p.ID, p.FirstName, p.LastName))));
+		}
+
+		[Test(Description = "record type support")]
+		public void Issue3357_RecordLikeClass([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			AreEqualWithComparer(
+				Person.Select(p => new Issue3357RecordLike(p.ID, p.FirstName, p.LastName))
+				.Concat(Person.Select(p => new Issue3357RecordLike(p.ID, p.FirstName, p.LastName))),
+
+				db.Person.Select(p => new Issue3357RecordLike(p.ID, p.FirstName, p.LastName))
+				.Concat(db.Person.Select(p => new Issue3357RecordLike(p.ID, p.FirstName, p.LastName))));
+		}
+
+		[Table]
+		public class Issue3323Table
+		{
+			[PrimaryKey                      ] public int     Id       { get; set; }
+			[Column(SkipOnEntityFetch = true)] public string? FistName { get; set; }
+			[Column(SkipOnEntityFetch = true)] public string? LastName { get; set; }
+			[Column(CanBeNull = false)       ] public string  Text     { get; set; } = null!;
+
+			[ExpressionMethod(nameof(FullNameExpr), IsColumn = true)]
+			public string FullName { get; set; } = null!;
+
+
+			private static Expression<Func<Issue3323Table, string>> FullNameExpr() => entity => entity.FistName + " " + entity.LastName;
+		}
+
+		[Test(Description = "calculated column in set select")]
+		public void Issue3323([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<Issue3323Table>();
+			tb.Insert(() => new Issue3323Table()
+			{
+				Id       = 1,
+				FistName = "one",
+				LastName = "two",
+				Text     = "text"
+			});
+
+			var res = tb.Concat(tb).ToArray();
+
+			Assert.AreEqual(2, res.Length);
+			Assert.AreEqual("one two", res[0].FullName);
+			Assert.AreEqual("one two", res[1].FullName);
+		}
+
+		[Test(Description = "calculated column in set select")]
+		public void Issue3323_Mixed([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<Issue3323Table>();
+			tb.Insert(() => new Issue3323Table()
+			{
+				Id       = 1,
+				FistName = "one",
+				LastName = "two",
+				Text     = "text"
+			});
+
+			var query1 = tb.Select(r => new { r.Id, Text = r.FullName });
+			var query2 = tb.Select(r => new { Id = r.Id + 1, Text = r.Text });
+
+			var res = query1.Concat(query2).ToArray().OrderBy(r => r.Id).ToArray();
+
+			Assert.AreEqual(2        , res.Length);
+			Assert.AreEqual("one two", res[0].Text);
+			Assert.AreEqual("text"   , res[1].Text);
+
+			res = query2.Concat(query1).ToArray().OrderBy(r => r.Id).ToArray();
+
+			Assert.AreEqual(2        , res.Length);
+			Assert.AreEqual("one two", res[0].Text);
+			Assert.AreEqual("text"   , res[1].Text);
+		}
+
+		[Test(Description = "NullReferenceException : Object reference not set to an instance of an object.")]
+		public void Issue2505([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var src = db.Person.AsQueryable();
+
+			var query1 = src.Select(i => new
+			{
+				Person = i,
+				Gender = i.MiddleName == null ? Gender.Male : Gender.Other,
+			});
+
+			var query2 = src.Select(i => new
+			{
+				Person = i,
+				Gender = i.MiddleName == null ? Gender.Male : Gender.Other,
+			});
+
+			query1
+				.UnionAll(query2)
+				.Select(i => new
+				{
+					Person = i.Person,
+					Gender = i.Gender,
+				})
+				.Where(i => i.Gender == Gender.Other)
+				.OrderByDescending(i => i.Person.FirstName)
+				.Select(i => new
+				{
+					Account = i.Person.LastName
+				})
+				.ToList();
+		}
+
+		[Table]
+		[Column(MemberName = $"{nameof(Name)}.{nameof(FullName.FirstName)}")]
+		[Column(MemberName = $"{nameof(Name)}.{nameof(FullName.LastName)}")]
+		public class ComplexPerson
+		{
+			[PrimaryKey] public int       Id   { get; set; }
+			             public FullName? Name { get; set; }
+		}
+
+		public class FullName
+		{
+			public string? FirstName { get; set; }
+			public string? LastName  { get; set; }
+		}
+
+		[ActiveIssue(3346)]
+		[Test(Description = "composite columns in union (also tests create table)")]
+		public void Issue3346_ProjectionBuild([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<ComplexPerson>();
+
+			var query1 = from x in tb
+						 where x.Id < 10
+						 select x;
+
+			var query2 = from x in tb
+						 where x.Id < 20
+						 select x;
+
+			query1.Union(query2).ToArray();
+		}
+
+		[ActiveIssue(3346)]
+		[Test(Description = "composite columns in union (also tests create table)")]
+		public void Issue3346_Count([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<ComplexPerson>();
+
+			var query1 = from x in tb
+						 where x.Id < 10
+						 select x;
+
+			var query2 = from x in tb
+						 where x.Id < 20
+						 select x;
+
+			query1.Union(query2).Count();
+		}
+
+		[ActiveIssue(3150)]
+		[Test(Description = "preserve constant columns")]
+		public void Issue3150([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var query1 = db.Person.Where(p => p.ID == 1).Select(p => new { p.ID, Name = new { p.FirstName, Marker = "id=1" } });
+			var query2 = db.Person.Where(p => p.ID == 2).Select(p => new { p.ID, Name = new { p.FirstName, Marker = "id=2" } });
+
+			var result = query1.Concat(query2).ToArray();
+
+			Assert.AreEqual(2, result.Length);
+			Assert.AreEqual(1, result.Select(r => r.Name.Marker == "id=1").Count());
+			Assert.AreEqual(1, result.Select(r => r.Name.Marker == "id=2").Count());
+		}
+
+		public class Issue2948MyModel
+		{
+			public int    Id   { get; set; }
+			public string Name { get; set; } = null!;
+		}
+
+		public class Issue2948RankData<T>
+		{
+			public long Rank  { get; set; }
+			public T    Model { get; set; } = default!;
+		}
+
+		[ActiveIssue(2948)]
+		[Test(Description = "InvalidCastException : Unable to cast object of type 'System.Linq.Expressions.MemberMemberBinding' to type 'System.Linq.Expressions.MemberAssignment'.")]
+		public void Issue2948([IncludeDataSources(true, TestProvName.AllSqlServer2008Plus)] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var main = (from p in db.Person
+						select new Issue2948RankData<Issue2948MyModel>()
+						{
+							Model = { Id = p.ID, Name = p.FirstName },
+							Rank  = Sql.Ext.RowNumber().Over().PartitionBy(p.ID).OrderBy(p.ID).ToValue()
+						}).Where(x => x.Rank == 1).Select(x => x.Model).AsSubQuery();
+
+			var first  = main.Where(x => x.Id != 2);
+			var second = main.Where(x => x.Id == 2).OrderByDescending(x => x.Name).Take(1);
+			var third  = main.Where(x => x.Id != 3).OrderBy(x => x.Name).Take(1);
+
+			var res = first.Concat(second).Concat(third).ToList();
+		}
+
+		[ActiveIssue(2932)]
+		[Test(Description = "invalid SQL for Any() subquery")]
+		public void Issue2932_Broken([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var query = db.Child.Select(p => new { p.ChildID, Sub = p.GrandChildren.Any() });
+
+			query.Concat(query).ToArray();
+		}
+
+		[Test(Description = "invalid SQL for Any() subquery")]
+		public void Issue2932_Works([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var query = db.Child.Select(p => new { p.ChildID, Sub = p.GrandChildren.Any() ? true : false });
+
+			query.Concat(query).ToArray();
+		}
+
+		[ActiveIssue(2619)]
+		[Test(Description = "set query with ORDER BY requires wrapping into subquery for some DBs")]
+		public void Issue2619_Query1([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			((from item in db.Person select item)
+				.OrderBy(i => i.ID))
+				.Union((from item in db.Person select item))
+				.ToList();
+		}
+
+		[ActiveIssue(2619)]
+		[Test(Description = "set query with ORDER BY requires wrapping into subquery for some DBs")]
+		public void Issue2619_Query2([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			(from item in db.Person select item)
+				.Union((from item in db.Person select item)
+				.OrderBy(i => i.ID))
+				.ToList();
+		}
+
+		[Test(Description = "ArgumentOutOfRangeException : Index was out of range. Must be non-negative and less than the size of the collection.")]
+		public void Issue2511_Query1([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var res = db.Person.LoadWith(p => p.Patient).Concat(db.Person.LoadWith(p => p.Patient).Take(2)).ToArray();
+			
+			Assert.AreEqual(6, res.Length);
+			Assert.AreEqual(2, res.Where(r => r.ID == 2).Count());
+			var pat = res.Where(r => r.ID == 2).First();
+			Assert.IsNotNull(pat.Patient);
+			Assert.AreEqual("Hallucination with Paranoid Bugs' Delirium of Persecution", pat.Patient!.Diagnosis);
+			pat = res.Where(r => r.ID == 2).Skip(1).First();
+			Assert.IsNotNull(pat.Patient);
+			Assert.AreEqual("Hallucination with Paranoid Bugs' Delirium of Persecution", pat.Patient!.Diagnosis);
+		}
+
+		[ActiveIssue(2511)]
+		[Test(Description = "Associations with Concat/Union or other Set operations are not supported")]
+		public void Issue2511_Query2([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var res = db.Person.LoadWith(p => p.Patient)
+				.Select(p => new Person()
+				{
+					ID         = p.ID,
+					FirstName  = p.FirstName,
+					LastName   = p.LastName,
+					MiddleName = p.MiddleName,
+					Gender     = p.Gender,
+					Patient    = p.Patient
+				}).Take(2)
+				.Concat(db.Person.LoadWith(p => p.Patient))
+				.ToArray();
+
+			Assert.AreEqual(6, res.Length);
+			var pat = res.Where(r => r.ID == 2).First();
+			Assert.IsNull(pat.Patient);
+			pat = res.Where(r => r.ID == 2).Skip(1).Single();
+			Assert.IsNotNull(pat.Patient);
+			Assert.AreEqual("Hallucination with Paranoid Bugs' Delirium of Persecution", pat.Patient!.Diagnosis);
+		}
+
+		[Test(Description = "Working version of Issue2511_Query2")]
+		public void Issue2511_Query3([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var res = db.Person.LoadWith(p => p.Patient)
+				.Select(p => new Person()
+				{
+					ID         = p.ID,
+					FirstName  = p.FirstName,
+					LastName   = p.LastName,
+					MiddleName = p.MiddleName,
+					Gender     = p.Gender,
+				}).Take(2)
+				.Concat(db.Person.LoadWith(p => p.Patient))
+				.ToArray();
+
+			Assert.AreEqual(6, res.Length);
+			var pat = res.Where(r => r.ID == 2).First();
+			Assert.IsNull(pat.Patient);
+			pat = res.Where(r => r.ID == 2).Skip(1).Single();
+			Assert.IsNull(pat.Patient);
+		}
 	}
 }

--- a/Tests/Linq/Linq/CteTests.cs
+++ b/Tests/Linq/Linq/CteTests.cs
@@ -11,6 +11,7 @@ using NUnit.Framework;
 
 namespace Tests.Linq
 {
+	using FluentAssertions;
 	using LinqToDB.Linq;
 	using Model;
 
@@ -991,7 +992,7 @@ namespace Tests.Linq
 
 		[ActiveIssue("Scalar recursive CTE are not working: SQL logic error near *: syntax error")]
 		[Test]
-		public void TestRecursiveScalar([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		public void TestRecursiveScalar([CteContextSource] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -1181,5 +1182,204 @@ namespace Tests.Linq
 		}
 		#endregion
 
+		private class Issue3359Projection
+		{
+			public string FirstName { get; set; } = null!;
+			public string LastName  { get; set; } = null!;
+		}
+
+		[Test(Description = "Test that we generate plain UNION without sub-queries (or query will be invalid)")]
+		public void Issue3359_MultipleSets([CteContextSource(
+			TestProvName.AllOracle, // too many unions (ORA-32041: UNION ALL operation in recursive WITH clause must have only two branches)
+			TestProvName.AllPostgreSQL, // too many joins? (42P19: recursive reference to query "cte" must not appear within its non-recursive term)
+			ProviderName.DB2 // joins (SQL0345N  The fullselect of the recursive common table expression "cte" must be the UNION of two or more fullselects and cannot include column functions, GROUP BY clause, HAVING clause, ORDER BY clause, or an explicit join including an ON clause.)
+			)] string context)
+		{
+			if (context.Contains(ProviderName.SQLite))
+			{
+				using var dc = (TestDataConnection)GetDataContext(context.Replace(".LinqService", string.Empty));
+				if (TestUtils.GetSqliteVersion(dc) < new Version(3, 34))
+				{
+					// SQLite Error 1: 'circular reference: cte'.
+					Assert.Inconclusive("SQLite version 3.34.0 or greater required");
+				}
+			}
+
+			using var db = GetDataContext(context);
+
+			var query = db.GetCte<Issue3359Projection>(cte =>
+			{
+				return db.Person.Select(p => new Issue3359Projection() { FirstName = p.FirstName, LastName = p.LastName })
+				.Concat(
+					from p in cte
+					join d in db.Doctor on p.FirstName equals d.Taxonomy
+					select new Issue3359Projection() { FirstName = p.FirstName, LastName = p.LastName }
+					)
+				.Concat(
+					from p in cte
+					join pat in db.Patient on p.FirstName equals pat.Diagnosis
+					select new Issue3359Projection() { FirstName = p.FirstName, LastName = p.LastName }
+					);
+			});
+
+			query.ToArray();
+
+			if (db is TestDataConnection cn)
+				cn.LastQuery!.Should().Contain("SELECT", Exactly.Times(4));
+		}
+
+
+
+		public record class  Issue3357RecordClass (int Id, string FirstName, string LastName);
+		public class Issue3357RecordLike
+		{
+			public Issue3357RecordLike(int Id, string FirstName, string LastName)
+			{
+				this.Id        = Id;
+				this.FirstName = FirstName;
+				this.LastName  = LastName;
+			}
+
+			public int    Id        { get; }
+			public string FirstName { get; }
+			public string LastName  { get; }
+		}
+
+		[Test(Description = "record type support")]
+		public void Issue3357_RecordClass([CteContextSource(ProviderName.DB2)] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var query = db.GetCte<Issue3357RecordClass>(cte =>
+			{
+				return db.Person.Select(p => new Issue3357RecordClass(p.ID, p.FirstName, p.LastName))
+				.Concat(
+					from p in cte
+					join r in db.Person on p.FirstName equals r.LastName
+					select new Issue3357RecordClass(r.ID, r.FirstName, r.LastName)
+					);
+			});
+
+			AreEqual(
+				Person.Select(p => new Issue3357RecordClass(p.ID, p.FirstName, p.LastName)),
+				query.ToArray());
+		}
+
+		[Test(Description = "record type support")]
+		public void Issue3357_RecordClass_DB2([IncludeDataSources(true, ProviderName.DB2)] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var query = db.GetCte<Issue3357RecordClass>(cte =>
+			{
+				return db.Person.Select(p => new Issue3357RecordClass(p.ID, p.FirstName, p.LastName))
+				.Concat(
+					from p in cte
+					from r in db.Person
+					where p.FirstName == r.LastName
+					select new Issue3357RecordClass(r.ID, r.FirstName, r.LastName)
+					);
+			});
+
+			AreEqual(
+				Person.Select(p => new Issue3357RecordClass(p.ID, p.FirstName, p.LastName)),
+				query.ToArray());
+		}
+
+		[Test(Description = "record type support")]
+		public void Issue3357_RecordLikeClass([CteContextSource(ProviderName.DB2)] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var query = db.GetCte<Issue3357RecordLike>(cte =>
+			{
+				return db.Person.Select(p => new Issue3357RecordLike(p.ID, p.FirstName, p.LastName))
+				.Concat(
+					from p in cte
+					join r in db.Person on p.FirstName equals r.LastName
+					select new Issue3357RecordLike(r.ID, r.FirstName, r.LastName)
+					);
+			});
+
+			AreEqualWithComparer(
+				Person.Select(p => new Issue3357RecordLike(p.ID, p.FirstName, p.LastName)),
+				query.ToArray());
+		}
+
+		[Test(Description = "record type support")]
+		public void Issue3357_RecordLikeClass_DB2([IncludeDataSources(true, ProviderName.DB2)] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var query = db.GetCte<Issue3357RecordLike>(cte =>
+			{
+				return db.Person.Select(p => new Issue3357RecordLike(p.ID, p.FirstName, p.LastName))
+				.Concat(
+					from p in cte
+					from r in db.Person
+					where p.FirstName == r.LastName
+					select new Issue3357RecordLike(r.ID, r.FirstName, r.LastName)
+					);
+			});
+
+			AreEqualWithComparer(
+				Person.Select(p => new Issue3357RecordLike(p.ID, p.FirstName, p.LastName)),
+				query.ToArray());
+		}
+
+		class CteEntity<TEntity> where TEntity : class
+		{
+			public TEntity Entity   { get; set; } = null!;
+			public Guid    Id       { get; set; }
+			public Guid?   ParentId { get; set; }
+			public int     Level    { get; set; }
+			public string? Label    { get; set; }
+		}
+
+		[Table]
+		class TestFolder
+		{
+			[Column] public Guid        Id       { get; set; }
+			[Column] public string?     Label    { get; set; }
+			[Column] public Guid?       ParentId { get; set; }
+
+			[Association(ThisKey = nameof(ParentId), OtherKey = nameof(Id))]
+			public TestFolder? Parent { get; set; }
+		}
+
+		[ActiveIssue(2264)]
+		[Test(Description = "Recursive common table expression 'CTE' does not contain a top-level UNION ALL operator.")]
+		public void Issue2264([CteContextSource] string context)
+		{
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<TestFolder>();
+
+			var query = db.GetCte<CteEntity<TestFolder>>("CTE", cte =>
+			{
+				return (tb
+					.Where(c => c.ParentId == null)
+					.Select(c =>
+						new CteEntity<TestFolder>()
+						{
+							Level     = 0,
+							Id        = c.Id,
+							ParentId  = c.ParentId,
+							Label     = c.Label,
+							Entity    = c
+						}))
+				.Concat(tb
+					.SelectMany(c => cte.InnerJoin(r => c.ParentId == r.Id),
+						(c, r)    => new CteEntity<TestFolder>
+						{
+							Level    = r.Level + 1,
+							Id       = c.Id,
+							ParentId = c.ParentId,
+							Label    = r.Label + '/' + c.Label,
+							Entity   = c
+						}));
+			});
+
+			query.ToArray();
+		}
 	}
 }

--- a/Tests/Linq/Linq/FSharpTests.cs
+++ b/Tests/Linq/Linq/FSharpTests.cs
@@ -106,5 +106,26 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 				FSharp.Issue2678.InsertAndSelectRecord(db);
 		}
+
+		[Test(Description = "record type support")]
+		public void Issue3357_FSharp1([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+			FSharp.Issue3357.Union1(db);
+		}
+
+		[Test(Description = "record type support")]
+		public void Issue3357_FSharp2([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+			FSharp.Issue3357.Union2(db);
+		}
+
+		[Test(Description = "record type support")]
+		public void Issue3357_FSharp3([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+			FSharp.Issue3357.Union3(db);
+		}
 	}
 }

--- a/Tests/Linq/Update/MergeTests.Operations.Insert.cs
+++ b/Tests/Linq/Update/MergeTests.Operations.Insert.cs
@@ -443,7 +443,8 @@ namespace Tests.xUpdate
 				var results = source.ToList();
 
 				// 5 commas after selected columns and 1 comma in join
-				Assert.AreEqual(6, db.LastQuery!.Count(c => c == ','));
+				var explicitJoin = db.LastQuery!.Contains("JOIN");
+				Assert.AreEqual(explicitJoin ? 5 : 6, db.LastQuery!.Count(c => c == ','));
 
 				Assert.AreEqual(16, results.Count);
 			}

--- a/Tests/Linq/UserTests/Issue3089Tests.cs
+++ b/Tests/Linq/UserTests/Issue3089Tests.cs
@@ -60,6 +60,7 @@ namespace Tests.UserTests
 			}
 		}
 
+		[ActiveIssue(3360)]
 		[Test]
 		public void TestUnion3([IncludeDataSources(TestProvName.AllPostgreSQL)] string context)
 		{
@@ -79,6 +80,7 @@ namespace Tests.UserTests
 			}
 		}
 
+		[ActiveIssue(3360)]
 		[Test]
 		public void TestUnion4([IncludeDataSources(TestProvName.AllPostgreSQL)] string context)
 		{

--- a/Tests/Tests.Playground/Tests.Playground.csproj
+++ b/Tests/Tests.Playground/Tests.Playground.csproj
@@ -8,7 +8,21 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<ProjectReference Include="..\FSharp\Tests.FSharp.fsproj" />
 		<Compile Include="..\Linq\Create\CreateData.cs" Link="CreateData.cs" />
+		<Compile Include="..\Linq\Linq\AnalyticTests.cs" Link="AnalyticTests.cs" />
+
+		<Compile Include="..\Linq\Linq\AssociationTests.cs" Link="AssociationTests.cs" />
+		<Compile Include="..\Linq\Linq\ConcatUnionTests.cs" Link="ConcatUnionTests.cs" />
+		<Compile Include="..\Linq\Linq\CteTests.cs" Link="CteTests.cs" />
+		<Compile Include="..\Linq\Linq\DataTypesTests.cs" Link="DataTypesTests.cs" />
+		<Compile Include="..\Linq\Linq\FSharpTests.cs" Link="FSharpTests.cs" />
+		<Compile Include="..\Linq\Linq\MappingTests.cs" Link="MappingTests.cs" />
+		<Compile Include="..\Linq\Linq\SelectTests.cs" Link="SelectTests.cs" />
+		<Compile Include="..\Linq\Update\MergeTests.cs" Link="MergeTests.cs" />
+		<Compile Include="..\Linq\Update\MergeTests.Operations.Insert.cs" Link="MergeTests.Operations.Insert.cs" />
+		<Compile Include="..\Linq\UserTests\Issue2800Tests.cs" Link="Issue2800Tests.cs" />
+		<Compile Include="..\Linq\UserTests\Issue3402Tests.cs" Link="Issue3402Tests.cs" />
 	</ItemGroup>
 
 </Project>

--- a/Tests/Tests.Playground/Tests.Playground.csproj
+++ b/Tests/Tests.Playground/Tests.Playground.csproj
@@ -10,19 +10,6 @@
 	<ItemGroup>
 		<ProjectReference Include="..\FSharp\Tests.FSharp.fsproj" />
 		<Compile Include="..\Linq\Create\CreateData.cs" Link="CreateData.cs" />
-		<Compile Include="..\Linq\Linq\AnalyticTests.cs" Link="AnalyticTests.cs" />
-
-		<Compile Include="..\Linq\Linq\AssociationTests.cs" Link="AssociationTests.cs" />
-		<Compile Include="..\Linq\Linq\ConcatUnionTests.cs" Link="ConcatUnionTests.cs" />
-		<Compile Include="..\Linq\Linq\CteTests.cs" Link="CteTests.cs" />
-		<Compile Include="..\Linq\Linq\DataTypesTests.cs" Link="DataTypesTests.cs" />
-		<Compile Include="..\Linq\Linq\FSharpTests.cs" Link="FSharpTests.cs" />
-		<Compile Include="..\Linq\Linq\MappingTests.cs" Link="MappingTests.cs" />
-		<Compile Include="..\Linq\Linq\SelectTests.cs" Link="SelectTests.cs" />
-		<Compile Include="..\Linq\Update\MergeTests.cs" Link="MergeTests.cs" />
-		<Compile Include="..\Linq\Update\MergeTests.Operations.Insert.cs" Link="MergeTests.Operations.Insert.cs" />
-		<Compile Include="..\Linq\UserTests\Issue2800Tests.cs" Link="Issue2800Tests.cs" />
-		<Compile Include="..\Linq\UserTests\Issue3402Tests.cs" Link="Issue3402Tests.cs" />
 	</ItemGroup>
 
 </Project>

--- a/linq2db.playground.slnf
+++ b/linq2db.playground.slnf
@@ -5,6 +5,7 @@
       "Source\\LinqToDB.Tools\\LinqToDB.Tools.csproj",
       "Source\\LinqToDB\\LinqToDB.csproj",
       "Tests\\Base\\Tests.Base.csproj",
+      "Tests\\FSharp\\Tests.FSharp.fsproj",
       "Tests\\Model\\Tests.Model.csproj",
       "Tests\\Tests.Playground\\Tests.Playground.csproj",
       "Tests\\VisualBasic\\Tests.VisualBasic.vbproj"


### PR DESCRIPTION
- fix #3357: add support for `record class` and record-like classes (class, initialized through constructor parameters) support to union queries.
- fix #3359: generate flat `set` query when set contains more than two queries (`q1 UNION q2 UNION q3` instead of `SELECT FROM (q1 UNION q2) UNION q3`) including generation inside of CTE
- fix #3323: fixed issues with calculated columns in `set` queries
- fix #2505: fixed issues with sort applied to `set` query with calculated columns
- added tests for existing (not fixed) `set` issues: #2264, #2511, #2619, #2932, #2948, #2966, #3150, #3346
- fixed discovered issue with Access ODBC provider. Queries like 'SELECT @p=null ...' are not supported and we need to generate `null` in select column as-is: `SELECT NULL ...`