### PR TITLE
Change defaults for Configuration.ContinueOnCapturedContext

### DIFF
--- a/Source/LinqToDB/Common/Configuration.cs
+++ b/Source/LinqToDB/Common/Configuration.cs
@@ -62,7 +62,7 @@ namespace LinqToDB.Common
 		/// Defines value to pass to <see cref="Task.ConfigureAwait(bool)"/> method for all linq2db internal await operations.
 		/// Default value: <c>false</c>.
 		/// </summary>
-		public static bool ContinueOnCapturedContext = false;
+		public static bool ContinueOnCapturedContext;
 
 		/// <summary>
 		/// Enables mapping expression to be compatible with <see cref="CommandBehavior.SequentialAccess"/> behavior.

--- a/Source/LinqToDB/Common/Configuration.cs
+++ b/Source/LinqToDB/Common/Configuration.cs
@@ -60,9 +60,9 @@ namespace LinqToDB.Common
 
 		/// <summary>
 		/// Defines value to pass to <see cref="Task.ConfigureAwait(bool)"/> method for all linq2db internal await operations.
-		/// Default value: <c>true</c>.
+		/// Default value: <c>false</c>.
 		/// </summary>
-		public static bool ContinueOnCapturedContext = true;
+		public static bool ContinueOnCapturedContext = false;
 
 		/// <summary>
 		/// Enables mapping expression to be compatible with <see cref="CommandBehavior.SequentialAccess"/> behavior.


### PR DESCRIPTION
Fix #3097
Update default value for `Configuration.ContinueOnCapturedContext` to `false`
