### PR TITLE
Refactor BasicSqlBuilder.DataProvider

### DIFF
--- a/Source/LinqToDB/DataProvider/Access/AccessODBCSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessODBCSqlBuilder.cs
@@ -8,21 +8,17 @@ namespace LinqToDB.DataProvider.Access
 	using Mapping;
 	using SqlProvider;
 
-	class AccessODBCSqlBuilder : AccessSqlBuilderBase
+	class AccessODBCSqlBuilder : AccessSqlBuilderBase<AccessODBCDataProvider>
 	{
-		public AccessODBCSqlBuilder(IDataProvider? provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
+		public AccessODBCSqlBuilder(AccessODBCDataProvider provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, sqlOptimizer, sqlProviderFlags)
-		{
-		}
+		{ }
 
-		AccessODBCSqlBuilder(BasicSqlBuilder parentBuilder) : base(parentBuilder)
-		{
-		}
+		AccessODBCSqlBuilder(AccessODBCSqlBuilder parentBuilder) : base(parentBuilder)
+		{ }
 
-		protected override ISqlBuilder CreateSqlBuilder()
-		{
-			return new AccessODBCSqlBuilder(this);
-		}
+		protected override BasicSqlBuilder<AccessODBCDataProvider> CreateSqlBuilder()
+			=> new AccessODBCSqlBuilder(this);
 
 		public override StringBuilder Convert(StringBuilder sb, string value, ConvertType convertType)
 		{
@@ -39,14 +35,10 @@ namespace LinqToDB.DataProvider.Access
 
 		protected override string? GetProviderTypeName(IDataContext dataContext, DbParameter parameter)
 		{
-			if (DataProvider is AccessODBCDataProvider provider)
-			{
-				var param = provider.TryGetProviderParameter(dataContext, parameter);
-				if (param != null)
-					return provider.Adapter.GetDbType(param).ToString();
-			}
-
-			return base.GetProviderTypeName(dataContext, parameter);
+			var param = DataProvider.TryGetProviderParameter(dataContext, parameter);
+			return param != null
+				? DataProvider.Adapter.GetDbType(param).ToString()
+				: base.GetProviderTypeName(dataContext, parameter);
 		}
 
 		protected override void BuildColumnExpression(SelectQuery? selectQuery, ISqlExpression expr, string? alias, ref bool addAlias)

--- a/Source/LinqToDB/DataProvider/Access/AccessOleDbSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessOleDbSqlBuilder.cs
@@ -1,38 +1,27 @@
-﻿﻿using System;
-﻿using System.Data;
-
-namespace LinqToDB.DataProvider.Access
+﻿﻿namespace LinqToDB.DataProvider.Access
 {
 	using System.Data.Common;
 	using Mapping;
 	using SqlProvider;
 
-	class AccessOleDbSqlBuilder : AccessSqlBuilderBase
+	class AccessOleDbSqlBuilder : AccessSqlBuilderBase<AccessOleDbDataProvider>
 	{
-		public AccessOleDbSqlBuilder(IDataProvider? provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
+		public AccessOleDbSqlBuilder(AccessOleDbDataProvider provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, sqlOptimizer, sqlProviderFlags)
-		{
-		}
+		{ }
 
-		AccessOleDbSqlBuilder(BasicSqlBuilder parentBuilder) : base(parentBuilder)
-		{
-		}
+		AccessOleDbSqlBuilder(AccessOleDbSqlBuilder parentBuilder) : base(parentBuilder)
+		{ }
 
-		protected override ISqlBuilder CreateSqlBuilder()
-		{
-			return new AccessOleDbSqlBuilder(this);
-		}
+		protected override BasicSqlBuilder<AccessOleDbDataProvider> CreateSqlBuilder()
+			=>  new AccessOleDbSqlBuilder(this);
 
 		protected override string? GetProviderTypeName(IDataContext dataContext, DbParameter parameter)
 		{
-			if (DataProvider is AccessOleDbDataProvider provider)
-			{
-				var param = provider.TryGetProviderParameter(dataContext, parameter);
-				if (param != null)
-					return provider.Adapter.GetDbType(param).ToString();
-			}
-
-			return base.GetProviderTypeName(dataContext, parameter);
+			var param = DataProvider.TryGetProviderParameter(dataContext, parameter);
+			return param != null
+				? DataProvider.Adapter.GetDbType(param).ToString()
+				: base.GetProviderTypeName(dataContext, parameter);
 		}
 	}
 }

--- a/Source/LinqToDB/DataProvider/Access/AccessSqlBuilderBase.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessSqlBuilderBase.cs
@@ -9,16 +9,14 @@ namespace LinqToDB.DataProvider.Access
 	using SqlProvider;
 	using SqlQuery;
 
-	abstract class AccessSqlBuilderBase : BasicSqlBuilder
+	abstract class AccessSqlBuilderBase<P> : BasicSqlBuilder<P> where P : IDataProvider
 	{
-		protected AccessSqlBuilderBase(IDataProvider? provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
+		protected AccessSqlBuilderBase(P provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, sqlOptimizer, sqlProviderFlags)
-		{
-		}
+		{ }
 
-		protected AccessSqlBuilderBase(BasicSqlBuilder parentBuilder) : base(parentBuilder)
-		{
-		}
+		protected AccessSqlBuilderBase(BasicSqlBuilder<P> parentBuilder) : base(parentBuilder)
+		{ }
 
 		public override int CommandCount(SqlStatement statement)
 		{

--- a/Source/LinqToDB/DataProvider/DB2/DB2LUWSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2LUWSqlBuilder.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace LinqToDB.DataProvider.DB2
+﻿namespace LinqToDB.DataProvider.DB2
 {
 	using System.Text;
 	using LinqToDB.SqlQuery;
@@ -9,19 +7,15 @@ namespace LinqToDB.DataProvider.DB2
 
 	class DB2LUWSqlBuilder : DB2SqlBuilderBase
 	{
-		public DB2LUWSqlBuilder(IDataProvider? provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
+		public DB2LUWSqlBuilder(DB2DataProvider provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, sqlOptimizer, sqlProviderFlags)
-		{
-		}
+		{ }
 
-		DB2LUWSqlBuilder(BasicSqlBuilder parentBuilder) : base(parentBuilder)
-		{
-		}
+		DB2LUWSqlBuilder(DB2LUWSqlBuilder parentBuilder) : base(parentBuilder)
+		{ }
 
-		protected override ISqlBuilder CreateSqlBuilder()
-		{
-			return new DB2LUWSqlBuilder(this);
-		}
+		protected override BasicSqlBuilder<DB2DataProvider> CreateSqlBuilder()
+			=> new DB2LUWSqlBuilder(this);
 
 		protected override DB2Version Version => DB2Version.LUW;
 

--- a/Source/LinqToDB/DataProvider/DB2/DB2SqlBuilderBase.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2SqlBuilderBase.cs
@@ -13,16 +13,14 @@ namespace LinqToDB.DataProvider.DB2
 	using SqlQuery;
 	using SqlProvider;
 
-	abstract partial class DB2SqlBuilderBase : BasicSqlBuilder
+	abstract partial class DB2SqlBuilderBase : BasicSqlBuilder<DB2DataProvider>
 	{
-		protected DB2SqlBuilderBase(IDataProvider? provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
-			: base(provider, mappingSchema, sqlOptimizer, sqlProviderFlags)
-		{
-		}
+		protected DB2SqlBuilderBase(DB2DataProvider provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
+			: base(provider,mappingSchema, sqlOptimizer, sqlProviderFlags)
+		{ }
 
-		protected DB2SqlBuilderBase(BasicSqlBuilder parentBuilder) : base(parentBuilder)
-		{
-		}
+		protected DB2SqlBuilderBase(DB2SqlBuilderBase parentBuilder) : base(parentBuilder)
+		{ }
 
 		SqlField? _identityField;
 
@@ -263,14 +261,10 @@ namespace LinqToDB.DataProvider.DB2
 				return string.Format("({0}{1}{2})", d.Precision.ToString(CultureInfo.InvariantCulture), InlineComma, d.Scale.ToString(CultureInfo.InvariantCulture));
 			}
 
-			if (DataProvider is DB2DataProvider provider)
-			{
-				var param = provider.TryGetProviderParameter(dataContext, parameter);
-				if (param != null)
-					return provider.Adapter.GetDbType(param).ToString();
-			}
-
-			return base.GetProviderTypeName(dataContext, parameter);
+			var param = DataProvider.TryGetProviderParameter(dataContext, parameter);
+			return param != null
+				? DataProvider.Adapter.GetDbType(param).ToString()
+				: base.GetProviderTypeName(dataContext, parameter);
 		}
 
 		protected override void BuildDropTableStatement(SqlDropTableStatement dropTable)

--- a/Source/LinqToDB/DataProvider/DB2/DB2zOSSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2zOSSqlBuilder.cs
@@ -1,25 +1,19 @@
-﻿using System;
-
-namespace LinqToDB.DataProvider.DB2
+﻿namespace LinqToDB.DataProvider.DB2
 {
 	using Mapping;
 	using SqlProvider;
 
 	class DB2zOSSqlBuilder : DB2SqlBuilderBase
 	{
-		public DB2zOSSqlBuilder(IDataProvider? provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
+		public DB2zOSSqlBuilder(DB2DataProvider provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, sqlOptimizer, sqlProviderFlags)
-		{
-		}
+		{ }
 
-		DB2zOSSqlBuilder(BasicSqlBuilder parentBuilder) : base(parentBuilder)
-		{
-		}
+		DB2zOSSqlBuilder(DB2zOSSqlBuilder parentBuilder) : base(parentBuilder)
+		{ }
 
-		protected override ISqlBuilder CreateSqlBuilder()
-		{
-			return new DB2zOSSqlBuilder(this);
-		}
+		protected override BasicSqlBuilder<DB2DataProvider> CreateSqlBuilder()
+			=> new DB2zOSSqlBuilder(this);
 
 		protected override DB2Version Version => DB2Version.zOS;
 	}

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdSqlBuilder.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Data;
 using System.Linq;
 using System.Text;
 
@@ -16,21 +15,17 @@ namespace LinqToDB.DataProvider.Firebird
 	using SqlProvider;
 	using System.Data.Common;
 
-	public partial class FirebirdSqlBuilder : BasicSqlBuilder
+	public partial class FirebirdSqlBuilder : BasicSqlBuilder<FirebirdDataProvider>
 	{
-		public FirebirdSqlBuilder(IDataProvider provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
+		public FirebirdSqlBuilder(FirebirdDataProvider provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, sqlOptimizer, sqlProviderFlags)
-		{
-		}
+		{ }
 
-		FirebirdSqlBuilder(BasicSqlBuilder parentBuilder) : base(parentBuilder)
-		{
-		}
+		FirebirdSqlBuilder(FirebirdSqlBuilder parentBuilder) : base(parentBuilder)
+		{ }
 
-		protected override ISqlBuilder CreateSqlBuilder()
-		{
-			return new FirebirdSqlBuilder(this);
-		}
+		protected override BasicSqlBuilder<FirebirdDataProvider> CreateSqlBuilder()
+			=> new FirebirdSqlBuilder(this);
 
 		protected override void BuildSelectClause(SelectQuery selectQuery)
 		{
@@ -317,14 +312,10 @@ namespace LinqToDB.DataProvider.Firebird
 
 		protected override string? GetProviderTypeName(IDataContext dataContext, DbParameter parameter)
 		{
-			if (DataProvider is FirebirdDataProvider provider)
-			{
-				var param = provider.TryGetProviderParameter(dataContext, parameter);
-				if (param != null)
-					return provider.Adapter.GetDbType(param).ToString();
-			}
-
-			return base.GetProviderTypeName(dataContext, parameter);
+			var param = DataProvider.TryGetProviderParameter(dataContext, parameter);
+			return param != null
+				? DataProvider.Adapter.GetDbType(param).ToString()
+				: base.GetProviderTypeName(dataContext, parameter);
 		}
 
 		protected override void BuildDeleteQuery(SqlDeleteStatement deleteStatement)

--- a/Source/LinqToDB/DataProvider/MySql/MySqlSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlSqlBuilder.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Linq;
 using System.Text;
 using System.Data.Common;
@@ -12,21 +11,18 @@ namespace LinqToDB.DataProvider.MySql
 	using SqlProvider;
 	using SqlQuery;
 
-	class MySqlSqlBuilder : BasicSqlBuilder
+	class MySqlSqlBuilder : BasicSqlBuilder<MySqlDataProvider>
 	{
-		public MySqlSqlBuilder(IDataProvider? provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
+
+		public MySqlSqlBuilder(MySqlDataProvider provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, sqlOptimizer, sqlProviderFlags)
-		{
-		}
+		{ }
 
-		MySqlSqlBuilder(BasicSqlBuilder parentBuilder) : base(parentBuilder)
-		{
-		}
+		MySqlSqlBuilder(MySqlSqlBuilder parentBuilder) : base(parentBuilder)
+		{ }
 
-		protected override ISqlBuilder CreateSqlBuilder()
-		{
-			return new MySqlSqlBuilder(this) { HintBuilder = HintBuilder };
-		}
+		protected override BasicSqlBuilder<MySqlDataProvider> CreateSqlBuilder()
+			=> new MySqlSqlBuilder(this) { HintBuilder = HintBuilder };
 
 		static MySqlSqlBuilder()
 		{
@@ -494,14 +490,10 @@ namespace LinqToDB.DataProvider.MySql
 
 		protected override string? GetProviderTypeName(IDataContext dataContext, DbParameter parameter)
 		{
-			if (DataProvider is MySqlDataProvider provider)
-			{
-				var param = provider.TryGetProviderParameter(dataContext, parameter);
-				if (param != null)
-					return provider.Adapter.GetDbType(param).ToString();
-			}
-
-			return base.GetProviderTypeName(dataContext, parameter);
+			var param = DataProvider.TryGetProviderParameter(dataContext, parameter);
+			return param != null
+				? DataProvider.Adapter.GetDbType(param).ToString()
+				: base.GetProviderTypeName(dataContext, parameter);
 		}
 
 		protected override void BuildTruncateTable(SqlTruncateTableStatement truncateTable)

--- a/Source/LinqToDB/DataProvider/Oracle/Oracle11SqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/Oracle11SqlBuilder.cs
@@ -1,31 +1,20 @@
-﻿using System;
-using System.Data;
-using System.Linq;
-
-namespace LinqToDB.DataProvider.Oracle
+﻿namespace LinqToDB.DataProvider.Oracle
 {
-	using Common;
 	using SqlQuery;
 	using SqlProvider;
-	using System.Text;
 	using Mapping;
-	using System.Data.Common;
 
 	partial class Oracle11SqlBuilder : OracleSqlBuilderBase
 	{
-		public Oracle11SqlBuilder(IDataProvider? provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
+		public Oracle11SqlBuilder(OracleDataProvider provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, sqlOptimizer, sqlProviderFlags)
-		{
-		}
+		{ }
 
-		protected Oracle11SqlBuilder(BasicSqlBuilder parentBuilder) : base(parentBuilder)
-		{
-		}
+		protected Oracle11SqlBuilder(Oracle11SqlBuilder parentBuilder) : base(parentBuilder)
+		{ }
 
-		protected override ISqlBuilder CreateSqlBuilder()
-		{
-			return new Oracle11SqlBuilder(this) { HintBuilder = HintBuilder };
-		}
+		protected override BasicSqlBuilder<OracleDataProvider> CreateSqlBuilder()
+			=> new Oracle11SqlBuilder(this) { HintBuilder = HintBuilder };
 
 		protected override string GetPhysicalTableName(ISqlTableSource table, string? alias, bool ignoreTableExpression = false, string? defaultDatabaseName = null)
 		{

--- a/Source/LinqToDB/DataProvider/Oracle/Oracle12SqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/Oracle12SqlBuilder.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace LinqToDB.DataProvider.Oracle
+﻿namespace LinqToDB.DataProvider.Oracle
 {
 	using Mapping;
 	using SqlProvider;
@@ -8,19 +6,15 @@ namespace LinqToDB.DataProvider.Oracle
 
 	class Oracle12SqlBuilder : OracleSqlBuilderBase
 	{
-		public Oracle12SqlBuilder(IDataProvider? provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
+		public Oracle12SqlBuilder(OracleDataProvider provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, sqlOptimizer, sqlProviderFlags)
-		{
-		}
+		{ }
 
-		Oracle12SqlBuilder(BasicSqlBuilder parentBuilder) : base(parentBuilder)
-		{
-		}
+		Oracle12SqlBuilder(Oracle12SqlBuilder parentBuilder) : base(parentBuilder)
+		{ }
 
-		protected override ISqlBuilder CreateSqlBuilder()
-		{
-			return new Oracle12SqlBuilder(this) { HintBuilder = HintBuilder };
-		}
+		protected override BasicSqlBuilder<OracleDataProvider> CreateSqlBuilder()
+			=> new Oracle12SqlBuilder(this) { HintBuilder = HintBuilder };
 
 		protected override bool CanSkipRootAliases(SqlStatement statement)
 		{
@@ -40,15 +34,9 @@ namespace LinqToDB.DataProvider.Oracle
 			return condition.Conditions.Count != 0;
 		}
 
-		protected override string? LimitFormat(SelectQuery selectQuery)
-		{
-			return "FETCH NEXT {0} ROWS ONLY";
-		}
+		protected override string? LimitFormat(SelectQuery selectQuery) => "FETCH NEXT {0} ROWS ONLY";
 
-		protected override string OffsetFormat(SelectQuery selectQuery)
-		{
-			return "OFFSET {0} ROWS";
-		}
+		protected override string OffsetFormat(SelectQuery selectQuery) => "OFFSET {0} ROWS";
 
 		protected override bool OffsetFirst => true;
 	}

--- a/Source/LinqToDB/DataProvider/Oracle/OracleSqlBuilderBase.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleSqlBuilderBase.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Data;
 using System.Linq;
 
 namespace LinqToDB.DataProvider.Oracle
@@ -11,16 +10,14 @@ namespace LinqToDB.DataProvider.Oracle
 	using Mapping;
 	using System.Data.Common;
 
-	abstract partial class OracleSqlBuilderBase : BasicSqlBuilder
+	abstract partial class OracleSqlBuilderBase : BasicSqlBuilder<OracleDataProvider>
 	{
-		public OracleSqlBuilderBase(IDataProvider? provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
+		public OracleSqlBuilderBase(OracleDataProvider provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, sqlOptimizer, sqlProviderFlags)
-		{
-		}
+		{ }
 
-		protected OracleSqlBuilderBase(BasicSqlBuilder parentBuilder) : base(parentBuilder)
-		{
-		}
+		protected OracleSqlBuilderBase(OracleSqlBuilderBase parentBuilder) : base(parentBuilder)
+		{ }
 
 		protected override void BuildSelectClause(SelectQuery selectQuery)
 		{
@@ -548,14 +545,10 @@ END;",
 
 		protected override string? GetProviderTypeName(IDataContext dataContext, DbParameter parameter)
 		{
-			if (DataProvider is OracleDataProvider provider)
-			{
-				var param = provider.TryGetProviderParameter(dataContext, parameter);
-				if (param != null)
-					return provider.Adapter.GetDbType(param).ToString();
-			}
-
-			return base.GetProviderTypeName(dataContext, parameter);
+			var param = DataProvider.TryGetProviderParameter(dataContext, parameter);
+			return param != null
+				? DataProvider.Adapter.GetDbType(param).ToString()
+				: base.GetProviderTypeName(dataContext, parameter);
 		}
 
 		protected override void BuildCreateTableCommand(SqlTable table)

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
@@ -85,7 +85,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			if (connection == null)
 				return MultipleRowsCopy(table, options, source);
 
-			var sqlBuilder = (BasicSqlBuilder)_provider.CreateSqlBuilder(table.DataContext.MappingSchema);
+			var sqlBuilder = (PostgreSQLSqlBuilder)_provider.CreateSqlBuilder(table.DataContext.MappingSchema);
 			var ed         = table.DataContext.MappingSchema.GetEntityDescriptor(typeof(T));
 			var tableName  = GetTableName(sqlBuilder, options, table);
 			var columns    = ed.Columns.Where(c => !c.SkipOnInsert || options.KeepIdentity == true && c.IsIdentity).ToArray();
@@ -105,7 +105,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 
 		private (NpgsqlProviderAdapter.NpgsqlDbType?[] npgsqlTypes, string?[] dbTypes, DbDataType[] columnTypes) BuildTypes(
 			NpgsqlProviderAdapter adapter,
-			BasicSqlBuilder       sqlBuilder,
+			PostgreSQLSqlBuilder  sqlBuilder,
 			ColumnDescriptor[]    columns)
 		{
 			var npgsqlTypes = new NpgsqlProviderAdapter.NpgsqlDbType?[columns.Length];
@@ -234,7 +234,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			if (connection == null)
 				return await MultipleRowsCopyAsync(table, options, source, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			var sqlBuilder  = (BasicSqlBuilder)_provider.CreateSqlBuilder(table.DataContext.MappingSchema);
+			var sqlBuilder  = (PostgreSQLSqlBuilder)_provider.CreateSqlBuilder(table.DataContext.MappingSchema);
 			var ed          = table.DataContext.MappingSchema.GetEntityDescriptor(typeof(T));
 			var tableName   = GetTableName(sqlBuilder, options, table);
 			var columns     = ed.Columns.Where(c => !c.SkipOnInsert || options.KeepIdentity == true && c.IsIdentity).ToArray();
@@ -336,7 +336,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			if (connection == null)
 				return await MultipleRowsCopyAsync(table, options, source, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			var sqlBuilder  = (BasicSqlBuilder)_provider.CreateSqlBuilder(table.DataContext.MappingSchema);
+			var sqlBuilder  = (PostgreSQLSqlBuilder)_provider.CreateSqlBuilder(table.DataContext.MappingSchema);
 			var ed          = table.DataContext.MappingSchema.GetEntityDescriptor(typeof(T));
 			var tableName   = GetTableName(sqlBuilder, options, table);
 			var columns     = ed.Columns.Where(c => !c.SkipOnInsert || options.KeepIdentity == true && c.IsIdentity).ToArray();

--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteSqlBuilder.cs
@@ -9,21 +9,17 @@ namespace LinqToDB.DataProvider.SQLite
 	using Mapping;
 	using LinqToDB.Extensions;
 
-	public class SQLiteSqlBuilder : BasicSqlBuilder
+	public class SQLiteSqlBuilder : BasicSqlBuilder<SQLiteDataProvider>
 	{
-		public SQLiteSqlBuilder(IDataProvider? provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
+		public SQLiteSqlBuilder(SQLiteDataProvider provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, sqlOptimizer, sqlProviderFlags)
-		{
-		}
+		{ }
 
-		SQLiteSqlBuilder(BasicSqlBuilder parentBuilder) : base(parentBuilder)
-		{
-		}
+		SQLiteSqlBuilder(SQLiteSqlBuilder parentBuilder) : base(parentBuilder)
+		{ }
 
-		protected override ISqlBuilder CreateSqlBuilder()
-		{
-			return new SQLiteSqlBuilder(this);
-		}
+		protected override BasicSqlBuilder<SQLiteDataProvider> CreateSqlBuilder()
+			=> new SQLiteSqlBuilder(this);
 
 		protected override bool SupportsColumnAliasesInSource => false;
 
@@ -47,15 +43,9 @@ namespace LinqToDB.DataProvider.SQLite
 			}
 		}
 
-		protected override string LimitFormat(SelectQuery selectQuery)
-		{
-			return "LIMIT {0}";
-		}
+		protected override string LimitFormat(SelectQuery selectQuery) => "LIMIT {0}";
 
-		protected override string OffsetFormat(SelectQuery selectQuery)
-		{
-			return "OFFSET {0}";
-		}
+		protected override string OffsetFormat(SelectQuery selectQuery) => "OFFSET {0}";
 
 		public override bool IsNestedJoinSupported => false;
 

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaOdbcSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaOdbcSqlBuilder.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Text;
+﻿using System.Text;
 
 namespace LinqToDB.DataProvider.SapHana
 {
@@ -9,19 +8,15 @@ namespace LinqToDB.DataProvider.SapHana
 
 	class SapHanaOdbcSqlBuilder : SapHanaSqlBuilder
 	{
-		public SapHanaOdbcSqlBuilder(IDataProvider? provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
+		public SapHanaOdbcSqlBuilder(SapHanaOdbcDataProvider provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, sqlOptimizer, sqlProviderFlags)
-		{
-		}
+		{ }
 
-		protected override ISqlBuilder CreateSqlBuilder()
-		{
-			return new SapHanaOdbcSqlBuilder(this);
-		}
+		protected SapHanaOdbcSqlBuilder(SapHanaOdbcSqlBuilder parentBuilder) : base(parentBuilder)
+		{ }
 
-		protected SapHanaOdbcSqlBuilder(BasicSqlBuilder parentBuilder) : base(parentBuilder)
-		{
-		}
+		protected override BasicSqlBuilder<IDataProvider> CreateSqlBuilder()
+			=> new SapHanaOdbcSqlBuilder(this);
 
 		public override StringBuilder Convert(StringBuilder sb, string value, ConvertType convertType)
 		{

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaSqlBuilder.cs
@@ -8,26 +8,20 @@ namespace LinqToDB.DataProvider.SapHana
 	using SqlProvider;
 	using Mapping;
 
-	partial class SapHanaSqlBuilder : BasicSqlBuilder
+	partial class SapHanaSqlBuilder : BasicSqlBuilder<IDataProvider>
 	{
-		public SapHanaSqlBuilder(IDataProvider? provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
+		public SapHanaSqlBuilder(IDataProvider provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, sqlOptimizer, sqlProviderFlags)
-		{
-		}
+		{ }
 
-		protected SapHanaSqlBuilder(BasicSqlBuilder parentBuilder) : base(parentBuilder)
-		{
-		}
+		protected SapHanaSqlBuilder(SapHanaSqlBuilder parentBuilder) : base(parentBuilder)
+		{ }
 
-		protected override ISqlBuilder CreateSqlBuilder()
-		{
-			return new SapHanaSqlBuilder(this);
-		}
+		protected override BasicSqlBuilder<IDataProvider> CreateSqlBuilder()
+			=> new SapHanaSqlBuilder(this);
 
 		public override int CommandCount(SqlStatement statement)
-		{
-			return statement.NeedsIdentity() ? 2 : 1;
-		}
+			=> statement.NeedsIdentity() ? 2 : 1;
 
 		protected override void BuildCommand(SqlStatement statement, int commandNumber)
 		{
@@ -44,10 +38,7 @@ namespace LinqToDB.DataProvider.SapHana
 			}
 		}
 
-		protected override string LimitFormat(SelectQuery selectQuery)
-		{
-			return "LIMIT {0}";
-		}
+		protected override string LimitFormat(SelectQuery selectQuery) => "LIMIT {0}";
 
 		protected override string OffsetFormat(SelectQuery selectQuery)
 		{

--- a/Source/LinqToDB/DataProvider/SqlCe/SqlCeSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlCe/SqlCeSqlBuilder.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Data.Common;
+﻿using System.Data.Common;
 using System.Text;
 
 namespace LinqToDB.DataProvider.SqlCe
@@ -8,21 +7,17 @@ namespace LinqToDB.DataProvider.SqlCe
 	using SqlProvider;
 	using Mapping;
 
-	class SqlCeSqlBuilder : BasicSqlBuilder
+	class SqlCeSqlBuilder : BasicSqlBuilder<SqlCeDataProvider>
 	{
-		public SqlCeSqlBuilder(IDataProvider? provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
+		public SqlCeSqlBuilder(SqlCeDataProvider provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, sqlOptimizer, sqlProviderFlags)
-		{
-		}
+		{ }
 
-		SqlCeSqlBuilder(BasicSqlBuilder parentBuilder) : base(parentBuilder)
-		{
-		}
+		SqlCeSqlBuilder(SqlCeSqlBuilder parentBuilder) : base(parentBuilder)
+		{ }
 
-		protected override ISqlBuilder CreateSqlBuilder()
-		{
-			return new SqlCeSqlBuilder(this);
-		}
+		protected override BasicSqlBuilder<SqlCeDataProvider> CreateSqlBuilder()
+			=> new SqlCeSqlBuilder(this);
 
 		protected override string? FirstFormat(SelectQuery selectQuery)
 		{
@@ -146,14 +141,10 @@ namespace LinqToDB.DataProvider.SqlCe
 
 		protected override string? GetProviderTypeName(IDataContext dataContext, DbParameter parameter)
 		{
-			if (DataProvider is SqlCeDataProvider provider)
-			{
-				var param = provider.TryGetProviderParameter(dataContext, parameter);
-				if (param != null)
-					return provider.Adapter.GetDbType(param).ToString();
-			}
-
-			return base.GetProviderTypeName(dataContext, parameter);
+			var param = DataProvider.TryGetProviderParameter(dataContext, parameter);
+			return param != null
+				? DataProvider.Adapter.GetDbType(param).ToString()
+				: base.GetProviderTypeName(dataContext, parameter);
 		}
 
 		protected override void BuildMergeStatement(SqlMergeStatement merge)

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2005SqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2005SqlBuilder.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace LinqToDB.DataProvider.SqlServer
+﻿namespace LinqToDB.DataProvider.SqlServer
 {
 	using SqlQuery;
 	using SqlProvider;
@@ -8,19 +6,15 @@ namespace LinqToDB.DataProvider.SqlServer
 
 	class SqlServer2005SqlBuilder : SqlServerSqlBuilder
 	{
-		public SqlServer2005SqlBuilder(IDataProvider? provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
+		public SqlServer2005SqlBuilder(SqlServerDataProvider provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, sqlOptimizer, sqlProviderFlags)
-		{
-		}
+		{ }
 
-		SqlServer2005SqlBuilder(BasicSqlBuilder parentBuilder) : base(parentBuilder)
-		{
-		}
+		SqlServer2005SqlBuilder(SqlServer2005SqlBuilder parentBuilder) : base(parentBuilder)
+		{ }
 
-		protected override ISqlBuilder CreateSqlBuilder()
-		{
-			return new SqlServer2005SqlBuilder(this);
-		}
+		protected override BasicSqlBuilder<SqlServerDataProvider> CreateSqlBuilder()
+			=> new SqlServer2005SqlBuilder(this);
 
 		protected override bool IsValuesSyntaxSupported => false;
 

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2008SqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2008SqlBuilder.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace LinqToDB.DataProvider.SqlServer
+﻿namespace LinqToDB.DataProvider.SqlServer
 {
 	using SqlQuery;
 	using SqlProvider;
@@ -8,19 +6,15 @@ namespace LinqToDB.DataProvider.SqlServer
 
 	partial class SqlServer2008SqlBuilder : SqlServerSqlBuilder
 	{
-		public SqlServer2008SqlBuilder(IDataProvider? provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
+		public SqlServer2008SqlBuilder(SqlServerDataProvider provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, sqlOptimizer, sqlProviderFlags)
-		{
-		}
+		{ }
 
-		SqlServer2008SqlBuilder(BasicSqlBuilder parentBuilder) : base(parentBuilder)
-		{
-		}
+		SqlServer2008SqlBuilder(SqlServer2008SqlBuilder parentBuilder) : base(parentBuilder)
+		{ }
 
-		protected override ISqlBuilder CreateSqlBuilder()
-		{
-			return new SqlServer2008SqlBuilder(this);
-		}
+		protected override BasicSqlBuilder<SqlServerDataProvider> CreateSqlBuilder()
+			=> new SqlServer2008SqlBuilder(this);
 
 		protected override void BuildInsertOrUpdateQuery(SqlInsertOrUpdateStatement insertOrUpdate)
 		{
@@ -28,6 +22,6 @@ namespace LinqToDB.DataProvider.SqlServer
 			StringBuilder.AppendLine(";");
 		}
 
-		public override string  Name => ProviderName.SqlServer2008;
+		public override string Name => ProviderName.SqlServer2008;
 	}
 }

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2012SqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2012SqlBuilder.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace LinqToDB.DataProvider.SqlServer
+﻿namespace LinqToDB.DataProvider.SqlServer
 {
 	using SqlQuery;
 	using SqlProvider;
@@ -8,29 +6,20 @@ namespace LinqToDB.DataProvider.SqlServer
 
 	partial class SqlServer2012SqlBuilder : SqlServerSqlBuilder
 	{
-		public SqlServer2012SqlBuilder(IDataProvider? provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
+		public SqlServer2012SqlBuilder(SqlServerDataProvider provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, sqlOptimizer, sqlProviderFlags)
-		{
-		}
+		{ }
 
-		protected SqlServer2012SqlBuilder(BasicSqlBuilder parentBuilder) : base(parentBuilder)
-		{
-		}
+		protected SqlServer2012SqlBuilder(SqlServer2012SqlBuilder parentBuilder) : base(parentBuilder)
+		{ }
 
-		protected override ISqlBuilder CreateSqlBuilder()
-		{
-			return new SqlServer2012SqlBuilder(this);
-		}
+		protected override BasicSqlBuilder<SqlServerDataProvider> CreateSqlBuilder()
+			=> new SqlServer2012SqlBuilder(this);
 
 		protected override string? LimitFormat(SelectQuery selectQuery)
-		{
-			return selectQuery.Select.SkipValue != null ? "FETCH NEXT {0} ROWS ONLY" : null;
-		}
+			=> selectQuery.Select.SkipValue != null ? "FETCH NEXT {0} ROWS ONLY" : null;
 
-		protected override string OffsetFormat(SelectQuery selectQuery)
-		{
-			return "OFFSET {0} ROWS";
-		}
+		protected override string OffsetFormat(SelectQuery selectQuery) => "OFFSET {0} ROWS";
 
 		protected override bool OffsetFirst => true;
 
@@ -40,6 +29,6 @@ namespace LinqToDB.DataProvider.SqlServer
 			StringBuilder.AppendLine(";");
 		}
 
-		public override string  Name => ProviderName.SqlServer2012;
+		public override string Name => ProviderName.SqlServer2012;
 	}
 }

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2014SqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2014SqlBuilder.cs
@@ -1,26 +1,20 @@
-﻿using System;
-
-namespace LinqToDB.DataProvider.SqlServer
+﻿namespace LinqToDB.DataProvider.SqlServer
 {
 	using SqlProvider;
 	using Mapping;
 
 	class SqlServer2014SqlBuilder : SqlServer2012SqlBuilder
 	{
-		public SqlServer2014SqlBuilder(IDataProvider? provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
+		public SqlServer2014SqlBuilder(SqlServerDataProvider provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, sqlOptimizer, sqlProviderFlags)
-		{
-		}
+		{ }
 
-		protected SqlServer2014SqlBuilder(BasicSqlBuilder parentBuilder) : base(parentBuilder)
-		{
-		}
+		protected SqlServer2014SqlBuilder(SqlServer2014SqlBuilder parentBuilder) : base(parentBuilder)
+		{ }
 
-		protected override ISqlBuilder CreateSqlBuilder()
-		{
-			return new SqlServer2014SqlBuilder(this);
-		}
+		protected override BasicSqlBuilder<SqlServerDataProvider> CreateSqlBuilder()
+			=> new SqlServer2014SqlBuilder(this);
 
-		public override string  Name => ProviderName.SqlServer2014;
+		public override string Name => ProviderName.SqlServer2014;
 	}
 }

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2016SqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2016SqlBuilder.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace LinqToDB.DataProvider.SqlServer
+﻿namespace LinqToDB.DataProvider.SqlServer
 {
 	using Mapping;
 	using SqlQuery;
@@ -8,24 +6,18 @@ namespace LinqToDB.DataProvider.SqlServer
 
 	class SqlServer2016SqlBuilder : SqlServer2014SqlBuilder
 	{
-		public SqlServer2016SqlBuilder(IDataProvider? provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
+		public SqlServer2016SqlBuilder(SqlServerDataProvider provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, sqlOptimizer, sqlProviderFlags)
-		{
-		}
+		{ }
 
-		protected SqlServer2016SqlBuilder(BasicSqlBuilder parentBuilder) : base(parentBuilder)
-		{
-		}
+		protected SqlServer2016SqlBuilder(SqlServer2016SqlBuilder parentBuilder) : base(parentBuilder)
+		{ }
 
-		protected override ISqlBuilder CreateSqlBuilder()
-		{
-			return new SqlServer2016SqlBuilder(this);
-		}
+		protected override BasicSqlBuilder<SqlServerDataProvider> CreateSqlBuilder()
+			=> new SqlServer2016SqlBuilder(this);
 
 		protected override void BuildDropTableStatement(SqlDropTableStatement dropTable)
-		{
-			BuildDropTableStatementIfExists(dropTable);
-		}
+			=> BuildDropTableStatementIfExists(dropTable);
 
 		public override string Name => ProviderName.SqlServer2016;
 	}

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2017SqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2017SqlBuilder.cs
@@ -1,25 +1,19 @@
-﻿using System;
-
-namespace LinqToDB.DataProvider.SqlServer
+﻿namespace LinqToDB.DataProvider.SqlServer
 {
 	using Mapping;
 	using SqlProvider;
 
 	class SqlServer2017SqlBuilder : SqlServer2016SqlBuilder
 	{
-		public SqlServer2017SqlBuilder(IDataProvider? provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
+		public SqlServer2017SqlBuilder(SqlServerDataProvider provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, sqlOptimizer, sqlProviderFlags)
-		{
-		}
+		{ }
 
-		protected SqlServer2017SqlBuilder(BasicSqlBuilder parentBuilder) : base(parentBuilder)
-		{
-		}
+		protected SqlServer2017SqlBuilder(SqlServer2017SqlBuilder parentBuilder) : base(parentBuilder)
+		{ }
 
-		protected override ISqlBuilder CreateSqlBuilder()
-		{
-			return new SqlServer2017SqlBuilder(this);
-		}
+		protected override BasicSqlBuilder<SqlServerDataProvider> CreateSqlBuilder()
+			=> new SqlServer2017SqlBuilder(this);
 
 		public override string Name => ProviderName.SqlServer2017;
 	}

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2019SqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2019SqlBuilder.cs
@@ -1,25 +1,19 @@
-﻿using System;
-
-namespace LinqToDB.DataProvider.SqlServer
+﻿namespace LinqToDB.DataProvider.SqlServer
 {
 	using Mapping;
 	using SqlProvider;
 
 	class SqlServer2019SqlBuilder : SqlServer2017SqlBuilder
 	{
-		public SqlServer2019SqlBuilder(IDataProvider? provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
+		public SqlServer2019SqlBuilder(SqlServerDataProvider provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, sqlOptimizer, sqlProviderFlags)
-		{
-		}
+		{ }
 
-		SqlServer2019SqlBuilder(BasicSqlBuilder parentBuilder) : base(parentBuilder)
-		{
-		}
+		SqlServer2019SqlBuilder(SqlServer2019SqlBuilder parentBuilder) : base(parentBuilder)
+		{ }
 
-		protected override ISqlBuilder CreateSqlBuilder()
-		{
-			return new SqlServer2019SqlBuilder(this);
-		}
+		protected override BasicSqlBuilder<SqlServerDataProvider> CreateSqlBuilder()
+			=> new SqlServer2019SqlBuilder(this);
 
 		public override string Name => ProviderName.SqlServer2019;
 	}

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlBuilder.cs
@@ -11,16 +11,14 @@ namespace LinqToDB.DataProvider.SqlServer
 	using SqlQuery;
 	using SqlProvider;
 
-	abstract class SqlServerSqlBuilder : BasicSqlBuilder
+	abstract class SqlServerSqlBuilder : BasicSqlBuilder<SqlServerDataProvider>
 	{
-		protected SqlServerSqlBuilder(IDataProvider? provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
+		protected SqlServerSqlBuilder(SqlServerDataProvider provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, sqlOptimizer, sqlProviderFlags)
-		{
-		}
+		{ }
 
-		protected SqlServerSqlBuilder(BasicSqlBuilder parentBuilder) : base(parentBuilder)
-		{
-		}
+		protected SqlServerSqlBuilder(SqlServerSqlBuilder parentBuilder) : base(parentBuilder)
+		{ }
 
 		protected override string? FirstFormat(SelectQuery selectQuery)
 		{
@@ -346,38 +344,26 @@ namespace LinqToDB.DataProvider.SqlServer
 
 		protected override string? GetTypeName(IDataContext dataContext, DbParameter parameter)
 		{
-			if (DataProvider is SqlServerDataProvider provider)
-			{
-				var param = provider.TryGetProviderParameter(dataContext, parameter);
-				if (param != null)
-					return provider.Adapter.GetTypeName(param);
-			}
-
-			return base.GetTypeName(dataContext, parameter);
+			var param = DataProvider.TryGetProviderParameter(dataContext, parameter);
+			return param != null
+				? DataProvider.Adapter.GetTypeName(param)
+				: base.GetTypeName(dataContext, parameter);
 		}
 
 		protected override string? GetUdtTypeName(IDataContext dataContext, DbParameter parameter)
 		{
-			if (DataProvider is SqlServerDataProvider provider)
-			{
-				var param = provider.TryGetProviderParameter(dataContext, parameter);
-				if (param != null)
-					return provider.Adapter.GetUdtTypeName(param);
-			}
-
-			return base.GetUdtTypeName(dataContext, parameter);
+			var param = DataProvider.TryGetProviderParameter(dataContext, parameter);
+			return param != null
+				? DataProvider.Adapter.GetUdtTypeName(param)
+				: base.GetUdtTypeName(dataContext, parameter);
 		}
 
 		protected override string? GetProviderTypeName(IDataContext dataContext, DbParameter parameter)
 		{
-			if (DataProvider is SqlServerDataProvider provider)
-			{
-				var param = provider.TryGetProviderParameter(dataContext, parameter);
-				if (param != null)
-					return provider.Adapter.GetDbType(param).ToString();
-			}
-
-			return base.GetProviderTypeName(dataContext, parameter);
+			var param = DataProvider.TryGetProviderParameter(dataContext, parameter);
+			return param != null
+				? DataProvider.Adapter.GetDbType(param).ToString()
+				: base.GetProviderTypeName(dataContext, parameter);
 		}
 
 		protected override void BuildTruncateTable(SqlTruncateTableStatement truncateTable)

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseSqlBuilder.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Text;
 using System.Data.Common;
 
@@ -10,21 +9,17 @@ namespace LinqToDB.DataProvider.Sybase
 	using SqlProvider;
 	using Mapping;
 
-	partial class SybaseSqlBuilder : BasicSqlBuilder
+	partial class SybaseSqlBuilder : BasicSqlBuilder<SybaseDataProvider>
 	{
-		public SybaseSqlBuilder(IDataProvider? provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
+		public SybaseSqlBuilder(SybaseDataProvider provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, sqlOptimizer, sqlProviderFlags)
-		{
-		}
+		{ }
 
-		SybaseSqlBuilder(BasicSqlBuilder parentBuilder) : base(parentBuilder)
-		{
-		}
+		SybaseSqlBuilder(SybaseSqlBuilder parentBuilder) : base(parentBuilder)
+		{ }
 
-		protected override ISqlBuilder CreateSqlBuilder()
-		{
-			return new SybaseSqlBuilder(this) { _skipAliases = _isSelect };
-		}
+		protected override BasicSqlBuilder<SybaseDataProvider> CreateSqlBuilder()
+			=> new SybaseSqlBuilder(this) { _skipAliases = _isSelect };
 
 		protected override void BuildGetIdentity(SqlInsertClause insertClause)
 		{
@@ -35,10 +30,7 @@ namespace LinqToDB.DataProvider.Sybase
 
 		protected override bool SupportsColumnAliasesInSource => true;
 
-		protected override string FirstFormat(SelectQuery selectQuery)
-		{
-			return "TOP {0}";
-		}
+		protected override string FirstFormat(SelectQuery selectQuery) => "TOP {0}";
 
 		bool _isSelect;
 		bool _skipAliases;
@@ -197,14 +189,10 @@ namespace LinqToDB.DataProvider.Sybase
 
 		protected override string? GetProviderTypeName(IDataContext dataContext, DbParameter parameter)
 		{
-			if (DataProvider is SybaseDataProvider provider)
-			{
-				var param = provider.TryGetProviderParameter(dataContext, parameter);
-				if (param != null)
-					return provider.Adapter.GetDbType(param).ToString();
-			}
-
-			return base.GetProviderTypeName(dataContext, parameter);
+			var param = DataProvider.TryGetProviderParameter(dataContext, parameter);
+			return param != null
+				? DataProvider.Adapter.GetDbType(param).ToString()
+				: base.GetProviderTypeName(dataContext, parameter);
 		}
 
 		protected override void BuildTruncateTable(SqlTruncateTableStatement truncateTable)

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.Merge.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.Merge.cs
@@ -6,7 +6,7 @@ namespace LinqToDB.SqlProvider
 	using LinqToDB.Common;
 	using SqlQuery;
 
-	public abstract partial class BasicSqlBuilder : ISqlBuilder
+	public abstract partial class BasicSqlBuilder<P> : ISqlBuilder
 	{
 		/// <summary>
 		/// If true, provider supports column aliases specification after table alias.

--- a/Tests/Base/TestProviders/TestNoopProvider.cs
+++ b/Tests/Base/TestProviders/TestNoopProvider.cs
@@ -302,14 +302,13 @@ namespace Tests
 		public override TableOptions    SupportedTableOptions => TableOptions.None;
 	}
 
-	internal class TestNoopSqlBuilder : BasicSqlBuilder
+	internal class TestNoopSqlBuilder : BasicSqlBuilder<TestNoopProvider>
 	{
-		public TestNoopSqlBuilder(IDataProvider provider, MappingSchema mappingSchema)
+		public TestNoopSqlBuilder(TestNoopProvider provider, MappingSchema mappingSchema)
 			: base(provider, mappingSchema, TestNoopSqlOptimizer.Instance, new SqlProviderFlags())
-		{
-		}
+		{ }
 
-		protected override ISqlBuilder CreateSqlBuilder() => throw new NotImplementedException();
+		protected override BasicSqlBuilder<TestNoopProvider> CreateSqlBuilder() => throw new NotImplementedException();
 
 		protected override void BuildInsertOrUpdateQuery(SqlInsertOrUpdateStatement insertOrUpdate)
 		{


### PR DESCRIPTION
- Make it non-nullable (it is never null)
- Make it generic to get rid of all the casts in derived classes

PostgreSqlBulkCopy could get rid of its casts if `CreateSqlBuilder` used co-variance, but our old .net targets don't allow that.
BasicSqlBuilder could also use the curiously recursive pattern but I feel like it's not worth doing here.