### PR TITLE
Added column descriptor detection from Coalesce operator.

### DIFF
--- a/Source/LinqToDB/SqlQuery/QueryHelper.cs
+++ b/Source/LinqToDB/SqlQuery/QueryHelper.cs
@@ -187,6 +187,15 @@ namespace LinqToDB.SqlQuery
 					var binary = (SqlBinaryExpression)expr;
 					return GetColumnDescriptor(binary.Expr1) ?? GetColumnDescriptor(binary.Expr2);
 				}
+				case QueryElementType.SqlFunction:
+				{
+					var function = (SqlFunction)expr;
+					if (function.Name == "Coalesce" && function.Parameters.Length == 2)
+					{
+						return GetColumnDescriptor(function.Parameters[0]);
+					}
+					break;
+				}
 			}
 			return null;
 		}

--- a/Tests/Linq/Linq/ValueConversionTests.cs
+++ b/Tests/Linq/Linq/ValueConversionTests.cs
@@ -393,6 +393,27 @@ namespace Tests.Linq
 		}
 
 		[Test]
+		public void CoalesceTest([DataSources(false)] string context)
+		{
+			var ms = CreateMappingSchema();
+
+			var testData = MainClass.TestData();
+			using (var db = GetDataContext(context, ms))
+			using (var table = db.CreateLocalTable(testData))
+			{
+				var query = from t1 in table
+					select new
+					{
+						Converted = t1.EnumNullable ?? t1.Enum,
+					};
+
+				var selectResult = query.ToArray();
+
+				selectResult.Should().HaveCount(10);
+			}
+		}
+
+		[Test]
 		public void BoolJoinTest([DataSources(false)] string context)
 		{
 			var ms = CreateMappingSchema();


### PR DESCRIPTION
Fixes https://github.com/linq2db/linq2db.EntityFrameworkCore/issues/226