### PR TITLE
Add a test for Associations

### DIFF
--- a/Source/LinqToDB/Linq/Builder/AssociationHelper.cs
+++ b/Source/LinqToDB/Linq/Builder/AssociationHelper.cs
@@ -119,8 +119,8 @@ namespace LinqToDB.Linq.Builder
 
 				if (expressionPredicate != null)
 				{
-					shouldAddDefaultIfEmpty = true;
-					shouldAddCacheCheck = true;
+					shouldAddDefaultIfEmpty = association.CanBeNull;
+					shouldAddCacheCheck     = true;
 
 					var replacedBody = expressionPredicate.GetBody(parentParam, childParam);
 
@@ -136,7 +136,7 @@ namespace LinqToDB.Linq.Builder
 					if (ed.QueryFilterFunc != null)
 					{
 						shouldAddDefaultIfEmpty = true;
-						shouldAddCacheCheck = true;
+						shouldAddCacheCheck     = true;
 					}
 				}
 

--- a/Source/LinqToDB/Linq/Builder/CountBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/CountBuilder.cs
@@ -86,6 +86,18 @@ namespace LinqToDB.Linq.Builder
 
 			var context = new CountContext(buildInfo.Parent, sequence, returnType);
 
+			if (sequence.IsExpression(null, 0, RequestFor.Field).Result)
+			{
+				var old = context.SelectQuery.Select.Columns.ToArray();
+				var sql = sequence.ConvertToIndex(null, 0, ConvertFlags.Field);
+
+				if (context.SelectQuery.Select.Columns.Count > old.Length)
+				{
+					context.SelectQuery.Select.Columns.Clear();
+					context.SelectQuery.Select.Columns.AddRange(old);
+				}
+			}
+
 			context.Sql        = context.SelectQuery;
 			context.FieldIndex = context.SelectQuery.Select.Add(SqlFunction.CreateCount(returnType, context.SelectQuery), "cnt");
 

--- a/Tests/Linq/Linq/AssociationTests.cs
+++ b/Tests/Linq/Linq/AssociationTests.cs
@@ -922,11 +922,11 @@ namespace Tests.Linq
 		{
 			[Column]
 			public int ID { get; set; }
+
 			[Association(ExpressionPredicate = nameof(ChildPredicate), CanBeNull = false)]
 			public NotNullChild Child { get; set; } = null!;
 
-			static Expression<Func<NotNullParent, NotNullChild, bool>> ChildPredicate 
-				=> (p, c) => p.ID == c.ParentID;
+			static Expression<Func<NotNullParent, NotNullChild, bool>> ChildPredicate => (p, c) => p.ID == c.ParentID;
 		}
 
 		[Table("NotNullChild")]
@@ -939,7 +939,7 @@ namespace Tests.Linq
 		[Test]
 		public void AssociationExpressionNotNull([DataSources] string context)
 		{
-			var parentData = new[] 
+			var parentData = new[]
 			{
 				new NotNullParent { ID = 1 },
 				new NotNullParent { ID = 2 },
@@ -950,13 +950,13 @@ namespace Tests.Linq
 				new NotNullChild { ParentID = 1 },
 			};
 
-			using (var db = GetDataContext(context))
-			using (var parent = db.CreateLocalTable("NotNullParent", parentData))
-			using (var child = db.CreateLocalTable("NotNullChild", childData))
-			{				
-				var query = parent.Select(p => p.Child.ParentID);	// Should be an INNER JOIN because CanBeNull = false
-				Assert.AreEqual(1, query.Count());
-			}
+			using var db     = GetDataContext(context);
+			using var parent = db.CreateLocalTable("NotNullParent", parentData);
+			using var child  = db.CreateLocalTable("NotNullChild", childData);
+
+			var query = parent.Select(p => p.Child.ParentID); // Should be an INNER JOIN because CanBeNull = false
+
+			Assert.AreEqual(1, query.Count());
 		}
 
 		[Test]


### PR DESCRIPTION
Exercises ExpressionPredicate + CanBeNull = false

I expect this to fail, in my project this configuration results in an OUTER JOIN despite CanBeNull = false.