### PR TITLE
Non-functional changes to tests from ClickHouse provider branch

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-Describe your issue.
+### Describe your issue
 
 If you have a question, first try to check our [documentation](https://linq2db.github.io/), especially [FAQ](https://linq2db.github.io/articles/FAQ.html) and search in [issues](https://github.com/linq2db/linq2db/issues) and [discussions](https://github.com/linq2db/linq2db/discussions) - maybe your question already answered there.
 
@@ -12,6 +12,7 @@ Stack trace:
 ```
 
 ### Steps to reproduce
+
 Include a complete code listing (or project/solution) that we can run to reproduce the issue.
 
 Partial code listings, or multiple fragments of code, will slow down our response or cause us to push the issue back to you to provide code to reproduce the issue.
@@ -21,8 +22,13 @@ Partial code listings, or multiple fragments of code, will slow down our respons
 ```
 
 ### Environment details
-linq2db version: *?*
-Database Server: *?*
-Database Provider: *?*
+
+`Linq To DB` version: *?*
+
+Database (with version): *?* (e.g. SQL Server 2019)
+
+ADO.NET Provider (with version): *?* (e.g. Microsoft.Data.SqlClient 4.1.0)
+
 Operating system: *?*
-.NET Framework: *?*
+
+.NET Version: *?*

--- a/Build/Azure/pipelines/templates/test-jobs.yml
+++ b/Build/Azure/pipelines/templates/test-jobs.yml
@@ -162,11 +162,11 @@ jobs:
       with_baselines: ${{ parameters.with_baselines }}
 
 ########################
-#  Tests: Ubuntu 20.04 #
+#  Tests: Ubuntu 22.04 #
 ########################
 - job: test_ubuntu_job
   pool:
-    vmImage: 'ubuntu-20.04'
+    vmImage: 'ubuntu-22.04'
   displayName: 'Tests: Linux'
   dependsOn: create_baselines_branch
   condition: ${{ parameters.enabled }}

--- a/Build/Azure/pipelines/templates/test-matrix.yml
+++ b/Build/Azure/pipelines/templates/test-matrix.yml
@@ -42,7 +42,7 @@ parameters:
 
 # OPERATION SYSTEM SELECTORS
 # - enable_os_windows  (true/false string) : enables testrun for windows 2022 image (windows-2022)
-# - enable_os_ubuntu   (true/false string) : enables testrun for Ubuntu 20.04 image (ubuntu-20.04)
+# - enable_os_ubuntu   (true/false string) : enables testrun for Ubuntu 22.04 image (ubuntu-22.04)
 # - enable_os_macos    (true/false string) : enables testrun for Mac OS image (macOS-10.15)
 
 # TARGET FRAMEWORK SELECTORS

--- a/Build/README.md
+++ b/Build/README.md
@@ -1,35 +1,45 @@
-This directory contains MSBUILD props files, used by solution projects and CI build scrips
+#
 
-## Props files
+This directory contains MSBUILD files, used by solution projects and CI build scrips
+
+## MSBUILD files
 
 ### All projects
-- linq2db.Default.props - default props, used by all projects. Contains generic properties, that are used by all projects.
+
+- linq2db.Default.props - default props, used by all projects. Contains generic properties that are used by all projects.
 
 ### Product projects
-- linq2db.Source.props - props for `LinqToDB` and `LinqToDB.Tools` projects. Imports linq2db.Default.props
+
+- linq2db.Source.props - props for projects from `Source` folder. Imports linq2db.Default.props
 
 ### Test Projects
+
 - linq2db.Tests.props - props, used by test projects. Imports linq2db.Default.props
-- linq2db.Tests.Providers.props - references to database providers, used by tests, and some other shared properties. Imports linq2db.Tests.props.
+- linq2db.Tests.Providers.props - references to database providers, used by test projects, and some other shared properties. Imports linq2db.Tests.props.
 
 ## CI Scripts
 
 ### SetVersion.ps1
+
 This script updates assembly `Version` property in `linq2db.Default.props` file using provided version number.
 
 Usage:
+
 ```
 SetVersion.ps1 -path <PATH_TO_PROPS_FILE> -version <VERSION>
 ```
 
 ### BuildNuspecs.ps1
-This script update nuspecs with missing properties like:
+
+This script updates nuspecs with missing properties like:
+
 - versions
 - copyright strings
 - repository details
 - etc
 
 Usage:
+
 ```
 BuildNuspecs.ps1 -path <NUSPEC_SEARCH_MASK> -version <NUGET_VERSION>[ -branch <BRANCH_NAME>]
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,29 +5,32 @@ uid: contributing
 
 ## Project structure
 
-#### Solution and folder structure
+### Solution and folder structure
 
-| Folder                     | Description                                                                                                                      |
-|--------------------------- |----------------------------------------------------------------------------------------------------------------------------------|
-|.\Build                     | Build and CI files, check readme.md in that folder                                                                               |
-|.\Data                      | Databases and database creation scripts for tests                                                                                |
-|.\NuGet                     | LINQ to DB NuGet packages build files                                                                                            |
-|.\Redist                    | Binaries, unavailable officially at NuGet, used by tests and nugets                                                              |
-|.\Source\LinqToDB           | LINQ to DB source code                                                                                                           |
-|.\Source\LinqToDB.Tools     | LINQ to DB Tools source code                                                                                                     |
-|.\Source\LinqToDB.AspNet    | LINQ to DB ASP.NET Core integration library source code                                                                          |
-|.\Source\LinqToDB.Templates | LINQ to DB t4models source code                                                                                                  |
-|.\Tests                     | Unit test projects folder                                                                                                        |
-|.\Tests\Base                | LINQ to DB testing framework                                                                                                     |
-|.\Tests\FSharp              | F# models and tests                                                                                                              |
-|.\Tests\Linq                | Main project for LINQ to DB unit tests                                                                                           |
-|.\Tests\Model               | Model classes for tests                                                                                                          |
-|.\Tests\Tests.T4            | T4 templates test project                                                                                                        |
-|.\Tests\Tests.Benchmarks    | Benchmarks                                                                                                                       |
-|.\Tests\Tests.PLayground    | Test project for use with linq2db.playground.sln lite test solution<br>Used for work on specific test without full solution load |
-|.\Tests\VisualBasic         | Visual Basic models and tests support                                                                                            |
+|Folder|Description|
+|-|-|
+|.\Build|Build and CI files, check readme.md in that folder|
+|.\Data|Databases and database creation scripts for tests|
+|.\NuGet|LINQ to DB NuGet packages build files|
+|.\Redist| Binaries, unavailable officially at NuGet, used by tests and nugets|
+|.\Source\LinqToDB| LINQ to DB source code|
+|.\Source\LinqToDB.AspNet| LINQ to DB ASP.NET Core integration library source code|
+|.\Source\LinqToDB.CLI| LINQ to DB CLI scaffold tool source code|
+|.\Source\LinqToDB.Remote.Grpc| LINQ to DB Remote Context GRPC client/server source code|
+|.\Source\LinqToDB.Remote.Wcf| LINQ to DB Remote Context WCF client/server source code|
+|.\Source\LinqToDB.Templates| LINQ to DB t4models source code|
+|.\Source\LinqToDB.Tools| LINQ to DB Tools source code|
+|.\Tests| Unit test projects folder|
+|.\Tests\Base|LINQ to DB testing framework|
+|.\Tests\FSharp|F# models and tests|
+|.\Tests\Linq|Main project for LINQ to DB unit tests|
+|.\Tests\Model|Model classes for tests|
+|.\Tests\Tests.T4|T4 templates test project|
+|.\Tests\Tests.Benchmarks| Benchmarks|
+|.\Tests\Tests.PLayground| Test project for use with linq2db.playground.sln lite test solution<br>Used for work on specific test without full solution load|
+|.\Tests\VisualBasic|Visual Basic models and tests support|
 
-Solutions:
+#### Solutions
 
 * `.\linq2db.sln` - full linq2db solution
 * `.\linq2db.playground.slnf` - ligthweight linq2db test solution. Used to work on specific test without loading of all payload of full solution
@@ -35,18 +38,14 @@ Solutions:
 
 #### Source projects
 
-| Project \ Target                                 |.NET 4.5 |.NET 4.6 |.NET 4.7.2 | .NET Standard 2.0 | .NET Standard 2.1 | .NET Core 3.1 | .NET 6.0 |
-|-------------------------------------------------:|:-------:|:-------:|:---------:|:-----------------:|:-----------------:|:-------------:|:--------:|
-| `.\Source\LinqToDB\LinqToDB.csproj`              |    √    |    √    |     √     |         √         |         √         |       √       |    √     |
-| `.\Source\LinqToDB\LinqToDB.Tools.csproj`        |    √    |    √    |           |         √         |                   |               |    √     |
-| `.\Source\LinqToDB\LinqToDB.AspNet.csproj`       |    √    |         |           |         √         |                   |               |    √     |
-
 Preferred target defines:
+
 - `NETFRAMEWORK` - `net45`, `net46` and `net472` target ifdef
 - `NETSTANDARD2_1PLUS` - targets with `netstandard2.1` support (`netstandard2.1`, `netcoreapp3.1`, `net6.0`). Don't use this define in test projects!
 - `NATIVE_ASYNC` - ifdef with native support for `ValueTask`, `IAsyncEnumerable<T>` and `IAsyncDisposable` types
 
 Other allowed target defines:
+
 - `NETSTANDARD2_1` - `netstandard2.1` target ifdef
 - `NETCOREAPP3_1` - `netcoreapp3.1` target ifdef
 - `NETSTANDARD2_0` - `netstandard2.0` target ifdef
@@ -56,66 +55,60 @@ Other allowed target defines:
 - `NET472` - `net472` target ifdef
 
 Allowed debugging defines:
-- `TRACK_BUILD` - ?
+
+- `TRACK_BUILD` - ???
 - `DEBUG` - for debug code in debug build. To disable debug code use `DEBUG1` rename
-- `OVERRIDETOSTRING` - enables ToString()` overrides for AST model (must be enabled in LinqToDB.csproj by renaming existing `OVERRIDETOSTRING1` define)
+- `OVERRIDETOSTRING` - enables `ToString()` overrides for AST model (must be enabled in LinqToDB.csproj by renaming existing `OVERRIDETOSTRING1` define)
 
 #### Test projects
 
-| Project \ Target                                   |.NET 4.7.2 | .NET Core 3.1 | .NET 6.0 |
-|---------------------------------------------------:|:---------:|:-------------:|:--------:|
-| `.\Tests\Base\Tests.Base.csproj`                   |     √     |       √       |    √     |
-| `.\Tests\FSharp\Tests.FSharp.fsproj`               |     √     |       √       |    √     |
-| `.\Tests\Linq\Tests.csproj`                        |     √     |       √       |    √     |
-| `.\Tests\Model\Tests.Model.csproj`                 |     √     |       √       |    √     |
-| `.\Tests\Tests.Benchmarks\Tests.Benchmarks.csproj` |     √     |       √       |    √     |
-| `.\Tests\Tests.Playground\Tests.Playground.csproj` |     √     |       √       |    √     |
-| `.\Tests\Tests.T4\Tests.T4.csproj`                 |     √     |       √       |    √     |
-| `.\Tests\VisualBasic\Tests.VisualBasic.vbproj`     |     √     |       √       |    √     |
-
+Tests targets: `net472`, `netcoreapp31`, `net6.0`
 
 Allowed target defines:
+
 - `NETCOREAPP3_1` - `netcoreapp3.1` target ifdef
 - `NET6_0` - `net6.0` target ifdef
 - `NET472` - `net472` target ifdef
 - `AZURE` - for Azure Pipelines CI builds
 
+## Build
 
-## Building
-
-You can use the solution to build and run tests. Also you can build whole solution or library using the following batch files:
+You can use solution to build and run tests. Also you can build whole solution or library using the following batch files:
 
 * `.\Build.cmd` - builds all the projects in the solution for Debug, Release and Azure configurations
 * `.\Compile.cmd` - builds LinqToDB project for Debug and Release configurations
 * `.\Clean.cmd` - cleanups solution projects for Debug, Release and Azure configurations
 * `.\Test.cmd` - build `Debug` configuration and run tests for `net472`, `netcoreapp3.1` and `net6.0` targets. You can set other configuration by passing it as first parameter, disable test targets by passing 0 to second (for `net472`),  third (for `netcoreapp3.1`) or fourth (for `net6.0`) parameter and format (default:html) as 6th parameter.
 
-Example of running Release build tests for `netcoreapp3.1` only with trx as output:
+Example of running `Release` build tests for `netcoreapp3.1` only with trx as output:
+
 ```
 test.cmd Release 0 1 0 0 0 trx
 ```
 
 ### Different platforms support
 
-Because of compiling for different platforms we do use:
+Because we target different TFMs, we use:
 
 * Conditional compilation. See supported defines above
-* Implementing missing classes and enums. There are some under `.\Source\LinqToDB\Compatibility` folder
+* Implementation of missing runtime functionality (usually copied from `dotnet/runtime` repository). Should be placed to `Source\Shared` folder with proper TFM `#ifdef`s (it will be picked by all projects automatically) and made explicitly internal to avoid conflicts.
 
 ## Branches
 
-* `master` - current development branch for next release
-* `release` - branch with the latest release
+* `master` - main development branch, contains code for next release
+* `release` - branch with the latest released version
 
 ## Run tests
 
-NUnit3 is used as unit testing framework. Most of tests are run for all supported databases, and written in same pattern:
+NUnit3 is used as unit-testing framework. Most of tests are run for all supported databases and written in same pattern:
 
 ```cs
+// TestBase - base class for all our tests
+// provides required testing infrastructure
 [TestFixture]
-public class Test: TestBase // TestBase - base class, provides base methods and object data sources
+public class Test: TestBase
 {
-    // DataSourcesAttribute - implements NUnit IParameterDataSource to provide testcases for enabled database providers
+    // DataSourcesAttribute - custom attribute to feed test with enabled database configurations
     [Test]
     public void Test([DataSources] string context)
     {
@@ -140,10 +133,8 @@ public class Test: TestBase // TestBase - base class, provides base methods and 
 `DataSourcesAttribute` generates tests for each enabled data provider. Configuration is taken
 from `.\Tests\DataProviders.json` and `.\Tests\UserDataProviders.json` (used first, if exists).
 
-
 Repository already contains pre-configured `UserDataProviders.json.template` configuration with basic setup for SQLite-based testing and all you need is to rename it to `UserDataProviders.json`, add connection string for other databases you want to test.
 `UserDataProviders.json` will be ignored by git, so you can edit it freely.
-
 
 Configuration file is used to specify user-specific settings such as connection strings to test databases and
 list of providers to test.
@@ -250,7 +241,6 @@ The `[User]DataProviders.json` is a regular JSON file:
         }
     }
 }
-
 ```
 
 To define your own configurations **DO NOT EDIT** `DataProviders.json` - create `.\Tests\Linq\UserDataProviders.json` and define needed configurations.
@@ -271,13 +261,10 @@ It builds solution, generate and publish nugets and runs tests for:
 For more details check [readme](https://github.com/linq2db/linq2db/blob/master/Build/Azure/README.md)
 
 CI builds are done for all branches and PRs.
-- Tests run for all branches and PRs except `release` branch
-- Nugets publishing to [Azure feeds](https://dev.azure.com/linq2db/linq2db/_packaging?_a=feed&feed=linq2db) enabled only for `branch`
-- Nugets publishing to [Nuget.org](https://www.nuget.org/profiles/LinqToDB) enabled only for `release` branch
 
-### Skip CI build
-
-If you want to skip building commit by CI (for example you have changed *.md files only) check this [message](https://developercommunity.visualstudio.com/comments/503497/view.html).
+* Tests run for all branches and PRs except `release` branch
+* Nugets publishing to [Azure feeds](https://dev.azure.com/linq2db/linq2db/_packaging?_a=feed&feed=linq2db) enabled only for `branch`
+* Nugets publishing to [Nuget.org](https://www.nuget.org/profiles/LinqToDB) enabled only for `release` branch
 
 ### Publishing packages
 
@@ -290,7 +277,7 @@ If you want to skip building commit by CI (for example you have changed *.md fil
 1. Create PR from `master` to `release` branch, in comments add [@testers](https://github.com/linq2db/linq2db/wiki/How-can-i-help#testing-how-to) to notify all testers that we are ready to release
 1. Wait few days for feedback from testers and approval from contributors
 1. Merge PR
-1. [Tag release](https://github.com/linq2db/linq2db/releases)
+1. [Tag release](https://github.com/linq2db/linq2db/releases) on `master` branch
 1. Update versions in `master` branch (this will lead to publish all next `master` builds as new version RC):
    * in [\Build\Azure\pipelines\templates\build-vars.yml](https://github.com/linq2db/linq2db/blob/master/Build/Azure/pipelines/templates/build-vars.yml) set `assemblyVersion` and `packageVersion` (for release and development) parameters to next version. Always use next minor version and change it to major only before release, if it should be new major version release
 
@@ -298,10 +285,13 @@ If you want to skip building commit by CI (for example you have changed *.md fil
 
 In general you should follow simple rules:
 
-* Development rules and regulations, code style
+* Code style should match exising code
+* There should be no compilation warnings (will fail CI builds)
 * Do not add new features without tests
 * Avoid direct pushes to `master` and `release` branches
 * To fix some issue or implement new feature create new branch and make pull request after you are ready to merge or create pull request as `work-in-progress` pull request. Merge your PR only after contributors' review.
+* bugfix branches must use `issue/<issue_id>` naming format
+* feature branches must use `feature/<issue_id_or_feature_name>` naming format
 * If you do have repository write access, it is recommended to use central repository instead of fork
 * Do not add new public classes, properties, methods without XML documentation on them
 * Read issues and help users

--- a/NuGet/CLI/README.md
+++ b/NuGet/CLI/README.md
@@ -74,4 +74,3 @@ Scaffold configs (response files) are convenient in many ways:
 - you can store scaffolding options for your project in source control and share with other developers
 - with many options it is hard to work with command line
 - some options not available from CLI or hard to use due to CLI nature (e.g. various issues with escaping of parameters)
-

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
-## LINQ to DB
+# LINQ to DB
 
 [![NuGet Version and Downloads count](https://buildstats.info/nuget/linq2db?includePreReleases=true)](https://www.nuget.org/profiles/LinqToDB) [![License](https://img.shields.io/github/license/linq2db/linq2db)](MIT-LICENSE.txt)
 [![Follow @linq2db](https://img.shields.io/twitter/follow/linq2db.svg)](https://twitter.com/linq2db) [!["good first issue" tasks](https://img.shields.io/github/issues/linq2db/linq2db/good%20first%20issue.svg)](https://github.com/linq2db/linq2db/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
 
 [![Master branch build](https://img.shields.io/azure-devops/build/linq2db/linq2db/5/master?label=build%20(master))](https://dev.azure.com/linq2db/linq2db/_build?definitionId=5&_a=summary) [![Latest build](https://img.shields.io/azure-devops/build/linq2db/linq2db/5?label=build%20(latest))](https://dev.azure.com/linq2db/linq2db/_build?definitionId=5&_a=summary)
 
-
-LINQ to DB is the fastest LINQ database access library offering a simple, light, fast, and type-safe layer between your POCO objects and your database. 
+LINQ to DB is the fastest LINQ database access library offering a simple, light, fast, and type-safe layer between your POCO objects and your database.
 
 Architecturally it is one step above micro-ORMs like Dapper, Massive, or PetaPoco, in that you work with LINQ expressions, not with magic strings, while maintaining a thin abstraction layer between your code and the database. Your queries are checked by the C# compiler and allow for easy refactoring.
 
@@ -16,25 +15,25 @@ In other words **LINQ to DB is type-safe SQL**.
 
 Development version nuget [feed](https://pkgs.dev.azure.com/linq2db/linq2db/_packaging/linq2db/nuget/v3/index.json) ([how to use](https://docs.microsoft.com/en-us/nuget/consume-packages/install-use-packages-visual-studio#package-sources))
 
-
 ## Standout Features
 
- - Rich Querying API:
-   - [Explicit Join Syntax](https://linq2db.github.io/articles/sql/Join-Operators.html) (In addition to standard LINQ join syntax.)
-   - [CTE Support](https://linq2db.github.io/articles/sql/CTE.html)
-   - [Bulk Copy/Insert](https://linq2db.github.io/articles/sql/Bulk-Copy.html)
-   - [Window/Analytic Functions](https://linq2db.github.io/articles/sql/Window-Functions-%28Analytic-Functions%29.html)
-   - [Merge API](https://linq2db.github.io/articles/sql/merge/Merge-API-Description.html)
- - Extensibility:
-   - [Ability to Map Custom SQL to Static Functions](https://github.com/linq2db/linq2db/tree/master/Source/LinqToDB/Sql/)
+- Rich Querying API:
+  - [Explicit Join Syntax](https://linq2db.github.io/articles/sql/Join-Operators.html) (In addition to standard LINQ join syntax.)
+  - [CTE Support](https://linq2db.github.io/articles/sql/CTE.html)
+  - [Bulk Copy/Insert](https://linq2db.github.io/articles/sql/Bulk-Copy.html)
+  - [Window/Analytic Functions](https://linq2db.github.io/articles/sql/Window-Functions-%28Analytic-Functions%29.html)
+  - [Merge API](https://linq2db.github.io/articles/sql/merge/Merge-API-Description.html)
+- Extensibility:
+  - [Ability to Map Custom SQL to Static Functions](https://github.com/linq2db/linq2db/tree/master/Source/LinqToDB/Sql/)
 
 Visit our [blog](http://blog.linq2db.com/) and see [Github.io documentation](https://linq2db.github.io/index.html) for more details.
 
 Code examples and demos can be found [here](https://github.com/linq2db/examples) or in [tests](https://github.com/linq2db/linq2db/tree/master/Tests/Linq).
 
-[Release Notes](https://github.com/linq2db/linq2db/wiki/Releases-and-Roadmap) page.
+[Release notes](https://github.com/linq2db/linq2db/wiki/Releases-and-Roadmap) page.
 
 ### Related linq2db and 3rd-party projects
+
 - [linq2db.EntityFrameworkCore](https://github.com/linq2db/linq2db.EntityFrameworkCore) (adds support for linq2db functionality in EF.Core projects)
 - [LINQPad Driver](https://github.com/linq2db/linq2db.LINQPad)
 - [DB2 iSeries Provider](https://github.com/LinqToDB4iSeries/Linq2DB4iSeries)
@@ -43,16 +42,16 @@ Code examples and demos can be found [here](https://github.com/linq2db/examples)
 - [ASP.NET CORE 5 Template](https://github.com/David-Mawer/LINQ2DB-MVC-Core-5)
 - [PostGIS extensions for linq2db](https://github.com/apdevelop/linq2db-postgis-extensions)
 
-
 Notable open-source users:
+
 - [nopCommerce](https://github.com/nopSolutions/nopCommerce) (starting from v4.30) - popular open-source e-commerce solution
 - [OdataToEntity](https://github.com/voronov-maxim/OdataToEntity) - library to create OData service from database context
 - [SunEngine](https://github.com/sunengine/SunEngine) - site, blog and forum engine
 
 Unmantained projects:
+
 - [LinqToDB.Identity](https://github.com/linq2db/LinqToDB.Identity) - ASP.NET Core Identity provider using linq2db
 - [IdentityServer4.LinqToDB](https://github.com/linq2db/IdentityServer4.LinqToDB) - IdentityServer4 persistence layer using linq2db
-
 
 ## How to help the project
 
@@ -61,7 +60,8 @@ No, this is not the donate link. We do need something really more valuable - you
 ## Let's get started
 
 From **NuGet**:
-* `Install-Package linq2db`
+
+- `Install-Package linq2db`
 
 ## Configuring connection strings
 
@@ -101,7 +101,6 @@ b.UseConnectionFactory(
 // pass configured options to data connection constructor
 var dc = new DataConnection(builder.Build());
 ```
-
 
 ### Using Config File (.NET Framework)
 
@@ -151,7 +150,6 @@ public class MySettings : ILinqToDBSettings
         }
     }
 }
-
 ```
 
 And later just set on program startup before the first query is done (Startup.cs for example):
@@ -166,7 +164,7 @@ See [article](https://linq2db.github.io/articles/get-started/asp-dotnet-core/ind
 
 ## Now let's create a **POCO** class
 
-You can generate POCO classes from your database using [T4 templates](https://linq2db.github.io/articles/T4.html).  These classes will be generated using the `Attribute configuration`. Demonstration video could be found [here](https://linq2db.github.io/articles/general/Video.html). 
+You can generate POCO classes from your database using [T4 templates](https://linq2db.github.io/articles/T4.html).  These classes will be generated using the `Attribute configuration`. Demonstration video could be found [here](https://linq2db.github.io/articles/general/Video.html).
 
 Alternatively, you can write them manually, using `Attribute configuration`, `Fluent configuration`, or inferring.
 
@@ -211,11 +209,11 @@ public class Product
 }
 ```
 
-Property `Name` will be ignored as it lacks `Column` attibute. 
+Property `Name` will be ignored as it lacks `Column` attibute.
 
 ### Fluent Configuration
 
-This method lets you configure your mapping dynamically at runtime. Furthermore, it lets you to have several different configurations if you need so. You will get all configuration abilities available with attribute configuration. These two approaches are interchangeable in its abilities. This kind of configuration is done through the class `MappingSchema`. 
+This method lets you configure your mapping dynamically at runtime. Furthermore, it lets you to have several different configurations if you need so. You will get all configuration abilities available with attribute configuration. These two approaches are interchangeable in its abilities. This kind of configuration is done through the class `MappingSchema`.
 
 With Fluent approach you can configure only things that require it explicitly. All other properties will be inferred by linq2db:
 
@@ -365,7 +363,7 @@ public static List<Product> All(bool onlyActive, string searchFor)
 
 ## Paging
 
-A lot of times we need to write code that returns only a subset of the entire dataset. We expand on the previous example to show what a product search function could look like. 
+A lot of times we need to write code that returns only a subset of the entire dataset. We expand on the previous example to show what a product search function could look like.
 
 Keep in mind that the code below will query the database twice. Once to find out the total number of records, something that is required by many paging controls, and once to return the actual data.
 
@@ -765,4 +763,5 @@ public class DbDataContext : DataConnection
 ```
 
 # More
+
 Still have questions left? Check out our [documentation site](https://linq2db.github.io) and [FAQ](https://linq2db.github.io/articles/FAQ.html)

--- a/Source/LinqToDB/Async/SafeAwaiter.cs
+++ b/Source/LinqToDB/Async/SafeAwaiter.cs
@@ -18,6 +18,15 @@ namespace LinqToDB.Async
 			return awaitable.Result;
 		}
 
+		public static T Run<T>(Func<Task<T>> task)
+		{
+			// awaited ValueTask retrieved in Task.Run context as doing it in main thread could cause deadlock too
+			var awaitable = Task.Run(async () => await task().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext));
+			awaitable.Wait();
+
+			return awaitable.Result;
+		}
+
 		public static void Run(Func<ValueTask> task)
 		{
 			Task.Run(async () => await task().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext)).Wait();

--- a/Source/LinqToDB/Common/Converter.cs
+++ b/Source/LinqToDB/Common/Converter.cs
@@ -32,27 +32,27 @@ namespace LinqToDB.Common
 
 		static Converter()
 		{
-			SetConverter<string,         char>       (v => v.Length == 0 ? '\0' : v[0]);
-			SetConverter<string,         Binary>     (v => new Binary(Convert.FromBase64String(v)));
-			SetConverter<Binary,         string>     (v => Convert.ToBase64String(v.ToArray()));
-			SetConverter<Binary,         byte[]>     (v => v.ToArray());
-			SetConverter<bool,           decimal>    (v => v ? 1m : 0m);
-			SetConverter<DateTimeOffset, DateTime>   (v => v.LocalDateTime);
-			SetConverter<string,         XmlDocument>(v => CreateXmlDocument(v));
-			SetConverter<string,         byte[]>     (v => Convert.FromBase64String(v));
-			SetConverter<byte[],         string>     (v => Convert.ToBase64String(v));
-			SetConverter<TimeSpan,       DateTime>   (v => DateTime.MinValue + v);
-			SetConverter<DateTime,       TimeSpan>   (v => v - DateTime.MinValue);
-			SetConverter<string,         DateTime>   (v => DateTime.Parse(v, CultureInfo.InvariantCulture, DateTimeStyles.NoCurrentDateDefault));
-			SetConverter<char,           bool>       (v => ToBoolean(v));
-			SetConverter<string,         bool>       (v => v.Length == 1 ? ToBoolean(v[0]) : bool.Parse(v));
+			SetConverter<string,         char>          (v => v.Length == 0 ? '\0' : v[0]);
+			SetConverter<string,         Binary>        (v => new Binary(Convert.FromBase64String(v)));
+			SetConverter<Binary,         string>        (v => Convert.ToBase64String(v.ToArray()));
+			SetConverter<Binary,         byte[]>        (v => v.ToArray());
+			SetConverter<bool,           decimal>       (v => v ? 1m : 0m);
+			SetConverter<DateTimeOffset, DateTime>      (v => v.LocalDateTime);
+			SetConverter<string,         XmlDocument>   (v => CreateXmlDocument(v));
+			SetConverter<string,         byte[]>        (v => Convert.FromBase64String(v));
+			SetConverter<byte[],         string>        (v => Convert.ToBase64String(v));
+			SetConverter<TimeSpan,       DateTime>      (v => DateTime.MinValue + v);
+			SetConverter<DateTime,       TimeSpan>      (v => v - DateTime.MinValue);
+			SetConverter<string,         DateTime>      (v => DateTime.Parse(v, CultureInfo.InvariantCulture, DateTimeStyles.NoCurrentDateDefault));
+			SetConverter<char,           bool>          (v => ToBoolean(v));
+			SetConverter<string,         bool>          (v => v.Length == 1 ? ToBoolean(v[0]) : bool.Parse(v));
 
 #if NET6_0_OR_GREATER
-			SetConverter<DateTime,       DateOnly>   (v => DateOnly.FromDateTime(v));
-			SetConverter<DateOnly,       DateTime>   (v => v.ToDateTime(TimeOnly.MinValue));
+			SetConverter<DateTime,       DateOnly>      (v => DateOnly.FromDateTime(v));
+			SetConverter<DateOnly,       DateTime>      (v => v.ToDateTime(TimeOnly.MinValue));
 
 			// use DateTime.Parse() because db processing may return strings that are full date/time.
-			SetConverter<string,         DateOnly>   (v => DateOnly.FromDateTime(DateTime.Parse(v, CultureInfo.InvariantCulture, DateTimeStyles.None)));
+			SetConverter<string,         DateOnly>      (v => DateOnly.FromDateTime(DateTime.Parse(v, CultureInfo.InvariantCulture, DateTimeStyles.None)));
 #endif
 
 			SetConverter<byte  , BitArray>(v => new BitArray(new byte[] { v }));

--- a/Source/LinqToDB/Data/DataConnection.Async.cs
+++ b/Source/LinqToDB/Data/DataConnection.Async.cs
@@ -35,6 +35,9 @@ namespace LinqToDB.Data
 		/// <returns>Database transaction object.</returns>
 		public virtual async Task<DataConnectionTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
 		{
+			if (!DataProvider.TransactionsSupported)
+				return new(this);
+
 			await EnsureConnectionAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 			// If transaction is open, we dispose it, it will rollback all changes.
@@ -74,6 +77,9 @@ namespace LinqToDB.Data
 		/// <returns>Database transaction object.</returns>
 		public virtual async Task<DataConnectionTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
 		{
+			if (!DataProvider.TransactionsSupported)
+				return new(this);
+
 			await EnsureConnectionAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 			// If transaction is open, we dispose it, it will rollback all changes.

--- a/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
+++ b/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
@@ -551,8 +551,8 @@ namespace LinqToDB.Data
 						idParam = dataConnection.CurrentCommand!.CreateParameter();
 
 						idParam.ParameterName = "IDENTITY_PARAMETER";
-						idParam.Direction = ParameterDirection.Output;
-						idParam.DbType = DbType.Decimal;
+						idParam.Direction     = ParameterDirection.Output;
+						idParam.DbType        = DbType.Decimal;
 
 						dataConnection.CurrentCommand!.Parameters.Add(idParam);
 					}

--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -1604,6 +1604,9 @@ namespace LinqToDB.Data
 		/// <returns>Database transaction object.</returns>
 		public virtual DataConnectionTransaction BeginTransaction()
 		{
+			if (!DataProvider.TransactionsSupported)
+				return new(this);
+
 			// If transaction is open, we dispose it, it will rollback all changes.
 			//
 			TransactionAsync?.Dispose();
@@ -1638,6 +1641,9 @@ namespace LinqToDB.Data
 		/// <returns>Database transaction object.</returns>
 		public virtual DataConnectionTransaction BeginTransaction(IsolationLevel isolationLevel)
 		{
+			if (!DataProvider.TransactionsSupported)
+				return new(this);
+
 			// If transaction is open, we dispose it, it will rollback all changes.
 			//
 			TransactionAsync?.Dispose();

--- a/Source/LinqToDB/Data/RetryPolicy/DbExceptionTransientExceptionDetector.cs
+++ b/Source/LinqToDB/Data/RetryPolicy/DbExceptionTransientExceptionDetector.cs
@@ -1,0 +1,20 @@
+﻿// IsTransient property added in .NET 5
+// Some providers implement it for other runtimes (e.g. MySqlConnector), but we don't handle them here (could be added on request)
+#if NET6_0_OR_GREATER
+using System;
+using System.Data.Common;
+
+namespace LinqToDB.Data.RetryPolicy
+{
+	/// <summary>
+	/// Detects the exceptions caused by transient failures. Provider must implement <see cref="DbException"/> IsTransient property.
+	/// </summary>
+	public class DbExceptionTransientExceptionDetector
+	{
+		public static bool ShouldRetryOn(Exception ex)
+		{
+			return ex is DbException dbEx && dbEx.IsTransient;
+		}
+	}
+}
+#endif

--- a/Source/LinqToDB/Data/RetryPolicy/TransientRetryPolicy.cs
+++ b/Source/LinqToDB/Data/RetryPolicy/TransientRetryPolicy.cs
@@ -1,0 +1,47 @@
+﻿// IsTransient property added in .NET 5
+// Some providers implement it for other runtimes (e.g. MySqlConnector), but we don't handle them here (could be added on request)
+#if NET6_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+
+namespace LinqToDB.Data.RetryPolicy
+{
+	using Common;
+	using Data.RetryPolicy;
+
+	/// <summary>
+	/// Retry policy handles exceptions with <c>DbException.IsTransient == true</c> (requires provider support and .NET 6 or greater).
+	/// </summary>
+	public sealed class TransientRetryPolicy : RetryPolicyBase
+	{
+		/// <summary>
+		/// Creates a new instance of <see cref="TransientRetryPolicy" />.
+		/// </summary>
+		public TransientRetryPolicy()
+			: this(Configuration.RetryPolicy.DefaultMaxRetryCount)
+		{ }
+
+		/// <summary>
+		/// Creates a new instance of <see cref="TransientRetryPolicy" />.
+		/// </summary>
+		/// <param name="maxRetryCount"> The maximum number of retry attempts. </param>
+		public TransientRetryPolicy(int maxRetryCount)
+			: this(maxRetryCount, Configuration.RetryPolicy.DefaultMaxDelay)
+		{ }
+
+		/// <summary>
+		/// Creates a new instance of <see cref="TransientRetryPolicy" />.
+		/// </summary>
+		/// <param name="maxRetryCount">The maximum number of retry attempts.</param>
+		/// <param name="maxRetryDelay">The maximum delay in milliseconds between retries.</param>
+		public TransientRetryPolicy(
+			int      maxRetryCount,
+			TimeSpan maxRetryDelay)
+			: base(maxRetryCount, maxRetryDelay)
+		{
+		}
+
+		protected override bool ShouldRetryOn(Exception exception) => DbExceptionTransientExceptionDetector.ShouldRetryOn(exception);
+	}
+}
+#endif

--- a/Source/LinqToDB/DataProvider/Access/AccessSchemaProviderBase.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessSchemaProviderBase.cs
@@ -35,7 +35,7 @@ namespace LinqToDB.DataProvider.Access
 			return base.GetSystemType(dataType, columnType, dataTypeInfo, length, precision, scale, options);
 		}
 
-		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? prec, int? scale)
+		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? precision, int? scale)
 		{
 			return dataType?.ToLower() switch
 			{

--- a/Source/LinqToDB/DataProvider/BulkCopyReader.cs
+++ b/Source/LinqToDB/DataProvider/BulkCopyReader.cs
@@ -3,26 +3,26 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
+using System.Threading.Tasks;
 #if NATIVE_ASYNC
 using System.Threading;
 #endif
 
 namespace LinqToDB.DataProvider
 {
-	using System.Diagnostics.CodeAnalysis;
-	using System.Threading.Tasks;
+	using Async;
 	using Common;
-	using LinqToDB.Async;
-	using LinqToDB.Data;
+	using Data;
 	using Mapping;
 
 	public class BulkCopyReader<T> : BulkCopyReader,
 #if NATIVE_ASYNC
 		IAsyncDisposable
 #else
-		Async.IAsyncDisposable
+		IAsyncDisposable
 #endif
 	{
 		readonly IEnumerator<T>?      _enumerator;

--- a/Source/LinqToDB/DataProvider/DB2/DB2LUWSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2LUWSchemaProvider.cs
@@ -301,7 +301,7 @@ WHERE
 			return base.GetDbType(options, columnType, dataType, length, precision, scale, udtCatalog, udtSchema, udtName);
 		}
 
-		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? prec, int? scale)
+		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? precision, int? scale)
 		{
 			return dataType switch
 			{

--- a/Source/LinqToDB/DataProvider/DataProviderBase.cs
+++ b/Source/LinqToDB/DataProvider/DataProviderBase.cs
@@ -29,28 +29,43 @@ namespace LinqToDB.DataProvider
 		{
 			Name             = name;
 			MappingSchema    = mappingSchema;
-			SqlProviderFlags = new SqlProviderFlags
+			// set default flags values explicitly even for default values
+			SqlProviderFlags = new SqlProviderFlags()
 			{
+				IsSybaseBuggyGroupBy                 = false,
+				IsParameterOrderDependent            = false,
 				AcceptsTakeAsParameter               = true,
+				AcceptsTakeAsParameterIfSkip         = false,
 				IsTakeSupported                      = true,
 				IsSkipSupported                      = true,
+				IsSkipSupportedIfTake                = false,
+				TakeHintsSupported                   = null,
 				IsSubQueryTakeSupported              = true,
 				IsSubQueryColumnSupported            = true,
+				IsSubQueryOrderBySupported           = false,
 				IsCountSubQuerySupported             = true,
+				IsIdentityParameterRequired          = false,
+				IsApplyJoinSupported                 = false,
 				IsInsertOrUpdateSupported            = true,
 				CanCombineParameters                 = true,
 				MaxInListValuesCount                 = int.MaxValue,
-				IsDistinctOrderBySupported           = true,
-				IsSubQueryOrderBySupported           = false,
 				IsUpdateSetTableAliasSupported       = true,
-				TakeHintsSupported                   = null,
+				OutputDeleteUseSpecialTable          = false,
+				OutputInsertUseSpecialTable          = false,
+				OutputUpdateUseSpecialTables         = false,
+				IsGroupByColumnRequred               = false,
 				IsCrossJoinSupported                 = true,
 				IsInnerJoinAsCrossSupported          = true,
+				IsCommonTableExpressionsSupported    = false,
+				IsDistinctOrderBySupported           = true,
 				IsOrderByAggregateFunctionsSupported = true,
 				IsAllSetOperationsSupported          = false,
 				IsDistinctSetOperationsSupported     = true,
-				IsUpdateFromSupported                = true,
+				IsCountDistinctSupported             = false,
 				AcceptsOuterExpressionInAggregate    = true,
+				IsUpdateFromSupported                = true,
+				DefaultMultiQueryIsolationLevel      = IsolationLevel.RepeatableRead,
+				RowConstructorSupport                = RowFeature.None,
 			};
 
 			SetField<DbDataReader, bool>    ((r,i) => r.GetBoolean (i));
@@ -78,6 +93,7 @@ namespace LinqToDB.DataProvider
 		public virtual  MappingSchema    MappingSchema         { get; }
 		public          SqlProviderFlags SqlProviderFlags      { get; }
 		public abstract TableOptions     SupportedTableOptions { get; }
+		public virtual  bool             TransactionsSupported => true;
 
 		public static Func<IDataProvider, DbConnection, DbConnection>? OnConnectionCreated { get; set; }
 

--- a/Source/LinqToDB/DataProvider/DynamicDataProviderBase.cs
+++ b/Source/LinqToDB/DataProvider/DynamicDataProviderBase.cs
@@ -24,8 +24,9 @@ namespace LinqToDB.DataProvider
 
 		public TProviderMappings Adapter { get; }
 
-		public override string? ConnectionNamespace => Adapter.ConnectionType.Namespace;
-		public override Type    DataReaderType      => Adapter.DataReaderType;
+		public override string? ConnectionNamespace   => Adapter.ConnectionType.Namespace;
+		public override Type    DataReaderType        => Adapter.DataReaderType;
+		public override bool    TransactionsSupported => Adapter.TransactionType != null;
 
 		Func<string, DbConnection>? _createConnection;
 
@@ -175,6 +176,9 @@ namespace LinqToDB.DataProvider
 
 		public virtual DbTransaction? TryGetProviderTransaction(IDataContext dataContext, DbTransaction transaction)
 		{
+			if (Adapter.TransactionType == null)
+				return null;
+
 			transaction = dataContext.UnwrapDataObjectInterceptor?.UnwrapTransaction(dataContext, transaction) ?? transaction;
 			return Adapter.TransactionType.IsSameOrParentOf(transaction.GetType()) ? transaction : null;
 		}

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdSchemaProvider.cs
@@ -444,7 +444,7 @@ FROM RDB$FUNCTION_ARGUMENTS p
 			return dataTypes;
 		}
 
-		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? prec, int? scale)
+		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? precision, int? scale)
 		{
 			return dataType?.ToLower() switch
 			{

--- a/Source/LinqToDB/DataProvider/IDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/IDataProvider.cs
@@ -23,6 +23,7 @@ namespace LinqToDB.DataProvider
 		MappingSchema    MappingSchema         { get; }
 		SqlProviderFlags SqlProviderFlags      { get; }
 		TableOptions     SupportedTableOptions { get; }
+		bool             TransactionsSupported { get; }
 		void             InitContext           (IDataContext dataContext);
 		DbConnection     CreateConnection      (string        connectionString);
 		ISqlBuilder      CreateSqlBuilder      (MappingSchema mappingSchema);

--- a/Source/LinqToDB/DataProvider/IDynamicProviderAdapter.cs
+++ b/Source/LinqToDB/DataProvider/IDynamicProviderAdapter.cs
@@ -31,7 +31,8 @@ namespace LinqToDB.DataProvider
 
 		/// <summary>
 		/// Gets type, that implements <see cref="DbTransaction"/> for current ADO.NET provider.
+		/// For providers/databases without transaction support contains <c>null</c>.
 		/// </summary>
-		Type TransactionType { get; }
+		Type? TransactionType { get; }
 	}
 }

--- a/Source/LinqToDB/DataProvider/Informix/InformixSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixSchemaProvider.cs
@@ -51,7 +51,7 @@ namespace LinqToDB.DataProvider.Informix
 			}.ToList();
 		}
 
-		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? prec, int? scale)
+		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? precision, int? scale)
 		{
 			return dataType switch
 			{

--- a/Source/LinqToDB/DataProvider/MySql/MySqlSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlSchemaProvider.cs
@@ -203,7 +203,7 @@ SELECT
 				.ToList();
 		}
 
-		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? prec, int? scale)
+		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? precision, int? scale)
 		{
 			return dataType?.ToLower() switch
 			{

--- a/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
@@ -39,7 +39,6 @@ namespace LinqToDB.DataProvider.Oracle
 			Provider = provider;
 			Version  = version;
 
-			//SqlProviderFlags.IsCountSubQuerySupported        = false;
 			SqlProviderFlags.IsIdentityParameterRequired       = true;
 			SqlProviderFlags.IsCommonTableExpressionsSupported = true;
 			SqlProviderFlags.IsSubQueryOrderBySupported        = true;

--- a/Source/LinqToDB/DataProvider/Oracle/OracleProviderAdapter.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleProviderAdapter.cs
@@ -222,15 +222,15 @@ namespace LinqToDB.DataProvider.Oracle
 		internal interface IBulkCopyAdapter
 		{
 			IBulkCopyService Create(
-				DbConnection connection,
-				BulkCopyOptions options,
-				string table,
-				string? schema,
-				int? notifyAfter,
+				DbConnection                connection,
+				BulkCopyOptions             options,
+				string                      table,
+				string?                     schema,
+				int?                        notifyAfter,
 				Action<BulkCopyRowsCopied>? rowsCopiedCallback,
-				BulkCopyRowsCopied rowsCopiedArgs,
-				int? batchSize,
-				int? timeout);
+				BulkCopyRowsCopied          rowsCopiedArgs,
+				int?                        batchSize,
+				int?                        timeout);
 		}
 
 		private sealed class OracleBulkCopyAdapter : IBulkCopyAdapter

--- a/Source/LinqToDB/DataProvider/Oracle/OracleSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleSchemaProvider.cs
@@ -524,7 +524,7 @@ WHERE SEQUENCE > 0 AND DATA_LEVEL = 0 AND OWNER = USER
 			return base.GetSystemType(dataType, columnType, dataTypeInfo, length, precision, scale, options);
 		}
 
-		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? prec, int? scale)
+		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? precision, int? scale)
 		{
 			switch (dataType)
 			{

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
@@ -85,7 +85,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			if (connection == null)
 				return MultipleRowsCopy(table, options, source);
 
-			var sqlBuilder = (BasicSqlBuilder)_provider.CreateSqlBuilder(table.DataContext.MappingSchema);
+			var sqlBuilder = (PostgreSQLSqlBuilder)_provider.CreateSqlBuilder(table.DataContext.MappingSchema);
 			var ed         = table.DataContext.MappingSchema.GetEntityDescriptor(typeof(T));
 			var tableName  = GetTableName(sqlBuilder, options, table);
 			var columns    = ed.Columns.Where(c => !c.SkipOnInsert || options.KeepIdentity == true && c.IsIdentity).ToArray();
@@ -105,7 +105,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 
 		private (NpgsqlProviderAdapter.NpgsqlDbType?[] npgsqlTypes, string?[] dbTypes, DbDataType[] columnTypes) BuildTypes(
 			NpgsqlProviderAdapter adapter,
-			BasicSqlBuilder       sqlBuilder,
+			PostgreSQLSqlBuilder  sqlBuilder,
 			ColumnDescriptor[]    columns)
 		{
 			var npgsqlTypes = new NpgsqlProviderAdapter.NpgsqlDbType?[columns.Length];
@@ -234,7 +234,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			if (connection == null)
 				return await MultipleRowsCopyAsync(table, options, source, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			var sqlBuilder  = (BasicSqlBuilder)_provider.CreateSqlBuilder(table.DataContext.MappingSchema);
+			var sqlBuilder  = (PostgreSQLSqlBuilder)_provider.CreateSqlBuilder(table.DataContext.MappingSchema);
 			var ed          = table.DataContext.MappingSchema.GetEntityDescriptor(typeof(T));
 			var tableName   = GetTableName(sqlBuilder, options, table);
 			var columns     = ed.Columns.Where(c => !c.SkipOnInsert || options.KeepIdentity == true && c.IsIdentity).ToArray();
@@ -336,7 +336,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			if (connection == null)
 				return await MultipleRowsCopyAsync(table, options, source, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
-			var sqlBuilder  = (BasicSqlBuilder)_provider.CreateSqlBuilder(table.DataContext.MappingSchema);
+			var sqlBuilder  = (PostgreSQLSqlBuilder)_provider.CreateSqlBuilder(table.DataContext.MappingSchema);
 			var ed          = table.DataContext.MappingSchema.GetEntityDescriptor(typeof(T));
 			var tableName   = GetTableName(sqlBuilder, options, table);
 			var columns     = ed.Columns.Where(c => !c.SkipOnInsert || options.KeepIdentity == true && c.IsIdentity).ToArray();

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLSchemaProvider.cs
@@ -471,7 +471,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			).ToList();
 		}
 
-		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? prec, int? scale)
+		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? precision, int? scale)
 		{
 			if (dataType == null)
 				return DataType.Undefined;

--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteDataProvider.cs
@@ -39,9 +39,7 @@ namespace LinqToDB.DataProvider.SQLite
 			SqlProviderFlags.IsInsertOrUpdateSupported         = false;
 			SqlProviderFlags.IsUpdateSetTableAliasSupported    = false;
 			SqlProviderFlags.IsCommonTableExpressionsSupported = true;
-			SqlProviderFlags.IsDistinctOrderBySupported        = true;
 			SqlProviderFlags.IsSubQueryOrderBySupported        = true;
-			SqlProviderFlags.IsDistinctSetOperationsSupported  = true;
 			SqlProviderFlags.IsUpdateFromSupported             = Adapter.SupportsUpdateFrom;
 			SqlProviderFlags.DefaultMultiQueryIsolationLevel   = IsolationLevel.Serializable;
 

--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteSchemaProvider.cs
@@ -158,7 +158,7 @@ namespace LinqToDB.DataProvider.SQLite
 			return dbConnection.Connection.DataSource;
 		}
 
-		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? prec, int? scale)
+		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? precision, int? scale)
 		{
 			// note that sqlite doesn't have types (it has facets) so type name will contain anything
 			// user specified in create table statement

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaDataProvider.cs
@@ -20,7 +20,6 @@ namespace LinqToDB.DataProvider.SapHana
 			SqlProviderFlags.IsParameterOrderDependent = true;
 
 			//supported flags
-			SqlProviderFlags.IsCountSubQuerySupported  = true;
 
 			//Exception: Sap.Data.Hana.HanaException
 			//Message: single-row query returns more than one row
@@ -29,12 +28,10 @@ namespace LinqToDB.DataProvider.SapHana
 			//instead of replace with left join, in which case returns incorrect data
 			SqlProviderFlags.IsSubQueryColumnSupported  = true;
 
-			SqlProviderFlags.IsTakeSupported            = true;
 			SqlProviderFlags.IsDistinctOrderBySupported = false;
 
 			//not supported flags
 			SqlProviderFlags.IsSubQueryTakeSupported   = false;
-			SqlProviderFlags.IsApplyJoinSupported      = false;
 			SqlProviderFlags.IsInsertOrUpdateSupported = false;
 			SqlProviderFlags.IsUpdateFromSupported     = false;
 			SqlProviderFlags.AcceptsOuterExpressionInAggregate = false;

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaOdbcDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaOdbcDataProvider.cs
@@ -19,7 +19,6 @@ namespace LinqToDB.DataProvider.SapHana
 			SqlProviderFlags.IsParameterOrderDependent = true;
 
 			//supported flags
-			SqlProviderFlags.IsCountSubQuerySupported  = true;
 
 			//Exception: Sap.Data.Hana.HanaException
 			//Message: single-row query returns more than one row
@@ -27,12 +26,10 @@ namespace LinqToDB.DataProvider.SapHana
 			//mark this as supported, it's better to throw exception
 			//then replace with left join, in which case returns incorrect data
 			SqlProviderFlags.IsSubQueryColumnSupported  = true;
-			SqlProviderFlags.IsTakeSupported            = true;
 			SqlProviderFlags.IsDistinctOrderBySupported = false;
 
 			//not supported flags
 			SqlProviderFlags.IsSubQueryTakeSupported           = false;
-			SqlProviderFlags.IsApplyJoinSupported              = false;
 			SqlProviderFlags.IsInsertOrUpdateSupported         = false;
 			SqlProviderFlags.AcceptsOuterExpressionInAggregate = false;
 

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaSchemaProvider.cs
@@ -445,7 +445,7 @@ namespace LinqToDB.DataProvider.SapHana
 			return base.GetSystemType(dataType, columnType, dataTypeInfo, length, precision, scale, options);
 		}
 
-		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? prec, int? scale)
+		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? precision, int? scale)
 		{
 			switch (dataType)
 			{

--- a/Source/LinqToDB/DataProvider/SqlCe/SqlCeSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlCe/SqlCeSchemaProvider.cs
@@ -133,7 +133,7 @@ INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE oc ON oc.CONSTRAINT_NAME = rc.UNI
 			};
 		}
 
-		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? prec, int? scale)
+		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? precision, int? scale)
 		{
 			return dataType?.ToLower() switch
 			{

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
@@ -50,10 +50,7 @@ namespace LinqToDB.DataProvider.SqlServer
 			Provider = provider;
 
 			SqlProviderFlags.IsDistinctOrderBySupported        = false;
-			SqlProviderFlags.IsSubQueryOrderBySupported        = false;
-			SqlProviderFlags.IsDistinctSetOperationsSupported  = true;
 			SqlProviderFlags.IsCountDistinctSupported          = true;
-			SqlProviderFlags.IsUpdateFromSupported             = true;
 			SqlProviderFlags.AcceptsOuterExpressionInAggregate = false;
 			SqlProviderFlags.OutputDeleteUseSpecialTable       = true;
 			SqlProviderFlags.OutputInsertUseSpecialTable       = true;

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerSchemaProvider.cs
@@ -297,7 +297,7 @@ namespace LinqToDB.DataProvider.SqlServer
 				.ToList();
 		}
 
-		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? prec, int? scale)
+		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? precision, int? scale)
 		{
 			switch (dataType)
 			{

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseDataProvider.cs
@@ -29,11 +29,9 @@ namespace LinqToDB.DataProvider.Sybase
 			SqlProviderFlags.AcceptsTakeAsParameter           = false;
 			SqlProviderFlags.IsSkipSupported                  = false;
 			SqlProviderFlags.IsSubQueryTakeSupported          = false;
-			//SqlProviderFlags.IsCountSubQuerySupported       = false;
 			SqlProviderFlags.CanCombineParameters             = false;
 			SqlProviderFlags.IsSybaseBuggyGroupBy             = true;
 			SqlProviderFlags.IsCrossJoinSupported             = false;
-			SqlProviderFlags.IsSubQueryOrderBySupported       = false;
 			SqlProviderFlags.IsDistinctOrderBySupported       = false;
 			SqlProviderFlags.IsDistinctSetOperationsSupported = false;
 

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseSchemaProvider.cs
@@ -17,7 +17,7 @@ namespace LinqToDB.DataProvider.Sybase
 			_provider = provider;
 		}
 
-		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? prec, int? scale)
+		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? precision, int? scale)
 		{
 			switch (dataType)
 			{

--- a/Source/LinqToDB/Linq/Builder/TableBuilder.CteTableContext.cs
+++ b/Source/LinqToDB/Linq/Builder/TableBuilder.CteTableContext.cs
@@ -145,8 +145,8 @@ namespace LinqToDB.Linq.Builder
 						if (alias == null)
 						{
 							alias = baseInfo?.MemberChain.LastOrDefault()?.Name ??
-						                  info.MemberChain.LastOrDefault()?.Name;
-						}	
+						                 info.MemberChain.LastOrDefault()?.Name;
+						}
 						var field    = RegisterCteField(baseInfo?.Sql, info.Sql, info.Index, alias);
 						return new SqlInfo(info.MemberChain, field);
 					})

--- a/Source/LinqToDB/Reflection/Methods.cs
+++ b/Source/LinqToDB/Reflection/Methods.cs
@@ -27,8 +27,9 @@ namespace LinqToDB.Reflection
 
 		public static class ADONet
 		{
-			public static readonly MethodInfo IsDBNull      = MemberHelper.MethodOf<DbDataReader>(r => r.IsDBNull(0));
-			public static readonly MethodInfo IsDBNullAsync = MemberHelper.MethodOf<DbDataReader>(r => r.IsDBNullAsync(0));
+			public static readonly MethodInfo   IsDBNull         = MemberHelper.MethodOf  <DbDataReader>(r => r.IsDBNull(0));
+			public static readonly MethodInfo   IsDBNullAsync    = MemberHelper.MethodOf  <DbDataReader>(r => r.IsDBNullAsync(0));
+			public static readonly PropertyInfo ConnectionString = MemberHelper.PropertyOf<DbConnection>(c => c.ConnectionString);
 		}
 
 		public static class Enumerable

--- a/Source/LinqToDB/Remote/LinqServiceSerializer.cs
+++ b/Source/LinqToDB/Remote/LinqServiceSerializer.cs
@@ -109,7 +109,7 @@ namespace LinqToDB.Remote
 							cnt++;
 						}
 
-					Builder.Insert(len, cnt.ToString(CultureInfo.CurrentCulture));
+					Builder.Insert(len, cnt.ToString(CultureInfo.InvariantCulture));
 				}
 			}
 

--- a/Source/LinqToDB/SchemaProvider/PrimaryKeyInfo.cs
+++ b/Source/LinqToDB/SchemaProvider/PrimaryKeyInfo.cs
@@ -5,9 +5,9 @@ namespace LinqToDB.SchemaProvider
 	[DebuggerDisplay("TableID = {TableID}, PrimaryKeyName = {PrimaryKeyName}, ColumnName = {ColumnName}, Ordinal = {Ordinal}")]
 	public class PrimaryKeyInfo
 	{
-		public string TableID        = null!;
-		public string PrimaryKeyName = null!;
-		public string ColumnName     = null!;
-		public int    Ordinal;
+		public string  TableID    = null!;
+		public string? PrimaryKeyName;
+		public string  ColumnName = null!;
+		public int     Ordinal;
 	}
 }

--- a/Source/LinqToDB/SchemaProvider/SchemaProviderBase.cs
+++ b/Source/LinqToDB/SchemaProvider/SchemaProviderBase.cs
@@ -12,7 +12,7 @@ namespace LinqToDB.SchemaProvider
 
 	public abstract class SchemaProviderBase : ISchemaProvider
 	{
-		protected abstract DataType                            GetDataType   (string? dataType, string? columnType, int? length, int? prec, int? scale);
+		protected abstract DataType                            GetDataType   (string? dataType, string? columnType, int? length, int? precision, int? scale);
 		protected abstract List<TableInfo>                     GetTables     (DataConnection dataConnection, GetSchemaOptions options);
 		protected abstract IReadOnlyCollection<PrimaryKeyInfo> GetPrimaryKeys(DataConnection dataConnection, IEnumerable<TableSchema> tables, GetSchemaOptions options);
 		protected abstract List<ColumnInfo>                    GetColumns    (DataConnection dataConnection, GetSchemaOptions options);

--- a/Source/LinqToDB/SchemaProvider/TableInfo.cs
+++ b/Source/LinqToDB/SchemaProvider/TableInfo.cs
@@ -7,7 +7,7 @@ namespace LinqToDB.SchemaProvider
 	{
 		public string  TableID = null!;
 		public string? CatalogName;
-		public string  SchemaName = null!;
+		public string? SchemaName;
 		public string  TableName = null!;
 		public string? Description;
 		public bool    IsDefaultSchema;

--- a/Source/LinqToDB/Sql/Readme.md
+++ b/Source/LinqToDB/Sql/Readme.md
@@ -10,17 +10,13 @@ Note that many of these are used automatically behind the scenes. For example, T
 
 At the same time, some people prefer having LINQ (or even lambda) expressions that read 'closer' to what the SQL will look like. Additionally, there are some constructs in many SQL dialects that do not have an equivalent operator/function in .NET.
 
-### Useful built in Expressions/Functions (That have no direct equivalent in .NET):
+### Useful built in Expressions/Functions (That have no direct equivalent in .NET)
 
- - `Sql.CurrentTimestamp` : Normally, `DateTime` instances passed into queries are parameterized on the client side. This includes `DateTime.Now`. `Sql.CurrentTimestamp` on the other hand will use the database server's current time instead of the time on the .NET server executing the query.
-
- - `Sql.Between` : Allows you to use `Between(myTable.MyColumn, 1, 2)` instead of an expression such as `(myTable.MyColumn >= 1 && myTable.MyColumn <=2)`.
-   - `Sql.NotBetween` : The inverse of `Sql.Between`
- 
- - `Sql.Reverse` : Reverses a string.
-
- - `Sql.Stuff` : Places a string inside another string, at the specified position. Please read the [SQL Server Documentation](https://docs.microsoft.com/en-us/sql/t-sql/functions/stuff-transact-sql?view=sql-server-2017) for an example of how this function may be used.
- 
+- `Sql.CurrentTimestamp` : Normally, `DateTime` instances passed into queries are parameterized on the client side. This includes `DateTime.Now`. `Sql.CurrentTimestamp` on the other hand will use the database server's current time instead of the time on the .NET server executing the query.
+- `Sql.Between` : Allows you to use `Between(myTable.MyColumn, 1, 2)` instead of an expression such as `(myTable.MyColumn >= 1 && myTable.MyColumn <=2)`.
+  - `Sql.NotBetween` : The inverse of `Sql.Between`
+- `Sql.Reverse` : Reverses a string.
+- `Sql.Stuff` : Places a string inside another string, at the specified position. Please read the [SQL Server Documentation](https://docs.microsoft.com/en-us/sql/t-sql/functions/stuff-transact-sql?view=sql-server-2017) for an example of how this function may be used.
 
 ## `Sql.ExpressionAttribute`
 
@@ -73,15 +69,12 @@ namespace MyProject
 }
 ```
 
-### Useful Attribute Properties:
+### Useful Attribute Properties
 
- - `PreferServerSide` : This will tell linq2db that you would prefer for the expression to be evaluated on the server if possible.
-
- - `ServerSideOnly` : This will tell linq2db that if the expression cannot be executed on the server (For example, it is inside a another method call that cannot be translated) that an exception should be thrown. This is useful when attempting to guarantee that filtering is done on the server (avoiding transferring large amounts of data.)
-
- - `InlineParameters` : Normally linq2db will parametetrize any variables passed into the expression. If this is set to true however, the values will instead be passed as (escaped) literals. Please note scalar values passed in will always be inlined, regardless of this parameter.
-
- - `IsPredicate` : In the case of expressions that are boolean, linq2db will normally add a `= 1` when the server requires it (such as SqlServer). If this is set to `true`, linq2db will not add this.  
+- `PreferServerSide` : This will tell linq2db that you would prefer for the expression to be evaluated on the server if possible.
+- `ServerSideOnly` : This will tell linq2db that if the expression cannot be executed on the server (For example, it is inside a another method call that cannot be translated) that an exception should be thrown. This is useful when attempting to guarantee that filtering is done on the server (avoiding transferring large amounts of data.)
+- `InlineParameters` : Normally linq2db will parametetrize any variables passed into the expression. If this is set to true however, the values will instead be passed as (escaped) literals. Please note scalar values passed in will always be inlined, regardless of this parameter.
+- `IsPredicate` : In the case of expressions that are boolean, linq2db will normally add a `= 1` when the server requires it (such as SqlServer). If this is set to `true`, linq2db will not add this.  
 
 ## `Sql.FunctionAttribute`
 

--- a/Source/LinqToDB/Sql/Sql.Row.cs
+++ b/Source/LinqToDB/Sql/Sql.Row.cs
@@ -3,7 +3,6 @@
 namespace LinqToDB
 {
 	using SqlQuery;
-	using PN = ProviderName;
 
 	partial class Sql
 	{

--- a/Source/LinqToDB/SqlProvider/RowFeature.cs
+++ b/Source/LinqToDB/SqlProvider/RowFeature.cs
@@ -5,17 +5,48 @@ namespace LinqToDB.SqlProvider
 	// changing this enum incorrectly could break remote context serialization
 	// e.g. WCF require flags to be sequential
 	// https://docs.microsoft.com/en-us/dotnet/framework/wcf/feature-details/enumeration-types-in-data-contracts
+	/// <summary>
+	/// ROW constructor (tuple) feature support flags.
+	/// </summary>
 	[Flags]
 	public enum RowFeature
 	{
-		IsNull          = 0b0_0000_0001, // (1, 2) IS NULL
-		Equality        = 0b0_0000_0010, // Operators = and <>
-		Comparisons     = 0b0_0000_0100, // >, >=, <, <=
-		Overlaps        = 0b0_0000_1000, // OVERLAPS
-		Between         = 0b0_0001_0000, // BETWEEN
+		None            = 0,
+		/// <summary>
+		/// Provider supports for IS NULL operator: <c>(1, 2) IS NULL</c>.
+		/// </summary>
+		IsNull          = 0b0_0000_0001,
+		/// <summary>
+		/// Provider supports equality (=, &lt;&gt;) operators with tuples.
+		/// </summary>
+		Equality        = 0b0_0000_0010,
+		/// <summary>
+		/// Provider supports comparison operators for tuples: &gt;, &gt;=, &lt;&lt;=.
+		/// </summary>
+		Comparisons     = 0b0_0000_0100,
+		/// <summary>
+		/// Provider supports OVERLAPS operator.
+		/// </summary>
+		Overlaps        = 0b0_0000_1000,
+		/// <summary>
+		/// Provider supports BETWEEN operator for tuples.
+		/// </summary>
+		Between         = 0b0_0001_0000,
+		/// <summary>
+		/// Provider supports subqueries in tuple constructor: <c>(SELECT 1, 2)</c>.
+		/// </summary>
 		CompareToSelect = 0b0_0010_0000, // Compare to (SELECT 1, 2)
-		In              = 0b0_0100_0000, // (1, 2) IN ((1, 2), (3, 4))
-		Update          = 0b0_1000_0000, // UPDATE T SET (COL1, COL2) = (SELECT 1, 2)
-		UpdateLiteral   = 0b1_0000_0000, // UPDATE T SET (COL1, COL2) = (1, 2)
+		/// <summary>
+		/// Provider supports tuples with IN operator: <c>(1, 2) IN ((1, 2), (3, 4))</c>.
+		/// </summary>
+		In              = 0b0_0100_0000,
+		/// <summary>
+		/// Provider supports tuples in SET clause with non-literal rvalue: <c>UPDATE T SET (COL1, COL2) = (SELECT 1, 2)</c>.
+		/// </summary>
+		Update          = 0b0_1000_0000,
+		/// <summary>
+		/// Provider supports tuples in SET clause with rvalue literal: <c>UPDATE T SET (COL1, COL2) = (1, 2)</c>.
+		/// </summary>
+		UpdateLiteral   = 0b1_0000_0000,
 	}
 }

--- a/Source/LinqToDB/SqlProvider/SqlProviderFlags.cs
+++ b/Source/LinqToDB/SqlProvider/SqlProviderFlags.cs
@@ -5,124 +5,228 @@ using System.Runtime.Serialization;
 
 namespace LinqToDB.SqlProvider
 {
+	using Common;
+	using DataProvider;
 	using SqlQuery;
 
 	[DataContract]
 	public sealed class SqlProviderFlags
 	{
+		/// <summary>
+		/// Enables fix for incorrect Sybase ASE behavior for following query:
+		/// <code>
+		/// -- will return single record with 0 value (incorrect)
+		/// SELECT 0 as [c1] FROM [Child] [t1] GROUP BY [t1].[ParentID]
+		/// </code>
+		/// Fix enables following SQL generation:
+		/// <code>
+		/// -- works correctly
+		/// SELECT [t1].[ParentID] as [c1] FROM [Child] [t1] GROUP BY [t1].[ParentID]
+		/// </code>
+		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
+		/// </summary>
 		[DataMember(Order =  1)]
 		public bool        IsSybaseBuggyGroupBy           { get; set; }
 
+		/// <summary>
+		/// Indicates that provider (not database!) uses positional parameters instead of named parameters (parameter values assigned in order they appear in query, not by parameter name).
+		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
+		/// </summary>
 		[DataMember(Order =  2)]
 		public bool        IsParameterOrderDependent      { get; set; }
 
+		/// <summary>
+		/// Indicates that TAKE/TOP/LIMIT could accept parameter.
+		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
+		/// </summary>
 		[DataMember(Order =  3)]
 		public bool        AcceptsTakeAsParameter         { get; set; }
+		/// <summary>
+		/// Indicates that TAKE/LIMIT could accept parameter only if also SKIP/OFFSET specified.
+		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
+		/// </summary>
 		[DataMember(Order =  4)]
 		public bool        AcceptsTakeAsParameterIfSkip   { get; set; }
+		/// <summary>
+		/// Indicates support for TOP/TAKE/LIMIT paging clause.
+		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
+		/// </summary>
 		[DataMember(Order =  5)]
 		public bool        IsTakeSupported                { get; set; }
+		/// <summary>
+		/// Indicates support for SKIP/OFFSET paging clause (parameter) without TAKE clause.
+		/// Provider could set this flag even if database not support it if emulates missing functionality.
+		/// E.g. : <c>TAKE [MAX_ALLOWED_VALUE] SKIP skip_value </c>
+		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
+		/// </summary>
 		[DataMember(Order =  6)]
 		public bool        IsSkipSupported                { get; set; }
+		/// <summary>
+		/// Indicates support for SKIP/OFFSET paging clause (parameter) only if also TAKE/LIMIT specified.
+		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
+		/// </summary>
 		[DataMember(Order =  7)]
 		public bool        IsSkipSupportedIfTake          { get; set; }
+		/// <summary>
+		/// Indicates supported TAKE/LIMIT hints.
+		/// Default (set by <see cref="DataProviderBase"/>): <c>null</c> (none).
+		/// </summary>
 		[DataMember(Order =  8)]
 		public TakeHints?  TakeHintsSupported              { get; set; }
+		/// <summary>
+		/// Indicates support for paging clause in subquery.
+		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
+		/// </summary>
 		[DataMember(Order =  9)]
 		public bool        IsSubQueryTakeSupported        { get; set; }
 
+		/// <summary>
+		/// Indicates support for scalar subquery in select list.
+		/// E.g. <c>SELECT (SELECT TOP 1 value FROM some_table) AS MyColumn, ...</c>
+		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
+		/// </summary>
 		[DataMember(Order = 10)]
 		public bool        IsSubQueryColumnSupported      { get; set; }
+		/// <summary>
+		/// Indicates support of <c>ORDER BY</c> clause in sub-queries.
+		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
+		/// </summary>
 		[DataMember(Order = 11)]
 		public bool        IsSubQueryOrderBySupported     { get; set; }
+		/// <summary>
+		/// Indicates that database supports count subquery as scalar in column.
+		/// <code>SELECT (SELECT COUNT(*) FROM some_table) FROM ...</code>
+		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
+		/// </summary>
 		[DataMember(Order = 12)]
 		public bool        IsCountSubQuerySupported       { get; set; }
 
+		/// <summary>
+		/// Indicates that provider requires explicit output parameter for insert with identity queries to get identity from database.
+		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
+		/// </summary>
 		[DataMember(Order = 13)]
 		public bool        IsIdentityParameterRequired    { get; set; }
+		/// <summary>
+		/// Indicates support for OUTER/CROSS APPLY.
+		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
+		/// </summary>
 		[DataMember(Order = 14)]
 		public bool        IsApplyJoinSupported           { get; set; }
+		/// <summary>
+		/// Indicates support for single-query insert-or-update operation support.
+		/// Otherwise two separate queries used to emulate operation (update, then insert if nothing found to update).
+		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
+		/// </summary>
 		[DataMember(Order = 15)]
 		public bool        IsInsertOrUpdateSupported      { get; set; }
+		/// <summary>
+		/// Indicates that provider could share parameter between statements in multi-statement batch.
+		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
+		/// </summary>
 		[DataMember(Order = 16)]
 		public bool        CanCombineParameters           { get; set; }
+		/// <summary>
+		/// Specifies limit of number of values in single <c>IN</c> predicate without splitting it into several IN's.
+		/// Default (set by <see cref="DataProviderBase"/>): <c>int.MaxValue</c> (basically means there is no limit).
+		/// </summary>
 		[DataMember(Order = 17)]
 		public int         MaxInListValuesCount           { get; set; }
+		/// <summary>
+		/// Indicates that SET clause in update statement could use table alias prefix for set columns (lvalue): <c> SET t_alias.field = value</c>.
+		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
+		/// </summary>
 		[DataMember(Order = 18)]
 		public bool        IsUpdateSetTableAliasSupported { get; set; }
 
 		/// <summary>
 		/// If <c>true</c>, removed record fields in OUTPUT clause of DELETE statement should be referenced using
 		/// table with special name (e.g. DELETED or OLD). Otherwise fields should be referenced using target table.
+		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
 		/// </summary>
 		[DataMember(Order = 19)]
 		public bool        OutputDeleteUseSpecialTable       { get; set; }
 		/// <summary>
 		/// If <c>true</c>, added record fields in OUTPUT clause of INSERT statement should be referenced using
 		/// table with special name (e.g. INSERTED or NEW). Otherwise fields should be referenced using target table.
+		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
 		/// </summary>
 		[DataMember(Order = 20)]
 		public bool        OutputInsertUseSpecialTable       { get; set; }
 		/// <summary>
 		/// If <c>true</c>, OUTPUT clause supports both OLD and NEW data in UPDATE statement using tables with special names.
 		/// Otherwise only current record fields (after update) available using target table.
+		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
 		/// </summary>
 		[DataMember(Order = 21)]
 		public bool        OutputUpdateUseSpecialTables      { get; set; }
 
 		/// <summary>
 		/// Provider requires that selected subquery column must be used in group by even for constant column.
+		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
 		/// </summary>
 		[DataMember(Order = 22)]
-		public bool        IsGroupByColumnRequred         { get; set; }
+		public bool        IsGroupByColumnRequred            { get; set; }
 
 		/// <summary>
-		/// Provider supports:
-		/// CROSS JOIN a Supported
+		/// Indicates support for CROSS JOIN.
+		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
 		/// </summary>
 		[DataMember(Order = 23)]
-		public bool IsCrossJoinSupported                  { get; set; }
+		public bool        IsCrossJoinSupported              { get; set; }
 
 		/// <summary>
-		/// Provider supports:
-		/// INNER JOIN a ON 1 = 1
+		/// Indicates support for CROSS JOIN emulation using <c>INNER JOIN a ON 1 = 1</c>.
+		/// Currently has no effect if <see cref="IsCrossJoinSupported"/> enabled but it is recommended to use proper value.
+		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
 		/// </summary>
 		[DataMember(Order = 24)]
 		public bool IsInnerJoinAsCrossSupported           { get; set; }
 
 		/// <summary>
-		/// Provider supports CTE expressions.
+		/// Indicates support of CTE expressions.
 		/// If provider does not support CTE, unsuported exception will be thrown when using CTE.
+		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
 		/// </summary>
 		[DataMember(Order = 25)]
 		public bool IsCommonTableExpressionsSupported     { get; set; }
 
 		/// <summary>
-		/// Provider supports DISTINCT and ORDER BY with fields that are not in projection.
+		/// Indicates that database supports and correctly handles DISTINCT queries with ORDER BY over fields missing from projection.
+		/// Otherwise:
+		/// <list>
+		/// <item>if <see cref="Configuration.Linq.KeepDistinctOrdered"/> is set: query will be converted to GROUP BY query</item>
+		/// <item>if <see cref="Configuration.Linq.KeepDistinctOrdered"/> is not set: non-projected columns will be removed from ordering</item>
+		/// </list>
+		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
 		/// </summary>
 		[DataMember(Order = 26)]
 		public bool IsDistinctOrderBySupported            { get; set; }
 
 		/// <summary>
-		/// Provider supports aggregate functions in ORDER BY statement.
+		/// Indicates support for aggregate functions in ORDER BY statement.
+		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
 		/// </summary>
 		[DataMember(Order = 27)]
 		public bool IsOrderByAggregateFunctionsSupported  { get; set; }
 
 		/// <summary>
-		/// Provider supports EXCEPT ALL, INTERSECT ALL set operators. Otherwise it will be emulated.
+		/// Provider supports EXCEPT ALL, INTERSECT ALL set operators. Otherwise they will be emulated.
+		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
 		/// </summary>
 		[DataMember(Order = 28)]
 		public bool IsAllSetOperationsSupported           { get; set; }
 
 		/// <summary>
 		/// Provider supports EXCEPT, INTERSECT set operators. Otherwise it will be emulated.
+		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
 		/// </summary>
 		[DataMember(Order = 29)]
 		public bool IsDistinctSetOperationsSupported      { get; set; }
 
 		/// <summary>
 		/// Provider supports COUNT(DISTINCT column) function. Otherwise it will be emulated.
+		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
 		/// </summary>
 		[DataMember(Order = 30)]
 		public bool IsCountDistinctSupported              { get; set; }
@@ -151,17 +255,19 @@ namespace LinqToDB.SqlProvider
 		/// ) AS Sum_Column
 		/// FROM table1 outer
 		///</code>
+		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
 		/// </summary>
 		[DataMember(Order = 31)]
 		public bool AcceptsOuterExpressionInAggregate { get; set; }
 
 		/// <summary>
-		/// Provider supports
+		/// Indicates support for following UPDATE syntax:
 		/// <code>
 		/// UPDATE A
 		/// SET ...
 		/// FROM B
-		/// </code> syntax
+		/// </code>
+		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
 		/// </summary>
 		[DataMember(Order = 32)]
 		public bool IsUpdateFromSupported             { get; set; }
@@ -171,6 +277,7 @@ namespace LinqToDB.SqlProvider
 		/// <code>
 		/// QB_NAME(qb)
 		/// </code>
+		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
 		/// </summary>
 		[DataMember(Order = 33)]
 		public bool IsNamingQueryBlockSupported       { get; set; }
@@ -194,14 +301,15 @@ namespace LinqToDB.SqlProvider
 		}
 
 		/// <summary>
-		/// Used when there is query which needs several additional database request for completing query.
-		/// Default is <see cref="IsolationLevel.RepeatableRead"/>
+		/// Used when there is query which needs several additional database requests for completing query (e.g. eager load or client-side GroupBy).
+		/// Default (set by <see cref="DataProviderBase"/>): <see cref="IsolationLevel.RepeatableRead"/>.
 		/// </summary>
 		[DataMember(Order = 34)]
-		public IsolationLevel DefaultMultiQueryIsolationLevel { get; set; } = IsolationLevel.RepeatableRead;
+		public IsolationLevel DefaultMultiQueryIsolationLevel { get; set; }
 
 		/// <summary>
 		/// Provider support Row Constructor `(1, 2, 3)` in various positions (flags)
+		/// Default (set by <see cref="DataProviderBase"/>): <see cref="RowFeature.None"/>.
 		/// </summary>
 		[DataMember(Order = 35)]
 		public RowFeature RowConstructorSupport { get; set; }

--- a/Source/LinqToDB/SqlQuery/ConvertVisitor.cs
+++ b/Source/LinqToDB/SqlQuery/ConvertVisitor.cs
@@ -960,6 +960,12 @@ namespace LinqToDB.SqlQuery
 								foreach (var column in q.Select.Columns)
 									sc.Columns.Add(column.Clone(q, objTree, static (q, e) => e is SqlColumn c && c.Parent == q));
 							}
+							else
+							{
+								for (var i = 0; i < q.Select.Columns.Count; i++)
+									if (ReferenceEquals(sc.Columns[i], q.Select.Columns[i]))
+										sc.Columns[i] = q.Select.Columns[i].Clone(q, objTree ??= new(), static (q, e) => e is SqlColumn c && c.Parent == q);
+							}
 
 							if (ReferenceEquals(fc, q.From))
 							{

--- a/Source/LinqToDB/SqlQuery/SqlValue.cs
+++ b/Source/LinqToDB/SqlQuery/SqlValue.cs
@@ -140,5 +140,10 @@ namespace LinqToDB.SqlQuery
 		}
 
 		#endregion
+
+		public void Deconstruct(out object? value)
+		{
+			value = Value;
+		}
 	}
 }

--- a/Tests/Base/ScopedSettings.cs
+++ b/Tests/Base/ScopedSettings.cs
@@ -3,6 +3,7 @@ using LinqToDB.Common;
 using LinqToDB.DataProvider.Firebird;
 using LinqToDB.DataProvider.Oracle;
 using LinqToDB.Linq;
+using LinqToDB.Mapping;
 using System;
 using System.Globalization;
 using System.Threading;
@@ -10,6 +11,41 @@ using Tests.Model;
 
 namespace Tests
 {
+	public class RestoreBaseTables : IDisposable
+	{
+		private readonly IDataContext _db;
+
+		public RestoreBaseTables(IDataContext db)
+		{
+			_db = db;
+		}
+
+		void IDisposable.Dispose()
+		{
+			using var _ = new DisableBaseline("isn't baseline query");
+
+			_db.GetTable<Parent>().Delete(p => p.ParentID > 7);
+			_db.GetTable<Child>().Delete(p => p.ParentID > 7 || p.ChildID > 77);
+
+			_db.GetTable<Patient>().Delete(p => p.PersonID > 4 || p.PersonID < 1);
+			_db.GetTable<Person>().Delete(p => p.ID > 4 || p.ID < 1);
+
+			_db.GetTable<LinqDataTypes2>().Delete(p => p.ID > 12 || p.ID < 1);
+			_db.GetTable<LinqDataTypes>()
+				.Set(_ => _.BinaryValue, () => null)
+				.Update();
+
+			_db.GetTable<AllTypes>().Delete(p => p.ID > 2 || p.ID < 1);
+		}
+
+		[Table]
+		[Table("ALLTYPES", Configuration = ProviderName.DB2)]
+		public class AllTypes
+		{
+			[Column] public int ID { get; set; }
+		}
+		}
+
 	public class InvariantCultureRegion : IDisposable
 	{
 		private readonly CultureInfo? _original;

--- a/Tests/Base/TestUtils.cs
+++ b/Tests/Base/TestUtils.cs
@@ -56,7 +56,7 @@ namespace Tests
 		[Sql.Expression("current server", ServerSideOnly = true, Configuration = ProviderName.DB2)]
 		[Sql.Function("current_database", ServerSideOnly = true, Configuration = ProviderName.PostgreSQL)]
 		[Sql.Function("DATABASE"        , ServerSideOnly = true, Configuration = ProviderName.MySql)]
-		[Sql.Function("DB_NAME"         , ServerSideOnly = true)]
+		[Sql.Function("DB_NAME", ServerSideOnly = true)]
 		private static string DbName()
 		{
 			throw new InvalidOperationException();
@@ -235,7 +235,7 @@ namespace Tests
 			}
 		}
 
-		public static TempTable<T> CreateLocalTable<T>(this IDataContext db, string? tableName = null, TableOptions tableOptions = TableOptions.NotSet)
+		public static TempTable<T> CreateLocalTable<T>(this IDataContext db, string? tableName = null, TableOptions tableOptions = TableOptions.CheckExistence)
 			where T : notnull
 		{
 			try

--- a/Tests/FSharp/InsertTest.fs
+++ b/Tests/FSharp/InsertTest.fs
@@ -26,12 +26,12 @@ let Insert1 (db : IDataContext) =
         cleanup() |> ignore
 
 
-let Insert2 (db : IDataContext) =
+let Insert2 (db : IDataContext, personId : int) =
 
     let p =
         { ComplexPerson.Name = { FirstName = "fn"; MiddleName = ""; LastName = "ln" }
           Gender = "M"
-          ID = 0 }
+          ID = personId }
 
     let id = query {
         for p in db.GetTable<Person>() do

--- a/Tests/FSharp/Tests.FSharp.fsproj
+++ b/Tests/FSharp/Tests.FSharp.fsproj
@@ -9,6 +9,7 @@
 		
 		<!--https://github.com/dotnet/fsharp/issues/12315-->
 		<DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+		<NoWarn>$(NoWarn);NU1507</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Tests/Linq/Data/RetryPolicyTest.cs
+++ b/Tests/Linq/Data/RetryPolicyTest.cs
@@ -86,7 +86,7 @@ namespace Tests.Data
 		{}
 
 		[Test]
-		public void RetryPoliceTest([DataSources(false)] string context)
+		public void TestRetryPolicy([DataSources(false)] string context)
 		{
 			var ret = new Retry();
 			Assert.Throws<TestException>(() =>
@@ -115,7 +115,7 @@ namespace Tests.Data
 		}
 
 		[Test]
-		public void RetryPoliceTestAsync([DataSources(false)] string context)
+		public void RetryPolicyTestAsync([DataSources(false)] string context)
 		{
 			var ret = new Retry();
 

--- a/Tests/Linq/DataProvider/Types/TypeTestsBase.cs
+++ b/Tests/Linq/DataProvider/Types/TypeTestsBase.cs
@@ -1,0 +1,247 @@
+﻿using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using System.Linq;
+using System.Numerics;
+using System.Net;
+using LinqToDB;
+using LinqToDB.Common;
+using LinqToDB.Data;
+using LinqToDB.Linq;
+using LinqToDB.Mapping;
+using NUnit.Framework;
+
+namespace Tests.DataProvider
+{
+	// base fixture for database-specific type tests
+	// privides test method TestType to test specific type configuration
+	[TestFixture]
+	public abstract class TypeTestsBase : TestBase
+	{
+		// Mapping for single type configuration testing for both nullable and non-nullable database columns
+		private class TypeTable<TType, TNullableType>
+		{
+			[Column(CanBeNull = false)] public TType          Column         { get; set; } = default!;
+			[Column(CanBeNull = true )] public TNullableType? ColumnNullable { get; set; }
+		}
+
+		/// <summary>
+		/// Returns default switch for disable parameters testing for database provider.
+		/// Used by TestType method when testParameters parameter is not set (or <c>null</c>).
+		/// </summary>
+		protected virtual bool TestParameters => true;
+
+		/// <summary>
+		/// Returns default bulk copy options for context.
+		/// </summary>
+		protected virtual BulkCopyOptions GetDefaultBulkCopyOptions(string context) => new();
+
+		/// <summary>
+		/// Performs single type configuration testing:
+		/// <list type="bullet">
+		/// <item>column type generation (CreateTable API)</item>
+		/// <item>nullable/non-nullable behavior</item>
+		/// <item>parameters</item>
+		/// <item>literals</item>
+		/// <item>all bulk copy methods</item>
+		/// <item>test extreme values support (e.g. min/max values allowed by type)</item>
+		/// </list>
+		/// 
+		/// Passing various values to method allows to test extreme values support. Recommended values to test:
+		/// <list type="bullet">
+		/// <item>default/null values</item>
+		/// <item>min/max values for ranged types</item>
+		/// <item>type specific special values. E.g. Epsilon and NaN/Inf for floating point types</item>
+		/// </list>
+		/// 
+		/// Parameter <paramref name="dbType"/> allows testing of various mapping configurations and should include:
+		/// <list type="bullet">
+		/// <item>default type mapping for tested .NET type (if exists)</item>
+		/// <item>default type mapping for <see cref="DataType"/> value, used for tested database type</item>
+		/// <item>test of various precision/scale values when applicable</item>
+		/// <item>additional .NET types testing if type could be mapped to different types</item>
+		/// </list>
+		/// </summary>
+		/// <typeparam name="TType">Non-nullable mapping column type.</typeparam>
+		/// <typeparam name="TNullableType">Nullable mapping column type.</typeparam>
+		/// <param name="context">Database context name.</param>
+		/// <param name="dbType">Type descriptor to apply to columns configuration.</param>
+		/// <param name="value">Value to test for non-nullable column.</param>
+		/// <param name="nullableValue">Value to test for nullable column.</param>
+		/// <param name="testParameters">Enable/disable parameters testing (default: <see cref="TestParameters"/>).</param>
+		/// <param name="skipNullable">Enable/disable nullable column testing (default: <c>false</c>).</param>
+		/// <param name="filterByValue">Enable/disable selection filter by non-nullable column (default: <c>true</c>).</param>
+		/// <param name="filterByNullableValue">Enable/disable selection filter by nullable column (default: <c>true</c>).</param>
+		/// <param name="getExpectedValue">Optional expected non-nullable value provider to use when value doesn't roundtrip.</param>
+		/// <param name="getExpectedNullableValue">Optional expected nullable value provider to use when value doesn't roundtrip.</param>
+		protected async ValueTask TestType<TType, TNullableType>(
+			string                                context,
+			DbDataType                            dbType,
+			TType                                 value,
+			TNullableType?                        nullableValue,
+			bool?                                 testParameters           = null,
+			bool                                  skipNullable             = false,
+			bool                                  filterByValue            = true,
+			bool                                  filterByNullableValue    = true,
+			Func<TType, TType>?                   getExpectedValue         = null,
+			Func<TNullableType?, TNullableType?>? getExpectedNullableValue = null)
+		{
+			testParameters ??= TestParameters;
+
+			// setup test table mapping
+			var ms = new MappingSchema();
+
+			var ent = ms.GetFluentMappingBuilder().Entity<TypeTable<TType, TNullableType>>();
+
+			var prop = ent.Property(e => e.Column);
+
+			if (dbType.DataType  != DataType.Undefined) prop.HasDataType (dbType.DataType       );
+			if (dbType.DbType    != null              ) prop.HasDbType   (dbType.DbType         );
+			if (dbType.Precision != null              ) prop.HasPrecision(dbType.Precision.Value);
+			if (dbType.Scale     != null              ) prop.HasScale    (dbType.Scale.Value    );
+			if (dbType.Length    != null              ) prop.HasLength   (dbType.Length.Value   );
+
+			if (!skipNullable)
+			{
+				var propN = ent.Property(e => e.ColumnNullable);
+
+				if (dbType.DataType  != DataType.Undefined) propN.HasDataType (dbType.DataType             );
+				if (dbType.DbType    != null              ) propN.HasDbType   ($"Nullable({dbType.DbType})");
+				if (dbType.Precision != null              ) propN.HasPrecision(dbType.Precision.Value      );
+				if (dbType.Scale     != null              ) propN.HasScale    (dbType.Scale.Value          );
+				if (dbType.Length    != null              ) propN.HasLength   (dbType.Length.Value         );
+			}
+			else
+				ent.Property(e => e.ColumnNullable).IsNotColumn();
+
+			// start testing
+			using var db = GetDataConnection(context, ms);
+
+			var data = new[] { new TypeTable<TType, TNullableType> { Column = value, ColumnNullable = nullableValue } };
+			using var table = db.CreateLocalTable(data);
+
+			// test parameter
+			if (testParameters == true)
+			{
+				db.InlineParameters = false;
+
+				db.OnNextCommandInitialized((_, cmd) =>
+				{
+					Assert.AreEqual(2, cmd.Parameters.Count);
+					return cmd;
+				});
+
+				AssertData(table, value, nullableValue, skipNullable, filterByValue, filterByNullableValue, getExpectedValue, getExpectedNullableValue);
+			}
+
+			// test literal
+			{
+				db.InlineParameters = true;
+				db.OnNextCommandInitialized((_, cmd) =>
+				{
+					Assert.AreEqual(0, cmd.Parameters.Count);
+					return cmd;
+				});
+
+				AssertData(table, value, nullableValue, skipNullable, filterByValue, filterByNullableValue, getExpectedValue, getExpectedNullableValue);
+				db.InlineParameters = false;
+			}
+
+			var options = GetDefaultBulkCopyOptions(context);
+
+			// test bulk copy modes
+			options = GetDefaultBulkCopyOptions(context);
+			options.BulkCopyType = BulkCopyType.RowByRow;
+			table.Delete();
+			db.BulkCopy(options, data);
+			AssertData(table, value, nullableValue, skipNullable, filterByValue, filterByNullableValue, getExpectedValue, getExpectedNullableValue);
+
+			options = GetDefaultBulkCopyOptions(context);
+			options.BulkCopyType = BulkCopyType.MultipleRows;
+			table.Delete();
+			db.BulkCopy(options, data);
+			AssertData(table, value, nullableValue, skipNullable, filterByValue, filterByNullableValue, getExpectedValue, getExpectedNullableValue);
+
+			options = GetDefaultBulkCopyOptions(context);
+			options.BulkCopyType = BulkCopyType.ProviderSpecific;
+			table.Delete();
+			db.BulkCopy(options, data);
+			AssertData(table, value, nullableValue, skipNullable, filterByValue, filterByNullableValue, getExpectedValue, getExpectedNullableValue);
+
+			// test async provider-specific bulk copy as it often has own implementation
+			options = GetDefaultBulkCopyOptions(context);
+			options.BulkCopyType = BulkCopyType.ProviderSpecific;
+			await table.DeleteAsync();
+			await db.BulkCopyAsync(options, data);
+			AssertData(table, value, nullableValue, skipNullable, filterByValue, filterByNullableValue, getExpectedValue, getExpectedNullableValue);
+
+#if NATIVE_ASYNC
+			options = GetDefaultBulkCopyOptions(context);
+			options.BulkCopyType = BulkCopyType.ProviderSpecific;
+			await table.DeleteAsync();
+			await db.BulkCopyAsync(options, data);
+			AssertData(table, value, nullableValue, skipNullable, filterByValue, filterByNullableValue, getExpectedValue, getExpectedNullableValue);
+#endif
+		}
+
+		/// <summary>
+		/// Assert test data:
+		/// <list type="bullet">
+		/// <item>select data row from table using both values in filter (to test literal/parameter filtering)</item>
+		/// <item>assert received data to match inserted data</item>
+		/// </list>
+		/// </summary>
+		/// <typeparam name="TType">Non-nullable mapping column type.</typeparam>
+		/// <typeparam name="TNullableType">Nullable mapping column type.</typeparam>
+		/// <param name="table">Test table.</param>
+		/// <param name="value">Value to test for non-nullable column.</param>
+		/// <param name="nullableValue">Value to test for nullable column.</param>
+		/// <param name="skipNullable">Enable/disable nullable column testing (default: <c>false</c>).</param>
+		/// <param name="filterByValue">Enable/disable selection filter by non-nullable column (default: <c>true</c>).</param>
+		/// <param name="filterByNullableValue">Enable/disable selection filter by nullable column (default: <c>true</c>).</param>
+		/// <param name="getExpectedValue">Optional expected non-nullable value provider to use when value doesn't roundtrip.</param>
+		/// <param name="getExpectedNullableValue">Optional expected nullable value provider to use when value doesn't roundtrip.</param>
+		private static void AssertData<TType, TNullableType>(
+			TempTable<TypeTable<TType, TNullableType>> table,
+			TType                                      value,
+			TNullableType?                             nullableValue,
+			bool                                       skipNullable,
+			bool                                       filterByValue,
+			bool                                       filterByNullableValue,
+			Func<TType, TType>?                        getExpectedValue,
+			Func<TNullableType?, TNullableType?>?      getExpectedNullableValue)
+		{
+			filterByNullableValue = filterByNullableValue && !skipNullable;
+
+			// build query filter and read data
+			// cast to object used to make comparison not complain in C# due to missing operator== implementation on tested types
+			// and at the same time preserve value type inference and = operator generation in SQL
+			var records =
+					filterByValue && filterByNullableValue
+					? table.Where(r => (object)r.Column! == (object)value! && (object?)r.ColumnNullable == (object?)nullableValue).ToArray()
+					: filterByValue
+						? table.Where(r => (object)r.Column! == (object)value!).ToArray()
+						: filterByNullableValue
+							? table.Where(r => (object?)r.ColumnNullable == (object?)nullableValue).ToArray()
+							: table.ToArray();
+
+			// assert data
+			Assert.AreEqual(1, records.Length);
+
+			var record = records[0];
+			Assert.AreEqual(getExpectedValue != null ? getExpectedValue(value) : value, record.Column);
+			if (!skipNullable)
+				Assert.AreEqual(getExpectedNullableValue != null ? getExpectedNullableValue(nullableValue) : nullableValue, record.ColumnNullable);
+		}
+
+#if NATIVE_ASYNC
+		private static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(IEnumerable<T> enumerable)
+		{
+			foreach (var item in enumerable)
+			{
+				yield return await Task.FromResult(item);
+			}
+		}
+#endif
+	}
+}

--- a/Tests/Linq/Linq/CompileTests.cs
+++ b/Tests/Linq/Linq/CompileTests.cs
@@ -123,14 +123,14 @@ namespace Tests.Linq
 
 				const int count = 100;
 
-				var threads = new Thread[count];
-				var results = new int   [count, 2];
+				var threads = new Task[count];
+				var results = new int [count, 2];
 
 				for (var i = 0; i < count; i++)
 				{
 					var n = i;
 
-					threads[i] = new Thread(() =>
+					threads[i] = Task.Run(() =>
 					{
 						using (var db = GetDataContext(context))
 						{
@@ -141,11 +141,7 @@ namespace Tests.Linq
 					});
 				}
 
-				for (var i = 0; i < count; i++)
-					threads[i].Start();
-
-				for (var i = 0; i < count; i++)
-					threads[i].Join();
+				Task.WaitAll(threads);
 
 				for (var i = 0; i < count; i++)
 					Assert.AreEqual(results[i, 0], results[i, 1]);
@@ -162,14 +158,14 @@ namespace Tests.Linq
 
 				const int count = 100;
 
-				var threads = new Thread[count];
-				var results = new int   [count, 2];
+				var threads = new Task[count];
+				var results = new int [count, 2];
 
 				for (var i = 0; i < count; i++)
 				{
 					var n = i;
 
-					threads[i] = new Thread(() =>
+					threads[i] = Task.Run(() =>
 					{
 						using (var db = GetDataContext(context))
 						{
@@ -180,11 +176,7 @@ namespace Tests.Linq
 					});
 				}
 
-				for (var i = 0; i < count; i++)
-					threads[i].Start();
-
-				for (var i = 0; i < count; i++)
-					threads[i].Join();
+				Task.WaitAll(threads);
 
 				for (var i = 0; i < count; i++)
 					Assert.AreEqual(results[i, 0], results[i, 1]);
@@ -196,14 +188,14 @@ namespace Tests.Linq
 		{
 			using (new DisableBaseline("Multi-threading"))
 			{
-				var threads = new Thread[100];
-				var results = new int   [100,2];
+				var threads = new Task[100];
+				var results = new int [100,2];
 
 				for (var i = 0; i < 100; i++)
 				{
 					var n = i;
 
-					threads[i] = new Thread(() =>
+					threads[i] = Task.Run(() =>
 					{
 						using (var db = GetDataContext(context))
 						{
@@ -214,11 +206,7 @@ namespace Tests.Linq
 					});
 				}
 
-				for (var i = 0; i < 100; i++)
-					threads[i].Start();
-
-				for (var i = 0; i < 100; i++)
-					threads[i].Join();
+				Task.WaitAll(threads);
 
 				for (var i = 0; i < 100; i++)
 					Assert.AreEqual(results[i, 0], results[i, 1]);
@@ -232,14 +220,14 @@ namespace Tests.Linq
 			{
 				var threadCount = 100;
 
-				var threads = new Thread[threadCount];
-				var results = new int   [threadCount,2];
+				var threads = new Task[threadCount];
+				var results = new int [threadCount,2];
 
 				for (var i = 0; i < threadCount; i++)
 				{
 					var n = i;
 
-					threads[i] = new Thread(() =>
+					threads[i] = Task.Run(() =>
 					{
 						using (var db = GetDataContext(context))
 						{
@@ -250,11 +238,7 @@ namespace Tests.Linq
 					});
 				}
 
-				for (var i = 0; i < threadCount; i++)
-					threads[i].Start();
-
-				for (var i = 0; i < threadCount; i++)
-					threads[i].Join();
+				Task.WaitAll(threads);
 
 				for (var i = 0; i < threadCount; i++)
 					Assert.AreEqual(results[i, 0], results[i, 1]);

--- a/Tests/Linq/Linq/ComplexTests2.cs
+++ b/Tests/Linq/Linq/ComplexTests2.cs
@@ -148,25 +148,11 @@ namespace Tests.Linq
 
 			using (new DisableLogging())
 			{
-				db.CreateLocalTable<Animal>();
-				db.CreateLocalTable<Eye>();
-				db.CreateLocalTable<Test>();
-
 				db.Insert(eye);
 				db.Insert(dog);
 				db.Insert(wildAnimal);
 				db.Insert(test);
 				db.Insert(test2);
-			}
-		}
-
-		void CleanupData(ITestDataContext db)
-		{
-			using (new DisableLogging())
-			{
-				db.DropTable<Animal>(throwExceptionIfNotExists: false);
-				db.DropTable<Eye>   (throwExceptionIfNotExists: false);
-				db.DropTable<Test>  (throwExceptionIfNotExists: false);
 			}
 		}
 
@@ -237,17 +223,13 @@ namespace Tests.Linq
 
 			using (new DisableBaseline("TODO: debug reason for inconsistent column order"))
 			using (var db = GetDataContext(context, ms))
+			using (db.CreateLocalTable<Animal>())
+			using (db.CreateLocalTable<Eye>())
+			using (db.CreateLocalTable<Test>())
 			{
-				try
-				{
-					InsertData(db);
-					var data =  db.GetTable<Animal>().ToList();
-					Assert.Null(((Dog)data.First()).Bla);
-				}
-				finally
-				{
-					CleanupData(db);
-				}
+				InsertData(db);
+				var data =  db.GetTable<Animal>().OrderBy(_ => _.Id).ToList();
+				Assert.Null(((Dog)data.First()).Bla);
 			}
 		}
 
@@ -258,17 +240,13 @@ namespace Tests.Linq
 
 			using (new DisableBaseline("TODO: debug reason for inconsistent column order"))
 			using (var db = GetDataContext(context, ms))
+			using (db.CreateLocalTable<Animal>())
+			using (db.CreateLocalTable<Eye>())
+			using (db.CreateLocalTable<Test>())
 			{
-				try
-				{
-					InsertData(db);
-					var data = db.GetTable<Animal>().LoadWith(x => ((Dog)x).Bla).ToList();
-					Assert.NotNull(((Dog)data.First()).Bla);
-				}
-				finally
-				{
-					CleanupData(db);
-				}
+				InsertData(db);
+				var data = db.GetTable<Animal>().LoadWith(x => ((Dog)x).Bla).OrderBy(_ => _.Id).ToList();
+				Assert.NotNull(((Dog)data.First()).Bla);
 			}
 		}
 
@@ -279,24 +257,20 @@ namespace Tests.Linq
 
 			using (new DisableBaseline("TODO: debug reason for inconsistent column order"))
 			using (var db = GetDataContext(context, ms))
+			using (db.CreateLocalTable<Animal>())
+			using (db.CreateLocalTable<Eye>())
+			using (db.CreateLocalTable<Test>())
 			{
-				try
-				{
-					InsertData(db);
-					var data = db.GetTable<Test>()
-						.LoadWith(x => ((Dog)x.TestAnimal!).Bla)
-						.OrderBy(x => x.Id)
-						.ToList();
+				InsertData(db);
+				var data = db.GetTable<Test>()
+					.LoadWith(x => ((Dog)x.TestAnimal!).Bla)
+					.OrderBy(x => x.Id)
+					.ToList();
 
-					Assert.Null(data.First().TestAnimal);
-					Assert.NotNull(((Dog)data.Skip(1).First().TestAnimal!).Bla);
-					Assert.NotNull(((Dog)data.Skip(1).First().TestAnimal!).DogName!.First);
-					Assert.NotNull(((Dog)data.Skip(1).First().TestAnimal!).DogName!.Second);
-				}
-				finally
-				{
-					CleanupData(db);
-				}
+				Assert.Null(data.First().TestAnimal);
+				Assert.NotNull(((Dog)data.Skip(1).First().TestAnimal!).Bla);
+				Assert.NotNull(((Dog)data.Skip(1).First().TestAnimal!).DogName!.First);
+				Assert.NotNull(((Dog)data.Skip(1).First().TestAnimal!).DogName!.Second);
 			}
 		}
 
@@ -307,19 +281,15 @@ namespace Tests.Linq
 
 			using (new DisableBaseline("TODO: debug reason for inconsistent column order"))
 			using (var db = GetDataContext(context, ms))
+			using (db.CreateLocalTable<Animal>())
+			using (db.CreateLocalTable<Eye>())
+			using (db.CreateLocalTable<Test>())
 			{
-				try
-				{
-					InsertData(db);
-					var data = db.GetTable<Dog>().ToList();
+				InsertData(db);
+				var data = db.GetTable<Dog>().ToList();
 
-					Assert.NotNull(data[0].DogName!.First);
-					Assert.NotNull(data[0].DogName!.Second);
-				}
-				finally
-				{
-					CleanupData(db);
-				}
+				Assert.NotNull(data[0].DogName!.First);
+				Assert.NotNull(data[0].DogName!.Second);
 			}
 		}
 
@@ -330,26 +300,22 @@ namespace Tests.Linq
 
 			using (new DisableBaseline("TODO: debug reason for inconsistent column order"))
 			using (var db = GetDataContext(context, ms))
+			using (db.CreateLocalTable<Animal>())
+			using (db.CreateLocalTable<Eye>())
+			using (db.CreateLocalTable<Test>())
 			{
-				try
-				{
-					InsertData(db);
-					var d = new Dog() { AnimalType = AnimalType.Big, AnimalType2 = AnimalType2.Big };
+				InsertData(db);
+				var d = new Dog() { AnimalType = AnimalType.Big, AnimalType2 = AnimalType2.Big };
 
-					Assert.NotNull(db.GetTable<Dog>().First(x => x.AnimalType == AnimalType.Big));
-					Assert.NotNull(db.GetTable<Dog>().First(x => x.AnimalType == d.AnimalType));
+				Assert.NotNull(db.GetTable<Dog>().First(x => x.AnimalType == AnimalType.Big));
+				Assert.NotNull(db.GetTable<Dog>().First(x => x.AnimalType == d.AnimalType));
 
-					Assert.NotNull(db.GetTable<Dog>().First(x => x.AnimalType2 == AnimalType2.Big));
-					Assert.NotNull(db.GetTable<Dog>().First(x => x.AnimalType2 == d.AnimalType2));
+				Assert.NotNull(db.GetTable<Dog>().First(x => x.AnimalType2 == AnimalType2.Big));
+				Assert.NotNull(db.GetTable<Dog>().First(x => x.AnimalType2 == d.AnimalType2));
 
-					Assert.NotNull(db.GetTable<Animal>().First(x => x is SuperWildAnimal));
+				Assert.NotNull(db.GetTable<Animal>().First(x => x is SuperWildAnimal));
 
-					Assert.NotNull(db.GetTable<Test>().First(x => x.TestAnimal is Dog && ((Dog)x.TestAnimal).EyeId == 1));
-				}
-				finally
-				{
-					CleanupData(db);
-				}
+				Assert.NotNull(db.GetTable<Test>().First(x => x.TestAnimal is Dog && ((Dog)x.TestAnimal).EyeId == 1));
 			}
 		}
 
@@ -360,23 +326,19 @@ namespace Tests.Linq
 
 			using (new DisableBaseline("TODO: debug reason for inconsistent column order"))
 			using (var db = GetDataContext(context, ms))
+			using (db.CreateLocalTable<Animal>())
+			using (db.CreateLocalTable<Eye>())
+			using (db.CreateLocalTable<Test>())
 			{
-				try
-				{
-					InsertData(db);
+				InsertData(db);
 
-					var dog = db.GetTable<Dog>().First();
+				var dog = db.GetTable<Dog>().First();
 
-					db.Update(dog);
-					db.Update((Animal)dog);
+				db.Update(dog);
+				db.Update((Animal)dog);
 
-					var bdog = new SuperBadDog();
-					db.Insert((Dog)bdog);
-				}
-				finally
-				{
-					CleanupData(db);
-				}
+				var bdog = new SuperBadDog();
+				db.Insert((Dog)bdog);
 			}
 		}
 
@@ -393,40 +355,35 @@ namespace Tests.Linq
 
 			var ms = SetMappings();
 			using (var db = GetDataContext(context, ms))
+			using (new RestoreBaseTables(db))
 			{
-				try
+				Person person = new PersonDerived()
 				{
-					Person person = new PersonDerived()
-					{
-						FirstName        = "test_inherited_insert",
-						LastName         = "test",
-						MiddleName       = "test",
-						Gender           = Gender.Unknown,
-						ColumnForOtherDB = 100500
-					};
+					FirstName        = "test_inherited_insert",
+					LastName         = "test",
+					MiddleName       = "test",
+					Gender           = Gender.Unknown,
+					ColumnForOtherDB = 100500
+				};
 
 					person.ID = db.InsertWithInt32Identity(person);
-					Validate();
 
-					db.Update(person);
-					Validate();
+				Validate();
 
-					db.Delete(person);
+				db.Update(person);
+				Validate();
 
-					void Validate()
-					{
-						var data = db.GetTable<Person>().FirstOrDefault(_ => _.FirstName == "test_inherited_insert")!;
-						Assert.IsNotNull(data);
-						Assert.AreEqual(person.ID        , data.ID);
-						Assert.AreEqual(person.FirstName , data.FirstName);
-						Assert.AreEqual(person.LastName  , data.LastName);
-						Assert.AreEqual(person.MiddleName, data.MiddleName);
-						Assert.AreEqual(person.Gender    , data.Gender);
-					}
-				}
-				finally
+				db.Delete(person);
+
+				void Validate()
 				{
-					db.GetTable<Person>().Where(_ => _.FirstName == "test_inherited_insert").Delete();
+					var data = db.GetTable<Person>().FirstOrDefault(_ => _.FirstName == "test_inherited_insert")!;
+					Assert.IsNotNull(data);
+					Assert.AreEqual(person.ID        , data.ID);
+					Assert.AreEqual(person.FirstName , data.FirstName);
+					Assert.AreEqual(person.LastName  , data.LastName);
+					Assert.AreEqual(person.MiddleName, data.MiddleName);
+					Assert.AreEqual(person.Gender    , data.Gender);
 				}
 			}
 		}
@@ -438,44 +395,40 @@ namespace Tests.Linq
 
 			using (new DisableBaseline("TODO: debug reason for inconsistent column order"))
 			using (var db = GetDataContext(context, ms))
+			using (db.CreateLocalTable<Animal>())
+			using (db.CreateLocalTable<Eye>())
+			using (db.CreateLocalTable<Test>())
 			{
-				try
+				InsertData(db);
+
+				Eye eye = new SauronsEye()
 				{
-					InsertData(db);
+					Id = 123,
+					Xy = "test321"
+				};
 
-					Eye eye = new SauronsEye()
-					{
-						Id = 123,
-						Xy = "test321"
-					};
+				var cnt = db.Insert(eye);
+				Validate(false);
 
-					var cnt = db.Insert(eye);
-					Validate(false);
+				cnt = db.InsertOrReplace(eye);
+				Validate(true);
 
-					cnt = db.InsertOrReplace(eye);
-					Validate(true);
+				cnt = db.Update(eye);
+				Validate(false);
 
-					cnt = db.Update(eye);
-					Validate(false);
+				db.Delete(eye);
 
-					db.Delete(eye);
-
-					void Validate(bool insertOrReplace)
-					{
-						if (insertOrReplace && context.IsAnyOf(TestProvName.AllOracleNative))
-							Assert.AreEqual(-1, cnt);
-						else
-							Assert.AreEqual(1, cnt);
-
-						var data = db.GetTable<Eye>().Where(_ => _.Id == 123).FirstOrDefault()!;
-						Assert.IsNotNull(data);
-						Assert.AreEqual(eye.Id, data.Id);
-						Assert.AreEqual(eye.Xy, data.Xy);
-					}
-				}
-				finally
+				void Validate(bool insertOrReplace)
 				{
-					CleanupData(db);
+					if (insertOrReplace && context.IsAnyOf(TestProvName.AllOracleNative))
+						Assert.AreEqual(-1, cnt);
+					else
+						Assert.AreEqual(1, cnt);
+
+					var data = db.GetTable<Eye>().Where(_ => _.Id == 123).FirstOrDefault()!;
+					Assert.IsNotNull(data);
+					Assert.AreEqual(eye.Id, data.Id);
+					Assert.AreEqual(eye.Xy, data.Xy);
 				}
 			}
 		}
@@ -487,57 +440,53 @@ namespace Tests.Linq
 
 			using (new DisableBaseline("TODO: debug reason for inconsistent column order"))
 			using (var db = GetDataContext(context, ms))
+			using (db.CreateLocalTable<Animal>())
+			using (db.CreateLocalTable<Eye>())
+			using (db.CreateLocalTable<Test>())
 			{
-				try
+				InsertData(db);
+
+				var dog = new Dog()
 				{
-					InsertData(db);
-
-					var dog = new Dog()
+					Id          = 666,
+					AnimalType  = AnimalType.Big,
+					AnimalType2 = AnimalType2.Small,
+					Name        = "Cerberus",
+					DogName     = new Name()
 					{
-						Id          = 666,
-						AnimalType  = AnimalType.Big,
-						AnimalType2 = AnimalType2.Small,
-						Name        = "Cerberus",
-						DogName     = new Name()
-						{
-							First  = "Good",
-							Second = "Dog"
-						},
-						EyeId = 2
-					};
+						First  = "Good",
+						Second = "Dog"
+					},
+					EyeId = 2
+				};
 
-					var cnt = db.Insert((Animal)dog);
-					Validate(false);
+				var cnt = db.Insert((Animal)dog);
+				Validate(false);
 
-					cnt = db.InsertOrReplace((Animal)dog);
-					Validate(true);
+				cnt = db.InsertOrReplace((Animal)dog);
+				Validate(true);
 
-					cnt = db.Update((Animal)dog);
-					Validate(false);
+				cnt = db.Update((Animal)dog);
+				Validate(false);
 
-					db.Delete((Animal)dog);
+				db.Delete((Animal)dog);
 
-					void Validate(bool insertOrReplace)
-					{
-						if (insertOrReplace && context.IsAnyOf(TestProvName.AllOracleNative))
-							Assert.AreEqual(-1, cnt);
-						else
-							Assert.AreEqual(1, cnt);
-
-						var data = db.GetTable<Dog>().Where(_ => _.Id == 666).FirstOrDefault()!;
-						Assert.IsNotNull(data);
-						Assert.AreEqual(dog.Id            , data.Id);
-						Assert.AreEqual(dog.AnimalType    , data.AnimalType);
-						Assert.AreEqual(dog.AnimalType2   , data.AnimalType2);
-						Assert.AreEqual(dog.Name          , data.Name);
-						Assert.AreEqual(dog.DogName.First , data.DogName!.First);
-						Assert.AreEqual(dog.DogName.Second, data.DogName!.Second);
-						Assert.AreEqual(dog.EyeId         , data.EyeId);
-					}
-				}
-				finally
+				void Validate(bool insertOrReplace)
 				{
-					CleanupData(db);
+					if (insertOrReplace && context.IsAnyOf(TestProvName.AllOracleNative))
+						Assert.AreEqual(-1, cnt);
+					else
+						Assert.AreEqual(1, cnt);
+
+					var data = db.GetTable<Dog>().Where(_ => _.Id == 666).FirstOrDefault()!;
+					Assert.IsNotNull(data);
+					Assert.AreEqual(dog.Id            , data.Id);
+					Assert.AreEqual(dog.AnimalType    , data.AnimalType);
+					Assert.AreEqual(dog.AnimalType2   , data.AnimalType2);
+					Assert.AreEqual(dog.Name          , data.Name);
+					Assert.AreEqual(dog.DogName.First , data.DogName!.First);
+					Assert.AreEqual(dog.DogName.Second, data.DogName!.Second);
+					Assert.AreEqual(dog.EyeId         , data.EyeId);
 				}
 			}
 		}

--- a/Tests/Linq/Linq/ConvertExpressionTests.cs
+++ b/Tests/Linq/Linq/ConvertExpressionTests.cs
@@ -605,7 +605,8 @@ namespace Tests.Linq
 					,
 					from p in db.Parent
 					let ch1 = db.Child.OrderBy(c => c.ParentID).FirstOrDefault(c => c.ParentID > 0)
-					let ch2 = db.Child.Where(c => c.ChildID > -100)
+					let ch2 = db.Child.OrderBy(c => c.ParentID).Where(c => c.ChildID > -100)
+					orderby p.ParentID
 					select new
 					{
 						First1 = ch1 == null ? 0 : ch1.ParentID,

--- a/Tests/Linq/Linq/ConvertTests.cs
+++ b/Tests/Linq/Linq/ConvertTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using FluentAssertions;
 using LinqToDB;
 using LinqToDB.Mapping;
+using LinqToDB.SqlQuery;
 using NUnit.Framework;
 using Tests.Model;
 
@@ -16,7 +17,7 @@ namespace Tests.Linq
 		public void Test1([DataSources(TestProvName.AllSQLite)] string context)
 		{
 			using (var db = GetDataContext(context))
-				Assert.AreEqual(1, (from t in db.Types where t.MoneyValue * t.ID == 1.11m  select t).Single().ID);
+				Assert.AreEqual(1, (from t in db.Types where t.MoneyValue * t.ID == 1.11m select t).Single().ID);
 		}
 
 		#region Int
@@ -1436,6 +1437,7 @@ namespace Tests.Linq
 						Prop_uint             = Sql.AsSql(x.Prop_uint            .ToString()),
 						Prop_ulong            = Sql.AsSql(x.Prop_ulong           .ToString()),
 						Prop_Guid             = Sql.AsSql(x.Prop_Guid            .ToString()),
+						Prop_DateTime         = Sql.AsSql(x.Prop_DateTime        .ToString()),
 						NullableProp_bool     = Sql.AsSql(x.NullableProp_bool    .ToString()),
 						NullableProp_byte     = Sql.AsSql(x.NullableProp_byte    .ToString()),
 						NullableProp_char     = Sql.AsSql(x.NullableProp_char    .ToString()),
@@ -1450,46 +1452,44 @@ namespace Tests.Linq
 						NullableProp_uint     = Sql.AsSql(x.NullableProp_uint    .ToString()),
 						NullableProp_ulong    = Sql.AsSql(x.NullableProp_ulong   .ToString()),
 						NullableProp_Guid     = Sql.AsSql(x.NullableProp_Guid    .ToString()),
-						Prop_DateTime         = Sql.AsSql(x.Prop_DateTime        .ToString()),
 						NullableProp_DateTime = Sql.AsSql(x.NullableProp_DateTime.ToString()),
 					})
 					.First();
 
 				var noSqlConverted = table.Select(x => new
 					{
-						Prop_bool            = x.Prop_bool ? "1" : "0",
-						Prop_byte            = x.Prop_byte            .ToString(CultureInfo.InvariantCulture),
-						Prop_char            = x.Prop_char            .ToString(CultureInfo.InvariantCulture),
-						Prop_decimal         = x.Prop_decimal         .ToString(CultureInfo.InvariantCulture),
-						Prop_double          = x.Prop_double          .ToString(CultureInfo.InvariantCulture),
-						Prop_short           = x.Prop_short           .ToString(CultureInfo.InvariantCulture),
-						Prop_int             = x.Prop_int             .ToString(CultureInfo.InvariantCulture),
-						Prop_long            = x.Prop_long            .ToString(CultureInfo.InvariantCulture),
-						Prop_sbyte           = x.Prop_sbyte           .ToString(CultureInfo.InvariantCulture),
-						Prop_float           = x.Prop_float           .ToString(CultureInfo.InvariantCulture),
-						Prop_ushort          = x.Prop_ushort          .ToString(CultureInfo.InvariantCulture),
-						Prop_uint            = x.Prop_uint            .ToString(CultureInfo.InvariantCulture),
-						Prop_ulong           = x.Prop_ulong           .ToString(CultureInfo.InvariantCulture),
-						Prop_Guid            = x.Prop_Guid            .ToString(),
-						NullableProp_bool    = x.NullableProp_bool == null ? "" : x.NullableProp_bool.Value ? "1" : "0",
-						NullableProp_byte    = x.NullableProp_byte    !.Value.ToString(CultureInfo.InvariantCulture),
-						NullableProp_char    = x.NullableProp_char    !.Value.ToString(CultureInfo.InvariantCulture),
-						NullableProp_decimal = x.NullableProp_decimal !.Value.ToString(CultureInfo.InvariantCulture),
-						NullableProp_double  = x.NullableProp_double  !.Value.ToString(CultureInfo.InvariantCulture),
-						NullableProp_short   = x.NullableProp_short   !.Value.ToString(CultureInfo.InvariantCulture),
-						NullableProp_int     = x.NullableProp_int     !.Value.ToString(CultureInfo.InvariantCulture),
-						NullableProp_long    = x.NullableProp_long    !.Value.ToString(CultureInfo.InvariantCulture),
-						NullableProp_sbyte   = x.NullableProp_sbyte   !.Value.ToString(CultureInfo.InvariantCulture),
-						NullableProp_float   = x.NullableProp_float   !.Value.ToString(CultureInfo.InvariantCulture),
-						NullableProp_ushort  = x.NullableProp_ushort  !.Value.ToString(CultureInfo.InvariantCulture),
-						NullableProp_uint    = x.NullableProp_uint    !.Value.ToString(CultureInfo.InvariantCulture),
-						NullableProp_ulong   = x.NullableProp_ulong   !.Value.ToString(CultureInfo.InvariantCulture),
-						NullableProp_Guid    = x.NullableProp_Guid    .ToString(),
-						Prop_DateTime         = Sql.AsSql(x.Prop_DateTime        .ToString()),
-						NullableProp_DateTime = Sql.AsSql(x.NullableProp_DateTime.ToString()),
+						Prop_bool             = x.Prop_bool ? "1" : "0",
+						Prop_byte             = x.Prop_byte            .ToString(CultureInfo.InvariantCulture),
+						Prop_char             = x.Prop_char            .ToString(CultureInfo.InvariantCulture),
+						Prop_decimal          = x.Prop_decimal         .ToString(CultureInfo.InvariantCulture),
+						Prop_double           = x.Prop_double          .ToString(CultureInfo.InvariantCulture),
+						Prop_short            = x.Prop_short           .ToString(CultureInfo.InvariantCulture),
+						Prop_int              = x.Prop_int             .ToString(CultureInfo.InvariantCulture),
+						Prop_long             = x.Prop_long            .ToString(CultureInfo.InvariantCulture),
+						Prop_sbyte            = x.Prop_sbyte           .ToString(CultureInfo.InvariantCulture),
+						Prop_float            = x.Prop_float           .ToString(CultureInfo.InvariantCulture),
+						Prop_ushort           = x.Prop_ushort          .ToString(CultureInfo.InvariantCulture),
+						Prop_uint             = x.Prop_uint            .ToString(CultureInfo.InvariantCulture),
+						Prop_ulong            = x.Prop_ulong           .ToString(CultureInfo.InvariantCulture),
+						Prop_Guid             = x.Prop_Guid            .ToString(),
+						Prop_DateTime         = x.Prop_DateTime        .ToString("yyyy-MM-dd HH:mm:ss.fffffff"),
+						NullableProp_bool     = x.NullableProp_bool == null ? "" : x.NullableProp_bool.Value ? "1" : "0",
+						NullableProp_byte     = x.NullableProp_byte    !.Value.ToString(CultureInfo.InvariantCulture),
+						NullableProp_char     = x.NullableProp_char    !.Value.ToString(CultureInfo.InvariantCulture),
+						NullableProp_decimal  = x.NullableProp_decimal !.Value.ToString(CultureInfo.InvariantCulture),
+						NullableProp_double   = x.NullableProp_double  !.Value.ToString(CultureInfo.InvariantCulture),
+						NullableProp_short    = x.NullableProp_short   !.Value.ToString(CultureInfo.InvariantCulture),
+						NullableProp_int      = x.NullableProp_int     !.Value.ToString(CultureInfo.InvariantCulture),
+						NullableProp_long     = x.NullableProp_long    !.Value.ToString(CultureInfo.InvariantCulture),
+						NullableProp_sbyte    = x.NullableProp_sbyte   !.Value.ToString(CultureInfo.InvariantCulture),
+						NullableProp_float    = x.NullableProp_float   !.Value.ToString(CultureInfo.InvariantCulture),
+						NullableProp_ushort   = x.NullableProp_ushort  !.Value.ToString(CultureInfo.InvariantCulture),
+						NullableProp_uint     = x.NullableProp_uint    !.Value.ToString(CultureInfo.InvariantCulture),
+						NullableProp_ulong    = x.NullableProp_ulong   !.Value.ToString(CultureInfo.InvariantCulture),
+						NullableProp_Guid     = x.NullableProp_Guid    !.Value.ToString(),
+						NullableProp_DateTime = x.NullableProp_DateTime!.Value.ToString("yyyy-MM-dd HH:mm:ss.fffffff"),
 					})
 					.First();
-
 
 				sqlConverted.Should().Be(noSqlConverted);
 			}

--- a/Tests/Linq/Linq/CteTests.cs
+++ b/Tests/Linq/Linq/CteTests.cs
@@ -909,7 +909,7 @@ namespace Tests.Linq
 					join c in cteQuery on p.ParentID equals c.Child!.ParentID
 					select new {p, c};
 
-				Assert.AreEqual(expected, result);
+				Assert.AreEqual(expected.ToList().OrderBy(_ => _.p.ParentID).ThenBy(_ => _.c.Child?.ChildID), result.OrderBy(_ => _.p.ParentID).ThenBy(_ => _.c.Child?.ChildID));
 			}
 		}
 

--- a/Tests/Linq/Linq/DataTypesTests.cs
+++ b/Tests/Linq/Linq/DataTypesTests.cs
@@ -18,8 +18,7 @@ namespace Tests.Linq
 	using LinqToDB.Data;
 	using Model;
 
-	// TODO: add more base types tests
-	// TODO: and more type test cases
+	// TODO: delete this test when we implement type tests for all databases similar to CLickHouse tests
 	[TestFixture]
 	public class DataTypesTests : TestBase
 	{
@@ -47,7 +46,7 @@ namespace Tests.Linq
 		{
 			using var db = (TestDataConnection)GetDataContext(context);
 
-			TestType<GuidTable, Guid>(db, GuidTable.Data);
+			TestType<GuidTable, Guid>(db, GuidTable.Data, context);
 		}
 		#endregion
 
@@ -67,7 +66,7 @@ namespace Tests.Linq
 		{
 			using var db = (TestDataConnection)GetDataContext(context);
 
-			TestType<ByteTable, byte>(db, ByteTable.Data);
+			TestType<ByteTable, byte>(db, ByteTable.Data, context);
 		}
 		#endregion
 
@@ -78,7 +77,7 @@ namespace Tests.Linq
 		{
 			public static DateOnlyTable[] Data = new[]
 			{
-				new DateOnlyTable() { Id = 1, Column = new DateOnly(1900, 1, 1), ColumnNullable = null },
+				new DateOnlyTable() { Id = 1, Column = new DateOnly(1950, 1, 1), ColumnNullable = null },
 				new DateOnlyTable() { Id = 2, Column = new DateOnly(2020, 2, 29), ColumnNullable = new DateOnly(2200, 1, 1) },
 			};
 		}
@@ -88,7 +87,7 @@ namespace Tests.Linq
 		{
 			using var db = (TestDataConnection)GetDataContext(context);
 
-			TestType<DateOnlyTable, DateOnly>(db, DateOnlyTable.Data);
+			TestType<DateOnlyTable, DateOnly>(db, DateOnlyTable.Data, context);
 		}
 #endif
 		#endregion
@@ -116,7 +115,7 @@ namespace Tests.Linq
 				data = data.Select(r => new BooleanTable() { Id = r.Id, Column = r.Column, ColumnNullable = r.ColumnNullable ?? false }).ToArray();
 			}
 
-			TestType<BooleanTable, bool>(db, data);
+			TestType<BooleanTable, bool>(db, data, context);
 		}
 		#endregion
 
@@ -142,7 +141,7 @@ namespace Tests.Linq
 		{
 			using var db = (TestDataConnection)GetDataContext(context);
 
-			TestType<IntEnumTable, IntEnum>(db, IntEnumTable.Data);
+			TestType<IntEnumTable, IntEnum>(db, IntEnumTable.Data, context);
 		}
 		#endregion
 
@@ -168,7 +167,7 @@ namespace Tests.Linq
 		{
 			using var db = (TestDataConnection)GetDataContext(context);
 
-			TestType<StringEnumTable, StringEnum>(db, StringEnumTable.Data);
+			TestType<StringEnumTable, StringEnum>(db, StringEnumTable.Data, context);
 		}
 		#endregion
 
@@ -176,7 +175,7 @@ namespace Tests.Linq
 		[Sql.Expression("{0} = {1}", IsPredicate = true)]
 		private static bool Equality(object? x, object? y) => throw new NotImplementedException();
 
-		private void TestType<TTable, TType>(DataConnection db, TTable[] data)
+		private void TestType<TTable, TType>(DataConnection db, TTable[] data, string context)
 			where TTable: TypeTable<TType>
 			where TType: struct
 		{

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -579,7 +579,7 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 				AreEqual(
 					from t in Types select RoundMilliseconds(Sql.AsSql(t.DateTimeValue.TimeOfDay)),
-					from t in db.Types select TruncMilliseconds(Sql.AsSql(t.DateTimeValue.TimeOfDay)));
+					from t in db.Types select RoundMilliseconds(Sql.AsSql(t.DateTimeValue.TimeOfDay)));
 		}
 
 		#endregion

--- a/Tests/Linq/Linq/DynamicResultTests.cs
+++ b/Tests/Linq/Linq/DynamicResultTests.cs
@@ -4,7 +4,7 @@ using LinqToDB.Data;
 using LinqToDB.Mapping;
 using NUnit.Framework;
 
-namespace Tests.Playground
+namespace Tests
 {
 	[TestFixture]
 	public class DynamicResultTests : TestBase

--- a/Tests/Linq/Linq/EnumMappingTests.cs
+++ b/Tests/Linq/Linq/EnumMappingTests.cs
@@ -204,7 +204,7 @@ namespace Tests.Linq
 				});
 
 				var result = db.GetTable<TestTable1>().Where(r => r.Id == RID && r.TestField == TestEnum1.Value2).Select(r => r.TestField).FirstOrDefault();
-				Assert.True(result == TestEnum1.Value2);
+				Assert.AreEqual(TestEnum1.Value2, result);
 			}
 		}
 
@@ -221,7 +221,7 @@ namespace Tests.Linq
 				});
 
 				var result = db.GetTable<TestTable2>().Where(r => r.Id == RID && r.TestField == TestEnum21.Value2).Select(r => r.TestField).FirstOrDefault();
-				Assert.True(result == TestEnum21.Value2);
+				Assert.AreEqual(TestEnum21.Value2, result);
 			}
 		}
 
@@ -240,7 +240,7 @@ namespace Tests.Linq
 				var result = db.GetTable<NullableTestTable1>()
 					.Where(r => r.Id == RID && r.TestField == TestEnum1.Value2)
 					.Select(r => r.TestField).FirstOrDefault();
-				Assert.True(result == TestEnum1.Value2);
+				Assert.AreEqual(TestEnum1.Value2, result);
 			}
 		}
 
@@ -284,7 +284,7 @@ namespace Tests.Linq
 					.Select(r => r.TestField)
 					.FirstOrDefault();
 
-				Assert.True(result == VAL2);
+				Assert.AreEqual(VAL2, result);
 			}
 		}
 
@@ -309,7 +309,7 @@ namespace Tests.Linq
 					.Select(r => r.TestField)
 					.FirstOrDefault();
 
-				Assert.True(result == VAL2);
+				Assert.AreEqual(VAL2, result);
 			}
 		}
 
@@ -334,7 +334,7 @@ namespace Tests.Linq
 					.Select(r => r.TestField)
 					.FirstOrDefault();
 
-				Assert.True(result == VAL2);
+				Assert.AreEqual(VAL2, result);
 			}
 		}
 
@@ -359,7 +359,7 @@ namespace Tests.Linq
 					.Select(r => r.TestField)
 					.FirstOrDefault();
 
-				Assert.True(result == VAL2);
+				Assert.AreEqual(VAL2, result);
 			}
 		}
 
@@ -403,7 +403,7 @@ namespace Tests.Linq
 					.FirstOrDefault()!;
 
 				Assert.NotNull(result);
-				Assert.True(result.TestField == TestEnum21.Value2);
+				Assert.AreEqual(TestEnum21.Value2, result.TestField);
 			}
 		}
 
@@ -425,7 +425,7 @@ namespace Tests.Linq
 					.FirstOrDefault()!;
 
 				Assert.NotNull(result);
-				Assert.True(result.TestField == TestEnum1.Value2);
+				Assert.AreEqual(TestEnum1.Value2, result.TestField);
 			}
 		}
 
@@ -447,7 +447,7 @@ namespace Tests.Linq
 					.FirstOrDefault()!;
 
 				Assert.NotNull(result);
-				Assert.True(result.TestField == TestEnum21.Value2);
+				Assert.AreEqual(TestEnum21.Value2, result.TestField);
 			}
 		}
 
@@ -463,7 +463,8 @@ namespace Tests.Linq
 					TestField = VAL2
 				});
 
-				Assert.True(1 == db.GetTable<TestTable1>().Delete(r => r.Id == RID && r.TestField == TestEnum1.Value2));
+				var cnt = db.GetTable<TestTable1>().Delete(r => r.Id == RID && r.TestField == TestEnum1.Value2);
+					Assert.AreEqual(1, cnt);
 			}
 		}
 
@@ -479,7 +480,8 @@ namespace Tests.Linq
 					TestField = VAL2
 				});
 
-				Assert.True(1 == db.GetTable<TestTable2>().Delete(r => r.Id == RID && r.TestField == TestEnum21.Value2));
+				var cnt = db.GetTable<TestTable2>().Delete(r => r.Id == RID && r.TestField == TestEnum21.Value2);
+					Assert.AreEqual(1, cnt);
 			}
 		}
 
@@ -495,8 +497,8 @@ namespace Tests.Linq
 					TestField = VAL2
 				});
 
-				Assert.True(1 == db.GetTable<NullableTestTable1>()
-					.Delete(r => r.Id == RID && r.TestField == TestEnum1.Value2));
+				var cnt = db.GetTable<NullableTestTable1>().Delete(r => r.Id == RID && r.TestField == TestEnum1.Value2);
+					Assert.AreEqual(1, cnt);
 			}
 		}
 
@@ -512,8 +514,8 @@ namespace Tests.Linq
 					TestField = VAL2
 				});
 
-				Assert.True(1 == db.GetTable<NullableTestTable2>()
-					.Delete(r => r.Id == RID && r.TestField == TestEnum21.Value2));
+				var cnt = db.GetTable<NullableTestTable2>().Delete(r => r.Id == RID && r.TestField == TestEnum21.Value2);
+					Assert.AreEqual(1, cnt);
 			}
 		}
 
@@ -533,7 +535,7 @@ namespace Tests.Linq
 					.Where(r => r.Id == RID && r.TestField == TestEnum1.Value1)
 					.Set(r => r.TestField, TestEnum1.Value2).Update();
 				var result = db.GetTable<RawTable>().Where(r => r.Id == RID && r.TestField == VAL2).Select(r => r.TestField).FirstOrDefault();
-				Assert.True(result == VAL2);
+				Assert.AreEqual(VAL2, result);
 			}
 		}
 
@@ -553,7 +555,7 @@ namespace Tests.Linq
 					.Where(r => r.Id == RID && r.TestField == TestEnum21.Value1)
 					.Set(r => r.TestField, TestEnum21.Value2).Update();
 				var result = db.GetTable<RawTable>().Where(r => r.Id == RID && r.TestField == VAL2).Select(r => r.TestField).FirstOrDefault();
-				Assert.True(result == VAL2);
+				Assert.AreEqual(VAL2, result);
 			}
 		}
 
@@ -572,7 +574,8 @@ namespace Tests.Linq
 				db.GetTable<TestTable2>()
 					.Where(r => r.Id == RID && r.Int32Field == TestEnum3.Value1)
 					.Set(r => r.Int32Field, () => TestEnum3.Value2).Update();
-				Assert.True(1 == db.GetTable<RawTable>().Where(r => r.Id == RID && r.Int32Field == 4).Count());
+
+				Assert.AreEqual(1, db.GetTable<RawTable>().Where(r => r.Id == RID && r.Int32Field == 4).Count());
 			}
 		}
 
@@ -592,7 +595,7 @@ namespace Tests.Linq
 					.Where(r => r.Id == RID && r.TestField == TestEnum1.Value1)
 					.Set(r => r.TestField, TestEnum1.Value2).Update();
 				var result = db.GetTable<RawTable>().Where(r => r.Id == RID && r.TestField == VAL2).Select(r => r.TestField).FirstOrDefault();
-				Assert.True(result == VAL2);
+				Assert.AreEqual(VAL2, result);
 			}
 		}
 
@@ -612,7 +615,7 @@ namespace Tests.Linq
 					.Where(r => r.Id == RID && r.TestField == TestEnum21.Value1)
 					.Set(r => r.TestField, TestEnum21.Value2).Update();
 				var result = db.GetTable<RawTable>().Where(r => r.Id == RID && r.TestField == VAL2).Select(r => r.TestField).FirstOrDefault();
-				Assert.True(result == VAL2);
+				Assert.AreEqual(VAL2, result);
 			}
 		}
 
@@ -631,7 +634,7 @@ namespace Tests.Linq
 				db.GetTable<NullableTestTable2>()
 					.Where(r => r.Id == RID && r.Int32Field == TestEnum3.Value1)
 					.Set(r => r.Int32Field, () => TestEnum3.Value2).Update();
-				Assert.True(1 == db.GetTable<RawTable>().Where(r => r.Id == RID && r.Int32Field == 4).Count());
+				Assert.AreEqual(1, db.GetTable<RawTable>().Where(r => r.Id == RID && r.Int32Field == 4).Count());
 			}
 		}
 
@@ -647,7 +650,7 @@ namespace Tests.Linq
 					TestField = VAL2
 				});
 
-				Assert.True(1 == db.GetTable<TestTable1>()
+				Assert.AreEqual(1, db.GetTable<TestTable1>()
 					.Where(r => r.Id == RID && new[] { TestEnum1.Value2 }.Contains(r.TestField)).Count());
 			}
 		}
@@ -664,7 +667,7 @@ namespace Tests.Linq
 					TestField = VAL2
 				});
 
-				Assert.True(1 == db.GetTable<TestTable2>().Where(r => r.Id == RID && new[] { TestEnum21.Value2 }.Contains(r.TestField)).Count());
+				Assert.AreEqual(1, db.GetTable<TestTable2>().Where(r => r.Id == RID && new[] { TestEnum21.Value2 }.Contains(r.TestField)).Count());
 			}
 		}
 
@@ -680,7 +683,7 @@ namespace Tests.Linq
 					TestField = VAL2
 				});
 
-				Assert.True(1 == db.GetTable<NullableTestTable1>()
+				Assert.AreEqual(1, db.GetTable<NullableTestTable1>()
 					.Where(r => r.Id == RID && new[] { (TestEnum1?)TestEnum1.Value2 }.Contains(r.TestField)).Count());
 			}
 		}
@@ -697,7 +700,7 @@ namespace Tests.Linq
 					TestField = VAL2
 				});
 
-				Assert.True(1 == db.GetTable<NullableTestTable2>()
+				Assert.AreEqual(1, db.GetTable<NullableTestTable2>()
 					.Where(r => r.Id == RID && new[] { (TestEnum21?)TestEnum21.Value2 }.Contains(r.TestField)).Count());
 			}
 		}
@@ -719,7 +722,7 @@ namespace Tests.Linq
 					.FirstOrDefault()!;
 
 				Assert.NotNull(result);
-				Assert.True(result.TestField == null);
+				Assert.IsNull(result.TestField);
 			}
 		}
 
@@ -740,7 +743,7 @@ namespace Tests.Linq
 					.FirstOrDefault()!;
 
 				Assert.NotNull(result);
-				Assert.True(result.TestField == null);
+				Assert.IsNull(result.TestField);
 			}
 		}
 
@@ -870,7 +873,7 @@ namespace Tests.Linq
 					})
 					.Insert(db.GetTable<TestTable1>(), r => r);
 
-				Assert.AreEqual(1, result);
+					Assert.AreEqual(1, result);
 				Assert.AreEqual(1, db.GetTable<RawTable>().Where(r => r.Id == RID && r.TestField == VAL1).Count());
 			}
 		}
@@ -898,7 +901,7 @@ namespace Tests.Linq
 					})
 					.Insert(db.GetTable<TestTable2>(), r => r);
 
-				Assert.AreEqual(1, result);
+					Assert.AreEqual(1, result);
 				Assert.AreEqual(1, db.GetTable<RawTable>().Where(r => r.Id == RID && r.TestField == VAL1).Count());
 			}
 		}
@@ -926,7 +929,7 @@ namespace Tests.Linq
 					})
 					.Insert(db.GetTable<NullableTestTable1>(), r => r);
 
-				Assert.AreEqual(1, result);
+					Assert.AreEqual(1, result);
 				Assert.AreEqual(1, db.GetTable<RawTable>().Where(r => r.Id == RID && r.TestField == VAL1).Count());
 			}
 		}
@@ -954,7 +957,7 @@ namespace Tests.Linq
 					})
 					.Insert(db.GetTable<NullableTestTable2>(), r => r);
 
-				Assert.AreEqual(1, result);
+					Assert.AreEqual(1, result);
 				Assert.AreEqual(1, db.GetTable<RawTable>().Where(r => r.Id == RID && r.TestField == VAL1).Count());
 			}
 		}
@@ -971,7 +974,8 @@ namespace Tests.Linq
 					TestField = VAL2
 				});
 
-				Assert.True(1 == db.GetTable<TestTable1>().Delete(r => r.Id == RID && r.TestField.Equals(TestEnum1.Value2)));
+				var cnt = db.GetTable<TestTable1>().Delete(r => r.Id == RID && r.TestField.Equals(TestEnum1.Value2));
+					Assert.AreEqual(1, cnt);
 			}
 		}
 
@@ -987,7 +991,8 @@ namespace Tests.Linq
 					TestField = VAL2
 				});
 
-				Assert.True(1 == db.GetTable<TestTable2>().Delete(r => r.Id == RID && r.TestField.Equals(TestEnum21.Value2)));
+				var cnt = db.GetTable<TestTable2>().Delete(r => r.Id == RID && r.TestField.Equals(TestEnum21.Value2));
+					Assert.AreEqual(1, cnt);
 			}
 		}
 
@@ -1003,8 +1008,9 @@ namespace Tests.Linq
 					TestField = VAL2
 				});
 
-				Assert.True(1 == db.GetTable<NullableTestTable1>()
-					.Delete(r => r.Id == RID && r.TestField.Equals(TestEnum1.Value2)));
+				var cnt = db.GetTable<NullableTestTable1>().Delete(r => r.Id == RID && r.TestField.Equals(TestEnum1.Value2));
+
+					Assert.AreEqual(1, cnt);
 			}
 		}
 
@@ -1020,8 +1026,9 @@ namespace Tests.Linq
 					TestField = VAL2
 				});
 
-				Assert.True(1 == db.GetTable<NullableTestTable2>()
-					.Delete(r => r.Id == RID && r.TestField.Equals(TestEnum21.Value2)));
+				var cnt = db.GetTable<NullableTestTable2>().Delete(r => r.Id == RID && r.TestField.Equals(TestEnum21.Value2));
+
+					Assert.AreEqual(1, cnt);
 			}
 		}
 

--- a/Tests/Linq/Linq/FSharpTests.cs
+++ b/Tests/Linq/Linq/FSharpTests.cs
@@ -82,7 +82,7 @@ namespace Tests.Linq
 		public void Insert2([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
-				FSharp.InsertTest.Insert2(db);
+				FSharp.InsertTest.Insert2(db, 0);
 		}
 
 		[ActiveIssue(417)]

--- a/Tests/Linq/Linq/FromSqlTests.cs
+++ b/Tests/Linq/Linq/FromSqlTests.cs
@@ -107,12 +107,14 @@ namespace Tests.Linq
 				var projection = query
 					.Where(c => c.Id > 10)
 					.Select(c => new { c.Value, c.Id })
+					.OrderBy(_ => _.Id)
 					.ToArray();
 
 				var expected = table
 					.Where(t => t.Id >= startId && t.Id < endId)
 					.Where(c => c.Id > 10)
 					.Select(c => new { c.Value, c.Id })
+					.OrderBy(_ => _.Id)
 					.ToArray();
 
 				Assert.AreEqual(expected, projection);
@@ -132,12 +134,14 @@ namespace Tests.Linq
 				var projection = query
 					.Where(c => c.Id > 10)
 					.Select(c => new { c.Value, c.Id })
+					.OrderBy(_ => _.Id)
 					.ToArray();
 
 				var expected = table
 					.Where(t => t.Id >= startId && t.Id < endId)
 					.Where(c => c.Id > 10)
 					.Select(c => new { c.Value, c.Id })
+					.OrderBy(_ => _.Id)
 					.ToArray();
 
 				Assert.AreEqual(expected, projection);
@@ -158,12 +162,13 @@ namespace Tests.Linq
 					.Where(c => c.Id > 10)
 					.Select(c => new { c.Value, c.Id });
 
-				var projection = queryWithProjection.ToArray();
+				var projection = queryWithProjection.OrderBy(_ => _.Id).ToArray();
 
 				var expected = table
 					.Where(t => t.Id >= startId && t.Id < endId)
 					.Where(c => c.Id > 10)
 					.Select(c => new { c.Value, c.Id })
+					.OrderBy(_ => _.Id)
 					.ToArray();
 
 				Assert.AreEqual(expected, projection);
@@ -186,12 +191,14 @@ namespace Tests.Linq
 				var projection = query
 					.Where(c => c.Id > 10)
 					.Select(c => new { c.Value, c.Id })
+					.OrderBy(_ => _.Id)
 					.ToArray();
 
 				var expected = table
 					.Where(t => t.Id >= startId && t.Id < endId)
 					.Where(c => c.Id > 10)
 					.Select(c => new { c.Value, c.Id })
+					.OrderBy(_ => _.Id)
 					.ToArray();
 
 				Assert.AreEqual(expected, projection);
@@ -214,12 +221,14 @@ namespace Tests.Linq
 				var projection = query
 					.Where(c => c.Id > 10)
 					.Select(c => new { c.Value, c.Id })
+					.OrderBy(_ => _.Id)
 					.ToArray();
 
 				var expected = table
 					.Where(t => t.Id >= startId && t.Id < endId)
 					.Where(c => c.Id > 10)
 					.Select(c => new { c.Value, c.Id })
+					.OrderBy(_ => _.Id)
 					.ToArray();
 
 				Assert.AreEqual(expected, projection);
@@ -239,12 +248,14 @@ namespace Tests.Linq
 				var projection = query
 					.Where(c => c.Id > 10)
 					.Select(c => new { c.Value, c.Id })
+					.OrderBy(_ => _.Id)
 					.ToArray();
 
 				var expected = table
 					.Where(t => t.Id >= startId && t.Id < endId)
 					.Where(c => c.Id > 10)
 					.Select(c => new { c.Value, c.Id })
+					.OrderBy(_ => _.Id)
 					.ToArray();
 
 				Assert.AreEqual(expected, projection);
@@ -268,12 +279,14 @@ namespace Tests.Linq
 				var projection = query
 					.Where(c => c.Id > 10)
 					.Select(c => new { c.Value, c.Id })
+					.OrderBy(_ => _.Id)
 					.ToArray();
 
 				var expected = table
 					.Where(t => t.Id >= startId && t.Id < endId)
 					.Where(c => c.Id > 10)
 					.Select(c => new { c.Value, c.Id })
+					.OrderBy(_ => _.Id)
 					.ToArray();
 
 				Assert.AreEqual(expected, projection);
@@ -298,12 +311,14 @@ namespace Tests.Linq
 				var projection = query
 					.Where(c => c.Id > 10)
 					.Select(c => new { c.Value, c.Id })
+					.OrderBy(_ => _.Id)
 					.ToArray();
 
 				var expected = table
 					.Where(t => t.Id >= startId && t.Id < endId)
 					.Where(c => c.Id > 10)
 					.Select(c => new { c.Value, c.Id })
+					.OrderBy(_ => _.Id)
 					.ToArray();
 
 				Assert.AreEqual(expected, projection);

--- a/Tests/Linq/Linq/IssueTests.cs
+++ b/Tests/Linq/Linq/IssueTests.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 
 using LinqToDB;
+using LinqToDB.Common;
 using LinqToDB.Data;
 using LinqToDB.Mapping;
 
@@ -11,8 +13,6 @@ using NUnit.Framework;
 
 namespace Tests.Linq
 {
-	using System.Collections.Generic;
-	using LinqToDB.Common;
 	using Model;
 
 	[TestFixture]
@@ -46,13 +46,13 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 			{
-				var t1 = db.Types2.First();
+				var t1 = db.Types2.Where(r => r.ID == 1).First();
 
 				t1.BoolValue = !t1.BoolValue;
 
 				db.Update(t1);
 
-				var t2 = db.Types2.First();
+				var t2 = db.Types2.First(r => r.ID == t1.ID);
 
 				Assert.That(t2.BoolValue, Is.EqualTo(t1.BoolValue));
 

--- a/Tests/Linq/Linq/JoinTests.cs
+++ b/Tests/Linq/Linq/JoinTests.cs
@@ -482,7 +482,7 @@ namespace Tests.Linq
 				Assert.AreEqual(list1[0].p.ParentID, list2[0].p.ParentID);
 				Assert.AreEqual(list1[0].lj.Count(), list2[0].lj.Count());
 
-				var ch2 = list2[0].lj.ToList();
+				var ch2 = list2[0].lj.OrderBy(_ => _.ChildID).ToList();
 
 				Assert.AreEqual(ch1[0].ParentID, ch2[0].ParentID);
 				Assert.AreEqual(ch1[0].ChildID,  ch2[0].ChildID);
@@ -2185,7 +2185,7 @@ namespace Tests.Linq
 					where fact.Id > 3
 					select new { fact, leftTag };
 
-				var results = t.ToArray();
+				var results = t.OrderBy(_ => _.fact.Id).ToArray();
 
 				Assert.AreEqual(2, results.Length);
 				Assert.AreEqual(4, results[0].fact.Id);
@@ -2208,7 +2208,7 @@ namespace Tests.Linq
 					where fact.Id > 3
 					select new { fact, leftTag };
 
-				var results = t.ToArray();
+				var results = t.OrderBy(_ => _.fact.Id).ToArray();
 
 				Assert.AreEqual(2, results.Length);
 				Assert.AreEqual(4, results[0].fact.Id);
@@ -2231,7 +2231,7 @@ namespace Tests.Linq
 					where fact.Id > 3
 					select new { fact, leftTag };
 
-				var results = t.ToArray();
+				var results = t.OrderBy(_ => _.fact.Id).ToArray();
 
 				Assert.AreEqual(2, results.Length);
 				Assert.AreEqual(4, results[0].fact.Id);
@@ -2254,7 +2254,7 @@ namespace Tests.Linq
 					where fact.Id > 3
 					select new { fact, leftTag = leftTag != null ? leftTag : null };
 
-				var results = t.ToArray();
+				var results = t.OrderBy(_ => _.fact.Id).ToArray();
 
 				Assert.AreEqual(2, results.Length);
 				Assert.AreEqual(4, results[0].fact.Id);
@@ -2276,7 +2276,7 @@ namespace Tests.Linq
 					where ft.fact.Id > 3
 					select ft;
 
-				var results = q.ToArray();
+				var results = q.OrderBy(_ => _.fact.Id).ToArray();
 
 				Assert.AreEqual(2, results.Length);
 				Assert.AreEqual(4, results[0].fact.Id);
@@ -2298,7 +2298,7 @@ namespace Tests.Linq
 					where ft.fact.Id > 3
 					select ft;
 
-				var results = q.ToArray();
+				var results = q.OrderBy(_ => _.fact.Id).ToArray();
 
 				Assert.AreEqual(2, results.Length);
 				Assert.AreEqual(4, results[0].fact.Id);
@@ -2321,7 +2321,7 @@ namespace Tests.Linq
 					where fact.Id > 3
 					select new { fact, leftTag };
 
-				var results = t.ToArray();
+				var results = t.OrderBy(_ => _.fact.Id).ToArray();
 
 				Assert.AreEqual(2, results.Length);
 				Assert.AreEqual(4, results[0].fact.Id);

--- a/Tests/Linq/Linq/LoadWithTests.cs
+++ b/Tests/Linq/Linq/LoadWithTests.cs
@@ -520,7 +520,14 @@ namespace Tests.Linq
 					.ThenLoad(ss => ss.ParentSubItem)
 					.LoadWith(m => m.SubItems2);
 				
-				var result = query.ToArray();
+				var result = query.OrderBy(_ => _.Id).ToArray();
+				foreach (var item in result)
+				{
+					item.SubItems1 = item.SubItems1.OrderBy(_ => _.Id).ToArray();
+					item.SubItems2 = item.SubItems2.OrderBy(_ => _.Id).ToArray();
+					foreach (var subItem in item.SubItems1)
+						subItem.SubSubItems = subItem.SubSubItems.OrderBy(_ => _.Id).ToArray();
+				}
 
 				Assert.That(result[0].SubItems1[0].SubSubItems[0].ParentSubItem, Is.Not.Null);
 
@@ -531,7 +538,14 @@ namespace Tests.Linq
 					.LoadWith(m => m.SubItems2, q => q.Where(e => e.Value == e.Value))
 					.ThenLoad(e => e.Parent);
 				
-				var result2 = query2.ToArray();
+				var result2 = query2.OrderBy(_ => _.Id).ToArray();
+				foreach (var item in result2)
+				{
+					item.SubItems1 = item.SubItems1.OrderBy(_ => _.Id).ToArray();
+					item.SubItems2 = item.SubItems2.OrderBy(_ => _.Id).ToArray();
+					foreach (var subItem in item.SubItems1)
+						subItem.SubSubItems = subItem.SubSubItems.OrderBy(_ => _.Id).ToArray();
+				}
 
 				Assert.That(result2[0].SubItems1[0].SubSubItems[0].ParentSubItem, Is.Not.Null);
 				Assert.That(result2[0].SubItems2[0].Parent, Is.Not.Null);
@@ -543,7 +557,14 @@ namespace Tests.Linq
 					.LoadWith(m => m.SubItems2)
 					.ThenLoad(e => e.Parent);
 
-				var result3 = query3.ToArray();
+				var result3 = query3.OrderBy(_ => _.Id).ToArray();
+				foreach (var item in result3)
+				{
+					item.SubItems1 = item.SubItems1.OrderBy(_ => _.Id).ToArray();
+					item.SubItems2 = item.SubItems2.OrderBy(_ => _.Id).ToArray();
+					foreach (var subItem in item.SubItems1)
+						subItem.SubSubItems = subItem.SubSubItems.OrderBy(_ => _.Id).ToArray();
+				}
 
 				Assert.That(result3[0].SubItems1[0].SubSubItems[0].ParentSubItem, Is.Not.Null);
 				Assert.That(result3[0].SubItems2[0].Parent, Is.Not.Null);
@@ -567,35 +588,35 @@ namespace Tests.Linq
 					select m;
 				
 				var query1 = filterQuery
-					.LoadWith(m => m.SubItems1.Where(e => e.ParentId % 2 == 0).Take(2));
+					.LoadWith(m => m.SubItems1.Where(e => e.ParentId % 2 == 0).OrderBy(_ => _.Id).Take(2));
 				
-				var result1 = query1.ToArray();
+				var result1 = query1.OrderBy(_ => _.Id).ToArray();
 				
 				Assert.That(result1[0].SubItems1.Length, Is.GreaterThan(0));
 				
 				
 				var query2 = filterQuery
-					.LoadWith(m => m.SubItems1.Where(e => e.ParentId % 2 == 0).Take(2),
+					.LoadWith(m => m.SubItems1.Where(e => e.ParentId % 2 == 0).OrderBy(_ => _.Id).Take(2),
 						e => e.Where(i => i.Value!.StartsWith("Sub1_")));
 				
-				var result2 = query2.ToArray();
+				var result2 = query2.OrderBy(_ => _.Id).ToArray();
 				
 				Assert.That(result2[0].SubItems1.Length, Is.GreaterThan(0));
 				
 				var query3 = filterQuery
-					.LoadWith(m => m.SubItems1[0].Parent!.SubItems2.Where(e => e.ParentId % 2 == 0).Take(2),
+					.LoadWith(m => m.SubItems1[0].Parent!.SubItems2.Where(e => e.ParentId % 2 == 0).OrderBy(_ => _.Id).Take(2),
 						e => e.Where(i => i.Value!.StartsWith("Sub2_")));
 				
-				var result3 = query3.ToArray();
+				var result3 = query3.OrderBy(_ => _.Id).ToArray();
 				
 				Assert.That(result3[0].SubItems1[0].Parent!.SubItems2.Length, Is.GreaterThan(0));
 				
 				var query3_1 = filterQuery
 					.LoadWith(m => m.SubItems1)
 					.ThenLoad(s => s.Parent)
-					.ThenLoad(p => p!.SubItems2.Where(e => e.ParentId % 2 == 0).Take(2), e => e.Where(i => i.Value!.StartsWith("Sub2_")));
+					.ThenLoad(p => p!.SubItems2.Where(e => e.ParentId % 2 == 0).OrderBy(_ => _.Id).Take(2), e => e.Where(i => i.Value!.StartsWith("Sub2_")));
 				
-				var result3_1 = query3_1.ToArray();
+				var result3_1 = query3_1.OrderBy(_ => _.Id).ToArray();
 				
 				Assert.That(result3_1[0].SubItems1[0].Parent!.SubItems2.Length, Is.GreaterThan(0));
 
@@ -603,7 +624,7 @@ namespace Tests.Linq
 					.LoadWith(m => m.SubItems1.Where(e => e.ParentId % 2 == 0),
 						e => e.Where(i => i.Value!.StartsWith("Sub1_")));
 
-				var result4 = query4.ToArray();
+				var result4 = query4.OrderBy(_ => _.Id).ToArray();
 
 				Assert.That(result4[0].SubItems1.Length, Is.GreaterThan(0));
 

--- a/Tests/Linq/Linq/NullIfTests.cs
+++ b/Tests/Linq/Linq/NullIfTests.cs
@@ -32,7 +32,9 @@ namespace Tests.Linq
 			[DataSources] string context)
 		{
 			using var db  = GetDataContext(context);
-			using var src = SetupSrcTable(db);
+			using var tb = SetupSrcTable(db);
+
+			var src = tb.OrderBy(_ => _.Int);
 
 			var ints = src.Select(s => Sql.NullIf(s.Int, 2)).ToArray();
 			ints[0].Should().Be(null);
@@ -64,7 +66,9 @@ namespace Tests.Linq
 			[DataSources] string context)
 		{
 			using var db  = GetDataContext(context);
-			using var src = SetupSrcTable(db);
+			using var tb = SetupSrcTable(db);
+
+			var src = tb.OrderBy(_ => _.Int);
 
 			var strings = src.Select(s => Sql.NullIf(s.String, "abc")).ToArray();
 			strings[0].Should().Be(null);

--- a/Tests/Linq/Linq/PaginationTests.cs
+++ b/Tests/Linq/Linq/PaginationTests.cs
@@ -89,7 +89,6 @@ namespace Tests.Linq
 			}
 		}
 
-
 		[Test]
 		public void ApplyOrderBy([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
 		{

--- a/Tests/Linq/Linq/SelectTests.cs
+++ b/Tests/Linq/Linq/SelectTests.cs
@@ -922,7 +922,7 @@ namespace Tests.Linq
 					InternalStr = t.StringValue
 				});
 
-				var result = query.Where(x => x.InternalStr != "").ToArray();
+				var result = query.Where(x => x.InternalStr != "").OrderBy(_ => _.Int).ToArray();
 				Assert.That(result[0].InternalStr, Is.EqualTo(Types.First().StringValue));
 			}
 		}
@@ -1121,6 +1121,7 @@ namespace Tests.Linq
 					from c in db.GetTable<ChildEntityObject>().LeftJoin(c => c.Id == m.Id)
 					select new
 					{
+						m.Id,
 						Child1 = c,
 						Child2 = c == null ? null : new ChildEntityObject { Id = c.Id, Value = c.Value },
 						Child3 = c != null ? c : new ChildEntityObject { Id = 4, Value = "Generated" },
@@ -1132,7 +1133,7 @@ namespace Tests.Linq
 							: c
 					};
 
-				var result = query.ToArray();
+				var result = query.OrderBy(_ => _.Id).ToArray();
 
 				Assert.NotNull(result[0].Child1);
 				Assert.IsNull (result[1].Child1);

--- a/Tests/Linq/Linq/TableFunctionTests.cs
+++ b/Tests/Linq/Linq/TableFunctionTests.cs
@@ -113,7 +113,7 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 			{
 				var q =
-					from p in Model.Functions.WithTabLock1<Parent>(db).SchemaName("dbo")
+					from p in Functions.WithTabLock1<Parent>(db).SchemaName("dbo")
 					select p;
 
 				q.ToList();

--- a/Tests/Linq/Linq/TagTests.cs
+++ b/Tests/Linq/Linq/TagTests.cs
@@ -270,7 +270,7 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 			using (var table = db.CreateLocalTable<TestTable>())
 			{
-				table.TagQuery(tag).Update(_ => new TestTable() { Id = 1 });
+				table.TagQuery(tag).Update(_ => new TestTable() { Fd = 1 });
 
 				var commandSql = GetCurrentBaselines();
 

--- a/Tests/Linq/Linq/TakeSkipTests.cs
+++ b/Tests/Linq/Linq/TakeSkipTests.cs
@@ -168,11 +168,11 @@ namespace Tests.Linq
 			using (new ParameterizeTakeSkip(withParameters))
 			using (var db = GetDataContext(context))
 			{
-				AreEqual(Child.Skip(3), db.Child.Skip(3));
+				AreEqual(Child.OrderBy(_ => _.ChildID).Skip(3), db.Child.OrderBy(_ => _.ChildID).Skip(3));
 
 				var currentCacheMissCount = Query<Child>.CacheMissCount;
 
-				AreEqual(Child.Skip(4), db.Child.Skip(4));
+				AreEqual(Child.OrderBy(_ => _.ChildID).Skip(4), db.Child.OrderBy(_ => _.ChildID).Skip(4));
 
 				Assert.That(Query<Child>.CacheMissCount, Is.EqualTo(currentCacheMissCount));
 			}
@@ -184,8 +184,8 @@ namespace Tests.Linq
 			using (new ParameterizeTakeSkip(withParameters))
 			using (var db = GetDataContext(context))
 				AreEqual(
-					(from ch in    Child where ch.ChildID > 3 || ch.ChildID < 4 select ch).Skip(3),
-					(from ch in db.Child where ch.ChildID > 3 || ch.ChildID < 4 select ch).Skip(3));
+					(from ch in    Child where ch.ChildID > 3 || ch.ChildID < 4 select ch).OrderBy(_ => _.ParentID).ThenBy(_ => _.ChildID).Skip(3),
+					(from ch in db.Child where ch.ChildID > 3 || ch.ChildID < 4 select ch).OrderBy(_ => _.ParentID).ThenBy(_ => _.ChildID).Skip(3));
 		}
 
 		[Test]
@@ -195,8 +195,8 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 			{
 				AreEqual(
-					(from ch in    Child where ch.ChildID >= 0 && ch.ChildID <= 100 select ch).Skip(3),
-					(from ch in db.Child where ch.ChildID >= 0 && ch.ChildID <= 100 select ch).Skip(3));
+					(from ch in    Child where ch.ChildID >= 0 && ch.ChildID <= 100 select ch).OrderBy(_ => _.ParentID).ThenBy(_ => _.ChildID).Skip(3),
+					(from ch in db.Child where ch.ChildID >= 0 && ch.ChildID <= 100 select ch).OrderBy(_ => _.ParentID).ThenBy(_ => _.ChildID).Skip(3));
 			}
 		}
 
@@ -230,7 +230,7 @@ namespace Tests.Linq
 			using (new ParameterizeTakeSkip(withParameters))
 			using (var db = GetDataContext(context))
 			{
-				AreEqual(Child.Skip(3), db.Child.Skip(() => 3));
+				AreEqual(Child.OrderBy(_ => _.ChildID).Skip(3), db.Child.OrderBy(_ => _.ChildID).Skip(() => 3));
 			}
 		}
 
@@ -241,7 +241,7 @@ namespace Tests.Linq
 			using (new ParameterizeTakeSkip(withParameters))
 			using (var db = GetDataContext(context))
 			{
-				AreEqual(Child.Skip(n), db.Child.Skip(() => n));
+				AreEqual(Child.OrderBy(_ => _.ChildID).Skip(n), db.Child.OrderBy(_ => _.ChildID).Skip(() => n));
 			}
 		}
 
@@ -566,10 +566,10 @@ namespace Tests.Linq
 			using (new ParameterizeTakeSkip(withParameters))
 			using (var db = GetDataContext(context))
 			{
-				var expected = (from p in Parent where p.ParentID > 1 select p).Skip(1).First();
+				var expected = (from p in Parent where p.ParentID > 1 select p).OrderBy(_ => _.ParentID).Skip(1).First();
 				var result = from p in db.GetTable<Parent>() select p;
 				result = from p in result where p.ParentID > 1 select p;
-				var b = result.Skip(1).First();
+				var b = result.OrderBy(_ => _.ParentID).Skip(1).First();
 
 				Assert.AreEqual(expected, b);
 				CheckTakeGlobalParams(db);
@@ -583,8 +583,8 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 			{
 				Assert.AreEqual(
-					(from p in    Parent where p.ParentID > 1 select p).ElementAt(at),
-					(from p in db.Parent where p.ParentID > 1 select p).ElementAt(at));
+					(from p in    Parent where p.ParentID > 1 select p).OrderBy(_ => _.ParentID).ElementAt(at),
+					(from p in db.Parent where p.ParentID > 1 select p).OrderBy(_ => _.ParentID).ElementAt(at));
 				CheckTakeGlobalParams(db);
 			}
 		}
@@ -596,8 +596,8 @@ namespace Tests.Linq
 			using (new ParameterizeTakeSkip(withParameters))
 			using (var db = GetDataContext(context))
 				Assert.AreEqual(
-					(from p in    Parent where p.ParentID > 1 select p).ElementAt(n),
-					(from p in db.Parent where p.ParentID > 1 select p).ElementAt(() => n));
+					(from p in    Parent where p.ParentID > 1 select p).OrderBy(_ => _.ParentID).ElementAt(n),
+					(from p in db.Parent where p.ParentID > 1 select p).OrderBy(_ => _.ParentID).ElementAt(() => n));
 		}
 
 		[Test]
@@ -608,8 +608,8 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 			{
 				Assert.AreEqual(
-					      (from p in    Parent where p.ParentID > 1 select p).ElementAt(n),
-					await (from p in db.Parent where p.ParentID > 1 select p).ElementAtAsync(() => n));
+					      (from p in    Parent where p.ParentID > 1 select p).OrderBy(_ => _.ParentID).ElementAt(n),
+					await (from p in db.Parent where p.ParentID > 1 select p).OrderBy(_ => _.ParentID).ElementAtAsync(() => n));
 				CheckTakeSkipParameterized(db);
 			}
 		}
@@ -621,8 +621,8 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 			{
 				Assert.AreEqual(
-					(from p in    Parent where p.ParentID > 1 select p).ElementAtOrDefault(3),
-					(from p in db.Parent where p.ParentID > 1 select p).ElementAtOrDefault(3));
+					(from p in    Parent where p.ParentID > 1 select p).OrderBy(_ => _.ParentID).ElementAtOrDefault(3),
+					(from p in db.Parent where p.ParentID > 1 select p).OrderBy(_ => _.ParentID).ElementAtOrDefault(3));
 				CheckTakeGlobalParams(db);
 			}
 		}
@@ -646,8 +646,8 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 			{
 				Assert.AreEqual(
-					(from p in    Parent where p.ParentID > 1 select p).ElementAtOrDefault(n),
-					(from p in db.Parent where p.ParentID > 1 select p).ElementAtOrDefault(() => n));
+					(from p in    Parent where p.ParentID > 1 select p).OrderBy(_ => _.ParentID).ElementAtOrDefault(n),
+					(from p in db.Parent where p.ParentID > 1 select p).OrderBy(_ => _.ParentID).ElementAtOrDefault(() => n));
 				CheckTakeSkipParameterized(db);
 			}
 		}
@@ -660,8 +660,8 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 			{
 				Assert.AreEqual(
-					      (from p in    Parent where p.ParentID > 1 select p).ElementAtOrDefault(n),
-					await (from p in db.Parent where p.ParentID > 1 select p).ElementAtOrDefaultAsync(() => n));
+					      (from p in    Parent where p.ParentID > 1 select p).OrderBy(_ => _.ParentID).ElementAtOrDefault(n),
+					await (from p in db.Parent where p.ParentID > 1 select p).OrderBy(_ => _.ParentID).ElementAtOrDefaultAsync(() => n));
 				CheckTakeSkipParameterized(db);
 			}
 		}
@@ -789,8 +789,13 @@ namespace Tests.Linq
 			{
 				var types = db.Types.ToList();
 
-				var q1 =    types.Concat(   types).Take(15);
+				var q1 = types.Concat(types).Take(15);
 				var q2 = db.Types.Concat(db.Types).Take(15);
+
+				{
+					q1 = q1.OrderBy(_ => _.ID);
+					q2 = q2.OrderBy(_ => _.ID);
+				}
 
 				AreEqual(
 					from e in q1

--- a/Tests/Linq/Linq/TestQueryCache.cs
+++ b/Tests/Linq/Linq/TestQueryCache.cs
@@ -149,7 +149,7 @@ namespace Tests.Linq
 
 			builder.Entity<SampleClass>()
 				.Property(e => e.Id).IsPrimaryKey()
-				.Property(e => e.StrKey).IsPrimaryKey().HasColumnName("Key" + columnName).HasLength(50)
+				.Property(e => e.StrKey).IsNullable(false).IsPrimaryKey().HasColumnName("Key" + columnName).HasLength(50)
 				.Property(e => e.Value).HasColumnName(columnName).HasLength(50);
 
 			builder.Entity<SampleClassWithIdentity>()

--- a/Tests/Linq/Linq/TypesTests.cs
+++ b/Tests/Linq/Linq/TypesTests.cs
@@ -211,29 +211,22 @@ namespace Tests.Linq
 		{
 			using (new DisableBaseline("Server-side guid generation test"))
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
+				db.Types.Insert(() => new LinqDataTypes
 				{
-					db.Types.Delete(_ => _.ID > 1000);
-					db.Types.Insert(() => new LinqDataTypes
-					{
-						ID            = 1001,
-						MoneyValue    = 1001,
-						DateTimeValue = Sql.CurrentTimestamp,
-						BoolValue     = true,
-						GuidValue     = Sql.NewGuid(),
-						BinaryValue   = new Binary(new byte[] { 1 }),
-						SmallIntValue = 1001
-					});
+					ID            = 1001,
+					MoneyValue    = 1001,
+					DateTimeValue = Sql.CurrentTimestamp,
+					BoolValue     = true,
+					GuidValue     = Sql.NewGuid(),
+					BinaryValue   = new Binary(new byte[] { 1 }),
+					SmallIntValue = 1001
+				});
 
-					var guid = db.Types.Single(_ => _.ID == 1001).GuidValue;
+				var guid = db.Types.Single(_ => _.ID == 1001).GuidValue;
 
-					Assert.AreEqual(1001, db.Types.Single(_ => _.GuidValue == guid).ID);
-				}
-				finally
-				{
-					db.Types.Delete(_ => _.ID > 1000);
-				}
+				Assert.AreEqual(1001, db.Types.Single(_ => _.GuidValue == guid).ID);
 			}
 		}
 
@@ -286,6 +279,7 @@ namespace Tests.Linq
 		public void UpdateBinary1([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
 				db.Types
 					.Where(t => t.ID == 1)
@@ -304,6 +298,7 @@ namespace Tests.Linq
 		public void UpdateBinary2([DataSources(ProviderName.SqlCe)] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
 				var ints     = new[] { 1, 2 };
 				var binaries = new[] { new byte[] { 1, 2, 3, 4, 5 }, new byte[] { 5, 4, 3, 2, 1 } };
@@ -530,25 +525,21 @@ namespace Tests.Linq
 			string context)
 		{
 			using (var db = GetDataContext(context))
-			using (new DeletePerson(db))
+			using (new RestoreBaseTables(db))
 			{
 				db.BeginTransaction();
 
-				var id =
-					db.Person
-						.InsertWithIdentity(() => new Person
-						{
-							FirstName = "擊敗奴隸",
-							LastName  = "Юникодкин",
-							Gender    = Gender.Male
-						});
-
-				Assert.NotNull(id);
+				db.Insert(new Person()
+				{
+					ID        = 100,
+					FirstName = "擊敗奴隸",
+					LastName  = "Юникодкин",
+					Gender    = Gender.Male
+				});
 
 				var person = db.Person.Single(p => p.FirstName == "擊敗奴隸" && p.LastName == "Юникодкин");
 
 				Assert.NotNull (person);
-				Assert.AreEqual(id, person.ID);
 				Assert.AreEqual("擊敗奴隸", person.FirstName);
 				Assert.AreEqual("Юникодкин", person.LastName);
 			}
@@ -814,88 +805,82 @@ namespace Tests.Linq
 			var skipId       = context.IsAnyOf(ProviderName.DB2) || context.IsAnyOf(TestProvName.AllSybase) || context.IsAnyOf(ProviderName.SqlCe);
 
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
 				db.InlineParameters = inline;
 
 				var maxID = db.GetTable<AllTypes>().Select(_ => _.ID).Max();
-				try
-				{
-					var real  = float.NaN;
-					var dbl   = double.NaN;
-					if (skipId)
-						db.GetTable<AllTypes>().Insert(() => new AllTypes()
-						{
-							floatDataType  = real,
-							doubleDataType = dbl,
-						});
-					else
-						db.GetTable<AllTypes>().Insert(() => new AllTypes()
-						{
-							ID             = 1000,
-							floatDataType  = real,
-							doubleDataType = dbl,
-						});
-					real = skipFloatInf ? float.NaN : float.NegativeInfinity;
-					dbl  = double.NegativeInfinity;
-					if (skipId)
-						db.GetTable<AllTypes>().Insert(() => new AllTypes()
-						{
-							floatDataType  = real,
-							doubleDataType = dbl,
-						});
-					else
-						db.GetTable<AllTypes>().Insert(() => new AllTypes()
-						{
-							ID             = 1001,
-							floatDataType  = real,
-							doubleDataType = dbl,
-						});
-					real = skipFloatInf ? float.NaN : float.PositiveInfinity;
-					dbl  = double.PositiveInfinity;
-					if (skipId)
-						db.GetTable<AllTypes>().Insert(() => new AllTypes()
-						{
-							floatDataType  = real,
-							doubleDataType = dbl,
-						});
-					else
-						db.GetTable<AllTypes>().Insert(() => new AllTypes()
-						{
-							ID             = 1002,
-							floatDataType  = real,
-							doubleDataType = dbl,
-						});
+				var real  = float.NaN;
+				var dbl   = double.NaN;
+				if (skipId)
+					db.GetTable<AllTypes>().Insert(() => new AllTypes()
+					{
+						floatDataType = real,
+						doubleDataType = dbl,
+					});
+				else
+					db.GetTable<AllTypes>().Insert(() => new AllTypes()
+					{
+						ID             = 1000,
+						floatDataType  = real,
+						doubleDataType = dbl,
+					});
+				real = skipFloatInf ? float.NaN : float.NegativeInfinity;
+				dbl  = double.NegativeInfinity;
+				if (skipId)
+					db.GetTable<AllTypes>().Insert(() => new AllTypes()
+					{
+						floatDataType  = real,
+						doubleDataType = dbl,
+					});
+				else
+					db.GetTable<AllTypes>().Insert(() => new AllTypes()
+					{
+						ID             = 1001,
+						floatDataType  = real,
+						doubleDataType = dbl,
+					});
+				real = skipFloatInf ? float.NaN : float.PositiveInfinity;
+				dbl  = double.PositiveInfinity;
+				if (skipId)
+					db.GetTable<AllTypes>().Insert(() => new AllTypes()
+					{
+						floatDataType  = real,
+						doubleDataType = dbl,
+					});
+				else
+					db.GetTable<AllTypes>().Insert(() => new AllTypes()
+					{
+						ID             = 1002,
+						floatDataType  = real,
+						doubleDataType = dbl,
+					});
 
-					var res = db.GetTable<AllTypes>()
-						.Where(_ => _.ID > maxID)
-						.OrderBy(_ => _.ID)
-						.Select(_ => new { _.floatDataType, _.doubleDataType})
-						.ToArray();
+				var res = db.GetTable<AllTypes>()
+					.Where(_ => _.ID > maxID)
+					.OrderBy(_ => _.ID)
+					.Select(_ => new { _.floatDataType, _.doubleDataType})
+					.ToArray();
 
-					Assert.AreEqual (3   , res.Length);
-					Assert.IsNaN    (res[0].floatDataType);
-					Assert.IsNaN    (res[0].doubleDataType);
+				Assert.AreEqual (3   , res.Length);
+				Assert.IsNaN    (res[0].floatDataType);
+				Assert.IsNaN    (res[0].doubleDataType);
 
-					Assert.IsNotNull(res[1].floatDataType);
-					Assert.IsNotNull(res[1].doubleDataType);
-					if (skipFloatInf)
-						Assert.IsNaN(res[0].floatDataType);
-					else
-						Assert.True     (float.IsNegativeInfinity(res[1].floatDataType!.Value));
-					Assert.True     (double.IsNegativeInfinity(res[1].doubleDataType!.Value));
+				Assert.IsNotNull(res[1].floatDataType);
+				Assert.IsNotNull(res[1].doubleDataType);
+				if (skipFloatInf)
+					Assert.IsNaN(res[0].floatDataType);
+				else
+					Assert.True(float.IsNegativeInfinity(res[1].floatDataType!.Value));
+				Assert.True(double.IsNegativeInfinity(res[1].doubleDataType!.Value));
 
-					Assert.IsNotNull(res[2].floatDataType);
-					Assert.IsNotNull(res[2].doubleDataType);
-					if (skipFloatInf)
-						Assert.IsNaN(res[0].floatDataType);
-					else
-						Assert.True     (float.IsPositiveInfinity(res[2].floatDataType!.Value));
-					Assert.True     (double.IsPositiveInfinity(res[2].doubleDataType!.Value));
-				}
-				finally
-				{
-					db.GetTable<AllTypes>().Where(_ => _.ID > maxID).Delete();
-				}
+				Assert.IsNotNull(res[2].floatDataType);
+				Assert.IsNotNull(res[2].doubleDataType);
+				if (skipFloatInf)
+					Assert.IsNaN(res[0].floatDataType);
+				else
+					Assert.True     (float.IsPositiveInfinity(res[2].floatDataType!.Value));
+				Assert.True     (double.IsPositiveInfinity(res[2].doubleDataType!.Value));
 			}
 		}
 

--- a/Tests/Linq/Linq/ValueConversionTests.cs
+++ b/Tests/Linq/Linq/ValueConversionTests.cs
@@ -175,7 +175,7 @@ namespace Tests.Linq
 			using (var table = db.CreateLocalTable(testData))
 			{
 				// Table Materialization
-				var result = table.ToArray();
+				var result = table.OrderBy(_ => _.Id).ToArray();
 
 				Assert.That(result[0].Value1, Is.Not.Null);
 				Assert.That(result[0].Value2!.Count, Is.GreaterThan(0));
@@ -216,17 +216,17 @@ namespace Tests.Linq
 						t.Value2,
 					};
 
-				var selectResult = query.ToArray();
+				var selectResult = query.OrderBy(_ => _.Id).ToArray();
 
 				Assert.That(selectResult[0].Value1, Is.Not.Null);
 				Assert.That(selectResult[0].Value2!.Count, Is.GreaterThan(0));
 				
-				var subqueryResult = query.AsSubQuery().ToArray();
+				var subqueryResult = query.AsSubQuery().OrderBy(_ => _.Id).ToArray();
 				
 				Assert.That(subqueryResult[0].Value1, Is.Not.Null);
 				Assert.That(subqueryResult[0].Value2!.Count, Is.GreaterThan(0));
 
-				var unionResult = query.Concat(query.AsSubQuery()).ToArray();
+				var unionResult = query.Concat(query.AsSubQuery()).OrderBy(_ => _.Id).ToArray();
 
 				var firstItem = unionResult.First();
 				Assert.That(firstItem.Value1, Is.Not.Null);

--- a/Tests/Linq/Linq/WhereTests.cs
+++ b/Tests/Linq/Linq/WhereTests.cs
@@ -1199,8 +1199,7 @@ namespace Tests.Linq
 					from p in Types
 					select new { Value = Math.Round(p.MoneyValue, 2) } into pp
 					where pp.Value != 0 && pp.Value != 7
-					select pp.Value
-					,
+					select pp.Value,
 					q);
 			}
 		}
@@ -1322,7 +1321,6 @@ namespace Tests.Linq
 			}
 		}
 
-
 		[Test]
 		public void WhereDateTimeTest1([DataSources] string context)
 		{
@@ -1337,7 +1335,6 @@ namespace Tests.Linq
 						.Select(_ => _));
 			}
 		}
-
 
 		[Test]
 		public void WhereDateTimeTest2([DataSources] string context)
@@ -1665,9 +1662,8 @@ namespace Tests.Linq
 		public void ExistsSqlTest1([DataSources(false)] string context)
 		{
 			using (var db = GetDataConnection(context))
-			using (db.BeginTransaction())
 			{
-				db.Parent.Where(p => db.Child.Select(c => c.ParentID).Contains(p.ParentID)).Delete();
+				db.Parent.Where(p => db.Child.Select(c => c.ParentID).Contains(p.ParentID + 100)).Delete();
 
 				Assert.False(db.LastQuery!.ToLower().Contains("iif(exists(") || db.LastQuery!.ToLower().Contains("when exists("));
 			}
@@ -1677,9 +1673,8 @@ namespace Tests.Linq
 		public void ExistsSqlTest2([DataSources(false)] string context)
 		{
 			using (var db = GetDataConnection(context))
-			using (db.BeginTransaction())
 			{
-				db.Parent.Where(p => p.Children.Any()).Delete();
+				db.Parent.Where(p => p.Children.Any() && p.ParentID > 100).Delete();
 
 				Assert.False(db.LastQuery!.ToLower().Contains("iif(exists(") || db.LastQuery!.ToLower().Contains("when exists("));
 			}
@@ -1694,7 +1689,6 @@ namespace Tests.Linq
 		public void OptionalObjectInCondition([DataSources(false)] string context)
 		{
 			using (var db = GetDataConnection(context))
-			using (db.BeginTransaction())
 			{
 				var p  = new Parameter() { Id = 1};
 				db.Person.Where(r => r.FirstName == (p != null ? p.Id.ToString() : null)).ToList();

--- a/Tests/Linq/Mapping/MappingAmbiguityTests.cs
+++ b/Tests/Linq/Mapping/MappingAmbiguityTests.cs
@@ -43,7 +43,7 @@ namespace Tests.Mapping
 			{
 				var sql = db.LastQuery!;
 
-				Assert.AreEqual(sql.Replace("\r", ""), @"CREATE TABLE [TestTable]
+				Assert.AreEqual(@"CREATE TABLE IF NOT EXISTS [TestTable]
 (
 	[ID]      INTEGER       NOT NULL,
 	[Field1]  INTEGER       NOT NULL,
@@ -55,7 +55,7 @@ namespace Tests.Mapping
 
 	CONSTRAINT [PK_TestTable] PRIMARY KEY ([ID])
 )
-".Replace("\r", ""));
+".Replace("\r", ""), sql.Replace("\r", ""));
 			}
 		}
 

--- a/Tests/Linq/Update/BulkCopyTests.cs
+++ b/Tests/Linq/Update/BulkCopyTests.cs
@@ -50,9 +50,9 @@ namespace Tests.xUpdate
 		[Test]
 		public async Task KeepIdentity_SkipOnInsertTrue(
 			[DataSources(false)]string context,
-			[Values(null, true, false)]bool? keepIdentity,
-			[Values] BulkCopyType copyType,
-			[Values(0, 1, 2)] int asyncMode) // 0 == sync, 1 == async, 2 == async with IAsyncEnumerable
+			[Values(null, true, false)                     ] bool? keepIdentity,
+			[Values                                        ] BulkCopyType copyType,
+			[Values(0, 1, 2)                               ] int asyncMode) // 0 == sync, 1 == async, 2 == async with IAsyncEnumerable
 		{
 			if ((context == ProviderName.Sybase) && copyType == BulkCopyType.ProviderSpecific && keepIdentity != true)
 				Assert.Inconclusive("Sybase native bulk copy doesn't support identity insert (despite documentation)");
@@ -105,12 +105,12 @@ namespace Tests.xUpdate
 									Value = 300
 								}
 							};
-						if (asyncMode == 0) // synchronous 
+						if (asyncMode == 0) // synchronous
 						{
 							db.BulkCopy(
 								options,
 								values);
-						} 
+						}
 						else if (asyncMode == 1) // asynchronous
 						{
 							await db.BulkCopyAsync(
@@ -267,38 +267,39 @@ namespace Tests.xUpdate
 			return true;
 		}
 
-		// DB2: 
+		// DB2:
 		[Test]
 		public void ReuseOptionTest([DataSources(false, ProviderName.DB2)] string context)
 		{
 			using (var db = GetDataConnection(context))
+			using (new RestoreBaseTables(db))
 			using (db.BeginTransaction())
 			{
 				var options = new BulkCopyOptions();
 
 				db.Parent.BulkCopy(options, new[] { new Parent { ParentID = 111001 } });
-				db.Child. BulkCopy(options, new[] { new Child  { ParentID = 111001 } });
+				db.Child .BulkCopy(options, new[] { new Child { ParentID = 111001 } });
 			}
 		}
-		
+
 		[Test]
 		public void UseParametersTest([DataSources(false)] string context)
 		{
 			using (var db = new TestDataConnection(context))
 			using (db.BeginTransaction())
-			{
-				var options = new BulkCopyOptions(){ UseParameters = true, MaxBatchSize = 50, BulkCopyType = BulkCopyType.MultipleRows };
-				var start   = 111001;
+		{
+			var options = new BulkCopyOptions(){ UseParameters = true, MaxBatchSize = 50, BulkCopyType = BulkCopyType.MultipleRows };
+			var start   = 111001;
 
-				var rowsToInsert = Enumerable.Range(start, 149)
-					.Select(r => new Parent() {ParentID = r, Value1 = r-start}).ToList();
+			var rowsToInsert = Enumerable.Range(start, 149)
+				.Select(r => new Parent() {ParentID = r, Value1 = r-start}).ToList();
 
-				db.Parent.BulkCopy(options, rowsToInsert);
+			db.Parent.BulkCopy(options, rowsToInsert);
 
-				Assert.AreEqual(rowsToInsert.Count,
-					db.Parent.Where(r =>
-						r.ParentID >= rowsToInsert[0].ParentID && r.ParentID <= rowsToInsert.Last().ParentID).Count());
-			}
+			Assert.AreEqual(rowsToInsert.Count,
+				db.Parent.Where(r =>
+					r.ParentID >= rowsToInsert[0].ParentID && r.ParentID <= rowsToInsert.Last().ParentID).Count());
+		}
 		}
 
 		[Table]
@@ -391,16 +392,16 @@ namespace Tests.xUpdate
 
 			[Column(Length = 50)]
 			public string? Value1 { get; set; }
-		}		
-		
+		}
+
 		class Inherited2 : BaseClass
 		{
 			public override int Discriminator => 2;
 
 			[Column(Length = 50)]
 			public string? Value2 { get; set; }
-		}		
-		
+		}
+
 		class Inherited3 : BaseClass
 		{
 			public override int Discriminator => 3;
@@ -412,7 +413,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public void BulcopyTPH(
+		public void BulkCopyTPH(
 			[DataSources(false)] string context,
 			[Values] BulkCopyType copyType)
 		{
@@ -437,7 +438,7 @@ namespace Tests.xUpdate
 			{
 				table.BulkCopy(new BulkCopyOptions { BulkCopyType = copyType }, data);
 
-				var items = table.ToArray();
+				var items = table.OrderBy(_ => _.Id).ToArray();
 
 				items[0].Id.Should().Be(1);
 				items[0].Discriminator.Should().Be(1);
@@ -458,7 +459,6 @@ namespace Tests.xUpdate
 				table.Single(x => ((Inherited1)x).Value1 == "Str1").Should().BeOfType(typeof(Inherited1));
 				table.Single(x => ((Inherited2)x).Value2 == "Str2").Should().BeOfType(typeof(Inherited2));
 				table.Single(x => ((Inherited3)x).Value3 == "Str3").Should().BeOfType(typeof(Inherited3));
-
 			}
 		}
 
@@ -479,14 +479,14 @@ namespace Tests.xUpdate
 		{
 			[Column(Length = 50)]
 			public string? Value1 { get; set; }
-		}		
-		
+		}
+
 		class InheritedDefault2 : BaseDefaultDiscriminator
 		{
 			[Column(Length = 50)]
 			public string? Value2 { get; set; }
-		}		
-		
+		}
+
 		class InheritedDefault3 : BaseDefaultDiscriminator
 		{
 			[Column(Length = 50)]
@@ -494,7 +494,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public void BulcopyTPHDefault(
+		public void BulkCopyTPHDefault(
 			[IncludeDataSources(false, TestProvName.AllSQLite)] string context,
 			[Values] BulkCopyType copyType)
 		{
@@ -510,7 +510,7 @@ namespace Tests.xUpdate
 			{
 				table.BulkCopy(new BulkCopyOptions { BulkCopyType = copyType }, data);
 
-				var items = table.ToArray();
+				var items = table.OrderBy(_ => _.Id).ToArray();
 
 				items[0].Id.Should().Be(1);
 				items[0].Discriminator.Should().Be(1);
@@ -533,7 +533,5 @@ namespace Tests.xUpdate
 				table.Single(x => ((InheritedDefault3)x).Value3 == "Str3").Should().BeOfType(typeof(InheritedDefault3));
 			}
 		}
-
-
 	}
 }

--- a/Tests/Linq/Update/DeleteTests.cs
+++ b/Tests/Linq/Update/DeleteTests.cs
@@ -22,22 +22,17 @@ namespace Tests.xUpdate
 		public void Delete1([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
 				var parent = new Parent1 { ParentID = 1001, Value1 = 1001 };
 
 				db.Delete(parent);
 				db.Insert(parent);
 
-				try
-				{
-					Assert.AreEqual(1, db.Parent.Count (p => p.ParentID == parent.ParentID));
-					Assert.AreEqual(1, db.Parent.Delete(p => p.ParentID == parent.ParentID));
-					Assert.AreEqual(0, db.Parent.Count (p => p.ParentID == parent.ParentID));
-				}
-				finally
-				{
-					db.Delete(parent);
-				}
+				Assert.AreEqual(1, db.Parent.Count (p => p.ParentID == parent.ParentID));
+				var cnt = db.Parent.Delete(p => p.ParentID == parent.ParentID);
+					Assert.AreEqual(1, cnt);
+				Assert.AreEqual(0, db.Parent.Count (p => p.ParentID == parent.ParentID));
 			}
 		}
 
@@ -45,22 +40,17 @@ namespace Tests.xUpdate
 		public void Delete2([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
 				var parent = new Parent1 { ParentID = 1001, Value1 = 1001 };
 
 				db.Delete(parent);
 				db.Insert(parent);
 
-				try
-				{
-					Assert.AreEqual(1, db.Parent.Count(p => p.ParentID == parent.ParentID));
-					Assert.AreEqual(1, db.Parent.Where(p => p.ParentID == parent.ParentID).Delete());
-					Assert.AreEqual(0, db.Parent.Count(p => p.ParentID == parent.ParentID));
-				}
-				finally
-				{
-					db.Delete(parent);
-				}
+				Assert.AreEqual(1, db.Parent.Count(p => p.ParentID == parent.ParentID));
+				var cnt = db.Parent.Where(p => p.ParentID == parent.ParentID).Delete();
+					Assert.AreEqual(1, cnt);
+				Assert.AreEqual(0, db.Parent.Count(p => p.ParentID == parent.ParentID));
 			}
 		}
 
@@ -68,22 +58,16 @@ namespace Tests.xUpdate
 		public void Delete3([DataSources(TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
-				{
-					db.Child.Delete(c => new[] { 1001, 1002 }.Contains(c.ChildID));
+				db.Child.Delete(c => new[] { 1001, 1002 }.Contains(c.ChildID));
 
-					db.Child.Insert(() => new Child { ParentID = 1, ChildID = 1001 });
-					db.Child.Insert(() => new Child { ParentID = 1, ChildID = 1002 });
+				db.Child.Insert(() => new Child { ParentID = 1, ChildID = 1001 });
+				db.Child.Insert(() => new Child { ParentID = 1, ChildID = 1002 });
 
-					Assert.AreEqual(3, db.Child.Count(c => c.ParentID == 1));
-					Assert.AreEqual(2, db.Child.Where(c => c.Parent!.ParentID == 1 && new[] { 1001, 1002 }.Contains(c.ChildID)).Delete());
-					Assert.AreEqual(1, db.Child.Count(c => c.ParentID == 1));
-				}
-				finally
-				{
-					db.Child.Delete(c => new[] { 1001, 1002 }.Contains(c.ChildID));
-				}
+				Assert.AreEqual(3, db.Child.Count(c => c.ParentID == 1));
+				Assert.AreEqual(2, db.Child.Where(c => c.Parent!.ParentID == 1 && new[] { 1001, 1002 }.Contains(c.ChildID)).Delete());
+				Assert.AreEqual(1, db.Child.Count(c => c.ParentID == 1));
 			}
 		}
 
@@ -91,22 +75,16 @@ namespace Tests.xUpdate
 		public void Delete4([DataSources(TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
-				{
-					db.GrandChild1.Delete(gc => new[] { 1001, 1002 }.Contains(gc.GrandChildID!.Value));
+				db.GrandChild1.Delete(gc => new[] { 1001, 1002 }.Contains(gc.GrandChildID!.Value));
 
-					db.GrandChild.Insert(() => new GrandChild { ParentID = 1, ChildID = 1, GrandChildID = 1001 });
-					db.GrandChild.Insert(() => new GrandChild { ParentID = 1, ChildID = 2, GrandChildID = 1002 });
+				db.GrandChild.Insert(() => new GrandChild { ParentID = 1, ChildID = 1, GrandChildID = 1001 });
+				db.GrandChild.Insert(() => new GrandChild { ParentID = 1, ChildID = 2, GrandChildID = 1002 });
 
-					Assert.AreEqual(3, db.GrandChild1.Count(gc => gc.ParentID == 1));
-					Assert.AreEqual(2, db.GrandChild1.Where(gc => gc.Parent!.ParentID == 1 && new[] { 1001, 1002 }.Contains(gc.GrandChildID!.Value)).Delete());
-					Assert.AreEqual(1, db.GrandChild1.Count(gc => gc.ParentID == 1));
-				}
-				finally
-				{
-					db.GrandChild1.Delete(gc => new[] { 1001, 1002 }.Contains(gc.GrandChildID!.Value));
-				}
+				Assert.AreEqual(3, db.GrandChild1.Count(gc => gc.ParentID == 1));
+				Assert.AreEqual(2, db.GrandChild1.Where(gc => gc.Parent!.ParentID == 1 && new[] { 1001, 1002 }.Contains(gc.GrandChildID!.Value)).Delete());
+				Assert.AreEqual(1, db.GrandChild1.Count(gc => gc.ParentID == 1));
 			}
 		}
 
@@ -129,7 +107,8 @@ namespace Tests.xUpdate
 					db.Parent.Insert(() => new Parent { ParentID = values[1], Value1 = 1 });
 
 					Assert.AreEqual(2, db.Parent.Count(_ => _.ParentID > 1000));
-					Assert.AreEqual(2, db.Parent.Delete(_ => values.Contains(_.ParentID)));
+					var cnt = db.Parent.Delete(_ => values.Contains(_.ParentID));
+						Assert.AreEqual(2, cnt);
 					Assert.AreEqual(0, db.Parent.Count(_ => _.ParentID > 1000));
 				}
 			}
@@ -414,29 +393,19 @@ namespace Tests.xUpdate
 		public void ContainsJoin1([DataSources(false, TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataConnection(context))
+			using (new RestoreBaseTables(db))
 			{
-				db.Child. Delete(c => c.ParentID >= 1000);
-				db.Parent.Delete(c => c.ParentID >= 1000);
+				var id = 1000;
 
-				try
-				{
-					var id = 1000;
+				db.Insert(new Parent { ParentID = id });
 
-					db.Insert(new Parent { ParentID = id });
+				for (var i = 0; i < 3; i++)
+					db.Insert(new Child { ParentID = id, ChildID = 1000 + i });
 
-					for (var i = 0; i < 3; i++)
-						db.Insert(new Child { ParentID = id, ChildID = 1000 + i });
+				var sql1 = ContainsJoin1Impl(db, new [] { 1000, 1001 });
+				var sql2 = ContainsJoin1Impl(db, new [] { 1002       });
 
-					var sql1 = ContainsJoin1Impl(db, new [] { 1000, 1001 });
-					var sql2 = ContainsJoin1Impl(db, new [] { 1002       });
-
-					Assert.That(sql1, Is.Not.EqualTo(sql2));
-				}
-				finally
-				{
-					db.Child. Delete(c => c.ParentID >= 1000);
-					db.Parent.Delete(c => c.ParentID >= 1000);
-				}
+				Assert.That(sql1, Is.Not.EqualTo(sql2));
 			}
 		}
 
@@ -455,7 +424,7 @@ namespace Tests.xUpdate
 
 					var ret = db.Parent.Delete(p => list.Contains(p) );
 
-					Assert.That(ret, Is.EqualTo(2));
+						Assert.That(ret, Is.EqualTo(2));
 				}
 				finally
 				{

--- a/Tests/Linq/Update/DeleteWithOutputTests.cs
+++ b/Tests/Linq/Update/DeleteWithOutputTests.cs
@@ -15,7 +15,7 @@ namespace Tests.xUpdate
 	{
 		private const string FeatureDeleteOutputMultiple = $"{TestProvName.AllSqlServer},{TestProvName.AllMariaDB},{TestProvName.AllPostgreSQL},{TestProvName.AllSQLiteClassic}";
 		private const string FeatureDeleteOutputSingle   = $"{TestProvName.AllSqlServer},{TestProvName.AllFirebird},{TestProvName.AllMariaDB},{TestProvName.AllPostgreSQL},{TestProvName.AllSQLiteClassic}";
-		private const string FeatureDeleteOutputInto     = TestProvName.AllSqlServer;
+		private const string FeatureDeleteOutputInto     = $"{TestProvName.AllSqlServer}";
 
 		[Table]
 		class TableWithData

--- a/Tests/Linq/Update/DynamicColumnsTests.cs
+++ b/Tests/Linq/Update/DynamicColumnsTests.cs
@@ -22,25 +22,18 @@ namespace Tests.xUpdate
 		public void InsertViaSqlProperty([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
-				{
-					var id = 1001;
+				var id = 1001;
 
-					db.Child.Delete(c => Sql.Property<int>(c, ChildIDColumn) > 1000);
+				var cnt = db
+					.Into(db.Child)
+					.Value(c => Sql.Property<int>(c, ParentIDColumn), () => 1)
+					.Value(c => Sql.Property<int>(c, ChildIDColumn), () => id)
+					.Insert();
+					Assert.AreEqual(1, cnt);
 
-					Assert.AreEqual(1,
-						db
-							.Into(db.Child)
-							.Value(c => Sql.Property<int>(c, ParentIDColumn), () => 1)
-							.Value(c => Sql.Property<int>(c, ChildIDColumn), () => id)
-							.Insert());
-					Assert.AreEqual(1, db.Child.Count(c => Sql.Property<int>(c, ChildIDColumn) == id));
-				}
-				finally
-				{
-					db.Child.Delete(c => Sql.Property<int>(c, ChildIDColumn) > 1000);
-				}
+				Assert.AreEqual(1, db.Child.Count(c => Sql.Property<int>(c, ChildIDColumn) == id));
 			}
 		}
 
@@ -48,26 +41,20 @@ namespace Tests.xUpdate
 		public void UpdateViaSqlProperty([DataSources(TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
-				{
-					var id = 1001;
+				var id = 1001;
 
-					db.Child.Delete(c => Sql.Property<int>(c, ChildIDColumn) > 1000);
-					db.Child.Insert(() => new Child { ParentID = 1, ChildID = id });
+				db.Child.Insert(() => new Child { ParentID = 1, ChildID = id });
 
-					Assert.AreEqual(1, db.Child.Count(c => Sql.Property<int>(c, ChildIDColumn) == id));
-					Assert.AreEqual(1,
-						db.Child
-							.Where(c => Sql.Property<int>(c, ChildIDColumn) == id && Sql.Property<int?>(Sql.Property<Parent>(c, "Parent"), "Value1") == 1)
-							.Set(c => Sql.Property<int>(c, ChildIDColumn), c => Sql.Property<int>(c, ChildIDColumn) + 1)
-							.Update());
-					Assert.AreEqual(1, db.Child.Count(c => Sql.Property<int>(c, ChildIDColumn) == id + 1));
-				}
-				finally
-				{
-					db.Child.Delete(c => Sql.Property<int>(c, ChildIDColumn) > 1000);
-				}
+				Assert.AreEqual(1, db.Child.Count(c => Sql.Property<int>(c, ChildIDColumn) == id));
+				var cnt = db.Child
+						.Where(c => Sql.Property<int>(c, ChildIDColumn) == id && Sql.Property<int?>(Sql.Property<Parent>(c, "Parent"), "Value1") == 1)
+						.Set(c => Sql.Property<int>(c, ChildIDColumn), c => Sql.Property<int>(c, ChildIDColumn) + 1)
+						.Update();
+				Assert.AreEqual(1, cnt);
+
+				Assert.AreEqual(1, db.Child.Count(c => Sql.Property<int>(c, ChildIDColumn) == id + 1));
 			}
 		}
 
@@ -75,26 +62,20 @@ namespace Tests.xUpdate
 		public void UpdateViaSqlPropertyValue([DataSources(TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
-				{
-					var id = 1001;
+				var id = 1001;
 
-					db.Child.Delete(c => Sql.Property<int>(c, ChildIDColumn) > 1000);
-					db.Child.Insert(() => new Child { ParentID = 1, ChildID = id });
+				db.Child.Insert(() => new Child { ParentID = 1, ChildID = id });
 
-					Assert.AreEqual(1, db.Child.Count(c => Sql.Property<int>(c, ChildIDColumn) == id));
-					Assert.AreEqual(1,
-						db.Child
-							.Where(c => Sql.Property<int>(c, ChildIDColumn) == id && Sql.Property<int?>(Sql.Property<Parent>(c, "Parent"), "Value1") == 1)
-							.Set(c => Sql.Property<int>(c, ChildIDColumn), 5000)
-							.Update());
-					Assert.AreEqual(1, db.Child.Count(c => Sql.Property<int>(c, ChildIDColumn) == 5000));
-				}
-				finally
-				{
-					db.Child.Delete(c => Sql.Property<int>(c, ChildIDColumn) > 1000);
-				}
+				Assert.AreEqual(1, db.Child.Count(c => Sql.Property<int>(c, ChildIDColumn) == id));
+				var cnt = db.Child
+						.Where(c => Sql.Property<int>(c, ChildIDColumn) == id && Sql.Property<int?>(Sql.Property<Parent>(c, "Parent"), "Value1") == 1)
+						.Set(c => Sql.Property<int>(c, ChildIDColumn), 5000)
+						.Update();
+				Assert.AreEqual(1, cnt);
+
+				Assert.AreEqual(1, db.Child.Count(c => Sql.Property<int>(c, ChildIDColumn) == 5000));
 			}
 		}
 
@@ -103,26 +84,22 @@ namespace Tests.xUpdate
 		{
 			var firstNameColumn = "FirstName";
 			var lastNameColumn  = "LastName";
+
 			using (var db = GetDataContext(context, ConfigureDynamicMyClass()))
+			using (new RestoreBaseTables(db))
 			{
-				try
-				{
-					Assert.AreEqual(1,
-						db
-							.GetTable<MyClass>()
-							.Value(c => Sql.Property<string>(c, firstNameColumn), () => "John")
-							.Value(c => Sql.Property<string>(c, lastNameColumn), () => "The Dynamic")
-							.Value(c => Sql.Property<Gender>(c, "Gender"), () => Gender.Male)
-							.Insert());
-					Assert.AreEqual(1,
-						db.GetTable<MyClass>().Count(c =>
-							Sql.Property<string>(c, firstNameColumn) == "John" &&
-							Sql.Property<string>(c, lastNameColumn) == "The Dynamic"));
-				}
-				finally
-				{
-					db.GetTable<MyClass>().Delete(c => Sql.Property<string>(c, lastNameColumn) == "The Dynamic");
-				}
+				var cnt = db
+					.GetTable<MyClass>()
+					.Value(c => Sql.Property<string>(c, firstNameColumn), () => "John")
+					.Value(c => Sql.Property<string>(c, lastNameColumn), () => "The Dynamic")
+					.Value(c => Sql.Property<Gender>(c, "Gender"), () => Gender.Male)
+					.Insert();
+					Assert.AreEqual(1, cnt);
+
+				Assert.AreEqual(1,
+					db.GetTable<MyClass>().Count(c =>
+						Sql.Property<string>(c, firstNameColumn) == "John" &&
+						Sql.Property<string>(c, lastNameColumn) == "The Dynamic"));
 			}
 		}
 
@@ -130,27 +107,23 @@ namespace Tests.xUpdate
 		public void UpdateDynamicColumn([DataSources(TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataContext(context, ConfigureDynamicMyClass()))
+			using (new RestoreBaseTables(db))
 			{
-				try
-				{
-					db.GetTable<MyClass>()
-						.Value(c => Sql.Property<string>(c, "FirstName"), () => "John")
-						.Value(c => Sql.Property<string>(c, "LastName"), () => "Limonadovy")
-						.Value(c => Sql.Property<Gender>(c, "Gender"), () => Gender.Male)
-						.Insert();
+				db.GetTable<MyClass>()
+					.Value(c => Sql.Property<string>(c, "FirstName"), () => "John")
+					.Value(c => Sql.Property<string>(c, "LastName"), () => "Limonadovy")
+					.Value(c => Sql.Property<Gender>(c, "Gender"), () => Gender.Male)
+					.Insert();
 
-					Assert.AreEqual(1, db.GetTable<MyClass>().Count(c => Sql.Property<string>(c, "LastName") == "Limonadovy"));
-					Assert.AreEqual(1,
-						db.GetTable<MyClass>()
-							.Where(c => Sql.Property<string>(c, "LastName") == "Limonadovy")
-							.Set(c => Sql.Property<string>(c, "FirstName"), () => "Johnny")
-							.Update());
-					Assert.AreEqual(1, db.GetTable<MyClass>().Count(c => Sql.Property<string>(c, "FirstName") == "Johnny" && Sql.Property<string>(c, "LastName") == "Limonadovy"));
-				}
-				finally
-				{
-					db.GetTable<MyClass>().Delete(c => Sql.Property<string>(c, "LastName") == "Limonadovy");
-				}
+				Assert.AreEqual(1, db.GetTable<MyClass>().Count(c => Sql.Property<string>(c, "LastName") == "Limonadovy"));
+
+				var cnt = db.GetTable<MyClass>()
+						.Where(c => Sql.Property<string>(c, "LastName") == "Limonadovy")
+						.Set(c => Sql.Property<string>(c, "FirstName"), () => "Johnny")
+						.Update();
+					Assert.AreEqual(1, cnt);
+
+				Assert.AreEqual(1, db.GetTable<MyClass>().Count(c => Sql.Property<string>(c, "FirstName") == "Johnny" && Sql.Property<string>(c, "LastName") == "Limonadovy"));
 			}
 		}
 

--- a/Tests/Linq/Update/InsertTests.cs
+++ b/Tests/Linq/Update/InsertTests.cs
@@ -45,18 +45,20 @@ namespace Tests.xUpdate
 				{
 					db.Types.Delete(c => c.ID > 1000);
 
-					Assert.AreEqual(
-						Types.Select(_ => _.ID / 3).Distinct().Count(),
-						db
-							.Types
-							.Select(_ => Math.Floor(_.ID / 3.0))
-							.Distinct()
-							.Insert(db.Types, _ => new LinqDataTypes
-							{
-								ID        = (int)(_ + 1001),
-								GuidValue = Sql.NewGuid(),
-								BoolValue = true
-							}));
+					var cnt = db
+						.Types
+						.Select(_ => Math.Floor(_.ID / 3.0))
+						.Distinct()
+						.Insert(db.Types, _ => new LinqDataTypes
+						{
+							ID        = (int)(_ + 1001),
+							GuidValue = Sql.NewGuid(),
+							BoolValue = true
+						});
+
+						Assert.AreEqual(
+							Types.Select(_ => _.ID / 3).Distinct().Count(),
+							cnt);
 				}
 				finally
 				{
@@ -84,16 +86,18 @@ namespace Tests.xUpdate
 				{
 					db.Types.Delete(c => c.ID > 1000);
 
-					Assert.AreEqual(
-						Types.Select(_ => _.ID / 3).Distinct().Count(),
-						db.Types
-							.Select(_ => Math.Floor(_.ID / 3.0))
-							.Distinct()
-							.Into(db.Types)
-								.Value(t => t.ID,        t => (int)(t + 1001))
-								.Value(t => t.GuidValue, t => Sql.NewGuid())
-								.Value(t => t.BoolValue, t => true)
-							.Insert());
+					var cnt = db.Types
+						.Select(_ => Math.Floor(_.ID / 3.0))
+						.Distinct()
+						.Into(db.Types)
+							.Value(t => t.ID,        t => (int)(t + 1001))
+							.Value(t => t.GuidValue, t => Sql.NewGuid())
+							.Value(t => t.BoolValue, t => true)
+						.Insert();
+
+						Assert.AreEqual(
+							Types.Select(_ => _.ID / 3).Distinct().Count(),
+							cnt);
 				}
 				finally
 				{
@@ -113,13 +117,13 @@ namespace Tests.xUpdate
 
 					db.Child.Delete(c => c.ChildID > 1000);
 
-					Assert.AreEqual(1,
-						db.Child
+					var cnt = db.Child
 						.Insert(() => new Child
 						{
 							ParentID = 1,
 							ChildID  = id
-						}));
+						});
+						Assert.AreEqual(1, cnt);
 
 					Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id));
 				}
@@ -141,12 +145,13 @@ namespace Tests.xUpdate
 
 					db.Child.Delete(c => c.ChildID > 1000);
 
-					Assert.AreEqual(1,
-						db
+					var cnt = db
 							.Into(db.Child)
 								.Value(c => c.ParentID, () => 1)
 								.Value(c => c.ChildID,  () => id)
-							.Insert());
+							.Insert();
+						Assert.AreEqual(1, cnt);
+
 					Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id));
 				}
 				finally
@@ -167,12 +172,13 @@ namespace Tests.xUpdate
 
 					await db.Child.DeleteAsync(c => c.ChildID > 1000);
 
-					Assert.AreEqual(1,
-						await db
+					var cnt = await db
 							.Into(db.Child)
 								.Value(c => c.ParentID, () => 1)
 								.Value(c => c.ChildID,  () => id)
-							.InsertAsync());
+							.InsertAsync();
+						Assert.AreEqual(1, cnt);
+
 					Assert.AreEqual(1, await db.Child.CountAsync(c => c.ChildID == id));
 				}
 				finally
@@ -193,14 +199,15 @@ namespace Tests.xUpdate
 
 					db.Child.Delete(c => c.ChildID > 1000);
 
-					Assert.AreEqual(1,
-						db.Child
+					var cnt = db.Child
 							.Where(c => c.ChildID == 11)
 							.Insert(db.Child, c => new Child
 							{
 								ParentID = c.ParentID,
 								ChildID  = id
-							}));
+							});
+						Assert.AreEqual(1, cnt);
+
 					Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id));
 				}
 				finally
@@ -221,14 +228,15 @@ namespace Tests.xUpdate
 
 					await db.Child.DeleteAsync(c => c.ChildID > 1000);
 
-					Assert.AreEqual(1,
-						await db.Child
+					var cnt = await db.Child
 							.Where(c => c.ChildID == 11)
 							.InsertAsync(db.Child, c => new Child
 							{
 								ParentID = c.ParentID,
 								ChildID  = id
-							}));
+							});
+						Assert.AreEqual(1, cnt);
+
 					Assert.AreEqual(1, await db.Child.CountAsync(c => c.ChildID == id));
 				}
 				finally
@@ -249,15 +257,16 @@ namespace Tests.xUpdate
 
 					db.Child.Delete(c => c.ChildID > 1000);
 
-					Assert.AreEqual(1,
-						db.Child
-							.Where(c => c.ChildID == 11)
-							.Select(c => new Child
-							{
-								ParentID = c.ParentID,
-								ChildID  = id
-							})
-							.Insert(db.Child, c => c));
+					var cnt = db.Child
+						.Where(c => c.ChildID == 11)
+						.Select(c => new Child
+						{
+							ParentID = c.ParentID,
+							ChildID  = id
+						})
+						.Insert(db.Child, c => c);
+						Assert.AreEqual(1, cnt);
+
 					Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id));
 				}
 				finally
@@ -278,13 +287,14 @@ namespace Tests.xUpdate
 
 					db.Child.Delete(c => c.ChildID > 1000);
 
-					Assert.AreEqual(1,
-						db.Child
+					var cnt = db.Child
 							.Where(c => c.ChildID == 11)
 							.Into(db.Child)
 								.Value(c => c.ParentID, c  => c.ParentID)
 								.Value(c => c.ChildID,  () => id)
-							.Insert());
+							.Insert();
+						Assert.AreEqual(1, cnt);
+
 					Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id));
 				}
 				finally
@@ -325,13 +335,14 @@ namespace Tests.xUpdate
 
 					await db.Child.DeleteAsync(c => c.ChildID > 1000);
 
-					Assert.AreEqual(1,
-						await db.Child
+					var cnt = await db.Child
 							.Where(c => c.ChildID == 11)
 							.Into(db.Child)
 								.Value(c => c.ParentID, c  => c.ParentID)
 								.Value(c => c.ChildID,  () => id)
-							.InsertAsync());
+							.InsertAsync();
+						Assert.AreEqual(1, cnt);
+
 					Assert.AreEqual(1, await db.Child.CountAsync(c => c.ChildID == id));
 				}
 				finally
@@ -352,13 +363,14 @@ namespace Tests.xUpdate
 
 					db.Child.Delete(c => c.ChildID > 1000);
 
-					Assert.AreEqual(1,
-						db.Child
+					var cnt = db.Child
 							.Where(c => c.ChildID == 11)
 							.Into(db.Child)
 								.Value(c => c.ParentID, c => c.ParentID)
 								.Value(c => c.ChildID,  id)
-							.Insert());
+							.Insert();
+						Assert.AreEqual(1, cnt);
+
 					Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id));
 				}
 				finally
@@ -377,13 +389,14 @@ namespace Tests.xUpdate
 				{
 					db.Parent.Delete(p => p.Value1 == 11);
 
-					Assert.AreEqual(1,
-						db.Child
+					var cnt = db.Child
 							.Where(c => c.ChildID == 11)
 							.Into(db.Parent)
 								.Value(p => p.ParentID, c => c.ParentID + 1000)
 								.Value(p => p.Value1,   c => (int?)c.ChildID)
-							.Insert());
+							.Insert();
+						Assert.AreEqual(1, cnt);
+
 					Assert.AreEqual(1, db.Parent.Count(p => p.Value1 == 11));
 				}
 				finally
@@ -421,7 +434,7 @@ namespace Tests.xUpdate
 					.Value(p => p.ModifiedOn, c => Sql.CurrentTimestamp)
 					.Insert();
 
-				Assert.That(affected, Is.EqualTo(2));
+					Assert.That(affected, Is.EqualTo(2));
 			}
 		}
 
@@ -436,12 +449,13 @@ namespace Tests.xUpdate
 
 					db.Child.Delete(c => c.ChildID > 1000);
 
-					Assert.AreEqual(1,
-						db
-							.Child
-								.Value(c => c.ChildID,  () => id)
-								.Value(c => c.ParentID, 1)
-							.Insert());
+					var cnt = db
+						.Child
+							.Value(c => c.ChildID,  () => id)
+							.Value(c => c.ParentID, 1)
+						.Insert();
+						Assert.AreEqual(1, cnt);
+
 					Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id));
 				}
 				finally
@@ -462,12 +476,13 @@ namespace Tests.xUpdate
 
 					db.Child.Delete(c => c.ChildID > 1000);
 
-					Assert.AreEqual(1,
-						db
-							.Child
-								.Value(c => c.ParentID, 1)
-								.Value(c => c.ChildID,  () => id)
-							.Insert());
+					var cnt = db
+						.Child
+							.Value(c => c.ParentID, 1)
+							.Value(c => c.ChildID,  () => id)
+						.Insert();
+						Assert.AreEqual(1, cnt);
+
 					Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id));
 				}
 				finally
@@ -491,14 +506,15 @@ namespace Tests.xUpdate
 
 					db.Insert(new Parent { ParentID = id, Value1 = id });
 
-					Assert.AreEqual(1,
-						db.Parent
-							.Where(p => p.ParentID == id)
-							.Insert(db.Child, p => new Child
-							{
-								ParentID = p.ParentID,
-								ChildID  = p.ParentID,
-							}));
+					var cnt = db.Parent
+						.Where(p => p.ParentID == id)
+						.Insert(db.Child, p => new Child
+						{
+							ParentID = p.ParentID,
+							ChildID  = p.ParentID,
+						});
+						Assert.AreEqual(1, cnt);
+
 					Assert.AreEqual(1, db.Child.Count(c => c.ParentID == id));
 				}
 				finally
@@ -670,15 +686,15 @@ namespace Tests.xUpdate
 						Value1   = TypeValue.Value2
 					};
 
-					Assert.AreEqual(1,
-						db.Parent4
+					var cnt = db.Parent4
 						.Insert(() => new Parent4
 						{
 							ParentID = 1001,
 							Value1   = p.Value1
-						}));
+						});
+						Assert.AreEqual(1, cnt);
 
-					Assert.AreEqual(1, db.Parent4.Count(_ => _.ParentID == id && _.Value1 == p.Value1));
+						Assert.AreEqual(1, db.Parent4.Count(_ => _.ParentID == id && _.Value1 == p.Value1));
 				}
 				finally
 				{
@@ -698,11 +714,11 @@ namespace Tests.xUpdate
 
 					db.Parent4.Delete(_ => _.ParentID > 1000);
 
-					Assert.AreEqual(1,
-						db.Parent4
+					var cnt = db.Parent4
 							.Value(_ => _.ParentID, id)
 							.Value(_ => _.Value1,   TypeValue.Value1)
-						.Insert());
+						.Insert();
+						Assert.AreEqual(1, cnt);
 
 					Assert.AreEqual(1, db.Parent4.Count(_ => _.ParentID == id));
 				}
@@ -724,11 +740,11 @@ namespace Tests.xUpdate
 
 					db.Parent4.Delete(_ => _.ParentID > 1000);
 
-					Assert.AreEqual(1,
-						db.Parent4
+					var cnt = db.Parent4
 							.Value(_ => _.ParentID, id)
 							.Value(_ => _.Value1,   () => TypeValue.Value1)
-						.Insert());
+						.Insert();
+						Assert.AreEqual(1, cnt);
 
 					Assert.AreEqual(1, db.Parent4.Count(_ => _.ParentID == id));
 				}
@@ -743,23 +759,16 @@ namespace Tests.xUpdate
 		public void InsertNull([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
-				{
-					db.Parent.Delete(p => p.ParentID == 1001);
+				var cnt = db
+					.Into(db.Parent)
+						.Value(p => p.ParentID, 1001)
+						.Value(p => p.Value1,   (int?)null)
+					.Insert();
+					Assert.AreEqual(1, cnt);
 
-					Assert.AreEqual(1,
-						db
-							.Into(db.Parent)
-								.Value(p => p.ParentID, 1001)
-								.Value(p => p.Value1,   (int?)null)
-							.Insert());
-					Assert.AreEqual(1, db.Parent.Count(p => p.ParentID == 1001));
-				}
-				finally
-				{
-					db.Parent.Delete(p => p.Value1 == 1001);
-				}
+				Assert.AreEqual(1, db.Parent.Count(p => p.ParentID == 1001));
 			}
 		}
 
@@ -1045,39 +1054,32 @@ namespace Tests.xUpdate
 			ResetPersonIdentity(context);
 
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				var id = 0;
-
-				try
+				var person = new Person
 				{
-					id = Convert.ToInt32(db.Person.InsertWithIdentity(() => new Person
-					{
-						FirstName = "John",
-						LastName  = "Shepard",
-						Gender    = Gender.Male
-					}));
+					FirstName = "John",
+					LastName  = "Shepard",
+					Gender    = Gender.Male
+				};
 
-					for (var i = 0; i < 3; i++)
-					{
-						db.Patient.InsertOrUpdate(
-							() => new Patient
-							{
-								PersonID  = id,
-								Diagnosis = "abc",
-							},
-							p => new Patient
-							{
-								Diagnosis = (p.Diagnosis.Length + i).ToString(),
-							});
-					}
+				var id = db.InsertWithInt32Identity(person);
 
-					Assert.AreEqual("3", db.Patient.Single(p => p.PersonID == id).Diagnosis);
-				}
-				finally
+				for (var i = 0; i < 3; i++)
 				{
-					db.Patient.Delete(p => p.PersonID == id);
-					db.Person. Delete(p => p.ID       == id);
+					db.Patient.InsertOrUpdate(
+						() => new Patient
+						{
+							PersonID  = id,
+							Diagnosis = "abc",
+						},
+						p => new Patient
+						{
+							Diagnosis = (p.Diagnosis.Length + i).ToString(),
+						});
 				}
+
+				Assert.AreEqual("3", db.Patient.Single(p => p.PersonID == id).Diagnosis);
 			}
 		}
 
@@ -1087,19 +1089,18 @@ namespace Tests.xUpdate
 			ResetPersonIdentity(context);
 
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				int id;
-				using (new DisableLogging())
-					id = Convert.ToInt32(db.Person.InsertWithIdentity(() => new Person
-					{
-						FirstName = "test",
-						LastName  = "subject",
-						Gender    = Gender.Unknown
-					}));
-
-				try
+				var person = new Person
 				{
-					var records = db.Patient.InsertOrUpdate(
+					FirstName = "test",
+					LastName  = "subject",
+					Gender    = Gender.Unknown
+				};
+
+				var id = db.InsertWithInt32Identity(person);
+
+				var records = db.Patient.InsertOrUpdate(
 						() => new Patient
 						{
 							PersonID  = id,
@@ -1109,51 +1110,37 @@ namespace Tests.xUpdate
 						{
 						});
 
-					try
+				List<Patient> patients;
+
+				using (new DisableLogging())
+					patients = db.Patient.Where(p => p.PersonID == id).ToList();
+
+				if (context.IsAnyOf(TestProvName.AllOracleNative))
+					Assert.AreEqual(-1, records);
+				else
+					Assert.AreEqual(1, records);
+
+				Assert.AreEqual(1, patients.Count);
+				Assert.AreEqual(id, patients[0].PersonID);
+				Assert.AreEqual("negative", patients[0].Diagnosis);
+
+				records = db.Patient.InsertOrUpdate(
+					() => new Patient
 					{
-						List<Patient> patients;
-
-						using (new DisableLogging())
-							patients = db.Patient.Where(p => p.PersonID == id).ToList();
-
-						if (context.IsAnyOf(TestProvName.AllOracleNative))
-							Assert.AreEqual(-1, records);
-						else
-							Assert.AreEqual(1, records);
-
-						Assert.AreEqual(1, patients.Count);
-						Assert.AreEqual(id, patients[0].PersonID);
-						Assert.AreEqual("negative", patients[0].Diagnosis);
-
-						records = db.Patient.InsertOrUpdate(
-							() => new Patient
-							{
-								PersonID  = id,
-								Diagnosis = "positive"
-							},
-							p => new Patient
-							{
-							});
-
-						using (new DisableLogging())
-							patients = db.Patient.Where(p => p.PersonID == id).ToList();
-
-						Assert.LessOrEqual(records, 0);
-						Assert.AreEqual(1, patients.Count);
-						Assert.AreEqual(id, patients[0].PersonID);
-						Assert.AreEqual("negative", patients[0].Diagnosis);
-					}
-					finally
+						PersonID = id,
+						Diagnosis = "positive"
+					},
+					p => new Patient
 					{
-						using (new DisableLogging())
-							db.Patient.Delete(p => p.PersonID == id);
-					}
-				}
-				finally
-				{
-					using (new DisableLogging())
-						db.Person.Delete(p => p.ID == id);
-				}
+					});
+
+				using (new DisableLogging())
+					patients = db.Patient.Where(p => p.PersonID == id).ToList();
+
+				Assert.LessOrEqual(records, 0);
+				Assert.AreEqual(1, patients.Count);
+				Assert.AreEqual(id, patients[0].PersonID);
+				Assert.AreEqual("negative", patients[0].Diagnosis);
 			}
 		}
 
@@ -1163,34 +1150,27 @@ namespace Tests.xUpdate
 			ResetPersonIdentity(context);
 
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				var id = 0;
-
-				try
+				var person = new Person
 				{
-					id = Convert.ToInt32(db.Person.InsertWithIdentity(() => new Person
-					{
-						FirstName = "John",
-						LastName  = "Shepard",
-						Gender    = Gender.Male
-					}));
+					FirstName = "John",
+					LastName  = "Shepard",
+					Gender    = Gender.Male
+				};
 
-					for (var i = 0; i < 3; i++)
-					{
-						db.InsertOrReplace(new Patient
-						{
-							PersonID  = id,
-							Diagnosis = ("abc" + i).ToString(),
-						});
-					}
+				var id = db.InsertWithInt32Identity(person);
 
-					Assert.AreEqual("abc2", db.Patient.Single(p => p.PersonID == id).Diagnosis);
-				}
-				finally
+				for (var i = 0; i < 3; i++)
 				{
-					db.Patient.Delete(p => p.PersonID == id);
-					db.Person. Delete(p => p.ID       == id);
+					db.InsertOrReplace(new Patient()
+					{
+						PersonID = id,
+						Diagnosis = ("abc" + i).ToString(),
+					});
 				}
+
+				Assert.AreEqual("abc2", db.Patient.Single(p => p.PersonID == id).Diagnosis);
 			}
 		}
 
@@ -1200,34 +1180,27 @@ namespace Tests.xUpdate
 			ResetPersonIdentity(context);
 
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				var id = 0;
-
-				try
+				var person = new Person
 				{
-					id = Convert.ToInt32(db.Person.InsertWithIdentity(() => new Person
-					{
-						FirstName = "John",
-						LastName  = "Shepard",
-						Gender    = Gender.Male
-					}));
+					FirstName = "John",
+					LastName  = "Shepard",
+					Gender    = Gender.Male
+				};
 
-					for (var i = 0; i < 3; i++)
-					{
-						await db.InsertOrReplaceAsync(new Patient
-						{
-							PersonID  = id,
-							Diagnosis = ("abc" + i).ToString(),
-						});
-					}
+				var id = db.InsertWithInt32Identity(person);
 
-					Assert.AreEqual("abc2", (await db.Patient.SingleAsync(p => p.PersonID == id)).Diagnosis);
-				}
-				finally
+				for (var i = 0; i < 3; i++)
 				{
-					await db.Patient.Where     (p => p.PersonID == id).DeleteAsync();
-					await db.Person.DeleteAsync(p => p.ID       == id);
+					await db.InsertOrReplaceAsync(new Patient
+					{
+						PersonID  = id,
+						Diagnosis = ("abc" + i).ToString(),
+					});
 				}
+
+				Assert.AreEqual("abc2", (await db.Patient.SingleAsync(p => p.PersonID == id)).Diagnosis);
 			}
 		}
 
@@ -1255,48 +1228,40 @@ namespace Tests.xUpdate
 			ResetPersonIdentity(context);
 
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				var id = 0;
-
-				try
+				var person = new Person
 				{
-					id = Convert.ToInt32(db.Person.InsertWithIdentity(() => new Person
-					{
-						FirstName = "John",
-						LastName  = "Shepard",
-						Gender    = Gender.Male
-					}));
+					FirstName = "John",
+					LastName  = "Shepard",
+					Gender    = Gender.Male
+				};
 
-					var diagnosis = "abc";
+				var id = db.InsertWithInt32Identity(person);
 
-					for (var i = 0; i < 3; i++)
-					{
-						db.Patient.InsertOrUpdate(
-							() => new Patient
-							{
-								PersonID  = id,
-								Diagnosis = "abc",
-							},
-							p => new Patient
-							{
-								Diagnosis = (p.Diagnosis.Length + i).ToString(),
-							},
-							() => new Patient
-							{
-								PersonID  = id,
-								//Diagnosis = diagnosis,
-							});
+				var diagnosis = "abc";
 
-						diagnosis = (diagnosis.Length + i).ToString();
-					}
-
-					Assert.AreEqual("3", db.Patient.Single(p => p.PersonID == id).Diagnosis);
-				}
-				finally
+				for (var i = 0; i < 3; i++)
 				{
-					db.Patient.Delete(p => p.PersonID == id);
-					db.Person. Delete(p => p.ID       == id);
+					db.Patient.InsertOrUpdate(
+						() => new Patient
+						{
+							PersonID  = id,
+							Diagnosis = "abc",
+						},
+						p => new Patient
+						{
+							Diagnosis = (p.Diagnosis.Length + i).ToString(),
+						},
+						() => new Patient
+						{
+							PersonID = id,
+						});
+
+					diagnosis = (diagnosis.Length + i).ToString();
 				}
+
+				Assert.AreEqual("3", db.Patient.Single(p => p.PersonID == id).Diagnosis);
 			}
 		}
 
@@ -1306,50 +1271,40 @@ namespace Tests.xUpdate
 			ResetPersonIdentity(context);
 
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				var id = 0;
-
-				try
+				var person = new Person
 				{
-					db.Person.Where(p => p.FirstName == "John" && p.LastName == "Shepard").Delete();
+					FirstName = "John",
+					LastName  = "Shepard",
+					Gender    = Gender.Male
+				};
 
-					id = await db.Person.InsertWithInt32IdentityAsync(() => new Person
-					{
-						FirstName = "John",
-						LastName  = "Shepard",
-						Gender    = Gender.Male
-					});
+				var id = db.InsertWithInt32Identity(person);
 
-					var diagnosis = "abc";
+				var diagnosis = "abc";
 
-					for (var i = 0; i < 3; i++)
-					{
-						await db.Patient.InsertOrUpdateAsync(
-							() => new Patient
-							{
-								PersonID  = id,
-								Diagnosis = "abc",
-							},
-							p => new Patient
-							{
-								Diagnosis = (p.Diagnosis.Length + i).ToString(),
-							},
-							() => new Patient
-							{
-								PersonID  = id,
-								//Diagnosis = diagnosis,
-							});
-
-						diagnosis = (diagnosis.Length + i).ToString();
-					}
-
-					Assert.AreEqual("3", (await db.Patient.SingleAsync(p => p.PersonID == id)).Diagnosis);
-				}
-				finally
+				for (var i = 0; i < 3; i++)
 				{
-					await db.Patient.DeleteAsync(p => p.PersonID == id);
-					await db.Person. DeleteAsync(p => p.ID       == id);
+					await db.Patient.InsertOrUpdateAsync(
+						() => new Patient
+						{
+							PersonID  = id,
+							Diagnosis = "abc",
+						},
+						p => new Patient
+						{
+							Diagnosis = (p.Diagnosis.Length + i).ToString(),
+						},
+						() => new Patient
+						{
+							PersonID = id,
+						});
+
+					diagnosis = (diagnosis.Length + i).ToString();
 				}
+
+				Assert.AreEqual("3", (await db.Patient.SingleAsync(p => p.PersonID == id)).Diagnosis);
 			}
 		}
 
@@ -1359,52 +1314,42 @@ namespace Tests.xUpdate
 			ResetPersonIdentity(context);
 
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				var id = 0;
-
-				try
+				var person = new Person
 				{
-					db.Person.Where(p => p.FirstName == "John" && p.LastName == "Shepard").Delete();
+					FirstName = "John",
+					LastName  = "Shepard",
+					Gender    = Gender.Male
+				};
 
-					id = await db.Person.InsertWithInt32IdentityAsync(() => new Person
-					{
-						FirstName = "John",
-						LastName  = "Shepard",
-						Gender    = Gender.Male
-					});
+				var id = db.InsertWithInt32Identity(person);
 
-					var diagnosis = "abc";
+				var diagnosis = "abc";
 
-					var id2 = id;
+				var id2 = id;
 
-					for (var i = 0; i < 3; i++)
-					{
-						await db.Patient.InsertOrUpdateAsync(
-							() => new Patient
-							{
-								PersonID  = id,
-								Diagnosis = "abc",
-							},
-							p => new Patient
-							{
-								Diagnosis = (p.Diagnosis.Length + i).ToString(),
-							},
-							() => new Patient
-							{
-								PersonID = id2,
-								//Diagnosis = diagnosis,
-							});
-
-						diagnosis = (diagnosis.Length + i).ToString();
-					}
-
-					Assert.AreEqual("3", (await db.Patient.SingleAsync(p => p.PersonID == id)).Diagnosis);
-				}
-				finally
+				for (var i = 0; i < 3; i++)
 				{
-					await db.Patient.DeleteAsync(p => p.PersonID == id);
-					await db.Person. DeleteAsync(p => p.ID       == id);
+					await db.Patient.InsertOrUpdateAsync(
+						() => new Patient
+						{
+							PersonID  = id,
+							Diagnosis = "abc",
+						},
+						p => new Patient
+						{
+							Diagnosis = (p.Diagnosis.Length + i).ToString(),
+						},
+						() => new Patient
+						{
+							PersonID = id2,
+						});
+
+					diagnosis = (diagnosis.Length + i).ToString();
 				}
+
+				Assert.AreEqual("3", (await db.Patient.SingleAsync(p => p.PersonID == id)).Diagnosis);
 			}
 		}
 
@@ -1414,40 +1359,33 @@ namespace Tests.xUpdate
 			ResetPersonIdentity(context);
 
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				var id = 0;
-
-				try
+				var person = new Person
 				{
-					id = Convert.ToInt32(db.Person.InsertWithIdentity(() => new Person
-					{
-						FirstName = "John",
-						LastName  = "Shepard",
-						Gender    = Gender.Male
-					}));
+					FirstName = "John",
+					LastName  = "Shepard",
+					Gender    = Gender.Male
+				};
 
-					for (var i = 0; i < 3; i++)
-					{
-						var diagnosis = "abc";
-						db.Patient.InsertOrUpdate(
-							() => new Patient
-							{
-								PersonID  = id,
-								Diagnosis = (Sql.AsSql(diagnosis).Length + i).ToString(),
-							},
-							p => new Patient
-							{
-								Diagnosis = (p.Diagnosis.Length + i).ToString(),
-							});
-					}
+				var id = db.InsertWithInt32Identity(person);
 
-					Assert.AreEqual("3", db.Patient.Single(p => p.PersonID == id).Diagnosis);
-				}
-				finally
+				for (var i = 0; i < 3; i++)
 				{
-					db.Patient.Delete(p => p.PersonID == id);
-					db.Person.Delete(p => p.ID == id);
+					var diagnosis = "abc";
+					db.Patient.InsertOrUpdate(
+						() => new Patient
+						{
+							PersonID = id,
+							Diagnosis = (Sql.AsSql(diagnosis).Length + i).ToString(),
+						},
+						p => new Patient
+						{
+							Diagnosis = (p.Diagnosis.Length + i).ToString(),
+						});
 				}
+
+				Assert.AreEqual("3", db.Patient.Single(p => p.PersonID == id).Diagnosis);
 			}
 		}
 
@@ -1463,8 +1401,8 @@ namespace Tests.xUpdate
 				{
 					((DataConnection)db).BulkCopy(1, new[]
 					{
-						new LinqDataTypes2 { ID = 1003, MoneyValue = 0m, DateTimeValue = null,         BoolValue = true,  GuidValue = new Guid("ef129165-6ffe-4df9-bb6b-bb16e413c883"), SmallIntValue =  null, IntValue = null    },
-						new LinqDataTypes2 { ID = 1004, MoneyValue = 0m, DateTimeValue = null,         BoolValue = true,  GuidValue = new Guid("ef129165-6ffe-4df9-bb6b-bb16e413c883"), SmallIntValue =  null, IntValue = null    }
+						new LinqDataTypes2 { ID = 1003, MoneyValue = 0m, DateTimeValue = null, BoolValue = true,  GuidValue = new Guid("ef129165-6ffe-4df9-bb6b-bb16e413c883"), SmallIntValue =  null, IntValue = null },
+						new LinqDataTypes2 { ID = 1004, MoneyValue = 0m, DateTimeValue = null, BoolValue = true,  GuidValue = new Guid("ef129165-6ffe-4df9-bb6b-bb16e413c883"), SmallIntValue =  null, IntValue = null }
 					});
 				}
 				finally
@@ -1502,24 +1440,17 @@ namespace Tests.xUpdate
 			var p = new ComplexPerson { Name = new FullName { FirstName = "fn", LastName = "ln" }, Gender = Gender.Male };
 
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
 				var id = db.Person.Max(t => t.ID);
 
-				try
-				{
-					db.Insert(p);
+				db.Insert(p);
 
-					var inserted = db.GetTable<ComplexPerson>().Single(p2 => p2.ID > id);
+				var inserted = db.GetTable<ComplexPerson>().Single(p2 => p2.ID > id || p2.ID == 0);
 
-					Assert.AreEqual(p.Name.FirstName, inserted.Name.FirstName);
-					Assert.AreEqual(p.Name.LastName, inserted.Name.LastName);
-					Assert.AreEqual(p.Gender, inserted.Gender);
-
-				}
-				finally
-				{
-					db.Person.Delete(t => t.ID > id);
-				}
+				Assert.AreEqual(p.Name.FirstName, inserted.Name.FirstName);
+				Assert.AreEqual(p.Name.LastName, inserted.Name.LastName);
+				Assert.AreEqual(p.Gender, inserted.Gender);
 			}
 		}
 
@@ -1527,22 +1458,14 @@ namespace Tests.xUpdate
 		public void Insert12([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				var id = db.Person.Max(t => t.ID);
-
-				try
-				{
-					db
-						.Into(db.GetTable<ComplexPerson>())
-							.Value(_ => _.Name.FirstName, "FirstName")
-							.Value(_ => _.Name.LastName,  () => "LastName")
-							.Value(_ => _.Gender,         Gender.Female)
-						.Insert();
-				}
-				finally
-				{
-					db.Person.Delete(t => t.ID > id);
-				}
+				db
+					.Into(db.GetTable<ComplexPerson>())
+						.Value(_ => _.Name.FirstName, "FirstName")
+						.Value(_ => _.Name.LastName,  () => "LastName")
+						.Value(_ => _.Gender,         Gender.Female)
+					.Insert();
 			}
 		}
 
@@ -1550,27 +1473,19 @@ namespace Tests.xUpdate
 		public void Insert13([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				var id = db.Person.Max(t => t.ID);
-
-				try
-				{
-					db
-						.GetTable<ComplexPerson>()
-						.Insert(() => new ComplexPerson
+				db
+					.GetTable<ComplexPerson>()
+					.Insert(() => new ComplexPerson
+					{
+						Name = new FullName
 						{
-							Name = new FullName
-							{
-								FirstName = "FirstName",
-								LastName  = "LastName"
-							},
-							Gender = Gender.Male,
-						});
-				}
-				finally
-				{
-					db.Person.Delete(t => t.ID > id);
-				}
+							FirstName = "FirstName",
+							LastName  = "LastName"
+						},
+						Gender = Gender.Male,
+					});
 			}
 		}
 
@@ -1848,16 +1763,18 @@ namespace Tests.xUpdate
 
 					// insert a row into the table
 					db.Insert(person, tableName: tableName, schemaName: schemaName);
-					var newId1 = db.InsertWithInt32Identity(person, tableName: tableName, schemaName: schemaName);
-					var newId2 = db.InsertWithIdentity(person, tableName: tableName, schemaName: schemaName);
+					{
+						var newId1 = db.InsertWithInt32Identity(person, tableName: tableName, schemaName: schemaName);
+						var newId2 = db.InsertWithIdentity(person, tableName: tableName, schemaName: schemaName);
 
-					var newCount = table.Count();
-					Assert.AreEqual(3, newCount);
+						var newCount = table.Count();
+						Assert.AreEqual(3, newCount);
 
-					Assert.AreNotEqual(newId1, newId2);
+						Assert.AreNotEqual(newId1, newId2);
 
-					var integritycount = table.Where(p => p.FirstName == "Steven" && p.LastName == "King" && p.Gender == Gender.Male).Count();
-					Assert.AreEqual(3, integritycount);
+						var integritycount = table.Where(p => p.FirstName == "Steven" && p.LastName == "King" && p.Gender == Gender.Male).Count();
+						Assert.AreEqual(3, integritycount);
+					}
 
 					table.Drop();
 				}
@@ -1892,16 +1809,18 @@ namespace Tests.xUpdate
 
 					// insert a row into the table
 					await db.InsertAsync(person, tableName: tableName, schemaName: schemaName);
-					var newId1 = await db.InsertWithInt32IdentityAsync(person, tableName: tableName, schemaName: schemaName);
-					var newId2 = await db.InsertWithIdentityAsync(person, tableName: tableName, schemaName: schemaName);
+					{
+						var newId1 = await db.InsertWithInt32IdentityAsync(person, tableName: tableName, schemaName: schemaName);
+						var newId2 = await db.InsertWithIdentityAsync(person, tableName: tableName, schemaName: schemaName);
 
-					var newCount = await table.CountAsync();
-					Assert.AreEqual(3, newCount);
+						var newCount = await table.CountAsync();
+						Assert.AreEqual(3, newCount);
 
-					Assert.AreNotEqual(newId1, newId2);
+						Assert.AreNotEqual(newId1, newId2);
 
-					var integritycount = await table.Where(p => p.FirstName == "Steven" && p.LastName == "King" && p.Gender == Gender.Male).CountAsync();
-					Assert.AreEqual(3, integritycount);
+						var integritycount = await table.Where(p => p.FirstName == "Steven" && p.LastName == "King" && p.Gender == Gender.Male).CountAsync();
+						Assert.AreEqual(3, integritycount);
+					}
 					await table.DropAsync();
 				}
 				finally
@@ -2121,7 +2040,8 @@ namespace Tests.xUpdate
 				var vi = table.AsValueInsertable();
 				vi = vi.Value(x => x.ID, 123).Value(x => x.FirstName, "John");
 
-				Assert.AreEqual(1, vi.Insert());
+				var cnt = vi.Insert();
+					Assert.AreEqual(1, cnt);
 				Assert.AreEqual(1, table.Count(x => x.ID == 123 && x.FirstName == "John"));
 			}
 		}

--- a/Tests/Linq/Update/InsertWithOutputTests.cs
+++ b/Tests/Linq/Update/InsertWithOutputTests.cs
@@ -21,7 +21,7 @@ namespace Tests.xUpdate
 		private const string FeatureInsertOutputSingle     = $"{TestProvName.AllSqlServer},{TestProvName.AllFirebird},{TestProvName.AllMariaDB},{TestProvName.AllPostgreSQL},{TestProvName.AllSQLiteClassic}";
 		private const string FeatureInsertOutputMultiple   = $"{TestProvName.AllSqlServer},{TestProvName.AllMariaDB},{TestProvName.AllPostgreSQL},{TestProvName.AllSQLiteClassic}";
 		private const string FeatureInsertOutputWithSchema = $"{TestProvName.AllSqlServer},{TestProvName.AllFirebird},{TestProvName.AllMariaDB},{TestProvName.AllSQLiteClassic}";
-		private const string FeatureInsertOutputInto       = TestProvName.AllSqlServer;
+		private const string FeatureInsertOutputInto       = $"{TestProvName.AllSqlServer}";
 
 		[Table]
 		class TableWithData

--- a/Tests/Linq/Update/MergeTests.Operations.IdentityInsert.cs
+++ b/Tests/Linq/Update/MergeTests.Operations.IdentityInsert.cs
@@ -1,12 +1,15 @@
 ﻿using System.Linq;
+using System.Linq.Expressions;
 
 using LinqToDB;
 using LinqToDB.Data;
+using LinqToDB.Mapping;
 
 using NUnit.Framework;
 
 namespace Tests.xUpdate
 {
+	using System;
 	using Model;
 
 	public partial class MergeTests
@@ -19,40 +22,40 @@ namespace Tests.xUpdate
 			using (var db = GetDataConnection(context))
 			using (db.BeginTransaction())
 			{
-				PrepareAssociationsData(db);
+				PrepareIdentityData(db, context);
 
-				var nextId = db.Person.Select(_ => _.ID).Max() + 1;
+				var nextId = db.GetTable<MPerson>().Select(_ => _.ID).Max() + 1;
 
-				var rows = db.Person
+				var rows = db.GetTable<MPerson>()
 					.Merge()
 					.Using(
-						db.Person.Select(p => new Person()
+						db.GetTable<MPerson>().Select(p => new MPerson()
 						{
-							ID = p.ID + 50,
-							FirstName = p.FirstName,
-							LastName = p.LastName,
-							Gender = p.Gender,
+							ID         = p.ID + 50,
+							FirstName  = p.FirstName,
+							LastName   = p.LastName,
+							Gender     = p.Gender,
 							MiddleName = p.MiddleName
 						}))
 					.On((t, s) => t.ID + 50 == s.ID && t.FirstName != "first 3")
 					.InsertWhenNotMatchedAnd(s => s.FirstName == "first 3")
 					.Merge();
 
-				var result = db.Person.OrderBy(_ => _.ID).ToList();
+				var result = db.GetTable<MPerson>().OrderBy(_ => _.ID).ToList();
 
 				AssertRowCount(1, rows, context);
 
 				Assert.AreEqual(7, result.Count);
 
-				AssertPerson(AssociationPersons[0], result[0]);
-				AssertPerson(AssociationPersons[1], result[1]);
-				AssertPerson(AssociationPersons[2], result[2]);
-				AssertPerson(AssociationPersons[3], result[3]);
-				AssertPerson(AssociationPersons[4], result[4]);
-				AssertPerson(AssociationPersons[5], result[5]);
+				AssertPerson(IdentityPersons[0], result[0]);
+				AssertPerson(IdentityPersons[1], result[1]);
+				AssertPerson(IdentityPersons[2], result[2]);
+				AssertPerson(IdentityPersons[3], result[3]);
+				AssertPerson(IdentityPersons[4], result[4]);
+				AssertPerson(IdentityPersons[5], result[5]);
 
-				AssociationPersons[2].ID = nextId;
-				AssertPerson(AssociationPersons[2], result[6]);
+				IdentityPersons[2].ID = nextId;
+				AssertPerson(IdentityPersons[2], result[6]);
 			}
 		}
 
@@ -68,37 +71,37 @@ namespace Tests.xUpdate
 			using (var db = GetDataConnection(context))
 			using (db.BeginTransaction())
 			{
-				PrepareAssociationsData(db);
+				PrepareIdentityData(db, context);
 
-				var nextId = db.Person.Select(_ => _.ID).Max() + 1;
+				var nextId = db.GetTable<MPerson>().Select(_ => _.ID).Max() + 1;
 
-				var rows = db.Person
+				var rows = db.GetTable<MPerson>()
 					.Merge()
-					.Using(db.Person)
+					.Using(db.GetTable<MPerson>())
 					.On((t, s) => t.ID == s.ID && t.FirstName != "first 3")
 					.InsertWhenNotMatchedAnd(
 						s => s.Patient!.Diagnosis.Contains("sick")
-						, s => new Model.Person()
+						, s => new MPerson()
 						{
-							ID = nextId + 1,
+							ID        = nextId + 1,
 							FirstName = "Inserted 1",
-							LastName = "Inserted 2",
-							Gender = Gender.Male
+							LastName  = "Inserted 2",
+							Gender    = Gender.Male
 						})
 					.Merge();
 
-				var result = db.Person.OrderBy(_ => _.ID).ToList();
+				var result = db.GetTable<MPerson>().OrderBy(_ => _.ID).ToList();
 
 				Assert.AreEqual(1, rows);
 
 				Assert.AreEqual(7, result.Count);
 
-				AssertPerson(AssociationPersons[0], result[0]);
-				AssertPerson(AssociationPersons[1], result[1]);
-				AssertPerson(AssociationPersons[2], result[2]);
-				AssertPerson(AssociationPersons[3], result[3]);
-				AssertPerson(AssociationPersons[4], result[4]);
-				AssertPerson(AssociationPersons[5], result[5]);
+				AssertPerson(IdentityPersons[0], result[0]);
+				AssertPerson(IdentityPersons[1], result[1]);
+				AssertPerson(IdentityPersons[2], result[2]);
+				AssertPerson(IdentityPersons[3], result[3]);
+				AssertPerson(IdentityPersons[4], result[4]);
+				AssertPerson(IdentityPersons[5], result[5]);
 
 				Assert.AreEqual(nextId + 1, result[6].ID);
 				Assert.AreEqual(Gender.Male, result[6].Gender);
@@ -120,36 +123,36 @@ namespace Tests.xUpdate
 			using (var db = GetDataConnection(context))
 			using (db.BeginTransaction())
 			{
-				PrepareAssociationsData(db);
+				PrepareIdentityData(db, context);
 
-				var nextId = db.Person.Select(_ => _.ID).Max() + 1;
+				var nextId = db.GetTable<MPerson>().Select(_ => _.ID).Max() + 1;
 
-				var rows = db.Person
+				var rows = db.GetTable<MPerson>()
 					.Merge()
-					.Using(db.Person)
+					.Using(db.GetTable<MPerson>())
 					.On((t, s) => t.ID == s.ID && t.FirstName != "first 3")
 					.InsertWhenNotMatchedAnd(
 						s => s.Patient!.Diagnosis.Contains("sick"),
-						s => new Model.Person()
+						s => new MPerson()
 						{
 							FirstName = "Inserted 1",
-							LastName = "Inserted 2",
-							Gender = Gender.Male
+							LastName  = "Inserted 2",
+							Gender    = Gender.Male
 						})
 					.Merge();
 
-				var result = db.Person.OrderBy(_ => _.ID).ToList();
+				var result = db.GetTable<MPerson>().OrderBy(_ => _.ID).ToList();
 
 				AssertRowCount(1, rows, context);
 
 				Assert.AreEqual(7, result.Count);
 
-				AssertPerson(AssociationPersons[0], result[0]);
-				AssertPerson(AssociationPersons[1], result[1]);
-				AssertPerson(AssociationPersons[2], result[2]);
-				AssertPerson(AssociationPersons[3], result[3]);
-				AssertPerson(AssociationPersons[4], result[4]);
-				AssertPerson(AssociationPersons[5], result[5]);
+				AssertPerson(IdentityPersons[0], result[0]);
+				AssertPerson(IdentityPersons[1], result[1]);
+				AssertPerson(IdentityPersons[2], result[2]);
+				AssertPerson(IdentityPersons[3], result[3]);
+				AssertPerson(IdentityPersons[4], result[4]);
+				AssertPerson(IdentityPersons[5], result[5]);
 
 				Assert.AreEqual(nextId, result[6].ID);
 				Assert.AreEqual(Gender.Male, result[6].Gender);
@@ -210,5 +213,105 @@ namespace Tests.xUpdate
 				Assert.AreEqual(23, result[2].Field);
 			}
 		}
+
+		#region Test Data (Identity/Association Tests)
+		[Table("Doctor")]
+		public class MDoctor
+		{
+			[PrimaryKey] public int    PersonID;
+			[Column    ] public string Taxonomy = null!;
+		}
+
+		[Table("Patient")]
+		public class MPatient
+		{
+			[PrimaryKey] public int    PersonID;
+			[Column    ] public string Diagnosis = null!;
+
+			[Association(ThisKey = nameof(PersonID), OtherKey = nameof(MPerson.ID), CanBeNull = false)]
+			public MPerson Person = null!;
+		}
+
+		[Table("Person")]
+		public class MPerson
+		{
+			[Column("PersonID", IsIdentity = true), PrimaryKey]
+														   public int     ID;
+			[Column(CanBeNull = false)                   ] public string  FirstName { get; set; } = null!;
+			[Column(CanBeNull = false)                   ] public string  LastName = null!;
+			[Column                                      ] public string? MiddleName;
+			[Column(DataType = DataType.Char, Length = 1)] public Gender  Gender;
+
+			[Association(ThisKey = "ID", OtherKey = "PersonID", CanBeNull = false)]
+			public MPatient Patient = null!;
+
+			[Association(QueryExpressionMethod = nameof(Query), CanBeNull = false)]
+			public MPatient PatientQuery = null!;
+
+			static Expression<Func<MPerson, IDataContext, IQueryable<MPatient>>> Query
+				=> (t, ctx) => ctx.GetTable<MPatient>().Where(p => p.PersonID == t.ID);
+		}
+
+		private static readonly MDoctor[] IdentityDoctors = new[]
+		{
+			new MDoctor() { PersonID = 105, Taxonomy = "Dr. Lector" },
+			new MDoctor() { PersonID = 106, Taxonomy = "Dr. who???" },
+		};
+
+		private static readonly MPatient[] IdentityPatients = new[]
+		{
+			new MPatient() { PersonID = 102, Diagnosis = "sick" },
+			new MPatient() { PersonID = 103, Diagnosis = "very sick" },
+		};
+
+		private static readonly MPerson[] IdentityPersons = new[]
+		{
+			new MPerson() { ID = 101, Gender = Gender.Female,  FirstName = "first 1",  LastName = "last 1" },
+			new MPerson() { ID = 102, Gender = Gender.Male,    FirstName = "first 2",  LastName = "last 2" },
+			new MPerson() { ID = 103, Gender = Gender.Other,   FirstName = "first 3",  LastName = "last 3" },
+			new MPerson() { ID = 104, Gender = Gender.Unknown, FirstName = "first 4",  LastName = "last 4" },
+			new MPerson() { ID = 105, Gender = Gender.Female,  FirstName = "first 5",  LastName = "last 5" },
+			new MPerson() { ID = 106, Gender = Gender.Male,    FirstName = "first 6",  LastName = "last 6" },
+		};
+
+		private static void AssertPerson(MPerson expected, MPerson actual)
+		{
+			Assert.AreEqual(expected.ID        , actual.ID);
+			Assert.AreEqual(expected.Gender    , actual.Gender);
+			Assert.AreEqual(expected.FirstName , actual.FirstName);
+			Assert.AreEqual(expected.LastName  , actual.LastName);
+			Assert.AreEqual(expected.MiddleName, actual.MiddleName);
+		}
+
+		private void PrepareIdentityData(ITestDataContext db, string context)
+		{
+			using var _1 = new DisableBaseline("Test Setup");
+			using var _2 = new DisableLogging();
+
+			db.Patient.Delete();
+			db.Doctor .Delete();
+			db.Person .Delete();
+
+			var id = 1;
+			foreach (var person in IdentityPersons)
+			{
+				person.ID = id++;
+
+				person.ID = Convert.ToInt32(db.InsertWithIdentity(person));
+			}
+
+			IdentityDoctors[0].PersonID = IdentityPersons[4].ID;
+			IdentityDoctors[1].PersonID = IdentityPersons[5].ID;
+
+			foreach (var doctor in IdentityDoctors)
+				db.Insert(doctor);
+
+			IdentityPatients[0].PersonID = IdentityPersons[2].ID;
+			IdentityPatients[1].PersonID = IdentityPersons[3].ID;
+
+			foreach (var patient in IdentityPatients)
+				db.Insert(patient);
+		}
+		#endregion
 	}
 }

--- a/Tests/Linq/Update/MergeTests.Types.cs
+++ b/Tests/Linq/Update/MergeTests.Types.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Text;
 
 using LinqToDB;
 using LinqToDB.Common;
@@ -237,7 +238,7 @@ namespace Tests.xUpdate
 				FieldBinary     = new byte[] { 255, 200, 100, 50, 20, 0 },
 				FieldGuid       = new Guid("ffffffff-ffff-ffff-ffff-ffffffffffff"),
 				FieldDecimal    = 99999999.9999999999M,
-				FieldDate       = new DateTime(3210, 11, 23),
+				FieldDate       = new DateTime(2110, 11, 23),
 				FieldTime       = TimeSpan.Zero,
 				FieldEnumString = StringEnum.Value3,
 				FieldEnumNumber = NumberEnum.Value2
@@ -263,7 +264,7 @@ namespace Tests.xUpdate
 				FieldBinary     = new byte[] { 255, 200, 100, 50, 20, 0 },
 				FieldGuid       = new Guid("ffffffff-ffff-ffff-FFFF-ffffffffffff"),
 				FieldDecimal    = -0.123M,
-				FieldDate       = new DateTime(3210, 11, 23),
+				FieldDate       = new DateTime(2111, 11, 23),
 				FieldTime       = TimeSpan.FromHours(24).Add(TimeSpan.FromTicks(-1)),
 				FieldEnumString = StringEnum.Value4,
 				FieldEnumNumber = NumberEnum.Value1
@@ -307,7 +308,7 @@ namespace Tests.xUpdate
 				FieldBinary     = new byte[] { 255, 200, 100, 50, 20, 0 },
 				FieldGuid       = new Guid("ffffffff-ffff-ffff-FFFF-ffffffffffff"),
 				FieldDecimal    = -0.123M,
-				FieldDate       = new DateTime(3210, 11, 23),
+				FieldDate       = new DateTime(2010, 11, 23),
 				FieldTime       = TimeSpan.FromHours(24).Add(TimeSpan.FromTicks(-1)),
 				FieldEnumString = StringEnum.Value4,
 				FieldEnumNumber = NumberEnum.Value1

--- a/Tests/Linq/Update/UpdateTests.cs
+++ b/Tests/Linq/Update/UpdateTests.cs
@@ -26,22 +26,18 @@ namespace Tests.xUpdate
 		public void Update1([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
-				{
-					var parent = new Parent1 { ParentID = 1001, Value1 = 1001 };
+				var parent = new Parent1 { ParentID = 1001, Value1 = 1001 };
 
-					db.Parent.Delete(p => p.ParentID > 1000);
-					db.Insert(parent);
+				db.Insert(parent);
 
-					Assert.AreEqual(1, db.Parent.Count (p => p.ParentID == parent.ParentID));
-					Assert.AreEqual(1, db.Parent.Update(p => p.ParentID == parent.ParentID, p => new Parent { ParentID = p.ParentID + 1 }));
-					Assert.AreEqual(1, db.Parent.Count (p => p.ParentID == parent.ParentID + 1));
-				}
-				finally
-				{
-					db.Child.Delete(c => c.ChildID > 1000);
-				}
+				Assert.AreEqual(1, db.Parent.Count(p => p.ParentID == parent.ParentID));
+
+				var cnt = db.Parent.Update(p => p.ParentID == parent.ParentID, p => new Parent { ParentID = p.ParentID + 1 });
+					Assert.AreEqual(1, cnt);
+
+				Assert.AreEqual(1, db.Parent.Count(p => p.ParentID == parent.ParentID + 1));
 			}
 		}
 
@@ -49,22 +45,18 @@ namespace Tests.xUpdate
 		public async Task Update1Async([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
-				{
-					var parent = new Parent1 { ParentID = 1001, Value1 = 1001 };
+				var parent = new Parent1 { ParentID = 1001, Value1 = 1001 };
 
-					await db.Parent.DeleteAsync(p => p.ParentID > 1000);
-					await db.InsertAsync(parent);
+				await db.InsertAsync(parent);
 
-					Assert.AreEqual(1, await db.Parent.CountAsync (p => p.ParentID == parent.ParentID));
-					Assert.AreEqual(1, await db.Parent.UpdateAsync(p => p.ParentID == parent.ParentID, p => new Parent { ParentID = p.ParentID + 1 }));
-					Assert.AreEqual(1, await db.Parent.CountAsync (p => p.ParentID == parent.ParentID + 1));
-				}
-				finally
-				{
-					await db.Child.DeleteAsync(c => c.ChildID > 1000);
-				}
+				Assert.AreEqual(1, await db.Parent.CountAsync(p => p.ParentID == parent.ParentID));
+
+				var cnt = await db.Parent.UpdateAsync(p => p.ParentID == parent.ParentID, p => new Parent { ParentID = p.ParentID + 1 });
+					Assert.AreEqual(1, cnt);
+
+				Assert.AreEqual(1, await db.Parent.CountAsync(p => p.ParentID == parent.ParentID + 1));
 			}
 		}
 
@@ -72,22 +64,18 @@ namespace Tests.xUpdate
 		public void Update2([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
-				{
-					var parent = new Parent1 { ParentID = 1001, Value1 = 1001 };
+				var parent = new Parent1 { ParentID = 1001, Value1 = 1001 };
 
-					db.Parent.Delete(p => p.ParentID > 1000);
-					db.Insert(parent);
+				db.Insert(parent);
 
-					Assert.AreEqual(1, db.Parent.Count(p => p.ParentID == parent.ParentID));
-					Assert.AreEqual(1, db.Parent.Where(p => p.ParentID == parent.ParentID).Update(p => new Parent { ParentID = p.ParentID + 1 }));
-					Assert.AreEqual(1, db.Parent.Count(p => p.ParentID == parent.ParentID + 1));
-				}
-				finally
-				{
-					db.Child.Delete(c => c.ChildID > 1000);
-				}
+				Assert.AreEqual(1, db.Parent.Count(p => p.ParentID == parent.ParentID));
+
+				var cnt = db.Parent.Where(p => p.ParentID == parent.ParentID).Update(p => new Parent { ParentID = p.ParentID + 1 });
+					Assert.AreEqual(1, cnt);
+
+				Assert.AreEqual(1, db.Parent.Count(p => p.ParentID == parent.ParentID + 1));
 			}
 		}
 
@@ -95,22 +83,18 @@ namespace Tests.xUpdate
 		public async Task Update2Async([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
-				{
-					var parent = new Parent1 { ParentID = 1001, Value1 = 1001 };
+				var parent = new Parent1 { ParentID = 1001, Value1 = 1001 };
 
-					await db.Parent.DeleteAsync(p => p.ParentID > 1000);
-					await db.InsertAsync(parent);
+				await db.InsertAsync(parent);
 
-					Assert.AreEqual(1, await db.Parent.CountAsync(p => p.ParentID == parent.ParentID));
-					Assert.AreEqual(1, await db.Parent.Where(p => p.ParentID == parent.ParentID).UpdateAsync(p => new Parent { ParentID = p.ParentID + 1 }));
-					Assert.AreEqual(1, await db.Parent.CountAsync(p => p.ParentID == parent.ParentID + 1));
-				}
-				finally
-				{
-					await db.Child.DeleteAsync(c => c.ChildID > 1000);
-				}
+				Assert.AreEqual(1, await db.Parent.CountAsync(p => p.ParentID == parent.ParentID));
+
+				var cnt = await db.Parent.Where(p => p.ParentID == parent.ParentID).UpdateAsync(p => new Parent { ParentID = p.ParentID + 1 });
+					Assert.AreEqual(1, cnt);
+
+				Assert.AreEqual(1, await db.Parent.CountAsync(p => p.ParentID == parent.ParentID + 1));
 			}
 		}
 
@@ -118,22 +102,15 @@ namespace Tests.xUpdate
 		public void Update3([DataSources(TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
-				{
-					var id = 1001;
+				var id = 1001;
 
-					db.Child.Delete(c => c.ChildID > 1000);
-					db.Child.Insert(() => new Child { ParentID = 1, ChildID = id});
+				db.Child.Insert(() => new Child { ParentID = 1, ChildID = id });
 
-					Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id));
-					Assert.AreEqual(1, db.Child.Where(c => c.ChildID == id && c.Parent!.Value1 == 1).Update(c => new Child { ChildID = c.ChildID + 1 }));
-					Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id + 1));
-				}
-				finally
-				{
-					db.Child.Delete(c => c.ChildID > 1000);
-				}
+				Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id));
+				Assert.AreEqual(1, db.Child.Where(c => c.ChildID == id && c.Parent!.Value1 == 1).Update(c => new Child { ChildID = c.ChildID + 1 }));
+				Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id + 1));
 			}
 		}
 
@@ -141,26 +118,19 @@ namespace Tests.xUpdate
 		public void Update4([DataSources(TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
-				{
-					var id = 1001;
+				var id = 1001;
 
-					db.Child.Delete(c => c.ChildID > 1000);
-					db.Child.Insert(() => new Child { ParentID = 1, ChildID = id});
+				db.Child.Insert(() => new Child { ParentID = 1, ChildID = id });
 
-					Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id));
-					Assert.AreEqual(1,
-						db.Child
-							.Where(c => c.ChildID == id && c.Parent!.Value1 == 1)
-								.Set(c => c.ChildID, c => c.ChildID + 1)
-							.Update());
-					Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id + 1));
-				}
-				finally
-				{
-					db.Child.Delete(c => c.ChildID > 1000);
-				}
+				Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id));
+				Assert.AreEqual(1,
+					db.Child
+						.Where(c => c.ChildID == id && c.Parent!.Value1 == 1)
+							.Set(c => c.ChildID, c => c.ChildID + 1)
+						.Update());
+				Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id + 1));
 			}
 		}
 
@@ -187,26 +157,19 @@ namespace Tests.xUpdate
 		public async Task Update4Async([DataSources(TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
-				{
-					var id = 1001;
+				var id = 1001;
 
-					await db.Child.DeleteAsync(c => c.ChildID > 1000);
-					await db.Child.InsertAsync(() => new Child { ParentID = 1, ChildID = id});
+				await db.Child.InsertAsync(() => new Child { ParentID = 1, ChildID = id });
 
-					Assert.AreEqual(1, await db.Child.CountAsync(c => c.ChildID == id));
-					Assert.AreEqual(1,
-						await db.Child
-							.Where(c => c.ChildID == id && c.Parent!.Value1 == 1)
-								.Set(c => c.ChildID, c => c.ChildID + 1)
-							.UpdateAsync());
-					Assert.AreEqual(1, await db.Child.CountAsync(c => c.ChildID == id + 1));
-				}
-				finally
-				{
-					await db.Child.DeleteAsync(c => c.ChildID > 1000);
-				}
+				Assert.AreEqual(1, await db.Child.CountAsync(c => c.ChildID == id));
+				Assert.AreEqual(1,
+					await db.Child
+						.Where(c => c.ChildID == id && c.Parent!.Value1 == 1)
+							.Set(c => c.ChildID, c => c.ChildID + 1)
+						.UpdateAsync());
+				Assert.AreEqual(1, await db.Child.CountAsync(c => c.ChildID == id + 1));
 			}
 		}
 
@@ -214,26 +177,19 @@ namespace Tests.xUpdate
 		public void Update5([DataSources(TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
-				{
-					var id = 1001;
+				var id = 1001;
 
-					db.Child.Delete(c => c.ChildID > 1000);
-					db.Child.Insert(() => new Child { ParentID = 1, ChildID = id });
+				db.Child.Insert(() => new Child { ParentID = 1, ChildID = id });
 
-					Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id));
-					Assert.AreEqual(1,
-						db.Child
-							.Where(c => c.ChildID == id && c.Parent!.Value1 == 1)
-								.Set(c => c.ChildID, () => id + 1)
-							.Update());
-					Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id + 1));
-				}
-				finally
-				{
-					db.Child.Delete(c => c.ChildID > 1000);
-				}
+				Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id));
+				Assert.AreEqual(1,
+					db.Child
+						.Where(c => c.ChildID == id && c.Parent!.Value1 == 1)
+							.Set(c => c.ChildID, () => id + 1)
+						.Update());
+				Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id + 1));
 			}
 		}
 
@@ -241,26 +197,21 @@ namespace Tests.xUpdate
 		public void Update6([DataSources(TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
-				{
-					var id = 1001;
+				var id = 1001;
 
-					db.Parent4.Delete(p => p.ParentID > 1000);
-					db.Insert(new Parent4 { ParentID = id, Value1 = TypeValue.Value1 });
+				db.Insert(new Parent4 { ParentID = id, Value1 = TypeValue.Value1 });
 
-					Assert.AreEqual(1, db.Parent4.Count(p => p.ParentID == id && p.Value1 == TypeValue.Value1));
-					Assert.AreEqual(1,
-						db.Parent4
-							.Where(p => p.ParentID == id)
-								.Set(p => p.Value1, () => TypeValue.Value2)
-							.Update());
-					Assert.AreEqual(1, db.Parent4.Count(p => p.ParentID == id && p.Value1 == TypeValue.Value2));
-				}
-				finally
-				{
-					db.Parent4.Delete(p => p.ParentID > 1000);
-				}
+				Assert.AreEqual(1, db.Parent4.Count(p => p.ParentID == id && p.Value1 == TypeValue.Value1));
+
+				var cnt = db.Parent4
+						.Where(p => p.ParentID == id)
+							.Set(p => p.Value1, () => TypeValue.Value2)
+						.Update();
+					Assert.AreEqual(1, cnt);
+
+				Assert.AreEqual(1, db.Parent4.Count(p => p.ParentID == id && p.Value1 == TypeValue.Value2));
 			}
 		}
 
@@ -268,33 +219,27 @@ namespace Tests.xUpdate
 		public void Update7([DataSources(TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
-				{
-					var id = 1001;
+				var id = 1001;
 
-					db.Parent4.Delete(p => p.ParentID > 1000);
-					db.Insert(new Parent4 { ParentID = id, Value1 = TypeValue.Value1 });
+				db.Insert(new Parent4 { ParentID = id, Value1 = TypeValue.Value1 });
 
-					Assert.AreEqual(1, db.Parent4.Count(p => p.ParentID == id && p.Value1 == TypeValue.Value1));
-					Assert.AreEqual(1,
-						db.Parent4
-							.Where(p => p.ParentID == id)
-								.Set(p => p.Value1, TypeValue.Value2)
-							.Update());
-					Assert.AreEqual(1, db.Parent4.Count(p => p.ParentID == id && p.Value1 == TypeValue.Value2));
+				Assert.AreEqual(1, db.Parent4.Count(p => p.ParentID == id && p.Value1 == TypeValue.Value1));
+				var cnt = db.Parent4
+						.Where(p => p.ParentID == id)
+							.Set(p => p.Value1, TypeValue.Value2)
+						.Update();
+					Assert.AreEqual(1, cnt);
+				Assert.AreEqual(1, db.Parent4.Count(p => p.ParentID == id && p.Value1 == TypeValue.Value2));
 
-					Assert.AreEqual(1,
-						db.Parent4
-							.Where(p => p.ParentID == id)
-								.Set(p => p.Value1, TypeValue.Value3)
-							.Update());
-					Assert.AreEqual(1, db.Parent4.Count(p => p.ParentID == id && p.Value1 == TypeValue.Value3));
-				}
-				finally
-				{
-					db.Parent4.Delete(p => p.ParentID > 1000);
-				}
+				cnt = db.Parent4
+						.Where(p => p.ParentID == id)
+							.Set(p => p.Value1, TypeValue.Value3)
+						.Update();
+					Assert.AreEqual(1, cnt);
+
+				Assert.AreEqual(1, db.Parent4.Count(p => p.ParentID == id && p.Value1 == TypeValue.Value3));
 			}
 		}
 
@@ -302,24 +247,17 @@ namespace Tests.xUpdate
 		public void Update8([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
-				{
-					var parent = new Parent1 { ParentID = 1001, Value1 = 1001 };
+				var parent = new Parent1 { ParentID = 1001, Value1 = 1001 };
 
-					db.Parent.Delete(p => p.ParentID > 1000);
-					db.Insert(parent);
+				db.Insert(parent);
 
-					parent.Value1++;
+				parent.Value1++;
 
-					db.Update(parent);
+				db.Update(parent);
 
-					Assert.AreEqual(1002, db.Parent.Single(p => p.ParentID == parent.ParentID).Value1);
-				}
-				finally
-				{
-					db.Child.Delete(c => c.ChildID > 1000);
-				}
+				Assert.AreEqual(1002, db.Parent.Single(p => p.ParentID == parent.ParentID).Value1);
 			}
 		}
 
@@ -338,28 +276,21 @@ namespace Tests.xUpdate
 			string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
-				{
-					var id = 1001;
+				var id = 1001;
 
-					db.Child.Delete(c => c.ChildID > 1000);
-					db.Child.Insert(() => new Child { ParentID = 1, ChildID = id});
+				db.Child.Insert(() => new Child { ParentID = 1, ChildID = id });
 
-					var q =
+				var q =
 						from c in db.Child
 						join p in db.Parent on c.ParentID equals p.ParentID
 						where c.ChildID == id && c.Parent!.Value1 == 1
 						select new { c, p };
 
-					Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id));
-					Assert.AreEqual(1, q.Update(db.Child, _ => new Child { ChildID = _.c.ChildID + 1, ParentID = _.p.ParentID }));
-					Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id + 1));
-				}
-				finally
-				{
-					db.Child.Delete(c => c.ChildID > 1000);
-				}
+				Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id));
+				Assert.AreEqual(1, q.Update(db.Child, _ => new Child { ChildID = _.c.ChildID + 1, ParentID = _.p.ParentID }));
+				Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id + 1));
 			}
 		}
 
@@ -378,28 +309,21 @@ namespace Tests.xUpdate
 			string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
-				{
-					var id = 1001;
+				var id = 1001;
 
-					db.Child.Delete(c => c.ChildID > 1000);
-					db.Child.Insert(() => new Child { ParentID = 1, ChildID = id});
+				db.Child.Insert(() => new Child { ParentID = 1, ChildID = id });
 
-					var q =
+				var q =
 						from p in db.Parent
 						join c in db.Child on p.ParentID equals c.ParentID
 						where c.ChildID == id && c.Parent!.Value1 == 1
 						select new { c, p };
 
-					Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id));
-					Assert.AreEqual(1, q.Update(db.Child, _ => new Child { ChildID = _.c.ChildID + 1, ParentID = _.p.ParentID }));
-					Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id + 1));
-				}
-				finally
-				{
-					db.Child.Delete(c => c.ChildID > 1000);
-				}
+				Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id));
+				Assert.AreEqual(1, q.Update(db.Child, _ => new Child { ChildID = _.c.ChildID + 1, ParentID = _.p.ParentID }));
+				Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id + 1));
 			}
 		}
 
@@ -494,32 +418,27 @@ namespace Tests.xUpdate
 		public void Update14([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
 				db.Insert(new Person()
 				{
+					ID        = 100,
 					FirstName = "Update14",
 					LastName  = "whatever"
 				});
 
-				try
-				{
-					var name = "Update14";
-					var idx = 4;
+				var name = "Update14";
+				var idx = 4;
 
-					db.Person
-						.Where(_ => _.FirstName.StartsWith("Update14"))
-						.Update(p => new Person()
-						{
-							LastName = (Sql.AsSql(name).Length + idx).ToString(),
-						});
+				db.Person
+					.Where(_ => _.FirstName.StartsWith("Update14"))
+					.Update(p => new Person()
+					{
+						LastName = (Sql.AsSql(name).Length + idx).ToString(),
+					});
 
-					var cnt = db.Person.Where(_ => _.FirstName.StartsWith("Update14")).Count();
-					Assert.AreEqual(1, cnt);
-				}
-				finally
-				{
-					db.Person.Where(_ => _.FirstName.StartsWith("Update14")).Delete();
-				}
+				var cnt = db.Person.Where(_ => _.FirstName.StartsWith("Update14")).Count();
+				Assert.AreEqual(1, cnt);
 			}
 		}
 
@@ -529,37 +448,32 @@ namespace Tests.xUpdate
 			ResetPersonIdentity(context);
 
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
 				var newName = "UpdateColumnFilterUpdated";
-				try
+				var p = new Person()
 				{
-					var p = new Person()
-					{
-						FirstName = newName,
-						LastName = "whatever",
-						MiddleName = "som middle name",
-						Gender = Gender.Male
-					};
+					ID         = 100,
+					FirstName  = newName,
+					LastName   = "whatever",
+					MiddleName = "som middle name",
+					Gender     = Gender.Male
+				};
 
-					db.Insert(p);
+				db.Insert(p);
 
-					p = db.GetTable<Person>().Where(x => x.FirstName == p.FirstName).First();
+				p = db.GetTable<Person>().Where(x => x.FirstName == p.FirstName).First();
 
-					p.MiddleName = "updated name";
+				p.MiddleName = "updated name";
 
-					db.Update(p, (a, b) => b.ColumnName != nameof(Model.Person.MiddleName) || withMiddleName);
+				db.Update(p, (a, b) => b.ColumnName != nameof(Model.Person.MiddleName) || withMiddleName);
 
-					p = db.GetTable<Person>().Where(x => x.FirstName == p.FirstName).First();
+				p = db.GetTable<Person>().Where(x => x.FirstName == p.FirstName).First();
 
-					if (withMiddleName)
-						Assert.AreEqual("updated name", p.MiddleName);
-					else
-						Assert.AreNotEqual("updated name", p.MiddleName);
-				}
-				finally
-				{
-					db.Person.Where(x => x.FirstName == newName).Delete();
-				}
+				if (withMiddleName)
+					Assert.AreEqual("updated name", p.MiddleName);
+				else
+					Assert.AreNotEqual("updated name", p.MiddleName);
 			}
 		}
 
@@ -569,42 +483,37 @@ namespace Tests.xUpdate
 			ResetPersonIdentity(context);
 
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
 				var newName = "UpdateColumnFilterUpdated";
 				var p = new Person()
 				{
+					ID        = 100,
 					FirstName = "UpdateColumnFilter",
 					LastName  = "whatever"
 				};
 
 				db.Insert(p);
 
-				try
-				{
-					p = db.GetTable<Person>().Where(x => x.FirstName == p.FirstName).Single();
+				p = db.GetTable<Person>().Where(x => x.FirstName == p.FirstName).Single();
 
-					p.FirstName = newName;
-					p.LastName  = newName;
+				p.FirstName = newName;
+				p.LastName  = newName;
 
-					var columsToUpdate = new HashSet<string> { nameof(p.FirstName) };
+				var columsToUpdate = new HashSet<string> { nameof(p.FirstName) };
 
-					db.Update(p, (a, b) => columsToUpdate.Contains(b.ColumnName));
+				db.Update(p, (a, b) => columsToUpdate.Contains(b.ColumnName));
 
-					var updatedPerson = db.GetTable<Person>().Where(x => x.ID == p.ID).Single();
-					Assert.AreEqual("whatever", updatedPerson.LastName);
-					Assert.AreEqual(newName   , updatedPerson.FirstName);
+				var updatedPerson = db.GetTable<Person>().Where(x => x.ID == p.ID).Single();
+				Assert.AreEqual("whatever", updatedPerson.LastName);
+				Assert.AreEqual(newName, updatedPerson.FirstName);
 
-					// test for cached update query - must update both columns
-					db.Update(p);
-					updatedPerson = db.GetTable<Person>().Where(_ => _.ID == p.ID).Single();
+				// test for cached update query - must update both columns
+				db.Update(p);
+				updatedPerson = db.GetTable<Person>().Where(_ => _.ID == p.ID).Single();
 
-					Assert.AreEqual(newName, updatedPerson.LastName);
-					Assert.AreEqual(newName, updatedPerson.FirstName);
-				}
-				finally
-				{
-					db.Person.Where(x => x.ID == p.ID).Delete();
-				}
+				Assert.AreEqual(newName, updatedPerson.LastName);
+				Assert.AreEqual(newName, updatedPerson.FirstName);
 			}
 		}
 
@@ -614,34 +523,28 @@ namespace Tests.xUpdate
 			ResetPersonIdentity(context);
 
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				db.Person.Where(_ => _.FirstName.StartsWith("UpdateComplex")).Delete();
-				try
+				var person = new ComplexPerson2
 				{
+					Name = new FullName
+					{
+						FirstName = "UpdateComplex",
+						LastName  = "Empty"
+					}
+				};
 
-					var id = Convert.ToInt32(db.InsertWithIdentity(
-						new ComplexPerson2
-						{
-							Name = new FullName
-							{
-								FirstName = "UpdateComplex",
-								LastName  = "Empty"
-							}
-						}));
+				int id;
+					id = db.InsertWithInt32Identity(person);
 
-					var obj = db.GetTable<ComplexPerson2>().First(_ => _.ID == id);
-					obj.Name.LastName = obj.Name.FirstName;
+				var obj = db.GetTable<ComplexPerson2>().First(_ => _.ID == id);
+				obj.Name.LastName = obj.Name.FirstName;
 
-					db.Update(obj);
+				db.Update(obj);
 
-					obj = db.GetTable<ComplexPerson2>().First(_ => _.ID == id);
+				obj = db.GetTable<ComplexPerson2>().First(_ => _.ID == id);
 
-					Assert.AreEqual(obj.Name.FirstName, obj.Name.LastName);
-				}
-				finally
-				{
-					db.Person.Where(_ => _.FirstName.StartsWith("UpdateComplex")).Delete();
-				}
+				Assert.AreEqual(obj.Name.FirstName, obj.Name.LastName);
 			}
 		}
 
@@ -651,35 +554,28 @@ namespace Tests.xUpdate
 			ResetPersonIdentity(context);
 
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				await db.Person.DeleteAsync(_ => _.FirstName.StartsWith("UpdateComplex"));
-
-				try
+				var person = new ComplexPerson2
 				{
+					Name = new FullName
+					{
+						FirstName = "UpdateComplex",
+						LastName  = "Empty"
+					}
+				};
 
-					var id = Convert.ToInt32(await db.InsertWithIdentityAsync(
-						new ComplexPerson2
-						{
-							Name = new FullName
-							{
-								FirstName = "UpdateComplex",
-								LastName  = "Empty"
-							}
-						}));
+				int id;
+					id = db.InsertWithInt32Identity(person);
 
-					var obj = await db.GetTable<ComplexPerson2>().FirstAsync(_ => _.ID == id);
-					obj.Name.LastName = obj.Name.FirstName;
+				var obj = await db.GetTable<ComplexPerson2>().FirstAsync(_ => _.ID == id);
+				obj.Name.LastName = obj.Name.FirstName;
 
-					await db.UpdateAsync(obj);
+				await db.UpdateAsync(obj);
 
-					obj = await db.GetTable<ComplexPerson2>().FirstAsync(_ => _.ID == id);
+				obj = await db.GetTable<ComplexPerson2>().FirstAsync(_ => _.ID == id);
 
-					Assert.AreEqual(obj.Name.FirstName, obj.Name.LastName);
-				}
-				finally
-				{
-					await db.Person.Where(_ => _.FirstName.StartsWith("UpdateComplex")).DeleteAsync();
-				}
+				Assert.AreEqual(obj.Name.FirstName, obj.Name.LastName);
 			}
 		}
 
@@ -691,37 +587,32 @@ namespace Tests.xUpdate
 			ResetPersonIdentity(context);
 
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				db.Person.Where(_ => _.FirstName.StartsWith("UpdateComplex")).Delete();
-				try
+				var person = new ComplexPerson2
 				{
-					var id = Convert.ToInt32(db.InsertWithIdentity(
-						new ComplexPerson2
-						{
-							Name = new FullName
-							{
-								FirstName = "UpdateComplex",
-								LastName  = "Empty",
-							},
-							Gender = Gender.Male
-						}));
+					Name = new FullName
+					{
+						FirstName = "UpdateComplex",
+						LastName  = "Empty",
+					},
+					Gender = Gender.Male
+				};
 
-					var cnt = db.GetTable<ComplexPerson2>()
+				int id;
+					id = db.InsertWithInt32Identity(person);
+
+				var cnt = db.GetTable<ComplexPerson2>()
 						.Where(_ => _.Name.FirstName.StartsWith("UpdateComplex"))
 						.Set(_ => _.Gender, _ => nullableGender.HasValue ? nullableGender.Value : _.Gender)
 						.Update();
 
 					Assert.AreEqual(1, cnt);
 
-					var obj = db.GetTable<ComplexPerson2>()
+				var obj = db.GetTable<ComplexPerson2>()
 						.First(_ => _.ID == id);
 
-					Assert.AreEqual(Gender.Other, obj.Gender);
-				}
-				finally
-				{
-					db.Person.Where(_ => _.FirstName.StartsWith("UpdateComplex")).Delete();
-				}
+				Assert.AreEqual(Gender.Other, obj.Gender);
 			}
 		}
 
@@ -731,37 +622,30 @@ namespace Tests.xUpdate
 			ResetPersonIdentity(context);
 
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				db.Person.Where(_ => _.FirstName.StartsWith("UpdateComplex")).Delete();
-				try
+				var person = new ComplexPerson2
 				{
+					Name = new FullName
+					{
+						FirstName = "UpdateComplex",
+						LastName  = "Empty",
+					}
+				};
 
-					var id = Convert.ToInt32(db.InsertWithIdentity(
-						new ComplexPerson2()
-						{
-							Name = new FullName
-							{
-								FirstName = "UpdateComplex",
-								LastName  = "Empty"
-							}
-						}));
+				int id;
+					id = db.InsertWithInt32Identity(person);
 
-					var cnt = db.GetTable<ComplexPerson2>()
+				var cnt = db.GetTable<ComplexPerson2>()
 						.Where(_ => _.Name.FirstName.StartsWith("UpdateComplex"))
 						.Set(_ => _.Name.LastName, _ => _.Name.FirstName)
 						.Update();
 
 					Assert.AreEqual(1, cnt);
 
-					var obj = db.GetTable<ComplexPerson2>().First(_ => _.ID == id);
+				var obj = db.GetTable<ComplexPerson2>().First(_ => _.ID == id);
 
-					Assert.AreEqual(obj.Name.FirstName, obj.Name.LastName);
-				}
-				finally
-				{
-					db.Person.Where(_ => _.FirstName.StartsWith("UpdateComplex")).Delete();
-				}
-
+				Assert.AreEqual(obj.Name.FirstName, obj.Name.LastName);
 			}
 		}
 
@@ -769,30 +653,20 @@ namespace Tests.xUpdate
 		public void UpdateAssociation1([DataSources(TestProvName.AllSybase, TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
 				const int childId  = 10000;
 				const int parentId = 20000;
 
-				try
-				{
-					db.Child. Delete(x => x.ChildID  == childId);
-					db.Parent.Delete(x => x.ParentID == parentId);
+				db.Parent.Insert(() => new Parent { ParentID = parentId, Value1 = parentId });
+				db.Child .Insert(() => new Child { ChildID = childId, ParentID = parentId });
 
-					db.Parent.Insert(() => new Parent { ParentID = parentId, Value1 = parentId });
-					db.Child. Insert(() => new Child  { ChildID = childId, ParentID = parentId });
-
-					var parents =
+				var parents =
 						from child in db.Child
 						where child.ChildID == childId
 						select child.Parent;
 
-					Assert.AreEqual(1, parents.Update(db.Parent, x => new Parent { Value1 = 5 }));
-				}
-				finally
-				{
-					db.Child. Delete(x => x.ChildID  == childId);
-					db.Parent.Delete(x => x.ParentID == parentId);
-				}
+				Assert.AreEqual(1, parents.Update(db.Parent, x => new Parent { Value1 = 5 }));
 			}
 		}
 
@@ -800,30 +674,20 @@ namespace Tests.xUpdate
 		public async Task UpdateAssociation1Async([DataSources(TestProvName.AllSybase, TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
 				const int childId  = 10000;
 				const int parentId = 20000;
 
-				try
-				{
-					await db.Child. DeleteAsync(x => x.ChildID  == childId);
-					await db.Parent.DeleteAsync(x => x.ParentID == parentId);
+				await db.Parent.InsertAsync(() => new Parent { ParentID = parentId, Value1 = parentId });
+				await db.Child.InsertAsync(() => new Child { ChildID = childId, ParentID = parentId });
 
-					await db.Parent.InsertAsync(() => new Parent { ParentID = parentId, Value1 = parentId });
-					await db.Child. InsertAsync(() => new Child  { ChildID = childId, ParentID = parentId });
-
-					var parents =
+				var parents =
 						from child in db.Child
 						where child.ChildID == childId
 						select child.Parent;
 
-					Assert.AreEqual(1, await parents.UpdateAsync(db.Parent, x => new Parent { Value1 = 5 }));
-				}
-				finally
-				{
-					await db.Child. DeleteAsync(x => x.ChildID  == childId);
-					await db.Parent.DeleteAsync(x => x.ParentID == parentId);
-				}
+				Assert.AreEqual(1, await parents.UpdateAsync(db.Parent, x => new Parent { Value1 = 5 }));
 			}
 		}
 
@@ -831,30 +695,20 @@ namespace Tests.xUpdate
 		public void UpdateAssociation2([DataSources(TestProvName.AllSybase, TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
 				const int childId  = 10000;
 				const int parentId = 20000;
 
-				try
-				{
-					db.Child. Delete(x => x.ChildID  == childId);
-					db.Parent.Delete(x => x.ParentID == parentId);
+				db.Parent.Insert(() => new Parent { ParentID = parentId, Value1 = parentId });
+				db.Child.Insert(() => new Child { ChildID = childId, ParentID = parentId });
 
-					db.Parent.Insert(() => new Parent { ParentID = parentId, Value1 = parentId });
-					db.Child. Insert(() => new Child  { ChildID = childId, ParentID = parentId });
-
-					var parents =
+				var parents =
 						from child in db.Child
 						where child.ChildID == childId
 						select child.Parent;
 
-					Assert.AreEqual(1, parents.Update(x => new Parent { Value1 = 5 }));
-				}
-				finally
-				{
-					db.Child. Delete(x => x.ChildID  == childId);
-					db.Parent.Delete(x => x.ParentID == parentId);
-				}
+				Assert.AreEqual(1, parents.Update(x => new Parent { Value1 = 5 }));
 			}
 		}
 
@@ -862,30 +716,20 @@ namespace Tests.xUpdate
 		public void UpdateAssociation3([DataSources(TestProvName.AllSybase, TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
 				const int childId  = 10000;
 				const int parentId = 20000;
 
-				try
-				{
-					db.Child. Delete(x => x.ChildID  == childId);
-					db.Parent.Delete(x => x.ParentID == parentId);
+				db.Parent.Insert(() => new Parent { ParentID = parentId, Value1 = parentId });
+				db.Child.Insert(() => new Child { ChildID = childId, ParentID = parentId });
 
-					db.Parent.Insert(() => new Parent { ParentID = parentId, Value1 = parentId });
-					db.Child. Insert(() => new Child  { ChildID = childId, ParentID = parentId });
-
-					var parents =
+				var parents =
 						from child in db.Child
 						where child.ChildID == childId
 						select child.Parent;
 
-					Assert.AreEqual(1, parents.Update(x => x.ParentID > 0, x => new Parent { Value1 = 5 }));
-				}
-				finally
-				{
-					db.Child. Delete(x => x.ChildID  == childId);
-					db.Parent.Delete(x => x.ParentID == parentId);
-				}
+				Assert.AreEqual(1, parents.Update(x => x.ParentID > 0, x => new Parent { Value1 = 5 }));
 			}
 		}
 
@@ -893,30 +737,20 @@ namespace Tests.xUpdate
 		public void UpdateAssociation4([DataSources(TestProvName.AllSybase, TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
 				const int childId  = 10000;
 				const int parentId = 20000;
 
-				try
-				{
-					db.Child. Delete(x => x.ChildID  == childId);
-					db.Parent.Delete(x => x.ParentID == parentId);
+				db.Parent.Insert(() => new Parent { ParentID = parentId, Value1 = parentId });
+				db.Child.Insert(() => new Child { ChildID = childId, ParentID = parentId });
 
-					db.Parent.Insert(() => new Parent { ParentID = parentId, Value1 = parentId });
-					db.Child. Insert(() => new Child  { ChildID = childId, ParentID = parentId });
-
-					var parents =
+				var parents =
 						from child in db.Child
 						where child.ChildID == childId
 						select child.Parent;
 
-					Assert.AreEqual(1, parents.Set(x => x.Value1, 5).Update());
-				}
-				finally
-				{
-					db.Child. Delete(x => x.ChildID  == childId);
-					db.Parent.Delete(x => x.ParentID == parentId);
-				}
+				Assert.AreEqual(1, parents.Set(x => x.Value1, 5).Update());
 			}
 		}
 
@@ -1004,28 +838,22 @@ namespace Tests.xUpdate
 		public void AsUpdatableTest([DataSources(TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
-				{
-					var id = 1001;
+				var id = 1001;
 
-					db.Child.Delete(c => c.ChildID > 1000);
-					db.Child.Insert(() => new Child { ParentID = 1, ChildID = id});
+				db.Child.Delete(c => c.ChildID > 1000);
+				db.Child.Insert(() => new Child { ParentID = 1, ChildID = id });
 
-					Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id));
+				Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id));
 
-					var q  = db.Child.Where(c => c.ChildID == id && c.Parent!.Value1 == 1);
-					var uq = q.AsUpdatable();
+				var q  = db.Child.Where(c => c.ChildID == id && c.Parent!.Value1 == 1);
+				var uq = q.AsUpdatable();
 
-					uq = uq.Set(c => c.ChildID, c => c.ChildID + 1);
+				uq = uq.Set(c => c.ChildID, c => c.ChildID + 1);
 
-					Assert.AreEqual(1, uq.Update());
-					Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id + 1));
-				}
-				finally
-				{
-					db.Child.Delete(c => c.ChildID > 1000);
-				}
+				Assert.AreEqual(1, uq.Update());
+				Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id + 1));
 			}
 		}
 
@@ -1033,29 +861,23 @@ namespace Tests.xUpdate
 		public void AsUpdatableDuplicate([DataSources(TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
-				{
-					var id = 1001;
+				var id = 1001;
 
-					db.Child.Delete(c => c.ChildID > 1000);
-					db.Child.Insert(() => new Child { ParentID = 1, ChildID = id });
+				db.Child.Delete(c => c.ChildID > 1000);
+				db.Child.Insert(() => new Child { ParentID = 1, ChildID = id });
 
-					Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id));
+				Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id));
 
-					var q  = db.Child.Where(c => c.ChildID == id && c.Parent!.Value1 == 1);
-					var uq = q.AsUpdatable();
+				var q  = db.Child.Where(c => c.ChildID == id && c.Parent!.Value1 == 1);
+				var uq = q.AsUpdatable();
 
-					uq = uq.Set(c => c.ChildID, c => c.ChildID + 1);
-					uq = uq.Set(c => c.ChildID, c => c.ChildID + 2);
+				uq = uq.Set(c => c.ChildID, c => c.ChildID + 1);
+				uq = uq.Set(c => c.ChildID, c => c.ChildID + 2);
 
-					Assert.AreEqual(1, uq.Update());
-					Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id + 2));
-				}
-				finally
-				{
-					db.Child.Delete(c => c.ChildID > 1000);
-				}
+				Assert.AreEqual(1, uq.Update());
+				Assert.AreEqual(1, db.Child.Count(c => c.ChildID == id + 2));
 			}
 		}
 
@@ -1098,29 +920,21 @@ namespace Tests.xUpdate
 			string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
+				using (new DisableLogging())
 				{
-					db.Parent.Delete(c => c.ParentID >= 1000);
-
-					using (new DisableLogging())
-					{
-						for (var i = 0; i < 10; i++)
-							db.Insert(new Parent { ParentID = 1000 + i });
-					}
-
-					var rowsAffected = db.Parent
-						.Where(p => p.ParentID >= 1000)
-						.Take(5)
-						.Set(p => p.Value1, 1)
-						.Update();
-
-					Assert.That(rowsAffected, Is.EqualTo(5));
+					for (var i = 0; i < 10; i++)
+						db.Insert(new Parent { ParentID = 1000 + i });
 				}
-				finally
-				{
-					db.Parent.Delete(c => c.ParentID >= 1000);
-				}
+
+				var rowsAffected = db.Parent
+					.Where(p => p.ParentID >= 1000)
+					.Take(5)
+					.Set(p => p.Value1, 1)
+					.Update();
+
+				Assert.That(rowsAffected, Is.EqualTo(5));
 			}
 		}
 
@@ -1140,32 +954,25 @@ namespace Tests.xUpdate
 			string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
+				using (new DisableLogging())
 				{
-					using (new DisableLogging())
-					{
-						db.Parent.Delete(c => c.ParentID >= 1000);
-						for (var i = 0; i < 10; i++)
-							db.Insert(new Parent { ParentID = 1000 + i });
-					}
-
-					var entities =
-						from x in db.Parent
-						where x.ParentID > 1000
-						orderby x.ParentID descending
-						select x;
-
-					var rowsAffected = entities
-						.Take(5)
-						.Update(x => new Parent { Value1 = 1 });
-
-					Assert.That(rowsAffected, Is.EqualTo(5));
+					for (var i = 0; i < 10; i++)
+						db.Insert(new Parent { ParentID = 1000 + i });
 				}
-				finally
-				{
-					db.Parent.Delete(c => c.ParentID >= 1000);
-				}
+
+				var entities =
+					from x in db.Parent
+					where x.ParentID > 1000
+					orderby x.ParentID descending
+					select x;
+
+				var rowsAffected = entities
+					.Take(5)
+					.Update(x => new Parent { Value1 = 1 });
+
+				Assert.That(rowsAffected, Is.EqualTo(5));
 			}
 		}
 
@@ -1185,35 +992,28 @@ namespace Tests.xUpdate
 			string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
+				using (new DisableLogging())
 				{
-					using (new DisableLogging())
-					{
-						db.Parent.Delete(c => c.ParentID >= 1000);
-						for (var i = 0; i < 10; i++)
-							db.Insert(new Parent {ParentID = 1000 + i});
-					}
-
-					var entities =
-						from x in db.Parent
-						where x.ParentID > 1000
-						orderby x.ParentID descending
-						select x;
-
-					var rowsAffected = entities
-						.Skip(1)
-						.Take(5)
-						.Update(x => new Parent { Value1 = 1 });
-
-					Assert.That(rowsAffected, Is.EqualTo(5));
-
-					Assert.False(db.Parent.Where(p => p.ParentID == 1000 + 9).Single().Value1 == 1);
+					for (var i = 0; i < 10; i++)
+						db.Insert(new Parent { ParentID = 1000 + i });
 				}
-				finally
-				{
-					db.Parent.Delete(c => c.ParentID >= 1000);
-				}
+
+				var entities =
+					from x in db.Parent
+					where x.ParentID > 1000
+					orderby x.ParentID descending
+					select x;
+
+				var rowsAffected = entities
+					.Skip(1)
+					.Take(5)
+					.Update(x => new Parent { Value1 = 1 });
+
+				Assert.That(rowsAffected, Is.EqualTo(5));
+
+				Assert.False(db.Parent.Where(p => p.ParentID == 1000 + 9).Single().Value1 == 1);
 			}
 		}
 
@@ -1230,31 +1030,24 @@ namespace Tests.xUpdate
 			string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
-				try
+				using (new DisableLogging())
 				{
-					using (new DisableLogging())
-					{
-						db.Parent.Delete(c => c.ParentID >= 1000);
-						for (var i = 0; i < 10; i++)
-							db.Insert(new Parent {ParentID = 1000 + i});
-					}
-
-					var entities =
-						from x in db.Parent
-						where x.ParentID > 1000
-						select x;
-
-					var rowsAffected = entities
-						.Take(5)
-						.Update(x => new Parent { Value1 = 1 });
-
-					Assert.That(rowsAffected, Is.EqualTo(5));
+					for (var i = 0; i < 10; i++)
+						db.Insert(new Parent { ParentID = 1000 + i });
 				}
-				finally
-				{
-					db.Parent.Delete(c => c.ParentID >= 1000);
-				}
+
+				var entities =
+					from x in db.Parent
+					where x.ParentID > 1000
+					select x;
+
+				var rowsAffected = entities
+					.Take(5)
+					.Update(x => new Parent { Value1 = 1 });
+
+				Assert.That(rowsAffected, Is.EqualTo(5));
 			}
 		}
 
@@ -1297,37 +1090,31 @@ namespace Tests.xUpdate
 			string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
 				var id = 100500;
-				try
+				db.Insert(new Parent1()
 				{
-					db.Insert(new Parent1()
-					{
-						ParentID = id
-					});
+					ParentID = id
+				});
 
-					var query = db.GetTable<Parent1>()
+				var query = db.GetTable<Parent1>()
 						.Where(_ => _.ParentID == id)
 						.Select(_ => new Parent1()
 						{
 							ParentID = _.ParentID
 						});
 
-					var queryResult = new Lazy<Parent1>(() => query.First());
+				var queryResult = new Lazy<Parent1>(() => query.First());
 
-					var cnt = db.GetTable<Parent1>()
+				var cnt = db.GetTable<Parent1>()
 						.Where(_ => _.ParentID == id && query.Count() > 0)
 						.Update(_ => new Parent1()
 						{
 							Value1 = queryResult.Value.ParentID
 						});
 
-					Assert.AreEqual(1, cnt);
-				}
-				finally
-				{
-					db.GetTable<Parent1>().Delete(_ => _.ParentID == id);
-				}
+				Assert.AreEqual(1, cnt);
 			}
 		}
 
@@ -1338,42 +1125,36 @@ namespace Tests.xUpdate
 		public void UpdateIssue321Regression([DataSources(ProviderName.DB2, TestProvName.AllInformix, TestProvName.AllFirebird)] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
 				var id = 100500;
 
-				try
+				var value1 = 3000m;
+				var value2 = 13621m;
+				var value3 = 60;
+
+				db.Insert(new LinqDataTypes2()
 				{
-					var value1 = 3000m;
-					var value2 = 13621m;
-					var value3 = 60;
+					ID = id,
+					MoneyValue = value1,
+					IntValue = value3
+				});
 
-					db.Insert(new LinqDataTypes2()
-					{
-						ID         = id,
-						MoneyValue = value1,
-						IntValue   = value3
-					});
+				db.GetTable<LinqDataTypes2>()
+					.Update(
+						_ => _.ID == id,
+						_ => new LinqDataTypes2
+						{
+							SmallIntValue = (short)(_.MoneyValue / (value2 / _.IntValue!))
+						});
 
-					db.GetTable<LinqDataTypes2>()
-						.Update(
-							_ => _.ID == id,
-							_ => new LinqDataTypes2
-							{
-								SmallIntValue = (short)(_.MoneyValue / (value2 / _.IntValue!))
-							});
-
-					var dbResult = db.GetTable<LinqDataTypes2>()
+				var dbResult = db.GetTable<LinqDataTypes2>()
 						.Where(_ => _.ID == id)
 						.Select(_ => _.SmallIntValue).First();
 
-					var expected = (short)(value1 / (value2 / value3));
+				var expected = (short)(value1 / (value2 / value3));
 
-					Assert.AreEqual(expected, dbResult);
-				}
-				finally
-				{
-					db.GetTable<LinqDataTypes2>().Delete(c => c.ID == id);
-				}
+				Assert.AreEqual(expected, dbResult);
 			}
 		}
 
@@ -1381,6 +1162,7 @@ namespace Tests.xUpdate
 		public void UpdateMultipleColumns([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
+			using (new RestoreBaseTables(db))
 			{
 				var ldt = new LinqDataTypes
 				{
@@ -1389,32 +1171,24 @@ namespace Tests.xUpdate
 					SmallIntValue = 100,
 				};
 
-				try
-				{
-					db.Types.Delete(c => c.ID == ldt.ID);
-					db.Types
-						.Value (t => t.ID,            ldt.ID)
-						.Value (t => t.MoneyValue,    () => ldt.MoneyValue)
-						.Value (t => t.SmallIntValue, () => ldt.SmallIntValue)
-						.Insert()
-						;
+				db.Types
+					.Value(t => t.ID, ldt.ID)
+					.Value(t => t.MoneyValue, () => ldt.MoneyValue)
+					.Value(t => t.SmallIntValue, () => ldt.SmallIntValue)
+					.Insert()
+					;
 
-					db.Types
-						.Where (t => t.ID == ldt.ID)
-						.Set   (t => t.MoneyValue,    () => 2000)
-						.Set   (t => t.SmallIntValue, () => 200)
-						.Update()
-						;
+				db.Types
+					.Where(t => t.ID == ldt.ID)
+					.Set(t => t.MoneyValue, () => 2000)
+					.Set(t => t.SmallIntValue, () => 200)
+					.Update()
+					;
 
-					var udt = db.Types.Single(t => t.ID == ldt.ID);
+				var udt = db.Types.Single(t => t.ID == ldt.ID);
 
-					Assert.That(udt.MoneyValue,    Is.Not.EqualTo(ldt.MoneyValue));
-					Assert.That(udt.SmallIntValue, Is.Not.EqualTo(ldt.SmallIntValue));
-				}
-				finally
-				{
-					db.Types.Delete(t => t.ID == ldt.ID);
-				}
+				Assert.That(udt.MoneyValue, Is.Not.EqualTo(ldt.MoneyValue));
+				Assert.That(udt.SmallIntValue, Is.Not.EqualTo(ldt.SmallIntValue));
 			}
 		}
 
@@ -1852,7 +1626,7 @@ namespace Tests.xUpdate
 					.Set(x => x.Items2, x => $"{x.Items2}{str}")
 					.Update();
 
-				var result = table.ToArray();
+				var result = table.OrderBy(_ => _.Id).ToArray();
 
 				Assert.That(result[0].Items1, Is.EqualTo("T1" + str));
 				Assert.That(result[0].Items2, Is.EqualTo("Z1" + str));

--- a/Tests/Linq/Update/UpdateWithOutputTests.cs
+++ b/Tests/Linq/Update/UpdateWithOutputTests.cs
@@ -15,12 +15,12 @@ namespace Tests.xUpdate
 	public class UpdateWithOutputTests : TestBase
 	{
 		private const string FeatureUpdateOutputWithOldSingle                      = $"{TestProvName.AllSqlServer},{TestProvName.AllFirebird}";
-		private const string FeatureUpdateOutputWithOldSingleNoAlternateRewrite    = TestProvName.AllSqlServer;
-		private const string FeatureUpdateOutputWithOldMultiple                    = TestProvName.AllSqlServer;
+		private const string FeatureUpdateOutputWithOldSingleNoAlternateRewrite    = $"{TestProvName.AllSqlServer}";
+		private const string FeatureUpdateOutputWithOldMultiple                    = $"{TestProvName.AllSqlServer}";
 		private const string FeatureUpdateOutputWithoutOldSingle                   = $"{TestProvName.AllSqlServer},{TestProvName.AllFirebird},{TestProvName.AllPostgreSQL},{TestProvName.AllSQLiteClassic}";
 		private const string FeatureUpdateOutputWithoutOldSingleNoAlternateRewrite = $"{TestProvName.AllSqlServer},{TestProvName.AllPostgreSQL}";
 		private const string FeatureUpdateOutputWithoutOldMultiple                 = $"{TestProvName.AllSqlServer},{TestProvName.AllPostgreSQL},{TestProvName.AllSQLiteClassic}";
-		private const string FeatureUpdateOutputInto                               = TestProvName.AllSqlServer;
+		private const string FeatureUpdateOutputInto                               = $"{TestProvName.AllSqlServer}";
 
 		class UpdateOutputComparer<T> : IEqualityComparer<UpdateOutput<T>>
 			where T : notnull

--- a/Tests/Linq/UserTests/Issue1057Tests.cs
+++ b/Tests/Linq/UserTests/Issue1057Tests.cs
@@ -113,7 +113,7 @@ namespace Tests.UserTests
 							ActualStageId = (p as Task).ActualStage!.Id
 						});
 
-					var res2 = query2.ToArray();
+					var res2 = query2.OrderBy(_ => _.Instance.Id).ToArray();
 
 					Assert.AreEqual(2, res2.Length);
 					Assert.IsNotNull(res2[0].Instance);

--- a/Tests/Linq/UserTests/Issue1268Tests.cs
+++ b/Tests/Linq/UserTests/Issue1268Tests.cs
@@ -12,7 +12,7 @@ namespace Tests.UserTests
 		[Table("DynamicColumnTable")]
 		class FullClass
 		{
-			[Column, Identity]
+			[Column]
 			         public int     Id        { get; set; }
 			[Column] public string? Name      { get; set; }
 			[Column] public bool    IsDeleted { get; set; }
@@ -21,7 +21,7 @@ namespace Tests.UserTests
 		[Table("DynamicColumnTable")]
 		class RepresentTable
 		{
-			[Column, Identity]
+			[Column]
 			         public int     Id        { get; set; }
 			[Column] public string? Name      { get; set; }
 
@@ -41,12 +41,12 @@ namespace Tests.UserTests
 			using (var db = GetDataContext(context, ms))
 			using (db.CreateLocalTable<FullClass>())
 			{
-				var obj1 = new RepresentTable { Name = "Some1" };
+				var obj1 = new RepresentTable { Id = 1, Name = "Some1" };
 				obj1.Values.Add("IsDeleted", true);
-				db.InsertWithIdentity(obj1);
+				db.Insert(obj1);
 
-				var obj2 = new RepresentTable { Name = "Some2" };
-				db.InsertWithIdentity(obj2);
+				var obj2 = new RepresentTable { Id = 2, Name = "Some2" };
+				db.Insert(obj2);
 
 				var loaded1 = db.GetTable<RepresentTable>().First(e => e.Name == "Some1");
 				Assert.AreEqual(true, loaded1.Values["IsDeleted"]);
@@ -56,6 +56,5 @@ namespace Tests.UserTests
 				Assert.AreEqual(false, loaded2.Values["IsDeleted"]);
 			}
 		}
-
 	}
 }

--- a/Tests/Linq/UserTests/Issue1298Tests.cs
+++ b/Tests/Linq/UserTests/Issue1298Tests.cs
@@ -60,10 +60,9 @@ namespace Tests.UserTests
 		{
 			using (var db = GetDataConnection(context))
 			using (db.BeginTransaction())
+			using (db.CreateLocalTable<mega_composites>())
+			using (db.CreateLocalTable<Qwerty>())
 			{
-				db.CreateTable<mega_composites>();
-				db.CreateTable<Qwerty>();
-
 				db.Insert(new Qwerty() { Id = 1, asdfgh = "res1" });
 				db.Insert(new Qwerty() { Id = 100500, asdfgh = "res100500" });
 
@@ -118,10 +117,9 @@ namespace Tests.UserTests
 		{
 			using (var db = GetDataConnection(context))
 			using (db.BeginTransaction())
+			using (db.CreateLocalTable<mega_composites>())
+			using (db.CreateLocalTable<Qwerty>())
 			{
-				db.CreateTable<mega_composites>();
-				db.CreateTable<Qwerty>();
-
 				db.Insert(new Qwerty() { Id = 1, asdfgh = "res1" });
 				db.Insert(new Qwerty() { Id = 100500, asdfgh = "res100500" });
 

--- a/Tests/Linq/UserTests/Issue1584Tests.cs
+++ b/Tests/Linq/UserTests/Issue1584Tests.cs
@@ -21,116 +21,116 @@ namespace Tests.UserTests
 		}
 		private class RateCharges
 		{
-		    public RateEntry? RateEntry { get; set; }
-		    public decimal FlatRate { get; set; }
-		    public decimal MinRate { get; set; }
-		    public decimal VariableRate { get; set; }
+			public RateEntry? RateEntry    { get; set; }
+			public decimal    FlatRate     { get; set; }
+			public decimal    MinRate      { get; set; }
+			public decimal    VariableRate { get; set; }
 		}
 
 		public class RateEntry
 		{
-		    public const string RateCategoryOrigin = "ORG";
-		    public const string RateCategoryDestination = "DST";
-		    public const string HazardoudsCommodityCode = "HAZ";
+			public const string RateCategoryOrigin      = "ORG";
+			public const string RateCategoryDestination = "DST";
+			public const string HazardoudsCommodityCode = "HAZ";
 
-		    public Guid TI_PK { get; set; }
-		    public short TI_LineOrder { get; set; }
-		    public DateTime TI_RateStartDate { get; set; }
-		    public DateTime? TI_RateEndDate { get; set; }
-		    public string? TI_RX_NKCurrency { get; set; }
-		    public int TI_Frequency { get; set; }
-		    public Guid? TI_OH_Supplier { get; set; }
-		    public Guid? TI_OH_TransportProvider { get; set; }
-		    public Guid? TI_OH_Consignor { get; set; }
-		    public Guid? TI_OH_Consignee { get; set; }
-		    public Guid? TI_OA_CartagePickupAddressOverride { get; set; }
-		    public Guid? TI_OA_CartageDeliveryAddressOverride { get; set; }
-		    public string? TI_CartagePickupAddressPostCode { get; set; }
-		    public string? TI_CartageDeliveryAddressPostCode { get; set; }
-		    public string? TI_RS_NKServiceLevel_NI { get; set; }
-		    public string? TI_OriginLRC { get; set; }
-		    public string? TI_DestinationLRC { get; set; }
-		    public string? TI_ViaLRC { get; set; }
-		    public string? TI_PageHeading { get; set; }
-		    public string? TI_PageOpeningText { get; set; }
-		    public string? TI_PageClosingText { get; set; }
-		    public Guid? TI_OH_AgentOverride { get; set; }
-		    public Guid? TI_ParentID { get; set; }
-		    public string? TI_QuotePageIncoTerm { get; set; }
-		    public string? TI_BuyersConsolRateMode { get; set; }
-		    public DateTime? TI_SystemCreateTimeUtc { get; set; }
-		    public string? TI_SystemCreateUser { get; set; }
-		    public DateTime? TI_SystemLastEditTimeUtc { get; set; }
-		    public string? TI_SystemLastEditUser { get; set; }
-		    public Guid TI_TH { get; set; }
-		    public Guid? TI_RC { get; set; }
-		    public string? TI_ContractNumber { get; set; }
-		    public string? TI_PL_NKCarrierServiceLevel { get; set; }
-		    public Guid? TI_TZ_OriginZone { get; set; }
-		    public Guid? TI_TZ_DestinationZone { get; set; }
-		    public bool TI_IsValid { get; set; }
-		    public bool TI_IsCrossTrade { get; set; }
-		    public bool TI_DataChecked { get; set; }
-		    public bool TI_MatchContainerRateClass { get; set; }
-		    public string? TI_TransitTime { get; set; }
-		    public string? TI_FrequencyUnit { get; set; }
+			public Guid      TI_PK                                { get; set; }
+			public short     TI_LineOrder                         { get; set; }
+			public DateTime  TI_RateStartDate                     { get; set; }
+			public DateTime? TI_RateEndDate                       { get; set; }
+			public string?   TI_RX_NKCurrency                     { get; set; }
+			public int       TI_Frequency                         { get; set; }
+			public Guid?     TI_OH_Supplier                       { get; set; }
+			public Guid?     TI_OH_TransportProvider              { get; set; }
+			public Guid?     TI_OH_Consignor                      { get; set; }
+			public Guid?     TI_OH_Consignee                      { get; set; }
+			public Guid?     TI_OA_CartagePickupAddressOverride   { get; set; }
+			public Guid?     TI_OA_CartageDeliveryAddressOverride { get; set; }
+			public string?   TI_CartagePickupAddressPostCode      { get; set; }
+			public string?   TI_CartageDeliveryAddressPostCode    { get; set; }
+			public string?   TI_RS_NKServiceLevel_NI              { get; set; }
+			public string?   TI_OriginLRC                         { get; set; }
+			public string?   TI_DestinationLRC                    { get; set; }
+			public string?   TI_ViaLRC                            { get; set; }
+			public string?   TI_PageHeading                       { get; set; }
+			public string?   TI_PageOpeningText                   { get; set; }
+			public string?   TI_PageClosingText                   { get; set; }
+			public Guid?     TI_OH_AgentOverride                  { get; set; }
+			public Guid?     TI_ParentID                          { get; set; }
+			public string?   TI_QuotePageIncoTerm                 { get; set; }
+			public string?   TI_BuyersConsolRateMode              { get; set; }
+			public DateTime? TI_SystemCreateTimeUtc               { get; set; }
+			public string?   TI_SystemCreateUser                  { get; set; }
+			public DateTime? TI_SystemLastEditTimeUtc             { get; set; }
+			public string?   TI_SystemLastEditUser                { get; set; }
+			public Guid      TI_TH                                { get; set; }
+			public Guid?     TI_RC                                { get; set; }
+			public string?   TI_ContractNumber                    { get; set; }
+			public string?   TI_PL_NKCarrierServiceLevel          { get; set; }
+			public Guid?     TI_TZ_OriginZone                     { get; set; }
+			public Guid?     TI_TZ_DestinationZone                { get; set; }
+			public bool      TI_IsValid                           { get; set; }
+			public bool      TI_IsCrossTrade                      { get; set; }
+			public bool      TI_DataChecked                       { get; set; }
+			public bool      TI_MatchContainerRateClass           { get; set; }
+			public string?   TI_TransitTime                       { get; set; }
+			public string?   TI_FrequencyUnit                     { get; set; }
 
-		    [ColumnAlias(nameof(TI_Mode)), Column(IsColumn = false)]
-		    public TransportType? TI_ModeTT { get; set; }
+			[ColumnAlias(nameof(TI_Mode)), Column(IsColumn = false)]
+			public TransportType? TI_ModeTT { get; set; }
 
-		    public string? TI_Mode { get; set; }
-		    public string? TI_RH_NKCommodityCode { get; set; }
-		    public string? TI_RateCategory { get; set; }
+			public string? TI_Mode               { get; set; }
+			public string? TI_RH_NKCommodityCode { get; set; }
+			public string? TI_RateCategory       { get; set; }
 
-		    [ColumnAlias(nameof(TI_RateCategory)), Column(IsColumn = false)]
-		    public TransportType? TI_RateCategoryTT { get; set; }
+			[ColumnAlias(nameof(TI_RateCategory)), Column(IsColumn = false)]
+			public TransportType? TI_RateCategoryTT { get; set; }
 
-		    public Guid? TI_FromID { get; set; }
-		    public string? TI_FromTableCode { get; set; }
-		    public Guid? TI_ToId { get; set; }
-		    public string? TI_ToTableCode { get; set; }
-		    public Guid? TI_OH_ControllingCustomer { get; set; }
-		    public Guid TI_GC_Publisher { get; set; }
-		    public bool TI_IsTact { get; set; }
-		    public string? TI_ParentTableCode { get; set; }
-		    public int TI_RateKey { get; set; }
+			public Guid?   TI_FromID                 { get; set; }
+			public string? TI_FromTableCode          { get; set; }
+			public Guid?   TI_ToId                   { get; set; }
+			public string? TI_ToTableCode            { get; set; }
+			public Guid?   TI_OH_ControllingCustomer { get; set; }
+			public Guid    TI_GC_Publisher           { get; set; }
+			public bool    TI_IsTact                 { get; set; }
+			public string? TI_ParentTableCode        { get; set; }
+			public int     TI_RateKey                { get; set; }
 
-		    [ExpressionMethod(nameof(GetModeExpression))]
-		    public TransportType? GetMode()
-		    {
-		        switch (TI_RateCategory)
-		        {
-		            case RateEntry.RateCategoryDestination:
-		            case RateEntry.RateCategoryOrigin:
-		                return TI_ModeTT;
-		            default:
-		                return TI_RateCategoryTT;
-		        }
-		    }
+			[ExpressionMethod(nameof(GetModeExpression))]
+			public TransportType? GetMode()
+			{
+				switch (TI_RateCategory)
+				{
+					case RateCategoryDestination:
+					case RateCategoryOrigin:
+						return TI_ModeTT;
+					default:
+						return TI_RateCategoryTT;
+				}
+			}
 
-		    private static Expression<Func<RateEntry, TransportType?>> GetModeExpression()
-		    {
-		        return rateEntry => rateEntry.TI_RateCategory == RateEntry.RateCategoryDestination
-		                            || rateEntry.TI_RateCategory == RateEntry.RateCategoryOrigin
-		            ? rateEntry.TI_ModeTT
-		            : rateEntry.TI_RateCategoryTT;
-		    }
+			private static Expression<Func<RateEntry, TransportType?>> GetModeExpression()
+			{
+				return rateEntry => rateEntry.TI_RateCategory == RateCategoryDestination
+									|| rateEntry.TI_RateCategory == RateCategoryOrigin
+					? rateEntry.TI_ModeTT
+					: rateEntry.TI_RateCategoryTT;
+			}
 		}
 
 		public class RateLines
 		{
-		    public Guid TL_PK { get; set; }
-		//a bunch of properties removed
-		    public Guid TL_TI { get; set; }
+			public Guid TL_PK { get; set; }
+			//a bunch of properties removed
+			public Guid TL_TI { get; set; }
 		}
 
 		public class RateLineItem
 		{
-		    public Guid TM_PK { get; set; }
-		    public byte TM_LineOrder { get; set; }
-		    public string? TM_Type { get; set; }
-		    public decimal TM_Value { get; set; }
-		    public Guid TM_TL { get; set; }
+			public Guid    TM_PK        { get; set; }
+			public byte    TM_LineOrder { get; set; }
+			public string? TM_Type      { get; set; }
+			public decimal TM_Value     { get; set; }
+			public Guid    TM_TL        { get; set; }
 		}
 		[Test]
 		public void CteTest([IncludeDataSources(TestProvName.AllSQLite)] string context)
@@ -141,28 +141,28 @@ namespace Tests.UserTests
 			using (db.CreateLocalTable<RateLineItem>())
 			{
 				var cte = (from rateEntry in db.GetTable<RateEntry>()
-					from rateLine in db.GetTable<RateLines>().LeftJoin(lines => lines.TL_TI == rateEntry.TI_PK)
-					from rateLineItem in db.GetTable<RateLineItem>().LeftJoin(items =>
+						   from rateLine in db.GetTable<RateLines>().LeftJoin(lines => lines.TL_TI == rateEntry.TI_PK)
+						   from rateLineItem in db.GetTable<RateLineItem>().LeftJoin(items =>
 						items.TM_TL == rateLine.TL_PK)
-					where (rateEntry.TI_RateEndDate == null || rateEntry.TI_RateEndDate > Sql.CurrentTimestamp)
-					      && rateLineItem.TM_Type.In("MIN", "FLT", "BAS", "UNT")
-					group rateLineItem by rateEntry
+						   where (rateEntry.TI_RateEndDate == null || rateEntry.TI_RateEndDate > Sql.CurrentTimestamp)
+						  && rateLineItem.TM_Type.In("MIN", "FLT", "BAS", "UNT")
+						   group rateLineItem by rateEntry
 					into _
-					select new RateCharges
-					{
-						RateEntry = _.Key,
-						FlatRate = _.Sum(r => r.TM_Type.In("FLT", "BAS") ? r.TM_Value : 0),
-						MinRate = _.Sum(r => r.TM_Type == "MIN" ? r.TM_Value : 0),
-						VariableRate = _.Sum(r => r.TM_Type == "UNT" ? r.TM_Value : 0)
-					}).AsCte("rateCost");
+						   select new RateCharges
+						   {
+							   RateEntry = _.Key,
+							   FlatRate = _.Sum(r => r.TM_Type.In("FLT", "BAS") ? r.TM_Value : 0),
+							   MinRate = _.Sum(r => r.TM_Type == "MIN" ? r.TM_Value : 0),
+							   VariableRate = _.Sum(r => r.TM_Type == "UNT" ? r.TM_Value : 0)
+						   }).AsCte("rateCost");
 
 				var query = from rateEntry in db.GetTable<RateEntry>()
-					from c in cte.InnerJoin(c => c.RateEntry!.TI_PK == rateEntry.TI_PK)
-					select new
-					{
-						RateEntry = rateEntry,
-						CTE = c
-					};
+							from c in cte.InnerJoin(c => c.RateEntry!.TI_PK == rateEntry.TI_PK)
+							select new
+							{
+								RateEntry = rateEntry,
+								CTE = c
+							};
 				var result = query.ToArray();
 			}
 		}

--- a/Tests/Linq/UserTests/Issue1585Tests.cs
+++ b/Tests/Linq/UserTests/Issue1585Tests.cs
@@ -38,7 +38,7 @@ namespace Tests.UserTests
 			{
 				try
 				{
-					db.DropTable<Test1585>();
+					db.DropTable<Test1585>(tableOptions: TableOptions.DropIfExists);
 				}
 				catch
 				{ }

--- a/Tests/Linq/UserTests/Issue1869Tests.cs
+++ b/Tests/Linq/UserTests/Issue1869Tests.cs
@@ -11,116 +11,102 @@ namespace Tests.UserTests
 	{
 		public class PropertyChangedNotifier
 		{
-			
 		}
 
-	    [Table(Name = "tblFtq")]
-	    public class FtqData : PropertyChangedNotifier
-	    {
-	        [Column, PrimaryKey, Identity]
-	        public int Id { get; set; }
-
-	        [Column, NotNull]
-	        public DateTime EntryDate { get; set; }
-
-	        [Column, NotNull]
-	        public byte EntryShift { get; set; }
-
-	        [Column, NotNull]
-	        public int Id_Operator { get; set; }
-
-	        [Column, NotNull]
-	        public int Id_Reference { get; set; }
-
-	        [Column, NotNull]
-	        public int Id_Defect { get; set; }
-
-	        [Column, NotNull]
-	        public int Qty { get; set; }
-
-//	        [Association(ThisKey = nameof(Id_Operator), OtherKey = nameof(General.User.UserId), CanBeNull = false)]
-//	        public User User { get; set; }
-//
-//	        [Association(ThisKey = nameof(Id_Reference), OtherKey = nameof(Ftq.Reference.Id), CanBeNull = false)]
-//	        public Reference Reference { get; set; }
-//
-	        [Association(ThisKey = nameof(Id_Defect), OtherKey = nameof(Issue1869Tests.Defect.Id), CanBeNull = false)]
-	        public Defect Defect { get; set; } = null!;
-		}
-
-	    [Table(Name = "tblDefect")]
-	    public class Defect : PropertyChangedNotifier
-	    {
-	        [Column, PrimaryKey, Identity]
-	        public int Id { get; set; }
-
-	        [Column, NotNull]
-	        public string Nam { get; set; } = null!;
+		[Table(Name = "tblFtq")]
+		public class FtqData : PropertyChangedNotifier
+		{
+			[Column, PrimaryKey, Identity]
+			public int Id { get; set; }
 
 			[Column, NotNull]
-	        public int Id_Workstation { get; set; }
-
-	        [Column, NotNull]
-	        public bool Ok { get; set; }
-
-	        [Column, NotNull]
-	        public bool Del { get; set; }
-	       
-	        [Association(ThisKey = nameof(Id_Workstation), OtherKey = nameof(Issue1869Tests.Workstation.Id), CanBeNull = false)]
-	        public Workstation Workstation { get; set; } = null!;
-		}
-
-	    [Table(Name = "tblWorkstation")]
-	    public class Workstation : PropertyChangedNotifier
-	    {
-	        [Column, PrimaryKey, Identity]
-	        public int Id { get; set; }
-
-	        [Column, NotNull]
-	        public int Id_WorkstationGroup { get; set; }
-
-	        [Column, NotNull]
-	        public string Nam { get; set; } = null!;
+			public DateTime EntryDate { get; set; }
 
 			[Column, NotNull]
-	        public bool Del { get; set; }
-	        
-	        [Association(ThisKey = nameof(Id_WorkstationGroup), OtherKey = nameof(Issue1869Tests.WorkstationGroup.Id), CanBeNull = false)]
-	        public WorkstationGroup WorkstationGroup { get; set; } = null!;
-		}
-
-	    [Table(Name = "tblWorkstationGroup")]
-	    public class WorkstationGroup : PropertyChangedNotifier
-	    {
-	        [Column, PrimaryKey, Identity]
-	        public int Id { get; set; }
-
-	        [Column, NotNull]
-	        public string Nam { get; set; } = null!;
+			public byte EntryShift { get; set; }
 
 			[Column, NotNull]
-	        public int Id_SectorPart { get; set; }
+			public int Id_Operator { get; set; }
 
-	        [Column, NotNull]
-	        public int Id_Sector { get; set; }
+			[Column, NotNull]
+			public int Id_Reference { get; set; }
 
-	        [Column, NotNull]
-	        public bool Del { get; set; }
+			[Column, NotNull]
+			public int Id_Defect { get; set; }
 
-//	        [Association(ThisKey = nameof(Id_Sector), OtherKey = nameof(Ftq.Sector.Id), CanBeNull = false)]
-//	        public Sector Sector { get; set; }
-//
-//	        [Association(ThisKey = nameof(Id_SectorPart), OtherKey = nameof(Ftq.SectorPart.Id), CanBeNull = false)]
-//	        public SectorPart SectorPart { get; set; }
-	    }
+			[Column, NotNull]
+			public int Qty { get; set; }
 
-	    [Table(Name = "tblMonth")]
-	    public class Month : PropertyChangedNotifier
-	    {
-	        [Column]
-	        public int MonthNumber { get; set; }
-	    }
+			[Association(ThisKey = nameof(Id_Defect), OtherKey = nameof(Issue1869Tests.Defect.Id), CanBeNull = false)]
+			public Defect Defect { get; set; } = null!;
+		}
 
+		[Table(Name = "tblDefect")]
+		public class Defect : PropertyChangedNotifier
+		{
+			[Column, PrimaryKey, Identity]
+			public int Id { get; set; }
+
+			[Column, NotNull]
+			public string Nam { get; set; } = null!;
+
+			[Column, NotNull]
+			public int Id_Workstation { get; set; }
+
+			[Column, NotNull]
+			public bool Ok { get; set; }
+
+			[Column, NotNull]
+			public bool Del { get; set; }
+
+			[Association(ThisKey = nameof(Id_Workstation), OtherKey = nameof(Issue1869Tests.Workstation.Id), CanBeNull = false)]
+			public Workstation Workstation { get; set; } = null!;
+		}
+
+		[Table(Name = "tblWorkstation")]
+		public class Workstation : PropertyChangedNotifier
+		{
+			[Column, PrimaryKey, Identity]
+			public int Id { get; set; }
+
+			[Column, NotNull]
+			public int Id_WorkstationGroup { get; set; }
+
+			[Column, NotNull]
+			public string Nam { get; set; } = null!;
+
+			[Column, NotNull]
+			public bool Del { get; set; }
+
+			[Association(ThisKey = nameof(Id_WorkstationGroup), OtherKey = nameof(Issue1869Tests.WorkstationGroup.Id), CanBeNull = false)]
+			public WorkstationGroup WorkstationGroup { get; set; } = null!;
+		}
+
+		[Table(Name = "tblWorkstationGroup")]
+		public class WorkstationGroup : PropertyChangedNotifier
+		{
+			[Column, PrimaryKey, Identity]
+			public int Id { get; set; }
+
+			[Column, NotNull]
+			public string Nam { get; set; } = null!;
+
+			[Column, NotNull]
+			public int Id_SectorPart { get; set; }
+
+			[Column, NotNull]
+			public int Id_Sector { get; set; }
+
+			[Column, NotNull]
+			public bool Del { get; set; }
+		}
+
+		[Table(Name = "tblMonth")]
+		public class Month : PropertyChangedNotifier
+		{
+			[Column]
+			public int MonthNumber { get; set; }
+		}
 
 		[Test]
 		public void TestLeftJoin([IncludeDataSources(TestProvName.AllAccess)] string context)
@@ -137,35 +123,35 @@ namespace Tests.UserTests
 				var sectorId = 1;
 
 				var query1 = from q in db.GetTable<FtqData>()
-					where q.EntryDate >= dateMin
-					      && q.EntryDate <= dateMax
-					      && q.Defect.Workstation.WorkstationGroup.Id_Sector == sectorId
-					let MonthNumber = q.EntryDate.Month
-					group q by new { MonthNumber, q.Defect.Workstation.Id_WorkstationGroup }
+							 where q.EntryDate >= dateMin
+						  && q.EntryDate <= dateMax
+						  && q.Defect.Workstation.WorkstationGroup.Id_Sector == sectorId
+							 let MonthNumber = q.EntryDate.Month
+							 group q by new { MonthNumber, q.Defect.Workstation.Id_WorkstationGroup }
 					into g
-					select new
-					{
-						MonthNumber = g.Key.MonthNumber,
-						Id_WorkstationGroup = g.Key.Id_WorkstationGroup,
-						Ftq = g.Sum(_ => _.Qty) / g.Sum(_ => _.Defect.Ok ? 0 : _.Qty)
-					};
+							 select new
+							 {
+								 MonthNumber = g.Key.MonthNumber,
+								 Id_WorkstationGroup = g.Key.Id_WorkstationGroup,
+								 Ftq = g.Sum(_ => _.Qty) / g.Sum(_ => _.Defect.Ok ? 0 : _.Qty)
+							 };
 
 				var query2 = from q in query1
-					group q by q.MonthNumber
+							 group q by q.MonthNumber
 					into g
-					select new
-					{
-						MonthNumber = g.Key,
-						Ftq = g.Sum(_ => _.Ftq)
-					};
+							 select new
+							 {
+								 MonthNumber = g.Key,
+								 Ftq = g.Sum(_ => _.Ftq)
+							 };
 
 				var query3 = from m in db.GetTable<Month>()
-					from q in query2.Where(q => q.MonthNumber == m.MonthNumber).DefaultIfEmpty()
-					select new
-					{
-						m,
-						q
-					};
+							 from q in query2.Where(q => q.MonthNumber == m.MonthNumber).DefaultIfEmpty()
+							 select new
+							 {
+								 m,
+								 q
+							 };
 
 				var result = query3.ToArray();
 

--- a/Tests/Linq/UserTests/Issue192Tests.cs
+++ b/Tests/Linq/UserTests/Issue192Tests.cs
@@ -18,10 +18,10 @@ namespace Tests.UserTests
 			[Column(Length = 50), NotNull]
 			public string Name   { get; set; } = null!;
 
-			[Column(DataType = DataType.Char), NotNull]
+			[Column(DataType = DataType.Char)]
 			public bool BoolValue { get; set; }
 
-			[Column(DataType = DataType.VarChar, Length = 50), Nullable]
+			[Column(DataType = DataType.VarChar, Length = 50)]
 			public Guid? GuidValue { get; set; }
 
 			public override string ToString()
@@ -70,7 +70,7 @@ namespace Tests.UserTests
 
 			ms.SetConvertExpression<bool,   DataParameter>(_ => DataParameter.Char(null, _ ? 'Y' : 'N'));
 			ms.SetConvertExpression<char,   bool>(_ => _ == 'Y');
-			ms.SetConvertExpression<string, bool>(_ => _.Trim() == "Y");
+				ms.SetConvertExpression<string, bool>(_ => _.Trim() == "Y");
 
 			ms.SetConvertExpression<Guid?,  DataParameter>(_ => DataParameter.VarChar(null, _.ToString()));
 			ms.SetConvertExpression<string, Guid?>(_ => Guid.Parse(_));

--- a/Tests/Linq/UserTests/Issue2647Tests.cs
+++ b/Tests/Linq/UserTests/Issue2647Tests.cs
@@ -21,7 +21,7 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void OrderBySybqueryTest([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		public void OrderBySubqueryTest([IncludeDataSources(TestProvName.AllSQLite)] string context)
 		{
 			using (var db = GetDataContext(context))
 			using (var table = db.CreateLocalTable<IssueClass>())

--- a/Tests/Linq/UserTests/Issue307Tests.cs
+++ b/Tests/Linq/UserTests/Issue307Tests.cs
@@ -20,7 +20,8 @@ namespace Tests.UserTests
 			{
 			}
 
-			[Column("PersonID"), Identity, PrimaryKey]
+			[Column("PersonID", IsIdentity = true)]
+			[PrimaryKey]
 			public int ID { get; set; }
 
 			[Column]
@@ -52,15 +53,16 @@ namespace Tests.UserTests
 			ResetPersonIdentity(context);
 
 			using (var db = GetDataContext(context))
-			using (new DeletePerson(db))
+			using (new RestoreBaseTables(db))
 			{
 				var obj = Entity307.Create();
 				obj.SetFirstName("FirstName307");
 				obj.LastName = "LastName307";
 
-				var id1 = Convert.ToInt32(db.InsertWithIdentity(obj));
+				int id;
+					id = db.InsertWithInt32Identity(obj);
 
-				var obj2 = db.GetTable<Entity307>().First(_ => _.ID == id1);
+				var obj2 = db.GetTable<Entity307>().First(_ => _.ID == id);
 
 				Assert.IsNull(obj2.MiddleName);
 				Assert.AreEqual(obj.FirstName, obj2.FirstName);

--- a/Tests/Linq/UserTests/Issue358Tests.cs
+++ b/Tests/Linq/UserTests/Issue358Tests.cs
@@ -98,6 +98,7 @@ namespace Tests.UserTests
 
 		static LinqDataTypes2 FixData(LinqDataTypes2 data)
 		{
+			data = data.Clone();
 			data.StringValue = null;
 			return data;
 		}

--- a/Tests/Linq/UserTests/Issue533Tests.cs
+++ b/Tests/Linq/UserTests/Issue533Tests.cs
@@ -24,7 +24,8 @@ namespace Tests.UserTests
 		public class Entity533
 		{
 			[SequenceName(ProviderName.Firebird, "PersonID")]
-			[Column("PersonID"), Identity, PrimaryKey]
+			[Column("PersonID", IsIdentity = true)]
+			[PrimaryKey]
 			public int      ID         { get; set; }
 
 			[Column]public Gender    Gender     { get; set; }
@@ -56,7 +57,7 @@ namespace Tests.UserTests
 			});
 
 			using (var db = GetDataContext(context, ms))
-			using (new DeletePerson(db))
+			using (new RestoreBaseTables(db))
 			{
 				var obj = new Entity533
 				{
@@ -64,9 +65,10 @@ namespace Tests.UserTests
 					LastName  = new MyString { Value = "LastName533" },
 				};
 
-				var id1 = Convert.ToInt32(db.InsertWithIdentity(obj));
+				int id;
+					id = db.InsertWithInt32Identity(obj);
 
-				var obj2 = db.GetTable<Entity533>().First(_ => _.ID == id1);
+				var obj2 = db.GetTable<Entity533>().First(_ => _.ID == id);
 
 				Assert.IsNull  (obj2.MiddleName);
 				Assert.AreEqual(obj.FirstName.Value, obj2.FirstName.Value);

--- a/Tests/Linq/UserTests/Issue693Tests.cs
+++ b/Tests/Linq/UserTests/Issue693Tests.cs
@@ -19,7 +19,8 @@ namespace Tests.UserTests
 		public class Entity533
 		{
 			[SequenceName(ProviderName.Firebird, "PersonID")]
-			[Column("PersonID"), Identity, PrimaryKey]
+			[Column("PersonID", IsIdentity = true)]
+			[PrimaryKey]
 			        public int     ID         { get; set; }
 
 			[Column]public Gender  Gender     { get; set; }
@@ -63,7 +64,7 @@ namespace Tests.UserTests
 			});
 
 			using (var db = GetDataContext(context, ms))
-			using (new DeletePerson(db))
+			using (new RestoreBaseTables(db))
 			{
 				var obj = new Entity533
 				{
@@ -73,7 +74,8 @@ namespace Tests.UserTests
 					Gender     = Gender.Male
 				};
 
-				var id1 = Convert.ToInt32(db.InsertWithIdentity(obj));
+				int id1;
+					id1 = db.InsertWithInt32Identity(obj);
 
 				var obj2 = new Entity533
 				{
@@ -83,7 +85,8 @@ namespace Tests.UserTests
 					Gender     = Gender.Male
 				};
 
-				var id2 = Convert.ToInt32(db.InsertWithIdentity(obj2));
+				int id2;
+					id2 = db.InsertWithInt32Identity(obj2);
 
 				var obj3 = db.GetTable<Entity533>().First(_ => _.ID == id1);
 				var obj4 = db.GetTable<Entity533>().First(_ => _.ID == id2);

--- a/Tests/Model/LinqDataTypes.cs
+++ b/Tests/Model/LinqDataTypes.cs
@@ -146,5 +146,22 @@ namespace Tests.Model
 		{
 			return string.Format("{{{0,2}, {1,7}, {2:O}, {3,5}, {4}, {5}, '{6}'}}", ID, MoneyValue, DateTimeValue, BoolValue, GuidValue, SmallIntValue, StringValue);
 		}
+
+		public LinqDataTypes2 Clone()
+		{
+			return new ()
+			{
+				ID             = ID,
+				MoneyValue     = MoneyValue,
+				DateTimeValue  = DateTimeValue,
+				DateTimeValue2 = DateTimeValue2,
+				BoolValue      = BoolValue,
+				GuidValue      = GuidValue,
+				SmallIntValue  = SmallIntValue,
+				IntValue       = IntValue,
+				BigIntValue    = BigIntValue,
+				StringValue    = StringValue,
+			};
+		}
 	}
 }

--- a/nuget.config
+++ b/nuget.config
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<packageSources>
+		<clear />
 		<add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
 	</packageSources>
-	<packageSourceMapping>
-		<packageSource key="nuget.org">
-			<package pattern="*" />
-		</packageSource>
-	</packageSourceMapping>
 </configuration>


### PR DESCRIPTION
To reduce test baselines noise in ClickHouse branch, I've moved test changes to separate PR.
Will be merged after tests pass.

Contains:
- [functional] transaction-less providers support
- [functional] `TransientRetryPolicy` retry policy for .net5+ to work with new `DbException.IsTransient` property
- [functional] fixed bug in select columns cloning in `ConvertVisitor`
- updates to markdown files
- switch to unbuntu 22 on CI
- fixed found typos in test names
- changes to tests to make them work with ClickHouse too (where it doesn't affect tested functionality):
  - ClickHouse has more changes to return data in random order for unordered queries - add ordering to queries/asserted data
  - ClickHouse doesn't support identity columns (and InsertWithIdentity) - use plain inserts where possible
  - ClickHouse doesn't support support transactions - cleanup default test tables in tests that modify them
  - ClickHouse date types support very narrow range of dates - update dates in tests to fit into this range