### PR TITLE
Small fixes from ClickHouse provider branch

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -101,7 +101,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' != 'net472' AND '$(TargetFramework)' != 'netcoreapp3.1' ">
-		<PackageVersion Include="MySqlConnector"                                        Version="2.1.10"        />
+		<PackageVersion Include="MySqlConnector"                                        Version="2.1.11"        />
 	</ItemGroup>
 
 </Project>

--- a/Source/LinqToDB/DataProvider/BulkCopyReader.cs
+++ b/Source/LinqToDB/DataProvider/BulkCopyReader.cs
@@ -18,12 +18,7 @@ namespace LinqToDB.DataProvider
 	using Data;
 	using Mapping;
 
-	public class BulkCopyReader<T> : BulkCopyReader,
-#if NATIVE_ASYNC
-		IAsyncDisposable
-#else
-		IAsyncDisposable
-#endif
+	public class BulkCopyReader<T> : BulkCopyReader, IAsyncDisposable
 	{
 		readonly IEnumerator<T>?      _enumerator;
 #if NATIVE_ASYNC

--- a/Source/LinqToDB/DataProvider/MySql/MySqlDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlDataProvider.cs
@@ -46,6 +46,16 @@ namespace LinqToDB.DataProvider.MySql
 
 			SetProviderField(Adapter.MySqlDateTimeType, Adapter.GetMySqlDateTimeMethodName, Adapter.DataReaderType);
 			SetToTypeField  (Adapter.MySqlDateTimeType, Adapter.GetMySqlDateTimeMethodName, Adapter.DataReaderType);
+
+			if (Adapter.GetTimeSpanMethodName != null) SetProviderField(typeof(TimeSpan), Adapter.GetTimeSpanMethodName, Adapter.DataReaderType);
+			if (Adapter.GetSByteMethodName    != null) SetProviderField(typeof(sbyte)   , Adapter.GetSByteMethodName   , Adapter.DataReaderType);
+			if (Adapter.GetUInt16MethodName   != null) SetProviderField(typeof(ushort)  , Adapter.GetUInt16MethodName  , Adapter.DataReaderType);
+			if (Adapter.GetUInt32MethodName   != null) SetProviderField(typeof(uint)    , Adapter.GetUInt32MethodName  , Adapter.DataReaderType);
+			if (Adapter.GetUInt64MethodName   != null) SetProviderField(typeof(ulong)   , Adapter.GetUInt64MethodName  , Adapter.DataReaderType);
+#if NET6_0_OR_GREATER
+			if (Adapter.GetTimeOnlyMethodName != null) SetProviderField(typeof(TimeOnly), Adapter.GetTimeOnlyMethodName, Adapter.DataReaderType);
+			if (Adapter.GetDateOnlyMethodName != null) SetProviderField(typeof(DateOnly), Adapter.GetDateOnlyMethodName, Adapter.DataReaderType);
+#endif
 		}
 
 		public override SchemaProvider.ISchemaProvider GetSchemaProvider()

--- a/Source/LinqToDB/DataProvider/MySql/MySqlProviderAdapter.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlProviderAdapter.cs
@@ -15,6 +15,8 @@ namespace LinqToDB.DataProvider.MySql
 
 	public abstract class MySqlProviderAdapter : IDynamicProviderAdapter
 	{
+		private static readonly Type[] _ordinalParameters = new Type[] { typeof(int) };
+
 		private static readonly object _mysqlDataSyncRoot      = new ();
 		private static readonly object _mysqlConnectorSyncRoot = new ();
 
@@ -72,8 +74,15 @@ namespace LinqToDB.DataProvider.MySql
 		/// MySqlConnector-only.
 		/// </summary>
 		public string? GetDateTimeOffsetMethodName { get; protected set; }
-		public string GetMySqlDateTimeMethodName { get;   protected set; } = null!;
-		public string ProviderTypesNamespace     { get;   protected set; } = null!;
+		public string? GetTimeSpanMethodName       { get; protected set; }
+		public string? GetTimeOnlyMethodName       { get; protected set; }
+		public string? GetDateOnlyMethodName       { get; protected set; }
+		public string? GetSByteMethodName          { get; protected set; }
+		public string? GetUInt16MethodName         { get; protected set; }
+		public string? GetUInt32MethodName         { get; protected set; }
+		public string? GetUInt64MethodName         { get; protected set; }
+		public string  GetMySqlDateTimeMethodName  { get; protected set; } = null!;
+		public string  ProviderTypesNamespace      { get; protected set; } = null!;
 
 		/// <summary>
 		/// Returns object, because both providers use different enums and we anyway don't need typed value.
@@ -88,7 +97,7 @@ namespace LinqToDB.DataProvider.MySql
 		{
 			internal BulkCopyAdapter(
 				Func<DbConnection, DbTransaction?, MySqlConnector.MySqlBulkCopy> bulkCopyCreator,
-				Func<int, string, MySqlBulkCopyColumnMapping>                      bulkCopyColumnMappingCreator)
+				Func<int, string, MySqlBulkCopyColumnMapping>                    bulkCopyColumnMappingCreator)
 			{
 				Create              = bulkCopyCreator;
 				CreateColumnMapping = bulkCopyColumnMappingCreator;
@@ -179,6 +188,10 @@ namespace LinqToDB.DataProvider.MySql
 					GetDbType                   = p => dbTypeGetter(p);
 					GetMySqlDecimalMethodName   = "GetMySqlDecimal";
 					GetDateTimeOffsetMethodName = null;
+					GetSByteMethodName          = dataReaderType.GetMethod("GetSByte",  _ordinalParameters)?.Name;
+					GetUInt16MethodName         = dataReaderType.GetMethod("GetUInt16", _ordinalParameters)?.Name;
+					GetUInt32MethodName         = dataReaderType.GetMethod("GetUInt32", _ordinalParameters)?.Name;
+					GetUInt64MethodName         = dataReaderType.GetMethod("GetUInt64", _ordinalParameters)?.Name;
 					GetMySqlDateTimeMethodName  = "GetMySqlDateTime";
 					ProviderTypesNamespace      = MySqlDataTypesNamespace;
 					MappingSchema               = mappingSchema;
@@ -364,6 +377,13 @@ namespace LinqToDB.DataProvider.MySql
 					GetMySqlDecimalMethodName   = mySqlDecimalType != null ? "GetMySqlDecimal" : null;
 					GetDateTimeOffsetMethodName = "GetDateTimeOffset";
 					GetMySqlDateTimeMethodName  = "GetMySqlDateTime";
+					GetTimeSpanMethodName       = dataReaderType.GetMethod("GetTimeSpan", _ordinalParameters)?.Name;
+					GetTimeOnlyMethodName       = dataReaderType.GetMethod("GetTimeOnly", _ordinalParameters)?.Name;
+					GetDateOnlyMethodName       = dataReaderType.GetMethod("GetDateOnly", _ordinalParameters)?.Name;
+					GetSByteMethodName          = dataReaderType.GetMethod("GetSByte", _ordinalParameters)?.Name;
+					GetUInt16MethodName         = dataReaderType.GetMethod("GetUInt16", _ordinalParameters)?.Name;
+					GetUInt32MethodName         = dataReaderType.GetMethod("GetUInt32", _ordinalParameters)?.Name;
+					GetUInt64MethodName         = dataReaderType.GetMethod("GetUInt64", _ordinalParameters)?.Name;
 					ProviderTypesNamespace      = typesNamespace;
 					MappingSchema               = mappingSchema;
 					BulkCopy                    = bulkCopy;

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
@@ -50,7 +50,6 @@ namespace LinqToDB.DataProvider.PostgreSQL
 
 			AddScalarType(typeof(string),    DataType.Text);
 			AddScalarType(typeof(TimeSpan),  DataType.Interval);
-			AddScalarType(typeof(TimeSpan?), DataType.Interval);
 
 #if NET6_0_OR_GREATER
 			SetValueToSqlConverter(typeof(DateOnly), (sb, dt, v) => BuildDate(sb, dt, (DateOnly)v));
@@ -65,7 +64,6 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			var ulongType = new SqlDataType(DataType.Decimal, typeof(decimal), 20, 0);
 			// set type for proper SQL type generation
 			AddScalarType(typeof(ulong ), ulongType);
-			AddScalarType(typeof(ulong?), ulongType);
 
 			SetConvertExpression<ulong , DataParameter>(value => new DataParameter(null, (decimal)value , DataType.Decimal) /*{ Precision = 20, Scale = 0 }*/);
 			SetConvertExpression<ulong?, DataParameter>(value => new DataParameter(null, (decimal?)value, DataType.Decimal) /*{ Precision = 20, Scale = 0 }*/, addNullCheck: false);

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaDataProvider.cs
@@ -17,23 +17,17 @@ namespace LinqToDB.DataProvider.SapHana
 	{
 		public SapHanaDataProvider() : base(ProviderName.SapHanaNative, MappingSchemaInstance, SapHanaProviderAdapter.GetInstance())
 		{
-			SqlProviderFlags.IsParameterOrderDependent = true;
-
-			//supported flags
-
+			SqlProviderFlags.IsParameterOrderDependent         = true;
 			//Exception: Sap.Data.Hana.HanaException
 			//Message: single-row query returns more than one row
 			//when expression returns more than 1 row
 			//mark this as supported, it's better to throw exception
 			//instead of replace with left join, in which case returns incorrect data
-			SqlProviderFlags.IsSubQueryColumnSupported  = true;
-
-			SqlProviderFlags.IsDistinctOrderBySupported = false;
-
-			//not supported flags
-			SqlProviderFlags.IsSubQueryTakeSupported   = false;
-			SqlProviderFlags.IsInsertOrUpdateSupported = false;
-			SqlProviderFlags.IsUpdateFromSupported     = false;
+			SqlProviderFlags.IsSubQueryColumnSupported         = true;
+			SqlProviderFlags.IsDistinctOrderBySupported        = false;
+			SqlProviderFlags.IsSubQueryTakeSupported           = false;
+			SqlProviderFlags.IsInsertOrUpdateSupported         = false;
+			SqlProviderFlags.IsUpdateFromSupported             = false;
 			SqlProviderFlags.AcceptsOuterExpressionInAggregate = false;
 
 			_sqlOptimizer = new SapHanaNativeSqlOptimizer(SqlProviderFlags);

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaOdbcDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaOdbcDataProvider.cs
@@ -15,20 +15,14 @@ namespace LinqToDB.DataProvider.SapHana
 	{
 		public SapHanaOdbcDataProvider() : base(ProviderName.SapHanaOdbc, MappingSchemaInstance, OdbcProviderAdapter.GetInstance())
 		{
-			//supported flags
-			SqlProviderFlags.IsParameterOrderDependent = true;
-
-			//supported flags
-
+			SqlProviderFlags.IsParameterOrderDependent         = true;
 			//Exception: Sap.Data.Hana.HanaException
 			//Message: single-row query returns more than one row
 			//when expression returns more than 1 row
 			//mark this as supported, it's better to throw exception
 			//then replace with left join, in which case returns incorrect data
-			SqlProviderFlags.IsSubQueryColumnSupported  = true;
-			SqlProviderFlags.IsDistinctOrderBySupported = false;
-
-			//not supported flags
+			SqlProviderFlags.IsSubQueryColumnSupported         = true;
+			SqlProviderFlags.IsDistinctOrderBySupported        = false;
 			SqlProviderFlags.IsSubQueryTakeSupported           = false;
 			SqlProviderFlags.IsInsertOrUpdateSupported         = false;
 			SqlProviderFlags.AcceptsOuterExpressionInAggregate = false;

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerMappingSchema.cs
@@ -167,7 +167,6 @@ namespace LinqToDB.DataProvider.SqlServer
 			AddScalarType(typeof(SqlXml),       SqlXml.     Null, true, DataType.Xml);
 
 			AddScalarType(typeof(DateTime),  DataType.DateTime2);
-			AddScalarType(typeof(DateTime?), DataType.DateTime2);
 
 			SqlServerTypes.Configure(this);
 

--- a/Source/LinqToDB/Expressions/ConvertFromDataReaderExpression.cs
+++ b/Source/LinqToDB/Expressions/ConvertFromDataReaderExpression.cs
@@ -89,6 +89,10 @@ namespace LinqToDB.Expressions
 			var toType = type.ToNullableUnderlying();
 
 			Expression ex;
+			Type? mapType = null;
+
+			if (toType.IsEnum)
+				mapType = ConvertBuilder.GetDefaultMappingFromEnumType(mappingSchema, toType);
 
 			if (converter != null)
 			{
@@ -97,7 +101,7 @@ namespace LinqToDB.Expressions
 			}
 			else
 			{
-				ex = dataContext.GetReaderExpression(dataReader, idx, dataReaderExpr, toType);
+				ex = dataContext.GetReaderExpression(dataReader, idx, dataReaderExpr, mapType?.ToNullableUnderlying() ?? toType);
 			}
 
 			if (ex.NodeType == ExpressionType.Lambda)
@@ -135,17 +139,14 @@ namespace LinqToDB.Expressions
 				{
 					ex = Convert(ex, toType);
 				}
-
 			}
 			else if (toType.IsEnum)
 			{
-				var mapType = ConvertBuilder.GetDefaultMappingFromEnumType(mappingSchema, toType)!;
-
 				if (mapType != ex.Type)
 				{
 					// Use only defined convert
-					var econv = mappingSchema.GetConvertExpression(ex.Type, type,    false, false) ??
-					            mappingSchema.GetConvertExpression(ex.Type, mapType, false)!;
+					var econv = mappingSchema.GetConvertExpression(ex.Type, type,     false, false) ??
+					            mappingSchema.GetConvertExpression(ex.Type, mapType!, false)!;
 
 					ex = InternalExtensions.ApplyLambdaToExpression(econv, ex);
 				}

--- a/Source/LinqToDB/Mapping/MappingSchema.cs
+++ b/Source/LinqToDB/Mapping/MappingSchema.cs
@@ -7,6 +7,8 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Net;
+using System.Net.Sockets;
 using System.Reflection;
 using System.Text;
 using System.Xml;
@@ -1337,49 +1339,31 @@ namespace LinqToDB.Mapping
 			public DefaultMappingSchema() : base(new DefaultMappingSchemaInfo())
 			{
 				AddScalarType(typeof(char),            new SqlDataType(DataType.NChar, typeof(char),  1, null, null, null));
-				AddScalarType(typeof(char?),           new SqlDataType(DataType.NChar, typeof(char?), 1, null, null, null));
 				AddScalarType(typeof(string),          DataType.NVarChar);
 				AddScalarType(typeof(decimal),         DataType.Decimal);
-				AddScalarType(typeof(decimal?),        DataType.Decimal);
 				AddScalarType(typeof(DateTime),        DataType.DateTime2);
-				AddScalarType(typeof(DateTime?),       DataType.DateTime2);
 				AddScalarType(typeof(DateTimeOffset),  DataType.DateTimeOffset);
-				AddScalarType(typeof(DateTimeOffset?), DataType.DateTimeOffset);
 				AddScalarType(typeof(TimeSpan),        DataType.Time);
-				AddScalarType(typeof(TimeSpan?),       DataType.Time);
 #if NET6_0_OR_GREATER
 				AddScalarType(typeof(DateOnly),        DataType.Date);
-				AddScalarType(typeof(DateOnly?),       DataType.Date);
 #endif
 				AddScalarType(typeof(byte[]),          DataType.VarBinary);
 				AddScalarType(typeof(Binary),          DataType.VarBinary);
 				AddScalarType(typeof(Guid),            DataType.Guid);
-				AddScalarType(typeof(Guid?),           DataType.Guid);
 				AddScalarType(typeof(object),          DataType.Variant);
 				AddScalarType(typeof(XmlDocument),     DataType.Xml);
 				AddScalarType(typeof(XDocument),       DataType.Xml);
 				AddScalarType(typeof(bool),            DataType.Boolean);
-				AddScalarType(typeof(bool?),           DataType.Boolean);
 				AddScalarType(typeof(sbyte),           DataType.SByte);
-				AddScalarType(typeof(sbyte?),          DataType.SByte);
 				AddScalarType(typeof(short),           DataType.Int16);
-				AddScalarType(typeof(short?),          DataType.Int16);
 				AddScalarType(typeof(int),             DataType.Int32);
-				AddScalarType(typeof(int?),            DataType.Int32);
 				AddScalarType(typeof(long),            DataType.Int64);
-				AddScalarType(typeof(long?),           DataType.Int64);
 				AddScalarType(typeof(byte),            DataType.Byte);
-				AddScalarType(typeof(byte?),           DataType.Byte);
 				AddScalarType(typeof(ushort),          DataType.UInt16);
-				AddScalarType(typeof(ushort?),         DataType.UInt16);
 				AddScalarType(typeof(uint),            DataType.UInt32);
-				AddScalarType(typeof(uint?),           DataType.UInt32);
 				AddScalarType(typeof(ulong),           DataType.UInt64);
-				AddScalarType(typeof(ulong?),          DataType.UInt64);
 				AddScalarType(typeof(float),           DataType.Single);
-				AddScalarType(typeof(float?),          DataType.Single);
 				AddScalarType(typeof(double),          DataType.Double);
-				AddScalarType(typeof(double?),         DataType.Double);
 
 				AddScalarType(typeof(BitArray),        DataType.BitArray);
 
@@ -1495,12 +1479,16 @@ namespace LinqToDB.Mapping
 		/// </summary>
 		/// <param name="type">Type to configure.</param>
 		/// <param name="dataType">Optional scalar data type.</param>
-		public void AddScalarType(Type type, DataType dataType = DataType.Undefined)
+		/// <param name="withNullable">Also register <see cref="Nullable{T}"/> type.</param>
+		public void AddScalarType(Type type, DataType dataType = DataType.Undefined, bool withNullable = true)
 		{
 			SetScalarType(type);
 
 			if (dataType != DataType.Undefined)
 				SetDataType(type, dataType);
+
+			if (withNullable && type.IsValueType && !type.IsNullable())
+				AddScalarType(type.AsNullable(), dataType, false);
 		}
 
 		/// <summary>
@@ -1508,11 +1496,18 @@ namespace LinqToDB.Mapping
 		/// </summary>
 		/// <param name="type">Type to configure.</param>
 		/// <param name="dataType">Database data type.</param>
-		public void AddScalarType(Type type, SqlDataType dataType)
+		/// <param name="withNullable">Also register <see cref="Nullable{T}"/> type.</param>
+		public void AddScalarType(Type type, SqlDataType dataType, bool withNullable = true)
 		{
 			SetScalarType(type);
 
 			SetDataType(type, dataType);
+
+			if (withNullable && type.IsValueType && !type.IsNullable())
+			{
+				var nullableType = type.AsNullable();
+				AddScalarType(nullableType, new SqlDataType(dataType.Type.WithSystemType(nullableType)), false);
+			}
 		}
 
 		#endregion

--- a/Source/LinqToDB/Sql/Sql.DateOnly.cs
+++ b/Source/LinqToDB/Sql/Sql.DateOnly.cs
@@ -12,83 +12,83 @@ namespace LinqToDB
 	public partial class Sql
 	{
 		#region DatePart
-		[Sql.Extension(               "DatePart",                                        ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilder))]
-		[Sql.Extension(PN.DB2,        "",                                                ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderDB2))]
-		[Sql.Extension(PN.Informix,   "",                                                ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderInformix))]
-		[Sql.Extension(PN.MySql,      "Extract({part} from {date})",                     ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderMySql))]
-		[Sql.Extension(PN.PostgreSQL, "Cast(Floor(Extract({part} from {date})) as int)", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderPostgre))]
-		[Sql.Extension(PN.Firebird,   "Cast(Floor(Extract({part} from {date})) as int)", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderFirebird))]
-		[Sql.Extension(PN.SQLite,     "Cast(StrFTime('%{part}', {date}) as int)",        ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderSqLite))]
-		[Sql.Extension(PN.Access,     "DatePart('{part}', {date})",                      ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderAccess))]
-		[Sql.Extension(PN.SapHana,    "",                                                ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderSapHana))]
-		[Sql.Extension(PN.Oracle,     "",                                                ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderOracle))]
-		public static int? DatePart([SqlQueryDependent] Sql.DateParts part, [ExprParameter] DateOnly? date)
+		[Extension(               "DatePart",                                        ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilder))]
+		[Extension(PN.DB2,        "",                                                ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderDB2))]
+		[Extension(PN.Informix,   "",                                                ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderInformix))]
+		[Extension(PN.MySql,      "Extract({part} from {date})",                     ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderMySql))]
+		[Extension(PN.PostgreSQL, "Cast(Floor(Extract({part} from {date})) as int)", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderPostgre))]
+		[Extension(PN.Firebird,   "Cast(Floor(Extract({part} from {date})) as int)", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderFirebird))]
+		[Extension(PN.SQLite,     "Cast(StrFTime('%{part}', {date}) as int)",        ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderSqLite))]
+		[Extension(PN.Access,     "DatePart('{part}', {date})",                      ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderAccess))]
+		[Extension(PN.SapHana,    "",                                                ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderSapHana))]
+		[Extension(PN.Oracle,     "",                                                ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderOracle))]
+		public static int? DatePart([SqlQueryDependent] DateParts part, [ExprParameter] DateOnly? date)
 		{
 			if (date == null)
 				return null;
 
 			return part switch
 			{
-				Sql.DateParts.Year      => date.Value.Year,
-				Sql.DateParts.Quarter   => (date.Value.Month - 1) / 3 + 1,
-				Sql.DateParts.Month     => date.Value.Month,
-				Sql.DateParts.DayOfYear => date.Value.DayOfYear,
-				Sql.DateParts.Day       => date.Value.Day,
-				Sql.DateParts.Week      => CultureInfo.CurrentCulture.Calendar.GetWeekOfYear(date.Value.ToDateTime(TimeOnly.MinValue), CalendarWeekRule.FirstDay, DayOfWeek.Sunday),
-				Sql.DateParts.WeekDay   => ((int)date.Value.DayOfWeek + 1 + Sql.DateFirst + 6) % 7 + 1,
-				_                       => throw new InvalidOperationException(),
+				DateParts.Year      => date.Value.Year,
+				DateParts.Quarter   => (date.Value.Month - 1) / 3 + 1,
+				DateParts.Month     => date.Value.Month,
+				DateParts.DayOfYear => date.Value.DayOfYear,
+				DateParts.Day       => date.Value.Day,
+				DateParts.Week      => CultureInfo.CurrentCulture.Calendar.GetWeekOfYear(date.Value.ToDateTime(TimeOnly.MinValue), CalendarWeekRule.FirstDay, DayOfWeek.Sunday),
+				DateParts.WeekDay   => ((int)date.Value.DayOfWeek + 1 + DateFirst + 6) % 7 + 1,
+				_                   => throw new InvalidOperationException(),
 			};
 		}
 		#endregion
 
 		#region DateAdd
 
-		[Sql.Extension("DateAdd"        , ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilder))]
-		[Sql.Extension(PN.PostgreSQL, "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderPostgreSQL))]
-		[Sql.Extension(PN.Oracle,     "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderOracle))]
-		[Sql.Extension(PN.DB2,        "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderDB2))]
-		[Sql.Extension(PN.Informix,   "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderInformix))]
-		[Sql.Extension(PN.MySql,      "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderMySql))]
-		[Sql.Extension(PN.SQLite,     "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateOnlyAddBuilderSQLite))]
-		[Sql.Extension(PN.Access,     "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderAccess))]
-		[Sql.Extension(PN.SapHana,    "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderSapHana))]
-		[Sql.Extension(PN.Firebird,   "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderFirebird))]
-		public static DateOnly? DateAdd([SqlQueryDependent] Sql.DateParts part, double? number, DateOnly? date)
+		[Extension("DateAdd"        , ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilder))]
+		[Extension(PN.PostgreSQL, "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderPostgreSQL))]
+		[Extension(PN.Oracle,     "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderOracle))]
+		[Extension(PN.DB2,        "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderDB2))]
+		[Extension(PN.Informix,   "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderInformix))]
+		[Extension(PN.MySql,      "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderMySql))]
+		[Extension(PN.SQLite,     "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateOnlyAddBuilderSQLite))]
+		[Extension(PN.Access,     "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderAccess))]
+		[Extension(PN.SapHana,    "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderSapHana))]
+		[Extension(PN.Firebird,   "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderFirebird))]
+		public static DateOnly? DateAdd([SqlQueryDependent] DateParts part, double? number, DateOnly? date)
 		{
 			if (number == null || date == null)
 				return null;
 
 			return part switch
 			{
-				Sql.DateParts.Year      => date.Value.AddYears((int)number),
-				Sql.DateParts.Quarter   => date.Value.AddMonths((int)number * 3),
-				Sql.DateParts.Month     => date.Value.AddMonths((int)number),
-				Sql.DateParts.DayOfYear => date.Value.AddDays((int)number.Value),
-				Sql.DateParts.Day       => date.Value.AddDays((int)number.Value),
-				Sql.DateParts.Week      => date.Value.AddDays((int)number.Value * 7),
-				Sql.DateParts.WeekDay   => date.Value.AddDays((int)number.Value),
-				_                       => throw new InvalidOperationException(),
+				DateParts.Year      => date.Value.AddYears((int)number),
+				DateParts.Quarter   => date.Value.AddMonths((int)number * 3),
+				DateParts.Month     => date.Value.AddMonths((int)number),
+				DateParts.DayOfYear => date.Value.AddDays((int)number.Value),
+				DateParts.Day       => date.Value.AddDays((int)number.Value),
+				DateParts.Week      => date.Value.AddDays((int)number.Value * 7),
+				DateParts.WeekDay   => date.Value.AddDays((int)number.Value),
+				_                   => throw new InvalidOperationException(),
 			};
 		}
 
-		class DateOnlyAddBuilderSQLite : Sql.IExtensionCallBuilder
+		class DateOnlyAddBuilderSQLite : IExtensionCallBuilder
 		{
-			public void Build(Sql.ISqExtensionBuilder builder)
+			public void Build(ISqExtensionBuilder builder)
 			{
-				var part   = builder.GetValue<Sql.DateParts>("part");
+				var part   = builder.GetValue<DateParts>("part");
 				var date   = builder.GetExpression("date");
 				var number = builder.GetExpression("number", true);
 
 				string expStr = "strftime('%Y-%m-%d', {0},";
 				switch (part)
 				{
-					case Sql.DateParts.Year:      expStr += "{1} || ' Year')"; break;
-					case Sql.DateParts.Quarter:   expStr += "({1}*3) || ' Month')"; break;
-					case Sql.DateParts.Month:     expStr += "{1} || ' Month')"; break;
-					case Sql.DateParts.DayOfYear:
-					case Sql.DateParts.WeekDay:
-					case Sql.DateParts.Day:       expStr += "{1} || ' Day')"; break;
-					case Sql.DateParts.Week:      expStr += "({1}*7) || ' Day')"; break;
+					case DateParts.Year:      expStr += "{1} || ' Year')"; break;
+					case DateParts.Quarter:   expStr += "({1}*3) || ' Month')"; break;
+					case DateParts.Month:     expStr += "{1} || ' Month')"; break;
+					case DateParts.DayOfYear:
+					case DateParts.WeekDay:
+					case DateParts.Day:       expStr += "{1} || ' Day')"; break;
+					case DateParts.Week:      expStr += "({1}*7) || ' Day')"; break;
 					default:
 						throw new InvalidOperationException($"Unexpected datepart: {part}");
 				}
@@ -100,13 +100,13 @@ namespace LinqToDB
 
 		#region DateDiff
 		[CLSCompliant(false)]
-		[Sql.Extension(               "DateDiff",      BuilderType = typeof(DateDiffBuilder))]
-		[Sql.Extension(PN.MySql,      "TIMESTAMPDIFF", BuilderType = typeof(DateDiffBuilder))]
-		[Sql.Extension(PN.DB2,        "",              BuilderType = typeof(DateDiffBuilderDB2))]
-		[Sql.Extension(PN.SapHana,    "",              BuilderType = typeof(DateDiffBuilderSapHana))]
-		[Sql.Extension(PN.SQLite,     "",              BuilderType = typeof(DateDiffBuilderSQLite))]
-		[Sql.Extension(PN.PostgreSQL, "",              BuilderType = typeof(DateDiffBuilderPostgreSql))]
-		[Sql.Extension(PN.Access,     "",              BuilderType = typeof(DateDiffBuilderAccess))]
+		[Extension(               "DateDiff",      BuilderType = typeof(DateDiffBuilder))]
+		[Extension(PN.MySql,      "TIMESTAMPDIFF", BuilderType = typeof(DateDiffBuilder))]
+		[Extension(PN.DB2,        "",              BuilderType = typeof(DateDiffBuilderDB2))]
+		[Extension(PN.SapHana,    "",              BuilderType = typeof(DateDiffBuilderSapHana))]
+		[Extension(PN.SQLite,     "",              BuilderType = typeof(DateDiffBuilderSQLite))]
+		[Extension(PN.PostgreSQL, "",              BuilderType = typeof(DateDiffBuilderPostgreSql))]
+		[Extension(PN.Access,     "",              BuilderType = typeof(DateDiffBuilderAccess))]
 		public static int? DateDiff(DateParts part, DateOnly? startDate, DateOnly? endDate)
 		{
 			if (startDate == null || endDate == null)

--- a/Source/LinqToDB/Sql/Sql.DateTime.cs
+++ b/Source/LinqToDB/Sql/Sql.DateTime.cs
@@ -10,7 +10,7 @@ namespace LinqToDB
 
 	public partial class Sql
 	{
-		[Sql.Enum]
+		[Enum]
 		public enum DateParts
 		{
 			Year        =  0,
@@ -23,14 +23,37 @@ namespace LinqToDB
 			/// Eeach database could have own week numbering logic, see notes below.
 			///
 			/// Current implementation uses following schemas per-provider:
-			/// C# evaluation: <c>CultureInfo.CurrentCulture.Calendar.GetWeekOfYear(date.Value, CalendarWeekRule.FirstDay, DayOfWeek.Sunday)</c>
+			/// C# evaluation:
+			/// <para>
+			/// <c>CultureInfo.CurrentCulture.Calendar.GetWeekOfYear(date.Value, CalendarWeekRule.FirstDay, DayOfWeek.Sunday)</c>
+			/// </para>
 			/// Databases:
-			/// US numbering schema used by: MS Access, SQL CE, SQL Server, SAP/Sybase ASE, Informix databases;
-			/// US 0-based numbering schema used by MySQL database;
-			/// ISO numbering schema with incorrect numbering of first week used by: SAP HANA database;
-			/// ISO numbering schema with proper numbering of first week used by: Firebird, PostgreSQL databases;
-			/// Primitive (each 7 days counted as week) numbering schema: DB2, Oracle databases;
-			/// SQLite numbering logic cannot be classified by human being.
+			/// <list type="bullet">
+			/// <item>US numbering schema used by:
+			/// <list type="bullet">
+			/// <item>MS Access</item>
+			/// <item>SQL CE</item>
+			/// <item>SQL Server</item>
+			/// <item>SAP/Sybase ASE</item>
+			/// <item>Informix</item>
+			/// </list>
+			/// </item>
+			/// <item>US 0-based numbering schema used by MySQL database</item>
+			/// <item>ISO numbering schema with incorrect numbering of first week used by SAP HANA database</item>
+			/// <item>ISO numbering schema with proper numbering of first week used by:
+			/// <list type="bullet">
+			/// <item>Firebird</item>
+			/// <item>PostgreSQL</item>
+			/// </list>
+			/// </item>
+			/// <item>Primitive (each 7 days counted as week) numbering schema:
+			/// <list type="bullet">
+			/// <item>DB2</item>
+			/// <item>Oracle</item>
+			/// </list>
+			/// </item>
+			/// <item>SQLite numbering logic cannot be classified by human being</item>
+			/// </list>
 			/// </summary>
 			Week        =  5,
 			WeekDay     =  6,
@@ -42,11 +65,11 @@ namespace LinqToDB
 
 		#region DatePart
 
-		internal class DatePartBuilder : Sql.IExtensionCallBuilder
+		internal class DatePartBuilder : IExtensionCallBuilder
 		{
-			public void Build(Sql.ISqExtensionBuilder builder)
+			public void Build(ISqExtensionBuilder builder)
 			{
-				var part    = builder.GetValue<Sql.DateParts>("part");
+				var part    = builder.GetValue<DateParts>("part");
 				var partStr = DatePartToStr(part);
 				var date    = builder.GetExpression("date");
 
@@ -58,46 +81,46 @@ namespace LinqToDB
 			{
 				return part switch
 				{
-					Sql.DateParts.Year          => "year",
-					Sql.DateParts.Quarter       => "quarter",
-					Sql.DateParts.Month         => "month",
-					Sql.DateParts.DayOfYear     => "dayofyear",
-					Sql.DateParts.Day           => "day",
-					Sql.DateParts.Week          => "week",
-					Sql.DateParts.WeekDay       => "weekday",
-					Sql.DateParts.Hour          => "hour",
-					Sql.DateParts.Minute        => "minute",
-					Sql.DateParts.Second        => "second",
-					Sql.DateParts.Millisecond   => "millisecond",
-					_                           => throw new InvalidOperationException($"Unexpected datepart: {part}")
+					DateParts.Year          => "year",
+					DateParts.Quarter       => "quarter",
+					DateParts.Month         => "month",
+					DateParts.DayOfYear     => "dayofyear",
+					DateParts.Day           => "day",
+					DateParts.Week          => "week",
+					DateParts.WeekDay       => "weekday",
+					DateParts.Hour          => "hour",
+					DateParts.Minute        => "minute",
+					DateParts.Second        => "second",
+					DateParts.Millisecond   => "millisecond",
+					_                       => throw new InvalidOperationException($"Unexpected datepart: {part}")
 				};
 			}
 		}
 
-		class DatePartBuilderMySql: Sql.IExtensionCallBuilder
+		class DatePartBuilderMySql: IExtensionCallBuilder
 		{
-			public void Build(Sql.ISqExtensionBuilder builder)
+			public void Build(ISqExtensionBuilder builder)
 			{
 				string? partStr = null;
-				var part = builder.GetValue<Sql.DateParts>("part");
+				var part = builder.GetValue<DateParts>("part");
 				switch (part)
 				{
-					case Sql.DateParts.Year        : partStr = "year";        break;
-					case Sql.DateParts.Quarter     : partStr = "quarter";     break;
-					case Sql.DateParts.Month       : partStr = "month";       break;
-					case Sql.DateParts.DayOfYear   :
+					case DateParts.Year        : partStr = "year";        break;
+					case DateParts.Quarter     : partStr = "quarter";     break;
+					case DateParts.Month       : partStr = "month";       break;
+					case DateParts.DayOfYear   :
 						builder.Expression = "DayOfYear({date})";
 						break;
-					case Sql.DateParts.Day         : partStr = "day";         break;
-					case Sql.DateParts.Week        : partStr = "week";        break;
-					case Sql.DateParts.WeekDay     :
+					case DateParts.Day         : partStr = "day";         break;
+					case DateParts.Week        : partStr = "week";        break;
+					case DateParts.WeekDay     :
 						builder.Expression = "WeekDay(Date_Add({date}, interval 1 day))";
 						builder.ResultExpression = builder.Inc(builder.ConvertToSqlExpression(Precedence.Primary));
 						return;
-					case Sql.DateParts.Hour        : partStr = "hour";        break;
-					case Sql.DateParts.Minute      : partStr = "minute";      break;
-					case Sql.DateParts.Second      : partStr = "second";      break;
-					case Sql.DateParts.Millisecond : partStr = "millisecond"; break;
+					case DateParts.Hour        : partStr = "hour";        break;
+					case DateParts.Minute      : partStr = "minute";      break;
+					case DateParts.Second      : partStr = "second";      break;
+					case DateParts.Millisecond : partStr = "millisecond"; break;
 					default:
 						throw new InvalidOperationException($"Unexpected datepart: {part}");
 				}
@@ -107,28 +130,28 @@ namespace LinqToDB
 			}
 		}
 
-		class DatePartBuilderPostgre: Sql.IExtensionCallBuilder
+		class DatePartBuilderPostgre: IExtensionCallBuilder
 		{
-			public void Build(Sql.ISqExtensionBuilder builder)
+			public void Build(ISqExtensionBuilder builder)
 			{
 				string? partStr = null;
-				var part = builder.GetValue<Sql.DateParts>("part");
+				var part = builder.GetValue<DateParts>("part");
 				switch (part)
 				{
-					case Sql.DateParts.Year        : partStr = "year";    break;
-					case Sql.DateParts.Quarter     : partStr = "quarter"; break;
-					case Sql.DateParts.Month       : partStr = "month";   break;
-					case Sql.DateParts.DayOfYear   : partStr = "doy";     break;
-					case Sql.DateParts.Day         : partStr = "day";     break;
-					case Sql.DateParts.Week        : partStr = "week";    break;
-					case Sql.DateParts.WeekDay     :
+					case DateParts.Year        : partStr = "year";    break;
+					case DateParts.Quarter     : partStr = "quarter"; break;
+					case DateParts.Month       : partStr = "month";   break;
+					case DateParts.DayOfYear   : partStr = "doy";     break;
+					case DateParts.Day         : partStr = "day";     break;
+					case DateParts.Week        : partStr = "week";    break;
+					case DateParts.WeekDay     :
 						builder.AddExpression("part", "dow");
 						builder.ResultExpression = builder.Inc(builder.ConvertToSqlExpression(Precedence.Primary));
 						return;
-					case Sql.DateParts.Hour        : partStr = "hour";    break;
-					case Sql.DateParts.Minute      : partStr = "minute";  break;
-					case Sql.DateParts.Second      : partStr = "second";  break;
-					case Sql.DateParts.Millisecond :
+					case DateParts.Hour        : partStr = "hour";    break;
+					case DateParts.Minute      : partStr = "minute";  break;
+					case DateParts.Second      : partStr = "second";  break;
+					case DateParts.Millisecond :
 						builder.Expression = "Cast(To_Char({date}, 'MS') as int)";
 						break;
 					default:
@@ -140,31 +163,31 @@ namespace LinqToDB
 			}
 		}
 
-		class DatePartBuilderSqLite: Sql.IExtensionCallBuilder
+		class DatePartBuilderSqLite: IExtensionCallBuilder
 		{
-			public void Build(Sql.ISqExtensionBuilder builder)
+			public void Build(ISqExtensionBuilder builder)
 			{
 				string? partStr = null;
-				var part = builder.GetValue<Sql.DateParts>("part");
+				var part = builder.GetValue<DateParts>("part");
 				switch (part)
 				{
-					case Sql.DateParts.Year        : partStr = "Y"; break;
-					case Sql.DateParts.Quarter     :
+					case DateParts.Year        : partStr = "Y"; break;
+					case DateParts.Quarter     :
 						builder.Expression = "Cast(strFTime('%m', {date}) as int)";
 						builder.ResultExpression = builder.Inc(builder.Div(builder.Dec(builder.ConvertToSqlExpression(Precedence.Primary)), 3));
 						return;
-					case Sql.DateParts.Month       : partStr = "m"; break;
-					case Sql.DateParts.DayOfYear   : partStr = "j"; break;
-					case Sql.DateParts.Day         : partStr = "d"; break;
-					case Sql.DateParts.Week        : partStr = "W"; break;
-					case Sql.DateParts.WeekDay     :
+					case DateParts.Month       : partStr = "m"; break;
+					case DateParts.DayOfYear   : partStr = "j"; break;
+					case DateParts.Day         : partStr = "d"; break;
+					case DateParts.Week        : partStr = "W"; break;
+					case DateParts.WeekDay     :
 						builder.Expression = "Cast(strFTime('%w', {date}) as int)";
 						builder.ResultExpression = builder.Inc(builder.ConvertToSqlExpression(Precedence.Primary));
 						return;
-					case Sql.DateParts.Hour        : partStr = "H"; break;
-					case Sql.DateParts.Minute      : partStr = "M"; break;
-					case Sql.DateParts.Second      : partStr = "S"; break;
-					case Sql.DateParts.Millisecond :
+					case DateParts.Hour        : partStr = "H"; break;
+					case DateParts.Minute      : partStr = "M"; break;
+					case DateParts.Second      : partStr = "S"; break;
+					case DateParts.Millisecond :
 						builder.Expression = "Cast(strFTime('%f', {date}) * 1000 as int) % 1000";
 						builder.Extension.Precedence = Precedence.Multiplicative;
 						break;
@@ -177,54 +200,53 @@ namespace LinqToDB
 			}
 		}
 
-		class DatePartBuilderAccess: Sql.IExtensionCallBuilder
+		class DatePartBuilderAccess: IExtensionCallBuilder
 		{
-			public void Build(Sql.ISqExtensionBuilder builder)
+			public void Build(ISqExtensionBuilder builder)
 			{
-				var part    = builder.GetValue<Sql.DateParts>("part");
+				var part    = builder.GetValue<DateParts>("part");
 				var partStr = part switch
 				{
-					Sql.DateParts.Year      => "yyyy",
-					Sql.DateParts.Quarter   => "q",
-					Sql.DateParts.Month     => "m",
-					Sql.DateParts.DayOfYear => "y",
-					Sql.DateParts.Day       => "d",
-					Sql.DateParts.Week      => "ww",
-					Sql.DateParts.WeekDay   => "w",
-					Sql.DateParts.Hour      => "h",
-					Sql.DateParts.Minute    => "n",
-					Sql.DateParts.Second    => "s",
+					DateParts.Year      => "yyyy",
+					DateParts.Quarter   => "q",
+					DateParts.Month     => "m",
+					DateParts.DayOfYear => "y",
+					DateParts.Day       => "d",
+					DateParts.Week      => "ww",
+					DateParts.WeekDay   => "w",
+					DateParts.Hour      => "h",
+					DateParts.Minute    => "n",
+					DateParts.Second    => "s",
 					_ => throw new InvalidOperationException($"Unexpected datepart: {part}"),
 				};
 				builder.AddExpression("part", partStr);
 			}
 		}
 
-
-		class DatePartBuilderSapHana: Sql.IExtensionCallBuilder
+		class DatePartBuilderSapHana: IExtensionCallBuilder
 		{
-			public void Build(Sql.ISqExtensionBuilder builder)
+			public void Build(ISqExtensionBuilder builder)
 			{
 				string exprStr;
-				var part = builder.GetValue<Sql.DateParts>("part");
+				var part = builder.GetValue<DateParts>("part");
 				switch (part)
 				{
-					case Sql.DateParts.Year        : exprStr = "Year({date})";                     break;
-					case Sql.DateParts.Quarter     :
+					case DateParts.Year        : exprStr = "Year({date})";                     break;
+					case DateParts.Quarter     :
 						builder.Expression = "Floor((Month({date})-1) / 3)";
 						builder.ResultExpression = builder.Inc(builder.ConvertToSqlExpression());
 						return;
-					case Sql.DateParts.Month       : exprStr = "Month({date})";                    break;
-					case Sql.DateParts.DayOfYear   : exprStr = "DayOfYear({date})";                break;
-					case Sql.DateParts.Day         : exprStr = "DayOfMonth({date})";               break;
-					case Sql.DateParts.Week        : exprStr = "Week({date})";                     break;
-					case Sql.DateParts.WeekDay     :
+					case DateParts.Month       : exprStr = "Month({date})";                    break;
+					case DateParts.DayOfYear   : exprStr = "DayOfYear({date})";                break;
+					case DateParts.Day         : exprStr = "DayOfMonth({date})";               break;
+					case DateParts.Week        : exprStr = "Week({date})";                     break;
+					case DateParts.WeekDay     :
 						builder.Expression = "MOD(Weekday({date}) + 1, 7)";
 						builder.ResultExpression = builder.Inc(builder.ConvertToSqlExpression());
 						return;
-					case Sql.DateParts.Hour        : exprStr = "Hour({date})";                     break;
-					case Sql.DateParts.Minute      : exprStr = "Minute({date})";                   break;
-					case Sql.DateParts.Second      : exprStr = "Second({date})";                   break;
+					case DateParts.Hour        : exprStr = "Hour({date})";                     break;
+					case DateParts.Minute      : exprStr = "Minute({date})";                   break;
+					case DateParts.Second      : exprStr = "Second({date})";                   break;
 					default:
 						throw new InvalidOperationException($"Unexpected datepart: {part}");
 				}
@@ -233,24 +255,24 @@ namespace LinqToDB
 			}
 		}
 
-		class DatePartBuilderInformix: Sql.IExtensionCallBuilder
+		class DatePartBuilderInformix: IExtensionCallBuilder
 		{
-			public void Build(Sql.ISqExtensionBuilder builder)
+			public void Build(ISqExtensionBuilder builder)
 			{
 				string exprStr;
-				var part = builder.GetValue<Sql.DateParts>("part");
+				var part = builder.GetValue<DateParts>("part");
 				switch (part)
 				{
-					case Sql.DateParts.Year        : exprStr = "Year({date})";          break;
-					case Sql.DateParts.Quarter:
+					case DateParts.Year        : exprStr = "Year({date})";          break;
+					case DateParts.Quarter:
 						{
 							builder.Expression       = "Month({date})";
 							builder.ResultExpression =
 								builder.Inc(builder.Div(builder.Dec(builder.ConvertToSqlExpression(Precedence.Primary)), 3));
 							return;
 						}
-					case Sql.DateParts.Month       : exprStr = "Month({date})";         break;
-					case Sql.DateParts.DayOfYear   :
+					case DateParts.Month       : exprStr = "Month({date})";         break;
+					case DateParts.DayOfYear   :
 						{
 							var param = builder.GetExpression("date");
 							builder.ResultExpression = builder.Inc(
@@ -266,18 +288,18 @@ namespace LinqToDB
 							);
 							return;
 						}
-					case Sql.DateParts.Day         : exprStr = "Day({date})";           break;
-					case Sql.DateParts.Week        : exprStr = "((Extend({date}, year to day) - (Mdy(12, 31 - WeekDay(Mdy(1, 1, year({date}))), Year({date}) - 1) + Interval(1) day to day)) / 7 + Interval(1) day to day)::char(10)::int"; break;
-					case Sql.DateParts.WeekDay     :
+					case DateParts.Day         : exprStr = "Day({date})";           break;
+					case DateParts.Week        : exprStr = "((Extend({date}, year to day) - (Mdy(12, 31 - WeekDay(Mdy(1, 1, year({date}))), Year({date}) - 1) + Interval(1) day to day)) / 7 + Interval(1) day to day)::char(10)::int"; break;
+					case DateParts.WeekDay     :
 						{
 							builder.Expression = "weekDay({date})";
 							builder.ResultExpression = builder.Inc(builder.ConvertToSqlExpression(Precedence.Primary));
 							return;
 						}
-					case Sql.DateParts.Hour        : exprStr = "({date}::datetime Hour to Hour)::char(3)::int";     break;
-					case Sql.DateParts.Minute      : exprStr = "({date}::datetime Minute to Minute)::char(3)::int"; break;
-					case Sql.DateParts.Second      : exprStr = "({date}::datetime Second to Second)::char(3)::int"; break;
-					case Sql.DateParts.Millisecond : exprStr = "Millisecond({date})";                               break;
+					case DateParts.Hour        : exprStr = "({date}::datetime Hour to Hour)::char(3)::int";     break;
+					case DateParts.Minute      : exprStr = "({date}::datetime Minute to Minute)::char(3)::int"; break;
+					case DateParts.Second      : exprStr = "({date}::datetime Second to Second)::char(3)::int"; break;
+					case DateParts.Millisecond : exprStr = "Millisecond({date})";                               break;
 					default:
 						throw new InvalidOperationException($"Unexpected datepart: {part}");
 				}
@@ -286,30 +308,30 @@ namespace LinqToDB
 			}
 		}
 
-		class DatePartBuilderOracle: Sql.IExtensionCallBuilder
+		class DatePartBuilderOracle: IExtensionCallBuilder
 		{
-			public void Build(Sql.ISqExtensionBuilder builder)
+			public void Build(ISqExtensionBuilder builder)
 			{
 				string partStr;
-				var part = builder.GetValue<Sql.DateParts>("part");
+				var part = builder.GetValue<DateParts>("part");
 				switch (part)
 				{
-					case Sql.DateParts.Year        : partStr = "To_Number(To_Char({date}, 'YYYY'))";                  break;
-					case Sql.DateParts.Quarter     : partStr = "To_Number(To_Char({date}, 'Q'))";                     break;
-					case Sql.DateParts.Month       : partStr = "To_Number(To_Char({date}, 'MM'))";                    break;
-					case Sql.DateParts.DayOfYear   : partStr = "To_Number(To_Char({date}, 'DDD'))";                   break;
-					case Sql.DateParts.Day         : partStr = "To_Number(To_Char({date}, 'DD'))";                    break;
-					case Sql.DateParts.Week        : partStr = "To_Number(To_Char({date}, 'WW'))";                    break;
-					case Sql.DateParts.WeekDay:
+					case DateParts.Year        : partStr = "To_Number(To_Char({date}, 'YYYY'))";                  break;
+					case DateParts.Quarter     : partStr = "To_Number(To_Char({date}, 'Q'))";                     break;
+					case DateParts.Month       : partStr = "To_Number(To_Char({date}, 'MM'))";                    break;
+					case DateParts.DayOfYear   : partStr = "To_Number(To_Char({date}, 'DDD'))";                   break;
+					case DateParts.Day         : partStr = "To_Number(To_Char({date}, 'DD'))";                    break;
+					case DateParts.Week        : partStr = "To_Number(To_Char({date}, 'WW'))";                    break;
+					case DateParts.WeekDay:
 						{
 							builder.Expression = "Mod(1 + Trunc({date}) - Trunc({date}, 'IW'), 7)";
 							builder.ResultExpression = builder.Inc(builder.ConvertToSqlExpression(Precedence.Primary));
 							return;
 						}
-					case Sql.DateParts.Hour        : partStr = "To_Number(To_Char({date}, 'HH24'))";                  break;
-					case Sql.DateParts.Minute      : partStr = "To_Number(To_Char({date}, 'MI'))";                    break;
-					case Sql.DateParts.Second      : partStr = "To_Number(To_Char({date}, 'SS'))";                    break;
-					case Sql.DateParts.Millisecond : partStr = "To_Number(To_Char({date}, 'FF'))";                    break;
+					case DateParts.Hour        : partStr = "To_Number(To_Char({date}, 'HH24'))";                  break;
+					case DateParts.Minute      : partStr = "To_Number(To_Char({date}, 'MI'))";                    break;
+					case DateParts.Second      : partStr = "To_Number(To_Char({date}, 'SS'))";                    break;
+					case DateParts.Millisecond : partStr = "To_Number(To_Char({date}, 'FF'))";                    break;
 					default:
 						throw new InvalidOperationException($"Unexpected datepart: {part}");
 				}
@@ -318,25 +340,25 @@ namespace LinqToDB
 			}
 		}
 
-		class DatePartBuilderDB2: Sql.IExtensionCallBuilder
+		class DatePartBuilderDB2: IExtensionCallBuilder
 		{
-			public void Build(Sql.ISqExtensionBuilder builder)
+			public void Build(ISqExtensionBuilder builder)
 			{
 				string partStr;
-				var part = builder.GetValue<Sql.DateParts>("part");
+				var part = builder.GetValue<DateParts>("part");
 				switch (part)
 				{
-					case Sql.DateParts.Year        : partStr = "To_Number(To_Char({date}, 'YYYY'))";                  break;
-					case Sql.DateParts.Quarter     : partStr = "To_Number(To_Char({date}, 'Q'))";                     break;
-					case Sql.DateParts.Month       : partStr = "To_Number(To_Char({date}, 'MM'))";                    break;
-					case Sql.DateParts.DayOfYear   : partStr = "To_Number(To_Char({date}, 'DDD'))";                   break;
-					case Sql.DateParts.Day         : partStr = "To_Number(To_Char({date}, 'DD'))";                    break;
-					case Sql.DateParts.Week        : partStr = "To_Number(To_Char({date}, 'WW'))";                    break;
-					case Sql.DateParts.WeekDay     : partStr = "DayOfWeek({date})";                                   break;
-					case Sql.DateParts.Hour        : partStr = "To_Number(To_Char({date}, 'HH24'))";                  break;
-					case Sql.DateParts.Minute      : partStr = "To_Number(To_Char({date}, 'MI'))";                    break;
-					case Sql.DateParts.Second      : partStr = "To_Number(To_Char({date}, 'SS'))";                    break;
-					case Sql.DateParts.Millisecond:
+					case DateParts.Year        : partStr = "To_Number(To_Char({date}, 'YYYY'))";                  break;
+					case DateParts.Quarter     : partStr = "To_Number(To_Char({date}, 'Q'))";                     break;
+					case DateParts.Month       : partStr = "To_Number(To_Char({date}, 'MM'))";                    break;
+					case DateParts.DayOfYear   : partStr = "To_Number(To_Char({date}, 'DDD'))";                   break;
+					case DateParts.Day         : partStr = "To_Number(To_Char({date}, 'DD'))";                    break;
+					case DateParts.Week        : partStr = "To_Number(To_Char({date}, 'WW'))";                    break;
+					case DateParts.WeekDay     : partStr = "DayOfWeek({date})";                                   break;
+					case DateParts.Hour        : partStr = "To_Number(To_Char({date}, 'HH24'))";                  break;
+					case DateParts.Minute      : partStr = "To_Number(To_Char({date}, 'MI'))";                    break;
+					case DateParts.Second      : partStr = "To_Number(To_Char({date}, 'SS'))";                    break;
+					case DateParts.Millisecond:
 						{
 							builder.Expression = "To_Number(To_Char({date}, 'FF'))";
 							builder.ResultExpression = builder.Div(builder.ConvertToSqlExpression(Precedence.Primary), 1000);
@@ -350,28 +372,28 @@ namespace LinqToDB
 			}
 		}
 
-		class DatePartBuilderFirebird: Sql.IExtensionCallBuilder
+		class DatePartBuilderFirebird: IExtensionCallBuilder
 		{
-			public void Build(Sql.ISqExtensionBuilder builder)
+			public void Build(ISqExtensionBuilder builder)
 			{
 				string partStr;
-				var part = builder.GetValue<Sql.DateParts>("part");
+				var part = builder.GetValue<DateParts>("part");
 				switch (part)
 				{
-					case Sql.DateParts.Year        : partStr = "year";        break;
-					case Sql.DateParts.Quarter     :
+					case DateParts.Year        : partStr = "year";        break;
+					case DateParts.Quarter     :
 						builder.Expression = "Extract(Month from {date})";
 						builder.ResultExpression = builder.Inc(builder.Div(builder.Dec(builder.ConvertToSqlExpression(Precedence.Primary)), 3));
 						return;
-					case Sql.DateParts.Month       : partStr = "month";       break;
-					case Sql.DateParts.DayOfYear   : partStr = "yearday";     break;
-					case Sql.DateParts.Day         : partStr = "day";         break;
-					case Sql.DateParts.Week        : partStr = "week";        break;
-					case Sql.DateParts.WeekDay     : partStr = "weekday";     break;
-					case Sql.DateParts.Hour        : partStr = "hour";        break;
-					case Sql.DateParts.Minute      : partStr = "minute";      break;
-					case Sql.DateParts.Second      : partStr = "second";      break;
-					case Sql.DateParts.Millisecond : partStr = "millisecond"; break;
+					case DateParts.Month       : partStr = "month";       break;
+					case DateParts.DayOfYear   : partStr = "yearday";     break;
+					case DateParts.Day         : partStr = "day";         break;
+					case DateParts.Week        : partStr = "week";        break;
+					case DateParts.WeekDay     : partStr = "weekday";     break;
+					case DateParts.Hour        : partStr = "hour";        break;
+					case DateParts.Minute      : partStr = "minute";      break;
+					case DateParts.Second      : partStr = "second";      break;
+					case DateParts.Millisecond : partStr = "millisecond"; break;
 					default:
 						throw new InvalidOperationException($"Unexpected datepart: {part}");
 				}
@@ -380,42 +402,42 @@ namespace LinqToDB
 
 				switch (part)
 				{
-					case Sql.DateParts.DayOfYear:
-					case Sql.DateParts.WeekDay:
+					case DateParts.DayOfYear:
+					case DateParts.WeekDay:
 						builder.ResultExpression = builder.Inc(builder.ConvertToSqlExpression(Precedence.Primary));
 						break;
 				}
 			}
 		}
 
-		[Sql.Extension(               "DatePart",                                        ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilder))]
-		[Sql.Extension(PN.DB2,        "",                                                ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderDB2))] // TODO: Not checked
-		[Sql.Extension(PN.Informix,   "",                                                ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderInformix))]
-		[Sql.Extension(PN.MySql,      "Extract({part} from {date})",                     ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderMySql))]
-		[Sql.Extension(PN.PostgreSQL, "Cast(Floor(Extract({part} from {date})) as int)", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderPostgre))]
-		[Sql.Extension(PN.Firebird,   "Cast(Floor(Extract({part} from {date})) as int)", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderFirebird))]
-		[Sql.Extension(PN.SQLite,     "Cast(StrFTime('%{part}', {date}) as int)",        ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderSqLite))]
-		[Sql.Extension(PN.Access,     "DatePart('{part}', {date})",                      ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderAccess))]
-		[Sql.Extension(PN.SapHana,    "",                                                ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderSapHana))]
-		[Sql.Extension(PN.Oracle,     "",                                                ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderOracle))]
-		public static int? DatePart([SqlQueryDependent] Sql.DateParts part, [ExprParameter] DateTime? date)
+		[Extension(               "DatePart",                                        ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilder))]
+		[Extension(PN.DB2,        "",                                                ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderDB2))] // TODO: Not checked
+		[Extension(PN.Informix,   "",                                                ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderInformix))]
+		[Extension(PN.MySql,      "Extract({part} from {date})",                     ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderMySql))]
+		[Extension(PN.PostgreSQL, "Cast(Floor(Extract({part} from {date})) as int)", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderPostgre))]
+		[Extension(PN.Firebird,   "Cast(Floor(Extract({part} from {date})) as int)", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderFirebird))]
+		[Extension(PN.SQLite,     "Cast(StrFTime('%{part}', {date}) as int)",        ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderSqLite))]
+		[Extension(PN.Access,     "DatePart('{part}', {date})",                      ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderAccess))]
+		[Extension(PN.SapHana,    "",                                                ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderSapHana))]
+		[Extension(PN.Oracle,     "",                                                ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderOracle))]
+		public static int? DatePart([SqlQueryDependent] DateParts part, [ExprParameter] DateTime? date)
 		{
 			if (date == null)
 				return null;
 
 			return part switch
 			{
-				Sql.DateParts.Year          => date.Value.Year,
-				Sql.DateParts.Quarter       => (date.Value.Month - 1) / 3 + 1,
-				Sql.DateParts.Month         => date.Value.Month,
-				Sql.DateParts.DayOfYear     => date.Value.DayOfYear,
-				Sql.DateParts.Day           => date.Value.Day,
-				Sql.DateParts.Week          => CultureInfo.CurrentCulture.Calendar.GetWeekOfYear(date.Value, CalendarWeekRule.FirstDay, DayOfWeek.Sunday),
-				Sql.DateParts.WeekDay       => ((int)date.Value.DayOfWeek + 1 + Sql.DateFirst + 6) % 7 + 1,
-				Sql.DateParts.Hour          => date.Value.Hour,
-				Sql.DateParts.Minute        => date.Value.Minute,
-				Sql.DateParts.Second        => date.Value.Second,
-				Sql.DateParts.Millisecond   => date.Value.Millisecond,
+				DateParts.Year          => date.Value.Year,
+				DateParts.Quarter       => (date.Value.Month - 1) / 3 + 1,
+				DateParts.Month         => date.Value.Month,
+				DateParts.DayOfYear     => date.Value.DayOfYear,
+				DateParts.Day           => date.Value.Day,
+				DateParts.Week          => CultureInfo.CurrentCulture.Calendar.GetWeekOfYear(date.Value, CalendarWeekRule.FirstDay, DayOfWeek.Sunday),
+				DateParts.WeekDay       => ((int)date.Value.DayOfWeek + 1 + DateFirst + 6) % 7 + 1,
+				DateParts.Hour          => date.Value.Hour,
+				DateParts.Minute        => date.Value.Minute,
+				DateParts.Second        => date.Value.Second,
+				DateParts.Millisecond   => date.Value.Millisecond,
 				_                           => throw new InvalidOperationException(),
 			};
 		}
@@ -424,11 +446,11 @@ namespace LinqToDB
 
 		#region DateAdd
 
-		class DateAddBuilder : Sql.IExtensionCallBuilder
+		class DateAddBuilder : IExtensionCallBuilder
 		{
 			public void Build(ISqExtensionBuilder builder)
 			{
-				var part    = builder.GetValue<Sql.DateParts>("part");
+				var part    = builder.GetValue<DateParts>("part");
 				var partStr = DatePartBuilder.DatePartToStr(part);
 				var date    = builder.GetExpression("date");
 				var number  = builder.GetExpression("number", true);
@@ -438,28 +460,28 @@ namespace LinqToDB
 			}
 		}
 
-		class DateAddBuilderOracle : Sql.IExtensionCallBuilder
+		class DateAddBuilderOracle : IExtensionCallBuilder
 		{
-			public void Build(Sql.ISqExtensionBuilder builder)
+			public void Build(ISqExtensionBuilder builder)
 			{
-				var part   = builder.GetValue<Sql.DateParts>("part");
+				var part   = builder.GetValue<DateParts>("part");
 				var date   = builder.GetExpression("date");
 				var number = builder.GetExpression("number", true);
 
 				string expStr;
 				switch (part)
 				{
-					case Sql.DateParts.Year        : expStr = "{0} * INTERVAL '1' YEAR"      ; break;
-					case Sql.DateParts.Quarter     : expStr = "{0} * INTERVAL '3' MONTH"     ; break;
-					case Sql.DateParts.Month       : expStr = "{0} * INTERVAL '1' MONTH"     ; break;
-					case Sql.DateParts.DayOfYear   :
-					case Sql.DateParts.WeekDay     :
-					case Sql.DateParts.Day         : expStr = "{0} * INTERVAL '1' DAY"       ; break;
-					case Sql.DateParts.Week        : expStr = "{0} * INTERVAL '7' DAY"       ; break;
-					case Sql.DateParts.Hour        : expStr = "{0} * INTERVAL '1' HOUR"      ; break;
-					case Sql.DateParts.Minute      : expStr = "{0} * INTERVAL '1' MINUTE"    ; break;
-					case Sql.DateParts.Second      : expStr = "{0} * INTERVAL '1' SECOND"    ; break;
-					case Sql.DateParts.Millisecond : expStr = "{0} * INTERVAL '0.001' SECOND"; break;
+					case DateParts.Year        : expStr = "{0} * INTERVAL '1' YEAR"      ; break;
+					case DateParts.Quarter     : expStr = "{0} * INTERVAL '3' MONTH"     ; break;
+					case DateParts.Month       : expStr = "{0} * INTERVAL '1' MONTH"     ; break;
+					case DateParts.DayOfYear   :
+					case DateParts.WeekDay     :
+					case DateParts.Day         : expStr = "{0} * INTERVAL '1' DAY"       ; break;
+					case DateParts.Week        : expStr = "{0} * INTERVAL '7' DAY"       ; break;
+					case DateParts.Hour        : expStr = "{0} * INTERVAL '1' HOUR"      ; break;
+					case DateParts.Minute      : expStr = "{0} * INTERVAL '1' MINUTE"    ; break;
+					case DateParts.Second      : expStr = "{0} * INTERVAL '1' SECOND"    ; break;
+					case DateParts.Millisecond : expStr = "{0} * INTERVAL '0.001' SECOND"; break;
 					default:
 						throw new InvalidOperationException($"Unexpected datepart: {part}");
 				}
@@ -471,11 +493,11 @@ namespace LinqToDB
 			}
 		}
 
-		class DateAddBuilderDB2 : Sql.IExtensionCallBuilder
+		class DateAddBuilderDB2 : IExtensionCallBuilder
 		{
-			public void Build(Sql.ISqExtensionBuilder builder)
+			public void Build(ISqExtensionBuilder builder)
 			{
-				var part   = builder.GetValue<Sql.DateParts>("part");
+				var part   = builder.GetValue<DateParts>("part");
 				var date   = builder.GetExpression("date");
 				var number = builder.GetExpression("number", true);
 
@@ -483,17 +505,17 @@ namespace LinqToDB
 
 				switch (part)
 				{
-					case Sql.DateParts.Year        : expStr = "{0} Year";                 break;
-					case Sql.DateParts.Quarter     : expStr = "({0} * 3) Month";          break;
-					case Sql.DateParts.Month       : expStr = "{0} Month";                break;
-					case Sql.DateParts.DayOfYear   :
-					case Sql.DateParts.WeekDay     :
-					case Sql.DateParts.Day         : expStr = "{0} Day";                  break;
-					case Sql.DateParts.Week        : expStr = "({0} * 7) Day";            break;
-					case Sql.DateParts.Hour        : expStr = "{0} Hour";                 break;
-					case Sql.DateParts.Minute      : expStr = "{0} Minute";               break;
-					case Sql.DateParts.Second      : expStr = "{0} Second";               break;
-					case Sql.DateParts.Millisecond : expStr = "({0} / 1000.0) Second";    break;
+					case DateParts.Year        : expStr = "{0} Year";                 break;
+					case DateParts.Quarter     : expStr = "({0} * 3) Month";          break;
+					case DateParts.Month       : expStr = "{0} Month";                break;
+					case DateParts.DayOfYear   :
+					case DateParts.WeekDay     :
+					case DateParts.Day         : expStr = "{0} Day";                  break;
+					case DateParts.Week        : expStr = "({0} * 7) Day";            break;
+					case DateParts.Hour        : expStr = "{0} Hour";                 break;
+					case DateParts.Minute      : expStr = "{0} Minute";               break;
+					case DateParts.Second      : expStr = "{0} Second";               break;
+					case DateParts.Millisecond : expStr = "({0} / 1000.0) Second";    break;
 					default:
 						throw new InvalidOperationException($"Unexpected datepart: {part}");
 				}
@@ -505,28 +527,28 @@ namespace LinqToDB
 			}
 		}
 
-		class DateAddBuilderInformix : Sql.IExtensionCallBuilder
+		class DateAddBuilderInformix : IExtensionCallBuilder
 		{
-			public void Build(Sql.ISqExtensionBuilder builder)
+			public void Build(ISqExtensionBuilder builder)
 			{
-				var part   = builder.GetValue<Sql.DateParts>("part");
+				var part   = builder.GetValue<DateParts>("part");
 				var date   = builder.GetExpression("date");
 				var number = builder.GetExpression("number", true);
 
 				string expStr;
 				switch (part)
 				{
-					case Sql.DateParts.Year        : expStr = "{0} + Interval({1}) Year to Year";       break;
-					case Sql.DateParts.Quarter     : expStr = "{0} + Interval({1}) Month to Month * 3"; break;
-					case Sql.DateParts.Month       : expStr = "{0} + Interval({1}) Month to Month";     break;
-					case Sql.DateParts.DayOfYear   :
-					case Sql.DateParts.WeekDay     :
-					case Sql.DateParts.Day         : expStr = "{0} + Interval({1}) Day to Day";         break;
-					case Sql.DateParts.Week        : expStr = "{0} + Interval({1}) Day to Day * 7";     break;
-					case Sql.DateParts.Hour        : expStr = "{0} + Interval({1}) Hour to Hour";       break;
-					case Sql.DateParts.Minute      : expStr = "{0} + Interval({1}) Minute to Minute";   break;
-					case Sql.DateParts.Second      : expStr = "{0} + Interval({1}) Second to Second";   break;
-					case Sql.DateParts.Millisecond : expStr = "{0} + Interval({1}) Second to Fraction * 1000";  break;
+					case DateParts.Year        : expStr = "{0} + Interval({1}) Year to Year";       break;
+					case DateParts.Quarter     : expStr = "{0} + Interval({1}) Month to Month * 3"; break;
+					case DateParts.Month       : expStr = "{0} + Interval({1}) Month to Month";     break;
+					case DateParts.DayOfYear   :
+					case DateParts.WeekDay     :
+					case DateParts.Day         : expStr = "{0} + Interval({1}) Day to Day";         break;
+					case DateParts.Week        : expStr = "{0} + Interval({1}) Day to Day * 7";     break;
+					case DateParts.Hour        : expStr = "{0} + Interval({1}) Hour to Hour";       break;
+					case DateParts.Minute      : expStr = "{0} + Interval({1}) Minute to Minute";   break;
+					case DateParts.Second      : expStr = "{0} + Interval({1}) Second to Second";   break;
+					case DateParts.Millisecond : expStr = "{0} + Interval({1}) Second to Fraction * 1000";  break;
 					default:
 						throw new InvalidOperationException($"Unexpected datepart: {part}");
 				}
@@ -535,28 +557,28 @@ namespace LinqToDB
 			}
 		}
 
-		class DateAddBuilderPostgreSQL : Sql.IExtensionCallBuilder
+		class DateAddBuilderPostgreSQL : IExtensionCallBuilder
 		{
-			public void Build(Sql.ISqExtensionBuilder builder)
+			public void Build(ISqExtensionBuilder builder)
 			{
-				var part   = builder.GetValue<Sql.DateParts>("part");
+				var part   = builder.GetValue<DateParts>("part");
 				var date   = builder.GetExpression("date");
 				var number = builder.GetExpression("number", true);
 
 				string expStr;
 				switch (part)
 				{
-					case Sql.DateParts.Year        : expStr = "{0} * Interval '1 Year'";         break;
-					case Sql.DateParts.Quarter     : expStr = "{0} * Interval '1 Month' * 3";    break;
-					case Sql.DateParts.Month       : expStr = "{0} * Interval '1 Month'";        break;
-					case Sql.DateParts.DayOfYear   :
-					case Sql.DateParts.WeekDay     :
-					case Sql.DateParts.Day         : expStr = "{0} * Interval '1 Day'";          break;
-					case Sql.DateParts.Week        : expStr = "{0} * Interval '1 Day' * 7";      break;
-					case Sql.DateParts.Hour        : expStr = "{0} * Interval '1 Hour'";         break;
-					case Sql.DateParts.Minute      : expStr = "{0} * Interval '1 Minute'";       break;
-					case Sql.DateParts.Second      : expStr = "{0} * Interval '1 Second'";       break;
-					case Sql.DateParts.Millisecond : expStr = "{0} * Interval '1 Millisecond'";  break;
+					case DateParts.Year        : expStr = "{0} * Interval '1 Year'";         break;
+					case DateParts.Quarter     : expStr = "{0} * Interval '1 Month' * 3";    break;
+					case DateParts.Month       : expStr = "{0} * Interval '1 Month'";        break;
+					case DateParts.DayOfYear   :
+					case DateParts.WeekDay     :
+					case DateParts.Day         : expStr = "{0} * Interval '1 Day'";          break;
+					case DateParts.Week        : expStr = "{0} * Interval '1 Day' * 7";      break;
+					case DateParts.Hour        : expStr = "{0} * Interval '1 Hour'";         break;
+					case DateParts.Minute      : expStr = "{0} * Interval '1 Minute'";       break;
+					case DateParts.Second      : expStr = "{0} * Interval '1 Second'";       break;
+					case DateParts.Millisecond : expStr = "{0} * Interval '1 Millisecond'";  break;
 					default:
 						throw new InvalidOperationException($"Unexpected datepart: {part}");
 				}
@@ -568,28 +590,28 @@ namespace LinqToDB
 			}
 		}
 
-		class DateAddBuilderMySql : Sql.IExtensionCallBuilder
+		class DateAddBuilderMySql : IExtensionCallBuilder
 		{
-			public void Build(Sql.ISqExtensionBuilder builder)
+			public void Build(ISqExtensionBuilder builder)
 			{
-				var part   = builder.GetValue<Sql.DateParts>("part");
+				var part   = builder.GetValue<DateParts>("part");
 				var date   = builder.GetExpression("date");
 				var number = builder.GetExpression("number", true);
 
 				string expStr;
 				switch (part)
 				{
-					case Sql.DateParts.Year        : expStr = "Interval {0} Year"; break;
-					case Sql.DateParts.Quarter     : expStr = "Interval {0} Quarter"; break;
-					case Sql.DateParts.Month       : expStr = "Interval {0} Month"; break;
-					case Sql.DateParts.DayOfYear   :
-					case Sql.DateParts.WeekDay     :
-					case Sql.DateParts.Day         : expStr = "Interval {0} Day";          break;
-					case Sql.DateParts.Week        : expStr = "Interval {0} Week"; break;
-					case Sql.DateParts.Hour        : expStr = "Interval {0} Hour"; break;
-					case Sql.DateParts.Minute      : expStr = "Interval {0} Minute"; break;
-					case Sql.DateParts.Second      : expStr = "Interval {0} Second"; break;
-					case Sql.DateParts.Millisecond : expStr = "Interval {0} Millisecond"; break;
+					case DateParts.Year        : expStr = "Interval {0} Year"; break;
+					case DateParts.Quarter     : expStr = "Interval {0} Quarter"; break;
+					case DateParts.Month       : expStr = "Interval {0} Month"; break;
+					case DateParts.DayOfYear   :
+					case DateParts.WeekDay     :
+					case DateParts.Day         : expStr = "Interval {0} Day";          break;
+					case DateParts.Week        : expStr = "Interval {0} Week"; break;
+					case DateParts.Hour        : expStr = "Interval {0} Hour"; break;
+					case DateParts.Minute      : expStr = "Interval {0} Minute"; break;
+					case DateParts.Second      : expStr = "Interval {0} Second"; break;
+					case DateParts.Millisecond : expStr = "Interval {0} Millisecond"; break;
 					default:
 						throw new InvalidOperationException($"Unexpected datepart: {part}");
 				}
@@ -599,28 +621,28 @@ namespace LinqToDB
 			}
 		}
 
-		class DateAddBuilderSQLite : Sql.IExtensionCallBuilder
+		class DateAddBuilderSQLite : IExtensionCallBuilder
 		{
-			public void Build(Sql.ISqExtensionBuilder builder)
+			public void Build(ISqExtensionBuilder builder)
 			{
-				var part   = builder.GetValue<Sql.DateParts>("part");
+				var part   = builder.GetValue<DateParts>("part");
 				var date   = builder.GetExpression("date");
 				var number = builder.GetExpression("number", true);
 
 				string expStr = "strftime('%Y-%m-%d %H:%M:%f', {0},";
 				switch (part)
 				{
-					case Sql.DateParts.Year        : expStr +=            "{1} || ' Year')"; break;
-					case Sql.DateParts.Quarter     : expStr +=       "({1}*3) || ' Month')"; break;
-					case Sql.DateParts.Month       : expStr +=           "{1} || ' Month')"; break;
-					case Sql.DateParts.DayOfYear   :
-					case Sql.DateParts.WeekDay     :
-					case Sql.DateParts.Day         : expStr +=             "{1} || ' Day')"; break;
-					case Sql.DateParts.Week        : expStr +=         "({1}*7) || ' Day')"; break;
-					case Sql.DateParts.Hour        : expStr +=            "{1} || ' Hour')"; break;
-					case Sql.DateParts.Minute      : expStr +=          "{1} || ' Minute')"; break;
-					case Sql.DateParts.Second      : expStr +=          "{1} || ' Second')"; break;
-					case Sql.DateParts.Millisecond : expStr += "({1}/1000.0) || ' Second')"; break;
+					case DateParts.Year        : expStr +=            "{1} || ' Year')"; break;
+					case DateParts.Quarter     : expStr +=       "({1}*3) || ' Month')"; break;
+					case DateParts.Month       : expStr +=           "{1} || ' Month')"; break;
+					case DateParts.DayOfYear   :
+					case DateParts.WeekDay     :
+					case DateParts.Day         : expStr +=             "{1} || ' Day')"; break;
+					case DateParts.Week        : expStr +=         "({1}*7) || ' Day')"; break;
+					case DateParts.Hour        : expStr +=            "{1} || ' Hour')"; break;
+					case DateParts.Minute      : expStr +=          "{1} || ' Minute')"; break;
+					case DateParts.Second      : expStr +=          "{1} || ' Second')"; break;
+					case DateParts.Millisecond : expStr += "({1}/1000.0) || ' Second')"; break;
 					default:
 						throw new InvalidOperationException($"Unexpected datepart: {part}");
 				}
@@ -629,26 +651,26 @@ namespace LinqToDB
 			}
 		}
 
-		class DateAddBuilderAccess : Sql.IExtensionCallBuilder
+		class DateAddBuilderAccess : IExtensionCallBuilder
 		{
-			public void Build(Sql.ISqExtensionBuilder builder)
+			public void Build(ISqExtensionBuilder builder)
 			{
-				var part   = builder.GetValue<Sql.DateParts>("part");
+				var part   = builder.GetValue<DateParts>("part");
 				var date   = builder.GetExpression("date");
 				var number = builder.GetExpression("number", true);
 
 				var partStr = part switch
 				{
-					Sql.DateParts.Year      => "yyyy",
-					Sql.DateParts.Quarter   => "q",
-					Sql.DateParts.Month     => "m",
-					Sql.DateParts.DayOfYear => "y",
-					Sql.DateParts.Day       => "d",
-					Sql.DateParts.Week      => "ww",
-					Sql.DateParts.WeekDay   => "w",
-					Sql.DateParts.Hour      => "h",
-					Sql.DateParts.Minute    => "n",
-					Sql.DateParts.Second    => "s",
+					DateParts.Year      => "yyyy",
+					DateParts.Quarter   => "q",
+					DateParts.Month     => "m",
+					DateParts.DayOfYear => "y",
+					DateParts.Day       => "d",
+					DateParts.Week      => "ww",
+					DateParts.WeekDay   => "w",
+					DateParts.Hour      => "h",
+					DateParts.Minute    => "n",
+					DateParts.Second    => "s",
 					_                       => throw new InvalidOperationException($"Unexpected datepart: {part}"),
 				};
 				builder.ResultExpression = new SqlFunction(typeof(DateTime?), "DateAdd",
@@ -656,40 +678,40 @@ namespace LinqToDB
 			}
 		}
 
-		class DateAddBuilderSapHana : Sql.IExtensionCallBuilder
+		class DateAddBuilderSapHana : IExtensionCallBuilder
 		{
-			public void Build(Sql.ISqExtensionBuilder builder)
+			public void Build(ISqExtensionBuilder builder)
 			{
-				var part   = builder.GetValue<Sql.DateParts>("part");
+				var part   = builder.GetValue<DateParts>("part");
 				var date   = builder.GetExpression("date");
 				var number = builder.GetExpression("number", true);
 
 				string function;
 				switch (part)
 				{
-					case Sql.DateParts.Year        : function = "Add_Years";   break;
-					case Sql.DateParts.Quarter     :
+					case DateParts.Year        : function = "Add_Years";   break;
+					case DateParts.Quarter     :
 						function = "Add_Months";
 						number   = builder.Mul(number, 3);
 						break;
-					case Sql.DateParts.Month       : function = "Add_Months";  break;
-					case Sql.DateParts.DayOfYear   :
-					case Sql.DateParts.Day         :
-					case Sql.DateParts.WeekDay     : function = "Add_Days";    break;
-					case Sql.DateParts.Week        :
+					case DateParts.Month       : function = "Add_Months";  break;
+					case DateParts.DayOfYear   :
+					case DateParts.Day         :
+					case DateParts.WeekDay     : function = "Add_Days";    break;
+					case DateParts.Week        :
 						function = "Add_Days";
 						number   = builder.Mul(number, 7);
 						break;
-					case Sql.DateParts.Hour        :
+					case DateParts.Hour        :
 						function = "Add_Seconds";
 						number   = builder.Mul(number, 3600);
 						break;
-					case Sql.DateParts.Minute      :
+					case DateParts.Minute      :
 						function = "Add_Seconds";
 						number   = builder.Mul(number, 60);
 						break;
-					case Sql.DateParts.Second      : function = "Add_Seconds"; break;
-					case Sql.DateParts.Millisecond:
+					case DateParts.Second      : function = "Add_Seconds"; break;
+					case DateParts.Millisecond:
 						function = "Add_Seconds";
 						number = builder.Div(number, 1000);
 						break;
@@ -701,25 +723,25 @@ namespace LinqToDB
 			}
 		}
 
-		class DateAddBuilderFirebird : Sql.IExtensionCallBuilder
+		class DateAddBuilderFirebird : IExtensionCallBuilder
 		{
-			public void Build(Sql.ISqExtensionBuilder builder)
+			public void Build(ISqExtensionBuilder builder)
 			{
-				var part   = builder.GetValue<Sql.DateParts>("part");
+				var part   = builder.GetValue<DateParts>("part");
 				var date   = builder.GetExpression("date");
 				var number = builder.GetExpression("number", true);
 
 				switch (part)
 				{
-					case Sql.DateParts.Quarter   :
+					case DateParts.Quarter   :
 						part   = DateParts.Month;
 						number  = builder.Mul(number, 3);
 						break;
-					case Sql.DateParts.DayOfYear :
-					case Sql.DateParts.WeekDay   :
+					case DateParts.DayOfYear :
+					case DateParts.WeekDay   :
 						part   = DateParts.Day;
 						break;
-					case Sql.DateParts.Week      :
+					case DateParts.Week      :
 						part   = DateParts.Day;
 						number = builder.Mul(number, 7);
 						break;
@@ -733,35 +755,35 @@ namespace LinqToDB
 
 
 
-		[Sql.Extension("DateAdd"        , ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilder))]
-		[Sql.Extension(PN.Oracle,     "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderOracle))]
-		[Sql.Extension(PN.DB2,        "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderDB2))]
-		[Sql.Extension(PN.Informix,   "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderInformix))]
-		[Sql.Extension(PN.PostgreSQL, "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderPostgreSQL))]
-		[Sql.Extension(PN.MySql,      "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderMySql))]
-		[Sql.Extension(PN.SQLite,     "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderSQLite))]
-		[Sql.Extension(PN.Access,     "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderAccess))]
-		[Sql.Extension(PN.SapHana,    "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderSapHana))]
-		[Sql.Extension(PN.Firebird,   "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderFirebird))]
-		public static DateTime? DateAdd([SqlQueryDependent] Sql.DateParts part, double? number, DateTime? date)
+		[Extension("DateAdd"        , ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilder))]
+		[Extension(PN.Oracle,     "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderOracle))]
+		[Extension(PN.DB2,        "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderDB2))]
+		[Extension(PN.Informix,   "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderInformix))]
+		[Extension(PN.PostgreSQL, "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderPostgreSQL))]
+		[Extension(PN.MySql,      "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderMySql))]
+		[Extension(PN.SQLite,     "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderSQLite))]
+		[Extension(PN.Access,     "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderAccess))]
+		[Extension(PN.SapHana,    "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderSapHana))]
+		[Extension(PN.Firebird,   "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderFirebird))]
+		public static DateTime? DateAdd([SqlQueryDependent] DateParts part, double? number, DateTime? date)
 		{
 			if (number == null || date == null)
 				return null;
 
 			return part switch
 			{
-				Sql.DateParts.Year          => date.Value.AddYears((int)number),
-				Sql.DateParts.Quarter       => date.Value.AddMonths((int)number * 3),
-				Sql.DateParts.Month         => date.Value.AddMonths((int)number),
-				Sql.DateParts.DayOfYear     => date.Value.AddDays(number.Value),
-				Sql.DateParts.Day           => date.Value.AddDays(number.Value),
-				Sql.DateParts.Week          => date.Value.AddDays(number.Value * 7),
-				Sql.DateParts.WeekDay       => date.Value.AddDays(number.Value),
-				Sql.DateParts.Hour          => date.Value.AddHours(number.Value),
-				Sql.DateParts.Minute        => date.Value.AddMinutes(number.Value),
-				Sql.DateParts.Second        => date.Value.AddSeconds(number.Value),
-				Sql.DateParts.Millisecond   => date.Value.AddMilliseconds(number.Value),
-				_                           => throw new InvalidOperationException(),
+				DateParts.Year          => date.Value.AddYears((int)number),
+				DateParts.Quarter       => date.Value.AddMonths((int)number * 3),
+				DateParts.Month         => date.Value.AddMonths((int)number),
+				DateParts.DayOfYear     => date.Value.AddDays(number.Value),
+				DateParts.Day           => date.Value.AddDays(number.Value),
+				DateParts.Week          => date.Value.AddDays(number.Value * 7),
+				DateParts.WeekDay       => date.Value.AddDays(number.Value),
+				DateParts.Hour          => date.Value.AddHours(number.Value),
+				DateParts.Minute        => date.Value.AddMinutes(number.Value),
+				DateParts.Second        => date.Value.AddSeconds(number.Value),
+				DateParts.Millisecond   => date.Value.AddMilliseconds(number.Value),
+				_                       => throw new InvalidOperationException(),
 			};
 		}
 
@@ -773,7 +795,7 @@ namespace LinqToDB
 		{
 			public void Build(ISqExtensionBuilder builder)
 			{
-				var part      = builder.GetValue<Sql.DateParts>(0);
+				var part      = builder.GetValue<DateParts>(0);
 				var startdate = builder.GetExpression(1);
 				var endDate   = builder.GetExpression(2);
 				var partSql   = new SqlExpression(DatePartBuilder.DatePartToStr(part), Precedence.Primary);
@@ -786,7 +808,7 @@ namespace LinqToDB
 		{
 			public void Build(ISqExtensionBuilder builder)
 			{
-				var part       = builder.GetValue<Sql.DateParts>(0);
+				var part       = builder.GetValue<DateParts>(0);
 				var startdate  = builder.GetExpression(1);
 				var endDate    = builder.GetExpression(2);
 				var divider    = 1;
@@ -815,7 +837,7 @@ namespace LinqToDB
 		{
 			public void Build(ISqExtensionBuilder builder)
 			{
-				var part       = builder.GetValue<Sql.DateParts>(0);
+				var part       = builder.GetValue<DateParts>(0);
 				var startDate  = builder.GetExpression(1);
 				var endDate    = builder.GetExpression(2);
 
@@ -832,11 +854,11 @@ namespace LinqToDB
 
 				switch (part)
 				{
-					case Sql.DateParts.Day         : resultExpr = builder.Div(resultExpr, 86400); break;
-					case Sql.DateParts.Hour        : resultExpr = builder.Div(resultExpr, 3600);  break;
-					case Sql.DateParts.Minute      : resultExpr = builder.Div(resultExpr, 60);    break;
-					case Sql.DateParts.Second      : break;
-					case Sql.DateParts.Millisecond :
+					case DateParts.Day         : resultExpr = builder.Div(resultExpr, 86400); break;
+					case DateParts.Hour        : resultExpr = builder.Div(resultExpr, 3600);  break;
+					case DateParts.Minute      : resultExpr = builder.Div(resultExpr, 60);    break;
+					case DateParts.Second      : break;
+					case DateParts.Millisecond :
 						resultExpr = builder.Add<int>(
 							builder.Mul(resultExpr, 1000),
 							builder.Div(
@@ -857,7 +879,7 @@ namespace LinqToDB
 		{
 			public void Build(ISqExtensionBuilder builder)
 			{
-				var part = builder.GetValue<Sql.DateParts>(0);
+				var part = builder.GetValue<DateParts>(0);
 				var startDate = builder.GetExpression(1);
 				var endDate = builder.GetExpression(2);
 
@@ -879,7 +901,7 @@ namespace LinqToDB
 		{
 			public void Build(ISqExtensionBuilder builder)
 			{
-				var part = builder.GetValue<Sql.DateParts>(0);
+				var part = builder.GetValue<DateParts>(0);
 				var startDate = builder.GetExpression(1);
 				var endDate = builder.GetExpression(2);
 				var expStr = part switch
@@ -902,7 +924,7 @@ namespace LinqToDB
 		{
 			public void Build(ISqExtensionBuilder builder)
 			{
-				var part = builder.GetValue<Sql.DateParts>(0);
+				var part = builder.GetValue<DateParts>(0);
 				var startDate = builder.GetExpression(1);
 				var endDate = builder.GetExpression(2);
 
@@ -934,7 +956,7 @@ namespace LinqToDB
 		{
 			public void Build(ISqExtensionBuilder builder)
 			{
-				var part = builder.GetValue<Sql.DateParts>(0);
+				var part = builder.GetValue<DateParts>(0);
 				var startDate = builder.GetExpression(1);
 				var endDate = builder.GetExpression(2);
 				var expStr = part switch
@@ -962,14 +984,14 @@ namespace LinqToDB
 		}
 
 		[CLSCompliant(false)]
-		[Sql.Extension(               "DateDiff",      BuilderType = typeof(DateDiffBuilder))]
-		[Sql.Extension(PN.MySql,      "TIMESTAMPDIFF", BuilderType = typeof(DateDiffBuilder))]
-		[Sql.Extension(PN.DB2,        "",              BuilderType = typeof(DateDiffBuilderDB2))]
-		[Sql.Extension(PN.SapHana,    "",              BuilderType = typeof(DateDiffBuilderSapHana))]
-		[Sql.Extension(PN.SQLite,     "",              BuilderType = typeof(DateDiffBuilderSQLite))]
-		[Sql.Extension(PN.Oracle,     "",              BuilderType = typeof(DateDiffBuilderOracle))]
-		[Sql.Extension(PN.PostgreSQL, "",              BuilderType = typeof(DateDiffBuilderPostgreSql))]
-		[Sql.Extension(PN.Access,     "",              BuilderType = typeof(DateDiffBuilderAccess))]
+		[Extension(               "DateDiff",      BuilderType = typeof(DateDiffBuilder))]
+		[Extension(PN.MySql,      "TIMESTAMPDIFF", BuilderType = typeof(DateDiffBuilder))]
+		[Extension(PN.DB2,        "",              BuilderType = typeof(DateDiffBuilderDB2))]
+		[Extension(PN.SapHana,    "",              BuilderType = typeof(DateDiffBuilderSapHana))]
+		[Extension(PN.SQLite,     "",              BuilderType = typeof(DateDiffBuilderSQLite))]
+		[Extension(PN.Oracle,     "",              BuilderType = typeof(DateDiffBuilderOracle))]
+		[Extension(PN.PostgreSQL, "",              BuilderType = typeof(DateDiffBuilderPostgreSql))]
+		[Extension(PN.Access,     "",              BuilderType = typeof(DateDiffBuilderAccess))]
 		public static int? DateDiff(DateParts part, DateTime? startDate, DateTime? endDate)
 		{
 			if (startDate == null || endDate == null)

--- a/Source/LinqToDB/Sql/Sql.DateTimeOffset.cs
+++ b/Source/LinqToDB/Sql/Sql.DateTimeOffset.cs
@@ -11,46 +11,46 @@ namespace LinqToDB
 	public partial class Sql
 	{
 		#region DatePart
-		[Sql.Extension(               "DatePart",                                        ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilder))]
-		[Sql.Extension(PN.DB2,        "",                                                ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderDB2))] // TODO: Not checked
-		[Sql.Extension(PN.Informix,   "",                                                ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderInformix))]
-		[Sql.Extension(PN.MySql,      "Extract({part} from {date})",                     ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderMySql))]
-		[Sql.Extension(PN.PostgreSQL, "Cast(Floor(Extract({part} from {date})) as int)", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderPostgre))]
-		[Sql.Extension(PN.Firebird,   "Cast(Floor(Extract({part} from {date})) as int)", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderFirebird))]
-		[Sql.Extension(PN.SQLite,     "Cast(StrFTime('%{part}', {date}) as int)",        ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderSqLite))]
-		[Sql.Extension(PN.Access,     "DatePart('{part}', {date})",                      ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderAccess))]
-		[Sql.Extension(PN.SapHana,    "",                                                ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderSapHana))]
-		[Sql.Extension(PN.Oracle,     "",                                                ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderOracle))]
-		public static int? DatePart([SqlQueryDependent] Sql.DateParts part, [ExprParameter] DateTimeOffset? date)
+		[Extension(               "DatePart",                                        ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilder))]
+		[Extension(PN.DB2,        "",                                                ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderDB2))] // TODO: Not checked
+		[Extension(PN.Informix,   "",                                                ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderInformix))]
+		[Extension(PN.MySql,      "Extract({part} from {date})",                     ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderMySql))]
+		[Extension(PN.PostgreSQL, "Cast(Floor(Extract({part} from {date})) as int)", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderPostgre))]
+		[Extension(PN.Firebird,   "Cast(Floor(Extract({part} from {date})) as int)", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderFirebird))]
+		[Extension(PN.SQLite,     "Cast(StrFTime('%{part}', {date}) as int)",        ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderSqLite))]
+		[Extension(PN.Access,     "DatePart('{part}', {date})",                      ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderAccess))]
+		[Extension(PN.SapHana,    "",                                                ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderSapHana))]
+		[Extension(PN.Oracle,     "",                                                ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DatePartBuilderOracle))]
+		public static int? DatePart([SqlQueryDependent] DateParts part, [ExprParameter] DateTimeOffset? date)
 		{
 			if (date == null)
 				return null;
 
 			return part switch
 			{
-				Sql.DateParts.Year          => date.Value.Year,
-				Sql.DateParts.Quarter       => (date.Value.Month - 1) / 3 + 1,
-				Sql.DateParts.Month         => date.Value.Month,
-				Sql.DateParts.DayOfYear     => date.Value.DayOfYear,
-				Sql.DateParts.Day           => date.Value.Day,
-				Sql.DateParts.Week          => CultureInfo.CurrentCulture.Calendar.GetWeekOfYear(date.Value.LocalDateTime, CalendarWeekRule.FirstDay, DayOfWeek.Sunday),
-				Sql.DateParts.WeekDay       => ((int)date.Value.DayOfWeek + 1 + Sql.DateFirst + 6) % 7 + 1,
-				Sql.DateParts.Hour          => date.Value.Hour,
-				Sql.DateParts.Minute        => date.Value.Minute,
-				Sql.DateParts.Second        => date.Value.Second,
-				Sql.DateParts.Millisecond   => date.Value.Millisecond,
-				_                           => throw new InvalidOperationException(),
+				DateParts.Year          => date.Value.Year,
+				DateParts.Quarter       => (date.Value.Month - 1) / 3 + 1,
+				DateParts.Month         => date.Value.Month,
+				DateParts.DayOfYear     => date.Value.DayOfYear,
+				DateParts.Day           => date.Value.Day,
+				DateParts.Week          => CultureInfo.CurrentCulture.Calendar.GetWeekOfYear(date.Value.LocalDateTime, CalendarWeekRule.FirstDay, DayOfWeek.Sunday),
+				DateParts.WeekDay       => ((int)date.Value.DayOfWeek + 1 + DateFirst + 6) % 7 + 1,
+				DateParts.Hour          => date.Value.Hour,
+				DateParts.Minute        => date.Value.Minute,
+				DateParts.Second        => date.Value.Second,
+				DateParts.Millisecond   => date.Value.Millisecond,
+				_                       => throw new InvalidOperationException(),
 			};
 		}
 		#endregion
 
 		#region DateAdd
 
-		class DateOffsetAddBuilder : Sql.IExtensionCallBuilder
+		class DateOffsetAddBuilder : IExtensionCallBuilder
 		{
 			public void Build(ISqExtensionBuilder builder)
 			{
-				var part    = builder.GetValue<Sql.DateParts>("part");
+				var part    = builder.GetValue<DateParts>("part");
 				var partStr = DatePartBuilder.DatePartToStr(part);
 				var date    = builder.GetExpression("date");
 				var number  = builder.GetExpression("number", true);
@@ -61,28 +61,28 @@ namespace LinqToDB
 			}
 		}
 
-		class DateOffsetAddBuilderPostgreSQL : Sql.IExtensionCallBuilder
+		class DateOffsetAddBuilderPostgreSQL : IExtensionCallBuilder
 		{
-			public void Build(Sql.ISqExtensionBuilder builder)
+			public void Build(ISqExtensionBuilder builder)
 			{
-				var part   = builder.GetValue<Sql.DateParts>("part");
+				var part   = builder.GetValue<DateParts>("part");
 				var date   = builder.GetExpression("date");
 				var number = builder.GetExpression("number", true);
 
 				string expStr;
 				switch (part)
 				{
-					case Sql.DateParts.Year        : expStr = "{0} * Interval '1 Year'";         break;
-					case Sql.DateParts.Quarter     : expStr = "{0} * Interval '1 Month' * 3";    break;
-					case Sql.DateParts.Month       : expStr = "{0} * Interval '1 Month'";        break;
-					case Sql.DateParts.DayOfYear   :
-					case Sql.DateParts.WeekDay     :
-					case Sql.DateParts.Day         : expStr = "{0} * Interval '1 Day'";          break;
-					case Sql.DateParts.Week        : expStr = "{0} * Interval '1 Day' * 7";      break;
-					case Sql.DateParts.Hour        : expStr = "{0} * Interval '1 Hour'";         break;
-					case Sql.DateParts.Minute      : expStr = "{0} * Interval '1 Minute'";       break;
-					case Sql.DateParts.Second      : expStr = "{0} * Interval '1 Second'";       break;
-					case Sql.DateParts.Millisecond : expStr = "{0} * Interval '1 Millisecond'";  break;
+					case DateParts.Year        : expStr = "{0} * Interval '1 Year'";         break;
+					case DateParts.Quarter     : expStr = "{0} * Interval '1 Month' * 3";    break;
+					case DateParts.Month       : expStr = "{0} * Interval '1 Month'";        break;
+					case DateParts.DayOfYear   :
+					case DateParts.WeekDay     :
+					case DateParts.Day         : expStr = "{0} * Interval '1 Day'";          break;
+					case DateParts.Week        : expStr = "{0} * Interval '1 Day' * 7";      break;
+					case DateParts.Hour        : expStr = "{0} * Interval '1 Hour'";         break;
+					case DateParts.Minute      : expStr = "{0} * Interval '1 Minute'";       break;
+					case DateParts.Second      : expStr = "{0} * Interval '1 Second'";       break;
+					case DateParts.Millisecond : expStr = "{0} * Interval '1 Millisecond'";  break;
 					default:
 						throw new InvalidOperationException($"Unexpected datepart: {part}");
 				}
@@ -94,35 +94,35 @@ namespace LinqToDB
 			}
 		}
 
-		[Sql.Extension("DateAdd"        , ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateOffsetAddBuilder))]
-		[Sql.Extension(PN.PostgreSQL, "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateOffsetAddBuilderPostgreSQL))]
-		[Sql.Extension(PN.Oracle,     "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderOracle))]
-		[Sql.Extension(PN.DB2,        "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderDB2))]
-		[Sql.Extension(PN.Informix,   "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderInformix))]
-		[Sql.Extension(PN.MySql,      "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderMySql))]
-		[Sql.Extension(PN.SQLite,     "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderSQLite))]
-		[Sql.Extension(PN.Access,     "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderAccess))]
-		[Sql.Extension(PN.SapHana,    "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderSapHana))]
-		[Sql.Extension(PN.Firebird,   "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderFirebird))]
-		public static DateTimeOffset? DateAdd([SqlQueryDependent] Sql.DateParts part, double? number, DateTimeOffset? date)
+		[Extension("DateAdd"        , ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateOffsetAddBuilder))]
+		[Extension(PN.PostgreSQL, "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateOffsetAddBuilderPostgreSQL))]
+		[Extension(PN.Oracle,     "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderOracle))]
+		[Extension(PN.DB2,        "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderDB2))]
+		[Extension(PN.Informix,   "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderInformix))]
+		[Extension(PN.MySql,      "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderMySql))]
+		[Extension(PN.SQLite,     "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderSQLite))]
+		[Extension(PN.Access,     "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderAccess))]
+		[Extension(PN.SapHana,    "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderSapHana))]
+		[Extension(PN.Firebird,   "", ServerSideOnly = false, PreferServerSide = false, BuilderType = typeof(DateAddBuilderFirebird))]
+		public static DateTimeOffset? DateAdd([SqlQueryDependent] DateParts part, double? number, DateTimeOffset? date)
 		{
 			if (number == null || date == null)
 				return null;
 
 			return part switch
 			{
-				Sql.DateParts.Year          => date.Value.AddYears((int)number),
-				Sql.DateParts.Quarter       => date.Value.AddMonths((int)number * 3),
-				Sql.DateParts.Month         => date.Value.AddMonths((int)number),
-				Sql.DateParts.DayOfYear     => date.Value.AddDays(number.Value),
-				Sql.DateParts.Day           => date.Value.AddDays(number.Value),
-				Sql.DateParts.Week          => date.Value.AddDays(number.Value * 7),
-				Sql.DateParts.WeekDay       => date.Value.AddDays(number.Value),
-				Sql.DateParts.Hour          => date.Value.AddHours(number.Value),
-				Sql.DateParts.Minute        => date.Value.AddMinutes(number.Value),
-				Sql.DateParts.Second        => date.Value.AddSeconds(number.Value),
-				Sql.DateParts.Millisecond   => date.Value.AddMilliseconds(number.Value),
-				_                           => throw new InvalidOperationException(),
+				DateParts.Year          => date.Value.AddYears((int)number),
+				DateParts.Quarter       => date.Value.AddMonths((int)number * 3),
+				DateParts.Month         => date.Value.AddMonths((int)number),
+				DateParts.DayOfYear     => date.Value.AddDays(number.Value),
+				DateParts.Day           => date.Value.AddDays(number.Value),
+				DateParts.Week          => date.Value.AddDays(number.Value * 7),
+				DateParts.WeekDay       => date.Value.AddDays(number.Value),
+				DateParts.Hour          => date.Value.AddHours(number.Value),
+				DateParts.Minute        => date.Value.AddMinutes(number.Value),
+				DateParts.Second        => date.Value.AddSeconds(number.Value),
+				DateParts.Millisecond   => date.Value.AddMilliseconds(number.Value),
+				_                       => throw new InvalidOperationException(),
 			};
 		}
 
@@ -130,13 +130,13 @@ namespace LinqToDB
 
 		#region DateDiff
 		[CLSCompliant(false)]
-		[Sql.Extension(               "DateDiff",      BuilderType = typeof(DateDiffBuilder))]
-		[Sql.Extension(PN.MySql,      "TIMESTAMPDIFF", BuilderType = typeof(DateDiffBuilder))]
-		[Sql.Extension(PN.DB2,        "",              BuilderType = typeof(DateDiffBuilderDB2))]
-		[Sql.Extension(PN.SapHana,    "",              BuilderType = typeof(DateDiffBuilderSapHana))]
-		[Sql.Extension(PN.SQLite,     "",              BuilderType = typeof(DateDiffBuilderSQLite))]
-		[Sql.Extension(PN.PostgreSQL, "",              BuilderType = typeof(DateDiffBuilderPostgreSql))]
-		[Sql.Extension(PN.Access,     "",              BuilderType = typeof(DateDiffBuilderAccess))]
+		[Extension(               "DateDiff",      BuilderType = typeof(DateDiffBuilder))]
+		[Extension(PN.MySql,      "TIMESTAMPDIFF", BuilderType = typeof(DateDiffBuilder))]
+		[Extension(PN.DB2,        "",              BuilderType = typeof(DateDiffBuilderDB2))]
+		[Extension(PN.SapHana,    "",              BuilderType = typeof(DateDiffBuilderSapHana))]
+		[Extension(PN.SQLite,     "",              BuilderType = typeof(DateDiffBuilderSQLite))]
+		[Extension(PN.PostgreSQL, "",              BuilderType = typeof(DateDiffBuilderPostgreSql))]
+		[Extension(PN.Access,     "",              BuilderType = typeof(DateDiffBuilderAccess))]
 		public static int? DateDiff(DateParts part, DateTimeOffset? startDate, DateTimeOffset? endDate)
 		{
 			if (startDate == null || endDate == null)

--- a/Source/LinqToDB/Sql/Sql.cs
+++ b/Source/LinqToDB/Sql/Sql.cs
@@ -249,12 +249,12 @@ namespace LinqToDB
 
 		#region Guid Functions
 
-		[Function  (PN.Oracle,   "Sys_Guid", ServerSideOnly = true, CanBeNull = false, IsPure = false)]
-		[Function  (PN.Firebird, "Gen_Uuid", ServerSideOnly = true, CanBeNull = false, IsPure = false)]
-		[Function  (PN.MySql,    "Uuid",     ServerSideOnly = true, CanBeNull = false, IsPure = false)]
-		[Expression(PN.Sybase,   "NewID(1)", ServerSideOnly = true, CanBeNull = false, IsPure = false)]
-		[Expression(PN.SapHana,  "SYSUUID",  ServerSideOnly = true, CanBeNull = false, IsPure = false)]
-		[Function  (             "NewID",    ServerSideOnly = true, CanBeNull = false, IsPure = false)]
+		[Function  (PN.Oracle,     "Sys_Guid",       ServerSideOnly = true, CanBeNull = false, IsPure = false)]
+		[Function  (PN.Firebird,   "Gen_Uuid",       ServerSideOnly = true, CanBeNull = false, IsPure = false)]
+		[Function  (PN.MySql,      "Uuid",           ServerSideOnly = true, CanBeNull = false, IsPure = false)]
+		[Expression(PN.Sybase,     "NewID(1)",       ServerSideOnly = true, CanBeNull = false, IsPure = false)]
+		[Expression(PN.SapHana,    "SYSUUID",        ServerSideOnly = true, CanBeNull = false, IsPure = false)]
+		[Function  (               "NewID",          ServerSideOnly = true, CanBeNull = false, IsPure = false)]
 		public static Guid NewGuid()
 		{
 			return Guid.NewGuid();
@@ -268,16 +268,14 @@ namespace LinqToDB
 		[Function("Convert", 0, 1, ServerSideOnly = true, IsNullable = IsNullableType.SameAsSecondParameter)]
 		public static TTo Convert<TTo,TFrom>(TTo to, TFrom from)
 		{
-			var dt = Common.ConvertTo<TTo>.From(from);
-			return dt;
+			return Common.ConvertTo<TTo>.From(from);
 		}
 
 		[CLSCompliant(false)]
 		[Function("Convert", 0, 1, 2, ServerSideOnly = true, IsNullable = IsNullableType.SameAsSecondParameter)]
 		public static TTo Convert<TTo, TFrom>(TTo to, TFrom from, int format)
 		{
-			var dt = Common.ConvertTo<TTo>.From(from);
-			return dt;
+			return Common.ConvertTo<TTo>.From(from);
 		}
 
 		[CLSCompliant(false)]
@@ -381,15 +379,15 @@ namespace LinqToDB
 
 		#region String Functions
 
-		[Function  (                                                   PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
-		[Function  (PN.Access,    "Len",                               PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
-		[Function  (PN.Firebird,  "Char_Length",                       PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
-		[Function  (PN.SqlServer, "Len",                               PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
-		[Function  (PN.SqlCe,     "Len",                               PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
-		[Function  (PN.Sybase,    "Len",                               PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
-		[Function  (PN.MySql,     "Char_Length",                       PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
-		[Function  (PN.Informix,  "CHAR_LENGTH",                       PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
-		[Expression(PN.DB2LUW,    "CHARACTER_LENGTH({0},CODEUNITS32)", PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
+		[Function  (                                                    PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
+		[Function  (PN.Access,     "Len",                               PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
+		[Function  (PN.Firebird,   "Char_Length",                       PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
+		[Function  (PN.SqlServer,  "Len",                               PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
+		[Function  (PN.SqlCe,      "Len",                               PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
+		[Function  (PN.Sybase,     "Len",                               PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
+		[Function  (PN.MySql,      "Char_Length",                       PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
+		[Function  (PN.Informix,   "CHAR_LENGTH",                       PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
+		[Expression(PN.DB2LUW,     "CHARACTER_LENGTH({0},CODEUNITS32)", PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
 		public static int? Length(string? str)
 		{
 			return str?.Length;
@@ -438,11 +436,11 @@ namespace LinqToDB
 		}
 
 		[CLSCompliant(false)]
-		[Function(                             IsNullable = IsNullableType.IfAnyParameterNullable)]
-		[Function(PN.DB2,      "Locate",       IsNullable = IsNullableType.IfAnyParameterNullable)]
-		[Function(PN.MySql,    "Locate",       IsNullable = IsNullableType.IfAnyParameterNullable)]
-		[Function(PN.SapHana,  "Locate", 1, 0, IsNullable = IsNullableType.IfAnyParameterNullable)]
-		[Function(PN.Firebird, "Position",     IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(                                     IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(PN.DB2,        "Locate",             IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(PN.MySql,      "Locate",             IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(PN.SapHana,    "Locate",       1, 0, IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(PN.Firebird,   "Position",           IsNullable = IsNullableType.IfAnyParameterNullable)]
 		public static int? CharIndex(string? substring, string? str)
 		{
 			if (str == null || substring == null) return null;
@@ -459,11 +457,11 @@ namespace LinqToDB
 			return substring.Length == 0 ? 0 : str.IndexOf(substring) + 1;
 		}
 
-		[Function(                                                           IsNullable = IsNullableType.IfAnyParameterNullable)]
-		[Function  (PN.DB2,      "Locate",                                   IsNullable = IsNullableType.IfAnyParameterNullable)]
-		[Function  (PN.MySql,    "Locate",                                   IsNullable = IsNullableType.IfAnyParameterNullable)]
-		[Function  (PN.Firebird, "Position",                                 IsNullable = IsNullableType.IfAnyParameterNullable)]
-		[Expression(PN.SapHana,  "Locate(Substring({1},{2} + 1),{0}) + {2}", IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(                                                             IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function  (PN.DB2,        "Locate",                                   IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function  (PN.MySql,      "Locate",                                   IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function  (PN.Firebird,   "Position",                                 IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Expression(PN.SapHana,    "Locate(Substring({1},{2} + 1),{0}) + {2}", IsNullable = IsNullableType.IfAnyParameterNullable)]
 		public static int? CharIndex(string? substring, string? str, int? start)
 		{
 			if (str == null || substring == null || start == null) return null;
@@ -472,13 +470,13 @@ namespace LinqToDB
 			return substring.Length == 0 ? 0 : str.IndexOf(substring, index) + 1;
 		}
 
-		[Function(                             IsNullable = IsNullableType.IfAnyParameterNullable)]
-		[Function(PN.DB2,      "Locate",       IsNullable = IsNullableType.IfAnyParameterNullable)]
-		[Function(PN.MySql,    "Locate",       IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(                                     IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(PN.DB2,        "Locate",             IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(PN.MySql,      "Locate",             IsNullable = IsNullableType.IfAnyParameterNullable)]
 #pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
-		[Function(PN.SapHana,  "Locate", 1, 0, IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(PN.SapHana,    "Locate",       1, 0, IsNullable = IsNullableType.IfAnyParameterNullable)]
 #pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant
-		[Function(PN.Firebird, "Position",     IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(PN.Firebird,   "Position",           IsNullable = IsNullableType.IfAnyParameterNullable)]
 		public static int? CharIndex(char? value, string? str)
 		{
 			if (value == null || str == null) return null;
@@ -486,13 +484,13 @@ namespace LinqToDB
 			return str.IndexOf(value.Value) + 1;
 		}
 
-		[Function(                                IsNullable = IsNullableType.IfAnyParameterNullable)]
-		[Function(PN.DB2,      "Locate",          IsNullable = IsNullableType.IfAnyParameterNullable)]
-		[Function(PN.MySql,    "Locate",          IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(                                                          IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(PN.DB2,        "Locate",                                  IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(PN.MySql,      "Locate",                                  IsNullable = IsNullableType.IfAnyParameterNullable)]
 #pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
-		[Function(PN.SapHana,  "Locate", 1, 0, 2, IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(PN.SapHana,    "Locate",       1, 0, 2,                   IsNullable = IsNullableType.IfAnyParameterNullable)]
 #pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant
-		[Function(PN.Firebird, "Position",        IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(PN.Firebird,   "Position",                                IsNullable = IsNullableType.IfAnyParameterNullable)]
 		public static int? CharIndex(char? value, string? str, int? start)
 		{
 			if (str == null || value == null || start == null) return null;
@@ -501,7 +499,7 @@ namespace LinqToDB
 			return str.IndexOf(value.Value, index) + 1;
 		}
 
-		[Function(IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(                              IsNullable = IsNullableType.IfAnyParameterNullable)]
 		public static string? Reverse(string? str)
 		{
 			if (string.IsNullOrEmpty(str)) return str;
@@ -511,8 +509,8 @@ namespace LinqToDB
 			return new string(chars);
 		}
 
-		[Function(                      PreferServerSide = true, IsNullable = IsNullableType.IfAnyParameterNullable)]
-		[Function(PN.SQLite, "LeftStr", PreferServerSide = true, IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(                           PreferServerSide = true, IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(PN.SQLite,     "LeftStr",  PreferServerSide = true, IsNullable = IsNullableType.IfAnyParameterNullable)]
 		public static string? Left(string? str, int? length)
 		{
 			if (length == null || str == null) return null;
@@ -522,8 +520,8 @@ namespace LinqToDB
 			return str.Substring(0, length.Value);
 		}
 
-		[Function(                       PreferServerSide = true, IsNullable = IsNullableType.IfAnyParameterNullable)]
-		[Function(PN.SQLite, "RightStr", PreferServerSide = true, IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(                            PreferServerSide = true, IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(PN.SQLite,     "RightStr",  PreferServerSide = true, IsNullable = IsNullableType.IfAnyParameterNullable)]
 		public static string? Right(string? str, int? length)
 		{
 			if (length == null || str == null) return null;
@@ -552,14 +550,14 @@ namespace LinqToDB
 			throw new NotImplementedException();
 		}
 
-		[Function(                                  IsNullable = IsNullableType.IfAnyParameterNullable)]
-		[Expression(PN.SapHana, "Lpad('',{0},' ')", IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(                                                        IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Expression(PN.SapHana,    "Lpad('',{0},' ')",                    IsNullable = IsNullableType.IfAnyParameterNullable)]
 		public static string? Space(int? length)
 		{
 			return length == null || length.Value < 0 ? null : "".PadRight(length.Value);
 		}
 
-		[Function(Name = "LPad", IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(               Name = "LPad",                            IsNullable = IsNullableType.IfAnyParameterNullable)]
 		public static string? PadLeft(string? str, int? length, char? paddingChar)
 		{
 			if (str == null || length == null || paddingChar == null) return null;
@@ -569,7 +567,7 @@ namespace LinqToDB
 			return str.PadLeft(length.Value, paddingChar.Value);
 		}
 
-		[Function(Name = "RPad", IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(               Name = "RPad",         IsNullable = IsNullableType.IfAnyParameterNullable)]
 		public static string? PadRight(string? str, int? length, char? paddingChar)
 		{
 			if (str == null || length == null || paddingChar == null) return null;
@@ -589,8 +587,8 @@ namespace LinqToDB
 			return str.Replace(oldValue, newValue);
 		}
 
-		[Function(                          IsNullable = IsNullableType.IfAnyParameterNullable)]
-		[Function(PN.Sybase, "Str_Replace", IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(                              IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(PN.Sybase,     "Str_Replace", IsNullable = IsNullableType.IfAnyParameterNullable)]
 		public static string? Replace(string? str, char? oldValue, char? newValue)
 		{
 			if (str == null || oldValue == null || newValue == null) return null;
@@ -601,7 +599,7 @@ namespace LinqToDB
 
 		#region IsNullOrWhiteSpace
 		// set of all White_Space characters per Unicode v13
-		const string WHITESPACES = "\x09\x0A\x0B\x0C\x0D\x20\x85\xA0\x1680\x2000\x2001\x2002\x2003\x2004\x2005\x2006\x2007\x2008\x2009\x200A\x2028\x2029\x205F\x3000";
+		const string WHITESPACES       = "\x09\x0A\x0B\x0C\x0D\x20\x85\xA0\x1680\x2000\x2001\x2002\x2003\x2004\x2005\x2006\x2007\x2008\x2009\x200A\x2028\x2029\x205F\x3000";
 		const string ASCII_WHITESPACES = "\x09\x0A\x0B\x0C\x0D\x20\x85\xA0";
 
 		/*
@@ -621,17 +619,17 @@ namespace LinqToDB
 		 * 2. [Informix} implementation use only ASCII whitespaces which probably will not work in some cases for WS outside of
 		 * ASCII range (currently works in our tests, but it could be that it depends on used encodings)
 		 */
-		[Extension(                  typeof(IsNullOrWhiteSpaceDefaultBuilder),       IsPredicate = true)]
-		[Extension(PN.Oracle,        typeof(IsNullOrWhiteSpaceOracleBuilder),        IsPredicate = true)]
-		[Extension(PN.Informix,      typeof(IsNullOrWhiteSpaceInformixBuilder),      IsPredicate = true)]
-		[Extension(PN.SqlServer,     typeof(IsNullOrWhiteSpaceSqlServerBuilder),     IsPredicate = true)]
-		[Extension(PN.SqlServer2017, typeof(IsNullOrWhiteSpaceSqlServer2017Builder), IsPredicate = true)]
-		[Extension(PN.SqlServer2019, typeof(IsNullOrWhiteSpaceSqlServer2017Builder), IsPredicate = true)]
-		[Extension(PN.Access,        typeof(IsNullOrWhiteSpaceAccessBuilder),        IsPredicate = true)]
-		[Extension(PN.Sybase,        typeof(IsNullOrWhiteSpaceSybaseBuilder),        IsPredicate = true)]
-		[Extension(PN.MySql,         typeof(IsNullOrWhiteSpaceMySqlBuilder),         IsPredicate = true)]
-		[Extension(PN.Firebird,      typeof(IsNullOrWhiteSpaceFirebirdBuilder),      IsPredicate = true)]
-		[Extension(PN.SqlCe,         typeof(IsNullOrWhiteSpaceSqlCeBuilder),         IsPredicate = true)]
+		[Extension(                  typeof(IsNullOrWhiteSpaceDefaultBuilder),                     IsPredicate = true)]
+		[Extension(PN.Oracle,        typeof(IsNullOrWhiteSpaceOracleBuilder),                      IsPredicate = true)]
+		[Extension(PN.Informix,      typeof(IsNullOrWhiteSpaceInformixBuilder),                    IsPredicate = true)]
+		[Extension(PN.SqlServer,     typeof(IsNullOrWhiteSpaceSqlServerBuilder),                   IsPredicate = true)]
+		[Extension(PN.SqlServer2017, typeof(IsNullOrWhiteSpaceSqlServer2017Builder),               IsPredicate = true)]
+		[Extension(PN.SqlServer2019, typeof(IsNullOrWhiteSpaceSqlServer2017Builder),               IsPredicate = true)]
+		[Extension(PN.Access,        typeof(IsNullOrWhiteSpaceAccessBuilder),                      IsPredicate = true)]
+		[Extension(PN.Sybase,        typeof(IsNullOrWhiteSpaceSybaseBuilder),                      IsPredicate = true)]
+		[Extension(PN.MySql,         typeof(IsNullOrWhiteSpaceMySqlBuilder),                       IsPredicate = true)]
+		[Extension(PN.Firebird,      typeof(IsNullOrWhiteSpaceFirebirdBuilder),                    IsPredicate = true)]
+		[Extension(PN.SqlCe,         typeof(IsNullOrWhiteSpaceSqlCeBuilder),                       IsPredicate = true)]
 		internal static bool IsNullOrWhiteSpace(string? str) => string.IsNullOrWhiteSpace(str);
 
 		// str IS NULL OR REPLACE...(str, WHITEPACES, '') == ''
@@ -913,24 +911,24 @@ namespace LinqToDB
 			return str?.TrimEnd();
 		}
 
-		[Function(                                IsNullable = IsNullableType.IfAnyParameterNullable)]
-		[Expression(PN.DB2, "Strip({0}, B, {1})", IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function(                                            IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Expression(PN.DB2,        "Strip({0}, B, {1})",      IsNullable = IsNullableType.IfAnyParameterNullable)]
 		public static string? Trim(string? str, char? ch)
 		{
 			return str == null || ch == null ? null : str.Trim(ch.Value);
 		}
 
-		[Expression(PN.Firebird, "TRIM(LEADING {1} FROM {0})", IsNullable = IsNullableType.IfAnyParameterNullable)]
-		[Expression(PN.DB2, "Strip({0}, L, {1})",              IsNullable = IsNullableType.IfAnyParameterNullable)]
-		[Function  (        "LTrim",                           IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Expression(PN.Firebird,   "TRIM(LEADING {1} FROM {0})", IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Expression(PN.DB2,        "Strip({0}, L, {1})",         IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function  (               "LTrim",                      IsNullable = IsNullableType.IfAnyParameterNullable)]
 		public static string? TrimLeft(string? str, char? ch)
 		{
 			return str == null || ch == null ? null : str.TrimStart(ch.Value);
 		}
 
-		[Expression(PN.Firebird, "TRIM(TRAILING {1} FROM {0})", IsNullable = IsNullableType.IfAnyParameterNullable)]
-		[Expression(PN.DB2, "Strip({0}, T, {1})",               IsNullable = IsNullableType.IfAnyParameterNullable)]
-		[Function  (        "RTrim",                            IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Expression(PN.Firebird,   "TRIM(TRAILING {1} FROM {0})", IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Expression(PN.DB2,        "Strip({0}, T, {1})",          IsNullable = IsNullableType.IfAnyParameterNullable)]
+		[Function  (               "RTrim",                       IsNullable = IsNullableType.IfAnyParameterNullable)]
 		public static string? TrimRight(string? str, char? ch)
 		{
 			return str == null || ch == null ? null : str.TrimEnd(ch.Value);
@@ -948,11 +946,11 @@ namespace LinqToDB
 			return str?.ToUpper();
 		}
 
-		[Expression("Lpad({0},{1},'0')",                                                    IsNullable = IsNullableType.SameAsFirstParameter)]
-		[Expression(PN.Sybase, "right(replicate('0',{1}) + cast({0} as varchar(255)),{1})", IsNullable = IsNullableType.SameAsFirstParameter)]
-		[Expression(PN.PostgreSQL, "Lpad({0}::text,{1},'0')",                               IsNullable = IsNullableType.SameAsFirstParameter)]
-		[Expression(PN.SqlServer, "format({0}, 'd{1}')",                                    IsNullable = IsNullableType.SameAsFirstParameter)]
-		[Expression(PN.SQLite, "printf('%0{1}d', {0})",                                     IsNullable = IsNullableType.SameAsFirstParameter)]
+		[Expression("Lpad({0},{1},'0')",                                                                            IsNullable = IsNullableType.SameAsFirstParameter)]
+		[Expression(PN.Sybase, "right(replicate('0',{1}) + cast({0} as varchar(255)),{1})",                         IsNullable = IsNullableType.SameAsFirstParameter)]
+		[Expression(PN.PostgreSQL, "Lpad({0}::text,{1},'0')",                                                       IsNullable = IsNullableType.SameAsFirstParameter)]
+		[Expression(PN.SqlServer, "format({0}, 'd{1}')",                                                            IsNullable = IsNullableType.SameAsFirstParameter)]
+		[Expression(PN.SQLite, "printf('%0{1}d', {0})",                                                             IsNullable = IsNullableType.SameAsFirstParameter)]
 		public static string? ZeroPad(int? val, int length)
 		{
 			return val?.ToString("d" + length);
@@ -1023,7 +1021,6 @@ namespace LinqToDB
 		[Function(PN.SqlServer, "DataLength",   PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
 		[Function(PN.SqlCe,     "DataLength",   PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
 		[Function(PN.Sybase,    "DataLength",   PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
-		[Function(PN.SQLite,    "Length",       PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
 		public static int? Length(Binary? value)
 		{
 			return value == null ? null : value.Length;
@@ -1039,7 +1036,6 @@ namespace LinqToDB
 		[Function(PN.SqlServer, "DataLength",   PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
 		[Function(PN.SqlCe,     "DataLength",   PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
 		[Function(PN.Sybase,    "DataLength",   PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
-		[Function(PN.SQLite,    "Length",       PreferServerSide = true, IsNullable = IsNullableType.SameAsFirstParameter)]
 		public static int? Length(byte[]? value)
 		{
 			return value == null ? null : value.Length;
@@ -1049,20 +1045,20 @@ namespace LinqToDB
 
 		#region DateTime Functions
 
-		[Property(             "CURRENT_TIMESTAMP", CanBeNull = false)]
-		[Property(PN.Informix, "CURRENT",           CanBeNull = false)]
-		[Property(PN.Access,   "Now",               CanBeNull = false)]
+		[Property(               "CURRENT_TIMESTAMP", CanBeNull = false)]
+		[Property(PN.Informix,   "CURRENT",           CanBeNull = false)]
+		[Property(PN.Access,     "Now",               CanBeNull = false)]
 		public static DateTime GetDate()
 		{
 			return DateTime.Now;
 		}
 
-		[Property(             "CURRENT_TIMESTAMP", ServerSideOnly = true, CanBeNull = false)]
-		[Property(PN.Firebird, "LOCALTIMESTAMP",    ServerSideOnly = true, CanBeNull = false)]
-		[Property(PN.Informix, "CURRENT",           ServerSideOnly = true, CanBeNull = false)]
-		[Property(PN.Access,   "Now",               ServerSideOnly = true, CanBeNull = false)]
-		[Function(PN.SqlCe,    "GetDate",           ServerSideOnly = true, CanBeNull = false)]
-		[Function(PN.Sybase,   "GetDate",           ServerSideOnly = true, CanBeNull = false)]
+		[Property(               "CURRENT_TIMESTAMP", ServerSideOnly = true, CanBeNull = false)]
+		[Property(PN.Firebird,   "LOCALTIMESTAMP",    ServerSideOnly = true, CanBeNull = false)]
+		[Property(PN.Informix,   "CURRENT",           ServerSideOnly = true, CanBeNull = false)]
+		[Property(PN.Access,     "Now",               ServerSideOnly = true, CanBeNull = false)]
+		[Function(PN.SqlCe,      "GetDate",           ServerSideOnly = true, CanBeNull = false)]
+		[Function(PN.Sybase,     "GetDate",           ServerSideOnly = true, CanBeNull = false)]
 		public static DateTime CurrentTimestamp => throw new LinqException("'CurrentTimestamp' is server side only property.");
 
 		[Function  (PN.SqlServer , "SYSUTCDATETIME"                      , ServerSideOnly = true, CanBeNull = false)]
@@ -1076,11 +1072,11 @@ namespace LinqToDB
 		[Expression(PN.Informix  , "datetime(1970-01-01 00:00:00) year to second + (dbinfo('utc_current')/86400)::int::char(9)::interval day(9) to day + (mod(dbinfo('utc_current'), 86400))::char(5)::interval second(5) to second", ServerSideOnly = true, CanBeNull = false, Precedence = Precedence.Additive)]
 		public static DateTime CurrentTimestampUtc => DateTime.UtcNow;
 
-		[Property(             "CURRENT_TIMESTAMP", CanBeNull = false)]
-		[Property(PN.Informix, "CURRENT",           CanBeNull = false)]
-		[Property(PN.Access,   "Now",               CanBeNull = false)]
-		[Function(PN.SqlCe,    "GetDate",           CanBeNull = false)]
-		[Function(PN.Sybase,   "GetDate",           CanBeNull = false)]
+		[Property(               "CURRENT_TIMESTAMP", CanBeNull = false)]
+		[Property(PN.Informix,   "CURRENT",           CanBeNull = false)]
+		[Property(PN.Access,     "Now",               CanBeNull = false)]
+		[Function(PN.SqlCe,      "GetDate",           CanBeNull = false)]
+		[Function(PN.Sybase,     "GetDate",           CanBeNull = false)]
 		public static DateTime CurrentTimestamp2 => DateTime.Now;
 
 		[Function(PN.SqlServer , "SYSDATETIMEOFFSET", ServerSideOnly = true, CanBeNull = false)]

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -265,17 +265,17 @@ namespace LinqToDB.SqlProvider
 
 		protected virtual void BuildDeleteQuery(SqlDeleteStatement deleteStatement)
 		{
-			BuildStep = Step.Tag;             BuildTag(deleteStatement);
-			BuildStep = Step.WithClause;      BuildWithClause(deleteStatement.With);
-			BuildStep = Step.DeleteClause;    BuildDeleteClause(deleteStatement);
+			BuildStep = Step.Tag;               BuildTag(deleteStatement);
+			BuildStep = Step.WithClause;        BuildWithClause(deleteStatement.With);
+			BuildStep = Step.DeleteClause;      BuildDeleteClause(deleteStatement);
 			BuildStep = Step.FromClause;      BuildFromClause(Statement, deleteStatement.SelectQuery);
-			BuildStep = Step.WhereClause;     BuildWhereClause(deleteStatement.SelectQuery);
-			BuildStep = Step.GroupByClause;   BuildGroupByClause(deleteStatement.SelectQuery);
-			BuildStep = Step.HavingClause;    BuildHavingClause(deleteStatement.SelectQuery);
-			BuildStep = Step.OrderByClause;   BuildOrderByClause(deleteStatement.SelectQuery);
-			BuildStep = Step.OffsetLimit;     BuildOffsetLimit(deleteStatement.SelectQuery);
-			BuildStep = Step.Output;          BuildOutputSubclause(deleteStatement.GetOutputClause());
-			BuildStep = Step.QueryExtensions; BuildQueryExtensions(deleteStatement);
+			BuildStep = Step.WhereClause;       BuildWhereClause(deleteStatement.SelectQuery);
+			BuildStep = Step.GroupByClause;     BuildGroupByClause(deleteStatement.SelectQuery);
+			BuildStep = Step.HavingClause;      BuildHavingClause(deleteStatement.SelectQuery);
+			BuildStep = Step.OrderByClause;     BuildOrderByClause(deleteStatement.SelectQuery);
+			BuildStep = Step.OffsetLimit;       BuildOffsetLimit(deleteStatement.SelectQuery);
+			BuildStep = Step.Output;            BuildOutputSubclause(deleteStatement.GetOutputClause());
+			BuildStep = Step.QueryExtensions;   BuildQueryExtensions(deleteStatement);
 		}
 
 		protected void BuildDeleteQuery2(SqlDeleteStatement deleteStatement)
@@ -487,43 +487,43 @@ namespace LinqToDB.SqlProvider
 
 				BuildObjectName(StringBuilder, new (cte.Name!), ConvertType.NameToQueryTable, true, TableOptions.NotSet);
 
-				if (cte.Fields!.Length > 3)
-				{
-					StringBuilder.AppendLine();
-					AppendIndent(); StringBuilder.AppendLine(OpenParens);
-					++Indent;
-
-					var firstField = true;
-					foreach (var field in cte.Fields)
+					if (cte.Fields!.Length > 3)
 					{
-						if (!firstField)
-							StringBuilder.AppendLine(Comma);
-						firstField = false;
-						AppendIndent();
-						Convert(StringBuilder, field.PhysicalName, ConvertType.NameToQueryField);
+						StringBuilder.AppendLine();
+						AppendIndent(); StringBuilder.AppendLine(OpenParens);
+						++Indent;
+
+						var firstField = true;
+						foreach (var field in cte.Fields)
+						{
+							if (!firstField)
+								StringBuilder.AppendLine(Comma);
+							firstField = false;
+							AppendIndent();
+							Convert(StringBuilder, field.PhysicalName, ConvertType.NameToQueryField);
+						}
+
+						--Indent;
+						StringBuilder.AppendLine();
+						AppendIndent(); StringBuilder.AppendLine(")");
 					}
-
-					--Indent;
-					StringBuilder.AppendLine();
-					AppendIndent(); StringBuilder.AppendLine(")");
-				}
-				else if (cte.Fields.Length > 0)
-				{
-					StringBuilder.Append(" (");
-
-					var firstField = true;
-					foreach (var field in cte.Fields)
+					else if (cte.Fields.Length > 0)
 					{
-						if (!firstField)
-							StringBuilder.Append(InlineComma);
-						firstField = false;
-						Convert(StringBuilder, field.PhysicalName, ConvertType.NameToQueryField);
+						StringBuilder.Append(" (");
+
+						var firstField = true;
+						foreach (var field in cte.Fields)
+						{
+							if (!firstField)
+								StringBuilder.Append(InlineComma);
+							firstField = false;
+							Convert(StringBuilder, field.PhysicalName, ConvertType.NameToQueryField);
+						}
+						StringBuilder.AppendLine(")");
 					}
-					StringBuilder.AppendLine(")");
-				}
-				else
+					else
 				{
-					StringBuilder.Append(' ');
+						StringBuilder.Append(' ');
 				}
 
 				AppendIndent();
@@ -1723,6 +1723,7 @@ namespace LinqToDB.SqlProvider
 					BuildTypedExpression(new SqlDataType(field), new SqlValue(field.Type, null));
 				else
 					BuildExpression(new SqlValue(field.Type, null));
+				StringBuilder.Append(' ');
 				Convert(StringBuilder, field.PhysicalName, ConvertType.NameToQueryField);
 			}
 
@@ -2128,10 +2129,10 @@ namespace LinqToDB.SqlProvider
 		#region Skip/Take
 
 		protected virtual bool   SkipFirst    => true;
-		protected virtual string? SkipFormat   => null;
-		protected virtual string? FirstFormat  (SelectQuery selectQuery) => null;
-		protected virtual string? LimitFormat  (SelectQuery selectQuery) => null;
-		protected virtual string? OffsetFormat (SelectQuery selectQuery) => null;
+		protected virtual string? SkipFormat  => null;
+		protected virtual string? FirstFormat (SelectQuery selectQuery) => null;
+		protected virtual string? LimitFormat (SelectQuery selectQuery) => null;
+		protected virtual string? OffsetFormat(SelectQuery selectQuery) => null;
 		protected virtual bool   OffsetFirst  => false;
 		protected virtual string TakePercent  => "PERCENT";
 		protected virtual string TakeTies     => "WITH TIES";
@@ -2183,20 +2184,20 @@ namespace LinqToDB.SqlProvider
 			var doTake = NeedTake(takeExpr)           && LimitFormat(selectQuery)  != null;
 
 			if (doSkip || doTake)
-			{
+		{
 				AppendIndent();
 
 				if (doSkip && OffsetFirst)
-				{
+		{
 					StringBuilder.AppendFormat(
 						OffsetFormat(selectQuery)!, WithStringBuilder(new StringBuilder(), () => BuildExpression(skipExpr!)));
 
 					if (doTake)
 						StringBuilder.Append(' ');
-				}
-
+		}
+		
 				if (doTake)
-				{
+		{
 					StringBuilder.AppendFormat(
 						LimitFormat(selectQuery)!, WithStringBuilder(new StringBuilder(), () => BuildExpression(takeExpr!)));
 
@@ -2848,7 +2849,7 @@ namespace LinqToDB.SqlProvider
 							var newParm = OptimizationContext.AddParameter(parm);
 							Convert(StringBuilder, newParm.Name!, ConvertType.NameToQueryParameter);
 						}
-					}
+				}
 
 					break;
 

--- a/Tests/Base/TestBase.cs
+++ b/Tests/Base/TestBase.cs
@@ -1352,6 +1352,9 @@ namespace Tests
 				}
 			}
 
+			if (provider != null)
+				AssertState(provider);
+
 			// dump baselines
 			var ctx = CustomTestContext.Get();
 
@@ -1374,6 +1377,45 @@ namespace Tests
 			}
 
 			CustomTestContext.Release();
+		}
+
+		// helper to detect tests that leave database in inconsistent state
+		// enable only for debug to not slowdown tests
+		private bool _badState;
+#pragma warning disable CA1805 // Do not initialize unnecessarily
+		private bool _assertStateEnabled = false;
+#pragma warning restore CA1805 // Do not initialize unnecessarily
+		private void AssertState(string context)
+		{
+			// don't fail tests if database is not consistent already
+			if (!_assertStateEnabled || _badState)
+				return;
+
+			using var _ = new DisableBaseline("isn't baseline query");
+			using var db = GetDataConnection(context);
+
+			try
+			{
+				AreEqual(Person.OrderBy(_ => _.ID), db.Person.OrderBy(_ => _.ID), ComparerBuilder.GetEqualityComparer<IPerson>());
+				AreEqual(Doctor.OrderBy(_ => _.PersonID), db.Doctor.OrderBy(_ => _.PersonID), ComparerBuilder.GetEqualityComparer<Doctor>());
+				AreEqual(Patient.OrderBy(_ => _.PersonID), db.Patient.OrderBy(_ => _.PersonID), ComparerBuilder.GetEqualityComparer<Patient>(_ => _.PersonID, _ => _.Diagnosis));
+
+				AreEqual(Parent.OrderBy(_ => _.ParentID), db.Parent.OrderBy(_ => _.ParentID), ComparerBuilder.GetEqualityComparer<Parent>(_ => _.ParentID, _ => _.Value1));
+				AreEqual(Child.OrderBy(_ => _.ParentID).ThenBy(_ => _.ChildID), db.Child.OrderBy(_ => _.ParentID).ThenBy(_ => _.ChildID), ComparerBuilder.GetEqualityComparer<Child>(_ => _.ParentID, _ => _.ChildID));
+				AreEqual(GrandChild.OrderBy(_ => _.ParentID).ThenBy(_ => _.ChildID).ThenBy(_ => _.GrandChildID), db.GrandChild.OrderBy(_ => _.ParentID).ThenBy(_ => _.ChildID).ThenBy(_ => _.GrandChildID), ComparerBuilder.GetEqualityComparer<GrandChild>(_ => _.ParentID, _ => _.ChildID, _ => _.GrandChildID));
+
+				AreEqual(InheritanceParent.OrderBy(_ => _.InheritanceParentId), db.InheritanceParent.OrderBy(_ => _.InheritanceParentId), ComparerBuilder.GetEqualityComparer<InheritanceParentBase>());
+				AreEqual(InheritanceChild.OrderBy(_ => _.InheritanceChildId), db.InheritanceChild.OrderBy(_ => _.InheritanceChildId), ComparerBuilder.GetEqualityComparer<InheritanceChildBase>(_ => _.InheritanceChildId, _ => _.TypeDiscriminator, _ => _.InheritanceParentId));
+
+				AreEqual(Types2.OrderBy(_ => _.ID), db.Types2.OrderBy(_ => _.ID), ComparerBuilder.GetEqualityComparer<LinqDataTypes2>());
+
+				// TODO: AllTypes
+			}
+			catch
+			{
+				_badState = true;
+				throw new InvalidOperationException("SMOrc");
+			}
 		}
 
 		protected string GetCurrentBaselines()

--- a/Tests/Linq/Linq/TakeSkipTests.cs
+++ b/Tests/Linq/Linq/TakeSkipTests.cs
@@ -784,6 +784,10 @@ namespace Tests.Linq
 		[Test]
 		public void TakeSkipJoin([DataSources(TestProvName.AllSybase)] string context, [Values] bool withParameters)
 		{
+			// orderby needed to preserve stable test results
+			// but access returns wrong number of records if orderby applied to subquery with take
+			var orderUnsupported = context.IsAnyOf(TestProvName.AllAccess);
+
 			using (new ParameterizeTakeSkip(withParameters))
 			using (var db = GetDataContext(context))
 			{
@@ -792,6 +796,7 @@ namespace Tests.Linq
 				var q1 = types.Concat(types).Take(15);
 				var q2 = db.Types.Concat(db.Types).Take(15);
 
+				if (!orderUnsupported)
 				{
 					q1 = q1.OrderBy(_ => _.ID);
 					q2 = q2.OrderBy(_ => _.ID);

--- a/Tests/Linq/Update/BulkCopyTests.cs
+++ b/Tests/Linq/Update/BulkCopyTests.cs
@@ -105,12 +105,12 @@ namespace Tests.xUpdate
 									Value = 300
 								}
 							};
-						if (asyncMode == 0) // synchronous
+						if (asyncMode == 0) // synchronous 
 						{
 							db.BulkCopy(
 								options,
 								values);
-						}
+						} 
 						else if (asyncMode == 1) // asynchronous
 						{
 							await db.BulkCopyAsync(
@@ -267,7 +267,7 @@ namespace Tests.xUpdate
 			return true;
 		}
 
-		// DB2:
+		// DB2: 
 		[Test]
 		public void ReuseOptionTest([DataSources(false, ProviderName.DB2)] string context)
 		{
@@ -283,11 +283,11 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public void UseParametersTest([DataSources(false)] string context)
+		public void UseParametersTest([DataSources(false, TestProvName.AllClickHouse)] string context)
 		{
-			using (var db = new TestDataConnection(context))
-			using (db.BeginTransaction())
-		{
+			using var db = new TestDataConnection(context);
+			using var _ = new RestoreBaseTables(db);
+			using var tr = db.BeginTransaction();
 			var options = new BulkCopyOptions(){ UseParameters = true, MaxBatchSize = 50, BulkCopyType = BulkCopyType.MultipleRows };
 			var start   = 111001;
 
@@ -299,7 +299,6 @@ namespace Tests.xUpdate
 			Assert.AreEqual(rowsToInsert.Count,
 				db.Parent.Where(r =>
 					r.ParentID >= rowsToInsert[0].ParentID && r.ParentID <= rowsToInsert.Last().ParentID).Count());
-		}
 		}
 
 		[Table]
@@ -392,16 +391,16 @@ namespace Tests.xUpdate
 
 			[Column(Length = 50)]
 			public string? Value1 { get; set; }
-		}
-
+		}		
+		
 		class Inherited2 : BaseClass
 		{
 			public override int Discriminator => 2;
 
 			[Column(Length = 50)]
 			public string? Value2 { get; set; }
-		}
-
+		}		
+		
 		class Inherited3 : BaseClass
 		{
 			public override int Discriminator => 3;
@@ -479,14 +478,14 @@ namespace Tests.xUpdate
 		{
 			[Column(Length = 50)]
 			public string? Value1 { get; set; }
-		}
-
+		}		
+		
 		class InheritedDefault2 : BaseDefaultDiscriminator
 		{
 			[Column(Length = 50)]
 			public string? Value2 { get; set; }
-		}
-
+		}		
+		
 		class InheritedDefault3 : BaseDefaultDiscriminator
 		{
 			[Column(Length = 50)]

--- a/Tests/Linq/Update/BulkCopyTests.cs
+++ b/Tests/Linq/Update/BulkCopyTests.cs
@@ -283,7 +283,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public void UseParametersTest([DataSources(false, TestProvName.AllClickHouse)] string context)
+		public void UseParametersTest([DataSources(false)] string context)
 		{
 			using var db = new TestDataConnection(context);
 			using var _ = new RestoreBaseTables(db);

--- a/Tests/Linq/Update/DropTableTests.cs
+++ b/Tests/Linq/Update/DropTableTests.cs
@@ -52,7 +52,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public void DropCurrentDatabaseTableWIthIdentityTest([DataSources] string context)
+		public void DropCurrentDatabaseTableWithIdentityTest([DataSources(TestProvName.AllClickHouse)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{

--- a/Tests/Linq/Update/DropTableTests.cs
+++ b/Tests/Linq/Update/DropTableTests.cs
@@ -52,7 +52,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public void DropCurrentDatabaseTableWithIdentityTest([DataSources(TestProvName.AllClickHouse)] string context)
+		public void DropCurrentDatabaseTableWithIdentityTest([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 			{


### PR DESCRIPTION
Small generic changes from ClickHouse PR:
- update `MySqlConnector` nuget and add more data reader methods support for it
- pick remaining non-functional changes
- fix `NULL` literal generation from enumerable source to have space between `NULL` and column alias
- register nullable structs in `MappingSchema.AddScalarType()` by default
- unwrap enums in `ConvertFromDataReaderExpression`