### PR TITLE
Refactor LIKE handling in BasicSqlOptimizer

### DIFF
--- a/Source/LinqToDB/DataProvider/Access/AccessSqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessSqlOptimizer.cs
@@ -31,6 +31,18 @@ namespace LinqToDB.DataProvider.Access
 			return base.ConvertLikePredicate(mappingSchema, predicate, context);
 		}
 
+		protected override string EscapeLikePattern(string str)
+		{
+			var newStr = DataTools.EscapeUnterminatedBracket(str);
+			if (newStr == str)
+				newStr = newStr.Replace("[", "[[]");
+
+			foreach (var s in LikeCharactersToEscape)
+				newStr = newStr.Replace(s, "[" + s + "]");
+
+			return newStr;
+		}
+
 		public override ISqlExpression EscapeLikeCharacters(ISqlExpression expression, ref ISqlExpression? escape)
 		{
 			throw new LinqException("Access does not support `Replace` function which is required for such query.");
@@ -144,7 +156,7 @@ namespace LinqToDB.DataProvider.Access
 			{
 				case "$ToLower$" : return new SqlFunction(func.SystemType, "LCase", func.IsAggregate, func.IsPure, func.Precedence, func.Parameters);
 				case "$ToUpper$" : return new SqlFunction(func.SystemType, "UCase", func.IsAggregate, func.IsPure, func.Precedence, func.Parameters);
-				case "Length"    : return new SqlFunction(func.SystemType, "LEN",   func.IsAggregate, func.IsPure, func.Precedence, func.Parameters);
+				case "Length"                : return new SqlFunction(func.SystemType, "LEN",   func.IsAggregate, func.IsPure, func.Precedence, func.Parameters);
 			}
 			return base.ConvertFunction(func);
 		}

--- a/Source/LinqToDB/SqlProvider/BasicSqlOptimizer.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlOptimizer.cs
@@ -2178,14 +2178,25 @@ namespace LinqToDB.SqlProvider
 			return predicate;
 		}
 
+		/// <summary>
+		/// Escape sequence/character to escape special characters in LIKE predicate (defined by <see cref="LikeCharactersToEscape"/>).
+		/// Default: <c>"~"</c>.
+		/// </summary>
 		public virtual string LikeEscapeCharacter         => "~";
 		public virtual string LikeWildcardCharacter       => "%";
-		public virtual bool   LikeHasCharacterSetSupport  => true;
 		public virtual bool   LikePatternParameterSupport => true;
 		public virtual bool   LikeValueParameterSupport   => true;
+		/// <summary>
+		/// Should be <c>true</c> for provider with <c>LIKE ... ESCAPE</c> modifier support.
+		/// Default: <c>true</c>.
+		/// </summary>
 		public virtual bool   LikeIsEscapeSupported       => true;
 
 		protected static  string[] StandardLikeCharactersToEscape = {"%", "_", "?", "*", "#", "[", "]"};
+		/// <summary>
+		/// Characters with special meaning in LIKE predicate (defined by <see cref="LikeCharactersToEscape"/>) that should be escaped to be used as matched character.
+		/// Default: <c>["%", "_", "?", "*", "#", "[", "]"]</c>.
+		/// </summary>
 		public virtual string[] LikeCharactersToEscape => StandardLikeCharactersToEscape;
 
 		public virtual string EscapeLikeCharacters(string str, string escape)
@@ -2220,19 +2231,18 @@ namespace LinqToDB.SqlProvider
 			return result;
 		}
 
-		protected virtual string EscapeLikeCharactersBrackets(string str, string[] toEscape)
+		/// <summary>
+		/// Implements LIKE pattern escaping logic for provider without ESCAPE clause support (<see cref="LikeIsEscapeSupported"/> is <c>false</c>).
+		/// Default logic prefix characters from <see cref="LikeCharactersToEscape"/> with <see cref="LikeEscapeCharacter"/>.
+		/// </summary>
+		/// <param name="str">Raw pattern value.</param>
+		/// <returns>Escaped pattern value.</returns>
+		protected virtual string EscapeLikePattern(string str)
 		{
-			var newStr = DataTools.EscapeUnterminatedBracket(str);
-			if (newStr == str)
-				newStr = newStr.Replace("[", "[[]");
+			foreach (var s in LikeCharactersToEscape)
+				str = str.Replace(s, LikeEscapeCharacter + s);
 
-			foreach (var s in toEscape)
-		{
-				if (s != "[" && s != "]")
-					newStr = newStr.Replace(s, "[" + s + "]");
-			}
-
-			return newStr;
+			return str;
 		}
 
 		public virtual ISqlExpression EscapeLikeCharacters(ISqlExpression expression, ref ISqlExpression? escape)
@@ -2253,6 +2263,13 @@ namespace LinqToDB.SqlProvider
 			return newExpr;
 		}
 
+		/// <summary>
+		/// LIKE predicate interceptor. Default implementation does nothing.
+		/// </summary>
+		/// <param name="mappingSchema">Current mapping schema.</param>
+		/// <param name="predicate">LIKE predicate.</param>
+		/// <param name="context">Parameters evaluation context for current query.</param>
+		/// <returns>Preprocessed predicate.</returns>
 		public virtual ISqlPredicate ConvertLikePredicate(
 			MappingSchema     mappingSchema,
 			SqlPredicate.Like predicate,
@@ -2273,7 +2290,7 @@ namespace LinqToDB.SqlProvider
 
 				var patternValue = LikeIsEscapeSupported
 					? EscapeLikeCharacters(patternRawValue, LikeEscapeCharacter)
-					: EscapeLikeCharactersBrackets(patternRawValue, LikeCharactersToEscape);
+					: EscapeLikePattern(patternRawValue);
 
 				patternValue = predicate.Kind switch
 				{
@@ -2318,8 +2335,7 @@ namespace LinqToDB.SqlProvider
 
 				patternExpr = OptimizeExpression(patternExpr, visitor);
 
-				return new SqlPredicate.Like(predicate.Expr1, predicate.IsNot, patternExpr,
-					LikeIsEscapeSupported ? escape : null);
+				return new SqlPredicate.Like(predicate.Expr1, predicate.IsNot, patternExpr, LikeIsEscapeSupported ? escape : null);
 			}
 		}
 


### PR DESCRIPTION
Another part of #3627

Move access-specific logic to Access optimizer so it doesn't interfere with ClickHouse implementation