### PR TITLE
SQL Server 2022 support

### DIFF
--- a/Build/Azure/README.md
+++ b/Build/Azure/README.md
@@ -97,6 +97,7 @@ Legend:
 |MS SQL Server 2016<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.3<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 5.0.0|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
 |MS SQL Server 2017<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.3<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 5.0.0<br>with FTS Tests|:heavy_check_mark:<sup>[2](#notes)</sup>|:heavy_check_mark:<sup>[2](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|
 |MS SQL Server 2019<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.3<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 5.0.0<br>with FTS Tests|:heavy_check_mark:<sup>[2](#notes)</sup>|:heavy_check_mark:<sup>[2](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|
+|MS SQL Server 2022 (CTP 2.1)<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.3<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 5.0.0<br>with FTS Tests|:heavy_check_mark:<sup>[2](#notes)</sup>|:heavy_check_mark:<sup>[2](#notes)</sup>|:heavy_check_mark:|:heavy_check_mark:|
 |Azure SQL<br>[System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) 4.8.3<br>[Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) 5.0.0|:x:|:x:|:x:|:x:|
 |Access<br>Jet 4.0 OLE DB|:heavy_check_mark:|:x:|:heavy_minus_sign:|:heavy_minus_sign:|
 |Access><br>ACE 12 OLE DB|:heavy_check_mark:|:heavy_check_mark:|:heavy_minus_sign:|:heavy_minus_sign:|
@@ -143,7 +144,7 @@ Legend:
 |`TestProvName.PostgreSQL12`|PostgreSQL 12||
 |`TestProvName.PostgreSQL13`|PostgreSQL 13||
 |`TestProvName.PostgreSQL14`|PostgreSQL 14||
-|`TestProvName.PostgreSQL15`|PostgreSQL 15||
+|`ProviderName.PostgreSQL15`|PostgreSQL 15||
 |`ProviderName.Firebird`|Firebird 2.5||
 |`TestProvName.Firebird3`|Firebird 3.0||
 |`TestProvName.Firebird4`|Firebird 4.0||
@@ -162,6 +163,8 @@ Legend:
 |`TestProvName.SqlServer2017MS`|SQL Server 2017 using Microsoft.Data.SqlClient||
 |`ProviderName.SqlServer2019`|SQL Server 2019 using System.Data.SqlClient||
 |`TestProvName.SqlServer2019MS`|SQL Server 2019 using Microsoft.Data.SqlClient||
+|`ProviderName.SqlServer2022`|SQL Server 2022 using System.Data.SqlClient||
+|`TestProvName.SqlServer2022MS`|SQL Server 2022 using Microsoft.Data.SqlClient||
 |`TestProvName.SqlServerSA`|SQL Server latest (2019) in SequentialAccess mode using System.Data.SqlClient||
 |`TestProvName.SqlServerSAMS`|SQL Server latest (2019) in SequentialAccess mode using Microsoft.Data.SqlClient||
 |`TestProvName.SqlServerContained`|SQL Server latest (2019) in contained database mode using System.Data.SqlClient||

--- a/Build/Azure/net472/sqlserver.2022.json
+++ b/Build/Azure/net472/sqlserver.2022.json
@@ -1,0 +1,9 @@
+﻿{
+	"NET472.Azure": {
+		"Providers": [
+			// disable to shorten test execution time
+			//"SqlServer.2022",
+			"SqlServer.2022.MS"
+		]
+	}
+}

--- a/Build/Azure/net60/sqlserver.2022.json
+++ b/Build/Azure/net60/sqlserver.2022.json
@@ -1,0 +1,8 @@
+﻿{
+	"NET60.Azure": {
+		"Providers": [
+			"SqlServer.2022",
+			"SqlServer.2022.MS"
+		]
+	}
+}

--- a/Build/Azure/netcoreapp31/sqlserver.2022.json
+++ b/Build/Azure/netcoreapp31/sqlserver.2022.json
@@ -1,0 +1,8 @@
+﻿{
+	"CORE31.Azure": {
+		"Providers": [
+			"SqlServer.2022",
+			"SqlServer.2022.MS"
+		]
+	}
+}

--- a/Build/Azure/pipelines/templates/test-matrix.yml
+++ b/Build/Azure/pipelines/templates/test-matrix.yml
@@ -695,6 +695,27 @@ jobs:
           ${{ if not(or(contains(parameters.db_filter, '[all]'), contains(parameters.db_filter, '[sqlserver.all]'), contains(parameters.db_filter, '[sqlserver.2019]'))) }}:
             enabled: false
 
+        - name: SqlServer2022
+          title: SQL Server 2022
+          config_win: sqlserver.2022
+          config_linux: sqlserver.2022
+          config_macos: sqlserver.2022
+          script_win_global: sqlserver.2022.cmd
+          script_linux_global: sqlserver.2022.sh
+          script_macos_global: sqlserver.2022.sh
+          install_docker_macos: true
+          enable_os_windows: true
+          enable_os_ubuntu: true
+          enable_os_macos:  true
+          enable_fw_net472: true
+          enable_fw_netcore31: false # reduce test time
+          enable_fw_net60: true
+          is_experimental: false
+          ${{ if or(contains(parameters.db_filter, '[all]'), contains(parameters.db_filter, '[sqlserver.all]'), contains(parameters.db_filter, '[sqlserver.2019]')) }}:
+            enabled: true
+          ${{ if not(or(contains(parameters.db_filter, '[all]'), contains(parameters.db_filter, '[sqlserver.all]'), contains(parameters.db_filter, '[sqlserver.2019]'))) }}:
+            enabled: false
+
 # Sybase ASE
         - name: Sybase
           title: Sybase ASE 16

--- a/Build/Azure/scripts/mac.pgsql15.sh
+++ b/Build/Azure/scripts/mac.pgsql15.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 # TODO: update tag to 15 when it is released
-# port 5415 port used instead of default one to avoid connection string conflicts with multiple versions of servers on same machine in local testing
-docker run -d --name pgsql -h pgsql -e POSTGRES_PASSWORD=Password12! -p 5415:5432 -v pgdb:/var/run/postgresql postgres:15beta3
+docker run -d --name pgsql -h pgsql -e POSTGRES_PASSWORD=Password12! -p 5432:5432 -v pgdb:/var/run/postgresql postgres:15beta3
 
 until docker exec pgsql psql -U postgres -c '\l'; do
 >&2 echo "Postgres is unavailable - sleeping"

--- a/Build/Azure/scripts/pgsql15.sh
+++ b/Build/Azure/scripts/pgsql15.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 # TODO: update tag to 15 when it is released
-# port 5415 port used instead of default one to avoid connection string conflicts with multiple versions of servers on same machine in local testing
-docker run -d --name pgsql -e POSTGRES_PASSWORD=Password12! -p 5415:5432 -v /var/run/postgresql:/var/run/postgresql postgres:15beta3
+docker run -d --name pgsql -e POSTGRES_PASSWORD=Password12! -p 5432:5432 -v /var/run/postgresql:/var/run/postgresql postgres:15beta3
 
 retries=0
 until docker exec pgsql psql -U postgres -c '\l' | grep -q 'testdata'; do

--- a/Build/Azure/scripts/sqlserver.2022.cmd
+++ b/Build/Azure/scripts/sqlserver.2022.cmd
@@ -1,0 +1,32 @@
+docker run -d -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Password12!" -p 1433:1433 -h mssql --name=mssql cagrin/mssql-server-ltsc2022:2022-preview
+docker ps -a
+
+echo "Waiting for SQL Server to accept connections"
+set max=100
+:repeat
+set /a max=max-1
+if %max% EQU 0 goto fail
+echo pinging sql server
+sleep 1
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "SELECT 1"
+if %errorlevel% NEQ 0 goto repeat
+echo "SQL Server is operational"
+
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "SELECT @@Version"
+
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData COLLATE Latin1_General_CS_AS;"
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS COLLATE Latin1_General_CS_AS;"
+
+REM FTS required
+goto:eof
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE Northwind;"
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE NorthwindMS;"
+docker cp northwind.sql mssql:northwind.sql
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -d Northwind -i northwind.sql
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -d NorthwindMS -i northwind.sql
+
+goto:eof
+
+:fail
+echo "Fail"
+docker logs mssql

--- a/Build/Azure/scripts/sqlserver.2022.cmd
+++ b/Build/Azure/scripts/sqlserver.2022.cmd
@@ -14,8 +14,8 @@ echo "SQL Server is operational"
 
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "SELECT @@Version"
 
-docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData COLLATE Latin1_General_CS_AS;"
-docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS COLLATE Latin1_General_CS_AS;"
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData;"
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS;"
 
 REM FTS required
 goto:eof

--- a/Build/Azure/scripts/sqlserver.2022.sh
+++ b/Build/Azure/scripts/sqlserver.2022.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=Password12!' -p 1433:1433 -h mssql --name=mssql -d mcr.microsoft.com/mssql/server:2022-latest
+docker ps -a
+
+# Wait for start
+echo "Waiting for SQL Server to accept connections"
+docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "SELECT 1"
+is_up=$?
+while [ $is_up -ne 0 ] ; do
+    docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "SELECT 1"
+    is_up=$?
+done
+echo "SQL Server is operational"
+
+docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'SELECT @@Version'
+
+docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestData;'
+docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataMS;'

--- a/Data/Create Scripts/PostgreSQL.sql
+++ b/Data/Create Scripts/PostgreSQL.sql
@@ -288,12 +288,10 @@ CREATE TABLE "AllTypes"
 -- SKIP PostgreSQL.9.2 BEGIN
 -- SKIP PostgreSQL.9.3 BEGIN
 -- SKIP PostgreSQL.9.5 BEGIN
--- SKIP PostgreSQL BEGIN
 	"macaddr8DataType"  macaddr8                   NULL,
 -- SKIP PostgreSQL.9.2 END
 -- SKIP PostgreSQL.9.3 END
 -- SKIP PostgreSQL.9.5 END
--- SKIP PostgreSQL END
 
 	"jsonDataType"        json                     NULL,
 -- SKIP PostgreSQL.9.2 BEGIN

--- a/Data/Create Scripts/SqlServer.sql
+++ b/Data/Create Scripts/SqlServer.sql
@@ -487,6 +487,8 @@ CREATE TABLE AllTypes
 -- SKIP SqlServer.2017.MS BEGIN
 -- SKIP SqlServer.2019 BEGIN
 -- SKIP SqlServer.2019.MS BEGIN
+-- SKIP SqlServer.2022 BEGIN
+-- SKIP SqlServer.2022.MS BEGIN
 -- SKIP SqlServer.SA BEGIN
 -- SKIP SqlServer.SA.MS BEGIN
 -- SKIP SqlServer.Contained BEGIN
@@ -517,6 +519,8 @@ CREATE TABLE AllTypes
 -- SKIP SqlServer.2017.MS END
 -- SKIP SqlServer.2019 END
 -- SKIP SqlServer.2019.MS END
+-- SKIP SqlServer.2022 END
+-- SKIP SqlServer.2022.MS END
 -- SKIP SqlServer.SA END
 -- SKIP SqlServer.SA.MS END
 -- SKIP SqlServer.Contained END
@@ -717,6 +721,8 @@ GO
 -- SKIP SqlServer.2017.MS BEGIN
 -- SKIP SqlServer.2019 BEGIN
 -- SKIP SqlServer.2019.MS BEGIN
+-- SKIP SqlServer.2022 BEGIN
+-- SKIP SqlServer.2022.MS BEGIN
 -- SKIP SqlServer.SA BEGIN
 -- SKIP SqlServer.SA.MS BEGIN
 -- SKIP SqlServer.Contained BEGIN
@@ -750,6 +756,8 @@ GO
 -- SKIP SqlServer.2017.MS END
 -- SKIP SqlServer.2019 END
 -- SKIP SqlServer.2019.MS END
+-- SKIP SqlServer.2022 END
+-- SKIP SqlServer.2022.MS END
 -- SKIP SqlServer.SA END
 -- SKIP SqlServer.SA.MS END
 -- SKIP SqlServer.Contained END

--- a/Data/Setup Scripts/readme.md
+++ b/Data/Setup Scripts/readme.md
@@ -1,5 +1,7 @@
 Contains database setup scripts for local testing
 
+### Linux (WSL2) images
+
 - `clickhouse.cmd` : Windows script to create or update docker container with ClickHouse instance
 - `pgsql92.cmd` : Windows script to create or update docker container with PostgreSQL 9.2 instance
 - `pgsql93.cmd` : Windows script to create or update docker container with PostgreSQL 9.3 instance
@@ -13,3 +15,9 @@ Contains database setup scripts for local testing
 - `sqlserver2017.cmd` : Windows script to create or update docker container with SQL Server 2017 (Linux-based) instance
 - `sqlserver2019.cmd` : Windows script to create or update docker container with SQL Server 2019 (Linux-based) instance (also creates databases for FTS, Contained and SequentialAccess test providers)
 - `sqlserver2022.cmd` : Windows script to create or update docker container with SQL Server 2022 (Linux-based) instance
+
+### Windows images
+
+Use of Windows-based images is not recommended as they probably will not work due to base image mismatch.
+
+- `sqlserver2022-win.cmd` : Windows script to create or update docker container with SQL Server 2022 (Windows-based) instance

--- a/Data/Setup Scripts/readme.md
+++ b/Data/Setup Scripts/readme.md
@@ -10,3 +10,4 @@ Contains database setup scripts for local testing
 - `pgsql13.cmd` : Windows script to create or update docker container with PostgreSQL 13 instance
 - `pgsql14.cmd` : Windows script to create or update docker container with PostgreSQL 14 instance
 - `pgsql15.cmd` : Windows script to create or update docker container with PostgreSQL 15 instance
+- `sqlserver2022.cmd` : Windows script to create or update docker container with SQL Server 2022 (Linux-based) instance

--- a/Data/Setup Scripts/readme.md
+++ b/Data/Setup Scripts/readme.md
@@ -10,4 +10,6 @@ Contains database setup scripts for local testing
 - `pgsql13.cmd` : Windows script to create or update docker container with PostgreSQL 13 instance
 - `pgsql14.cmd` : Windows script to create or update docker container with PostgreSQL 14 instance
 - `pgsql15.cmd` : Windows script to create or update docker container with PostgreSQL 15 instance
+- `sqlserver2017.cmd` : Windows script to create or update docker container with SQL Server 2017 (Linux-based) instance
+- `sqlserver2019.cmd` : Windows script to create or update docker container with SQL Server 2019 (Linux-based) instance (also creates databases for FTS, Contained and SequentialAccess test providers)
 - `sqlserver2022.cmd` : Windows script to create or update docker container with SQL Server 2022 (Linux-based) instance

--- a/Data/Setup Scripts/sqlserver2017.cmd
+++ b/Data/Setup Scripts/sqlserver2017.cmd
@@ -1,0 +1,17 @@
+ECHO OFF
+
+REM try to remove existing container
+docker stop sql2017
+docker rm -f sql2017
+
+REM use pull to get latest layers (run will use cached layers)
+docker pull mcr.microsoft.com/mssql/server:2017-latest
+docker run -e ACCEPT_EULA=Y -e SA_PASSWORD=Password12! -p 1417:1433 --name sql2017 -d mcr.microsoft.com/mssql/server:2017-latest
+
+ECHO pause to wait for SQL Server startup completion
+timeout 15
+
+REM create test databases
+docker exec sql2017 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData;"
+docker exec sql2017 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS;"
+

--- a/Data/Setup Scripts/sqlserver2019.cmd
+++ b/Data/Setup Scripts/sqlserver2019.cmd
@@ -1,0 +1,39 @@
+ECHO OFF
+
+REM try to remove existing container
+docker stop sql2019
+docker rm -f sql2019
+
+REM use pull to get latest layers (run will use cached layers)
+REM docker pull mcr.microsoft.com/mssql/server:2019-latest
+REM docker run -e ACCEPT_EULA=Y -e SA_PASSWORD=Password12! -p 1419:1433 --name sql2019 -d mcr.microsoft.com/mssql/server:2019-latest
+docker pull huyttq/sqlserver-2019-with-fts:2019
+docker run -e ACCEPT_EULA=Y -e SA_PASSWORD=Password12! -p 1419:1433 --name sql2019 -d huyttq/sqlserver-2019-with-fts:2019
+
+ECHO pause to wait for SQL Server startup completion
+timeout 40
+
+REM create test databases
+REM docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData;"
+REM docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS;"
+
+docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData COLLATE Latin1_General_CS_AS WITH CATALOG_COLLATION = SQL_Latin1_General_CP1_CI_AS;"
+docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS COLLATE Latin1_General_CS_AS WITH CATALOG_COLLATION = SQL_Latin1_General_CP1_CI_AS;"
+
+docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataSA;"
+docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMSSA;"
+
+docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "sp_configure 'contained database authentication', 1;"
+docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "RECONFIGURE;"
+docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataContained CONTAINMENT = PARTIAL;"
+docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMSContained CONTAINMENT = PARTIAL;"
+
+docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE Northwind;"
+docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE NorthwindMS;"
+
+docker cp "../Create Scripts/Northwind.sql" sql2019:/northwind.sql
+
+docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -d Northwind -i /northwind.sql
+docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -d NorthwindMS -i /northwind.sql
+
+

--- a/Data/Setup Scripts/sqlserver2022-win.cmd
+++ b/Data/Setup Scripts/sqlserver2022-win.cmd
@@ -5,8 +5,8 @@ docker stop sql2022
 docker rm -f sql2022
 
 REM use pull to get latest layers (run will use cached layers)
-docker pull mcr.microsoft.com/mssql/server:2022-latest
-docker run -e ACCEPT_EULA=Y -e SA_PASSWORD=Password12! -p 1422:1433 --name sql2022 -d mcr.microsoft.com/mssql/server:2022-latest
+docker pull cagrin/mssql-server-ltsc2022:2022-preview
+docker run -e ACCEPT_EULA=Y -e SA_PASSWORD=Password12! -p 1422:1433 --name sql2022 -d cagrin/mssql-server-ltsc2022:2022-preview
 
 ECHO pause to wait for SQL Server startup completion
 timeout 15

--- a/Data/Setup Scripts/sqlserver2022.cmd
+++ b/Data/Setup Scripts/sqlserver2022.cmd
@@ -12,6 +12,7 @@ ECHO pause to wait for SQL Server startup completion
 timeout 15
 
 REM create test databases
-docker exec sql2022 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData;"
-docker exec sql2022 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS;"
+REM collation added temporary due to issues with image
+docker exec sql2022 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData  COLLATE SQL_Latin1_General_CP1_CI_AS;"
+docker exec sql2022 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS  COLLATE SQL_Latin1_General_CP1_CI_AS;"
 

--- a/Data/Setup Scripts/sqlserver2022.cmd
+++ b/Data/Setup Scripts/sqlserver2022.cmd
@@ -1,0 +1,17 @@
+ECHO OFF
+
+REM try to remove existing container
+docker stop sql2022
+docker rm -f sql2022
+
+REM use pull to get latest layers (run will use cached layers)
+docker pull mcr.microsoft.com/mssql/server:2022-latest
+docker run -e ACCEPT_EULA=Y -e SA_PASSWORD=Password12! -p 1422:1433 --name sql2022 -d mcr.microsoft.com/mssql/server:2022-latest
+
+ECHO pause to wait for SQL Server startup completion
+timeout 15
+
+REM create test databases
+docker exec sql2022 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData;"
+docker exec sql2022 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS;"
+

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2005SqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2005SqlBuilder.cs
@@ -1,10 +1,8 @@
-﻿using System;
-
-namespace LinqToDB.DataProvider.SqlServer
+﻿namespace LinqToDB.DataProvider.SqlServer
 {
-	using SqlQuery;
-	using SqlProvider;
 	using Mapping;
+	using SqlProvider;
+	using SqlQuery;
 
 	class SqlServer2005SqlBuilder : SqlServerSqlBuilder
 	{

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2008SqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2008SqlBuilder.cs
@@ -1,10 +1,8 @@
-﻿using System;
-
-namespace LinqToDB.DataProvider.SqlServer
+﻿namespace LinqToDB.DataProvider.SqlServer
 {
-	using SqlQuery;
-	using SqlProvider;
 	using Mapping;
+	using SqlProvider;
+	using SqlQuery;
 
 	partial class SqlServer2008SqlBuilder : SqlServerSqlBuilder
 	{

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2012SqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2012SqlBuilder.cs
@@ -1,10 +1,8 @@
-﻿using System;
-
-namespace LinqToDB.DataProvider.SqlServer
+﻿namespace LinqToDB.DataProvider.SqlServer
 {
-	using SqlQuery;
-	using SqlProvider;
 	using Mapping;
+	using SqlProvider;
+	using SqlQuery;
 
 	partial class SqlServer2012SqlBuilder : SqlServerSqlBuilder
 	{

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2012SqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2012SqlOptimizer.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using LinqToDB.SqlQuery;
 
 namespace LinqToDB.DataProvider.SqlServer
 {
 	using SqlProvider;
+	using SqlQuery;
 
 	class SqlServer2012SqlOptimizer : SqlServerSqlOptimizer
 	{

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2014SqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2014SqlBuilder.cs
@@ -1,9 +1,7 @@
-﻿using System;
-
-namespace LinqToDB.DataProvider.SqlServer
+﻿namespace LinqToDB.DataProvider.SqlServer
 {
-	using SqlProvider;
 	using Mapping;
+	using SqlProvider;
 
 	class SqlServer2014SqlBuilder : SqlServer2012SqlBuilder
 	{

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2016SqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2016SqlBuilder.cs
@@ -1,10 +1,8 @@
-﻿using System;
-
-namespace LinqToDB.DataProvider.SqlServer
+﻿namespace LinqToDB.DataProvider.SqlServer
 {
 	using Mapping;
-	using SqlQuery;
 	using SqlProvider;
+	using SqlQuery;
 
 	class SqlServer2016SqlBuilder : SqlServer2014SqlBuilder
 	{

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2017SqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2017SqlBuilder.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace LinqToDB.DataProvider.SqlServer
+﻿namespace LinqToDB.DataProvider.SqlServer
 {
 	using Mapping;
 	using SqlProvider;

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2017SqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2017SqlOptimizer.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace LinqToDB.DataProvider.SqlServer
+﻿namespace LinqToDB.DataProvider.SqlServer
 {
 	using SqlProvider;
 

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2019SqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2019SqlBuilder.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace LinqToDB.DataProvider.SqlServer
+﻿namespace LinqToDB.DataProvider.SqlServer
 {
 	using Mapping;
 	using SqlProvider;
@@ -12,7 +10,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		{
 		}
 
-		SqlServer2019SqlBuilder(BasicSqlBuilder parentBuilder) : base(parentBuilder)
+		protected SqlServer2019SqlBuilder(BasicSqlBuilder parentBuilder) : base(parentBuilder)
 		{
 		}
 

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2019SqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2019SqlOptimizer.cs
@@ -1,12 +1,14 @@
-﻿using System;
-
-namespace LinqToDB.DataProvider.SqlServer
+﻿namespace LinqToDB.DataProvider.SqlServer
 {
 	using SqlProvider;
 
 	class SqlServer2019SqlOptimizer : SqlServer2012SqlOptimizer
 	{
 		public SqlServer2019SqlOptimizer(SqlProviderFlags sqlProviderFlags) : base(sqlProviderFlags, SqlServerVersion.v2019)
+		{
+		}
+
+		protected SqlServer2019SqlOptimizer(SqlProviderFlags sqlProviderFlags, SqlServerVersion version) : base(sqlProviderFlags, version)
 		{
 		}
 	}

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2022SqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2022SqlBuilder.cs
@@ -1,0 +1,32 @@
+﻿namespace LinqToDB.DataProvider.SqlServer
+{
+	using LinqToDB.SqlQuery;
+	using Mapping;
+	using SqlProvider;
+
+	class SqlServer2022SqlBuilder : SqlServer2019SqlBuilder
+	{
+		public SqlServer2022SqlBuilder(IDataProvider? provider, MappingSchema mappingSchema, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
+			: base(provider, mappingSchema, sqlOptimizer, sqlProviderFlags)
+		{
+		}
+
+		SqlServer2022SqlBuilder(BasicSqlBuilder parentBuilder) : base(parentBuilder)
+		{
+		}
+
+		protected override ISqlBuilder CreateSqlBuilder()
+		{
+			return new SqlServer2022SqlBuilder(this);
+		}
+
+		public override string Name => ProviderName.SqlServer2022;
+
+		protected override void BuildIsDistinctPredicate(SqlPredicate.IsDistinct expr)
+		{
+			BuildExpression(GetPrecedence(expr), expr.Expr1);
+			StringBuilder.Append(expr.IsNot ? " IS NOT DISTINCT FROM " : " IS DISTINCT FROM ");
+			BuildExpression(GetPrecedence(expr), expr.Expr2);
+		}
+	}
+}

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2022SqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2022SqlOptimizer.cs
@@ -1,0 +1,11 @@
+﻿namespace LinqToDB.DataProvider.SqlServer
+{
+	using SqlProvider;
+
+	class SqlServer2022SqlOptimizer : SqlServer2019SqlOptimizer
+	{
+		public SqlServer2022SqlOptimizer(SqlProviderFlags sqlProviderFlags) : base(sqlProviderFlags, SqlServerVersion.v2022)
+		{
+		}
+	}
+}

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerBulkCopy.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace LinqToDB.DataProvider.SqlServer
 {
-	using System.Data;
-	using System.Threading;
 	using Data;
 	using SqlProvider;
 

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
@@ -23,6 +23,7 @@ namespace LinqToDB.DataProvider.SqlServer
 	class SqlServerDataProvider2016SystemDataSqlClient    : SqlServerDataProvider { public SqlServerDataProvider2016SystemDataSqlClient   () : base(ProviderName.SqlServer2016, SqlServerVersion.v2016, SqlServerProvider.SystemDataSqlClient)    {} }
 	class SqlServerDataProvider2017SystemDataSqlClient    : SqlServerDataProvider { public SqlServerDataProvider2017SystemDataSqlClient   () : base(ProviderName.SqlServer2017, SqlServerVersion.v2017, SqlServerProvider.SystemDataSqlClient)    {} }
 	class SqlServerDataProvider2019SystemDataSqlClient    : SqlServerDataProvider { public SqlServerDataProvider2019SystemDataSqlClient   () : base(ProviderName.SqlServer2019, SqlServerVersion.v2019, SqlServerProvider.SystemDataSqlClient)    {} }
+	class SqlServerDataProvider2022SystemDataSqlClient    : SqlServerDataProvider { public SqlServerDataProvider2022SystemDataSqlClient   () : base(ProviderName.SqlServer2022, SqlServerVersion.v2022, SqlServerProvider.SystemDataSqlClient)    {} }
 	class SqlServerDataProvider2005MicrosoftDataSqlClient : SqlServerDataProvider { public SqlServerDataProvider2005MicrosoftDataSqlClient() : base(ProviderName.SqlServer2005, SqlServerVersion.v2005, SqlServerProvider.MicrosoftDataSqlClient) {} }
 	class SqlServerDataProvider2008MicrosoftDataSqlClient : SqlServerDataProvider { public SqlServerDataProvider2008MicrosoftDataSqlClient() : base(ProviderName.SqlServer2008, SqlServerVersion.v2008, SqlServerProvider.MicrosoftDataSqlClient) {} }
 	class SqlServerDataProvider2012MicrosoftDataSqlClient : SqlServerDataProvider { public SqlServerDataProvider2012MicrosoftDataSqlClient() : base(ProviderName.SqlServer2012, SqlServerVersion.v2012, SqlServerProvider.MicrosoftDataSqlClient) {} }
@@ -30,6 +31,7 @@ namespace LinqToDB.DataProvider.SqlServer
 	class SqlServerDataProvider2016MicrosoftDataSqlClient : SqlServerDataProvider { public SqlServerDataProvider2016MicrosoftDataSqlClient() : base(ProviderName.SqlServer2016, SqlServerVersion.v2016, SqlServerProvider.MicrosoftDataSqlClient) {} }
 	class SqlServerDataProvider2017MicrosoftDataSqlClient : SqlServerDataProvider { public SqlServerDataProvider2017MicrosoftDataSqlClient() : base(ProviderName.SqlServer2017, SqlServerVersion.v2017, SqlServerProvider.MicrosoftDataSqlClient) {} }
 	class SqlServerDataProvider2019MicrosoftDataSqlClient : SqlServerDataProvider { public SqlServerDataProvider2019MicrosoftDataSqlClient() : base(ProviderName.SqlServer2019, SqlServerVersion.v2019, SqlServerProvider.MicrosoftDataSqlClient) {} }
+	class SqlServerDataProvider2022MicrosoftDataSqlClient : SqlServerDataProvider { public SqlServerDataProvider2022MicrosoftDataSqlClient() : base(ProviderName.SqlServer2022, SqlServerVersion.v2022, SqlServerProvider.MicrosoftDataSqlClient) {} }
 
 	public abstract class SqlServerDataProvider : DynamicDataProviderBase<SqlServerProviderAdapter>
 	{
@@ -72,6 +74,7 @@ namespace LinqToDB.DataProvider.SqlServer
 				SqlServerVersion.v2016 => new SqlServer2016SqlOptimizer(SqlProviderFlags),
 				SqlServerVersion.v2017 => new SqlServer2017SqlOptimizer(SqlProviderFlags),
 				SqlServerVersion.v2019 => new SqlServer2019SqlOptimizer(SqlProviderFlags),
+				SqlServerVersion.v2022 => new SqlServer2022SqlOptimizer(SqlProviderFlags),
 				_                      => new SqlServer2008SqlOptimizer(SqlProviderFlags),
 			};
 
@@ -126,6 +129,7 @@ namespace LinqToDB.DataProvider.SqlServer
 					SqlServerVersion.v2016 => new SqlServerMappingSchema.SqlServer2016MappingSchema(),
 					SqlServerVersion.v2017 => new SqlServerMappingSchema.SqlServer2017MappingSchema(),
 					SqlServerVersion.v2019 => new SqlServerMappingSchema.SqlServer2019MappingSchema(),
+					SqlServerVersion.v2022 => new SqlServerMappingSchema.SqlServer2022MappingSchema(),
 					_                      => new SqlServerMappingSchema.SqlServer2008MappingSchema(),
 				};
 			}
@@ -151,6 +155,7 @@ namespace LinqToDB.DataProvider.SqlServer
 				SqlServerVersion.v2016 => new SqlServer2016SqlBuilder(this, mappingSchema, GetSqlOptimizer(), SqlProviderFlags),
 				SqlServerVersion.v2017 => new SqlServer2017SqlBuilder(this, mappingSchema, GetSqlOptimizer(), SqlProviderFlags),
 				SqlServerVersion.v2019 => new SqlServer2019SqlBuilder(this, mappingSchema, GetSqlOptimizer(), SqlProviderFlags),
+				SqlServerVersion.v2022 => new SqlServer2022SqlBuilder(this, mappingSchema, GetSqlOptimizer(), SqlProviderFlags),
 				_                      => throw new InvalidOperationException(),
 			};
 		}
@@ -491,7 +496,6 @@ namespace LinqToDB.DataProvider.SqlServer
 				cancellationToken);
 		}
 #endif
-
 		#endregion
 	}
 }

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerExtensions.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerExtensions.cs
@@ -1,8 +1,8 @@
-﻿using LinqToDB.Linq;
-using LinqToDB.Mapping;
-using System;
+﻿using System;
 using System.Linq;
 using System.Linq.Expressions;
+using LinqToDB.Linq;
+using LinqToDB.Mapping;
 
 namespace LinqToDB.DataProvider.SqlServer
 {

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerFactory.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerFactory.cs
@@ -1,10 +1,10 @@
-﻿using JetBrains.Annotations;
+﻿using System.Collections.Generic;
+using System.Linq;
+
+using JetBrains.Annotations;
 
 namespace LinqToDB.DataProvider.SqlServer
 {
-	using System.Collections.Generic;
-	using System.Linq;
-
 	using Configuration;
 
 	[UsedImplicitly]
@@ -29,6 +29,7 @@ namespace LinqToDB.DataProvider.SqlServer
 				"2016" => SqlServerTools.GetDataProvider(SqlServerVersion.v2016, provider),
 				"2017" => SqlServerTools.GetDataProvider(SqlServerVersion.v2017, provider),
 				"2019" => SqlServerTools.GetDataProvider(SqlServerVersion.v2019, provider),
+				"2022" => SqlServerTools.GetDataProvider(SqlServerVersion.v2022, provider),
 				_      => SqlServerTools.GetDataProvider(SqlServerVersion.v2008, provider),
 			};
 		}

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerHints.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerHints.cs
@@ -261,6 +261,7 @@ namespace LinqToDB.DataProvider.SqlServer
 //		[Sql.QueryExtension(ProviderName.SqlServer2016, Sql.QueryExtensionScope.QueryHint, typeof(ParamsExtensionBuilder), "USE HINT")]
 		[Sql.QueryExtension(ProviderName.SqlServer2017, Sql.QueryExtensionScope.QueryHint, typeof(ParamsExtensionBuilder), "USE HINT")]
 		[Sql.QueryExtension(ProviderName.SqlServer2019, Sql.QueryExtensionScope.QueryHint, typeof(ParamsExtensionBuilder), "USE HINT")]
+		[Sql.QueryExtension(ProviderName.SqlServer2022, Sql.QueryExtensionScope.QueryHint, typeof(ParamsExtensionBuilder), "USE HINT")]
 		[Sql.QueryExtension(null,                       Sql.QueryExtensionScope.None,      typeof(NoneExtensionBuilder))]
 		public static ISqlServerSpecificQueryable<TSource> OptionUseHint<TSource>(
 			this ISqlServerSpecificQueryable<TSource> source,
@@ -308,6 +309,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		[Sql.QueryExtension(ProviderName.SqlServer2016, Sql.QueryExtensionScope.QueryHint, typeof(TableParamsExtensionBuilder))]
 		[Sql.QueryExtension(ProviderName.SqlServer2017, Sql.QueryExtensionScope.QueryHint, typeof(TableParamsExtensionBuilder))]
 		[Sql.QueryExtension(ProviderName.SqlServer2019, Sql.QueryExtensionScope.QueryHint, typeof(TableParamsExtensionBuilder))]
+		[Sql.QueryExtension(ProviderName.SqlServer2022, Sql.QueryExtensionScope.QueryHint, typeof(TableParamsExtensionBuilder))]
 		[Sql.QueryExtension(null,                       Sql.QueryExtensionScope.None,      typeof(NoneExtensionBuilder))]
 		public static ISqlServerSpecificQueryable<TSource> OptionTableHint<TSource>(
 			this ISqlServerSpecificQueryable<TSource> source,
@@ -411,6 +413,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		[Sql.QueryExtension(ProviderName.SqlServer2016, Sql.QueryExtensionScope.TableHint, typeof(HintExtensionBuilder))]
 		[Sql.QueryExtension(ProviderName.SqlServer2017, Sql.QueryExtensionScope.TableHint, typeof(HintExtensionBuilder))]
 		[Sql.QueryExtension(ProviderName.SqlServer2019, Sql.QueryExtensionScope.TableHint, typeof(HintExtensionBuilder))]
+		[Sql.QueryExtension(ProviderName.SqlServer2022, Sql.QueryExtensionScope.TableHint, typeof(HintExtensionBuilder))]
 		[Sql.QueryExtension(null,                       Sql.QueryExtensionScope.None,      typeof(NoneExtensionBuilder))]
 		public static ISqlServerSpecificTable<TSource> TableHint2012Plus<TSource>(this ISqlServerSpecificTable<TSource> table, [SqlQueryDependent] string hint)
 			where TSource : notnull
@@ -428,6 +431,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		[Sql.QueryExtension(ProviderName.SqlServer2016, Sql.QueryExtensionScope.TableHint, typeof(HintExtensionBuilder))]
 		[Sql.QueryExtension(ProviderName.SqlServer2017, Sql.QueryExtensionScope.TableHint, typeof(HintExtensionBuilder))]
 		[Sql.QueryExtension(ProviderName.SqlServer2019, Sql.QueryExtensionScope.TableHint, typeof(HintExtensionBuilder))]
+		[Sql.QueryExtension(ProviderName.SqlServer2022, Sql.QueryExtensionScope.TableHint, typeof(HintExtensionBuilder))]
 		[Sql.QueryExtension(null,                       Sql.QueryExtensionScope.None,      typeof(NoneExtensionBuilder))]
 		static ISqlServerSpecificTable<TSource> TableHint2014Plus<TSource>(this ISqlServerSpecificTable<TSource> table, [SqlQueryDependent] string hint)
 			where TSource : notnull
@@ -536,6 +540,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		[Sql.QueryExtension(ProviderName.SqlServer2016, Sql.QueryExtensionScope.TablesInScopeHint, typeof(HintExtensionBuilder))]
 		[Sql.QueryExtension(ProviderName.SqlServer2017, Sql.QueryExtensionScope.TablesInScopeHint, typeof(HintExtensionBuilder))]
 		[Sql.QueryExtension(ProviderName.SqlServer2019, Sql.QueryExtensionScope.TablesInScopeHint, typeof(HintExtensionBuilder))]
+		[Sql.QueryExtension(ProviderName.SqlServer2022, Sql.QueryExtensionScope.TablesInScopeHint, typeof(HintExtensionBuilder))]
 		[Sql.QueryExtension(null,                       Sql.QueryExtensionScope.None,              typeof(NoneExtensionBuilder))]
 		public static ISqlServerSpecificQueryable<TSource> TablesInScopeHint2012Plus<TSource>(
 			this ISqlServerSpecificQueryable<TSource> source,
@@ -563,6 +568,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		[Sql.QueryExtension(ProviderName.SqlServer2016, Sql.QueryExtensionScope.TablesInScopeHint, typeof(HintExtensionBuilder))]
 		[Sql.QueryExtension(ProviderName.SqlServer2017, Sql.QueryExtensionScope.TablesInScopeHint, typeof(HintExtensionBuilder))]
 		[Sql.QueryExtension(ProviderName.SqlServer2019, Sql.QueryExtensionScope.TablesInScopeHint, typeof(HintExtensionBuilder))]
+		[Sql.QueryExtension(ProviderName.SqlServer2022, Sql.QueryExtensionScope.TablesInScopeHint, typeof(HintExtensionBuilder))]
 		[Sql.QueryExtension(null,                       Sql.QueryExtensionScope.None,              typeof(NoneExtensionBuilder))]
 		public static ISqlServerSpecificQueryable<TSource> TablesInScopeHint2014Plus<TSource>(
 			this ISqlServerSpecificQueryable<TSource> source,
@@ -718,6 +724,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Query source with join hints.</returns>
 		[LinqTunnel, Pure]
 		[Sql.QueryExtension(ProviderName.SqlServer2019, Sql.QueryExtensionScope.QueryHint, typeof(HintExtensionBuilder))]
+		[Sql.QueryExtension(ProviderName.SqlServer2022, Sql.QueryExtensionScope.QueryHint, typeof(HintExtensionBuilder))]
 		[Sql.QueryExtension(null,                       Sql.QueryExtensionScope.None,      typeof(NoneExtensionBuilder))]
 		public static ISqlServerSpecificQueryable<TSource> QueryHint2019Plus<TSource>(this ISqlServerSpecificQueryable<TSource> source, [SqlQueryDependent] string hint)
 			where TSource : notnull
@@ -745,6 +752,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		[Sql.QueryExtension(ProviderName.SqlServer2016, Sql.QueryExtensionScope.QueryHint, typeof(HintExtensionBuilder))]
 		[Sql.QueryExtension(ProviderName.SqlServer2017, Sql.QueryExtensionScope.QueryHint, typeof(HintExtensionBuilder))]
 		[Sql.QueryExtension(ProviderName.SqlServer2019, Sql.QueryExtensionScope.QueryHint, typeof(HintExtensionBuilder))]
+		[Sql.QueryExtension(ProviderName.SqlServer2022, Sql.QueryExtensionScope.QueryHint, typeof(HintExtensionBuilder))]
 		[Sql.QueryExtension(null,                   Sql.QueryExtensionScope.None,      typeof(NoneExtensionBuilder))]
 		public static ISqlServerSpecificQueryable<TSource> QueryHint2008Plus<TSource>(this ISqlServerSpecificQueryable<TSource> source, [SqlQueryDependent] string hint)
 			where TSource : notnull
@@ -771,6 +779,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		[Sql.QueryExtension(ProviderName.SqlServer2016, Sql.QueryExtensionScope.QueryHint, typeof(HintExtensionBuilder))]
 		[Sql.QueryExtension(ProviderName.SqlServer2017, Sql.QueryExtensionScope.QueryHint, typeof(HintExtensionBuilder))]
 		[Sql.QueryExtension(ProviderName.SqlServer2019, Sql.QueryExtensionScope.QueryHint, typeof(HintExtensionBuilder))]
+		[Sql.QueryExtension(ProviderName.SqlServer2022, Sql.QueryExtensionScope.QueryHint, typeof(HintExtensionBuilder))]
 		[Sql.QueryExtension(null,                   Sql.QueryExtensionScope.None,      typeof(NoneExtensionBuilder))]
 		public static ISqlServerSpecificQueryable<TSource> QueryHint2012Plus<TSource>(this ISqlServerSpecificQueryable<TSource> source, [SqlQueryDependent] string hint)
 			where TSource : notnull
@@ -795,6 +804,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		[Sql.QueryExtension(ProviderName.SqlServer2016, Sql.QueryExtensionScope.QueryHint, typeof(HintExtensionBuilder))]
 		[Sql.QueryExtension(ProviderName.SqlServer2017, Sql.QueryExtensionScope.QueryHint, typeof(HintExtensionBuilder))]
 		[Sql.QueryExtension(ProviderName.SqlServer2019, Sql.QueryExtensionScope.QueryHint, typeof(HintExtensionBuilder))]
+		[Sql.QueryExtension(ProviderName.SqlServer2022, Sql.QueryExtensionScope.QueryHint, typeof(HintExtensionBuilder))]
 		[Sql.QueryExtension(null,                   Sql.QueryExtensionScope.None,      typeof(NoneExtensionBuilder))]
 		public static ISqlServerSpecificQueryable<TSource> QueryHint2016Plus<TSource>(this ISqlServerSpecificQueryable<TSource> source, [SqlQueryDependent] string hint)
 			where TSource : notnull

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerMappingSchema.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerMappingSchema.cs
@@ -4,18 +4,18 @@ using System.Data.SqlTypes;
 using System.Globalization;
 using System.IO;
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Xml;
-using System.Runtime.CompilerServices;
 
 namespace LinqToDB.DataProvider.SqlServer
 {
 	using Common;
 	using Expressions;
-	using Metadata;
-	using Mapping;
-	using SqlQuery;
 	using Extensions;
+	using Mapping;
+	using Metadata;
+	using SqlQuery;
 
 	sealed class SqlServerMappingSchema : LockedMappingSchema
 	{
@@ -624,6 +624,28 @@ namespace LinqToDB.DataProvider.SqlServer
 		public sealed class SqlServer2019MappingSchema : LockedMappingSchema
 		{
 			public SqlServer2019MappingSchema() : base(ProviderName.SqlServer2019, Instance)
+			{
+				ColumnNameComparer = StringComparer.OrdinalIgnoreCase;
+
+				SetValueToSqlConverter(typeof(TimeSpan)      , (sb, dt, v) => ConvertTimeSpanToSql      (sb, dt, (TimeSpan)v             , true, true));
+				SetValueToSqlConverter(typeof(SqlDateTime)   , (sb, dt, v) => ConvertDateTimeToSql      (sb, dt, (DateTime)(SqlDateTime)v, true, true));
+				SetValueToSqlConverter(typeof(DateTime)      , (sb, dt, v) => ConvertDateTimeToSql      (sb, dt, (DateTime)v             , true, true));
+				SetValueToSqlConverter(typeof(DateTimeOffset), (sb, dt, v) => ConvertDateTimeOffsetToSql(sb, dt, (DateTimeOffset)v       , true, true));
+
+#if NET6_0_OR_GREATER
+				SetValueToSqlConverter(typeof(DateOnly)      , (sb, dt, v) => ConvertDateToSql          (sb, dt, (DateOnly)v             , true, true));
+#endif
+			}
+
+			public override LambdaExpression? TryGetConvertExpression(Type @from, Type to)
+			{
+				return Instance.TryGetConvertExpression(@from, to);
+			}
+		}
+
+		public sealed class SqlServer2022MappingSchema : LockedMappingSchema
+		{
+			public SqlServer2022MappingSchema() : base(ProviderName.SqlServer2022, Instance)
 			{
 				ColumnNameComparer = StringComparer.OrdinalIgnoreCase;
 

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerSchemaProvider.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlTypes;
 using System.Linq;
 
 namespace LinqToDB.DataProvider.SqlServer
 {
 	using Data;
 	using SchemaProvider;
-	using System.Data;
-	using System.Data.SqlTypes;
 
 	class SqlServerSchemaProvider : SchemaProviderBase
 	{

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerSpecific.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerSpecific.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Linq.Expressions;
 
 using JetBrains.Annotations;

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerSqlBuilder.cs
@@ -8,8 +8,8 @@ namespace LinqToDB.DataProvider.SqlServer
 {
 	using Common;
 	using Mapping;
-	using SqlQuery;
 	using SqlProvider;
+	using SqlQuery;
 
 	abstract class SqlServerSqlBuilder : BasicSqlBuilder
 	{

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerTools.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerTools.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Data;
 using System.Data.Common;
 using System.Reflection;
 using System.Text;
@@ -28,6 +27,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		static readonly Lazy<IDataProvider> _sqlServerDataProvider2016sdc = CreateDataProvider<SqlServerDataProvider2016SystemDataSqlClient>();
 		static readonly Lazy<IDataProvider> _sqlServerDataProvider2017sdc = CreateDataProvider<SqlServerDataProvider2017SystemDataSqlClient>();
 		static readonly Lazy<IDataProvider> _sqlServerDataProvider2019sdc = CreateDataProvider<SqlServerDataProvider2019SystemDataSqlClient>();
+		static readonly Lazy<IDataProvider> _sqlServerDataProvider2022sdc = CreateDataProvider<SqlServerDataProvider2022SystemDataSqlClient>();
 		// Microsoft.Data.SqlClient
 		static readonly Lazy<IDataProvider> _sqlServerDataProvider2005mdc = CreateDataProvider<SqlServerDataProvider2005MicrosoftDataSqlClient>();
 		static readonly Lazy<IDataProvider> _sqlServerDataProvider2008mdc = CreateDataProvider<SqlServerDataProvider2008MicrosoftDataSqlClient>();
@@ -36,6 +36,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		static readonly Lazy<IDataProvider> _sqlServerDataProvider2016mdc = CreateDataProvider<SqlServerDataProvider2016MicrosoftDataSqlClient>();
 		static readonly Lazy<IDataProvider> _sqlServerDataProvider2017mdc = CreateDataProvider<SqlServerDataProvider2017MicrosoftDataSqlClient>();
 		static readonly Lazy<IDataProvider> _sqlServerDataProvider2019mdc = CreateDataProvider<SqlServerDataProvider2019MicrosoftDataSqlClient>();
+		static readonly Lazy<IDataProvider> _sqlServerDataProvider2022mdc = CreateDataProvider<SqlServerDataProvider2022MicrosoftDataSqlClient>();
 
 		static Lazy<IDataProvider> CreateDataProvider<T>()
 			where T : SqlServerDataProvider, new()
@@ -100,6 +101,7 @@ namespace LinqToDB.DataProvider.SqlServer
 					if (css.Name.Contains("2016") || css.ProviderName?.Contains("2016") == true) return GetDataProvider(SqlServerVersion.v2016, provider);
 					if (css.Name.Contains("2017") || css.ProviderName?.Contains("2017") == true) return GetDataProvider(SqlServerVersion.v2017, provider);
 					if (css.Name.Contains("2019") || css.ProviderName?.Contains("2019") == true) return GetDataProvider(SqlServerVersion.v2019, provider);
+					if (css.Name.Contains("2022") || css.ProviderName?.Contains("2022") == true) return GetDataProvider(SqlServerVersion.v2022, provider);
 
 					if (AutoDetectProvider)
 					{
@@ -122,6 +124,8 @@ namespace LinqToDB.DataProvider.SqlServer
 										cmd.CommandText = "SELECT compatibility_level FROM sys.databases WHERE name = db_name()";
 										var level = Converter.ChangeTypeTo<int>(cmd.ExecuteScalar());
 
+										if (level >= 160)
+											return GetDataProvider(SqlServerVersion.v2022, provider);
 										if (level >= 150)
 											return GetDataProvider(SqlServerVersion.v2019, provider);
 										if (level >= 140)
@@ -149,8 +153,9 @@ namespace LinqToDB.DataProvider.SqlServer
 											case 12 : return GetDataProvider(SqlServerVersion.v2014, provider);
 											case 13 : return GetDataProvider(SqlServerVersion.v2016, provider);
 											case 14 : return GetDataProvider(SqlServerVersion.v2017, provider);
-											//case 15 : // v2019 : no own dialect yet
-											default : return GetDataProvider(SqlServerVersion.v2019, provider);
+											case 15 : return GetDataProvider(SqlServerVersion.v2019, provider);
+											//case 16 :
+											default : return GetDataProvider(SqlServerVersion.v2022, provider);
 										}
 									}
 								}
@@ -183,6 +188,7 @@ namespace LinqToDB.DataProvider.SqlServer
 				(SqlServerProvider.SystemDataSqlClient,    SqlServerVersion.v2016) => _sqlServerDataProvider2016sdc.Value,
 				(SqlServerProvider.SystemDataSqlClient,    SqlServerVersion.v2017) => _sqlServerDataProvider2017sdc.Value,
 				(SqlServerProvider.SystemDataSqlClient,    SqlServerVersion.v2019) => _sqlServerDataProvider2019sdc.Value,
+				(SqlServerProvider.SystemDataSqlClient,    SqlServerVersion.v2022) => _sqlServerDataProvider2022sdc.Value,
 				(SqlServerProvider.SystemDataSqlClient,    _                     ) => _sqlServerDataProvider2008sdc.Value,
 				(SqlServerProvider.MicrosoftDataSqlClient, SqlServerVersion.v2005) => _sqlServerDataProvider2005mdc.Value,
 				(SqlServerProvider.MicrosoftDataSqlClient, SqlServerVersion.v2012) => _sqlServerDataProvider2012mdc.Value,
@@ -190,6 +196,7 @@ namespace LinqToDB.DataProvider.SqlServer
 				(SqlServerProvider.MicrosoftDataSqlClient, SqlServerVersion.v2016) => _sqlServerDataProvider2016mdc.Value,
 				(SqlServerProvider.MicrosoftDataSqlClient, SqlServerVersion.v2017) => _sqlServerDataProvider2017mdc.Value,
 				(SqlServerProvider.MicrosoftDataSqlClient, SqlServerVersion.v2019) => _sqlServerDataProvider2019mdc.Value,
+				(SqlServerProvider.MicrosoftDataSqlClient, SqlServerVersion.v2022) => _sqlServerDataProvider2022mdc.Value,
 				(SqlServerProvider.MicrosoftDataSqlClient, _                     ) => _sqlServerDataProvider2008mdc.Value,
 				_ => _sqlServerDataProvider2008sdc.Value,
 			};

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerVersion.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerVersion.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace LinqToDB.DataProvider.SqlServer
+﻿namespace LinqToDB.DataProvider.SqlServer
 {
 	public enum SqlServerVersion
 	{
@@ -11,5 +9,6 @@ namespace LinqToDB.DataProvider.SqlServer
 		v2016,
 		v2017,
 		v2019,
+		v2022,
 	}
 }

--- a/Source/LinqToDB/DataProvider/SqlServer/SystemDataSqlServerAttributeReader.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SystemDataSqlServerAttributeReader.cs
@@ -7,7 +7,6 @@ namespace LinqToDB.Metadata
 {
 	using Common;
 	using Extensions;
-	using LinqToDB.DataProvider.SqlServer;
 	using Mapping;
 
 	/// <summary>

--- a/Source/LinqToDB/ProviderName.cs
+++ b/Source/LinqToDB/ProviderName.cs
@@ -95,6 +95,11 @@ namespace LinqToDB
 		/// </summary>
 		public const string SqlServer2019 = "SqlServer.2019";
 		/// <summary>
+		/// Microsoft SQL Server 2022 provider.
+		/// Used as configuration name for SQL Server 2019 mapping schema <see cref="SqlServerMappingSchema.SqlServer2022MappingSchema"/>.
+		/// </summary>
+		public const string SqlServer2022 = "SqlServer.2022";
+		/// <summary>
 		/// MySql provider.
 		/// Used as configuration name for MySql mapping schema <see cref="DataProvider.MySql.MySqlMappingSchema"/>.
 		/// </summary>

--- a/Source/LinqToDB/Sql/Sql.Analytic.cs
+++ b/Source/LinqToDB/Sql/Sql.Analytic.cs
@@ -112,7 +112,7 @@ namespace LinqToDB
 			{
 				case Sql.Nulls.None   :
 				case Sql.Nulls.Respect:
-					// no need to add RESPECT NULLS, as it is default behavior and token itself supported only by Oracle and Informix
+					// no need to add RESPECT NULLS, as it is default behavior and token itself supported only by Oracle, Informix and SQL Server 2022
 					return string.Empty;
 				case Sql.Nulls.Ignore :
 					return "IGNORE NULLS";
@@ -708,6 +708,7 @@ namespace LinqToDB
 			throw new LinqException($"'{nameof(DenseRank)}' is server-side method.");
 		}
 
+		[Sql.Extension("FIRST_VALUE({expr}){_}{modifier?}", TokenName = FunctionToken, BuilderType = typeof(ApplyNullsModifier), ChainPrecedence = 1, IsWindowFunction = true, Configuration = ProviderName.SqlServer2022)]
 		[Sql.Extension("FIRST_VALUE({expr}{_}{modifier?})", TokenName = FunctionToken, BuilderType = typeof(ApplyNullsModifier), ChainPrecedence = 1, IsWindowFunction = true)]
 		public static IAggregateFunctionSelfContained<T> FirstValue<T>(this Sql.ISqlExtension? ext, [ExprParameter] T expr, [SqlQueryDependent] Sql.Nulls nulls)
 		{
@@ -744,6 +745,7 @@ namespace LinqToDB
 			throw new LinqException($"'{nameof(Lag)}' is server-side method.");
 		}
 
+		[Sql.Extension("LAST_VALUE({expr}){_}{modifier?}", TokenName = FunctionToken, BuilderType = typeof(ApplyNullsModifier), ChainPrecedence = 1, IsWindowFunction = true, Configuration = ProviderName.SqlServer2022)]
 		[Sql.Extension("LAST_VALUE({expr}{_}{modifier?})", TokenName = FunctionToken, BuilderType = typeof(ApplyNullsModifier), ChainPrecedence = 1, IsWindowFunction = true)]
 		public static IAggregateFunctionSelfContained<T> LastValue<T>(this Sql.ISqlExtension? ext, [ExprParameter] T expr, [SqlQueryDependent] Sql.Nulls nulls)
 		{

--- a/Source/LinqToDB/Sql/Sql.Strings.cs
+++ b/Source/LinqToDB/Sql/Sql.Strings.cs
@@ -54,6 +54,7 @@ namespace LinqToDB
 			}
 		}
 
+		[Extension(PN.SqlServer2022, "STRING_AGG({source}, {separator}){_}{aggregation_ordering?}",       IsAggregate = true, ChainPrecedence = 10, BuilderType = typeof(StringAggSql2017Builder))]
 		[Extension(PN.SqlServer2019, "STRING_AGG({source}, {separator}){_}{aggregation_ordering?}",       IsAggregate = true, ChainPrecedence = 10, BuilderType = typeof(StringAggSql2017Builder))]
 		[Extension(PN.SqlServer2017, "STRING_AGG({source}, {separator}){_}{aggregation_ordering?}",       IsAggregate = true, ChainPrecedence = 10, BuilderType = typeof(StringAggSql2017Builder))]
 		[Extension(PN.PostgreSQL,    "STRING_AGG({source}, {separator}{_}{order_by_clause?})",            IsAggregate = true, ChainPrecedence = 10)]
@@ -83,6 +84,7 @@ namespace LinqToDB
 			return new AggregateFunctionNotOrderedImpl<string?, string>(query);
 		}
 
+		[Extension(PN.SqlServer2022, "STRING_AGG({selector}, {separator}){_}{aggregation_ordering?}",       IsAggregate = true, ChainPrecedence = 10, BuilderType = typeof(StringAggSql2017Builder))]
 		[Extension(PN.SqlServer2019, "STRING_AGG({selector}, {separator}){_}{aggregation_ordering?}",       IsAggregate = true, ChainPrecedence = 10, BuilderType = typeof(StringAggSql2017Builder))]
 		[Extension(PN.SqlServer2017, "STRING_AGG({selector}, {separator}){_}{aggregation_ordering?}",       IsAggregate = true, ChainPrecedence = 10, BuilderType = typeof(StringAggSql2017Builder))]
 		[Extension(PN.PostgreSQL,    "STRING_AGG({selector}, {separator}{_}{order_by_clause?})",            IsAggregate = true, ChainPrecedence = 10)]
@@ -104,6 +106,7 @@ namespace LinqToDB
 			throw new LinqException($"'{nameof(StringAggregate)}' is server-side method.");
 		}
 
+		[Extension(PN.SqlServer2022, "STRING_AGG({selector}, {separator}){_}{aggregation_ordering?}",       IsAggregate = true, ChainPrecedence = 10, BuilderType = typeof(StringAggSql2017Builder))]
 		[Extension(PN.SqlServer2019, "STRING_AGG({selector}, {separator}){_}{aggregation_ordering?}",       IsAggregate = true, ChainPrecedence = 10, BuilderType = typeof(StringAggSql2017Builder))]
 		[Extension(PN.SqlServer2017, "STRING_AGG({selector}, {separator}){_}{aggregation_ordering?}",       IsAggregate = true, ChainPrecedence = 10, BuilderType = typeof(StringAggSql2017Builder))]
 		[Extension(PN.PostgreSQL,    "STRING_AGG({selector}, {separator}{_}{order_by_clause?})",            IsAggregate = true, ChainPrecedence = 10)]
@@ -135,6 +138,7 @@ namespace LinqToDB
 			return new AggregateFunctionNotOrderedImpl<T, string>(query);
 		}
 
+		[Extension(PN.SqlServer2022, "STRING_AGG({source}, {separator}){_}{aggregation_ordering?}",       IsAggregate = true, ChainPrecedence = 10, BuilderType = typeof(StringAggSql2017Builder))]
 		[Extension(PN.SqlServer2019, "STRING_AGG({source}, {separator}){_}{aggregation_ordering?}",       IsAggregate = true, ChainPrecedence = 10, BuilderType = typeof(StringAggSql2017Builder))]
 		[Extension(PN.SqlServer2017, "STRING_AGG({source}, {separator}){_}{aggregation_ordering?}",       IsAggregate = true, ChainPrecedence = 10, BuilderType = typeof(StringAggSql2017Builder))]
 		[Extension(PN.PostgreSQL,    "STRING_AGG({source}, {separator}{_}{order_by_clause?})",            IsAggregate = true, ChainPrecedence = 10)]
@@ -266,6 +270,7 @@ namespace LinqToDB
 		/// <param name="separator">The string to use as a separator. <paramref name="separator" /> is included in the returned string only if <paramref name="arguments" /> has more than one element.</param>
 		/// <param name="arguments">A collection that contains the strings to concatenate.</param>
 		/// <returns></returns>
+		[Extension(PN.SqlServer2022, "CONCAT_WS({separator}, {argument, ', '})", BuilderType = typeof(CommonConcatWsArgumentsBuilder), BuilderValue = "ISNULL({0}, '')")]
 		[Extension(PN.SqlServer2019, "CONCAT_WS({separator}, {argument, ', '})", BuilderType = typeof(CommonConcatWsArgumentsBuilder), BuilderValue = "ISNULL({0}, '')")]
 		[Extension(PN.SqlServer2017, "CONCAT_WS({separator}, {argument, ', '})", BuilderType = typeof(CommonConcatWsArgumentsBuilder), BuilderValue = "ISNULL({0}, '')")]
 		[Extension(PN.PostgreSQL,    "CONCAT_WS({separator}, {argument, ', '})", BuilderType = typeof(CommonConcatWsArgumentsBuilder), BuilderValue = null)]

--- a/Source/LinqToDB/Sql/Sql.Types.cs
+++ b/Source/LinqToDB/Sql/Sql.Types.cs
@@ -114,6 +114,7 @@ namespace LinqToDB
 
 			[Property(PN.PostgreSQL,    "TimeStamp",      ServerSideOnly=true, CanBeNull = false)]
 			[Property(PN.Firebird,      "TimeStamp",      ServerSideOnly=true, CanBeNull = false)]
+			[Property(PN.SqlServer2022, "DateTimeOffset", ServerSideOnly=true, CanBeNull = false)]
 			[Property(PN.SqlServer2019, "DateTimeOffset", ServerSideOnly=true, CanBeNull = false)]
 			[Property(PN.SqlServer2017, "DateTimeOffset", ServerSideOnly=true, CanBeNull = false)]
 			[Property(PN.SqlServer2016, "DateTimeOffset", ServerSideOnly=true, CanBeNull = false)]

--- a/Source/LinqToDB/Sql/Sql.cs
+++ b/Source/LinqToDB/Sql/Sql.cs
@@ -643,6 +643,7 @@ namespace LinqToDB
 		[Extension(PN.SqlServer,     typeof(IsNullOrWhiteSpaceSqlServerBuilder),                   IsPredicate = true)]
 		[Extension(PN.SqlServer2017, typeof(IsNullOrWhiteSpaceSqlServer2017Builder),               IsPredicate = true)]
 		[Extension(PN.SqlServer2019, typeof(IsNullOrWhiteSpaceSqlServer2017Builder),               IsPredicate = true)]
+		[Extension(PN.SqlServer2022, typeof(IsNullOrWhiteSpaceSqlServer2017Builder),               IsPredicate = true)]
 		[Extension(PN.Access,        typeof(IsNullOrWhiteSpaceAccessBuilder),                      IsPredicate = true)]
 		[Extension(PN.Sybase,        typeof(IsNullOrWhiteSpaceSybaseBuilder),                      IsPredicate = true)]
 		[Extension(PN.MySql,         typeof(IsNullOrWhiteSpaceMySqlBuilder),                       IsPredicate = true)]

--- a/Tests/Base/TestProvName.cs
+++ b/Tests/Base/TestProvName.cs
@@ -129,6 +129,7 @@ namespace Tests
 		public const string SqlServer2016MS              = "SqlServer.2016.MS";
 		public const string SqlServer2017MS              = "SqlServer.2017.MS";
 		public const string SqlServer2019MS              = "SqlServer.2019.MS";
+		public const string SqlServer2022MS              = "SqlServer.2022.MS";
 
 		public const string SqlServerSequentialAccess    = "SqlServer.SA";
 		public const string SqlServerSequentialAccessMS  = "SqlServer.SA.MS";
@@ -149,14 +150,16 @@ namespace Tests
 		public const string AllSqlServer2016             = $"{ProviderName.SqlServer2016},{SqlServer2016MS}";
 		public const string AllSqlServer2017             = $"{ProviderName.SqlServer2017},{SqlServer2017MS}";
 		public const string AllSqlServer2019             = $"{ProviderName.SqlServer2019},{SqlServer2019MS},{AllSqlServerSequentialAccess},{AllSqlServerContained}";
+		public const string AllSqlServer2022             = $"{ProviderName.SqlServer2022},{SqlServer2022MS}";
 		public const string AllSqlServer2008Minus        = $"{AllSqlServer2005},{AllSqlServer2008}";
-		public const string AllSqlServer2019Plus         = $"{AllSqlServer2019},{AllSqlAzure}";
+		public const string AllSqlServer2022Plus         = $"{AllSqlServer2022},{AllSqlAzure}";
+		public const string AllSqlServer2019Plus         = $"{AllSqlServer2019},{AllSqlServer2022Plus}";
 		public const string AllSqlServer2017Plus         = $"{AllSqlServer2017},{AllSqlServer2019Plus}";
 		public const string AllSqlServer2016Plus         = $"{AllSqlServer2016},{AllSqlServer2017Plus}";
-		public const string AllSqlServer2012PlusNoAzure  = $"{AllSqlServer2012},{AllSqlServer2014},{AllSqlServer2016},{AllSqlServer2017},{AllSqlServer2019}";
 		public const string AllSqlServer2012Plus         = $"{AllSqlServer2012},{AllSqlServer2014},{AllSqlServer2016Plus}";
 		public const string AllSqlServer2008Plus         = $"{AllSqlServer2008},{AllSqlServer2012Plus}";
-		public const string AllSqlServerNoAzure          = $"{AllSqlServer2005},{AllSqlServer2008},{AllSqlServer2012},{AllSqlServer2014},{AllSqlServer2016},{AllSqlServer2017},{AllSqlServer2019}";
+		public const string AllSqlServer2012PlusNoAzure  = $"{AllSqlServer2012},{AllSqlServer2014},{AllSqlServer2016},{AllSqlServer2017},{AllSqlServer2019},{AllSqlServer2022}";
+		public const string AllSqlServerNoAzure          = $"{AllSqlServer2005},{AllSqlServer2008},{AllSqlServer2012PlusNoAzure}";
 		public const string AllSqlServer                 = $"{AllSqlServerNoAzure},{AllSqlAzure}";
 		#endregion
 

--- a/Tests/DataProviders.json
+++ b/Tests/DataProviders.json
@@ -156,6 +156,14 @@
 				"Provider": "Microsoft.Data.SqlClient",
 				"ConnectionString": "Server=DBHost\\SQLSERVER2019;Database=TestData;User Id=sa;Password=TestPassword;Encrypt=true;TrustServerCertificate=true"
 			},
+			"SqlServer.2022": {
+				"Provider": "System.Data.SqlClient",
+				"ConnectionString": "Server=DBHost\\SQLSERVER2019;Database=TestData;User Id=sa;Password=TestPassword;Encrypt=true;TrustServerCertificate=true"
+			},
+			"SqlServer.2022.MS": {
+				"Provider": "Microsoft.Data.SqlClient",
+				"ConnectionString": "Server=DBHost\\SQLSERVER2019;Database=TestData;User Id=sa;Password=TestPassword;Encrypt=true;TrustServerCertificate=true"
+			},
 			"SqlServer.SA": {
 				"Provider": "System.Data.SqlClient",
 				"ConnectionString": "Server=DBHost\\SQLSERVER2019;Database=TestData;User Id=sa;Password=TestPassword;Encrypt=true;TrustServerCertificate=true"
@@ -312,7 +320,7 @@
 			"PostgreSQL.12": { "Provider": "Npgsql", "ConnectionString": "Server=localhost;Port=5432;Database=testdata;User Id=postgres;Password=Password12!;Pooling=true;MinPoolSize=10;MaxPoolSize=100" },
 			"PostgreSQL.13": { "Provider": "Npgsql", "ConnectionString": "Server=localhost;Port=5432;Database=testdata;User Id=postgres;Password=Password12!;Pooling=true;MinPoolSize=10;MaxPoolSize=100" },
 			"PostgreSQL.14": { "Provider": "Npgsql", "ConnectionString": "Server=localhost;Port=5432;Database=testdata;User Id=postgres;Password=Password12!;Pooling=true;MinPoolSize=10;MaxPoolSize=100" },
-			"PostgreSQL.15": { "Provider": "Npgsql", "ConnectionString": "Server=localhost;Port=5415;Database=testdata;User Id=postgres;Password=Password12!;Pooling=true;MinPoolSize=10;MaxPoolSize=100" },
+			"PostgreSQL.15": { "Provider": "Npgsql", "ConnectionString": "Server=localhost;Port=5432;Database=testdata;User Id=postgres;Password=Password12!;Pooling=true;MinPoolSize=10;MaxPoolSize=100" },
 
 			"Firebird" : { "ConnectionString": "DataSource=localhost;Port=3050;Database=/firebird/data/testdb.fdb;User Id=sysdba;Password=masterkey;charset=UTF8"                    },
 			"Firebird3": { "ConnectionString": "DataSource=localhost;Port=3050;Database=/firebird/data/testdb.fdb;User Id=sysdba;Password=masterkey;charset=UTF8;wirecrypt=disabled" },
@@ -332,6 +340,8 @@
 			"SqlServer.2017.MS"     : { "Provider": "Microsoft.Data.SqlClient", "ConnectionString": "Server=localhost;Database=TestDataMS;User Id=sa;Password=Password12!;Encrypt=true;TrustServerCertificate=true"          },
 			"SqlServer.2019"        : { "Provider": "System.Data.SqlClient"   , "ConnectionString": "Server=localhost;Database=TestData;User Id=sa;Password=Password12!;Encrypt=true;TrustServerCertificate=true"            },
 			"SqlServer.2019.MS"     : { "Provider": "Microsoft.Data.SqlClient", "ConnectionString": "Server=localhost;Database=TestDataMS;User Id=sa;Password=Password12!;Encrypt=true;TrustServerCertificate=true"          },
+			"SqlServer.2022"        : { "Provider": "System.Data.SqlClient"   , "ConnectionString": "Server=localhost;Database=TestData;User Id=sa;Password=Password12!;Encrypt=true;TrustServerCertificate=true"            },
+			"SqlServer.2022.MS"     : { "Provider": "Microsoft.Data.SqlClient", "ConnectionString": "Server=localhost;Database=TestDataMS;User Id=sa;Password=Password12!;Encrypt=true;TrustServerCertificate=true"          },
 			"SqlServer.SA"          : { "Provider": "System.Data.SqlClient"   , "ConnectionString": "Server=localhost;Database=TestDataSA;User Id=sa;Password=Password12!;Encrypt=true;TrustServerCertificate=true"          },
 			"SqlServer.SA.MS"       : { "Provider": "Microsoft.Data.SqlClient", "ConnectionString": "Server=localhost;Database=TestDataMSSA;User Id=sa;Password=Password12!;Encrypt=true;TrustServerCertificate=true"        },
 			"SqlServer.Contained"   : { "Provider": "System.Data.SqlClient"   , "ConnectionString": "Server=localhost;Database=TestDataContained;User Id=sa;Password=Password12!;Encrypt=true;TrustServerCertificate=true"   },
@@ -402,6 +412,8 @@
 			"SqlServer.2017.MS",
 			"SqlServer.2019",
 			"SqlServer.2019.MS",
+			"SqlServer.2022",
+			"SqlServer.2022.MS",
 			"SqlServer.SA",
 			"SqlServer.SA.MS",
 			"SqlServer.Contained",

--- a/Tests/Linq/Linq/DateTimeOffsetTests.cs
+++ b/Tests/Linq/Linq/DateTimeOffsetTests.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 using System.Linq;
+using System.Runtime.InteropServices;
 using LinqToDB;
+using LinqToDB.Mapping;
+using LinqToDB.Tools;
 using NUnit.Framework;
 
 namespace Tests.Linq
 {
-	using System.Runtime.InteropServices;
-	using LinqToDB.Mapping;
-	using LinqToDB.Tools;
-
 	[TestFixture]
 	public class DateTimeOffsetTests : TestBase
 	{

--- a/Tests/Linq/Linq/IsDistinctFromTests.cs
+++ b/Tests/Linq/Linq/IsDistinctFromTests.cs
@@ -1,8 +1,9 @@
-﻿using LinqToDB;
+﻿using System.Linq;
+using System.Runtime.InteropServices;
+using FluentAssertions;
+using LinqToDB;
 using LinqToDB.Data;
 using NUnit.Framework;
-using System.Linq;
-using FluentAssertions;
 
 namespace Tests.Linq
 {
@@ -26,6 +27,11 @@ namespace Tests.Linq
 			[DataSources]        string context,
 			[Values(2, 4, null)] int?   value)
 		{
+			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && context.IsAnyOf(TestProvName.AllSqlServer2022Plus))
+			{
+				Assert.Inconclusive("CTP2.1 docker image required");
+			}
+
 			using var db  = GetDataContext(context);
 			using var src = SetupSrcTable(db);
 
@@ -49,6 +55,11 @@ namespace Tests.Linq
 			[DataSources(TestProvName.AllAccess)] string context,
 			[Values("abc", "xyz", null)] string? value)
 		{
+			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && context.IsAnyOf(TestProvName.AllSqlServer2022Plus))
+			{
+				Assert.Inconclusive("CTP2.1 docker image required");
+			}
+
 			using var db  = GetDataContext(context);
 			using var src = SetupSrcTable(db);
 
@@ -85,11 +96,11 @@ namespace Tests.Linq
 				c2.LastQuery.Should().NotContainAny("5", "6");
 		}
 
-		class Src 
+		class Src
 		{
-			public int Int { get; set; }
-			public int? NullableInt { get; set; }
-			public string String { get; set; } = null!;
+			public int     Int            { get; set; }
+			public int?    NullableInt    { get; set; }
+			public string  String         { get; set; } = null!;
 			public string? NullableString { get; set; }
 		}
 	}

--- a/Tests/Linq/Linq/IsDistinctFromTests.cs
+++ b/Tests/Linq/Linq/IsDistinctFromTests.cs
@@ -27,9 +27,9 @@ namespace Tests.Linq
 			[DataSources]        string context,
 			[Values(2, 4, null)] int?   value)
 		{
-			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && context.IsAnyOf(TestProvName.AllSqlServer2022Plus))
+			if (context.IsAnyOf(TestProvName.AllSqlServer2022Plus))
 			{
-				Assert.Inconclusive("CTP2.1 docker image required");
+				Assert.Inconclusive("Temporary disabled. CTP2.1 docker image required");
 			}
 
 			using var db  = GetDataContext(context);
@@ -55,9 +55,9 @@ namespace Tests.Linq
 			[DataSources(TestProvName.AllAccess)] string context,
 			[Values("abc", "xyz", null)] string? value)
 		{
-			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && context.IsAnyOf(TestProvName.AllSqlServer2022Plus))
+			if (context.IsAnyOf(TestProvName.AllSqlServer2022Plus))
 			{
-				Assert.Inconclusive("CTP2.1 docker image required");
+				Assert.Inconclusive("Temporary disabled. CTP2.1 docker image required");
 			}
 
 			using var db  = GetDataContext(context);

--- a/Tests/Linq/Update/MergeTests.Operations.Update.cs
+++ b/Tests/Linq/Update/MergeTests.Operations.Update.cs
@@ -746,15 +746,15 @@ namespace Tests.xUpdate
 
 				var rows = table
 					.Merge()
-					.Using(GetSource2(db).ToList().Select(_ => new
+					.Using(GetSource2(db).ToList().OrderBy(_ => _.OtherId).Select(_ => new
 					{
-						@in = _.OtherId,
-						join = _.OtherField1,
-						outer = _.OtherField2,
-						inner = _.OtherField3,
-						with = _.OtherField4,
-						left = _.OtherField5,
-						Left = _.OtherField2
+						@in    = _.OtherId,
+						join   = _.OtherField1,
+						outer  = _.OtherField2,
+						inner  = _.OtherField3,
+						with   = _.OtherField4,
+						left   = _.OtherField5,
+						Left   = _.OtherField2
 					}))
 					.On((t, s) => t.Id == s.@in)
 					.UpdateWhenMatchedAnd(

--- a/Tests/UserDataProviders.json.template
+++ b/Tests/UserDataProviders.json.template
@@ -38,6 +38,8 @@
 			//"SqlServer.2017.MS",
 			//"SqlServer.2019",
 			//"SqlServer.2019.MS",
+			//"SqlServer.2022",
+			//"SqlServer.2022.MS",
 			//"SqlServer.SA",
 			//"SqlServer.SA.MS",
 			//"SqlServer.Contained",
@@ -150,6 +152,8 @@
 			//"SqlServer.2017.MS",
 			//"SqlServer.2019",
 			//"SqlServer.2019.MS",
+			//"SqlServer.2022",
+			//"SqlServer.2022.MS",
 			//"SqlServer.SA",
 			//"SqlServer.SA.MS",
 			//"SqlServer.Contained",
@@ -256,6 +260,8 @@
 			//"SqlServer.2017.MS",
 			//"SqlServer.2019",
 			//"SqlServer.2019.MS",
+			//"SqlServer.2022",
+			//"SqlServer.2022.MS",
 			//"SqlServer.SA",
 			//"SqlServer.SA.MS",
 			//"SqlServer.Contained",
@@ -377,11 +383,19 @@
 				"Provider": "Microsoft.Data.SqlClient",
 				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
 			},
-			"SqlServer.2018": {
+			"SqlServer.2019": {
 				"Provider": "System.Data.SqlClient",
 				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
 			},
-			"SqlServer.2018.MS": {
+			"SqlServer.2019.MS": {
+				"Provider": "Microsoft.Data.SqlClient",
+				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
+			},
+			"SqlServer.2022": {
+				"Provider": "System.Data.SqlClient",
+				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
+			},
+			"SqlServer.2022.MS": {
 				"Provider": "Microsoft.Data.SqlClient",
 				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
 			},

--- a/Tests/UserDataProviders.json.template
+++ b/Tests/UserDataProviders.json.template
@@ -328,7 +328,8 @@
 		]
 	},
 
-	// for those providers you should specify connection string first to use them
+	// For those providers you should specify connection string first to use them.
+	// If we have setup script for database in "Data\Setup Scripts" folder, connection string is already set
 	"MyConnectionStrings": {
 		"BasedOn": "CommonConnectionStrings",
 		"DefaultConfiguration": "SQLite.Classic",
@@ -375,54 +376,20 @@
 				"Provider": "Microsoft.Data.SqlClient",
 				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
 			},
-			"SqlServer.2017": {
-				"Provider": "System.Data.SqlClient",
-				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
-			},
-			"SqlServer.2017.MS": {
-				"Provider": "Microsoft.Data.SqlClient",
-				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
-			},
-			"SqlServer.2019": {
-				"Provider": "System.Data.SqlClient",
-				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
-			},
-			"SqlServer.2019.MS": {
-				"Provider": "Microsoft.Data.SqlClient",
-				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
-			},
-			"SqlServer.2022": {
-				"Provider": "System.Data.SqlClient",
-				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
-			},
-			"SqlServer.2022.MS": {
-				"Provider": "Microsoft.Data.SqlClient",
-				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
-			},
-			"SqlServer.SA": {
-				"Provider": "System.Data.SqlClient",
-				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
-			},
-			"SqlServer.SA.MS": {
-				"Provider": "Microsoft.Data.SqlClient",
-				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
-			},
-			"SqlServer.Contained": {
-				"Provider": "System.Data.SqlClient",
-				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
-			},
-			"SqlServer.Contained.MS": {
-				"Provider": "Microsoft.Data.SqlClient",
-				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
-			},
-			"SqlServer.Northwind": {
-				"Provider": "System.Data.SqlClient",
-				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
-			},
-			"SqlServer.Northwind.MS": {
-				"Provider": "Microsoft.Data.SqlClient",
-				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
-			},
+
+			"SqlServer.2017"        : { "Provider": "System.Data.SqlClient"   , "ConnectionString": "Server=localhost,1417;Database=TestData;User Id=sa;Password=Password12!;Encrypt=true;TrustServerCertificate=true"          },
+			"SqlServer.2017.MS"     : { "Provider": "Microsoft.Data.SqlClient", "ConnectionString": "Server=localhost,1417;Database=TestDataMS;User Id=sa;Password=Password12!;Encrypt=true;TrustServerCertificate=true"        },
+			"SqlServer.2019"        : { "Provider": "System.Data.SqlClient"   , "ConnectionString": "Server=localhost,1419;Database=TestData;User Id=sa;Password=Password12!;Encrypt=true;TrustServerCertificate=true"          },
+			"SqlServer.2019.MS"     : { "Provider": "Microsoft.Data.SqlClient", "ConnectionString": "Server=localhost,1419;Database=TestDataMS;User Id=sa;Password=Password12!;Encrypt=true;TrustServerCertificate=true"        },
+			"SqlServer.2022"        : { "Provider": "System.Data.SqlClient"   , "ConnectionString": "Server=localhost,1422;Database=TestData;User Id=sa;Password=Password12!;Encrypt=true;TrustServerCertificate=true"          },
+			"SqlServer.2022.MS"     : { "Provider": "Microsoft.Data.SqlClient", "ConnectionString": "Server=localhost,1422;Database=TestDataMS;User Id=sa;Password=Password12!;Encrypt=true;TrustServerCertificate=true"        },
+			"SqlServer.SA"          : { "Provider": "System.Data.SqlClient"   , "ConnectionString": "localhost,1419;Database=TestDataSA;User Id=sa;Password=Password12!;Encrypt=true;TrustServerCertificate=true"               },
+			"SqlServer.SA.MS"       : { "Provider": "Microsoft.Data.SqlClient", "ConnectionString": "localhost,1419;Database=TestDataMSSA;User Id=sa;Password=Password12!;Encrypt=true;TrustServerCertificate=true"             },
+			"SqlServer.Contained"   : { "Provider": "System.Data.SqlClient"   , "ConnectionString": "localhost,1419;Database=TestDataContained;User Id=sa;Password=Password12!Encrypt=true;TrustServerCertificate=true"         },
+			"SqlServer.Contained.MS": { "Provider": "Microsoft.Data.SqlClient", "ConnectionString": "localhost,1419;Database=TestDataMSContained;User Id=sa;Password=Password12!;Encrypt=true;TrustServerCertificate=true"      },
+			"SqlServer.Northwind"   : { "Provider": "System.Data.SqlClient"   , "ConnectionString": "localhost,1419;Database=Northwind;User Id=sa;Password=Password12!;Encrypt=true;TrustServerCertificate=true"                },
+			"SqlServer.Northwind.MS": { "Provider": "Microsoft.Data.SqlClient", "ConnectionString": "localhost,1419;Database=NorthwindMS;User Id=sa;Password=Password12!;Encrypt=true;TrustServerCertificate=true"              },
+
 			"SqlServer.Azure": {
 				"Provider": "System.Data.SqlClient",
 				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
@@ -539,42 +506,17 @@
 				"Provider": "Devart.Data.Oracle",
 				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
 			},
-			"PostgreSQL.9.2": {
-				"Provider": "Npgsql",
-				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
-			},
-			"PostgreSQL.9.3": {
-				"Provider": "Npgsql",
-				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
-			},
-			"PostgreSQL.9.5": {
-				"Provider": "Npgsql",
-				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
-			},
-			"PostgreSQL.10": {
-				"Provider": "Npgsql",
-				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
-			},
-			"PostgreSQL.11": {
-				"Provider": "Npgsql",
-				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
-			},
-			"PostgreSQL.12": {
-				"Provider": "Npgsql",
-				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
-			},
-			"PostgreSQL.13": {
-				"Provider": "Npgsql",
-				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
-			},
-			"PostgreSQL.14": {
-				"Provider": "Npgsql",
-				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
-			},
-			"PostgreSQL.15": {
-				"Provider": "Npgsql",
-				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
-			},
+
+			"PostgreSQL.9.2": { "Provider": "Npgsql", "ConnectionString": "Server=localhost;Port=5492;Database=testdata;User Id=postgres;Password=Password12!;Pooling=true;MinPoolSize=10;MaxPoolSize=100;" },
+			"PostgreSQL.9.3": { "Provider": "Npgsql", "ConnectionString": "Server=localhost;Port=5493;Database=testdata;User Id=postgres;Password=Password12!;Pooling=true;MinPoolSize=10;MaxPoolSize=100;" },
+			"PostgreSQL.9.5": { "Provider": "Npgsql", "ConnectionString": "Server=localhost;Port=5495;Database=testdata;User Id=postgres;Password=Password12!;Pooling=true;MinPoolSize=10;MaxPoolSize=100;" },
+			"PostgreSQL.10" : { "Provider": "Npgsql", "ConnectionString": "Server=localhost;Port=5410;Database=testdata;User Id=postgres;Password=Password12!;Pooling=true;MinPoolSize=10;MaxPoolSize=100;" },
+			"PostgreSQL.11" : { "Provider": "Npgsql", "ConnectionString": "Server=localhost;Port=5411;Database=testdata;User Id=postgres;Password=Password12!;Pooling=true;MinPoolSize=10;MaxPoolSize=100;" },
+			"PostgreSQL.12" : { "Provider": "Npgsql", "ConnectionString": "Server=localhost;Port=5412;Database=testdata;User Id=postgres;Password=Password12!;Pooling=true;MinPoolSize=10;MaxPoolSize=100;" },
+			"PostgreSQL.13" : { "Provider": "Npgsql", "ConnectionString": "Server=localhost;Port=5413;Database=testdata;User Id=postgres;Password=Password12!;Pooling=true;MinPoolSize=10;MaxPoolSize=100;" },
+			"PostgreSQL.14" : { "Provider": "Npgsql", "ConnectionString": "Server=localhost;Port=5414;Database=testdata;User Id=postgres;Password=Password12!;Pooling=true;MinPoolSize=10;MaxPoolSize=100;" },
+			"PostgreSQL.15" : { "Provider": "Npgsql", "ConnectionString": "Server=localhost;Port=5415;Database=testdata;User Id=postgres;Password=Password12!;Pooling=true;MinPoolSize=10;MaxPoolSize=100;" },
+
 			"Sybase": {
 				"Provider": "Sybase.Data.AseClient",
 				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
@@ -590,15 +532,10 @@
 			"SapHana.Odbc": {
 				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
 			},
-			"ClickHouse.Octonica": {
-				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
-			},
-			"ClickHouse.Client": {
-				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
-			},
-			"ClickHouse.MySql": {
-				"ConnectionString": "TODO_ADD_CONNECTION_STRING"
-			}
+
+			"ClickHouse.Octonica": { "Provider": "Octonica.ClickHouseClient", "ConnectionString": "Host=localhost;Port=9000;Database=testdb1;User=testuser;Password=testuser" },
+			"ClickHouse.Client"  : { "Provider": "ClickHouse.Client",         "ConnectionString": "Host=localhost;Port=8123;Database=testdb2;Username=testuser;Password=testuser;UseSession=true" },
+			"ClickHouse.MySql"   : { "Provider": "MySqlConnector",            "ConnectionString": "Host=localhost;Port=9004;Database=testdb3;Username=testuser;Password=testuser;Pooling=false;" }
 		}
 	},
 

--- a/linq2db.sln
+++ b/linq2db.sln
@@ -490,6 +490,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Local", "Local", "{6CB875B4
 		Data\Setup Scripts\readme.md = Data\Setup Scripts\readme.md
 		Data\Setup Scripts\sqlserver2017.cmd = Data\Setup Scripts\sqlserver2017.cmd
 		Data\Setup Scripts\sqlserver2019.cmd = Data\Setup Scripts\sqlserver2019.cmd
+		Data\Setup Scripts\sqlserver2022-win.cmd = Data\Setup Scripts\sqlserver2022-win.cmd
 		Data\Setup Scripts\sqlserver2022.cmd = Data\Setup Scripts\sqlserver2022.cmd
 	EndProjectSection
 EndProject

--- a/linq2db.sln
+++ b/linq2db.sln
@@ -281,6 +281,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "net472", "net472", "{B7AADC
 		Build\Azure\net472\sqlserver.2016.json = Build\Azure\net472\sqlserver.2016.json
 		Build\Azure\net472\sqlserver.2017.json = Build\Azure\net472\sqlserver.2017.json
 		Build\Azure\net472\sqlserver.2019.json = Build\Azure\net472\sqlserver.2019.json
+		Build\Azure\net472\sqlserver.2022.json = Build\Azure\net472\sqlserver.2022.json
 		Build\Azure\net472\sqlserver.extras.json = Build\Azure\net472\sqlserver.extras.json
 	EndProjectSection
 EndProject
@@ -333,6 +334,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{49A3
 		Build\Azure\scripts\sqlserver.2017.sh = Build\Azure\scripts\sqlserver.2017.sh
 		Build\Azure\scripts\sqlserver.2019.cmd = Build\Azure\scripts\sqlserver.2019.cmd
 		Build\Azure\scripts\sqlserver.2019.sh = Build\Azure\scripts\sqlserver.2019.sh
+		Build\Azure\scripts\sqlserver.2022.cmd = Build\Azure\scripts\sqlserver.2022.cmd
+		Build\Azure\scripts\sqlserver.2022.sh = Build\Azure\scripts\sqlserver.2022.sh
 		Build\Azure\scripts\sqlserver.extras.cmd = Build\Azure\scripts\sqlserver.extras.cmd
 		Build\Azure\scripts\sybase.sh = Build\Azure\scripts\sybase.sh
 	EndProjectSection
@@ -391,6 +394,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "netcoreapp31", "netcoreapp3
 		Build\Azure\netcoreapp31\sqlserver.2016.json = Build\Azure\netcoreapp31\sqlserver.2016.json
 		Build\Azure\netcoreapp31\sqlserver.2017.json = Build\Azure\netcoreapp31\sqlserver.2017.json
 		Build\Azure\netcoreapp31\sqlserver.2019.json = Build\Azure\netcoreapp31\sqlserver.2019.json
+		Build\Azure\netcoreapp31\sqlserver.2022.json = Build\Azure\netcoreapp31\sqlserver.2022.json
 		Build\Azure\netcoreapp31\sqlserver.extras.json = Build\Azure\netcoreapp31\sqlserver.extras.json
 		Build\Azure\netcoreapp31\sqlserver.fts.2019.json = Build\Azure\netcoreapp31\sqlserver.fts.2019.json
 		Build\Azure\netcoreapp31\sybase.json = Build\Azure\netcoreapp31\sybase.json
@@ -443,6 +447,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "net60", "net60", "{AA850554
 		Build\Azure\net60\sqlserver.2016.json = Build\Azure\net60\sqlserver.2016.json
 		Build\Azure\net60\sqlserver.2017.json = Build\Azure\net60\sqlserver.2017.json
 		Build\Azure\net60\sqlserver.2019.json = Build\Azure\net60\sqlserver.2019.json
+		Build\Azure\net60\sqlserver.2022.json = Build\Azure\net60\sqlserver.2022.json
 		Build\Azure\net60\sqlserver.extras.json = Build\Azure\net60\sqlserver.extras.json
 		Build\Azure\net60\sqlserver.fts.2019.json = Build\Azure\net60\sqlserver.fts.2019.json
 		Build\Azure\net60\sybase.json = Build\Azure\net60\sybase.json
@@ -483,6 +488,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Local", "Local", "{6CB875B4
 		Data\Setup Scripts\pgsql93.cmd = Data\Setup Scripts\pgsql93.cmd
 		Data\Setup Scripts\pgsql95.cmd = Data\Setup Scripts\pgsql95.cmd
 		Data\Setup Scripts\readme.md = Data\Setup Scripts\readme.md
+		Data\Setup Scripts\sqlserver2022.cmd = Data\Setup Scripts\sqlserver2022.cmd
 	EndProjectSection
 EndProject
 Global

--- a/linq2db.sln
+++ b/linq2db.sln
@@ -488,6 +488,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Local", "Local", "{6CB875B4
 		Data\Setup Scripts\pgsql93.cmd = Data\Setup Scripts\pgsql93.cmd
 		Data\Setup Scripts\pgsql95.cmd = Data\Setup Scripts\pgsql95.cmd
 		Data\Setup Scripts\readme.md = Data\Setup Scripts\readme.md
+		Data\Setup Scripts\sqlserver2017.cmd = Data\Setup Scripts\sqlserver2017.cmd
+		Data\Setup Scripts\sqlserver2019.cmd = Data\Setup Scripts\sqlserver2019.cmd
 		Data\Setup Scripts\sqlserver2022.cmd = Data\Setup Scripts\sqlserver2022.cmd
 	EndProjectSection
 EndProject


### PR DESCRIPTION
Fix #3659

- add new SQL Server dialect (`SqlServerVersion.v2022`)
- add `SQL Server 2022` to CI
- add support for [`INGORE NULLS`](https://docs.microsoft.com/en-us/sql/t-sql/functions/first-value-transact-sql?view=sql-server-ver15) qualifier for `FIRST_VALUE`/`LAST_VALUE` window functions (CTP 2.0)
- add support for [`IS [NOT] DISTINCT FROM`](https://docs.microsoft.com/en-us/sql/t-sql/queries/is-distinct-from-transact-sql?view=sql-server-ver15) operator (CTP 2.1)

Currently `DISTINCT FROM` tests disabled, as all available docker images still use CTP2.0
