### PR TITLE
ClickHouse 22.8.1 updates

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -60,8 +60,9 @@
 		<PackageVersion Include="MiniProfiler.Shared"                                   Version="4.2.22"        />
 		<!--don't update due to https://github.com/OData/WebApi/issues/2653-->
 		<PackageVersion Include="Microsoft.AspNet.OData"                                Version="7.5.14"        />
+		<!--don't update due to https://github.com/OData/AspNetCoreOData/issues/420#issuecomment-1219208060-->
 		<PackageVersion Include="Microsoft.AspNetCore.OData"                            Version="8.0.4"         />
-		<PackageVersion Include="NodaTime"                                              Version="3.1.1"         />
+		<PackageVersion Include="NodaTime"                                              Version="3.1.2"         />
 		<PackageVersion Include="Humanizer.Core"                                        Version="2.14.1"        />
 		<PackageVersion Include="System.Linq.Dynamic.Core"                              Version="1.2.19"        />
 		<PackageVersion Include="dotMorten.Microsoft.SqlServer.Types"                    Version="1.5.0"         />

--- a/Tests/Linq/DataProvider/Types/ClickHouseTypeTests.cs
+++ b/Tests/Linq/DataProvider/Types/ClickHouseTypeTests.cs
@@ -372,12 +372,16 @@ namespace Tests.DataProvider
 		{
 			// https://clickhouse.com/docs/en/sql-reference/data-types/date32/
 
-			var min = new DateTime(1925, 1, 1);
-			var max = new DateTime(2283, 11, 11);
+			var min = new DateTime(1900, 1, 1);
+			var max = new DateTime(2299, 12, 31);
 
-			// https://github.com/Octonica/ClickHouseClient/issues/60
+			// https://github.com/Octonica/ClickHouseClient/issues/66
 			if (context.IsAnyOf(ProviderName.ClickHouseOctonica))
+			{
+				// https://github.com/Octonica/ClickHouseClient/issues/60
 				min = new DateTime(1925, 1, 2);
+				max = new DateTime(2283, 11, 11);
+			}
 
 			// Date32
 #if NET6_0_OR_GREATER
@@ -446,15 +450,16 @@ namespace Tests.DataProvider
 		{
 			// https://clickhouse.com/docs/en/sql-reference/data-types/datetime64/
 
-			var min = new DateTime(1925, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
+			var min = new DateTime(1900, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
 			// DateTime/DateTimeOffset cannot store precision 8/9 without precision loss
-			var max = new DateTime(2283, 11, 11, 23, 59, 59, 999, DateTimeKind.Unspecified).AddTicks(9999);
+			var max = new DateTime(2299, 12, 31, 23, 59, 59, 999, DateTimeKind.Unspecified).AddTicks(9999);
 			// https://github.com/ClickHouse/ClickHouse/issues/38730
 			var max9 = new DateTime(2262, 4, 11, 23, 47, 16, 854, DateTimeKind.Unspecified).AddTicks(7758);
 			var val = TestData.DateTime;
 
 			// https://github.com/Octonica/ClickHouseClient/issues/60
 			// https://github.com/Octonica/ClickHouseClient/issues/62
+			// https://github.com/Octonica/ClickHouseClient/issues/66
 			if (context.IsAnyOf(ProviderName.ClickHouseOctonica))
 				min = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Unspecified).AddSeconds(1);
 


### PR DESCRIPTION
- [NodaTime](https://www.nuget.org/packages/NodaTime): 3.1.1 -> 3.1.2
- [ClickHouse] Extend tested `Date32`/`DateTime64` ranges to new limits from ClickHouse 22.8.1
