### PR TITLE
[CLI] Fix transformation option parsing and help

### DIFF
--- a/Source/LinqToDB.CLI/CommandLine/Commands/HelpCommand.cs
+++ b/Source/LinqToDB.CLI/CommandLine/Commands/HelpCommand.cs
@@ -379,6 +379,7 @@ namespace LinqToDB.CommandLine
 			{
 				case NameTransformation.SplitByUnderscore: value = "\"split_by_underscore\""; break;
 				case NameTransformation.Association      : value = "\"association\""        ; break;
+				case NameTransformation.None             : value = "\"none\""               ; break;
 				default:
 					throw new InvalidOperationException($"Unknown transformation option: {options.Transformation}");
 			}

--- a/Source/LinqToDB.CLI/CommandLine/Commands/ScaffoldCommand.Options.cs
+++ b/Source/LinqToDB.CLI/CommandLine/Commands/ScaffoldCommand.Options.cs
@@ -400,8 +400,9 @@ Customization using compiled assembly has several requirements:
 - prefix                           : string? : optional name prefix
 - suffix                           : string? : optional name suffix
 - transformation                   : string  : base name transformation logic (see values below)
+    + ""none""                : no transformations applied, treat whole identifier as one word
     + ""split_by_underscore"" : split base name, got from database object name, into separate words by underscore (_)
-    + ""t4""                  : emulation of identifier generation logic for association name used by T4 templates (compat. option)
+    + ""association""         : emulation of identifier generation logic for association name used by T4 templates (compat. option)
 - pluralize_if_ends_with_word_only : bool    : when set, pluralization not applied if name ends with non-word (e.g. with digit)
 - ignore_all_caps                  : bool    : when set, casing not applied to names that contain only uppercase letters
 If you don't specify some property, CLI will use default value for current option. This allows you to override only some properties without need to specify all properties.

--- a/Source/LinqToDB.CLI/CommandLine/Options/NamingCliOption.cs
+++ b/Source/LinqToDB.CLI/CommandLine/Options/NamingCliOption.cs
@@ -137,6 +137,7 @@ namespace LinqToDB.CommandLine
 						var transformationValue = property.Value.GetString()!;
 						switch (transformationValue.ToLowerInvariant())
 						{
+							case "none"               : options.Transformation = NameTransformation.None             ; break;
 							case "split_by_underscore": options.Transformation = NameTransformation.SplitByUnderscore; break;
 							case "association"        : options.Transformation = NameTransformation.Association      ; break;
 							default                   :

--- a/Source/LinqToDB.CLI/CommandLine/Options/OptionType.cs
+++ b/Source/LinqToDB.CLI/CommandLine/Options/OptionType.cs
@@ -35,7 +35,7 @@
 		/// Language identifier naming options.
 		/// Value is an object with following properties:
 		/// <list type="bullet">
-		/// <item>"transformation": "split_by_underscore" (default) | "t4" - custom transformation, applied to original name.</item>
+		/// <item>"transformation": "split_by_underscore" (default) | "none" | "association" - custom transformation, applied to original name.</item>
 		/// <item>"case": "none" (default) | "pascal_case" | "camel_case" | "snake_case" | "lower_case" | "upper_case" | "t4_pluralized" | "t4"</item>
 		/// <item>"pluralization": "none" (default) | "singular" | "plural" | "plural_multiple_characters"</item>
 		/// <item>"prefix": string?</item>


### PR DESCRIPTION
Fix #3676

- accept `transformation: none` option from command-line/`json` config
- update help to list `transformation: none` option
- update help to list `transformation: association` option instead of non-existing `transformation: t4`
