### PR TITLE
Dependencies update

### DIFF
--- a/Build/Azure/README.md
+++ b/Build/Azure/README.md
@@ -73,11 +73,11 @@ Legend:
 |SQLite [3.38.5.1](https://www.sqlite.org/draft/releaselog/current.html)<br>[System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite.Core/) 1.0.116<br>with [MiniProfiler](https://www.nuget.org/packages/MiniProfiler.Shared/) 4.2.22<br>without mappings to underlying provider|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |SQLite [3.38.5.1](https://www.sqlite.org/draft/releaselog/current.html)<br>[System.Data.SQLite](https://www.nuget.org/packages/System.Data.SQLite.Core/) 1.0.116<br>with [MiniProfiler](https://www.nuget.org/packages/MiniProfiler.Shared/) 4.2.22<br>with mappings to underlying provider|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |MySQL 5.6<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.30|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|MySQL 5.6<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 0.69.10/1.3.14/2.1.12|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|MySQL 5.6<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 0.69.10/1.3.14/2.1.13|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |MySQL (latest)<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.30|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|MySQL (latest)<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 0.69.10/1.3.14/2.1.12|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|MySQL (latest)<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 0.69.10/1.3.14/2.1.13|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |MariaDB (latest)<br>[MySql.Data](https://www.nuget.org/packages/MySql.Data/) 8.0.30|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|MariaDB (latest)<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 0.69.10/1.3.14/2.1.12|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|MariaDB (latest)<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 0.69.10/1.3.14/2.1.13|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |PostgreSQL 10<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 7.0.0-preview.7 |:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |PostgreSQL 11<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 7.0.0-preview.7 |:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |PostgreSQL 12<br>[Npgsql](https://www.nuget.org/packages/Npgsql/) 7.0.0-preview.7 |:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
@@ -112,7 +112,7 @@ Legend:
 |SAP HANA 2.0 SPS 05r57<br>ODBC Provider|:x:|:x:|:heavy_check_mark:|:x:|
 |ClickHouse (latest)<br>[Octonica.ClickHouseClient](https://www.nuget.org/packages/Octonica.ClickHouseClient/) 2.2.9|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 |ClickHouse (latest)<br>[ClickHouse.Client](https://www.nuget.org/packages/ClickHouse.Client/) 4.2.2|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
-|ClickHouse (latest)<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 0.69.10/1.3.14/2.1.12|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|ClickHouse (latest)<br>[MySqlConnector](https://www.nuget.org/packages/MySqlConnector/) 0.69.10/1.3.14/2.1.13|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:|
 
 ### Notes
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,16 +42,16 @@
 		<PackageVersion Include="Net.IBM.Data.Db2-lnx"                                  Version="6.0.0.200"     />
 		<PackageVersion Include="Net.IBM.Data.Db2-osx"                                  Version="6.0.0.200"     />
 		<PackageVersion Include="Npgsql"                                                Version="7.0.0-preview.7" />
-		<PackageVersion Include="ClickHouse.Client"                                     Version="5.0.3"         />
+		<PackageVersion Include="ClickHouse.Client"                                     Version="5.0.4"         />
 		<PackageVersion Include="Octonica.ClickHouseClient"                             Version="2.2.9"         />
 		<PackageVersion Include="Microsoft.Data.Sqlite"                                 Version="6.0.8"         />
-		<PackageVersion Include="Microsoft.SqlServer.Types"                             Version="160.600.9-ctp2p0" />
+		<PackageVersion Include="Microsoft.SqlServer.Types"                             Version="160.900.6-rc0" />
 		<!--tests support-->
 		<PackageVersion Include="NUnit"                                                 Version="3.13.3"        />
 		<PackageVersion Include="NUnit3TestAdapter"                                     Version="4.2.1"         />
-		<PackageVersion Include="Microsoft.NET.Test.Sdk"                                Version="17.3.0"        />
+		<PackageVersion Include="Microsoft.NET.Test.Sdk"                                Version="17.3.1"        />
 		<PackageVersion Include="FluentAssertions"                                      Version="6.7.0"         />
-		<PackageVersion Include="BenchmarkDotNet"                                       Version="0.13.1"        />
+		<PackageVersion Include="BenchmarkDotNet"                                       Version="0.13.2"        />
 		<PackageVersion Include="JetBrains.Profiler.Api"                                Version="1.1.8"         />
 		<PackageVersion Include="FSharp.Core"                                           Version="6.0.5"         />
 		<!--packages for test projects-->
@@ -72,7 +72,7 @@
 		<!--remote targets + remote examples targets-->
 		<!--source-->
 		<PackageVersion Include="protobuf-net.Grpc"                                     Version="1.0.171"       />
-		<PackageVersion Include="Grpc.Net.Client"                                       Version="2.47.0"        />
+		<PackageVersion Include="Grpc.Net.Client"                                       Version="2.48.0"        />
 		<!--examples-->
 		<PackageVersion Include="linq2db.t4models"                                      Version="4.0.0-preview.10" />
 		<!--tests-->
@@ -105,7 +105,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' != 'net472' AND '$(TargetFramework)' != 'netcoreapp3.1' ">
-		<PackageVersion Include="MySqlConnector"                                        Version="2.1.12"        />
+		<PackageVersion Include="MySqlConnector"                                        Version="2.1.13"        />
 	</ItemGroup>
 
 </Project>

--- a/NuGet/linq2db.MySqlConnector.nuspec
+++ b/NuGet/linq2db.MySqlConnector.nuspec
@@ -14,7 +14,7 @@
 		<readme>README.md</readme>
 		<dependencies>
 			<dependency id="linq2db"        version="4.0.0"  />
-			<dependency id="MySqlConnector" version="2.1.12" />
+			<dependency id="MySqlConnector" version="2.1.13" />
 		</dependencies>
 		<contentFiles>
 			<files include="**\*" buildAction="None" />

--- a/NuGet/linq2db.Remote.Grpc.nuspec
+++ b/NuGet/linq2db.Remote.Grpc.nuspec
@@ -12,7 +12,7 @@
 		<dependencies>
 			<group targetFramework=".NETStandard2.0">
 				<dependency id="linq2db"           version="4.0.0"   />
-				<dependency id="Grpc.Net.Client"   version="2.47.0"  />
+				<dependency id="Grpc.Net.Client"   version="2.48.0"  />
 				<dependency id="protobuf-net.Grpc" version="1.0.171" />
 			</group>
 		</dependencies>


### PR DESCRIPTION
- [Grpc.Net.Client](https://www.nuget.org/packages/Grpc.Net.Client): 2.47.0 -> 2.48.0
- [ClickHouse.Client](https://www.nuget.org/packages/ClickHouse.Client): 5.0.3 -> 5.0.4 (tested manually)
- [MySqlConnector](https://www.nuget.org/packages/MySqlConnector): 2.1.12 -> 2.1.13
- [Microsoft.SqlServer.Types](https://www.nuget.org/packages/Microsoft.SqlServer.Types): 160.600.9-ctp2p0 -> 160.900.6-rc0
- [Microsoft.NET.Test.Sdk](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk): 17.3.0 -> 17.3.1
- [BenchmarkDotNet](https://www.nuget.org/packages/BenchmarkDotNet): 0.13.1 -> 0.13.2
