### PR TITLE
SQL Server 2022 RC.0 support

### DIFF
--- a/Build/Azure/pipelines/templates/test-matrix.yml
+++ b/Build/Azure/pipelines/templates/test-matrix.yml
@@ -704,7 +704,7 @@ jobs:
           script_linux_global: sqlserver.2022.sh
           script_macos_global: sqlserver.2022.sh
           install_docker_macos: true
-          enable_os_windows: true
+          enable_os_windows: false # true : wait for RC0+ docker image
           enable_os_ubuntu: true
           enable_os_macos:  true
           enable_fw_net472: true

--- a/Tests/Base/TestProvName.cs
+++ b/Tests/Base/TestProvName.cs
@@ -152,6 +152,7 @@ namespace Tests
 		public const string AllSqlServer2019             = $"{ProviderName.SqlServer2019},{SqlServer2019MS},{AllSqlServerSequentialAccess},{AllSqlServerContained}";
 		public const string AllSqlServer2022             = $"{ProviderName.SqlServer2022},{SqlServer2022MS}";
 		public const string AllSqlServer2008Minus        = $"{AllSqlServer2005},{AllSqlServer2008}";
+		public const string AllSqlServer2019Minus        = $"{AllSqlServer2008Minus},{AllSqlServer2012},{AllSqlServer2014},{AllSqlServer2016},{AllSqlServer2017},{AllSqlServer2019}";
 		public const string AllSqlServer2022Plus         = $"{AllSqlServer2022},{AllSqlAzure}";
 		public const string AllSqlServer2019Plus         = $"{AllSqlServer2019},{AllSqlServer2022Plus}";
 		public const string AllSqlServer2017Plus         = $"{AllSqlServer2017},{AllSqlServer2019Plus}";

--- a/Tests/Linq/Linq/IsDistinctFromTests.cs
+++ b/Tests/Linq/Linq/IsDistinctFromTests.cs
@@ -2,6 +2,7 @@
 using LinqToDB;
 using LinqToDB.Data;
 using NUnit.Framework;
+using System.Runtime.InteropServices;
 
 namespace Tests.Linq
 {
@@ -25,11 +26,6 @@ namespace Tests.Linq
 			[DataSources]        string context,
 			[Values(2, 4, null)] int?   value)
 		{
-			if (context.IsAnyOf(TestProvName.AllSqlServer2022Plus))
-			{
-				Assert.Inconclusive("Temporary disabled. CTP2.1 docker image required");
-			}
-
 			using var db  = GetDataContext(context);
 			using var src = SetupSrcTable(db);
 
@@ -53,11 +49,6 @@ namespace Tests.Linq
 			[DataSources(TestProvName.AllAccess)] string context,
 			[Values("abc", "xyz", null)] string? value)
 		{
-			if (context.IsAnyOf(TestProvName.AllSqlServer2022Plus))
-			{
-				Assert.Inconclusive("Temporary disabled. CTP2.1 docker image required");
-			}
-
 			using var db  = GetDataContext(context);
 			using var src = SetupSrcTable(db);
 

--- a/Tests/Linq/Linq/StringFunctionTests.cs
+++ b/Tests/Linq/Linq/StringFunctionTests.cs
@@ -1178,6 +1178,32 @@ namespace Tests.Linq
 		}
 
 		[Test]
+		public void TrimLeftCharacters([DataSources(TestProvName.AllAccess, ProviderName.SqlCe, TestProvName.AllSqlServer2019Minus, TestProvName.AllSybase)] string context)
+		{
+			using var db = GetDataContext(context);
+			var q =
+				from p in db.Person
+				where p.ID == 1
+				select new { p.ID, Name = "  " + p.FirstName + " " } into pp
+				where pp.Name.TrimStart(' ', 'J') == "ohn "
+				select pp;
+			Assert.AreEqual(1, q.ToList().First().ID);
+		}
+
+		[Test]
+		public void TrimRightCharacters([DataSources(TestProvName.AllAccess, ProviderName.SqlCe, TestProvName.AllSqlServer2019Minus, TestProvName.AllSybase)] string context)
+		{
+			using var db = GetDataContext(context);
+			var q =
+				from p in db.Person
+				where p.ID == 1
+				select new { p.ID, Name = "  " + p.FirstName + " " } into pp
+				where pp.Name.TrimEnd(' ', 'n') == "  Joh"
+				select pp;
+			Assert.AreEqual(1, q.ToList().First().ID);
+		}
+
+		[Test]
 		public void ToLower([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))


### PR DESCRIPTION
- enable `CTP2.1`/`RC.0` features testing (linux-only for now, need fresh windows docker image)
- enable `IS [NOT] DISTINCT FROM` operator tests
- fix `TrimEnd`/`TrimStart(chars)` mapping
