### PR TITLE
[WIP] Introducing an AST factory

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": ".NET Core Launch (console)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceFolder}/Source/Test/bin/Debug/net6.0/Test.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/Source/Test",
+      "console": "internalConsole",
+      "stopAtEntry": false
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "dotnet-test-explorer.enableTelemetry": false,
+  "dotnet-test-explorer.testProjectPath": "./Tests/Linq/Tests.csproj",
+  "dotnet-test-explorer.testArguments": "-f net6.0 --no-restore"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/Tests/Tests.Benchmarks/linq2db.Benchmarks.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "publish",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "publish",
+        "${workspaceFolder}/Tests/Tests.Benchmarks/linq2db.Benchmarks.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "watch",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "watch",
+        "run",
+        "${workspaceFolder}/Tests/Tests.Benchmarks/linq2db.Benchmarks.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}

--- a/Source/.vscode/launch.json
+++ b/Source/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "OS-COMMENT1": "Use IntelliSense to find out which attributes exist for C# debugging",
+      "OS-COMMENT2": "Use hover for the description of the existing attributes",
+      "OS-COMMENT3": "For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md",
+      "name": ".NET Core Launch (console)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "OS-COMMENT4": "If you have changed target frameworks, make sure to update the program path.",
+      "program": "${workspaceFolder}/TestInsertAll/bin/Debug/net5.0/TestInsertAll.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/TestInsertAll",
+      "OS-COMMENT5": "For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console",
+      "console": "internalConsole",
+      "stopAtEntry": false
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach",
+      "processId": "${command:pickProcess}"
+    }
+  ]
+}

--- a/Source/.vscode/settings.json
+++ b/Source/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "bracketLens.mode": "auto",
+  "bracketLens.minBracketScopeLines": 40
+}

--- a/Source/.vscode/tasks.json
+++ b/Source/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/TestInsertAll/TestInsertAll.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "publish",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "publish",
+        "${workspaceFolder}/TestInsertAll/TestInsertAll.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "watch",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "watch",
+        "run",
+        "${workspaceFolder}/TestInsertAll/TestInsertAll.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}

--- a/Source/LinqToDB/Data/DataConnection.Linq.cs
+++ b/Source/LinqToDB/Data/DataConnection.Linq.cs
@@ -19,6 +19,7 @@ namespace LinqToDB.Data
 		SqlProviderFlags IDataContext.SqlProviderFlags      => DataProvider.SqlProviderFlags;
 		TableOptions     IDataContext.SupportedTableOptions => DataProvider.SupportedTableOptions;
 		Type             IDataContext.DataReaderType        => DataProvider.DataReaderType;
+		AstFactory       IDataContext.AstFactory            => DataProvider.GetAstFactory();
 
 		bool             IDataContext.CloseAfterUse    { get; set; }
 

--- a/Source/LinqToDB/DataContext.cs
+++ b/Source/LinqToDB/DataContext.cs
@@ -11,6 +11,7 @@ namespace LinqToDB
 	using Linq;
 	using Mapping;
 	using SqlProvider;
+	using SqlQuery;
 
 	/// <summary>
 	/// Implements abstraction over non-persistent database connection that could be released after query or transaction execution.
@@ -142,6 +143,8 @@ namespace LinqToDB
 		/// Gets database provider implementation.
 		/// </summary>
 		public IDataProvider DataProvider        => _optionsBuilder.DataProvider!;
+
+		public AstFactory    AstFactory          => DataProvider.GetAstFactory();
 
 		/// <summary>
 		/// Gets or sets context identifier. Uses provider's name by default.

--- a/Source/LinqToDB/DataProvider/Access/AccessODBCDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessODBCDataProvider.cs
@@ -37,7 +37,7 @@ namespace LinqToDB.DataProvider.Access
 			SetToType<DbDataReader, ushort, short>("SMALLINT", (r, i) => unchecked((ushort)r.GetInt16(i)));
 			SetProviderField<DbDataReader, TimeSpan, DateTime>((r, i) => r.GetDateTime(i) - new DateTime(1899, 12, 30));
 
-			_sqlOptimizer = new AccessODBCSqlOptimizer(SqlProviderFlags);
+			_sqlOptimizer = new AccessODBCSqlOptimizer(SqlProviderFlags, GetAstFactory());
 		}
 
 		public override TableOptions SupportedTableOptions => TableOptions.None;

--- a/Source/LinqToDB/DataProvider/Access/AccessODBCSqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessODBCSqlOptimizer.cs
@@ -6,9 +6,9 @@
 
 	class AccessODBCSqlOptimizer : AccessSqlOptimizer
 	{
-		public AccessODBCSqlOptimizer(SqlProviderFlags sqlProviderFlags) : base(sqlProviderFlags)
-		{
-		}
+		public AccessODBCSqlOptimizer(SqlProviderFlags sqlProviderFlags, AstFactory ast) 
+			: base(sqlProviderFlags, ast)
+		{ }
 
 		public override SqlStatement Finalize(MappingSchema mappingSchema, SqlStatement statement)
 		{

--- a/Source/LinqToDB/DataProvider/Access/AccessOleDbDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessOleDbDataProvider.cs
@@ -31,7 +31,7 @@ namespace LinqToDB.DataProvider.Access
 
 			SetProviderField<DbDataReader, TimeSpan, DateTime>((r, i) => r.GetDateTime(i) - new DateTime(1899, 12, 30));
 
-			_sqlOptimizer = new AccessSqlOptimizer(SqlProviderFlags);
+			_sqlOptimizer = new AccessSqlOptimizer(SqlProviderFlags, GetAstFactory());
 		}
 
 		public override TableOptions SupportedTableOptions => TableOptions.None;

--- a/Source/LinqToDB/DataProvider/Access/AccessSqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessSqlOptimizer.cs
@@ -6,9 +6,9 @@ namespace LinqToDB.DataProvider.Access
 
 	class AccessSqlOptimizer : BasicSqlOptimizer
 	{
-		public AccessSqlOptimizer(SqlProviderFlags sqlProviderFlags) : base(sqlProviderFlags)
-		{
-		}
+		public AccessSqlOptimizer(SqlProviderFlags sqlProviderFlags, AstFactory ast) 
+			: base(sqlProviderFlags, ast)
+		{ }
 
 		public override bool CanCompareSearchConditions => true;
 
@@ -80,21 +80,19 @@ namespace LinqToDB.DataProvider.Access
 
 			if (predicate.CaseSensitive.EvaluateBoolExpression(visitor.Context.OptimizationContext.Context) == true)
 			{
-				SqlPredicate.ExprExpr? subStrPredicate = null;
+				ISqlPredicate? subStrPredicate = null;
 
 				switch (predicate.Kind)
 				{
 					case SqlPredicate.SearchString.SearchKind.StartsWith:
 					{
-						subStrPredicate =
-							new SqlPredicate.ExprExpr(
-								new SqlFunction(typeof(int), "InStr",
-									new SqlValue(1),
-									predicate.Expr1,
-									predicate.Expr2,
-									new SqlValue(0)),
-								SqlPredicate.Operator.Equal,
-								new SqlValue(1), null);
+						subStrPredicate = ast.Equal(							
+							new SqlFunction(typeof(int), "InStr",
+								ast.One,
+								predicate.Expr1,
+								predicate.Expr2,
+								ast.Zero),
+							ast.One);
 
 						break;
 					}
@@ -107,29 +105,26 @@ namespace LinqToDB.DataProvider.Access
 								new SqlFunction(typeof(int), "Length", predicate.Expr2)), "+",
 							new SqlValue(1));
 
-						subStrPredicate =
-							new SqlPredicate.ExprExpr(
-								new SqlFunction(typeof(int), "InStr",
-									indexExpr,
-									predicate.Expr1,
-									predicate.Expr2,
-									new SqlValue(0)),
-								SqlPredicate.Operator.Equal,
-								indexExpr, null);
+						subStrPredicate = ast.Equal(							
+							new SqlFunction(typeof(int), "InStr",
+								indexExpr,
+								predicate.Expr1,
+								predicate.Expr2,
+								ast.Zero),
+							indexExpr);
 
 						break;
 					}
 					case SqlPredicate.SearchString.SearchKind.Contains:
 					{
-						subStrPredicate =
-							new SqlPredicate.ExprExpr(
-								new SqlFunction(typeof(int), "InStr",
-									new SqlValue(1),
-									predicate.Expr1,
-									predicate.Expr2,
-									new SqlValue(0)),
-								SqlPredicate.Operator.GreaterOrEqual,
-								new SqlValue(1), null);
+						subStrPredicate = ast.GreaterEqual(
+							new SqlFunction(typeof(int), "InStr",
+								ast.One,
+								predicate.Expr1,
+								predicate.Expr2,
+								ast.Zero),
+							ast.One);
+
 						break;
 					}
 
@@ -137,25 +132,26 @@ namespace LinqToDB.DataProvider.Access
 
 				if (subStrPredicate != null)
 				{
-					var result = new SqlSearchCondition(
+					return new SqlSearchCondition(
 						new SqlCondition(false, like, predicate.IsNot),
 						new SqlCondition(predicate.IsNot, subStrPredicate));
-
-					return result;
 				}
 			}
 
 			return like;
 		}
 
-		protected override ISqlExpression ConvertFunction(SqlFunction func)
+		protected override ISqlExpression ConvertFunction(ISqlExpression expr)
 		{
+			if (expr is not SqlFunction func) return expr;
+
 			switch (func.Name)
 			{
 				case PseudoFunctions.TO_LOWER: return new SqlFunction(func.SystemType, "LCase", func.IsAggregate, func.IsPure, func.Precedence, func.Parameters);
 				case PseudoFunctions.TO_UPPER: return new SqlFunction(func.SystemType, "UCase", func.IsAggregate, func.IsPure, func.Precedence, func.Parameters);
 				case "Length"                : return new SqlFunction(func.SystemType, "LEN",   func.IsAggregate, func.IsPure, func.Precedence, func.Parameters);
 			}
+			
 			return base.ConvertFunction(func);
 		}
 	}

--- a/Source/LinqToDB/DataProvider/ClickHouse/ClickHouseDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/ClickHouse/ClickHouseDataProvider.cs
@@ -53,7 +53,7 @@ namespace LinqToDB.DataProvider.ClickHouse
 			// 2. not tested as we don't support parameters currently
 			//SqlProviderFlags.AcceptsTakeAsParameter = true;
 
-			_sqlOptimizer = new ClickHouseSqlOptimizer(SqlProviderFlags);
+			_sqlOptimizer = new ClickHouseSqlOptimizer(SqlProviderFlags, GetAstFactory());
 
 			if (Adapter.GetSByteReaderMethod          != null) SetProviderField(typeof(sbyte         ), Adapter.GetSByteReaderMethod,          Adapter.DataReaderType);
 			if (Adapter.GetUInt16ReaderMethod         != null) SetProviderField(typeof(ushort        ), Adapter.GetUInt16ReaderMethod,         Adapter.DataReaderType);

--- a/Source/LinqToDB/DataProvider/DB2/DB2DataProvider.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2DataProvider.cs
@@ -28,7 +28,7 @@
 			SetCharFieldToType<char>("CHAR", DataTools.GetCharExpression);
 			SetCharField            ("CHAR", (r, i) => r.GetString(i).TrimEnd(' '));
 
-			_sqlOptimizer = new DB2SqlOptimizer(SqlProviderFlags);
+			_sqlOptimizer = new DB2SqlOptimizer(SqlProviderFlags, GetAstFactory());
 
 			SetProviderField(Adapter.DB2Int64Type       , typeof(long)    , Adapter.GetDB2Int64ReaderMethod       , dataReaderType: Adapter.DataReaderType);
 			SetProviderField(Adapter.DB2Int32Type       , typeof(int)     , Adapter.GetDB2Int32ReaderMethod       , dataReaderType: Adapter.DataReaderType);

--- a/Source/LinqToDB/DataProvider/DB2/DB2SqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2SqlOptimizer.cs
@@ -6,9 +6,9 @@
 
 	class DB2SqlOptimizer : BasicSqlOptimizer
 	{
-		public DB2SqlOptimizer(SqlProviderFlags sqlProviderFlags) : base(sqlProviderFlags)
-		{
-		}
+		public DB2SqlOptimizer(SqlProviderFlags sqlProviderFlags, AstFactory ast) 
+			: base(sqlProviderFlags, ast)
+		{ }
 
 		public override SqlStatement TransformStatement(SqlStatement statement)
 		{
@@ -131,8 +131,9 @@
 			return expression;
 		}
 
-		protected override ISqlExpression ConvertFunction(SqlFunction func)
+		protected override ISqlExpression ConvertFunction(ISqlExpression expr)
 		{
+			if (expr is not SqlFunction func) return expr;
 			func = ConvertFunctionParameters(func, false);
 			return base.ConvertFunction(func);
 		}

--- a/Source/LinqToDB/DataProvider/DataProviderBase.cs
+++ b/Source/LinqToDB/DataProvider/DataProviderBase.cs
@@ -14,6 +14,7 @@ namespace LinqToDB.DataProvider
 	using Mapping;
 	using SchemaProvider;
 	using SqlProvider;
+	using SqlQuery;
 
 	public abstract class DataProviderBase : IDataProvider
 	{
@@ -111,6 +112,10 @@ namespace LinqToDB.DataProvider
 		protected abstract DbConnection  CreateConnectionInternal (string connectionString);
 		public    abstract ISqlBuilder   CreateSqlBuilder(MappingSchema mappingSchema);
 		public    abstract ISqlOptimizer GetSqlOptimizer ();
+
+		// FIXME(jods): GetAstFactory() should be abstract once overriden in every provider
+		private readonly AstFactory _ast = new AstFactory();
+		public virtual AstFactory GetAstFactory() => _ast;
 
 		public virtual DbCommand InitCommand(DataConnection dataConnection, DbCommand command, CommandType commandType, string commandText, DataParameter[]? parameters, bool withParameters)
 		{

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdDataProvider.cs
@@ -32,7 +32,7 @@
 			SetProviderField<DbDataReader, TimeSpan,DateTime>((r,i) => r.GetDateTime(i) - new DateTime(1970, 1, 1));
 			SetProviderField<DbDataReader, DateTime,DateTime>((r,i) => GetDateTime(r.GetDateTime(i)));
 
-			_sqlOptimizer = sqlOptimizer ?? new FirebirdSqlOptimizer(SqlProviderFlags);
+			_sqlOptimizer = sqlOptimizer ?? new FirebirdSqlOptimizer(SqlProviderFlags, GetAstFactory());
 		}
 
 		static DateTime GetDateTime(DateTime value)

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdSqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdSqlOptimizer.cs
@@ -7,9 +7,9 @@
 
 	public class FirebirdSqlOptimizer : BasicSqlOptimizer
 	{
-		public FirebirdSqlOptimizer(SqlProviderFlags sqlProviderFlags) : base(sqlProviderFlags)
-		{
-		}
+		public FirebirdSqlOptimizer(SqlProviderFlags sqlProviderFlags, AstFactory ast) 
+			: base(sqlProviderFlags, ast)
+		{ }
 
 		public override SqlStatement Finalize(MappingSchema mappingSchema, SqlStatement statement)
 		{
@@ -227,10 +227,10 @@
 			return expression;
 		}
 
-		protected override ISqlExpression ConvertFunction(SqlFunction func)
+		protected override ISqlExpression ConvertFunction(ISqlExpression expr)
 		{
-			func = ConvertFunctionParameters(func, false);
-			
+			if (expr is not SqlFunction func) return expr;
+			func = ConvertFunctionParameters(func, false);			
 			return base.ConvertFunction(func);
 		}
 

--- a/Source/LinqToDB/DataProvider/IDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/IDataProvider.cs
@@ -8,6 +8,7 @@ namespace LinqToDB.DataProvider
 	using Mapping;
 	using SchemaProvider;
 	using SqlProvider;
+	using SqlQuery;
 
 	public interface IDataProvider
 	{
@@ -23,6 +24,7 @@ namespace LinqToDB.DataProvider
 		DbConnection     CreateConnection      (string        connectionString);
 		ISqlBuilder      CreateSqlBuilder      (MappingSchema mappingSchema);
 		ISqlOptimizer    GetSqlOptimizer       ();
+		AstFactory       GetAstFactory         ();
 		/// <summary>
 		/// Initializes <see cref="DataConnection"/> command object.
 		/// </summary>

--- a/Source/LinqToDB/DataProvider/Informix/InformixDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixDataProvider.cs
@@ -38,7 +38,7 @@
 			SetField<DbDataReader, double >((r, i) => GetDouble (r, i));
 			SetField<DbDataReader, decimal>((r, i) => GetDecimal(r, i));
 
-			_sqlOptimizer = new InformixSqlOptimizer(SqlProviderFlags);
+			_sqlOptimizer = new InformixSqlOptimizer(SqlProviderFlags, GetAstFactory());
 
 			if (Adapter.GetBigIntReaderMethod != null)
 				SetField(typeof(long), "BIGINT", Adapter.GetBigIntReaderMethod, false, dataReaderType: Adapter.DataReaderType);

--- a/Source/LinqToDB/DataProvider/Informix/InformixSqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixSqlOptimizer.cs
@@ -7,9 +7,9 @@
 
 	class InformixSqlOptimizer : BasicSqlOptimizer
 	{
-		public InformixSqlOptimizer(SqlProviderFlags sqlProviderFlags) : base(sqlProviderFlags)
-		{
-		}
+		public InformixSqlOptimizer(SqlProviderFlags sqlProviderFlags, AstFactory ast)
+			: base(sqlProviderFlags, ast)
+		{ }
 
 		public override bool IsParameterDependedElement(IQueryElement element)
 		{
@@ -214,8 +214,9 @@
 			return expression;
 		}
 
-		protected override ISqlExpression ConvertFunction(SqlFunction func)
+		protected override ISqlExpression ConvertFunction(ISqlExpression expr)
 		{
+			if (expr is not SqlFunction func) return expr;
 			func = ConvertFunctionParameters(func, false);
 			return base.ConvertFunction(func);
 		}

--- a/Source/LinqToDB/DataProvider/MySql/MySqlDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlDataProvider.cs
@@ -21,7 +21,7 @@
 			SqlProviderFlags.IsNamingQueryBlockSupported       = true;
 			SqlProviderFlags.RowConstructorSupport             = RowFeature.Equality | RowFeature.Comparisons | RowFeature.CompareToSelect | RowFeature.In;
 
-			_sqlOptimizer = new MySqlSqlOptimizer(SqlProviderFlags);
+			_sqlOptimizer = new MySqlSqlOptimizer(SqlProviderFlags, GetAstFactory());
 
 			// configure provider-specific data readers
 			if (Adapter.GetMySqlDecimalMethodName != null)

--- a/Source/LinqToDB/DataProvider/MySql/MySqlSqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlSqlOptimizer.cs
@@ -8,9 +8,9 @@
 
 	class MySqlSqlOptimizer : BasicSqlOptimizer
 	{
-		public MySqlSqlOptimizer(SqlProviderFlags sqlProviderFlags) : base(sqlProviderFlags)
-		{
-		}
+		public MySqlSqlOptimizer(SqlProviderFlags sqlProviderFlags, AstFactory ast)
+			: base(sqlProviderFlags, ast)
+		{ }
 
 		public override bool CanCompareSearchConditions => true;
 
@@ -136,9 +136,9 @@
 				{
 					case SqlPredicate.SearchString.SearchKind.Contains:
 					{
-						newPredicate = new SqlPredicate.ExprExpr(
-							new SqlFunction(typeof(int), "LOCATE", searchExpr, dataExpr), SqlPredicate.Operator.Greater,
-							new SqlValue(0), null);
+						newPredicate = ast.Greater(
+							new SqlFunction(typeof(int), "LOCATE", searchExpr, dataExpr),
+							ast.Zero);
 						break;
 					}
 				}

--- a/Source/LinqToDB/DataProvider/Oracle/Oracle11SqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/Oracle11SqlOptimizer.cs
@@ -7,9 +7,9 @@
 
 	public class Oracle11SqlOptimizer : BasicSqlOptimizer
 	{
-		public Oracle11SqlOptimizer(SqlProviderFlags sqlProviderFlags) : base(sqlProviderFlags)
-		{
-		}
+		public Oracle11SqlOptimizer(SqlProviderFlags sqlProviderFlags, AstFactory ast) 
+			: base(sqlProviderFlags, ast)
+		{ }
 
 		public override SqlStatement Finalize(MappingSchema mappingSchema, SqlStatement statement)
 		{
@@ -87,8 +87,8 @@
 							if (string1 == "")
 							{
 								var sc = new SqlSearchCondition();
-								sc.Conditions.Add(new SqlCondition(false, new SqlPredicate.ExprExpr(expr.Expr1, expr.Operator, expr.Expr2, null), true));
-								sc.Conditions.Add(new SqlCondition(false, new SqlPredicate.IsNull(expr.Expr2, false), true));
+								sc.Conditions.Add(new SqlCondition(false, ast.Comparison(expr.Expr1, expr.Operator, expr.Expr2), true));
+								sc.Conditions.Add(new SqlCondition(false, ast.IsNull(expr.Expr2), true));
 								return sc;
 							}
 						}
@@ -99,8 +99,8 @@
 							if (string2 == "")
 							{
 								var sc = new SqlSearchCondition();
-								sc.Conditions.Add(new SqlCondition(false, new SqlPredicate.ExprExpr(expr.Expr1, expr.Operator, expr.Expr2, null), true));
-								sc.Conditions.Add(new SqlCondition(false, new SqlPredicate.IsNull(expr.Expr1, false), true));
+								sc.Conditions.Add(new SqlCondition(false, ast.Comparison(expr.Expr1, expr.Operator, expr.Expr2), true));
+								sc.Conditions.Add(new SqlCondition(false, ast.IsNull(expr.Expr1), true));
 								return sc;
 							}
 						}
@@ -300,8 +300,9 @@
 				withStack: false);
 		}
 
-		protected override ISqlExpression ConvertFunction(SqlFunction func)
+		protected override ISqlExpression ConvertFunction(ISqlExpression expr)
 		{
+			if (expr is not SqlFunction func) return expr;
 			func = ConvertFunctionParameters(func, false);
 			return base.ConvertFunction(func);
 		}

--- a/Source/LinqToDB/DataProvider/Oracle/Oracle12SqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/Oracle12SqlOptimizer.cs
@@ -5,9 +5,9 @@
 
 	public class Oracle12SqlOptimizer : Oracle11SqlOptimizer
 	{
-		public Oracle12SqlOptimizer(SqlProviderFlags sqlProviderFlags) : base(sqlProviderFlags)
-		{
-		}
+		public Oracle12SqlOptimizer(SqlProviderFlags sqlProviderFlags, AstFactory ast) 
+			: base(sqlProviderFlags, ast)
+		{ }
 
 		public override SqlStatement TransformStatement(SqlStatement statement)
 		{
@@ -23,8 +23,10 @@
 			return statement;
 		}
 
-		protected override ISqlExpression ConvertFunction(SqlFunction func)
+		protected override ISqlExpression ConvertFunction(ISqlExpression expr)
 		{
+			if (expr is not SqlFunction func) return expr;
+			
 			func = ConvertFunctionParameters(func, false);
 
 			switch (func.Name)

--- a/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
@@ -54,9 +54,9 @@
 			SetCharFieldToType<char>("NChar", DataTools.GetCharExpression);
 
 			if (version == OracleVersion.v11)
-				_sqlOptimizer = new Oracle11SqlOptimizer(SqlProviderFlags);
+				_sqlOptimizer = new Oracle11SqlOptimizer(SqlProviderFlags, GetAstFactory());
 			else
-				_sqlOptimizer = new Oracle12SqlOptimizer(SqlProviderFlags);
+				_sqlOptimizer = new Oracle12SqlOptimizer(SqlProviderFlags, GetAstFactory());
 
 			foreach (var (type, method) in Adapter.CustomReaders)
 				SetProviderField(type, type, method, dataReaderType: Adapter.DataReaderType);

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
@@ -44,7 +44,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			SetCharField("bpchar"   , (r,i) => r.GetString(i).TrimEnd(' '));
 			SetCharField("character", (r,i) => r.GetString(i).TrimEnd(' '));
 
-			_sqlOptimizer = new PostgreSQLSqlOptimizer(SqlProviderFlags);
+			_sqlOptimizer = new PostgreSQLSqlOptimizer(SqlProviderFlags, GetAstFactory());
 
 			ConfigureTypes();
 		}

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLSqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLSqlOptimizer.cs
@@ -7,9 +7,9 @@
 
 	class PostgreSQLSqlOptimizer : BasicSqlOptimizer
 	{
-		public PostgreSQLSqlOptimizer(SqlProviderFlags sqlProviderFlags) : base(sqlProviderFlags)
-		{
-		}
+		public PostgreSQLSqlOptimizer(SqlProviderFlags sqlProviderFlags, AstFactory ast)
+			: base(sqlProviderFlags, ast)
+		{ }
 
 		public override bool CanCompareSearchConditions => true;
 

--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteDataProvider.cs
@@ -43,7 +43,7 @@ namespace LinqToDB.DataProvider.SQLite
 				                                         RowFeature.CompareToSelect | RowFeature.Between     | RowFeature.Update;
 			}
 
-			_sqlOptimizer = new SQLiteSqlOptimizer(SqlProviderFlags);
+			_sqlOptimizer = new SQLiteSqlOptimizer(SqlProviderFlags, GetAstFactory());
 
 			/*
 			 * WHAT'S WRONG WITH SQLITE:

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaDataProvider.cs
@@ -23,7 +23,7 @@
 			SqlProviderFlags.IsUpdateFromSupported             = false;
 			SqlProviderFlags.AcceptsOuterExpressionInAggregate = false;
 
-			_sqlOptimizer = new SapHanaNativeSqlOptimizer(SqlProviderFlags);
+			_sqlOptimizer = new SapHanaNativeSqlOptimizer(SqlProviderFlags, GetAstFactory());
 		}
 
 		public override SchemaProvider.ISchemaProvider GetSchemaProvider()

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaNativeSqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaNativeSqlOptimizer.cs
@@ -1,12 +1,12 @@
 ﻿namespace LinqToDB.DataProvider.SapHana
 {
+	using LinqToDB.SqlQuery;
 	using SqlProvider;
 
 	class SapHanaNativeSqlOptimizer : SapHanaSqlOptimizer
 	{
-		public SapHanaNativeSqlOptimizer(SqlProviderFlags sqlProviderFlags) : base(sqlProviderFlags)
-		{
-		}
+		public SapHanaNativeSqlOptimizer(SqlProviderFlags sqlProviderFlags, AstFactory ast)
+			: base(sqlProviderFlags, ast)
+		{ }
 	}
-
 }

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaOdbcDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaOdbcDataProvider.cs
@@ -22,7 +22,7 @@
 			SqlProviderFlags.IsInsertOrUpdateSupported         = false;
 			SqlProviderFlags.AcceptsOuterExpressionInAggregate = false;
 
-			_sqlOptimizer = new SapHanaSqlOptimizer(SqlProviderFlags);
+			_sqlOptimizer = new SapHanaSqlOptimizer(SqlProviderFlags, GetAstFactory());
 		}
 
 		public override SchemaProvider.ISchemaProvider GetSchemaProvider()

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaSqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaSqlOptimizer.cs
@@ -6,10 +6,9 @@
 
 	class SapHanaSqlOptimizer : BasicSqlOptimizer
 	{
-		public SapHanaSqlOptimizer(SqlProviderFlags sqlProviderFlags) : base(sqlProviderFlags)
-		{
-
-		}
+		public SapHanaSqlOptimizer(SqlProviderFlags sqlProviderFlags, AstFactory ast)
+			: base(sqlProviderFlags, ast)
+		{ }
 
 		public override SqlStatement TransformStatement(SqlStatement statement)
 		{
@@ -69,7 +68,7 @@
 		}
 
 		//this is for Tests.Linq.Common.CoalesceLike test
-		static SqlFunction ConvertCase(SqlFunction? func, Type systemType, ISqlExpression[] parameters, int start)
+		SqlFunction ConvertCase(SqlFunction? func, Type systemType, ISqlExpression[] parameters, int start)
 		{
 			var len  = parameters.Length - start;
 			var cond = parameters[start];
@@ -77,9 +76,7 @@
 			if (start == 0 && SqlExpression.NeedsEqual(cond))
 			{
 				cond = new SqlSearchCondition(
-					new SqlCondition(
-						false,
-						new SqlPredicate.ExprExpr(cond, SqlPredicate.Operator.Equal, new SqlValue(1), null)));
+					new SqlCondition(false, ast.Equal(cond, ast.One)));
 			}
 
 			const string name = "CASE";
@@ -100,8 +97,9 @@
 		}
 
 		//this is for Tests.Linq.Common.CoalesceLike test
-		protected override ISqlExpression ConvertFunction(SqlFunction func)
+		protected override ISqlExpression ConvertFunction(ISqlExpression expr)
 		{
+			if (expr is not SqlFunction func) return expr;
 			func = ConvertFunctionParameters(func, false);
 			switch (func.Name)
 			{

--- a/Source/LinqToDB/DataProvider/SqlCe/SqlCeDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlCe/SqlCeDataProvider.cs
@@ -34,7 +34,7 @@ namespace LinqToDB.DataProvider.SqlCe
 			SetCharField("NChar",    (r,i) => r.GetString(i).TrimEnd(' '));
 			SetCharField("NVarChar", (r,i) => r.GetString(i).TrimEnd(' '));
 
-			_sqlOptimizer = new SqlCeSqlOptimizer(SqlProviderFlags);
+			_sqlOptimizer = new SqlCeSqlOptimizer(SqlProviderFlags, GetAstFactory());
 		}
 
 		#region Overrides

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2005SqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2005SqlOptimizer.cs
@@ -5,9 +5,9 @@
 
 	class SqlServer2005SqlOptimizer : SqlServerSqlOptimizer
 	{
-		public SqlServer2005SqlOptimizer(SqlProviderFlags sqlProviderFlags) : base(sqlProviderFlags, SqlServerVersion.v2005)
-		{
-		}
+		public SqlServer2005SqlOptimizer(SqlProviderFlags sqlProviderFlags, AstFactory ast)
+			: base(sqlProviderFlags, SqlServerVersion.v2005, ast)
+		{ }
 
 		public override SqlStatement TransformStatement(SqlStatement statement)
 		{
@@ -21,8 +21,9 @@
 			return statement;
 		}
 
-		protected override ISqlExpression ConvertFunction(SqlFunction func)
+		protected override ISqlExpression ConvertFunction(ISqlExpression expr)
 		{
+			if (expr is not SqlFunction func) return expr;
 			func = ConvertFunctionParameters(func, false);
 			return base.ConvertFunction(func);
 		}

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2008SqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2008SqlOptimizer.cs
@@ -5,9 +5,9 @@
 	
 	class SqlServer2008SqlOptimizer : SqlServerSqlOptimizer
 	{
-		public SqlServer2008SqlOptimizer(SqlProviderFlags sqlProviderFlags) : base(sqlProviderFlags, SqlServerVersion.v2008)
-		{
-		}
+		public SqlServer2008SqlOptimizer(SqlProviderFlags sqlProviderFlags, AstFactory ast)
+			: base(sqlProviderFlags, SqlServerVersion.v2008, ast)
+		{ }
 
 		public override SqlStatement TransformStatement(SqlStatement statement)
 		{
@@ -21,8 +21,9 @@
 		}
 
 
-		protected override ISqlExpression ConvertFunction(SqlFunction func)
+		protected override ISqlExpression ConvertFunction(ISqlExpression expr)
 		{
+			if (expr is not SqlFunction func) return expr;
 			func = ConvertFunctionParameters(func, false);
 			return base.ConvertFunction(func);
 		}

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2014SqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2014SqlOptimizer.cs
@@ -1,11 +1,12 @@
 ﻿namespace LinqToDB.DataProvider.SqlServer
 {
+	using LinqToDB.SqlQuery;
 	using SqlProvider;
 
 	class SqlServer2014SqlOptimizer : SqlServer2012SqlOptimizer
 	{
-		public SqlServer2014SqlOptimizer(SqlProviderFlags sqlProviderFlags) : base(sqlProviderFlags, SqlServerVersion.v2016)
-		{
-		}
+		public SqlServer2014SqlOptimizer(SqlProviderFlags sqlProviderFlags, AstFactory ast)
+			: base(sqlProviderFlags, SqlServerVersion.v2016, ast)
+		{ }
 	}
 }

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2016SqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2016SqlOptimizer.cs
@@ -1,11 +1,12 @@
 ﻿namespace LinqToDB.DataProvider.SqlServer
 {
+	using LinqToDB.SqlQuery;
 	using SqlProvider;
 
 	class SqlServer2016SqlOptimizer : SqlServer2012SqlOptimizer
 	{
-		public SqlServer2016SqlOptimizer(SqlProviderFlags sqlProviderFlags) : base(sqlProviderFlags, SqlServerVersion.v2016)
-		{
-		}
+		public SqlServer2016SqlOptimizer(SqlProviderFlags sqlProviderFlags, AstFactory ast)
+			: base(sqlProviderFlags, SqlServerVersion.v2016, ast)
+		{ }
 	}
 }

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2017SqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2017SqlOptimizer.cs
@@ -1,11 +1,12 @@
 ﻿namespace LinqToDB.DataProvider.SqlServer
 {
+	using LinqToDB.SqlQuery;
 	using SqlProvider;
 
 	class SqlServer2017SqlOptimizer : SqlServer2012SqlOptimizer
 	{
-		public SqlServer2017SqlOptimizer(SqlProviderFlags sqlProviderFlags) : base(sqlProviderFlags, SqlServerVersion.v2017)
-		{
-		}
+		public SqlServer2017SqlOptimizer(SqlProviderFlags sqlProviderFlags, AstFactory ast)
+			: base(sqlProviderFlags, SqlServerVersion.v2017, ast)
+		{ }
 	}
 }

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2019SqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2019SqlOptimizer.cs
@@ -1,15 +1,16 @@
 ﻿namespace LinqToDB.DataProvider.SqlServer
 {
+	using LinqToDB.SqlQuery;
 	using SqlProvider;
 
 	class SqlServer2019SqlOptimizer : SqlServer2012SqlOptimizer
 	{
-		public SqlServer2019SqlOptimizer(SqlProviderFlags sqlProviderFlags) : base(sqlProviderFlags, SqlServerVersion.v2019)
-		{
-		}
+		public SqlServer2019SqlOptimizer(SqlProviderFlags sqlProviderFlags, AstFactory ast)
+			: base(sqlProviderFlags, SqlServerVersion.v2019, ast)
+		{ }
 
-		protected SqlServer2019SqlOptimizer(SqlProviderFlags sqlProviderFlags, SqlServerVersion version) : base(sqlProviderFlags, version)
-		{
-		}
+		protected SqlServer2019SqlOptimizer(SqlProviderFlags sqlProviderFlags, SqlServerVersion version, AstFactory ast)
+			: base(sqlProviderFlags, version, ast)
+		{ }
 	}
 }

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServer2022SqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServer2022SqlOptimizer.cs
@@ -1,11 +1,12 @@
 ﻿namespace LinqToDB.DataProvider.SqlServer
 {
+	using LinqToDB.SqlQuery;
 	using SqlProvider;
 
 	class SqlServer2022SqlOptimizer : SqlServer2019SqlOptimizer
 	{
-		public SqlServer2022SqlOptimizer(SqlProviderFlags sqlProviderFlags) : base(sqlProviderFlags, SqlServerVersion.v2022)
-		{
-		}
+		public SqlServer2022SqlOptimizer(SqlProviderFlags sqlProviderFlags, AstFactory ast)
+			: base(sqlProviderFlags, SqlServerVersion.v2022, ast)
+		{ }
 	}
 }

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
@@ -62,14 +62,14 @@ namespace LinqToDB.DataProvider.SqlServer
 
 			_sqlOptimizer = version switch
 			{
-				SqlServerVersion.v2005 => new SqlServer2005SqlOptimizer(SqlProviderFlags),
-				SqlServerVersion.v2012 => new SqlServer2012SqlOptimizer(SqlProviderFlags),
-				SqlServerVersion.v2014 => new SqlServer2014SqlOptimizer(SqlProviderFlags),
-				SqlServerVersion.v2016 => new SqlServer2016SqlOptimizer(SqlProviderFlags),
-				SqlServerVersion.v2017 => new SqlServer2017SqlOptimizer(SqlProviderFlags),
-				SqlServerVersion.v2019 => new SqlServer2019SqlOptimizer(SqlProviderFlags),
-				SqlServerVersion.v2022 => new SqlServer2022SqlOptimizer(SqlProviderFlags),
-				_                      => new SqlServer2008SqlOptimizer(SqlProviderFlags),
+				SqlServerVersion.v2005 => new SqlServer2005SqlOptimizer(SqlProviderFlags, GetAstFactory()),
+				SqlServerVersion.v2012 => new SqlServer2012SqlOptimizer(SqlProviderFlags, GetAstFactory()),
+				SqlServerVersion.v2014 => new SqlServer2014SqlOptimizer(SqlProviderFlags, GetAstFactory()),
+				SqlServerVersion.v2016 => new SqlServer2016SqlOptimizer(SqlProviderFlags, GetAstFactory()),
+				SqlServerVersion.v2017 => new SqlServer2017SqlOptimizer(SqlProviderFlags, GetAstFactory()),
+				SqlServerVersion.v2019 => new SqlServer2019SqlOptimizer(SqlProviderFlags, GetAstFactory()),
+				SqlServerVersion.v2022 => new SqlServer2022SqlOptimizer(SqlProviderFlags, GetAstFactory()),
+				_                      => new SqlServer2008SqlOptimizer(SqlProviderFlags, GetAstFactory()),
 			};
 
 			// missing:

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseDataProvider.cs
@@ -37,7 +37,7 @@ namespace LinqToDB.DataProvider.Sybase
 			SetProviderField<DbDataReader, TimeSpan,DateTime>((r,i) => r.GetDateTime(i) - new DateTime(1900, 1, 1));
 			SetField<DbDataReader, DateTime>("time", (r,i) => GetDateTimeAsTime(r.GetDateTime(i)));
 
-			_sqlOptimizer = new SybaseSqlOptimizer(SqlProviderFlags);
+			_sqlOptimizer = new SybaseSqlOptimizer(SqlProviderFlags, GetAstFactory());
 		}
 
 		static DateTime GetDateTimeAsTime(DateTime value)

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseSqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseSqlOptimizer.cs
@@ -6,9 +6,9 @@
 
 	class SybaseSqlOptimizer : BasicSqlOptimizer
 	{
-		public SybaseSqlOptimizer(SqlProviderFlags sqlProviderFlags) : base(sqlProviderFlags)
-		{
-		}
+		public SybaseSqlOptimizer(SqlProviderFlags sqlProviderFlags, AstFactory ast)
+			: base(sqlProviderFlags, ast)
+		{ }
 
 		public override SqlStatement TransformStatement(SqlStatement statement)
 		{
@@ -23,8 +23,10 @@
 
 		public override string[] LikeCharactersToEscape => SybaseCharactersToEscape;
 
-		protected override ISqlExpression ConvertFunction(SqlFunction func)
+		protected override ISqlExpression ConvertFunction(ISqlExpression expr)
 		{
+			if (expr is not SqlFunction func) return expr;
+			
 			func = ConvertFunctionParameters(func, false);
 
 			switch (func.Name)

--- a/Source/LinqToDB/IDataContext.cs
+++ b/Source/LinqToDB/IDataContext.cs
@@ -8,6 +8,7 @@ namespace LinqToDB
 	using Interceptors;
 	using Mapping;
 	using SqlProvider;
+	using SqlQuery;
 
 	/// <summary>
 	/// Database connection abstraction interface.
@@ -33,6 +34,7 @@ namespace LinqToDB
 		/// Gets SQL optimizer service factory method for current context data provider.
 		/// </summary>
 		Func<ISqlOptimizer> GetSqlOptimizer       { get; }
+		AstFactory          AstFactory            { get; }
 		/// <summary>
 		/// Gets SQL support flags for current context data provider.
 		/// </summary>

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
@@ -97,6 +97,7 @@ namespace LinqToDB.Linq.Builder
 		private  HashSet<Expression>?              _subQueryExpressions;
 		readonly ExpressionTreeOptimizationContext _optimizationContext;
 		readonly ParametersContext                 _parametersContext;
+		readonly AstFactory                        _ast;
 
 		public ExpressionTreeOptimizationContext   OptimizationContext => _optimizationContext;
 		public ParametersContext                   ParametersContext   => _parametersContext;
@@ -118,7 +119,8 @@ namespace LinqToDB.Linq.Builder
 			Expression                        expression,
 			ParameterExpression[]?            compiledParameters)
 		{
-			_query               = query;
+			_ast                 = dataContext.AstFactory;
+			_query               = query;			
 
 			CollectQueryDepended(expression);
 

--- a/Source/LinqToDB/Remote/LinqServiceSerializer.cs
+++ b/Source/LinqToDB/Remote/LinqServiceSerializer.cs
@@ -968,8 +968,6 @@ namespace LinqToDB.Remote
 							var elem = (SqlPredicate.NotExpr)e;
 
 							Append(elem.Expr1);
-							Append(elem.IsNot);
-							Append(elem.Precedence);
 
 							break;
 						}
@@ -1817,11 +1815,9 @@ namespace LinqToDB.Remote
 
 					case QueryElementType.NotExprPredicate :
 						{
-							var expr1      = Read<ISqlExpression>()!;
-							var isNot      = ReadBool();
-							var precedence = ReadInt();
+							var expr1      = Read<ISqlPredicate>()!;
 
-							obj = new SqlPredicate.NotExpr(expr1, isNot, precedence);
+							obj = new SqlPredicate.NotExpr(expr1);
 
 							break;
 						}

--- a/Source/LinqToDB/Sql/Sql.Row.cs
+++ b/Source/LinqToDB/Sql/Sql.Row.cs
@@ -79,7 +79,7 @@
 			{
 				var args = Array.ConvertAll(builder.Arguments, x => builder.ConvertExpressionToSql(x));
 				builder.ResultExpression = new SqlSearchCondition(new SqlCondition(false,
-					new SqlPredicate.ExprExpr(args[0], SqlPredicate.Operator.Overlaps, args[1], false)));
+					new SqlPredicate.ExprExpr(args[0], SqlPredicate.Operator.Overlaps, args[1], null)));
 			}
 		}
 	}

--- a/Source/LinqToDB/Sql/Sql.cs
+++ b/Source/LinqToDB/Sql/Sql.cs
@@ -685,15 +685,17 @@ namespace LinqToDB
 				var condition = new SqlCondition(
 					false,
 					new SqlPredicate.NotExpr(
-						new SqlExpression(
-							typeof(bool),
-							"{0} SIMILAR TO {1}",
-							Precedence.Comparison,
-							SqlFlags.IsPredicate,
-							str,
-							new SqlValue(typeof(string), whiteSpaces)),
-						true,
-						Precedence.LogicalNegation),
+						new SqlPredicate.Expr(
+							new SqlExpression(
+								typeof(bool),
+								"{0} SIMILAR TO {1}",
+								Precedence.Comparison,
+								SqlFlags.IsPredicate,
+								str,
+								new SqlValue(typeof(string), whiteSpaces)
+							)
+						)
+					),
 					true);
 
 				if (str.CanBeNull)
@@ -716,15 +718,17 @@ namespace LinqToDB
 				var condition = new SqlCondition(
 					false,
 					new SqlPredicate.NotExpr(
-						new SqlExpression(
-							typeof(bool),
-							"{0} RLIKE {1}",
-							Precedence.Comparison,
-							SqlFlags.IsPredicate,
-							str,
-							new SqlValue(typeof(string), whiteSpaces)),
-						true,
-						Precedence.LogicalNegation),
+						new SqlPredicate.Expr(
+							new SqlExpression(
+								typeof(bool),
+								"{0} RLIKE {1}",
+								Precedence.Comparison,
+								SqlFlags.IsPredicate,
+								str,
+								new SqlValue(typeof(string), whiteSpaces)
+							)
+						)
+					),
 					true);
 
 				if (str.CanBeNull)
@@ -1006,7 +1010,7 @@ namespace LinqToDB
 							100 :
 							SqlDataType.GetMaxDisplaySize(dataContext.MappingSchema.GetDataType(arg.SystemType).Type.DataType);
 
-						arr[i] = PseudoFunctions.MakeConvert(new SqlDataType(DataType.VarChar, typeof(string), len, null, null, null), new SqlDataType(arg.GetExpressionType()), arg);
+						arr[i] = dataContext.AstFactory.Convert(new SqlDataType(DataType.VarChar, typeof(string), len, null, null, null), arg);
 					}
 				}
 

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -2358,15 +2358,8 @@ namespace LinqToDB.SqlProvider
 				case QueryElementType.NotExprPredicate:
 					{
 						var p = (SqlPredicate.NotExpr)predicate;
-
-						if (p.IsNot)
-							StringBuilder.Append("NOT ");
-
-						BuildExpression(
-							((SqlPredicate.NotExpr)predicate).IsNot
-								? Precedence.LogicalNegation
-								: GetPrecedence((SqlPredicate.NotExpr)predicate),
-							((SqlPredicate.NotExpr)predicate).Expr1);
+						StringBuilder.Append("NOT ");
+						BuildPredicate(Precedence.LogicalNegation, p.Expr1.Precedence, p.Expr1);
 					}
 
 					break;

--- a/Source/LinqToDB/SqlQuery/AstFactory.cs
+++ b/Source/LinqToDB/SqlQuery/AstFactory.cs
@@ -1,0 +1,262 @@
+using System;
+using Config = LinqToDB.Common.Configuration;
+
+namespace LinqToDB.SqlQuery
+{
+	public class AstFactory
+	{
+		#region Ctor
+
+		public AstFactory() 
+		{
+			// REVIEW(jods): a real True/False predicate node might be nice for DBs that have BOOLEAN support
+			TruePredicate = Equal(One, One);
+			FalsePredicate = Equal(One, Zero);
+		}
+
+		#endregion
+
+		#region Predicates 
+
+		public ISqlPredicate IsNotNull(ISqlExpression expr) => IsNull(expr, isNot: true);
+
+		public ISqlPredicate IsNull(ISqlExpression expr, bool isNot = false)
+		{
+			return expr.CanBeNull
+				? new SqlPredicate.IsNull(expr, isNot)
+				: isNot ? TruePredicate : FalsePredicate;
+		}
+
+		public ISqlPredicate Equal(ISqlExpression left, ISqlExpression right, bool configNulls = false)
+			=> Comparison(left, SqlPredicate.Operator.Equal, right, configNulls);
+
+		public ISqlPredicate NotEqual(ISqlExpression left, ISqlExpression right, bool configNulls = false)
+			=> Comparison(left, SqlPredicate.Operator.NotEqual, right, configNulls);
+
+		public ISqlPredicate Greater(ISqlExpression left, ISqlExpression right, bool configNulls = false)
+			=> Comparison(left, SqlPredicate.Operator.Greater, right, configNulls);
+
+		public ISqlPredicate GreaterEqual(ISqlExpression left, ISqlExpression right, bool configNulls = false)
+			=> Comparison(left, SqlPredicate.Operator.GreaterOrEqual, right, configNulls);
+
+		public ISqlPredicate NotGreaterEqual(ISqlExpression left, ISqlExpression right, bool configNulls = false)
+			=> Comparison(left, SqlPredicate.Operator.NotGreater, right, configNulls);
+
+		public ISqlPredicate Less(ISqlExpression left, ISqlExpression right, bool configNulls = false)
+			=> Comparison(left, SqlPredicate.Operator.Less, right, configNulls);
+
+		public ISqlPredicate LessEqual(ISqlExpression left, ISqlExpression right, bool configNulls = false)
+			=> Comparison(left, SqlPredicate.Operator.LessOrEqual, right, configNulls);
+
+		public ISqlPredicate NotLess(ISqlExpression left, ISqlExpression right, bool configNulls = false)
+			=> Comparison(left, SqlPredicate.Operator.NotLess, right, configNulls);
+
+		public ISqlPredicate Overlaps(ISqlExpression left, ISqlExpression right)
+			=> Comparison(left, SqlPredicate.Operator.Overlaps, right, configNulls: false);
+
+		public ISqlPredicate Comparison(
+			ISqlExpression left, 
+			SqlPredicate.Operator op, 
+			ISqlExpression right, 
+			bool configNulls = false)
+		{
+			bool? withNull = configNulls && Config.Linq.CompareNullsAsValues ? true : null;
+			return new SqlPredicate.ExprExpr(left, op, right, withNull);
+		}
+
+		public SqlSearchCondition And(params ISqlPredicate[] operands)
+			=> And((ICollection<ISqlPredicate>)operands);
+
+		public SqlSearchCondition And(ICollection<ISqlPredicate> operands)
+		{
+			// TODO(jods): ensure nested AND are flattened. It's done by the Expression parser for efficiency,
+			// but it isn't guaranteed when manipulating the AST, e.g. by optimizations.
+			return new SqlSearchCondition(
+				operands.Select(x => new SqlCondition(isNot: false, x))
+			);
+		}
+
+		public SqlSearchCondition Or(params ISqlPredicate[] operands)
+			=> Or((ICollection<ISqlPredicate>)operands);
+
+		public SqlSearchCondition Or(ICollection<ISqlPredicate> operands)
+		{
+			// TODO(jods): ensure nested OR are flattened. It's done by the Expression parser for efficiency,
+			// but it isn't guaranteed when manipulating the AST, e.g. by optimizations.
+			return new SqlSearchCondition(
+				operands.Select(x => new SqlCondition(isNot: false, x, isOr: true))
+			);
+		}
+
+		public ISqlPredicate Not(ISqlPredicate a)
+		{
+			return a is IInvertibleElement { CanInvert: true } i
+				? i.Invert()
+				: new SqlPredicate.NotExpr(a);
+		}
+
+		// REVIEW(jods): this is ugly and inefficient, can't all ISqlPredicate be ISqlExpression?
+		// Or completely split ISqlExpresion and ISqlPredicate (after all they are used in different contexts).
+		// Or at least can we have a ISqlExpression node that is more efficient at representing a predicate than SqlSearchCondition!
+		public ISqlExpression ToExpression(ISqlPredicate predicate)
+		{
+			return predicate is ISqlExpression expr
+				? expr
+				: new SqlSearchCondition(
+					new SqlCondition(isNot: false, predicate)
+				);
+		}
+
+		#endregion
+
+		#region Expressions:Constants
+
+		// Cached commonly used nodes
+		public readonly SqlValue MinusOne = new SqlValue(-1);
+		public readonly SqlValue Zero     = new SqlValue(0);
+		public readonly SqlValue One      = new SqlValue(1);
+
+		public readonly SqlValue True     = new SqlValue(true);
+		public readonly SqlValue False    = new SqlValue(false);
+
+		public readonly ISqlPredicate TruePredicate;
+		public readonly ISqlPredicate FalsePredicate;
+
+		#endregion
+
+		#region Expressions:Numbers
+
+		public ISqlExpression Negate(ISqlExpression a, Type sysType)
+			=> new SqlBinaryExpression(sysType, MinusOne, "*", a, Precedence.Multiplicative);
+		public ISqlExpression Add(ISqlExpression a, ISqlExpression b, Type sysType)
+			=> new SqlBinaryExpression(sysType, a, "+", b, Precedence.Additive);
+
+		public ISqlExpression Subtract(ISqlExpression a, ISqlExpression b, Type sysType)
+			=> new SqlBinaryExpression(sysType, a, "-", b, Precedence.Subtraction);
+
+		public ISqlExpression Multiply(ISqlExpression a, ISqlExpression b, Type sysType)
+			=> new SqlBinaryExpression(sysType, a, "*", b, Precedence.Multiplicative);
+
+		public ISqlExpression Divide(ISqlExpression a, ISqlExpression b, Type sysType)
+			=> new SqlBinaryExpression(sysType, a, "/", b, Precedence.Multiplicative);
+
+		public ISqlExpression Mod(ISqlExpression a, ISqlExpression b, Type sysType)
+			=> new SqlBinaryExpression(sysType, a, "%", b, Precedence.Multiplicative);
+
+		public ISqlExpression Power(ISqlExpression a, ISqlExpression b, Type sysType)
+			=> new SqlFunction(sysType, "Power", a, b);
+
+		#endregion
+
+		#region Expressions:Bits
+
+		public ISqlExpression BitAnd(ISqlExpression a, ISqlExpression b, Type sysType)
+			=> new SqlBinaryExpression(sysType, a, "&", b, Precedence.Bitwise);
+
+		public ISqlExpression BitOr(ISqlExpression a, ISqlExpression b, Type sysType)
+			=> new SqlBinaryExpression(sysType, a, "|", b, Precedence.Bitwise);
+
+		public ISqlExpression BitXor(ISqlExpression a, ISqlExpression b, Type sysType)
+			=> new SqlBinaryExpression(sysType, a, "^", b, Precedence.Bitwise);
+
+		#endregion
+
+		#region Expressions:Logic
+
+		public ISqlExpression Coalesce(ISqlExpression a, ISqlExpression b, Type sysType)
+		{
+			// Flatten nested Coalesce calls
+			var ua = QueryHelper.UnwrapExpression(a);
+			var ub = QueryHelper.UnwrapExpression(b);
+			ISqlExpression[] values = (ua, ub) switch
+			{
+				(SqlFunction { Name: "Coalesce" or PseudoFunctions.COALESCE } ca, 
+				 SqlFunction { Name: "Coalesce" or PseudoFunctions.COALESCE } cb)    => ToArray(ca.Parameters, cb.Parameters),
+				(SqlFunction { Name: "Coalesce" or PseudoFunctions.COALESCE } ca, _) => ToArray(ca.Parameters, b),
+				(_, SqlFunction { Name: "Coalesce" or PseudoFunctions.COALESCE } cb) => ToArray(a, cb.Parameters),
+				_ => new[] { a, b },
+			};
+
+			return new SqlFunction(sysType, PseudoFunctions.COALESCE, isAggregate: false, isPure: true, values)
+			{
+				CanBeNull = values.All(v => v.CanBeNull),
+			};
+		}
+
+		public ISqlExpression If(ISqlExpression condition, ISqlExpression whenTrue, ISqlExpression whenFalse, Type sysType)
+		{			
+			// Flatten chained else-if calls
+			var uf = QueryHelper.UnwrapExpression(whenFalse);
+			if (uf is SqlFunction { Name: "CASE" } f)
+			{
+				return new SqlFunction(sysType, "CASE", ToArray(condition, whenTrue, f.Parameters))
+				{
+					CanBeNull = whenTrue.CanBeNull | whenFalse.CanBeNull
+				};
+			}
+
+			return new SqlFunction(sysType, "CASE", condition, whenTrue, whenFalse) 
+			{ 
+				CanBeNull = whenTrue.CanBeNull | whenFalse.CanBeNull,
+			};
+		}
+
+		#endregion
+
+		#region Expressions:Types
+
+		public ISqlExpression Convert(SqlDataType toType, ISqlExpression value, SqlDataType? fromType = null)
+		{
+			return new SqlFunction(
+				toType.SystemType, 
+				PseudoFunctions.CONVERT, 
+				isAggregate: false, 
+				isPure: true, 
+				toType, 
+				fromType ?? new SqlDataType(value.GetExpressionType()), 
+				value)
+			{
+				CanBeNull = value.CanBeNull
+			};
+		}
+
+		#endregion
+
+		#region Private utilities
+
+		private static T[] ToArray<T>(T[] a, T[] b)
+		{
+			var result = new T[a.Length + b.Length];
+			a.CopyTo(result, 0);
+			b.CopyTo(result, a.Length);
+			return result;
+		}
+
+		private static T[] ToArray<T>(T[] a, T b)
+		{
+			var result = new T[a.Length + 1];
+			a.CopyTo(result, 0);
+			result[a.Length] = b;
+			return result;
+		}
+
+		private static T[] ToArray<T>(T a, T[] b)
+		{
+			var result = new T[1 + b.Length];
+			result[0] = a;
+			b.CopyTo(result, 1);
+			return result;
+		}
+
+		private static T[] ToArray<T>(T a, T b, T[] c)
+		{
+			var result = new T[2 + c.Length];
+			result[0] = a;
+			result[1] = b;
+			c.CopyTo(result, 2);
+			return result;
+		}
+
+		#endregion 
+	}
+}

--- a/Source/LinqToDB/SqlQuery/CloneVisitor.cs
+++ b/Source/LinqToDB/SqlQuery/CloneVisitor.cs
@@ -531,7 +531,7 @@ namespace LinqToDB.SqlQuery
 				{
 					var expr = (SqlPredicate.NotExpr)(IQueryElement)element;
 					// TODO: children Clone called before _objectTree update (original cloning logic)
-					_objectTree.Add(element, clone = new SqlPredicate.NotExpr(Clone(expr.Expr1), expr.IsNot, expr.Precedence));
+					_objectTree.Add(element, clone = new SqlPredicate.NotExpr(Clone(expr.Expr1)));
 					break;
 				}
 

--- a/Source/LinqToDB/SqlQuery/ConvertVisitor.cs
+++ b/Source/LinqToDB/SqlQuery/ConvertVisitor.cs
@@ -381,10 +381,10 @@ namespace LinqToDB.SqlQuery
 					case QueryElementType.NotExprPredicate:
 					{
 						var p = (SqlPredicate.NotExpr)element;
-						var e = (ISqlExpression?)ConvertInternal(p.Expr1);
+						var e = (ISqlPredicate?)ConvertInternal(p.Expr1);
 
 						if (e != null && !ReferenceEquals(p.Expr1, e))
-							newElement = new SqlPredicate.NotExpr(e, p.IsNot, p.Precedence);
+							newElement = new SqlPredicate.NotExpr(e);
 
 						break;
 					}

--- a/Source/LinqToDB/SqlQuery/IInvertibleElement.cs
+++ b/Source/LinqToDB/SqlQuery/IInvertibleElement.cs
@@ -2,7 +2,7 @@
 {
 	public interface IInvertibleElement
 	{
-		bool CanInvert();
-		IQueryElement Invert();
+		bool CanInvert { get; }
+		ISqlPredicate Invert();
 	}
 }

--- a/Source/LinqToDB/SqlQuery/PseudoFunctions.cs
+++ b/Source/LinqToDB/SqlQuery/PseudoFunctions.cs
@@ -95,18 +95,5 @@
 		/// Function to return first non-null argument: <c>COALESCE(values...)</c>
 		/// </summary>
 		public const string COALESCE = "$Coalesce$";
-		public static SqlFunction MakeCoalesce(Type systemType, params ISqlExpression[] values)
-		{
-			var canBeNull = true;
-
-			foreach (var value in values)
-				if (!value.CanBeNull)
-					canBeNull = false;
-
-			return new SqlFunction(systemType, COALESCE, false, true, values)
-			{
-				CanBeNull = canBeNull
-			};
-		}
 	}
 }

--- a/Source/LinqToDB/SqlQuery/SelectQueryOptimizer.cs
+++ b/Source/LinqToDB/SqlQuery/SelectQueryOptimizer.cs
@@ -519,9 +519,9 @@
 				}
 			}
 
-			if (condition.IsNot && condition.Predicate is IInvertibleElement invertibleElement && invertibleElement.CanInvert())
+			if (condition.IsNot && condition.Predicate is IInvertibleElement { CanInvert: true } invertibleElement)
 			{
-				return new SqlCondition(false, (ISqlPredicate)invertibleElement.Invert(), condition.IsOr);
+				return new SqlCondition(false, invertibleElement.Invert(), condition.IsOr);
 			}
 
 			return condition;
@@ -552,7 +552,7 @@
 				{
 					var exprExpr = (SqlPredicate.ExprExpr)cond.Predicate;
 
-					if (cond.IsNot && exprExpr.CanInvert())
+					if (cond.IsNot && exprExpr.CanInvert)
 					{
 						exprExpr = (SqlPredicate.ExprExpr)exprExpr.Invert();
 						newCond  = new SqlCondition(false, exprExpr, newCond.IsOr);
@@ -590,8 +590,8 @@
 						}
 						else if (expr.Expr1 is SqlSearchCondition expCond && expCond.Conditions.Count == 1)
 						{
-							if (expCond.Conditions[0].Predicate is IInvertibleElement invertible && invertible.CanInvert())
-								newCond = new SqlCondition(false, (ISqlPredicate)invertible.Invert(), newCond.IsOr);
+							if (expCond.Conditions[0].Predicate is IInvertibleElement { CanInvert: true } invertible)
+								newCond = new SqlCondition(false, invertible.Invert(), newCond.IsOr);
 						}
 					}
 				}
@@ -686,9 +686,9 @@
 							isNot = !isNot;
 
 						var predicate = sc.Conditions[0].Predicate;
-						if (isNot && predicate is IInvertibleElement invertible && invertible.CanInvert())
+						if (isNot && predicate is IInvertibleElement { CanInvert: true } invertible)
 						{
-							predicate = (ISqlPredicate)invertible.Invert();
+							predicate = invertible.Invert();
 							isNot = !isNot;
 						}
 

--- a/Source/LinqToDB/SqlQuery/SqlFunction.cs
+++ b/Source/LinqToDB/SqlQuery/SqlFunction.cs
@@ -2,7 +2,7 @@
 
 namespace LinqToDB.SqlQuery
 {
-	public class SqlFunction : ISqlExpression//ISqlTableSource
+	public sealed class SqlFunction : ISqlExpression//ISqlTableSource
 	{
 		public SqlFunction(Type systemType, string name, params ISqlExpression[] parameters)
 			: this(systemType, name, false, true, SqlQuery.Precedence.Primary, parameters)

--- a/Source/LinqToDB/SqlQuery/SqlSearchCondition.cs
+++ b/Source/LinqToDB/SqlQuery/SqlSearchCondition.cs
@@ -2,7 +2,7 @@
 
 namespace LinqToDB.SqlQuery
 {
-	public class SqlSearchCondition : ConditionBase<SqlSearchCondition, SqlSearchCondition.Next>, ISqlPredicate, ISqlExpression, IInvertibleElement
+	public sealed class SqlSearchCondition : ConditionBase<SqlSearchCondition, SqlSearchCondition.Next>, ISqlPredicate, ISqlExpression, IInvertibleElement
 	{
 		public SqlSearchCondition()
 		{
@@ -91,12 +91,9 @@ namespace LinqToDB.SqlQuery
 
 		#region IInvertibleElement Members
 
-		public bool CanInvert()
-		{
-			return Conditions.Count > 0 && Conditions.Count(c => c.IsNot) > Conditions.Count / 2;
-		}
+		public bool CanInvert => Conditions.Count > 0 && Conditions.Count(c => c.IsNot) > Conditions.Count / 2;
 
-		public IQueryElement Invert()
+		public ISqlPredicate Invert()
 		{
 			if (Conditions.Count == 0)
 			{

--- a/Source/Test/.vscode/launch.json
+++ b/Source/Test/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "OS-COMMENT1": "Use IntelliSense to find out which attributes exist for C# debugging",
+      "OS-COMMENT2": "Use hover for the description of the existing attributes",
+      "OS-COMMENT3": "For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md",
+      "name": ".NET Core Launch (console)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "OS-COMMENT4": "If you have changed target frameworks, make sure to update the program path.",
+      "program": "${workspaceFolder}/bin/Debug/net5.0/Test.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}",
+      "OS-COMMENT5": "For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console",
+      "console": "internalConsole",
+      "stopAtEntry": false
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach",
+      "processId": "${command:pickProcess}"
+    }
+  ]
+}

--- a/Source/Test/.vscode/tasks.json
+++ b/Source/Test/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/Test.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "publish",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "publish",
+        "${workspaceFolder}/Test.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "watch",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "watch",
+        "run",
+        "${workspaceFolder}/Test.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}

--- a/Source/Test/Program.cs
+++ b/Source/Test/Program.cs
@@ -1,0 +1,259 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using LinqToDB;
+using LinqToDB.Data;
+using LinqToDB.DataProvider.Oracle;
+using LinqToDB.DataProvider.SqlServer;
+using LinqToDB.Linq;
+using LinqToDB.Mapping;
+using LinqToDB.Tools;
+using Moq;
+using Moq.Protected;
+using Oracle.ManagedDataAccess.Types;
+
+#region Mocks 
+
+DbParameter MockParameter()
+{
+	return new Mock<DbParameter>()
+		.SetupProperty(x => x.ParameterName)
+		.SetupProperty(x => x.Value)
+		.Object;
+}
+
+var parameters = new List<object>();
+var ps = new Mock<DbParameterCollection>();
+ps.Setup(x => x.Count).Returns(() => parameters.Count);
+ps.Setup(x => x.GetEnumerator()).Returns(() => parameters.GetEnumerator());
+ps.Setup(x => x.Add(It.IsAny<object>())).Callback((object p) => parameters.Add(p));
+
+var reader = new Mock<DbDataReader>();
+reader.Setup(x => x.Read()).Returns(false);
+
+var cmd = new Mock<DbCommand>();
+cmd.Protected().Setup<DbParameterCollection>("DbParameterCollection").Returns(ps.Object);
+cmd.Protected().Setup<DbParameter>("CreateDbParameter").Returns(MockParameter);
+cmd.SetupProperty(x => x.CommandText);
+cmd.Protected().Setup<DbDataReader>("ExecuteDbDataReader", ItExpr.IsAny<CommandBehavior>()).Returns(() => reader.Object);
+
+var con = new Mock<DbConnection>();
+con.Protected().Setup<DbCommand>("CreateDbCommand").Returns(cmd.Object);
+
+DataConnection.TurnTraceSwitchOn();
+
+//var providerType = typeof(OracleDataProvider).Assembly.GetType("LinqToDB.DataProvider.Oracle.OracleDataProviderManaged12");
+//var provider = (OracleDataProvider)Activator.CreateInstance(providerType);
+var providerType = typeof(SqlServerDataProvider).Assembly.GetType("LinqToDB.DataProvider.SqlServer.SqlServerDataProvider2019MicrosoftDataSqlClient");
+var provider = (SqlServerDataProvider)Activator.CreateInstance(providerType);
+//  (OracleDataProvider)providerType
+//     .GetConstructor(
+//       BindingFlags.NonPublic | BindingFlags.CreateInstance | BindingFlags.Instance, 
+//       null, 
+//       new[] { typeof(string) }, 
+//       null
+//     )
+//     .Invoke();
+
+var db = new DataConnection(
+	provider,
+	con.Object);
+
+#endregion
+
+Console.WriteLine("Starting tests...");
+
+// (from a in db.GetTable<Basic>()
+//  from b in db.GetTable<Basic>().LeftJoin(b => a.Id == b.Id)
+//  select Sql.AsSql(b == null ? a.Id : b.Id))
+//  .ToList();
+// Console.WriteLine("OUTER JOIN");
+// Console.WriteLine("=================");
+// Console.WriteLine(cmd.Object.CommandText);
+
+// (from a in db.GetTable<Table3>()
+// join b in db.GetTable<Table3>() on a.ParentID equals b.ParentID + 2
+// select 1)
+// .ToList();
+// Console.WriteLine("INNER JOIN");
+// Console.WriteLine("=================");
+// Console.WriteLine(cmd.Object.CommandText);
+
+var values = new Table3[] 
+{
+	new() { ParentID = 1, ChildID = null },
+	new() { ParentID = 2, ChildID = null },
+};
+
+//db.Update(new Table3 { ParentID = 10000, ChildID = null, GrandChildID = 1000 });
+
+int a = 3;
+
+db.GetTable<Table3>()
+	.Where(p => (a == 1 ? 3 : a == 2 ? 4 : 5) == 4)
+	.ToList();
+Console.WriteLine("update null PK");
+Console.WriteLine("=================");
+Console.WriteLine(cmd.Object.CommandText);
+
+//TestAll(true);
+//TestIsNull(true);
+//TestIsNull(false);
+//TestAllEnums(true);
+//TestAllCEnums(false);
+
+void TestAll(bool nulls)
+{
+	Console.WriteLine("\n---------------------------\nCompareNullsAsValues = " + nulls + "\n---------------------------\n");
+	LinqToDB.Common.Configuration.Linq.CompareNullsAsValues = nulls;
+	Query.ClearCaches();
+
+	TestOne(x => x.A == x.B, "A == B");
+	TestOne(x => x.A != x.B, "A != B");
+	TestOne(x => x.A >= x.B, "A >= B");
+	TestOne(x => x.A > x.B, "A > B");
+	TestOne(x => x.A <= x.B, "A <= B");
+	TestOne(x => x.A < x.B, "A < B");
+
+	TestOne(x => !(x.A == x.B), "NOT A == B");
+	TestOne(x => !(x.A != x.B), "NOT A != B");
+	TestOne(x => !(x.A >= x.B), "NOT A >= B");
+	TestOne(x => !(x.A > x.B), "NOT A > B");
+	TestOne(x => !(x.A <= x.B), "NOT A <= B");
+	TestOne(x => !(x.A < x.B), "NOT A < B");	
+}
+
+void TestIsNull(bool nulls)
+{
+	Console.WriteLine("\n---------------------------\nCompareNullsAsValues = " + nulls + "\n---------------------------\n");
+	LinqToDB.Common.Configuration.Linq.CompareNullsAsValues = nulls;
+	Query.ClearCaches();
+	int? nilvar = null;
+	TestOne(x => x.A == null, "A == null");
+	TestOne(x => x.A == nilvar, "A == nilvar");
+	TestOne(x => Sql.Row(x.A, x.B) == null, "(A, B) == null");
+}
+
+void TestAllEnums(bool nulls)
+{
+	Console.WriteLine("\n---------------------------\nCompareNullsAsValues = " + nulls + "\n---------------------------\n");
+	LinqToDB.Common.Configuration.Linq.CompareNullsAsValues = nulls;
+	Query.ClearCaches();
+
+	TestOne(x => x.Enum == x.Enum, "Enum == Enum");
+	TestOne(x => x.Enum != x.Enum, "Enum != Enum");
+	TestOne(x => x.Enum >= x.Enum, "Enum >= Enum");
+	TestOne(x => x.Enum > x.Enum, "Enum > Enum");
+	TestOne(x => x.Enum <= x.Enum, "Enum <= Enum");
+	TestOne(x => x.Enum < x.Enum, "Enum < Enum");
+
+	TestOne(x => !(x.Enum == x.Enum), "NOT Enum == Enum");
+	TestOne(x => !(x.Enum != x.Enum), "NOT Enum != Enum");
+	TestOne(x => !(x.Enum >= x.Enum), "NOT Enum >= Enum");
+	TestOne(x => !(x.Enum > x.Enum), "NOT Enum > Enum");
+	TestOne(x => !(x.Enum <= x.Enum), "NOT Enum <= Enum");
+	TestOne(x => !(x.Enum < x.Enum), "NOT Enum < Enum");	
+}
+
+void TestAllCEnums(bool nulls)
+{
+	Console.WriteLine("\n---------------------------\nCompareNullsAsValues = " + nulls + "\n---------------------------\n");
+	LinqToDB.Common.Configuration.Linq.CompareNullsAsValues = nulls;
+	Query.ClearCaches();
+
+	TestOne(x => x.CEnum == x.CEnum, "CEnum == CEnum");
+	TestOne(x => x.CEnum != x.CEnum, "CEnum != CEnum");
+	TestOne(x => x.CEnum >= x.CEnum, "CEnum >= CEnum");
+	TestOne(x => x.CEnum > x.CEnum, "CEnum > CEnum");
+	TestOne(x => x.CEnum <= x.CEnum, "CEnum <= CEnum");
+	TestOne(x => x.CEnum < x.CEnum, "CEnum < CEnum");
+
+	TestOne(x => !(x.CEnum == x.CEnum), "NOT CEnum == CEnum");
+	TestOne(x => !(x.CEnum != x.CEnum), "NOT CEnum != CEnum");
+	TestOne(x => !(x.CEnum >= x.CEnum), "NOT CEnum >= CEnum");
+	TestOne(x => !(x.CEnum > x.CEnum), "NOT CEnum > CEnum");
+	TestOne(x => !(x.CEnum <= x.CEnum), "NOT CEnum <= CEnum");
+	TestOne(x => !(x.CEnum < x.CEnum), "NOT CEnum < CEnum");	
+}
+
+void TestOne(Expression<Func<Basic, bool>> where, string name)
+{
+	db.GetTable<Basic>().Where(where).ToList();
+	Console.WriteLine("--- " + name);
+	Console.WriteLine(cmd.Object.CommandText);
+}
+
+void SetupSrcTable(IDataContext db)
+{
+	db.GetFluentMappingBuilder()
+		.Entity<Basic>()
+			.Property(e => e.CEnum)
+				.HasDataType(DataType.VarChar)
+				.HasConversion(v => $"___{v}___", v => (ConvertedEnum)Enum.Parse(typeof(ConvertedEnum), v.Substring(3, v.Length - 6)));
+
+	// var data = new[]
+	// {
+	// 	new Src { Id = 1 },
+	// 	new Src { Id = 2, Int = 2, Enum = ContainsEnum.Value2, CEnum = ConvertedEnum.Value2 },
+	// };
+
+	// var src  = db.CreateLocalTable(data);
+	// return src;
+}
+
+class Basic
+{
+	[PrimaryKey]
+	public int Id { get; set; }
+	public int? A { get; set; }
+	public int? B { get; set; }
+	public ContainsEnum?  Enum  { get; set; }
+	public ConvertedEnum? CEnum { get; set; }
+}
+
+enum ContainsEnum
+{
+	[MapValue("ONE")  ] Value1,
+	[MapValue("TWO")  ] Value2,
+	[MapValue("THREE")] Value3,
+	[MapValue("FOUR") ] Value4,
+}
+
+enum ConvertedEnum
+{
+	Value1,
+	Value2,
+	Value3,
+	Value4,
+}
+
+class Parent
+{
+	[PrimaryKey]
+	public int? ID { get; set; }
+	public string? Name {get;set;}
+}
+
+class Child
+{
+	[PrimaryKey]
+	public int ID { get; set; }
+	public int ParentID {get;set;}	
+	[Association(ThisKey = "ParentID", OtherKey = "ID" )]
+	public Parent? Parent {get;set;}
+}
+
+[Table("GrandChild")]
+class Table3
+{	
+	[PrimaryKey(1)] public int? ParentID;
+	[PrimaryKey(2)] public int? ChildID;
+	[Column]        public int? GrandChildID;
+	[Column] public int NotNull;
+}

--- a/Source/Test/Test.csproj
+++ b/Source/Test/Test.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\LinqToDB\LinqToDB.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="3.21.1" />
+	<PackageReference Include="Microsoft.Data.SqlClient" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/Tests/.vscode/launch.json
+++ b/Tests/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      // Use IntelliSense to find out which attributes exist for C# debugging
+      // Use hover for the description of the existing attributes
+      // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+      "name": ".NET Core Launch (console)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      // If you have changed target frameworks, make sure to update the program path.
+      "program": "${workspaceFolder}/Tests.Benchmarks/bin/Debug/netcoreapp3.1/linq2db.Benchmarks.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/Tests.Benchmarks",
+      // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+      "console": "internalConsole",
+      "stopAtEntry": false
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach"
+    }
+  ]
+}

--- a/Tests/.vscode/tasks.json
+++ b/Tests/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/Tests.Benchmarks/linq2db.Benchmarks.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "publish",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "publish",
+        "${workspaceFolder}/Tests.Benchmarks/linq2db.Benchmarks.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "watch",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "watch",
+        "run",
+        "--project",
+        "${workspaceFolder}/Tests.Benchmarks/linq2db.Benchmarks.csproj"
+      ],
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}

--- a/Tests/Base/TestProviders/TestNoopProvider.cs
+++ b/Tests/Base/TestProviders/TestNoopProvider.cs
@@ -320,8 +320,7 @@ namespace Tests
 		public static ISqlOptimizer Instance = new TestNoopSqlOptimizer();
 
 		private TestNoopSqlOptimizer()
-			: base(new SqlProviderFlags())
-		{
-		}
+			: base(new SqlProviderFlags(), new AstFactory())
+		{ }
 	}
 }

--- a/Tests/Linq/Samples/DataContextDecoratorTests.cs
+++ b/Tests/Linq/Samples/DataContextDecoratorTests.cs
@@ -7,6 +7,7 @@ using LinqToDB.Interceptors;
 using LinqToDB.Linq;
 using LinqToDB.Mapping;
 using LinqToDB.SqlProvider;
+using LinqToDB.SqlQuery;
 
 using NUnit.Framework;
 
@@ -32,6 +33,7 @@ namespace Tests.Samples
 			public string              ContextName           => _context.ContextName;
 			public int                 ContextID             => _context.ContextID;
 			public Func<ISqlOptimizer> GetSqlOptimizer       => _context.GetSqlOptimizer;
+			public AstFactory          AstFactory            => _context.AstFactory;
 			public Type                DataReaderType        => _context.DataReaderType;
 			public Func<ISqlBuilder>   CreateSqlProvider     => _context.CreateSqlProvider;
 			public List<string>        NextQueryHints        => _context.NextQueryHints;

--- a/Tests/Linq/UserTests/Issue982Tests.cs
+++ b/Tests/Linq/UserTests/Issue982Tests.cs
@@ -13,9 +13,9 @@ namespace Tests.UserTests
 	{
 		private class Issue982FirebirdSqlOptimizer : FirebirdSqlOptimizer
 		{
-			public Issue982FirebirdSqlOptimizer(SqlProviderFlags sqlProviderFlags) : base(sqlProviderFlags)
-			{
-			}
+			public Issue982FirebirdSqlOptimizer(SqlProviderFlags sqlProviderFlags) 
+				: base(sqlProviderFlags, new AstFactory())
+			{ }
 
 			public override SqlStatement Finalize(MappingSchema mappingSchema, SqlStatement statement)
 			{


### PR DESCRIPTION
This is an attempt at improving the internals of linq2db, there is no change for users.
As linq2db is large and complex, the changes in the PR are just "getting started" and far from complete, although as I will discuss below it should probably be merged incrementally in multiple steps..

## Main idea: add an AST factory
The core idea of this PR is to introduce a factory class to create our SQL abstract syntax tree.
So, instead of new'ing up nodes with `new SqlPredicate.IsNull(...)` and friends, we call into `ast.IsNull(...)`.

## What's the difference anyway?!
`new T` must return an instance of `T`, whereas a factory could return any `ISqlExpression`.
This opens up quite a few possibilities:

### Local optimizations
The AST factory can apply local transformations and return an equivalent, optimized expression. I think I've seen this referred to as _optimization by construction_.

For example, if you call `and(...)` with a series of nodes that incl. a `false` constant, the factory would just return a `false` constant; Nested calls to `coalesce(...)` can be flattened in a single node.

Today, these transformations are generally done by `SqlOptimizer`. Doing them at construction time largely reduces the number of allocations, which is beneficial for performance.

To illustrate, consider the expression `isnull(row(x, y))` in a provider that doesn't support `row`.
Today, compilation could go like this:
```
isnull( row(x, y) )         # Parsed AST -> 2 nodes (in addition to x, y)
and( isnull(x), isnull(y) ) # Optimizer lowers to non-row code -> 3 new nodes
and( isnull(x), false )     # Optimizer notices y cannot be null, simplifies -> 2 new nodes
false                       # Optimizers sees "and" is always false -> 0 new node (hopefully reuses false node)
```
With a builder, the same process happens but immediately at construction without visiting anything, and without constructing intermediate nodes:
```
ast.row(x, y)           # Temporary row(x, y) must still be built by expression parser -> 1 node.
ast.isnull( row(x, y) ) # This call notices the row and immediately calls SQL equivalent -> 0 node.
ast.and( 
  ast.isnull( x ),      # Allocates a temporary isnull(x) -> 1 node
  ast.isnull( y )       # Notices y is non-nullable and returns a cached "false" node -> 0 allocation
)                       # ast.and call notices one parameter is false and returns it -> 0 allocation
```
Summary: current design allocates 7 nodes (in addition to x, y); factory only allocates 2!

> **Note**
> This doesn't remove or replace `SqlOptimizer`. It is still useful for _global_ optimizations, i.e. transforms that need more context than just the current node.

### Interning
Common constants or expressions such as `null`, `0`, `1`, `true`, `false` are cached and re-used, reducing allocations.
If the codebase is 100% going through the AST factory, we can take advantage of the fact that values are interned and make reference equalities rather than pattern matching to check if something is a well-known value like `0`.

### Provider-specific translations
The factory could be a static class, but I've made it an instance, so that we can have provider-specific factories.
This enable provider-specific transformations, such as lowering unsupported expressions like `SqlRow` in the previous example.

### Enforcing invariants
The factory can enforce some constraints on our AST nodes, for example we could guarantee that a some structures like `or`, `coalesce` are always flattened, which makes further processing more efficient.

## Benefits of AST factory
### Performance
As explained above, a factory can apply transformations at construction without allocating nodes.
This improves performance because it reduces GC pressure and requires less "visiting".
### Separation of concerns
Some optimizations are actually made by the expression parser.
This complicates the parser with things that are not its responsibilities. 
Furthermore, those optimizations are either not applied later when the tree is transformed, or duplicated.
With a dedicated class that consistently does these transforms, the calling code can be simplified.

I think that if you look at the code that is already modified in this PR, the result is IMHO generally much cleaner -- and I'm only getting started.
### Future-proof
This is a first step, that will help future refactorings. 
I think our SQL AST is not ideal and there are changes I would like to make for cleaner code and more efficient execution.
This abstraction layer, once complete, will make it easier to apply those changes project-wide.

### Provider-independent remoting?
This is a long-term idea that is not on my map for now, but anyway:
Instead of serializing a provider specific AST on the client, we could call into a "generic" AST factory that does nothing but creates a neutral structure to serialize these calls.
On the server, we can rebuild the AST by making the same calls into a provider-specific factory.
This could make the client provider-agnostic, which is nice to have, IMHO.

## Rollout
Obviously this is a very large-scale change, as there are calls to AST constructors all over the place.
I've started the work just so that you can get a better grasp of what the code would actually look like.

I think this is gonna be too annoying to merge to fully do in a single PR.
**If we commit to this idea**, I think we should regularly merge progress. Not all the code calls into the factory, but everything is still working and can be released.

There's a lot to do, in waves:
- Replace all ctors usage;
- Make AstFactory provider-specific, move provider transformations into it;
- Move local optimizations in factory (from SqlOptimizer and other places);