### PR TITLE
Don't visit tree when not required

### DIFF
--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
@@ -355,25 +355,17 @@ namespace LinqToDB.Linq.Builder
 
 		Expression ConvertParameters(Expression expression)
 		{
+			if (CompiledParameters == null) return expression;
+
 			return expression.Transform(CompiledParameters, static(compiledParameters, expr) =>
 			{
-				switch (expr.NodeType)
+				if (expr.NodeType == ExpressionType.Parameter)
 				{
-					case ExpressionType.Parameter:
-						if (compiledParameters != null)
-						{
-							var idx = Array.IndexOf(compiledParameters, (ParameterExpression)expr);
-
-							if (idx > 0)
-								return
-									Expression.Convert(
-										Expression.ArrayIndex(
-											ParametersParam,
-											ExpressionInstances.Int32(idx)),
-										expr.Type);
-						}
-
-						break;
+					var idx = Array.IndexOf(compiledParameters, (ParameterExpression)expr);
+					if (idx >= 0)
+						return Expression.Convert(
+							Expression.ArrayIndex(ParametersParam, ExpressionInstances.Int32(idx)),
+							expr.Type);
 				}
 
 				return expr;


### PR DESCRIPTION
Minor changes:

1. `compiledParameters` is a constant, so I took it out of the visitor delegate.
2. When `compiledParameters == null` the visitor does nothing so there is no point in visiting at all (potential perf improvement).
3. **Please review:** I was super suprised by `idx > 0` which seems like a typo and should be `idx >= 0`. I thought maybe the first argument was special but the calling code is super generic so I don't see why. If this was not a bug, it needs a comment to explain.
4. I reformatted the method slightly to make it more flat and readable.