### PR TITLE
[Minor] Fix misuse of Russian letters in English words.

### DIFF
--- a/Source/LinqToDB/Linq/Builder/ExpressionTreeOptimizationContext.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionTreeOptimizationContext.cs
@@ -605,7 +605,7 @@ namespace LinqToDB.Linq.Builder
 					var ll = Expressions.ConvertMember(MappingSchema, ue.Operand?.Type, ue.Operand!.Type.GetProperty(nameof(Array.Length))!);
 					if (ll != null)
 					{
-						var ex = СonvertMemberExpression(expr, ue.Operand!, ll);
+						var ex = ConvertMemberExpression(expr, ue.Operand!, ll);
 
 						return new TransformInfo(ex, false, true);
 					}
@@ -633,7 +633,7 @@ namespace LinqToDB.Linq.Builder
 
 					if (l != null)
 					{
-						var ex = СonvertMemberExpression(expr, me.Expression!, l);
+						var ex = ConvertMemberExpression(expr, me.Expression!, l);
 
 						return new TransformInfo(AliasCall(ex, alias!), false, true);
 					}
@@ -743,7 +743,7 @@ namespace LinqToDB.Linq.Builder
 			return result;
 		}
 
-		private static Expression СonvertMemberExpression(Expression expr, Expression root, LambdaExpression l)
+		private static Expression ConvertMemberExpression(Expression expr, Expression root, LambdaExpression l)
 		{
 			var body  = l.Body.Unwrap();
 			var parms = l.Parameters.ToDictionary(p => p);

--- a/Source/LinqToDB/SqlQuery/ConvertVisitor.cs
+++ b/Source/LinqToDB/SqlQuery/ConvertVisitor.cs
@@ -1179,7 +1179,7 @@ namespace LinqToDB.SqlQuery
 						var insertedT = ConvertInternal(output.InsertedTable) as SqlTable;
 						var deletedT  = ConvertInternal(output.DeletedTable)  as SqlTable;
 						var outputT   = ConvertInternal(output.OutputTable)   as SqlTable;
-						var outputС   = output.OutputColumns != null ? ConvertSafe(output.OutputColumns) : null;
+						var outputC   = output.OutputColumns != null ? ConvertSafe(output.OutputColumns) : null;
 
 						List<SqlSetExpression>? outputItems = null;
 
@@ -1190,7 +1190,7 @@ namespace LinqToDB.SqlQuery
 							insertedT != null && !ReferenceEquals(output.InsertedTable, insertedT) ||
 							deletedT  != null && !ReferenceEquals(output.DeletedTable, deletedT)   ||
 							outputT   != null && !ReferenceEquals(output.OutputTable, outputT)     ||
-							outputС   != null && !ReferenceEquals(output.OutputColumns, outputС)   ||
+							outputC   != null && !ReferenceEquals(output.OutputColumns, outputC)   ||
 							output.HasOutputItems && outputItems != null && !ReferenceEquals(output.OutputItems, outputItems)
 						)
 						{
@@ -1199,7 +1199,7 @@ namespace LinqToDB.SqlQuery
 								InsertedTable = insertedT ?? output.InsertedTable,
 								DeletedTable  = deletedT  ?? output.DeletedTable,
 								OutputTable   = outputT   ?? output.OutputTable,
-								OutputColumns = outputС   ?? output.OutputColumns,
+								OutputColumns = outputC   ?? output.OutputColumns,
 							};
 
 							if (outputItems != null)

--- a/Tests/Linq/DataProvider/SybaseTests.cs
+++ b/Tests/Linq/DataProvider/SybaseTests.cs
@@ -356,7 +356,7 @@ namespace Tests.DataProvider
 		{
 			get
 			{
-				yield return new StringTestCase("'\u2000\u2001\u2002\u2003\uabab\u03bctесt", "u&'''\\2000\\2001\\2002\\2003\\abab\\03bctесt'", "Test case 1");
+				yield return new StringTestCase("'\u2000\u2001\u2002\u2003\uabab\u03bctest", "u&'''\\2000\\2001\\2002\\2003\\abab\\03bctest'", "Test case 1");
 				// this case fails for parameters, because driver terminates parameter value at \0 character
 				//yield return Tuple.Create("\0test", "char(0) + 'test'");
 			}

--- a/Tests/Linq/DataProvider/SybaseTests.cs
+++ b/Tests/Linq/DataProvider/SybaseTests.cs
@@ -356,7 +356,7 @@ namespace Tests.DataProvider
 		{
 			get
 			{
-				yield return new StringTestCase("'\u2000\u2001\u2002\u2003\uabab\u03bctest", "u&'''\\2000\\2001\\2002\\2003\\abab\\03bctest'", "Test case 1");
+				yield return new StringTestCase("'\u2000\u2001\u2002\u2003\uabab\u03bctесt", "u&'''\\2000\\2001\\2002\\2003\\abab\\03bctесt'", "Test case 1");
 				// this case fails for parameters, because driver terminates parameter value at \0 character
 				//yield return Tuple.Create("\0test", "char(0) + 'test'");
 			}

--- a/Tests/Linq/Linq/FullTextTests.SqlServer.cs
+++ b/Tests/Linq/Linq/FullTextTests.SqlServer.cs
@@ -1905,7 +1905,7 @@ namespace Tests.Linq
 			{
 				var q =
 					from c in db.Category
-					where Sql.Ext.SqlServer().Contains("aнанас", c.Description, c.Description)
+					where Sql.Ext.SqlServer().Contains("ананас", c.Description, c.Description)
 					orderby c.CategoryID descending
 					select c;
 
@@ -1913,7 +1913,7 @@ namespace Tests.Linq
 
 				Assert.AreEqual(0, results.Count);
 
-				Assert.That(db.LastQuery!.Contains("CONTAINS(([c_1].[Description], [c_1].[Description]), N'aнанас')"));
+				Assert.That(db.LastQuery!.Contains("CONTAINS(([c_1].[Description], [c_1].[Description]), N'ананас')"));
 			}
 		}
 


### PR DESCRIPTION
I found that Russian letters misused in Englush words in few places and fix it. (not sure about Sybase inclusion).

Please, feel free to close this PR as the unimportant one.