### PR TITLE
New Set() overloads for UPDATE

### DIFF
--- a/Source/LinqToDB/Linq/Builder/UpdateBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/UpdateBuilder.cs
@@ -354,11 +354,11 @@ namespace LinqToDB.Linq.Builder
 
 					if (argument is NewExpression newExpr && newExpr.Type.IsAnonymous())
 					{
-						BuildNew(newExpr, Expression.MakeMemberAccess(path, member));
+						BuildNew(newExpr, pe);
 					}
 					else if (argument is MemberInitExpression initExpr && !into.IsExpression(pe, 1, RequestFor.Field).Result)
 					{
-						BuildMemberInit(initExpr, Expression.MakeMemberAccess(path, member));
+						BuildMemberInit(initExpr, pe);
 					}
 					else
 					{

--- a/Source/LinqToDB/Linq/IUpdatable.cs
+++ b/Source/LinqToDB/Linq/IUpdatable.cs
@@ -1,6 +1,9 @@
-﻿namespace LinqToDB.Linq
+﻿using System.Linq;
+
+namespace LinqToDB.Linq
 {
 	public interface IUpdatable<T>
 	{
+		internal IQueryable<T> Query { get; }
 	}
 }

--- a/Source/LinqToDB/Linq/Internals.cs
+++ b/Source/LinqToDB/Linq/Internals.cs
@@ -37,7 +37,7 @@ namespace LinqToDB.Linq
 		/// </summary>
 		public static IDataContext GetDataContext<T>(IUpdatable<T> updatable)
 		{
-			return GetDataContext(((LinqExtensions.Updatable<T>)updatable).Query);
+			return GetDataContext(updatable.Query);
 		}
 
 		/// <summary>

--- a/Source/LinqToDB/LinqExtensions.Update.cs
+++ b/Source/LinqToDB/LinqExtensions.Update.cs
@@ -1074,7 +1074,7 @@ namespace LinqToDB
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
-			var query = ((Updatable<T>)source).Query;
+			var query = source.Query;
 			var currentSource = ProcessSourceQueryable?.Invoke(query) ?? query;
 
 			return currentSource.Provider.CreateQuery<UpdateOutput<T>>(
@@ -1104,7 +1104,7 @@ namespace LinqToDB
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
-			var query = ((Updatable<T>)source).Query;
+			var query = source.Query;
 			var currentSource = ProcessSourceQueryable?.Invoke(query) ?? query;
 
 			return currentSource.Provider.CreateQuery<UpdateOutput<T>>(
@@ -1141,7 +1141,7 @@ namespace LinqToDB
 			if (source           == null) throw new ArgumentNullException(nameof(source));
 			if (outputExpression == null) throw new ArgumentNullException(nameof(outputExpression));
 
-			var query         = ((Updatable<T>)source).Query;
+			var query         = source.Query;
 			var currentSource = ProcessSourceQueryable?.Invoke(query) ?? query;
 
 			return currentSource.Provider.CreateQuery<TOutput>(
@@ -1180,7 +1180,7 @@ namespace LinqToDB
 			if (source ==           null) throw new ArgumentNullException(nameof(source));
 			if (outputExpression == null) throw new ArgumentNullException(nameof(outputExpression));
 
-			var query = ((Updatable<T>)source).Query;
+			var query = source.Query;
 			var currentSource = ProcessSourceQueryable?.Invoke(query) ?? query;
 
 			return currentSource.Provider.CreateQuery<TOutput>(
@@ -1213,7 +1213,7 @@ namespace LinqToDB
 			if (source      == null) throw new ArgumentNullException(nameof(source));
 			if (outputTable == null) throw new ArgumentNullException(nameof(outputTable));
 
-			var query = ((Updatable<T>)source).Query;
+			var query = source.Query;
 			var currentSource = ProcessSourceQueryable?.Invoke(query) ?? query;
 
 			return currentSource.Provider.Execute<int>(
@@ -1247,7 +1247,7 @@ namespace LinqToDB
 			if (source      == null) throw new ArgumentNullException(nameof(source));
 			if (outputTable == null) throw new ArgumentNullException(nameof(outputTable));
 
-			var query = ((Updatable<T>)source).Query;
+			var query = source.Query;
 			var currentSource = ProcessSourceQueryable?.Invoke(query) ?? query;
 
 			var expr =
@@ -1290,7 +1290,7 @@ namespace LinqToDB
 			if (outputTable      == null) throw new ArgumentNullException(nameof(outputTable));
 			if (outputExpression == null) throw new ArgumentNullException(nameof(outputExpression));
 
-			var query = ((Updatable<T>)source).Query;
+			var query = source.Query;
 			var currentSource = ProcessSourceQueryable?.Invoke(query) ?? query;
 
 			return currentSource.Provider.Execute<int>(
@@ -1331,7 +1331,7 @@ namespace LinqToDB
 			if (outputTable      == null) throw new ArgumentNullException(nameof(outputTable));
 			if (outputExpression == null) throw new ArgumentNullException(nameof(outputExpression));
 
-			var query = ((Updatable<T>)source).Query;
+			var query = source.Query;
 			var currentSource = ProcessSourceQueryable?.Invoke(query) ?? query;
 
 			var expr =

--- a/Source/LinqToDB/Reflection/Methods.cs
+++ b/Source/LinqToDB/Reflection/Methods.cs
@@ -185,10 +185,12 @@ namespace LinqToDB.Reflection
 				public static readonly MethodInfo SetQueryableExpression = MemberHelper.MethodOfGeneric<IQueryable<LW1>>(q => q.Set(e => e.Value1, () => 1));
 				public static readonly MethodInfo SetQueryablePrev       = MemberHelper.MethodOfGeneric<IQueryable<LW1>>(q => q.Set(e => e.Value1, prev => 1));
 				public static readonly MethodInfo SetQueryableValue      = MemberHelper.MethodOfGeneric<IQueryable<LW1>>(q => q.Set(e => e.Value1, 1));
+				public static readonly MethodInfo SetQueryableSubQuery   = MemberHelper.MethodOfGeneric<IQueryable<LW1>>(q => q.Set(e => (IQueryable<LW1>)null!));
 				public static readonly MethodInfo SetUpdatableSetCustom  = MemberHelper.MethodOfGeneric<IUpdatable<LW1>>(q => q.Set(e => string.Empty));
 				public static readonly MethodInfo SetUpdatableExpression = MemberHelper.MethodOfGeneric<IUpdatable<LW1>>(q => q.Set(e => e.Value1, () => 1));
 				public static readonly MethodInfo SetUpdatablePrev       = MemberHelper.MethodOfGeneric<IUpdatable<LW1>>(q => q.Set(e => e.Value1, prev => 1));
 				public static readonly MethodInfo SetUpdatableValue      = MemberHelper.MethodOfGeneric<IUpdatable<LW1>>(q => q.Set(e => e.Value1, 1));
+				public static readonly MethodInfo SetUpdatableSubQuery   = MemberHelper.MethodOfGeneric<IUpdatable<LW1>>(q => q.Set(e => (IQueryable<LW1>)null!));
 			}
 
 			public static class Insert

--- a/Tests/Linq/Update/UpdateTests.cs
+++ b/Tests/Linq/Update/UpdateTests.cs
@@ -1715,6 +1715,57 @@ namespace Tests.xUpdate
 			read.Value6.Should().Be(UpdateSetEnum.Value3);
 		}
 
+		[Test]
+		public void TestSetQueryableRow(
+			// Native `UPDATE SET ROW(a, b) = SELECT 1, 2` support required
+			[IncludeDataSources(true,	
+				ProviderName.DB2,
+				TestProvName.AllPostgreSQL95Plus,
+				TestProvName.AllOracle)] string context)
+		{
+			var data = new UpdateSetTest[]
+			{
+				new () { Id = 1, Value2 = 1 },
+				new () { Id = 2, Value2 = 20, Value5 = 1 },
+				new () { Id = 3, Value3 = UpdateSetEnum.Value3, Value4 = TestData.Guid4 },
+			};
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(data);
+
+			int affected = table
+				.Where(x => x.Id == 1)
+				.Set(x => x.Value1, TestData.Guid1)
+				.Set(old => from x in table
+							where x.Id == 2
+							select new UpdateSetTest 
+							{
+								Value2 = old.Value2 + x.Value5!.Value,
+								Value5 = x.Value2,
+								Value3 = UpdateSetEnum.Value1,
+							})
+				.Set(old => table
+					.Select(x => new UpdateSetTest
+					{
+						Value4 = x.Value4,
+						Value6 = old.Value2 == 1 ? x.Value3 : UpdateSetEnum.Value1,
+					})
+					.Where(x => x.Id == 3))
+				.Update();
+
+			var read = table.First(x => x.Id == 1);
+
+			affected.Should().Be(1);
+			read.Should().BeEquivalentTo(new UpdateSetTest
+			{
+				Id     = 1,
+				Value2 = 2,
+				Value3 = UpdateSetEnum.Value1,
+				Value4 = TestData.Guid4,
+				Value5 = 20,
+				Value6 = UpdateSetEnum.Value3,
+			});
+		}
+
 		[Table]
 		class MainTable
 		{

--- a/Tests/Linq/Update/UpdateTests.cs
+++ b/Tests/Linq/Update/UpdateTests.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
+using FluentAssertions;
+
 using LinqToDB;
 using LinqToDB.Data;
 using LinqToDB.Mapping;
@@ -1680,6 +1682,37 @@ namespace Tests.xUpdate
 				Assert.That(result[1].Items2, Is.EqualTo("Z2" + str));
 
 			}
+		}
+
+		[Test]
+		public void TestSetInitializer([DataSources] string context)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(UpdateSetTest.Data);
+			
+			int affected = table
+				.Where(x => x.Id == 1)
+				.Set(old => new ()
+				{
+					Value2 = 20,
+					Value5 = old.Value2 * 5,
+				})
+				.Set(_ => new ()
+				{
+					Value1 = TestData.Guid6,
+					Value3 = UpdateSetEnum.Value3,
+				})
+				.Set(x => x.Value6, UpdateSetEnum.Value3)
+				.Update();
+
+			var read = table.First(x => x.Id == 1);
+
+			affected.Should().Be(1);
+			read.Value1.Should().Be(TestData.Guid6);
+			read.Value2.Should().Be(20);
+			read.Value3.Should().Be(UpdateSetEnum.Value3);
+			read.Value5.Should().Be(50);
+			read.Value6.Should().Be(UpdateSetEnum.Value3);
 		}
 
 		[Table]


### PR DESCRIPTION
Syntax `t.Update(old => new T { A = 1, B = 2 })` is great but not always usable.
When one wants to add setters dynamically or set multiple fields with `ROW (A, B) = ...`, one needs to use the `.Set()` family of APIs.
These only allow defining setters one-by-one, so I'm adding some new overloads to make it more convenient to use.

### Set a new initializer
Basically works _exactly_ like `Update` above, but can be called multiple times amongst other `.Set()` calls.
```csharp 
var updated = table
  .Set(old => new () { A = 1, B = old.B + 1 })
  .Update();

// Equivalent with current apis:
var updated = table
  .Set(t => t.A, 1)
  .Set(t => t.B, old => old.B + 1)
  .Update();
```

### Set a ROW with single query
Consider this:
```csharp
table
  .Set(
    x => Sql.Row(x.A, x.B),
    old => query.Select(q => Sql.Row(1, q.C)).Single())
  .Update();
```
It works and it is conceptually equivalent to the generated SQL.
But that is not optimal C#:
1. The fields names are far from their values. It's ok with 2-3 such as the example above, but it's not very clear with more.
2. C# typing is strict for `SqlRow<T1, T2>`, no implicit conversions. Assigning `int` to `int?` has to be wrapped into `AsNullable()`.
3. Because the value must be a single `SqlRow`, one generally has to add `.Single()`.
4. `Sql.Row` is limited to 8 elements, it is impossible to update more fields. Larger tables are far from uncommon.

I'm removing all of those 4 pain points with the following new overload that accepts a `IQueryable<T>`, that should select an initializer like the basic `Update()` example above:
```csharp
// Equivalent to previous example
table
  .Set(old => query.Select(q => new T { A = 1, B = q.C }))
  .Update();
```