### PR TITLE
Improve log when db type can not be determined

### DIFF
--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -3168,6 +3168,7 @@ namespace LinqToDB.SqlProvider
 				StringBuilder.Append(type.Type.DbType);
 			else
 			{
+				var systemType = type.Type.SystemType.FullName;
 				if (type.Type.DataType == DataType.Undefined)
 					type = MappingSchema.GetDataType(type.Type.SystemType);
 
@@ -3179,7 +3180,7 @@ namespace LinqToDB.SqlProvider
 
 				if (type.Type.DataType == DataType.Undefined)
 					// give some hint to user that it is expected situation and he need to fix something on his side
-					throw new LinqToDBException("Database type cannot be determined automatically and must be specified explicitly");
+					throw new LinqToDBException($"Database column type cannot be determined automatically and must be specified explicitly for system type {systemType}");
 
 				BuildDataTypeFromDataType(type, forCreateTable, canBeNull);
 			}


### PR DESCRIPTION
Helps to figure out which column is the issue when creating table with type that can not be determined.

Log was:
> Unhandled exception. LinqToDB.LinqToDBException: Database type cannot be determined automatically and must be specified explicitly

Now (diff in bold):
> Unhandled exception. LinqToDB.LinqToDBException: Database **column** type cannot be determined automatically and must be specified explicitly **for system type NodaTime.Instant**