### PR TITLE
Fix C# init-only support for older TFMs

### DIFF
--- a/Source/Shared/IsExternalInit.cs
+++ b/Source/Shared/IsExternalInit.cs
@@ -1,4 +1,6 @@
-﻿#if !NET5_0_OR_GREATER
+﻿// don't use conditional compilation
+// see https://github.com/dotnet/runtime/issues/79082
+
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
@@ -17,4 +19,3 @@ namespace System.Runtime.CompilerServices
 	{
 	}
 }
-#endif


### PR DESCRIPTION
Critical issue discovered during https://github.com/linq2db/linq2db/pull/3530 testing.

Workaround to https://github.com/dotnet/runtime/issues/79082