### PR TITLE
Update Sql.Collate nullability

### DIFF
--- a/Source/LinqToDB.Tools/Mapper/ExpressionBuilder.cs
+++ b/Source/LinqToDB.Tools/Mapper/ExpressionBuilder.cs
@@ -241,7 +241,7 @@ namespace LinqToDB.Tools.Mapper
 			return New(type);
 		}
 
-		[return: NotNullIfNotNull("expr")]
+		[return: NotNullIfNotNull(nameof(expr))]
 		static Expression? Convert(Expression? expr, Type toType) =>
 			expr == null ? null : expr.Type == toType ? expr : Expression.Convert(expr, toType);
 

--- a/Source/LinqToDB/DataProvider/DataTools.cs
+++ b/Source/LinqToDB/DataProvider/DataTools.cs
@@ -14,7 +14,7 @@ namespace LinqToDB.DataProvider
 		/// <summary>
 		/// Improved version of <c>Replace("[", "[[]")</c> code, used before.
 		/// </summary>
-		[return: NotNullIfNotNull("str")]
+		[return: NotNullIfNotNull(nameof(str))]
 		public static string? EscapeUnterminatedBracket(string? str)
 		{
 			if (str == null)

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlFn.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlFn.cs
@@ -172,7 +172,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns expression, translated to data_type.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "CAST({expression} as {data_type})", ServerSideOnly=true, BuilderType=typeof(DataTypeBuilder))]
-		[return: NotNullIfNotNull("expression")]
+		[return: NotNullIfNotNull(nameof(expression))]
 		public static T Cast<T>([ExprParameter] object? expression, [SqlQueryDependent] SqlType<T> data_type)
 		{
 			throw new InvalidOperationException($"'{nameof(Cast)}' is a server side only function.");
@@ -187,7 +187,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns expression, translated to data_type.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "CAST({expression} as {data_type})", ServerSideOnly=true, BuilderType=typeof(DataTypeBuilder))]
-		[return: NotNullIfNotNull("expression")]
+		[return: NotNullIfNotNull(nameof(expression))]
 		public static T Cast<T>([ExprParameter] object? expression, [SqlQueryDependent] Func<SqlType<T>> data_type)
 		{
 			throw new InvalidOperationException($"'{nameof(Cast)}' is a server side only function.");
@@ -201,7 +201,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns expression, translated to data_type.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Expression(ProviderName.SqlServer, "CAST({0} as {1})", ServerSideOnly=true)]
-		[return: NotNullIfNotNull("expression")]
+		[return: NotNullIfNotNull(nameof(expression))]
 		public static T Cast<T>(object? expression)
 		{
 			throw new InvalidOperationException($"'{nameof(Cast)}' is a server side only function.");
@@ -220,7 +220,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns expression, translated to data_type.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "CONVERT({data_type}, {expression})", ServerSideOnly=true, BuilderType=typeof(DataTypeBuilder))]
-		[return: NotNullIfNotNull("expression")]
+		[return: NotNullIfNotNull(nameof(expression))]
 		public static T Convert<T>([SqlQueryDependent] SqlType<T> data_type, [ExprParameter] object? expression)
 		{
 			throw new InvalidOperationException($"'{nameof(Convert)}' is a server side only function.");
@@ -235,7 +235,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns expression, translated to data_type.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "CONVERT({data_type}, {expression})", ServerSideOnly=true, BuilderType=typeof(DataTypeBuilder))]
-		[return: NotNullIfNotNull("expression")]
+		[return: NotNullIfNotNull(nameof(expression))]
 		public static T Convert<T>([SqlQueryDependent] Func<SqlType<T>> data_type, [ExprParameter] object? expression)
 		{
 			throw new InvalidOperationException($"'{nameof(Convert)}' is a server side only function.");
@@ -249,7 +249,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns expression, translated to data_type.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Expression(ProviderName.SqlServer, "CONVERT({1}, {0})", ServerSideOnly=true)]
-		[return: NotNullIfNotNull("expression")]
+		[return: NotNullIfNotNull(nameof(expression))]
 		public static T Convert<T>([ExprParameter] object? expression)
 		{
 			throw new InvalidOperationException($"'{nameof(Convert)}' is a server side only function.");
@@ -264,7 +264,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns expression, translated to data_type.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "CONVERT({data_type}, {expression}, {style})", ServerSideOnly=true, BuilderType=typeof(DataTypeBuilder))]
-		[return: NotNullIfNotNull("expression")]
+		[return: NotNullIfNotNull(nameof(expression))]
 		public static T Convert<T>([SqlQueryDependent] SqlType<T> data_type, [ExprParameter] object? expression, [SqlQueryDependent, ExprParameter] int style)
 		{
 			throw new InvalidOperationException($"'{nameof(Convert)}' is a server side only function.");
@@ -279,7 +279,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns expression, translated to data_type.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "CONVERT({data_type}, {expression}, {style})", ServerSideOnly=true, BuilderType=typeof(DataTypeBuilder))]
-		[return: NotNullIfNotNull("expression")]
+		[return: NotNullIfNotNull(nameof(expression))]
 		public static T Convert<T>([SqlQueryDependent] Func<SqlType<T>> data_type, [ExprParameter] object? expression, [SqlQueryDependent, ExprParameter] int style)
 		{
 			throw new InvalidOperationException($"'{nameof(Convert)}' is a server side only function.");
@@ -293,7 +293,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns expression, translated to data_type.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Expression(ProviderName.SqlServer, "CONVERT({2}, {0}, {1})", ServerSideOnly=true)]
-		[return: NotNullIfNotNull("expression")]
+		[return: NotNullIfNotNull(nameof(expression))]
 		public static T Convert<T>([ExprParameter] object? expression, [SqlQueryDependent, ExprParameter] int style)
 		{
 			throw new InvalidOperationException($"'{nameof(Convert)}' is a server side only function.");
@@ -401,7 +401,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns expression, translated to data_type.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "TRY_CAST({expression} as {data_type})", ServerSideOnly=true, BuilderType=typeof(DataTypeBuilder))]
-		[return: NotNullIfNotNull("expression")]
+		[return: NotNullIfNotNull(nameof(expression))]
 		public static T TryCast<T>([ExprParameter] object? expression, [SqlQueryDependent] SqlType<T> data_type)
 		{
 			throw new InvalidOperationException($"'{nameof(TryCast)}' is a server side only function.");
@@ -416,7 +416,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns expression, translated to data_type.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "TRY_CAST({expression} as {data_type})", ServerSideOnly=true, BuilderType=typeof(DataTypeBuilder))]
-		[return: NotNullIfNotNull("expression")]
+		[return: NotNullIfNotNull(nameof(expression))]
 		public static T TryCast<T>([ExprParameter] object? expression, [SqlQueryDependent] Func<SqlType<T>> data_type)
 		{
 			throw new InvalidOperationException($"'{nameof(TryCast)}' is a server side only function.");
@@ -430,7 +430,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns expression, translated to data_type.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Expression(ProviderName.SqlServer, "TRY_CAST({0} as {1})", ServerSideOnly=true)]
-		[return: NotNullIfNotNull("expression")]
+		[return: NotNullIfNotNull(nameof(expression))]
 		public static T TryCast<T>([ExprParameter] object? expression)
 		{
 			throw new InvalidOperationException($"'{nameof(TryCast)}' is a server side only function.");
@@ -449,7 +449,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns expression, translated to data_type.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "TRY_CONVERT({data_type}, {expression})", ServerSideOnly=true, BuilderType=typeof(DataTypeBuilder))]
-		[return: NotNullIfNotNull("expression")]
+		[return: NotNullIfNotNull(nameof(expression))]
 		public static T TryConvert<T>([SqlQueryDependent] SqlType<T> data_type, [ExprParameter] object? expression)
 		{
 			throw new InvalidOperationException($"'{nameof(TryConvert)}' is a server side only function.");
@@ -464,7 +464,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns expression, translated to data_type.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "TRY_CONVERT({data_type}, {expression})", ServerSideOnly=true, BuilderType=typeof(DataTypeBuilder))]
-		[return: NotNullIfNotNull("expression")]
+		[return: NotNullIfNotNull(nameof(expression))]
 		public static T TryConvert<T>([SqlQueryDependent] Func<SqlType<T>> data_type, [ExprParameter] object? expression)
 		{
 			throw new InvalidOperationException($"'{nameof(TryConvert)}' is a server side only function.");
@@ -478,7 +478,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns expression, translated to data_type.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Expression(ProviderName.SqlServer, "TRY_CONVERT({1}, {0})", ServerSideOnly=true)]
-		[return: NotNullIfNotNull("expression")]
+		[return: NotNullIfNotNull(nameof(expression))]
 		public static T TryConvert<T>([ExprParameter] object? expression)
 		{
 			throw new InvalidOperationException($"'{nameof(TryConvert)}' is a server side only function.");
@@ -493,7 +493,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns expression, translated to data_type.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "TRY_CONVERT({data_type}, {expression}, {style})", ServerSideOnly=true, BuilderType=typeof(DataTypeBuilder))]
-		[return: NotNullIfNotNull("expression")]
+		[return: NotNullIfNotNull(nameof(expression))]
 		public static T TryConvert<T>([SqlQueryDependent] SqlType<T> data_type, [ExprParameter] object? expression, [SqlQueryDependent, ExprParameter] int style)
 		{
 			throw new InvalidOperationException($"'{nameof(TryConvert)}' is a server side only function.");
@@ -508,7 +508,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns expression, translated to data_type.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "TRY_CONVERT({data_type}, {expression}, {style})", ServerSideOnly=true, BuilderType=typeof(DataTypeBuilder))]
-		[return: NotNullIfNotNull("expression")]
+		[return: NotNullIfNotNull(nameof(expression))]
 		public static T TryConvert<T>([SqlQueryDependent] Func<SqlType<T>> data_type, [ExprParameter] object? expression, [SqlQueryDependent, ExprParameter] int style)
 		{
 			throw new InvalidOperationException($"'{nameof(TryConvert)}' is a server side only function.");
@@ -522,7 +522,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns expression, translated to data_type.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Expression(ProviderName.SqlServer, "TRY_CONVERT({2}, {0}, {1})", ServerSideOnly=true)]
-		[return: NotNullIfNotNull("expression")]
+		[return: NotNullIfNotNull(nameof(expression))]
 		public static T TryConvert<T>([ExprParameter] object? expression, [SqlQueryDependent, ExprParameter] int style)
 		{
 			throw new InvalidOperationException($"'{nameof(TryConvert)}' is a server side only function.");
@@ -541,7 +541,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns the result of the expression, translated to the requested data type.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "TRY_PARSE({string_value} as {data_type})", ServerSideOnly=true, BuilderType=typeof(DataTypeBuilder))]
-		[return: NotNullIfNotNull("string_value")]
+		[return: NotNullIfNotNull(nameof(string_value))]
 		public static T TryParse<T>([ExprParameter] string string_value, [SqlQueryDependent] SqlType<T> data_type)
 		{
 			throw new InvalidOperationException($"'{nameof(TryParse)}' is a server side only function.");
@@ -556,7 +556,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns the result of the expression, translated to the requested data type.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "TRY_PARSE({string_value} as {data_type})", ServerSideOnly=true, BuilderType=typeof(DataTypeBuilder))]
-		[return: NotNullIfNotNull("string_value")]
+		[return: NotNullIfNotNull(nameof(string_value))]
 		public static T TryParse<T>([ExprParameter] string string_value, [SqlQueryDependent] Func<SqlType<T>> data_type)
 		{
 			throw new InvalidOperationException($"'{nameof(TryParse)}' is a server side only function.");
@@ -570,7 +570,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns the result of the expression, translated to the requested data type.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Expression(ProviderName.SqlServer, "TRY_PARSE({0} as {1})", ServerSideOnly=true)]
-		[return: NotNullIfNotNull("string_value")]
+		[return: NotNullIfNotNull(nameof(string_value))]
 		public static T TryParse<T>([ExprParameter] string string_value)
 		{
 			throw new InvalidOperationException($"'{nameof(TryParse)}' is a server side only function.");
@@ -586,7 +586,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns the result of the expression, translated to the requested data type.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "TRY_PARSE({string_value} as {data_type} USING {culture})", ServerSideOnly=true, BuilderType=typeof(DataTypeBuilder))]
-		[return: NotNullIfNotNull("string_value")]
+		[return: NotNullIfNotNull(nameof(string_value))]
 		public static T TryParse<T>([ExprParameter] string string_value, [SqlQueryDependent] SqlType<T> data_type, [ExprParameter, SqlQueryDependent] string culture)
 		{
 			throw new InvalidOperationException($"'{nameof(TryParse)}' is a server side only function.");
@@ -602,7 +602,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns the result of the expression, translated to the requested data type.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "TRY_PARSE({string_value} as {data_type} USING {culture})", ServerSideOnly=true, BuilderType=typeof(DataTypeBuilder))]
-		[return: NotNullIfNotNull("string_value")]
+		[return: NotNullIfNotNull(nameof(string_value))]
 		public static T TryParse<T>([ExprParameter] string string_value, [SqlQueryDependent] Func<SqlType<T>> data_type, [ExprParameter, SqlQueryDependent] string culture)
 		{
 			throw new InvalidOperationException($"'{nameof(TryParse)}' is a server side only function.");
@@ -617,7 +617,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns the result of the expression, translated to the requested data type.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Expression(ProviderName.SqlServer, "TRY_PARSE({0} as {2} USING {1})", ServerSideOnly=true)]
-		[return: NotNullIfNotNull("string_value")]
+		[return: NotNullIfNotNull(nameof(string_value))]
 		public static T TryParse<T>([ExprParameter] string string_value, [ExprParameter, SqlQueryDependent] string culture)
 		{
 			throw new InvalidOperationException($"'{nameof(TryParse)}' is a server side only function.");
@@ -658,7 +658,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "DATALENGTH", 0, ServerSideOnly=true)]
 		[CLSCompliant(false)]
-		[return: NotNullIfNotNull("expression")]
+		[return: NotNullIfNotNull(nameof(expression))]
 		public static int? DataLength<T>(T expression)
 		{
 			throw new InvalidOperationException($"'{nameof(DataLength)}' is a server side only function.");
@@ -693,7 +693,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "DATALENGTH", 0, ServerSideOnly=true)]
 		[CLSCompliant(false)]
-		[return: NotNullIfNotNull("expression")]
+		[return: NotNullIfNotNull(nameof(expression))]
 		public static long? DataLengthBig<T>(T expression)
 		{
 			throw new InvalidOperationException($"'{nameof(DataLengthBig)}' is a server side only function.");
@@ -835,7 +835,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>varchar</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "DATEADD({datepart}, {number}, {date})", ServerSideOnly=true, BuilderType=typeof(DatePartBuilder))]
-		[return: NotNullIfNotNull("date")]
+		[return: NotNullIfNotNull(nameof(date))]
 		public static DateTime? DateAdd([SqlQueryDependent] DateParts datepart, [ExprParameter] int? number, [ExprParameter] string? date)
 		{
 			throw new InvalidOperationException($"'{nameof(DateAdd)}' is a server side only function.");
@@ -852,7 +852,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>varchar</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "DATEADD({datepart}, {number}, {date})", ServerSideOnly=true, BuilderType=typeof(DatePartBuilder))]
-		[return: NotNullIfNotNull("date")]
+		[return: NotNullIfNotNull(nameof(date))]
 		public static DateTime? DateAdd([SqlQueryDependent] DateParts datepart, [ExprParameter] int? number, [ExprParameter] DateTime? date)
 		{
 			throw new InvalidOperationException($"'{nameof(DateAdd)}' is a server side only function.");
@@ -869,7 +869,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>varchar</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "DATEADD({datepart}, {number}, {date})", ServerSideOnly=true, BuilderType=typeof(DatePartBuilder))]
-		[return: NotNullIfNotNull("date")]
+		[return: NotNullIfNotNull(nameof(date))]
 		public static DateTimeOffset? DateAdd([SqlQueryDependent] DateParts datepart, [ExprParameter] int? number, [ExprParameter] DateTimeOffset? date)
 		{
 			throw new InvalidOperationException($"'{nameof(DateAdd)}' is a server side only function.");
@@ -886,7 +886,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>varchar</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "DATEADD({datepart}, {number}, {date})", ServerSideOnly=true, BuilderType=typeof(DatePartBuilder))]
-		[return: NotNullIfNotNull("date")]
+		[return: NotNullIfNotNull(nameof(date))]
 		public static TimeSpan? DateAdd([SqlQueryDependent] DateParts datepart, [ExprParameter] int? number, [ExprParameter] TimeSpan? date)
 		{
 			throw new InvalidOperationException($"'{nameof(DateAdd)}' is a server side only function.");
@@ -1205,7 +1205,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>nvarchar</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "DATENAME({datepart}, {date})", ServerSideOnly=true, BuilderType=typeof(DatePartBuilder))]
-		[return: NotNullIfNotNull("date")]
+		[return: NotNullIfNotNull(nameof(date))]
 		public static string? DateName([SqlQueryDependent] DateParts datepart, [ExprParameter] string? date)
 		{
 			throw new InvalidOperationException($"'{nameof(DateName)}' is a server side only function.");
@@ -1219,7 +1219,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>nvarchar</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "DATENAME({datepart}, {date})", ServerSideOnly=true, BuilderType=typeof(DatePartBuilder))]
-		[return: NotNullIfNotNull("date")]
+		[return: NotNullIfNotNull(nameof(date))]
 		public static string? DateName([SqlQueryDependent] DateParts datepart, [ExprParameter] DateTime? date)
 		{
 			throw new InvalidOperationException($"'{nameof(DateName)}' is a server side only function.");
@@ -1233,7 +1233,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>nvarchar</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "DATENAME({datepart}, {date})", ServerSideOnly=true, BuilderType=typeof(DatePartBuilder))]
-		[return: NotNullIfNotNull("date")]
+		[return: NotNullIfNotNull(nameof(date))]
 		public static string? DateName([SqlQueryDependent] DateParts datepart, [ExprParameter] DateTimeOffset? date)
 		{
 			throw new InvalidOperationException($"'{nameof(DateName)}' is a server side only function.");
@@ -1247,7 +1247,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>nvarchar</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "DATENAME({datepart}, {date})", ServerSideOnly=true, BuilderType=typeof(DatePartBuilder))]
-		[return: NotNullIfNotNull("date")]
+		[return: NotNullIfNotNull(nameof(date))]
 		public static string? DateName([SqlQueryDependent] DateParts datepart, [ExprParameter] TimeSpan? date)
 		{
 			throw new InvalidOperationException($"'{nameof(DateName)}' is a server side only function.");
@@ -1265,7 +1265,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>int</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "DATEPART({datepart}, {date})", ServerSideOnly=true, BuilderType=typeof(DatePartBuilder))]
-		[return: NotNullIfNotNull("date")]
+		[return: NotNullIfNotNull(nameof(date))]
 		public static int? DatePart([SqlQueryDependent] DateParts datepart, [ExprParameter] string? date)
 		{
 			throw new InvalidOperationException($"'{nameof(DatePart)}' is a server side only function.");
@@ -1279,7 +1279,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>int</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "DATEPART({datepart}, {date})", ServerSideOnly=true, BuilderType=typeof(DatePartBuilder))]
-		[return: NotNullIfNotNull("date")]
+		[return: NotNullIfNotNull(nameof(date))]
 		public static int? DatePart([SqlQueryDependent] DateParts datepart, [ExprParameter] DateTime? date)
 		{
 			throw new InvalidOperationException($"'{nameof(DatePart)}' is a server side only function.");
@@ -1293,7 +1293,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>int</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "DATEPART({datepart}, {date})", ServerSideOnly=true, BuilderType=typeof(DatePartBuilder))]
-		[return: NotNullIfNotNull("date")]
+		[return: NotNullIfNotNull(nameof(date))]
 		public static int? DatePart([SqlQueryDependent] DateParts datepart, [ExprParameter] DateTimeOffset? date)
 		{
 			throw new InvalidOperationException($"'{nameof(DatePart)}' is a server side only function.");
@@ -1307,7 +1307,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>int</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Extension(ProviderName.SqlServer, "DATEPART({datepart}, {date})", ServerSideOnly=true, BuilderType=typeof(DatePartBuilder))]
-		[return: NotNullIfNotNull("date")]
+		[return: NotNullIfNotNull(nameof(date))]
 		public static int? DatePart([SqlQueryDependent] DateParts datepart, [ExprParameter] TimeSpan? date)
 		{
 			throw new InvalidOperationException($"'{nameof(DatePart)}' is a server side only function.");
@@ -1324,7 +1324,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>int</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "DAY", ServerSideOnly=true)]
-		[return: NotNullIfNotNull("date")]
+		[return: NotNullIfNotNull(nameof(date))]
 		public static int? Day(string? date)
 		{
 			throw new InvalidOperationException($"'{nameof(Day)}' is a server side only function.");
@@ -1337,7 +1337,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>int</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "DAY", ServerSideOnly=true)]
-		[return: NotNullIfNotNull("date")]
+		[return: NotNullIfNotNull(nameof(date))]
 		public static int? Day(DateTime? date)
 		{
 			throw new InvalidOperationException($"'{nameof(Day)}' is a server side only function.");
@@ -1350,7 +1350,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>int</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "DAY", ServerSideOnly=true)]
-		[return: NotNullIfNotNull("date")]
+		[return: NotNullIfNotNull(nameof(date))]
 		public static int? Day(DateTimeOffset? date)
 		{
 			throw new InvalidOperationException($"'{nameof(Day)}' is a server side only function.");
@@ -1368,7 +1368,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>date</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "EOMONTH", ServerSideOnly=true)]
-		[return: NotNullIfNotNull("start_date")]
+		[return: NotNullIfNotNull(nameof(start_date))]
 		public static DateTime? EndOfMonth(string? start_date)
 		{
 			throw new InvalidOperationException($"'{nameof(EndOfMonth)}' is a server side only function.");
@@ -1383,7 +1383,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>date</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "EOMONTH", ServerSideOnly=true)]
-		[return: NotNullIfNotNull("start_date")]
+		[return: NotNullIfNotNull(nameof(start_date))]
 		public static DateTime? EndOfMonth(string? start_date, int? month_to_add)
 		{
 			throw new InvalidOperationException($"'{nameof(EndOfMonth)}' is a server side only function.");
@@ -1397,7 +1397,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>date</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "EOMONTH", ServerSideOnly=true)]
-		[return: NotNullIfNotNull("start_date")]
+		[return: NotNullIfNotNull(nameof(start_date))]
 		public static DateTime? EndOfMonth(DateTime? start_date)
 		{
 			throw new InvalidOperationException($"'{nameof(EndOfMonth)}' is a server side only function.");
@@ -1412,7 +1412,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>date</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "EOMONTH", ServerSideOnly=true)]
-		[return: NotNullIfNotNull("start_date")]
+		[return: NotNullIfNotNull(nameof(start_date))]
 		public static DateTime? EndOfMonth(DateTime? start_date, int? month_to_add)
 		{
 			throw new InvalidOperationException($"'{nameof(EndOfMonth)}' is a server side only function.");
@@ -1515,7 +1515,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>int</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "MONTH", ServerSideOnly=true)]
-		[return: NotNullIfNotNull("date")]
+		[return: NotNullIfNotNull(nameof(date))]
 		public static int? Month(string? date)
 		{
 			throw new InvalidOperationException($"'{nameof(Month)}' is a server side only function.");
@@ -1528,7 +1528,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>int</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "MONTH", ServerSideOnly=true)]
-		[return: NotNullIfNotNull("date")]
+		[return: NotNullIfNotNull(nameof(date))]
 		public static int? Month(DateTime? date)
 		{
 			throw new InvalidOperationException($"'{nameof(Month)}' is a server side only function.");
@@ -1541,7 +1541,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>int</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "MONTH", ServerSideOnly=true)]
-		[return: NotNullIfNotNull("date")]
+		[return: NotNullIfNotNull(nameof(date))]
 		public static int? Month(DateTimeOffset? date)
 		{
 			throw new InvalidOperationException($"'{nameof(Month)}' is a server side only function.");
@@ -1558,7 +1558,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>int</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "YEAR", ServerSideOnly=true)]
-		[return: NotNullIfNotNull("date")]
+		[return: NotNullIfNotNull(nameof(date))]
 		public static int? Year(string? date)
 		{
 			throw new InvalidOperationException($"'{nameof(Year)}' is a server side only function.");
@@ -1571,7 +1571,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>int</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "YEAR", ServerSideOnly=true)]
-		[return: NotNullIfNotNull("date")]
+		[return: NotNullIfNotNull(nameof(date))]
 		public static int? Year(DateTime? date)
 		{
 			throw new InvalidOperationException($"'{nameof(Year)}' is a server side only function.");
@@ -1584,7 +1584,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>int</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "YEAR", ServerSideOnly=true)]
-		[return: NotNullIfNotNull("date")]
+		[return: NotNullIfNotNull(nameof(date))]
 		public static int? Year(DateTimeOffset? date)
 		{
 			throw new InvalidOperationException($"'{nameof(Year)}' is a server side only function.");
@@ -1601,7 +1601,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>int</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "SWITCHOFFSET", ServerSideOnly=true)]
-		[return: NotNullIfNotNull("datetimeoffset_expression")]
+		[return: NotNullIfNotNull(nameof(datetimeoffset_expression))]
 		public static DateTimeOffset? SwitchOffset(DateTimeOffset? datetimeoffset_expression, string timezoneoffset_expression)
 		{
 			throw new InvalidOperationException($"'{nameof(SwitchOffset)}' is a server side only function.");
@@ -1614,7 +1614,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>int</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "TODATETIMEOFFSET", ServerSideOnly=true)]
-		[return: NotNullIfNotNull("datetime_expression")]
+		[return: NotNullIfNotNull(nameof(datetime_expression))]
 		public static DateTimeOffset? ToDatetimeOffset(DateTimeOffset? datetime_expression, string timezoneoffset_expression)
 		{
 			throw new InvalidOperationException($"'{nameof(ToDatetimeOffset)}' is a server side only function.");
@@ -1634,7 +1634,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns 1 if the string contains valid JSON; otherwise, returns 0. Returns null if expression is null.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "ISJSON", ServerSideOnly = true)]
-		[return: NotNullIfNotNull("expression")]
+		[return: NotNullIfNotNull(nameof(expression))]
 		public static bool? IsJson(string? expression)
 		{
 			throw new InvalidOperationException($"'{nameof(IsJson)}' is a server side only function.");
@@ -1680,7 +1680,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns the updated value of expression as properly formatted JSON text.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "JSON_MODIFY", ServerSideOnly=true)]
-		[return: NotNullIfNotNull("expression")]
+		[return: NotNullIfNotNull(nameof(expression))]
 		public static string? JsonModify(string? expression, string path, string newValue)
 		{
 			throw new InvalidOperationException($"'{nameof(JsonModify)}' is a server side only function.");
@@ -1778,7 +1778,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Returns the same type as numeric_expression.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "ABS", ServerSideOnly=true, IgnoreGenericParameters=true)]
-		[return: NotNullIfNotNull("numeric_expression")]
+		[return: NotNullIfNotNull(nameof(numeric_expression))]
 		public static T Abs<T>(T numeric_expression)
 		{
 			throw new InvalidOperationException($"'{nameof(Abs)}' is a server side only function.");
@@ -1794,7 +1794,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>float</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "ACOS", ServerSideOnly=true, IgnoreGenericParameters=true)]
-		[return: NotNullIfNotNull("float_expression")]
+		[return: NotNullIfNotNull(nameof(float_expression))]
 		public static T Acos<T>(T float_expression)
 		{
 			throw new InvalidOperationException($"'{nameof(Acos)}' is a server side only function.");
@@ -1810,7 +1810,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>float</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "ASIN", ServerSideOnly=true, IgnoreGenericParameters=true)]
-		[return: NotNullIfNotNull("float_expression")]
+		[return: NotNullIfNotNull(nameof(float_expression))]
 		public static T Asin<T>(T float_expression)
 		{
 			throw new InvalidOperationException($"'{nameof(Asin)}' is a server side only function.");
@@ -1825,7 +1825,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>float</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "ATAN", ServerSideOnly=true, IgnoreGenericParameters=true)]
-		[return: NotNullIfNotNull("float_expression")]
+		[return: NotNullIfNotNull(nameof(float_expression))]
 		public static T Atan<T>(T float_expression)
 		{
 			throw new InvalidOperationException($"'{nameof(Atan)}' is a server side only function.");
@@ -1841,7 +1841,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>float</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "ATN2", ServerSideOnly=true, IgnoreGenericParameters=true)]
-		[return: NotNullIfNotNull("float_expression")]
+		[return: NotNullIfNotNull(nameof(float_expression))]
 		public static T Atn2<T>(T float_expression, T float_expression2)
 		{
 			throw new InvalidOperationException($"'{nameof(Atn2)}' is a server side only function.");
@@ -1856,7 +1856,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Return values have the same type as <c>numeric_expression</c>.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "CEILING", ServerSideOnly=true, IgnoreGenericParameters=true)]
-		[return: NotNullIfNotNull("numeric_expression")]
+		[return: NotNullIfNotNull(nameof(numeric_expression))]
 		public static T Ceiling<T>(T numeric_expression)
 		{
 			throw new InvalidOperationException($"'{nameof(Ceiling)}' is a server side only function.");
@@ -1871,7 +1871,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>float</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "COS", ServerSideOnly=true, IgnoreGenericParameters=true)]
-		[return: NotNullIfNotNull("float_expression")]
+		[return: NotNullIfNotNull(nameof(float_expression))]
 		public static T Cos<T>(T float_expression)
 		{
 			throw new InvalidOperationException($"'{nameof(Cos)}' is a server side only function.");
@@ -1886,7 +1886,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>float</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "COT", ServerSideOnly=true, IgnoreGenericParameters=true)]
-		[return: NotNullIfNotNull("float_expression")]
+		[return: NotNullIfNotNull(nameof(float_expression))]
 		public static T Cot<T>(T float_expression)
 		{
 			throw new InvalidOperationException($"'{nameof(Cot)}' is a server side only function.");
@@ -1901,7 +1901,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Return values have the same type as <c>numeric_expression</c>.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "DEGREES", ServerSideOnly=true, IgnoreGenericParameters=true)]
-		[return: NotNullIfNotNull("numeric_expression")]
+		[return: NotNullIfNotNull(nameof(numeric_expression))]
 		public static T Degrees<T>(T numeric_expression)
 		{
 			throw new InvalidOperationException($"'{nameof(Degrees)}' is a server side only function.");
@@ -1916,7 +1916,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>float</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "EXP", ServerSideOnly=true, IgnoreGenericParameters=true)]
-		[return: NotNullIfNotNull("float_expression")]
+		[return: NotNullIfNotNull(nameof(float_expression))]
 		public static T Exp<T>(T float_expression)
 		{
 			throw new InvalidOperationException($"'{nameof(Exp)}' is a server side only function.");
@@ -1931,7 +1931,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Return values have the same type as <c>numeric_expression</c>.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "FLOOR", ServerSideOnly=true, IgnoreGenericParameters=true)]
-		[return: NotNullIfNotNull("numeric_expression")]
+		[return: NotNullIfNotNull(nameof(numeric_expression))]
 		public static T Floor<T>(T numeric_expression)
 		{
 			throw new InvalidOperationException($"'{nameof(Floor)}' is a server side only function.");
@@ -1946,7 +1946,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>float</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "LOG", ServerSideOnly=true, IgnoreGenericParameters=true)]
-		[return: NotNullIfNotNull("float_expression")]
+		[return: NotNullIfNotNull(nameof(float_expression))]
 		public static T Log<T>(T float_expression)
 		{
 			throw new InvalidOperationException($"'{nameof(Log)}' is a server side only function.");
@@ -1962,7 +1962,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>float</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "LOG", ServerSideOnly=true, IgnoreGenericParameters=true)]
-		[return: NotNullIfNotNull("float_expression")]
+		[return: NotNullIfNotNull(nameof(float_expression))]
 		public static T Log<T>(T float_expression, int @base)
 		{
 			throw new InvalidOperationException($"'{nameof(Log)}' is a server side only function.");
@@ -1977,7 +1977,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>float</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "LOG", ServerSideOnly=true, IgnoreGenericParameters=true)]
-		[return: NotNullIfNotNull("float_expression")]
+		[return: NotNullIfNotNull(nameof(float_expression))]
 		public static T Log10<T>(T float_expression)
 		{
 			throw new InvalidOperationException($"'{nameof(Log10)}' is a server side only function.");
@@ -2006,7 +2006,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>float</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "POWER", ServerSideOnly=true, IgnoreGenericParameters=true)]
-		[return: NotNullIfNotNull("float_expression")]
+		[return: NotNullIfNotNull(nameof(float_expression))]
 		public static T Power<T>(T float_expression, T y)
 		{
 			throw new InvalidOperationException($"'{nameof(Power)}' is a server side only function.");
@@ -2021,7 +2021,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Return values have the same type as <c>numeric_expression</c>.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "SIGN", ServerSideOnly=true, IgnoreGenericParameters=true)]
-		[return: NotNullIfNotNull("numeric_expression")]
+		[return: NotNullIfNotNull(nameof(numeric_expression))]
 		public static T Sign<T>(T numeric_expression)
 		{
 			throw new InvalidOperationException($"'{nameof(Sign)}' is a server side only function.");
@@ -2068,7 +2068,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Return values have the same type as <c>numeric_expression</c>.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "ROUND", ServerSideOnly=true, IgnoreGenericParameters=true)]
-		[return: NotNullIfNotNull("numeric_expression")]
+		[return: NotNullIfNotNull(nameof(numeric_expression))]
 		public static T Round<T>(T numeric_expression, int length, int function)
 		{
 			throw new InvalidOperationException($"'{nameof(Round)}' is a server side only function.");
@@ -2088,7 +2088,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Return values have the same type as <c>numeric_expression</c>.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "ROUND", ServerSideOnly=true, IgnoreGenericParameters=true)]
-		[return: NotNullIfNotNull("numeric_expression")]
+		[return: NotNullIfNotNull(nameof(numeric_expression))]
 		public static T Round<T>(T numeric_expression, int length)
 		{
 			throw new InvalidOperationException($"'{nameof(Round)}' is a server side only function.");
@@ -2103,7 +2103,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>Return values have the same type as <c>numeric_expression</c>.</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "RADIANS", ServerSideOnly=true, IgnoreGenericParameters=true)]
-		[return: NotNullIfNotNull("numeric_expression")]
+		[return: NotNullIfNotNull(nameof(numeric_expression))]
 		public static T Radians<T>(T numeric_expression)
 		{
 			throw new InvalidOperationException($"'{nameof(Radians)}' is a server side only function.");
@@ -2118,7 +2118,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>float</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "SIN", ServerSideOnly=true, IgnoreGenericParameters=true)]
-		[return: NotNullIfNotNull("float_expression")]
+		[return: NotNullIfNotNull(nameof(float_expression))]
 		public static T Sin<T>(T float_expression, T y)
 		{
 			throw new InvalidOperationException($"'{nameof(Sin)}' is a server side only function.");
@@ -2133,7 +2133,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>float</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "SQRT", ServerSideOnly=true, IgnoreGenericParameters=true)]
-		[return: NotNullIfNotNull("float_expression")]
+		[return: NotNullIfNotNull(nameof(float_expression))]
 		public static T Sqrt<T>(T float_expression)
 		{
 			throw new InvalidOperationException($"'{nameof(Sqrt)}' is a server side only function.");
@@ -2148,7 +2148,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>float</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "SQUARE", ServerSideOnly=true, IgnoreGenericParameters=true)]
-		[return: NotNullIfNotNull("float_expression")]
+		[return: NotNullIfNotNull(nameof(float_expression))]
 		public static T Square<T>(T float_expression)
 		{
 			throw new InvalidOperationException($"'{nameof(Square)}' is a server side only function.");
@@ -2163,7 +2163,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		/// <returns>float</returns>
 		/// <exception cref="InvalidOperationException" />
 		[Sql.Function(ProviderName.SqlServer, "TAN", ServerSideOnly=true, IgnoreGenericParameters=true)]
-		[return: NotNullIfNotNull("float_expression")]
+		[return: NotNullIfNotNull(nameof(float_expression))]
 		public static T Tan<T>(T float_expression)
 		{
 			throw new InvalidOperationException($"'{nameof(Tan)}' is a server side only function.");

--- a/Source/LinqToDB/Expressions/ExpressionExtensions.cs
+++ b/Source/LinqToDB/Expressions/ExpressionExtensions.cs
@@ -206,7 +206,7 @@ namespace LinqToDB.Expressions
 		/// replace expression with the returned value of the given <paramref name="func"/>.
 		/// </summary>
 		/// <returns>The modified expression.</returns>
-		[return: NotNullIfNotNull("expr")]
+		[return: NotNullIfNotNull(nameof(expr))]
 		public static Expression? Transform<TContext>(this Expression? expr, TContext context, [InstantHandle] Func<TContext, Expression, Expression> func)
 		{
 			if (expr == null)
@@ -220,7 +220,7 @@ namespace LinqToDB.Expressions
 		/// replace expression with the returned value of the given <paramref name="func"/>.
 		/// </summary>
 		/// <returns>The modified expression.</returns>
-		[return: NotNullIfNotNull("expr")]
+		[return: NotNullIfNotNull(nameof(expr))]
 		public static Expression? Transform(this Expression? expr, [InstantHandle] Func<Expression, Expression> func)
 		{
 			if (expr == null)
@@ -233,7 +233,7 @@ namespace LinqToDB.Expressions
 
 		#region Transform2
 
-		[return: NotNullIfNotNull("expr")]
+		[return: NotNullIfNotNull(nameof(expr))]
 		public static Expression? Transform<TContext>(this Expression? expr, TContext context, Func<TContext, Expression, TransformInfo> func)
 		{
 			if (expr == null)
@@ -242,7 +242,7 @@ namespace LinqToDB.Expressions
 			return new TransformInfoVisitor<TContext>(context, func).Transform(expr);
 		}
 
-		[return: NotNullIfNotNull("expr")]
+		[return: NotNullIfNotNull(nameof(expr))]
 		public static Expression? Transform(this Expression? expr, Func<Expression, TransformInfo> func)
 		{
 			if (expr == null)

--- a/Source/LinqToDB/Expressions/ExpressionVisitors/TransformInfoVisitor.cs
+++ b/Source/LinqToDB/Expressions/ExpressionVisitors/TransformInfoVisitor.cs
@@ -43,7 +43,7 @@ namespace LinqToDB.Expressions
 			return new TransformInfoVisitor<TContext>(context, func);
 		}
 
-		[return: NotNullIfNotNull("expr")]
+		[return: NotNullIfNotNull(nameof(expr))]
 		public Expression? Transform(Expression? expr)
 		{
 			if (expr == null)

--- a/Source/LinqToDB/Expressions/ExpressionVisitors/TransformVisitor.cs
+++ b/Source/LinqToDB/Expressions/ExpressionVisitors/TransformVisitor.cs
@@ -42,7 +42,7 @@ namespace LinqToDB.Expressions
 			return new TransformVisitor<TContext>(context, func);
 		}
 
-		[return: NotNullIfNotNull("expr")]
+		[return: NotNullIfNotNull(nameof(expr))]
 		public Expression? Transform(Expression? expr)
 		{
 			if (expr == null)

--- a/Source/LinqToDB/Expressions/InternalExtensions.cs
+++ b/Source/LinqToDB/Expressions/InternalExtensions.cs
@@ -72,7 +72,7 @@ namespace LinqToDB.Expressions
 		public static LambdaExpression UnwrapLambda(this Expression ex)
 			=> (LambdaExpression)((UnaryExpression)ex).Operand.Unwrap();
 
-		[return: NotNullIfNotNull("ex")]
+		[return: NotNullIfNotNull(nameof(ex))]
 		public static Expression? Unwrap(this Expression? ex)
 		{
 			if (ex == null)
@@ -89,7 +89,7 @@ namespace LinqToDB.Expressions
 			return ex;
 		}
 
-		[return: NotNullIfNotNull("ex")]
+		[return: NotNullIfNotNull(nameof(ex))]
 		public static Expression? UnwrapConvert(this Expression? ex)
 		{
 			if (ex == null)
@@ -109,7 +109,7 @@ namespace LinqToDB.Expressions
 			return ex;
 		}
 
-		[return: NotNullIfNotNull("ex")]
+		[return: NotNullIfNotNull(nameof(ex))]
 		public static Expression? UnwrapConvertToObject(this Expression? ex)
 		{
 			if (ex == null)
@@ -130,7 +130,7 @@ namespace LinqToDB.Expressions
 			return ex;
 		}
 
-		[return: NotNullIfNotNull("ex")]
+		[return: NotNullIfNotNull(nameof(ex))]
 		public static Expression? UnwrapWithAs(this Expression? ex)
 		{
 			return ex?.NodeType switch
@@ -219,7 +219,7 @@ namespace LinqToDB.Expressions
 			return accessors;
 		}
 
-		[return: NotNullIfNotNull("expr")]
+		[return: NotNullIfNotNull(nameof(expr))]
 		public static Expression? GetRootObject(Expression? expr, MappingSchema mapping)
 		{
 			if (expr == null)
@@ -574,7 +574,7 @@ namespace LinqToDB.Expressions
 		/// </summary>
 		/// <param name="expression">Expression to optimize.</param>
 		/// <returns>Optimized expression.</returns>
-		[return: NotNullIfNotNull("expression")]
+		[return: NotNullIfNotNull(nameof(expression))]
 		public static Expression? OptimizeExpression(this Expression? expression, MappingSchema mappingSchema)
 		{
 			return TransformInfoVisitor<MappingSchema>.Create(mappingSchema, OptimizeExpressionTransformer).Transform(expression);

--- a/Source/LinqToDB/Expressions/TypeMapper/TypeMapper.cs
+++ b/Source/LinqToDB/Expressions/TypeMapper/TypeMapper.cs
@@ -802,7 +802,7 @@ namespace LinqToDB.Expressions
 			return ctx.Aborted ? null : converted;
 		}
 
-		[return: NotNullIfNotNull("mapperType")]
+		[return: NotNullIfNotNull(nameof(mapperType))]
 		private ICustomMapper? CreateTypeMapper(Type? mapperType)
 		{
 			if (mapperType == null)
@@ -1248,7 +1248,7 @@ namespace LinqToDB.Expressions
 
 		#endregion
 
-		[return: NotNullIfNotNull("instance")]
+		[return: NotNullIfNotNull(nameof(instance))]
 		public TR? Wrap<TR>(object? instance)
 			where TR: TypeWrapper
 		{
@@ -1258,7 +1258,7 @@ namespace LinqToDB.Expressions
 			return (TR)Wrap(typeof(TR), instance);
 		}
 
-		[return: NotNullIfNotNull("instance")]
+		[return: NotNullIfNotNull(nameof(instance))]
 		private object? Wrap(Type wrapperType, object? instance)
 		{
 			if (instance == null)

--- a/Source/LinqToDB/Extensions/ReflectionExtensions.cs
+++ b/Source/LinqToDB/Extensions/ReflectionExtensions.cs
@@ -907,7 +907,7 @@ namespace LinqToDB.Extensions
 
 #region MethodInfo extensions
 
-		[return: NotNullIfNotNull("method")]
+		[return: NotNullIfNotNull(nameof(method))]
 		public static PropertyInfo? GetPropertyInfo(this MethodInfo? method)
 		{
 			if (method != null)

--- a/Source/LinqToDB/Linq/Builder/EagerLoading.cs
+++ b/Source/LinqToDB/Linq/Builder/EagerLoading.cs
@@ -1641,7 +1641,7 @@ namespace LinqToDB.Linq.Builder
 		}
 
 
-		[return: NotNullIfNotNull("body")]
+		[return: NotNullIfNotNull(nameof(body))]
 		internal static Expression? ReplaceParametersWithChangedType(Expression? body, IList<ParameterExpression> before, IList<ParameterExpression> after)
 		{
 			if (body == null)
@@ -1691,7 +1691,7 @@ namespace LinqToDB.Linq.Builder
 			return newBody;
 		}
 
-		[return: NotNullIfNotNull("expr")]
+		[return: NotNullIfNotNull(nameof(expr))]
 		internal static Expression? FinalizeExpressionKeys(HashSet<Expression> stable, Expression? expr)
 		{
 			if (expr == null)

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.cs
@@ -1590,7 +1590,7 @@ namespace LinqToDB.Linq.Builder
 
 		Dictionary<Expression, Expression>? _rootExpressions;
 
-		[return: NotNullIfNotNull("expr")]
+		[return: NotNullIfNotNull(nameof(expr))]
 		public Expression? GetRootObject(Expression? expr)
 		{
 			if (expr == null)

--- a/Source/LinqToDB/Sql/Sql.Collate.cs
+++ b/Source/LinqToDB/Sql/Sql.Collate.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 using LinqToDB.Expressions;
 using LinqToDB.SqlQuery;
@@ -17,7 +18,8 @@ namespace LinqToDB
 		[Extension("", ServerSideOnly = true, BuilderType = typeof(DB2LUWCollationBuilder)    , Configuration = ProviderName.DB2LUW)]
 		[Extension("", ServerSideOnly = true, BuilderType = typeof(PostgreSQLCollationBuilder), Configuration = ProviderName.PostgreSQL)]
 		[Extension("", ServerSideOnly = true, BuilderType = typeof(NamedCollationBuilder))]
-		public static string Collate(this string expr, [SqlQueryDependent] string collation)
+		[return: NotNullIfNotNull(nameof(expr))]
+		public static string? Collate(this string? expr, [SqlQueryDependent] string collation)
 			=> throw new InvalidOperationException($"{nameof(Sql)}.{nameof(Sql.Collate)} is server-side only API.");
 
 		internal sealed class NamedCollationBuilder : IExtensionCallBuilder
@@ -32,7 +34,10 @@ namespace LinqToDB
 				if (!ValidateCollation(collation))
 					throw new InvalidOperationException($"Invalid collation: {collation}");
 
-				builder.ResultExpression = new SqlExpression(typeof(string), $"{{0}} COLLATE {collation}", Precedence.Primary, expr);
+				builder.ResultExpression = new SqlExpression(typeof(string), $"{{0}} COLLATE {collation}", Precedence.Primary, expr)
+				{
+					CanBeNull = expr.CanBeNull
+				};
 			}
 
 			/// <summary>
@@ -53,7 +58,10 @@ namespace LinqToDB
 				var expr      = builder.GetExpression("expr");
 				var collation = builder.GetValue<string>("collation").Replace("\"", "\"\"");
 
-				builder.ResultExpression = new SqlExpression(typeof(string), $"{{0}} COLLATE \"{collation}\"", Precedence.Primary, expr);
+				builder.ResultExpression = new SqlExpression(typeof(string), $"{{0}} COLLATE \"{collation}\"", Precedence.Primary, expr)
+				{
+					CanBeNull = expr.CanBeNull
+				};
 			}
 		}
 
@@ -65,7 +73,10 @@ namespace LinqToDB
 				var collation = builder.GetValue<string>("collation");
 
 				// collation cannot be parameter
-				builder.ResultExpression = new SqlExpression(typeof(string), $"COLLATION_KEY_BIT({{0}}, {{1}})", Precedence.Primary, expr, new SqlValue(typeof(string), collation));
+				builder.ResultExpression = new SqlExpression(typeof(string), $"COLLATION_KEY_BIT({{0}}, {{1}})", Precedence.Primary, expr, new SqlValue(typeof(string), collation))
+				{
+					CanBeNull = expr.CanBeNull
+				};
 			}
 		}
 	}

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -115,7 +115,7 @@ namespace LinqToDB.SqlProvider
 
 		#region Helpers
 
-		[return: NotNullIfNotNull("element")]
+		[return: NotNullIfNotNull(nameof(element))]
 		public T? ConvertElement<T>(T? element)
 			where T : class, IQueryElement
 		{

--- a/Source/LinqToDB/SqlProvider/BasicSqlOptimizer.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlOptimizer.cs
@@ -1929,7 +1929,7 @@ namespace LinqToDB.SqlProvider
 
 		#region Conversion
 
-		[return: NotNullIfNotNull("element")]
+		[return: NotNullIfNotNull(nameof(element))]
 		public virtual IQueryElement? ConvertElement(MappingSchema mappingSchema, IQueryElement? element, OptimizationContext context)
 		{
 			return OptimizeElement(mappingSchema, element, context, true);

--- a/Source/LinqToDB/SqlProvider/ISqlOptimizer.cs
+++ b/Source/LinqToDB/SqlProvider/ISqlOptimizer.cs
@@ -27,7 +27,7 @@ namespace LinqToDB.SqlProvider
 		/// <summary>
 		/// Converts query element to specific provider dialect. 
 		/// </summary>
-		[return: NotNullIfNotNull("element")]
+		[return: NotNullIfNotNull(nameof(element))]
 		IQueryElement? ConvertElement(MappingSchema mappingSchema, IQueryElement? element, OptimizationContext context);
 
 	}

--- a/Source/LinqToDB/SqlQuery/CloneVisitor.cs
+++ b/Source/LinqToDB/SqlQuery/CloneVisitor.cs
@@ -33,7 +33,7 @@ namespace LinqToDB.SqlQuery
 			_doCloneStatic = doClone;
 		}
 
-		[return: NotNullIfNotNull("elements")]
+		[return: NotNullIfNotNull(nameof(elements))]
 		public T[]? Clone<T>(T[]? elements)
 			where T : class, IQueryElement
 		{
@@ -121,7 +121,7 @@ namespace LinqToDB.SqlQuery
 		// note on clone implementation:
 		// 1. when cloning element, add it first to _objectTree before cloing it's members to avoid issues, when child elements contain reference to current element
 		// 2. use _objectTree.Add() instead of _objectTree[e] = clone; to detect double clone errors
-		[return: NotNullIfNotNull("element")]
+		[return: NotNullIfNotNull(nameof(element))]
 		internal T? Clone<T>(T? element)
 			where T: class, IQueryElement
 		{

--- a/Source/LinqToDB/SqlQuery/ConvertVisitor.cs
+++ b/Source/LinqToDB/SqlQuery/ConvertVisitor.cs
@@ -144,7 +144,7 @@ namespace LinqToDB.SqlQuery
 			return null;
 		}
 
-		[return: NotNullIfNotNull("element")]
+		[return: NotNullIfNotNull(nameof(element))]
 		internal IQueryElement? ConvertInternal(IQueryElement? element)
 		{
 			if (element == null)

--- a/Source/LinqToDB/SqlQuery/QueryVisitorExtensions.cs
+++ b/Source/LinqToDB/SqlQuery/QueryVisitorExtensions.cs
@@ -78,7 +78,7 @@ namespace LinqToDB.SqlQuery
 		#endregion
 
 		#region Clone
-		[return: NotNullIfNotNull("element")]
+		[return: NotNullIfNotNull(nameof(element))]
 		public static T? Clone<T>(this T? element, Dictionary<IQueryElement, IQueryElement> objectTree)
 			where T : class, IQueryElement
 		{
@@ -88,7 +88,7 @@ namespace LinqToDB.SqlQuery
 			return new CloneVisitor<object?>(objectTree, null).Clone(element);
 		}
 
-		[return: NotNullIfNotNull("elements")]
+		[return: NotNullIfNotNull(nameof(elements))]
 		public static T[]? Clone<T>(this T[]? elements, Dictionary<IQueryElement, IQueryElement> objectTree)
 			where T : class, IQueryElement
 		{
@@ -98,7 +98,7 @@ namespace LinqToDB.SqlQuery
 			return new CloneVisitor<object?>(objectTree, null).Clone(elements);
 		}
 
-		[return: NotNullIfNotNull("element")]
+		[return: NotNullIfNotNull(nameof(element))]
 		public static T? Clone<T, TContext>(this T? element, TContext context, Dictionary<IQueryElement, IQueryElement> objectTree, Func<TContext, IQueryElement, bool> doClone)
 			where T : class, IQueryElement
 		{
@@ -108,7 +108,7 @@ namespace LinqToDB.SqlQuery
 			return new CloneVisitor<TContext>(objectTree, context, doClone).Clone(element);
 		}
 
-		[return: NotNullIfNotNull("element")]
+		[return: NotNullIfNotNull(nameof(element))]
 		public static T? Clone<T, TContext>(this T? element, TContext context, Func<TContext, IQueryElement, bool> doClone)
 			where T : class, IQueryElement
 		{
@@ -118,7 +118,7 @@ namespace LinqToDB.SqlQuery
 			return new CloneVisitor<TContext>(null, context, doClone).Clone(element);
 		}
 
-		[return: NotNullIfNotNull("element")]
+		[return: NotNullIfNotNull(nameof(element))]
 		public static T? Clone<T>(this T? element, Func<IQueryElement, bool> doClone)
 			where T : class, IQueryElement
 		{
@@ -128,7 +128,7 @@ namespace LinqToDB.SqlQuery
 			return new CloneVisitor<object?>(null, doClone).Clone(element);
 		}
 
-		[return: NotNullIfNotNull("element")]
+		[return: NotNullIfNotNull(nameof(element))]
 		public static T? Clone<T>(this T? element)
 			where T : class, IQueryElement
 		{

--- a/Tests/Linq/Linq/PaginationExtensions.cs
+++ b/Tests/Linq/Linq/PaginationExtensions.cs
@@ -89,7 +89,7 @@ namespace Tests.Linq
 
 		#region Helpers
 
-		[return: NotNullIfNotNull("ex")]
+		[return: NotNullIfNotNull(nameof(ex))]
 		static Expression? Unwrap(this Expression? ex)
 		{
 			if (ex == null)


### PR DESCRIPTION
fix #3579

Also migrate `NotNullIfNotNull` attribute usages to use nameof (C# 11)