### PR TITLE
Implement IAsyncDisposable for DataContextTransaction

### DIFF
--- a/Tests/Linq/Data/TransactionTests.cs
+++ b/Tests/Linq/Data/TransactionTests.cs
@@ -199,6 +199,25 @@ namespace Tests.Data
 		}
 
 		[Test]
+		public async Task AutoRollbackTransactionAsync([DataSources(false, TestProvName.AllClickHouse)] string context)
+		{
+			await using (var db = GetDataConnection(context))
+			using (new RestoreBaseTables(db))
+			{
+				await db.InsertAsync(new Parent { ParentID = 1010, Value1 = 1010 });
+
+				await using (db.BeginTransaction())
+				{
+					db.Parent.Update(t => t.ParentID == 1010, t => new Parent { Value1 = 1012 });
+				}
+
+				var p = await db.Parent.FirstAsync(t => t.ParentID == 1010);
+
+				Assert.That(p.Value1, Is.Not.EqualTo(1012));
+			}
+		}
+
+		[Test]
 		public void CommitTransaction([DataSources(false, TestProvName.AllClickHouse)] string context)
 		{
 			using (var db = GetDataConnection(context))


### PR DESCRIPTION
This adds an `IAsyncDisposable` implementation for `DataContextTransaction`s.

Note: `DataConnectionTransaction` already implements `IAsyncDisposable`