### PR TITLE
Schema/scaffold suport for temporal tables

### DIFF
--- a/Source/LinqToDB.CLI/CommandLine/Commands/ScaffoldCommand.Configuration.cs
+++ b/Source/LinqToDB.CLI/CommandLine/Commands/ScaffoldCommand.Configuration.cs
@@ -255,6 +255,7 @@ namespace LinqToDB.CommandLine
 			// simple flags
 			if (options.Remove(SchemaOptions.PreferProviderTypes       , out value)) settings.PreferProviderSpecificTypes = (bool)value!;
 			if (options.Remove(SchemaOptions.IgnoreDuplicateFKs        , out value)) settings.IgnoreDuplicateForeignKeys  = (bool)value!;
+			if (options.Remove(SchemaOptions.IgnoreSystemHistoryTables , out value)) settings.IgnoreSystemHistoryTables   = (bool)value!;
 			if (options.Remove(SchemaOptions.UseSafeSchemaLoadOnly     , out value)) settings.UseSafeSchemaLoad           = (bool)value!;
 			if (options.Remove(SchemaOptions.LoadDatabaseName          , out value)) settings.LoadDatabaseName            = (bool)value!;
 			if (options.Remove(SchemaOptions.LoadProcedureSchema       , out value)) settings.LoadProceduresSchema        = (bool)value!;

--- a/Source/LinqToDB.CLI/CommandLine/Commands/ScaffoldCommand.Options.cs
+++ b/Source/LinqToDB.CLI/CommandLine/Commands/ScaffoldCommand.Options.cs
@@ -1242,6 +1242,20 @@ When this option is not set, CLI tool use database-specific logic to detect defa
 					_t4ModeOptions.Schema.LoadDatabaseName);
 
 			/// <summary>
+			/// Don't load history tables for SQL Server temporal tables.
+			/// </summary>
+			public static readonly CliOption IgnoreSystemHistoryTables = new BooleanCliOption(
+					"mssql-ignore-temporal-history-tables",
+					null,
+					false,
+					"ignore history tables for SQL Server temporal tables (SQL Server 2016+ only)",
+					null,
+					null,
+					null,
+					_defaultOptions.Schema.IgnoreSystemHistoryTables,
+					_t4ModeOptions.Schema.IgnoreSystemHistoryTables);
+
+			/// <summary>
 			/// Use only safe schema load methods to load table function and store procedure result-set schema option.
 			/// </summary>
 			public static readonly CliOption UseSafeSchemaLoadOnly = new BooleanCliOption(

--- a/Source/LinqToDB.Tools/Scaffold/Options/ScaffoldOptions.cs
+++ b/Source/LinqToDB.Tools/Scaffold/Options/ScaffoldOptions.cs
@@ -42,6 +42,7 @@ namespace LinqToDB.Scaffold
 			options.Schema.IncludeSchemas              = true;
 			options.Schema.DefaultSchemas              = null;
 			options.Schema.IncludeCatalogs             = true;
+			options.Schema.IgnoreSystemHistoryTables   = false;
 			options.Schema.UseSafeSchemaLoad           = false;
 			options.Schema.LoadDatabaseName            = false;
 			options.Schema.LoadProceduresSchema        = true;

--- a/Source/LinqToDB.Tools/Scaffold/Options/SchemaOptions.cs
+++ b/Source/LinqToDB.Tools/Scaffold/Options/SchemaOptions.cs
@@ -39,6 +39,15 @@ namespace LinqToDB.Scaffold
 		/// </list>
 		/// </summary>
 		public Func<SqlObjectName, bool, bool> LoadTableOrView { get; set; } = (_, _) => true;
+
+		/// <summary>
+		/// This option applied only to SQL Server 2016+ and, when enabled, removes history tables information for temporal tables from schema load results.
+		/// <list type="bullet">
+		/// <item>Default: <c>false</c></item>
+		/// <item>In T4 compability mode: <c>false</c></item>
+		/// </list>
+		/// </summary>
+		public bool IgnoreSystemHistoryTables { get; set; }
 		#endregion
 
 		#region Foreign Keys

--- a/Source/LinqToDB.Tools/Schema/LegacySchemaProvider.cs
+++ b/Source/LinqToDB.Tools/Schema/LegacySchemaProvider.cs
@@ -702,8 +702,9 @@ namespace LinqToDB.Schema
 				throw new InvalidOperationException($"{nameof(GetSchemaOptions)}.{nameof(GetSchemaOptions.LoadProcedure)} called for non-table returning object {p.ProcedureName}");
 			};
 
-			legacyOptions.LoadTable     = t => options.LoadTableOrView(new SqlObjectName(t.Name, Schema: t.Schema), t.IsView);
-			legacyOptions.UseSchemaOnly = options.UseSafeSchemaLoad;
+			legacyOptions.LoadTable                 = t => options.LoadTableOrView(new SqlObjectName(t.Name, Schema: t.Schema), t.IsView);
+			legacyOptions.UseSchemaOnly             = options.UseSafeSchemaLoad;
+			legacyOptions.IgnoreSystemHistoryTables = options.IgnoreSystemHistoryTables;
 
 			return legacyOptions;
 		}

--- a/Source/LinqToDB/SchemaProvider/GetSchemaOptions.cs
+++ b/Source/LinqToDB/SchemaProvider/GetSchemaOptions.cs
@@ -29,6 +29,10 @@ namespace LinqToDB.SchemaProvider
 		/// Should linq2db use <see cref="string"/> for char(1) type or <see cref="char"/>. Default type: <see cref="char"/> (<c>false</c>).
 		/// </summary>
 		public bool     GenerateChar1AsString;
+		/// <summary>
+		/// Only for SQL Server. Doesn't return history table schema for temporal tables.
+		/// </summary>
+		public bool     IgnoreSystemHistoryTables;
 
 		/// <summary>
 		/// Default Schema name.

--- a/Tests/Linq/DataProvider/SqlServerTests.cs
+++ b/Tests/Linq/DataProvider/SqlServerTests.cs
@@ -1982,5 +1982,177 @@ AS
 				}
 			}
 		}
+
+		private const string CREATE_TEMPORAL = @"
+-- simple temporal table
+CREATE TABLE TemporalTable1
+(
+	Id INT NOT NULL PRIMARY KEY CLUSTERED,
+	Name NVARCHAR(10) NULL,
+	ValidFrom DATETIME2 GENERATED ALWAYS AS ROW START NOT NULL,
+	ValidTo DATETIME2 GENERATED ALWAYS AS ROW END NOT NULL,
+	PERIOD FOR SYSTEM_TIME (ValidFrom, ValidTo)
+) WITH (SYSTEM_VERSIONING = ON)
+
+-- with explicit history table name
+CREATE TABLE TemporalTable2
+(
+	Id INT NOT NULL PRIMARY KEY CLUSTERED,
+	Name NVARCHAR(10) NULL,
+	ValidFrom DATETIME2 GENERATED ALWAYS AS ROW START NOT NULL,
+	ValidTo DATETIME2 GENERATED ALWAYS AS ROW END NOT NULL,
+	PERIOD FOR SYSTEM_TIME (ValidFrom, ValidTo)
+) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = dbo.TemporalTable2History))
+
+
+-- with user-defined history table
+CREATE TABLE TemporalTable3History
+(
+	Id INT NOT NULL,
+	Name NVARCHAR(10) NULL,
+	ValidFrom DATETIME2 NOT NULL,
+	ValidTo DATETIME2 NOT NULL
+)
+
+CREATE TABLE TemporalTable3
+(
+	Id INT NOT NULL PRIMARY KEY CLUSTERED,
+	Name NVARCHAR(10) NULL,
+	ValidFrom DATETIME2 GENERATED ALWAYS AS ROW START NOT NULL,
+	ValidTo DATETIME2 GENERATED ALWAYS AS ROW END NOT NULL,
+	PERIOD FOR SYSTEM_TIME (ValidFrom, ValidTo)
+) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = dbo.TemporalTable3History))
+
+-- with hidden period columns
+CREATE TABLE TemporalTable4
+(
+	Id INT NOT NULL PRIMARY KEY CLUSTERED,
+	Name NVARCHAR(10) NULL,
+	ValidFrom DATETIME2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
+	ValidTo DATETIME2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+	PERIOD FOR SYSTEM_TIME (ValidFrom, ValidTo)
+) WITH (SYSTEM_VERSIONING = ON)";
+
+		private const string DROP_TEMPORAL = @"
+IF OBJECT_ID('dbo.TemporalTable1', 'U') IS NOT NULL ALTER TABLE TemporalTable1 SET ( SYSTEM_VERSIONING = OFF)
+IF OBJECT_ID('dbo.TemporalTable2', 'U') IS NOT NULL ALTER TABLE TemporalTable2 SET ( SYSTEM_VERSIONING = OFF)
+IF OBJECT_ID('dbo.TemporalTable3', 'U') IS NOT NULL ALTER TABLE TemporalTable3 SET ( SYSTEM_VERSIONING = OFF)
+IF OBJECT_ID('dbo.TemporalTable4', 'U') IS NOT NULL ALTER TABLE TemporalTable4 SET ( SYSTEM_VERSIONING = OFF)
+
+DROP TABLE IF EXISTS TemporalTable1
+DROP TABLE IF EXISTS TemporalTable2
+DROP TABLE IF EXISTS TemporalTable3
+DROP TABLE IF EXISTS TemporalTable4
+DROP TABLE IF EXISTS TemporalTable2History
+DROP TABLE IF EXISTS TemporalTable3History
+";
+
+		[Test]
+		public void TestTemporalTableSchema([IncludeDataSources(false, TestProvName.AllSqlServer2016Plus)] string context)
+		{
+			using var db = new TestDataConnection(context);
+
+			db.Execute(DROP_TEMPORAL);
+			db.Execute(CREATE_TEMPORAL);
+
+			try
+			{
+				var schema = db.DataProvider.GetSchemaProvider().GetSchema(db);
+
+				AssertTemporalTable(schema.Tables.Where(t => t.TableName == "TemporalTable1").SingleOrDefault());
+				AssertTemporalTable(schema.Tables.Where(t => t.TableName == "TemporalTable2").SingleOrDefault());
+				AssertTemporalTable(schema.Tables.Where(t => t.TableName == "TemporalTable3").SingleOrDefault());
+				AssertTemporalTable(schema.Tables.Where(t => t.TableName == "TemporalTable4").SingleOrDefault());
+
+				AssertHistoryTable(schema.Tables.Where(t => t.TableName == "TemporalTable2History").SingleOrDefault());
+				AssertHistoryTable(schema.Tables.Where(t => t.TableName == "TemporalTable3History").SingleOrDefault());
+			}
+			finally
+			{
+				db.Execute(DROP_TEMPORAL);
+			}
+
+			static void AssertTemporalTable(TableSchema? table)
+			{
+				Assert.IsNotNull(table);
+
+				Assert.AreEqual(4, table!.Columns.Count);
+
+				AssertColumn(table!, "Id", false);
+				AssertColumn(table!, "Name", false);
+				AssertColumn(table!, "ValidFrom", true);
+				AssertColumn(table!, "ValidTo", true);
+			}
+
+			static void AssertHistoryTable(TableSchema? table)
+			{
+				Assert.IsNotNull(table);
+
+				Assert.AreEqual(4, table!.Columns.Count);
+
+				AssertColumn(table!, "Id", true);
+				AssertColumn(table!, "Name", true);
+				AssertColumn(table!, "ValidFrom", true);
+				AssertColumn(table!, "ValidTo", true);
+			}
+
+			static void AssertColumn(TableSchema table, string name, bool readOnly)
+			{
+				var column = table.Columns.Where(c => c.ColumnName == name).SingleOrDefault();
+				Assert.IsNotNull(column);
+				Assert.AreEqual(readOnly, column!.SkipOnInsert);
+				Assert.AreEqual(readOnly, column!.SkipOnUpdate);
+			}
+		}
+
+		[Test]
+		public void TestTemporalTableSchemaHideSystemTables([IncludeDataSources(false, TestProvName.AllSqlServer2016Plus)] string context)
+		{
+			using var db = new TestDataConnection(context);
+
+			db.Execute(DROP_TEMPORAL);
+			db.Execute(CREATE_TEMPORAL);
+
+			try
+			{
+				var options = new GetSchemaOptions()
+				{
+					IgnoreSystemHistoryTables = true
+				};
+				var schema = db.DataProvider.GetSchemaProvider().GetSchema(db, options);
+
+				AssertTemporalTable(schema.Tables.Where(t => t.TableName == "TemporalTable1").SingleOrDefault());
+				AssertTemporalTable(schema.Tables.Where(t => t.TableName == "TemporalTable2").SingleOrDefault());
+				AssertTemporalTable(schema.Tables.Where(t => t.TableName == "TemporalTable3").SingleOrDefault());
+				AssertTemporalTable(schema.Tables.Where(t => t.TableName == "TemporalTable4").SingleOrDefault());
+
+				Assert.IsNull(schema.Tables.Where(t => t.TableName == "TemporalTable2History").SingleOrDefault());
+				Assert.IsNull(schema.Tables.Where(t => t.TableName == "TemporalTable3History").SingleOrDefault());
+			}
+			finally
+			{
+				db.Execute(DROP_TEMPORAL);
+			}
+
+			static void AssertTemporalTable(TableSchema? table)
+			{
+				Assert.IsNotNull(table);
+
+				Assert.AreEqual(4, table!.Columns.Count);
+
+				AssertColumn(table!, "Id", false);
+				AssertColumn(table!, "Name", false);
+				AssertColumn(table!, "ValidFrom", true);
+				AssertColumn(table!, "ValidTo", true);
+			}
+
+			static void AssertColumn(TableSchema table, string name, bool readOnly)
+			{
+				var column = table.Columns.Where(c => c.ColumnName == name).SingleOrDefault();
+				Assert.IsNotNull(column);
+				Assert.AreEqual(readOnly, column!.SkipOnInsert);
+				Assert.AreEqual(readOnly, column!.SkipOnUpdate);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Fix #3854

- mark from/to columns as read-only
- mark all columns in history tables as read-only
- add option to schema/cli to ignore historry tables