### PR TITLE
FIx ValueConverter support for RemoteContext

### DIFF
--- a/Source/LinqToDB/Remote/LinqService.cs
+++ b/Source/LinqToDB/Remote/LinqService.cs
@@ -373,7 +373,14 @@ namespace LinqToDB.Remote
 				// ugh...
 				// still if it fails here due to empty columns - it is a bug in columns generation
 
-				var fieldType = selectExpressions[i].SystemType!;
+				var fieldType      = selectExpressions[i].SystemType!;
+				var valueConverter = QueryHelper.GetValueConverter(selectExpressions[i]);
+				if (valueConverter != null)
+				{
+					// value converter applied on client side for both directions
+					// here on read we need to prepare expected by converter type
+					fieldType = valueConverter.FromProviderExpression.Parameters[0].Type;
+				}
 
 				// async compiled query support
 				if (fieldType.IsGenericType && fieldType.GetGenericTypeDefinition() == typeof(Task<>))
@@ -402,23 +409,21 @@ namespace LinqToDB.Remote
 
 			for (var i = 0; i < ret.FieldCount; i++)
 				columnReaders[i] = new ConvertFromDataReaderExpression.ColumnReader(db, db.MappingSchema,
-					ret.FieldTypes[i], i, QueryHelper.GetValueConverter(selectExpressions[i]), true);
+					// converter must be null, see notes above
+					ret.FieldTypes[i], i, converter: null, true);
 
 			while (rd.DataReader!.Read())
 			{
-				var data = new string  [rd.DataReader!.FieldCount];
+				var data = new string[rd.DataReader!.FieldCount];
 
 				ret.RowCount++;
 
 				for (var i = 0; i < ret.FieldCount; i++)
 				{
-					if (!rd.DataReader!.IsDBNull(i))
-					{
-						var value = columnReaders[i].GetValue(reader);
+					var value = columnReaders[i].GetValue(reader);
 
-						if (value != null)
-							data[i] = SerializationConverter.Serialize(SerializationMappingSchema, value);
-					}
+					if (value != null)
+						data[i] = SerializationConverter.Serialize(SerializationMappingSchema, value);
 				}
 
 				ret.Data.Add(data);

--- a/Source/LinqToDB/Remote/LinqService.cs
+++ b/Source/LinqToDB/Remote/LinqService.cs
@@ -420,10 +420,13 @@ namespace LinqToDB.Remote
 
 				for (var i = 0; i < ret.FieldCount; i++)
 				{
-					var value = columnReaders[i].GetValue(reader);
+					if (!reader.IsDBNull(i))
+					{
+						var value = columnReaders[i].GetValue(reader);
 
-					if (value != null)
-						data[i] = SerializationConverter.Serialize(SerializationMappingSchema, value);
+						if (value != null)
+							data[i] = SerializationConverter.Serialize(SerializationMappingSchema, value);
+					}
 				}
 
 				ret.Data.Add(data);

--- a/Source/LinqToDB/Remote/LinqServiceSerializer.cs
+++ b/Source/LinqToDB/Remote/LinqServiceSerializer.cs
@@ -1627,7 +1627,7 @@ namespace LinqToDB.Remote
 							ReadDelayedObject(table =>
 							{
 								field.Table = table as ISqlTableSource;
-								if (table is SqlTable sqlTable)
+								if (table is SqlTable sqlTable && sqlTable.ObjectType != null)
 								{
 									var ed = _ms.GetEntityDescriptor(sqlTable.ObjectType);
 									field.ColumnDescriptor = ed[field.Name]!;

--- a/Source/LinqToDB/Remote/LinqServiceSerializer.cs
+++ b/Source/LinqToDB/Remote/LinqServiceSerializer.cs
@@ -262,7 +262,7 @@ namespace LinqToDB.Remote
 
 		public class DeserializerBase
 		{
-			private   readonly MappingSchema _ms;
+			protected readonly MappingSchema _ms;
 			protected readonly Dictionary<int,object>         ObjectIndices  = new ();
 			protected readonly Dictionary<int,Action<object>> DelayedObjects = new ();
 
@@ -1627,6 +1627,11 @@ namespace LinqToDB.Remote
 							ReadDelayedObject(table =>
 							{
 								field.Table = table as ISqlTableSource;
+								if (table is SqlTable sqlTable)
+								{
+									var ed = _ms.GetEntityDescriptor(sqlTable.ObjectType);
+									field.ColumnDescriptor = ed[field.Name]!;
+								}
 							});
 
 							break;


### PR DESCRIPTION
Fixed incorrect data read using remote context for columns with ValueConverter applied. Discovered when tried to reproduce #3830