### PR TITLE
Fix inconsistencies in MappingSchema-based attributes handling

### DIFF
--- a/Source/LinqToDB/Common/Internal/IdentifierBuilder.cs
+++ b/Source/LinqToDB/Common/Internal/IdentifierBuilder.cs
@@ -12,13 +12,13 @@ namespace LinqToDB.Common.Internal
 	using Expressions;
 	using Linq;
 
-	sealed class IdentifierBuilder
+	public sealed class IdentifierBuilder
 	{
-		public IdentifierBuilder()
+		internal IdentifierBuilder()
 		{
 		}
 
-		public IdentifierBuilder(object? data)
+		internal IdentifierBuilder(object? data)
 		{
 			Add(data);
 		}
@@ -38,7 +38,7 @@ namespace LinqToDB.Common.Internal
 
 		readonly StringBuilder _stringBuilder = new ();
 
-		public IdentifierBuilder Add(string? data)
+		internal IdentifierBuilder Add(string? data)
 		{
 			_stringBuilder
 				.Append('.')
@@ -47,7 +47,7 @@ namespace LinqToDB.Common.Internal
 			return this;
 		}
 
-		public IdentifierBuilder Add(object? data)
+		internal IdentifierBuilder Add(object? data)
 		{
 			_stringBuilder
 				.Append('.')
@@ -59,7 +59,7 @@ namespace LinqToDB.Common.Internal
 		static          int                              _identifierCounter;
 		static readonly ConcurrentDictionary<string,int> _identifiers = new ();
 
-		public int CreateID()
+		internal int CreateID()
 		{
 			var key = _stringBuilder.ToString();
 			var id  = _identifiers.GetOrAdd(key, static _ => CreateNextID());
@@ -71,7 +71,7 @@ namespace LinqToDB.Common.Internal
 			return id;
 		}
 
-		public static int CreateNextID() => Interlocked.Increment(ref _identifierCounter);
+		internal static int CreateNextID() => Interlocked.Increment(ref _identifierCounter);
 
 		static          int                               _typeCounter;
 		static readonly ConcurrentDictionary<Type,string> _types = new ();
@@ -79,6 +79,11 @@ namespace LinqToDB.Common.Internal
 		public static string GetObjectID(Type? obj)
 		{
 			return obj == null ? string.Empty : _types.GetOrAdd(obj, static _ => Interlocked.Increment(ref _typeCounter).ToString());
+		}
+
+		internal static string GetObjectID<T>(T[]? arr)
+		{
+			return arr == null ? string.Empty : $"[{string.Join(",", arr)}]";
 		}
 
 		static          int                              _expressionCounter;
@@ -97,7 +102,7 @@ namespace LinqToDB.Common.Internal
 		static          int                                 _objectCounter;
 		static readonly ConcurrentDictionary<object,string> _objects = new ();
 
-		public static string GetObjectID(object? obj)
+		internal static string GetObjectID(object? obj)
 		{
 			return obj switch
 			{

--- a/Source/LinqToDB/Data/RecordReaderBuilder.cs
+++ b/Source/LinqToDB/Data/RecordReaderBuilder.cs
@@ -53,7 +53,7 @@ namespace LinqToDB.Data
 
 			var entityDescriptor = MappingSchema.GetEntityDescriptor(objectType);
 
-			var recordType = RecordsHelper.GetRecordType(MappingSchema, objectType);
+			var recordType = RecordsHelper.GetRecordType(objectType);
 			var expr = recordType == RecordType.NotRecord
 				? BuildDefaultConstructor(entityDescriptor, objectType)
 				: BuildRecordConstructor (entityDescriptor, objectType, recordType);
@@ -183,7 +183,7 @@ namespace LinqToDB.Data
 				members = new List<MemberAccessor>();
 				foreach (var member in typeAccessor.Members)
 				{
-					if (-1 != RecordsHelper.GetFSharpRecordMemberSequence(MappingSchema, typeAccessor.Type, member.MemberInfo))
+					if (-1 != RecordsHelper.GetFSharpRecordMemberSequence(member.MemberInfo))
 						members.Add(member);
 				}
 			}
@@ -229,7 +229,7 @@ namespace LinqToDB.Data
 						}
 
 						var typeAcc          = TypeAccessor.GetAccessor(member.Type);
-						var memberRecordType = RecordsHelper.GetRecordType(MappingSchema, member.Type);
+						var memberRecordType = RecordsHelper.GetRecordType(member.Type);
 
 						var exprs = GetExpressions(typeAcc, memberRecordType, cols).ToList();
 

--- a/Source/LinqToDB/ExpressionMethodAttribute.cs
+++ b/Source/LinqToDB/ExpressionMethodAttribute.cs
@@ -5,7 +5,7 @@ using JetBrains.Annotations;
 
 namespace LinqToDB
 {
-	using LinqToDB.Common.Internal;
+	using Common.Internal;
 	using Mapping;
 
 	/// <summary>

--- a/Source/LinqToDB/ExpressionMethodAttribute.cs
+++ b/Source/LinqToDB/ExpressionMethodAttribute.cs
@@ -5,6 +5,7 @@ using JetBrains.Annotations;
 
 namespace LinqToDB
 {
+	using LinqToDB.Common.Internal;
 	using Mapping;
 
 	/// <summary>
@@ -99,7 +100,7 @@ namespace LinqToDB
 
 		public override string GetObjectID()
 		{
-			return $".{Configuration}.{MethodName}.{(IsColumn?1:0)}.{Alias}.";
+			return $".{Configuration}.{MethodName}.{IdentifierBuilder.GetObjectID(Expression)}.{(IsColumn?1:0)}.{Alias}.";
 		}
 	}
 }

--- a/Source/LinqToDB/Expressions/SqlQueryDependentParamsAttribute.cs
+++ b/Source/LinqToDB/Expressions/SqlQueryDependentParamsAttribute.cs
@@ -18,6 +18,7 @@ namespace LinqToDB.Expressions
 
 			return base.ExpressionsEqual(context, expr1, expr2, comparer);
 		}
+
 		public override IEnumerable<Expression> SplitExpression(Expression expression)
 		{
 			var val = expression.EvaluateExpression();

--- a/Source/LinqToDB/Linq/Builder/EnumerableContext.cs
+++ b/Source/LinqToDB/Linq/Builder/EnumerableContext.cs
@@ -201,7 +201,7 @@ namespace LinqToDB.Linq.Builder
 				var membersWithOrder = new List<(int sequence, MemberAccessor ma)>();
 				foreach (var member in typeAccessor.Members)
 				{
-					var sequence = RecordsHelper.GetFSharpRecordMemberSequence(Builder.MappingSchema, typeAccessor.Type, member.MemberInfo);
+					var sequence = RecordsHelper.GetFSharpRecordMemberSequence(member.MemberInfo);
 					if (sequence != -1)
 					{
 						membersWithOrder.Add((sequence, member));
@@ -271,7 +271,7 @@ namespace LinqToDB.Linq.Builder
 							}
 
 							var typeAcc          = TypeAccessor.GetAccessor(member.Type);
-							var memberRecordType = RecordsHelper.GetRecordType(Builder.MappingSchema, member.Type);
+							var memberRecordType = RecordsHelper.GetRecordType(member.Type);
 
 							var exprs = GetExpressions(typeAcc, memberRecordType, cols).ToList();
 
@@ -476,7 +476,7 @@ namespace LinqToDB.Linq.Builder
 			if (buildBlock && _variable != null)
 				return _variable;
 
-			var recordType       = RecordsHelper.GetRecordType(Builder.MappingSchema, objectType);
+			var recordType       = RecordsHelper.GetRecordType(objectType);
 			var entityDescriptor = Builder.MappingSchema.GetEntityDescriptor(objectType);
 
 			// choosing type that can be instantiated

--- a/Source/LinqToDB/Linq/Builder/SetOperationBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/SetOperationBuilder.cs
@@ -416,7 +416,7 @@ namespace LinqToDB.Linq.Builder
 
 						if (nctor != null)
 						{
-							var recordType = RecordsHelper.GetRecordType(Builder.MappingSchema, nctor.Type);
+							var recordType = RecordsHelper.GetRecordType(nctor.Type);
 							if ((recordType & RecordType.CallConstructorOnRead) != 0)
 							{
 								if (nctor.Members != null)

--- a/Source/LinqToDB/Linq/Builder/TableBuilder.TableContext.cs
+++ b/Source/LinqToDB/Linq/Builder/TableBuilder.TableContext.cs
@@ -230,7 +230,7 @@ namespace LinqToDB.Linq.Builder
 				if (buildBlock && _variable != null)
 					return _variable;
 
-				var recordType       = RecordsHelper.GetRecordType(Builder.MappingSchema, objectType);
+				var recordType       = RecordsHelper.GetRecordType(objectType);
 				var entityDescriptor = Builder.MappingSchema.GetEntityDescriptor(objectType);
 
 				// choosing type that can be instantiated
@@ -391,7 +391,7 @@ namespace LinqToDB.Linq.Builder
 					var membersWithOrder = new List<(int sequence, MemberAccessor ma)>();
 					foreach (var member in typeAccessor.Members)
 					{
-						var sequence = RecordsHelper.GetFSharpRecordMemberSequence(Builder.MappingSchema, typeAccessor.Type, member.MemberInfo);
+						var sequence = RecordsHelper.GetFSharpRecordMemberSequence(member.MemberInfo);
 						if (sequence != -1)
 						{
 							membersWithOrder.Add((sequence, member));
@@ -457,7 +457,7 @@ namespace LinqToDB.Linq.Builder
 								}
 
 								var typeAcc  = TypeAccessor.GetAccessor(member.Type);
-								var memberRecordType = RecordsHelper.GetRecordType(Builder.MappingSchema, member.Type);
+								var memberRecordType = RecordsHelper.GetRecordType(member.Type);
 
 								var exprs = GetExpressions(typeAcc, memberRecordType, cols).ToList();
 

--- a/Source/LinqToDB/Mapping/AssociationAttribute.cs
+++ b/Source/LinqToDB/Mapping/AssociationAttribute.cs
@@ -2,6 +2,7 @@
 using System.Linq.Expressions;
 
 using JetBrains.Annotations;
+using LinqToDB.Common.Internal;
 
 namespace LinqToDB.Mapping
 {
@@ -161,7 +162,7 @@ namespace LinqToDB.Mapping
 
 		public override string GetObjectID()
 		{
-			return $".{Configuration}.{ThisKey}.{OtherKey}.{ExpressionPredicate}.{QueryExpressionMethod}.{Storage}.{(CanBeNull?1:0)}.{AliasName}.";
+			return $".{Configuration}.{ThisKey}.{OtherKey}.{ExpressionPredicate}.{IdentifierBuilder.GetObjectID(Predicate)}.{QueryExpressionMethod}.{IdentifierBuilder.GetObjectID(QueryExpression)}.{Storage}.{(CanBeNull?1:0)}.{AliasName}.";
 		}
 	}
 }

--- a/Source/LinqToDB/Mapping/AssociationAttribute.cs
+++ b/Source/LinqToDB/Mapping/AssociationAttribute.cs
@@ -2,10 +2,11 @@
 using System.Linq.Expressions;
 
 using JetBrains.Annotations;
-using LinqToDB.Common.Internal;
 
 namespace LinqToDB.Mapping
 {
+	using Common.Internal;
+
 	/// <summary>
 	/// Defines relation between tables or views.
 	/// Could be applied to:

--- a/Source/LinqToDB/Mapping/DataTypeAttribute.cs
+++ b/Source/LinqToDB/Mapping/DataTypeAttribute.cs
@@ -10,7 +10,7 @@ namespace LinqToDB.Mapping
 	[AttributeUsage(
 		AttributeTargets.Field | AttributeTargets.Property,
 		AllowMultiple = true, Inherited = true)]
-	public class DataTypeAttribute : Attribute
+	public class DataTypeAttribute : MappingAttribute
 	{
 		/// <summary>
 		/// Creates attribute instance.
@@ -57,5 +57,10 @@ namespace LinqToDB.Mapping
 		/// Gets or sets the name of the database column type.
 		/// </summary>
 		public string? DbType { get; set; }
+
+		public override string GetObjectID()
+		{
+			return $".{Configuration}.{DataType}.{DbType}.";
+		}
 	}
 }

--- a/Source/LinqToDB/Mapping/DynamicColumnAccessorAttribute.cs
+++ b/Source/LinqToDB/Mapping/DynamicColumnAccessorAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq.Expressions;
+using LinqToDB.Common.Internal;
 
 namespace LinqToDB.Mapping
 {
@@ -81,7 +82,7 @@ namespace LinqToDB.Mapping
 
 		public override string GetObjectID()
 		{
-			return $".{Configuration}.{SetterMethod}.{GetterMethod}.{SetterExpressionMethod}.{GetterExpressionMethod}.";
+			return $".{Configuration}.{SetterMethod}.{GetterMethod}.{SetterExpressionMethod}.{GetterExpressionMethod}.{IdentifierBuilder.GetObjectID(SetterExpression)}.{IdentifierBuilder.GetObjectID(GetterExpression)}.";
 		}
 	}
 }

--- a/Source/LinqToDB/Mapping/DynamicColumnAccessorAttribute.cs
+++ b/Source/LinqToDB/Mapping/DynamicColumnAccessorAttribute.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Linq.Expressions;
-using LinqToDB.Common.Internal;
 
 namespace LinqToDB.Mapping
 {
+	using Common.Internal;
+
 	/// <summary>
 	/// Configure setter and getter methods for dynamic columns.
 	/// </summary>

--- a/Source/LinqToDB/Mapping/DynamicColumnsStoreAttribute.cs
+++ b/Source/LinqToDB/Mapping/DynamicColumnsStoreAttribute.cs
@@ -16,9 +16,6 @@ namespace LinqToDB.Mapping
 		/// </summary>
 		public string? Configuration { get; set; }
 
-		public override string GetObjectID()
-		{
-			return $"{Configuration}";
-		}
+		public override string GetObjectID() => Configuration ?? string.Empty;
 	}
 }

--- a/Source/LinqToDB/Mapping/IdentityAttribute.cs
+++ b/Source/LinqToDB/Mapping/IdentityAttribute.cs
@@ -34,9 +34,6 @@ namespace LinqToDB.Mapping
 		/// </summary>
 		public string? Configuration { get; set; }
 
-		public override string GetObjectID()
-		{
-			return $"{Configuration}";
-		}
+		public override string GetObjectID() => Configuration ?? string.Empty;
 	}
 }

--- a/Source/LinqToDB/Mapping/MapValueAttribute.cs
+++ b/Source/LinqToDB/Mapping/MapValueAttribute.cs
@@ -21,7 +21,7 @@ namespace LinqToDB.Mapping
 	/// </para>
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Field, AllowMultiple=true)]
-	public class MapValueAttribute : Attribute
+	public class MapValueAttribute : MappingAttribute
 	{
 		/// <summary>
 		/// Adds <see cref="MapValueAttribute"/> mapping to enum field. If you don't specify <see cref="Value"/> property,
@@ -95,5 +95,10 @@ namespace LinqToDB.Mapping
 		/// database value.
 		/// </summary>
 		public bool   IsDefault     { get; set; }
+
+		public override string GetObjectID()
+		{
+			return $".{Configuration}.{(IsDefault ? 1 : 0)}.{Value}.";
+		}
 	}
 }

--- a/Source/LinqToDB/Mapping/MappingSchema.cs
+++ b/Source/LinqToDB/Mapping/MappingSchema.cs
@@ -1024,6 +1024,8 @@ namespace LinqToDB.Mapping
 		/// <returns>Attributes of specified type.</returns>
 		public T[] GetAttributes<T>(Type type, bool inherit = true)
 			where T : Attribute
+			// TODO: v5: enforce MappingAttribute here and on MetadataReaders
+			//where T : MappingAttribute
 		{
 			if (MetadataReaders.Length == 0)
 				return Array<T>.Empty;
@@ -1063,6 +1065,8 @@ namespace LinqToDB.Mapping
 		/// <returns>Attributes of specified type.</returns>
 		public T[] GetAttributes<T>(Type type, MemberInfo memberInfo, bool inherit = true)
 			where T : Attribute
+			// TODO: v5: enforce MappingAttribute here and on MetadataReaders
+			//where T : MappingAttribute
 		{
 			if (MetadataReaders.Length == 0)
 				return Array<T>.Empty;
@@ -1101,6 +1105,8 @@ namespace LinqToDB.Mapping
 		/// <returns>First found attribute of specified type or <c>null</c>, if no attributes found.</returns>
 		public T? GetAttribute<T>(Type type, bool inherit = true)
 			where T : Attribute
+			// TODO: v5: enforce MappingAttribute here and on MetadataReaders
+			//where T : MappingAttribute
 		{
 			var attrs = GetAttributes<T>(type, inherit);
 			return attrs.Length == 0 ? null : attrs[0];
@@ -1116,6 +1122,8 @@ namespace LinqToDB.Mapping
 		/// <returns>First found attribute of specified type or <c>null</c>, if no attributes found.</returns>
 		public T? GetAttribute<T>(Type type, MemberInfo memberInfo, bool inherit = true)
 			where T : Attribute
+			// TODO: v5: enforce MappingAttribute here and on MetadataReaders
+			//where T : MappingAttribute
 		{
 			var attrs = GetAttributes<T>(type, memberInfo, inherit);
 			return attrs.Length == 0 ? null : attrs[0];
@@ -1134,6 +1142,8 @@ namespace LinqToDB.Mapping
 		public T[] GetAttributes<T>(Type type, Func<T,string?> configGetter, bool inherit = true,
 			bool exactForConfiguration = false)
 			where T : Attribute
+			// TODO: v5: enforce MappingAttribute here and on MetadataReaders
+			//where T : MappingAttribute
 		{
 			var list  = new List<T>();
 			var attrs = GetAttributes<T>(type, inherit);
@@ -1168,6 +1178,8 @@ namespace LinqToDB.Mapping
 		public T[] GetAttributes<T>(Type type, MemberInfo memberInfo, Func<T,string?> configGetter, bool inherit = true,
 			bool exactForConfiguration = false)
 			where T : Attribute
+			// TODO: v5: enforce MappingAttribute here and on MetadataReaders
+			//where T : MappingAttribute
 		{
 			var list  = new List<T>();
 			var attrs = GetAttributes<T>(type, memberInfo, inherit);
@@ -1199,6 +1211,8 @@ namespace LinqToDB.Mapping
 		/// <returns>First found attribute of specified type or <c>null</c>, if no attributes found.</returns>
 		public T? GetAttribute<T>(Type type, Func<T,string?> configGetter, bool inherit = true)
 			where T : Attribute
+			// TODO: v5: enforce MappingAttribute here and on MetadataReaders
+			//where T : MappingAttribute
 		{
 			var attrs = GetAttributes(type, configGetter, inherit);
 			return attrs.Length == 0 ? null : attrs[0];
@@ -1216,6 +1230,8 @@ namespace LinqToDB.Mapping
 		/// <returns>First found attribute of specified type or <c>null</c>, if no attributes found.</returns>
 		public T? GetAttribute<T>(Type type, MemberInfo memberInfo, Func<T,string?> configGetter, bool inherit = true)
 			where T : Attribute
+			// TODO: v5: enforce MappingAttribute here and on MetadataReaders
+			//where T : MappingAttribute
 		{
 			var attrs = GetAttributes(type, memberInfo, configGetter, inherit);
 			return attrs.Length == 0 ? null : attrs[0];

--- a/Source/LinqToDB/Mapping/NullableAttribute.cs
+++ b/Source/LinqToDB/Mapping/NullableAttribute.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace LinqToDB.Mapping
 {
@@ -9,7 +9,7 @@ namespace LinqToDB.Mapping
 	/// Using this attribute, you can allow <c>NULL</c> values for identity columns.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple=true)]
-	public class NullableAttribute : Attribute
+	public class NullableAttribute : MappingAttribute
 	{
 		/// <summary>
 		/// Creates attribute isntance.
@@ -51,5 +51,10 @@ namespace LinqToDB.Mapping
 		/// Default value: <c>true</c>.
 		/// </summary>
 		public bool   CanBeNull     { get; set; }
+
+		public override string GetObjectID()
+		{
+			return $".{Configuration}.{(CanBeNull ? 1 : 0)}.";
+		}
 	}
 }

--- a/Source/LinqToDB/Mapping/QueryFilterAttribute.cs
+++ b/Source/LinqToDB/Mapping/QueryFilterAttribute.cs
@@ -3,7 +3,7 @@
 namespace LinqToDB.Mapping
 {
 	/// <summary>
-	/// Contains reference to filter function defined by <see cref="EntityMappingBuilder{T}.HasQueryFilter(System.Func{System.Linq.IQueryable{T},LinqToDB.IDataContext,System.Linq.IQueryable{T}})"/>
+	/// Contains reference to filter function defined by <see cref="EntityMappingBuilder{T}.HasQueryFilter(Func{System.Linq.IQueryable{T},IDataContext,System.Linq.IQueryable{T}})"/>
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface)]
 	public class QueryFilterAttribute : MappingAttribute
@@ -17,7 +17,7 @@ namespace LinqToDB.Mapping
 
 		public override string GetObjectID()
 		{
-			return $"..";
+			return $".{FilterFunc?.GetHashCode()}.";
 		}
 	}
 }

--- a/Source/LinqToDB/Mapping/ScalarTypeAttribute.cs
+++ b/Source/LinqToDB/Mapping/ScalarTypeAttribute.cs
@@ -6,12 +6,12 @@ namespace LinqToDB.Mapping
 	/// Overrides default scalar detection for target class or structure.
 	/// By default linq2db treats primitives and structs as scalar types.
 	/// This attribute allows you to mark class or struct as scalar type or mark struct as non-scalar type.
-	/// Also see <seealso cref="LinqToDB.Common.Configuration.IsStructIsScalarType"/>.
+	/// Also see <seealso cref="Common.Configuration.IsStructIsScalarType"/>.
 	/// Note that if you marks some type as scalar, you will need to define custom mapping logic between object of
 	/// that type and data parameter using <seealso cref="MappingSchema.SetConvertExpression(Type, Type, System.Linq.Expressions.LambdaExpression, bool)"/> methods.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = true, Inherited = true)]
-	public class ScalarTypeAttribute : Attribute
+	public class ScalarTypeAttribute : MappingAttribute
 	{
 		/// <summary>
 		/// Creates attribute instance.
@@ -63,5 +63,10 @@ namespace LinqToDB.Mapping
 		/// Default value: <c>true</c>.
 		/// </summary>
 		public bool   IsScalar      { get; set; }
+
+		public override string GetObjectID()
+		{
+			return $".{Configuration}.{(IsScalar ? 1 : 0)}.";
+		}
 	}
 }

--- a/Source/LinqToDB/Mapping/SkipValuesByListAttribute.cs
+++ b/Source/LinqToDB/Mapping/SkipValuesByListAttribute.cs
@@ -11,7 +11,7 @@ namespace LinqToDB.Mapping
 	/// custom Attribute derived from this to override <see cref="SkipBaseAttribute.ShouldSkip"/>
 	/// </summary>
 	[CLSCompliant(false)]
-	public abstract class SkipValuesByListAttribute: SkipBaseAttribute
+	public abstract class SkipValuesByListAttribute : SkipBaseAttribute
 	{
 		/// <summary>
 		/// Gets collection with values to skip.
@@ -40,12 +40,7 @@ namespace LinqToDB.Mapping
 
 		public override string GetObjectID()
 		{
-			var sb = new StringBuilder(base.GetObjectID());
-
-			foreach (var value in Values)
-				sb.Append(value).Append('.');
-
-			return sb.ToString();
+			return $"{base.GetObjectID()}.{string.Join(".", Values)}.";
 		}
 	}
 }

--- a/Source/LinqToDB/Mapping/SkipValuesOnInsertAttribute.cs
+++ b/Source/LinqToDB/Mapping/SkipValuesOnInsertAttribute.cs
@@ -20,10 +20,5 @@ namespace LinqToDB.Mapping
 		/// Operations, affected by value skipping.
 		/// </summary>
 		public override SkipModification Affects => SkipModification.Insert;
-
-		public override string GetObjectID()
-		{
-			return $".{(int)Affects}.";
-		}
 	}
 }

--- a/Source/LinqToDB/Mapping/SkipValuesOnUpdateAttribute.cs
+++ b/Source/LinqToDB/Mapping/SkipValuesOnUpdateAttribute.cs
@@ -20,10 +20,5 @@ namespace LinqToDB.Mapping
 		/// Operations, affected by value skipping.
 		/// </summary>
 		public override SkipModification Affects => SkipModification.Update;
-
-		public override string GetObjectID()
-		{
-			return $".{(int)Affects}.";
-		}
 	}
 }

--- a/Source/LinqToDB/Sql/Sql.EnumAttribute.cs
+++ b/Source/LinqToDB/Sql/Sql.EnumAttribute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using LinqToDB.Mapping;
 
 // ReSharper disable CheckNamespace
 
@@ -7,8 +8,9 @@ namespace LinqToDB
 	partial class Sql
 	{
 		[AttributeUsage(AttributeTargets.Enum, AllowMultiple = false, Inherited = false)]
-		public class EnumAttribute : Attribute
+		public class EnumAttribute : MappingAttribute
 		{
+			public override string GetObjectID() => "..";
 		}
 	}
 }

--- a/Source/LinqToDB/Sql/Sql.EnumAttribute.cs
+++ b/Source/LinqToDB/Sql/Sql.EnumAttribute.cs
@@ -1,10 +1,11 @@
 ﻿using System;
-using LinqToDB.Mapping;
 
 // ReSharper disable CheckNamespace
 
 namespace LinqToDB
 {
+	using Mapping;
+
 	partial class Sql
 	{
 		[AttributeUsage(AttributeTargets.Enum, AllowMultiple = false, Inherited = false)]

--- a/Source/LinqToDB/Sql/Sql.ExpressionAttribute.cs
+++ b/Source/LinqToDB/Sql/Sql.ExpressionAttribute.cs
@@ -9,6 +9,7 @@ using JetBrains.Annotations;
 namespace LinqToDB
 {
 	using Expressions;
+	using LinqToDB.Common.Internal;
 	using Mapping;
 	using SqlQuery;
 
@@ -21,7 +22,7 @@ namespace LinqToDB
 		[PublicAPI]
 		[Serializable]
 		[AttributeUsage(AttributeTargets.Property | AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
-		public class ExpressionAttribute : Attribute
+		public class ExpressionAttribute : MappingAttribute
 		{
 			/// <summary>
 			/// Creates an Expression that will be used in SQL,
@@ -519,6 +520,11 @@ namespace LinqToDB
 			}
 
 			public virtual bool GetIsPredicate(Expression expression) => IsPredicate;
+
+			public override string GetObjectID()
+			{
+				return $".{Configuration}.{Expression}.{IdentifierBuilder.GetObjectID(ArgIndices)}.{Precedence}.{(ServerSideOnly ? 1 : 0)}.{(PreferServerSide ? 1 : 0)}.{(InlineParameters ? 1 : 0)}.{(ExpectExpression ? 1 : 0)}.{(IsPredicate ? 1 : 0)}.{(IsAggregate ? 1 : 0)}.{(IsWindowFunction ? 1 : 0)}.{(IsPure ? 1 : 0)}.{(int)IsNullable}.{(IgnoreGenericParameters ? 1 : 0)}.{(CanBeNull ? 1 : 0)}.";
+			}
 		}
 	}
 }

--- a/Source/LinqToDB/Sql/Sql.ExpressionAttribute.cs
+++ b/Source/LinqToDB/Sql/Sql.ExpressionAttribute.cs
@@ -9,7 +9,7 @@ using JetBrains.Annotations;
 namespace LinqToDB
 {
 	using Expressions;
-	using LinqToDB.Common.Internal;
+	using Common.Internal;
 	using Mapping;
 	using SqlQuery;
 

--- a/Source/LinqToDB/Sql/Sql.ExtensionAttribute.cs
+++ b/Source/LinqToDB/Sql/Sql.ExtensionAttribute.cs
@@ -16,6 +16,7 @@ namespace LinqToDB
 	using Common;
 	using Expressions;
 	using Extensions;
+	using LinqToDB.Common.Internal;
 	using Mapping;
 	using SqlQuery;
 
@@ -954,6 +955,11 @@ namespace LinqToDB
 					mainExtension.CanBeNull, IsNullable);
 
 				return res;
+			}
+
+			public override string GetObjectID()
+			{
+				return $"{base.GetObjectID()}.{TokenName}.{IdentifierBuilder.GetObjectID(BuilderType)}.{BuilderValue}.{ChainPrecedence}.";
 			}
 		}
 	}

--- a/Source/LinqToDB/Sql/Sql.ExtensionAttribute.cs
+++ b/Source/LinqToDB/Sql/Sql.ExtensionAttribute.cs
@@ -16,7 +16,7 @@ namespace LinqToDB
 	using Common;
 	using Expressions;
 	using Extensions;
-	using LinqToDB.Common.Internal;
+	using Common.Internal;
 	using Mapping;
 	using SqlQuery;
 

--- a/Source/LinqToDB/Sql/Sql.FunctionAttribute.cs
+++ b/Source/LinqToDB/Sql/Sql.FunctionAttribute.cs
@@ -102,6 +102,11 @@ namespace LinqToDB
 					CanBeNull = GetCanBeNull(parameters)
 				};
 			}
+
+			public override string GetObjectID()
+			{
+				return $"{base.GetObjectID()}.{Name}.";
+			}
 		}
 	}
 }

--- a/Source/LinqToDB/Sql/Sql.PropertyAttribute.cs
+++ b/Source/LinqToDB/Sql/Sql.PropertyAttribute.cs
@@ -78,6 +78,11 @@ namespace LinqToDB
 					CanBeNull = GetCanBeNull(Array<ISqlExpression>.Empty)
 				};
 			}
+
+			public override string GetObjectID()
+			{
+				return $"{base.GetObjectID()}.{Name}.";
+			}
 		}
 	}
 }

--- a/Source/LinqToDB/Sql/Sql.QueryExtensionAttribute.cs
+++ b/Source/LinqToDB/Sql/Sql.QueryExtensionAttribute.cs
@@ -7,7 +7,7 @@ namespace LinqToDB
 {
 	using Common;
 	using Linq.Builder;
-	using LinqToDB.Common.Internal;
+	using Common.Internal;
 	using Mapping;
 	using SqlQuery;
 

--- a/Source/LinqToDB/Sql/Sql.QueryExtensionAttribute.cs
+++ b/Source/LinqToDB/Sql/Sql.QueryExtensionAttribute.cs
@@ -7,6 +7,7 @@ namespace LinqToDB
 {
 	using Common;
 	using Linq.Builder;
+	using LinqToDB.Common.Internal;
 	using Mapping;
 	using SqlQuery;
 
@@ -16,7 +17,7 @@ namespace LinqToDB
 		/// Defines custom query extension builder.
 		/// </summary>
 		[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, AllowMultiple = true)]
-		public class QueryExtensionAttribute : Attribute
+		public class QueryExtensionAttribute : MappingAttribute
 		{
 			public QueryExtensionAttribute(QueryExtensionScope scope, Type extensionBuilderType)
 			{
@@ -125,6 +126,11 @@ namespace LinqToDB
 				}
 
 				return mapping.GetAttributes<QueryExtensionAttribute>(memberInfo.ReflectedType!, memberInfo, a => a.Configuration, inherit: true, exactForConfiguration: true);
+			}
+
+			public override string GetObjectID()
+			{
+				return $".{Configuration}.{(int)Scope}.{IdentifierBuilder.GetObjectID(ExtensionBuilderType)}.{IdentifierBuilder.GetObjectID(ExtensionArguments)}.";
 			}
 		}
 	}

--- a/Source/LinqToDB/Sql/Sql.TableExpressionAttribute.cs
+++ b/Source/LinqToDB/Sql/Sql.TableExpressionAttribute.cs
@@ -36,6 +36,7 @@ namespace LinqToDB
 			{
 			}
 
+			// TODO: V5 consider removal of Name+Expression
 			protected new string? Name => base.Name;
 
 			public string? Expression

--- a/Source/LinqToDB/Sql/Sql.TableFunctionAttribute.cs
+++ b/Source/LinqToDB/Sql/Sql.TableFunctionAttribute.cs
@@ -6,8 +6,8 @@ using LinqToDB.Mapping;
 
 namespace LinqToDB
 {
-	using LinqToDB.Common.Internal;
-	using LinqToDB.SqlProvider;
+	using Common.Internal;
+	using SqlProvider;
 	using SqlQuery;
 
 	partial class Sql

--- a/Source/LinqToDB/Sql/Sql.TableFunctionAttribute.cs
+++ b/Source/LinqToDB/Sql/Sql.TableFunctionAttribute.cs
@@ -6,6 +6,7 @@ using LinqToDB.Mapping;
 
 namespace LinqToDB
 {
+	using LinqToDB.Common.Internal;
 	using LinqToDB.SqlProvider;
 	using SqlQuery;
 
@@ -13,7 +14,7 @@ namespace LinqToDB
 	{
 		[Serializable]
 		[AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
-		public class TableFunctionAttribute : Attribute
+		public class TableFunctionAttribute : MappingAttribute
 		{
 			public TableFunctionAttribute()
 			{
@@ -69,6 +70,11 @@ namespace LinqToDB
 					Package : Package  ?? table.TableName.Package);
 
 				table.TableArguments = ExpressionAttribute.PrepareArguments(context, string.Empty, ArgIndices, true, knownExpressions, genericTypes, converter);
+			}
+
+			public override string GetObjectID()
+			{
+				return $".{Configuration}.{Name}.{Schema}.{Database}.{Server}.{Package}.{IdentifierBuilder.GetObjectID(ArgIndices)}.";
 			}
 		}
 	}

--- a/Tests/Linq/Linq/GenericExtensionsTests.cs
+++ b/Tests/Linq/Linq/GenericExtensionsTests.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Reflection;
 
 using LinqToDB;
+using LinqToDB.Common.Internal;
+using LinqToDB.Mapping;
 
 using NUnit.Framework;
 
@@ -12,7 +14,7 @@ namespace Tests.Linq
 	using Model;
 
 	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-	public class ExtensionChoiceAttribute : Attribute
+	public class ExtensionChoiceAttribute : MappingAttribute
 	{
 		public ExtensionChoiceAttribute(string configuration, string expression, params Type?[] types)
 		{
@@ -23,7 +25,12 @@ namespace Tests.Linq
 
 		public string  Configuration { get; set; }
 		public string  Expression    { get; set; }
-		public Type?[] Types         { get; }
+		public Type?[] Types { get; }
+
+		public override string GetObjectID()
+		{
+			return $".{Configuration}.{Expression}.[{string.Join(",", Types.Select(IdentifierBuilder.GetObjectID))}].";
+		}
 	}
 
 	sealed class GenericBuilder : Sql.IExtensionCallBuilder

--- a/Tests/Linq/Mapping/FluentMappingTests.cs
+++ b/Tests/Linq/Mapping/FluentMappingTests.cs
@@ -436,7 +436,6 @@ namespace Tests.Mapping
 			var od2 = ms.GetEntityDescriptor(typeof(MyClass));
 
 			Assert.AreEqual("Name2", od2.Name.Name);
-
 		}
 
 		[Test]
@@ -741,6 +740,43 @@ namespace Tests.Mapping
 
 			for (var i = 0; i < records.Length; i++)
 				Assert.AreEqual(records[0].Id + i, records[i].Id);
+		}
+
+		[Table("Person")]
+		sealed class EnumPerson
+		{
+			[Column] public int        PersonID;
+			[Column] public GenderEnum Gender;
+		}
+
+		public enum GenderEnum
+		{
+			Male,
+			Female,
+			Unknown,
+			Other,
+		}
+
+		[Test]
+		public void MapValueTest([DataSources] string context)
+		{
+			var ms = new MappingSchema();
+			var mb = ms.GetFluentMappingBuilder();
+
+			mb.HasAttribute(typeof(GenderEnum).GetField(nameof(GenderEnum.Male))!,    new MapValueAttribute("M"));
+			mb.HasAttribute(typeof(GenderEnum).GetField(nameof(GenderEnum.Female))!,  new MapValueAttribute("F"));
+			mb.HasAttribute(typeof(GenderEnum).GetField(nameof(GenderEnum.Unknown))!, new MapValueAttribute("U"));
+			mb.HasAttribute(typeof(GenderEnum).GetField(nameof(GenderEnum.Other))!,   new MapValueAttribute("O"));
+
+			using var db = GetDataContext(context, ms);
+
+			var records = db.GetTable<EnumPerson>().OrderBy(r => r.PersonID).ToArray();
+
+			Assert.AreEqual(4, records.Length);
+			Assert.AreEqual(GenderEnum.Male,   records[0].Gender);
+			Assert.AreEqual(GenderEnum.Male,   records[1].Gender);
+			Assert.AreEqual(GenderEnum.Female, records[2].Gender);
+			Assert.AreEqual(GenderEnum.Male,   records[3].Gender);
 		}
 	}
 }


### PR DESCRIPTION
Fix #3825

This is second issue related to MappingSchema refactoring in 4.0 (see #3701) so I've reviewed all attributes, resolved through `MappingSchema` and added proper base attribute.

In v5 (due to breaking change), we must enforce MappingAttribute constraint on MappingSchema and metadata provider attribute methods.