### PR TITLE
T4: Do not reference native assemblies when scaffolding

### DIFF
--- a/Source/LinqToDB.CLI/CommandLine/Commands/ScaffoldCommand.Interceptors.cs
+++ b/Source/LinqToDB.CLI/CommandLine/Commands/ScaffoldCommand.Interceptors.cs
@@ -267,7 +267,7 @@ namespace LinqToDB.CommandLine
 			var (status, templateAsembly) = CompileAndLoadAssembly(TEMPLATE_ASSEMBLY_NAME, templateCode, references);
 
 			// find and instantiate template host class
-			var type = templateAsembly!.GetType(TEMPLATE_CLASS_NAME);
+			var type = templateAsembly!.GetTypes().FirstOrDefault(type => type.Name == TEMPLATE_CLASS_NAME);
 			if (type == null)
 			{
 				Console.Error.WriteLine("Cannot find template in T4 file. Make sure you didn't changed @template directive");
@@ -403,7 +403,6 @@ namespace LinqToDB.CommandLine
 				if (!asmName.Contains(".Native."))
 					referencesList.Add(MetadataReference.CreateFromFile(Path.Combine(fwPath, asmName)));
 			}
-
 			var usings = new List<string>();
 			foreach (var directive in template.Directives)
 			{

--- a/Source/LinqToDB.CLI/CommandLine/Commands/ScaffoldCommand.Interceptors.cs
+++ b/Source/LinqToDB.CLI/CommandLine/Commands/ScaffoldCommand.Interceptors.cs
@@ -399,7 +399,10 @@ namespace LinqToDB.CommandLine
 			// reference netstandard + System*
 			referencesList.Add(MetadataReference.CreateFromFile(Path.Combine(fwPath, "netstandard.dll")));
 			foreach (var asmName in Directory.GetFiles(fwPath, "System*.dll"))
-				referencesList.Add(MetadataReference.CreateFromFile(Path.Combine(fwPath, asmName)));
+			{
+				if (!asmName.Contains(".Native."))
+					referencesList.Add(MetadataReference.CreateFromFile(Path.Combine(fwPath, asmName)));
+			}
 
 			var usings = new List<string>();
 			foreach (var directive in template.Directives)


### PR DESCRIPTION
Fixes #3896 

Occurs when .net 7 is picked up rather than .net 6.

Loading native only assemblies caused the T4 compilation to fail.
The generated type in the in memory assembly has a namespace so the gettype returns null in .net 7 too.

Error fixed:

```
dotnet linq2db scaffold -i Portal.json -c "Server=localhost;Database=Portal;TrustServerCertificate=true;Integrated Security=SSPI" --customize Generic.tt
AssemblyResolve: Microsoft.CodeAnalysis.resources, Version=4.4.0.0, Culture=en-GB, PublicKeyToken=31bf3856ad364e35
AssemblyResolve: Microsoft.CodeAnalysis.resources, Version=4.4.0.0, Culture=en, PublicKeyToken=31bf3856ad364e35
//------------------------------------------------------------------------------
// <auto-generated>
//     This code was generated by a tool.
//
//     Changes to this file may cause incorrect behavior and will be lost if
//     the code is regenerated.
// </auto-generated>
//------------------------------------------------------------------------------

namespace Microsoft.VisualStudio.TextTemplating41cbbac5 {
    using System;
    using System.Collections.Generic;
    using System.Linq;
    using LinqToDB.CodeModel;
    using LinqToDB.DataModel;
    using LinqToDB.Schema;
    using LinqToDB.Scaffold;
    using LinqToDB.SqlQuery;


    public partial class CustomT4Scaffolder : LinqToDB.LinqToDBHost {

        public override string TransformText() {
            this.GenerationEnvironment = null;
            this.Write("// @template directive is pre-configured and shouldn\'t be edited\r\n");
            this.Write(@"
// specify additional references using @assembly directive. E.g. (remove space before #@)
// (full path expected or user can get ""The given assembly name or codebase was invalid"" error)
// < #@ assembly name=""c:\path_to\Npgsql.dll"" #>
// linq2db.dll, linq2db.Tools.dll, and runtime's System*.dll assemblies already refereced

// additional namespace imports (usings)
");
            this.Write("*SNIP - Near default template*" ;
            return this.GenerationEnvironment.ToString();
        }

        public override void Initialize() {
            base.Initialize();
        }
    }
}

T4 compilation failed:
AssemblyResolve: Microsoft.CodeAnalysis.CSharp.resources, Version=4.4.0.0, Culture=en-GB, PublicKeyToken=31bf3856ad364e35
AssemblyResolve: Microsoft.CodeAnalysis.CSharp.resources, Version=4.4.0.0, Culture=en, PublicKeyToken=31bf3856ad364e35
        error CS0009: Metadata file 'C:\Program Files\dotnet\shared\Microsoft.NETCore.App\7.0.1\System.IO.Compression.Native.dll' could not be opened -- PE image doesn't contain managed metadata.
Unhandled exception: Object reference not set to an instance of an object.
   at LinqToDB.CommandLine.ScaffoldCommand.CompileTemplateAndLoadAssembly(String templateCode, IReadOnlyCollection`1 references, IReadOnlyCollection`1 imports)
   at LinqToDB.CommandLine.ScaffoldCommand.LoadInterceptorsFromT4(String t4templatePath, ScaffoldOptions options)
   at LinqToDB.CommandLine.ScaffoldCommand.LoadInterceptors(String interceptorsPath, ScaffoldOptions options)
   at LinqToDB.CommandLine.ScaffoldCommand.Execute(CliController controller, String[] rawArgs, Dictionary`2 options, IReadOnlyCollection`1 unknownArgs)
   at LinqToDB.CommandLine.CliController.Execute(String[] args)
   at LinqToDB.Tools.Program.Main(String[] args)
```