### PR TITLE
Association fixes

### DIFF
--- a/Source/LinqToDB/Linq/Builder/AssociationHelper.cs
+++ b/Source/LinqToDB/Linq/Builder/AssociationHelper.cs
@@ -119,8 +119,8 @@ namespace LinqToDB.Linq.Builder
 
 				if (expressionPredicate != null)
 				{
-					shouldAddDefaultIfEmpty = true;
-					shouldAddCacheCheck = true;
+					shouldAddDefaultIfEmpty = association.CanBeNull;
+					shouldAddCacheCheck     = true;
 
 					var replacedBody = expressionPredicate.GetBody(parentParam, childParam);
 
@@ -136,7 +136,7 @@ namespace LinqToDB.Linq.Builder
 					if (ed.QueryFilterFunc != null)
 					{
 						shouldAddDefaultIfEmpty = true;
-						shouldAddCacheCheck = true;
+						shouldAddCacheCheck     = true;
 					}
 				}
 

--- a/Source/LinqToDB/Linq/Builder/AssociationHelper.cs
+++ b/Source/LinqToDB/Linq/Builder/AssociationHelper.cs
@@ -294,7 +294,7 @@ namespace LinqToDB.Linq.Builder
 
 			var tableSource = tableContext.SelectQuery.From.Tables.First();
 			var join = new SqlFromClause.Join(isOuter ? JoinType.OuterApply : JoinType.CrossApply, context.SelectQuery,
-				descriptor.GenerateAlias(), true, null);
+				descriptor.GenerateAlias(), isOuter, null);
 
 			tableSource.Joins.Add(join.JoinedTable);
 

--- a/Source/LinqToDB/Linq/Builder/CountBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/CountBuilder.cs
@@ -86,17 +86,18 @@ namespace LinqToDB.Linq.Builder
 
 			var context = new CountContext(buildInfo.Parent, sequence, returnType);
 
-			//if (sequence.IsExpression(null, 0, RequestFor.Field).Result)
-			//{
-			//	var old = context.SelectQuery.Select.Columns.ToArray();
-			//	var sql = sequence.ConvertToIndex(null, 0, ConvertFlags.Field);
+			// new parser waiting room
+			if (sequence.IsExpression(null, 0, RequestFor.Field).Result)
+			{
+				var old = context.SelectQuery.Select.Columns.ToArray();
+				var sql = sequence.ConvertToIndex(null, 0, ConvertFlags.Field);
 
-			//	if (context.SelectQuery.Select.Columns.Count > old.Length)
-			//	{
-			//		context.SelectQuery.Select.Columns.Clear();
-			//		context.SelectQuery.Select.Columns.AddRange(old);
-			//	}
-			//}
+				if (context.SelectQuery.Select.Columns.Count > old.Length)
+				{
+					context.SelectQuery.Select.Columns.Clear();
+					context.SelectQuery.Select.Columns.AddRange(old);
+				}
+			}
 
 			context.Sql        = context.SelectQuery;
 			context.FieldIndex = context.SelectQuery.Select.Add(SqlFunction.CreateCount(returnType, context.SelectQuery), "cnt");

--- a/Source/LinqToDB/Linq/Builder/CountBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/CountBuilder.cs
@@ -86,6 +86,18 @@ namespace LinqToDB.Linq.Builder
 
 			var context = new CountContext(buildInfo.Parent, sequence, returnType);
 
+			//if (sequence.IsExpression(null, 0, RequestFor.Field).Result)
+			//{
+			//	var old = context.SelectQuery.Select.Columns.ToArray();
+			//	var sql = sequence.ConvertToIndex(null, 0, ConvertFlags.Field);
+
+			//	if (context.SelectQuery.Select.Columns.Count > old.Length)
+			//	{
+			//		context.SelectQuery.Select.Columns.Clear();
+			//		context.SelectQuery.Select.Columns.AddRange(old);
+			//	}
+			//}
+
 			context.Sql        = context.SelectQuery;
 			context.FieldIndex = context.SelectQuery.Select.Add(SqlFunction.CreateCount(returnType, context.SelectQuery), "cnt");
 

--- a/Tests/Linq/Linq/AssociationTests.cs
+++ b/Tests/Linq/Linq/AssociationTests.cs
@@ -916,7 +916,7 @@ namespace Tests.Linq
 		}
 
 		[Table]
-		class NotNullParent
+		sealed class NotNullParent
 		{
 			[Column] public int ID { get; set; }
 
@@ -936,7 +936,7 @@ namespace Tests.Linq
 		}
 
 		[Table]
-		class NotNullChild
+		sealed class NotNullChild
 		{
 			[Column] public int ParentID { get; set; }
 


### PR DESCRIPTION
Fix #3658

Replaces #3657

Fixes:
- respect `CanBeNull` for association with custom predicate
- respect associations in select for `Count` scalar queries
- don't remove "unused" **INNER** join for `Count` scalar query with association field access