### PR TITLE
Break fluent mapping configuration explicitly

### DIFF
--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -728,13 +728,6 @@ namespace LinqToDB.Data
 			_dataContextInterceptor?.OnClosed(new (this));
 		}
 
-		public FluentMappingBuilder GetFluentMappingBuilder()
-		{
-			if (MappingSchema.IsLockable)
-				MappingSchema = new(MappingSchema);
-			return MappingSchema.GetFluentMappingBuilder();
-		}
-
 		#endregion
 
 		#region Command

--- a/Source/LinqToDB/DataContext.cs
+++ b/Source/LinqToDB/DataContext.cs
@@ -524,11 +524,6 @@ namespace LinqToDB
 			return new QueryRunner(this, ((IDataContext)GetDataConnection()).GetQueryRunner(query, queryNumber, expression, parameters, preambles));
 		}
 
-		public FluentMappingBuilder GetFluentMappingBuilder()
-		{
-			return MappingSchema.GetFluentMappingBuilder();
-		}
-
 		sealed class QueryRunner : IQueryRunner
 		{
 			public QueryRunner(DataContext dataContext, IQueryRunner queryRunner)

--- a/Source/LinqToDB/IDataContext.cs
+++ b/Source/LinqToDB/IDataContext.cs
@@ -133,7 +133,5 @@ namespace LinqToDB
 		void RemoveInterceptor(IInterceptor interceptor);
 
 		IUnwrapDataObjectInterceptor? UnwrapDataObjectInterceptor { get; }
-
-		FluentMappingBuilder GetFluentMappingBuilder();
 	}
 }

--- a/Source/LinqToDB/Mapping/MappingSchema.cs
+++ b/Source/LinqToDB/Mapping/MappingSchema.cs
@@ -1210,17 +1210,6 @@ namespace LinqToDB.Mapping
 			return Schemas[0].MetadataReader?.GetDynamicColumns(type) ?? Array<MemberInfo>.Empty;
 		}
 
-		/// <summary>
-		/// Gets fluent mapping builder for current schema.
-		/// </summary>
-		/// <returns>Fluent mapping builder.</returns>
-		public FluentMappingBuilder GetFluentMappingBuilder()
-		{
-			if (!IsLocked)
-				return new (this);
-			throw new LinqToDBException("MappingSchema is locked. Fluent Mapping is not supported.");
-		}
-
 		#endregion
 
 		#region Configuration

--- a/Source/LinqToDB/Remote/RemoteDataContextBase.cs
+++ b/Source/LinqToDB/Remote/RemoteDataContextBase.cs
@@ -440,11 +440,6 @@ namespace LinqToDB.Remote
 			}
 		}
 
-		public FluentMappingBuilder GetFluentMappingBuilder()
-		{
-			return MappingSchema.GetFluentMappingBuilder();
-		}
-
 		public virtual void Dispose()
 		{
 			Disposed = true;

--- a/Source/LinqToDB/TempTable.cs
+++ b/Source/LinqToDB/TempTable.cs
@@ -630,6 +630,9 @@ namespace LinqToDB
 
 	public static partial class DataExtensions
 	{
+		private const string CreateTempTable_LockedSchemaError  = $"{nameof(CreateTempTable)} API with 'setTable' parameter cannot be used for context with read-only mapping schema. Enable writeable {nameof(MappingSchema)} for context using {nameof(DataOptionsExtensions)}.{nameof(DataOptionsExtensions.UseEnableContextSchemaEdit)}(true) configuration option.";
+		private const string IntoTempTable_LockedSchemaError    = $"{nameof(IntoTempTable)  } API with 'setTable' parameter cannot be used for context with read-only mapping schema. Enable writeable {nameof(MappingSchema)} for context using {nameof(DataOptionsExtensions)}.{nameof(DataOptionsExtensions.UseEnableContextSchemaEdit)}(true) configuration option.";
+
 		#region CreateTempTable
 
 		/// <summary>
@@ -743,7 +746,11 @@ namespace LinqToDB
 		/// <typeparam name="T">Table record mapping class.</typeparam>
 		/// <param name="db">Database connection instance.</param>
 		/// <param name="items">Query to get records to populate created table with initial data.</param>
-		/// <param name="setTable">Action to modify <typeparamref name="T"/> entity's mapping using fluent mapping.</param>
+		/// <param name="setTable">Action to modify <typeparamref name="T"/> entity's mapping using fluent mapping.
+		/// Note that context mapping schema must be writable to allow it.
+		/// You can enable writable <see cref="MappingSchema"/> using <see cref="DataOptionsExtensions.UseEnableContextSchemaEdit(DataOptions, bool)"/> configuration helper
+		/// or enable writeable schemata globally using <see cref="Common.Configuration.Linq.EnableContextSchemaEdit" /> option.
+		/// Latter option is not recommended as it will affect performance significantly.</param>
 		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
 		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
@@ -763,9 +770,10 @@ namespace LinqToDB
 			TableOptions                    tableOptions = TableOptions.IsTemporary)
 			where T : class
 		{
-			if (setTable == null) throw new ArgumentNullException(nameof(setTable));
+			if (setTable == null           ) throw new ArgumentNullException(nameof(setTable));
+			if (db.MappingSchema.IsLockable) throw new LinqToDBException(CreateTempTable_LockedSchemaError);
 
-			var builder = db.GetFluentMappingBuilder();
+			var builder = new FluentMappingBuilder(db.MappingSchema);
 			setTable(builder.Entity<T>());
 			builder.Build();
 
@@ -807,7 +815,11 @@ namespace LinqToDB
 		/// <param name="db">Database connection instance.</param>
 		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
 		/// <param name="items">Query to get records to populate created table with initial data.</param>
-		/// <param name="setTable">Action to modify <typeparamref name="T"/> entity's mapping using fluent mapping.</param>
+		/// <param name="setTable">Action to modify <typeparamref name="T"/> entity's mapping using fluent mapping.
+		/// Note that context mapping schema must be writable to allow it.
+		/// You can enable writable <see cref="MappingSchema"/> using <see cref="DataOptionsExtensions.UseEnableContextSchemaEdit(DataOptions, bool)"/> configuration helper
+		/// or enable writeable schemata globally using <see cref="Common.Configuration.Linq.EnableContextSchemaEdit" /> option.
+		/// Latter option is not recommended as it will affect performance significantly.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
 		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="action">Optional action that will be executed after table creation but before it populated with data from <paramref name="items"/>.</param>
@@ -826,9 +838,10 @@ namespace LinqToDB
 			TableOptions                    tableOptions = TableOptions.IsTemporary)
 			where T : class
 		{
-			if (setTable == null) throw new ArgumentNullException(nameof(setTable));
+			if (setTable == null           ) throw new ArgumentNullException(nameof(setTable));
+			if (db.MappingSchema.IsLockable) throw new LinqToDBException(CreateTempTable_LockedSchemaError);
 
-			var builder = db.GetFluentMappingBuilder();
+			var builder = new FluentMappingBuilder(db.MappingSchema);
 			setTable(builder.Entity<T>());
 			builder.Build();
 
@@ -954,7 +967,11 @@ namespace LinqToDB
 		/// <typeparam name="T">Table record mapping class.</typeparam>
 		/// <param name="db">Database connection instance.</param>
 		/// <param name="items">Query to get records to populate created table with initial data.</param>
-		/// <param name="setTable">Action to modify <typeparamref name="T"/> entity's mapping using fluent mapping.</param>
+		/// <param name="setTable">Action to modify <typeparamref name="T"/> entity's mapping using fluent mapping.
+		/// Note that context mapping schema must be writable to allow it.
+		/// You can enable writable <see cref="MappingSchema"/> using <see cref="DataOptionsExtensions.UseEnableContextSchemaEdit(DataOptions, bool)"/> configuration helper
+		/// or enable writeable schemata globally using <see cref="Common.Configuration.Linq.EnableContextSchemaEdit" /> option.
+		/// Latter option is not recommended as it will affect performance significantly.</param>
 		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
 		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
@@ -976,9 +993,10 @@ namespace LinqToDB
 			CancellationToken               cancellationToken = default)
 			where T : class
 		{
-			if (setTable == null) throw new ArgumentNullException(nameof(setTable));
+			if (setTable == null           ) throw new ArgumentNullException(nameof(setTable));
+			if (db.MappingSchema.IsLockable) throw new LinqToDBException(CreateTempTable_LockedSchemaError);
 
-			var builder = db.GetFluentMappingBuilder();
+			var builder = new FluentMappingBuilder(db.MappingSchema);
 			setTable(builder.Entity<T>());
 			builder.Build();
 
@@ -1022,7 +1040,11 @@ namespace LinqToDB
 		/// <param name="db">Database connection instance.</param>
 		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
 		/// <param name="items">Query to get records to populate created table with initial data.</param>
-		/// <param name="setTable">Action to modify <typeparamref name="T"/> entity's mapping using fluent mapping.</param>
+		/// <param name="setTable">Action to modify <typeparamref name="T"/> entity's mapping using fluent mapping.
+		/// Note that context mapping schema must be writable to allow it.
+		/// You can enable writable <see cref="MappingSchema"/> using <see cref="DataOptionsExtensions.UseEnableContextSchemaEdit(DataOptions, bool)"/> configuration helper
+		/// or enable writeable schemata globally using <see cref="Common.Configuration.Linq.EnableContextSchemaEdit" /> option.
+		/// Latter option is not recommended as it will affect performance significantly.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
 		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
 		/// <param name="action">Optional asynchronous action that will be executed after table creation but before it populated with data from <paramref name="items"/>.</param>
@@ -1043,9 +1065,10 @@ namespace LinqToDB
 			CancellationToken               cancellationToken = default)
 			where T : class
 		{
-			if (setTable == null) throw new ArgumentNullException(nameof(setTable));
+			if (setTable == null           ) throw new ArgumentNullException(nameof(setTable));
+			if (db.MappingSchema.IsLockable) throw new LinqToDBException(CreateTempTable_LockedSchemaError);
 
-			var builder = db.GetFluentMappingBuilder();
+			var builder = new FluentMappingBuilder(db.MappingSchema);
 			setTable(builder.Entity<T>());
 			builder.Build();
 
@@ -1094,7 +1117,11 @@ namespace LinqToDB
 		/// <param name="action">Optional action that will be executed after table creation, but before it populated with data from <paramref name="items"/>.</param>
 		/// <param name="serverName">Optional name of linked server. If not specified, value from mapping will be used.</param>
 		/// <param name="tableOptions">Optional Table options. Default is <see cref="TableOptions.IsTemporary"/>.</param>
-		/// <param name="setTable">Action to modify <typeparamref name="T"/> entity's mapping using fluent mapping.</param>
+		/// <param name="setTable">Action to modify <typeparamref name="T"/> entity's mapping using fluent mapping.
+		/// Note that context mapping schema must be writable to allow it.
+		/// You can enable writable <see cref="MappingSchema"/> using <see cref="DataOptionsExtensions.UseEnableContextSchemaEdit(DataOptions, bool)"/> configuration helper
+		/// or enable writeable schemata globally using <see cref="Common.Configuration.Linq.EnableContextSchemaEdit" /> option.
+		/// Latter option is not recommended as it will affect performance significantly.</param>
 		/// <returns>Returns temporary table instance.</returns>
 		public static TempTable<T> IntoTempTable<T>(
 			this IQueryable<T>               items,
@@ -1111,7 +1138,9 @@ namespace LinqToDB
 			{
 				if (setTable != null)
 				{
-					var builder = eq.DataContext.GetFluentMappingBuilder();
+					if (eq.DataContext.MappingSchema.IsLockable) throw new LinqToDBException(IntoTempTable_LockedSchemaError);
+
+					var builder = new FluentMappingBuilder(eq.DataContext.MappingSchema);
 					setTable(builder.Entity<T>());
 					builder.Build();
 				}
@@ -1157,7 +1186,11 @@ namespace LinqToDB
 		/// </summary>
 		/// <typeparam name="T">Table record mapping class.</typeparam>
 		/// <param name="items">Query to get records to populate created table with initial data.</param>
-		/// <param name="setTable">Action to modify <typeparamref name="T"/> entity's mapping using fluent mapping.</param>
+		/// <param name="setTable">Action to modify <typeparamref name="T"/> entity's mapping using fluent mapping.
+		/// Note that context mapping schema must be writable to allow it.
+		/// You can enable writable <see cref="MappingSchema"/> using <see cref="DataOptionsExtensions.UseEnableContextSchemaEdit(DataOptions, bool)"/> configuration helper
+		/// or enable writeable schemata globally using <see cref="Common.Configuration.Linq.EnableContextSchemaEdit" /> option.
+		/// Latter option is not recommended as it will affect performance significantly.</param>
 		/// <param name="tableName">Optional name of temporary table. If not specified, value from mapping will be used.</param>
 		/// <param name="databaseName">Optional name of table's database. If not specified, value from mapping will be used.</param>
 		/// <param name="schemaName">Optional name of table schema/owner. If not specified, value from mapping will be used.</param>
@@ -1182,7 +1215,9 @@ namespace LinqToDB
 			{
 				if (setTable != null)
 				{
-					var builder = eq.DataContext.GetFluentMappingBuilder();
+					if (eq.DataContext.MappingSchema.IsLockable) throw new LinqToDBException(IntoTempTable_LockedSchemaError);
+
+					var builder = new FluentMappingBuilder(eq.DataContext.MappingSchema);
 					setTable(builder.Entity<T>());
 					builder.Build();
 				}

--- a/Tests/Linq/DataProvider/InformixTests.cs
+++ b/Tests/Linq/DataProvider/InformixTests.cs
@@ -498,7 +498,7 @@ namespace Tests.DataProvider
 			{
 				var ms = new MappingSchema();
 
-				ms.GetFluentMappingBuilder()
+				new FluentMappingBuilder(ms)
 					.Entity<AllType>()
 						.HasTableName("AllTypeCreateTest")
 					.Build();

--- a/Tests/Linq/DataProvider/OracleTests.cs
+++ b/Tests/Linq/DataProvider/OracleTests.cs
@@ -996,7 +996,7 @@ namespace Tests.DataProvider
 				{
 					var ms = new MappingSchema();
 
-					ms.GetFluentMappingBuilder()
+					new FluentMappingBuilder(ms)
 						.Entity<LinqDataTypes>()
 							.Property(e => e.GuidValue)
 								.IsNotColumn()
@@ -1005,7 +1005,7 @@ namespace Tests.DataProvider
 
 					if (context.IsAnyOf(TestProvName.AllOracleNative))
 					{
-						ms.GetFluentMappingBuilder()
+						new FluentMappingBuilder(ms)
 							.Entity<LinqDataTypes>()
 								.Property(e => e.BoolValue)
 									.HasDataType(DataType.Int16)
@@ -1050,7 +1050,7 @@ namespace Tests.DataProvider
 				{
 					var ms = new MappingSchema();
 
-					ms.GetFluentMappingBuilder()
+					new FluentMappingBuilder(ms)
 						.Entity<LinqDataTypes>()
 							.Property(e => e.GuidValue)
 								.IsNotColumn()
@@ -1058,7 +1058,7 @@ namespace Tests.DataProvider
 
 					if (context.IsAnyOf(TestProvName.AllOracleNative))
 					{
-						ms.GetFluentMappingBuilder()
+						new FluentMappingBuilder(ms)
 							.Entity<LinqDataTypes>()
 								.Property(e => e.BoolValue)
 									.HasDataType(DataType.Int16)
@@ -1099,7 +1099,7 @@ namespace Tests.DataProvider
 				{
 					var ms = new MappingSchema();
 
-					ms.GetFluentMappingBuilder()
+					new FluentMappingBuilder(ms)
 						.Entity<LinqDataTypes>()
 							.Property(e => e.GuidValue)
 								.IsNotColumn()
@@ -1107,7 +1107,7 @@ namespace Tests.DataProvider
 
 					if (context.IsAnyOf(TestProvName.AllOracleNative))
 					{
-						ms.GetFluentMappingBuilder()
+						new FluentMappingBuilder(ms)
 							.Entity<LinqDataTypes>()
 								.Property(e => e.BoolValue)
 									.HasDataType(DataType.Int16)
@@ -1153,7 +1153,7 @@ namespace Tests.DataProvider
 
 					if (context.IsAnyOf(TestProvName.AllOracleNative))
 					{
-						ms.GetFluentMappingBuilder()
+						new FluentMappingBuilder(ms)
 							.Entity<LinqDataTypes>()
 							.Property(e => e.BoolValue)
 							.HasDataType(DataType.Int16)
@@ -1638,7 +1638,7 @@ namespace Tests.DataProvider
 				{
 					var ms = new MappingSchema();
 
-					ms.GetFluentMappingBuilder()
+					new FluentMappingBuilder(ms)
 						.Entity<LinqDataTypesBC>()
 							.Property(e => e.GuidValue)
 								.IsNotColumn()
@@ -1676,7 +1676,7 @@ namespace Tests.DataProvider
 				{
 					var ms = new MappingSchema();
 
-					ms.GetFluentMappingBuilder()
+					new FluentMappingBuilder(ms)
 						.Entity<LinqDataTypesBC>()
 							.Property(e => e.GuidValue)
 								.IsNotColumn()
@@ -1752,7 +1752,7 @@ namespace Tests.DataProvider
 
 				var ms = new MappingSchema();
 
-				ms.GetFluentMappingBuilder()
+				new FluentMappingBuilder(ms)
 					.Entity<LinqDataTypes2>()
 						.Property(e => e.GuidValue)
 							.IsNotColumn()
@@ -1787,7 +1787,7 @@ namespace Tests.DataProvider
 
 				var ms = new MappingSchema();
 
-				ms.GetFluentMappingBuilder()
+				new FluentMappingBuilder(ms)
 					.Entity<LinqDataTypes2>()
 						.Property(e => e.GuidValue)
 							.IsNotColumn()
@@ -2674,7 +2674,7 @@ namespace Tests.DataProvider
 					try
 					{
 
-						db.MappingSchema.GetFluentMappingBuilder()
+						new FluentMappingBuilder(db.MappingSchema)
 							.Entity<Issue723Table>()
 							.HasSchemaName("C##ISSUE723SCHEMA")
 							.Build();
@@ -4104,11 +4104,14 @@ CREATE TABLE ""TABLE_A""(
 			using (var table = db.CreateLocalTable<NativeIdentity>())
 			{
 				var ms = new MappingSchema();
-				ms.GetFluentMappingBuilder().Entity<NativeIdentity>()
-					.HasColumn(e => e.Id)
-					.HasColumn(e => e.Field)
-					.HasIdentity(e => e.Id)
+
+				new FluentMappingBuilder(ms)
+					.Entity<NativeIdentity>()
+						.HasColumn(e => e.Id)
+						.HasColumn(e => e.Field)
+							.HasIdentity(e => e.Id)
 					.Build();
+
 				db.AddMappingSchema(ms);
 
 				var initialData = new []

--- a/Tests/Linq/DataProvider/PostgreSQLTests.cs
+++ b/Tests/Linq/DataProvider/PostgreSQLTests.cs
@@ -2194,7 +2194,7 @@ namespace Tests.DataProvider
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<DataTypeBinaryMapping>()
 					.Property(p => p.Binary).HasDataType(DataType.Binary).IsNullable(false)
 				.Build();

--- a/Tests/Linq/DataProvider/SqlServerTests.cs
+++ b/Tests/Linq/DataProvider/SqlServerTests.cs
@@ -1278,7 +1278,7 @@ namespace Tests.DataProvider
 			using var db = GetDataConnection(context);
 			var       ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<AllTypes>()
 					.HasTableName("AllTypeCreateTest")
 				.Build();
@@ -1300,7 +1300,7 @@ namespace Tests.DataProvider
 			{
 				var ms = new MappingSchema();
 
-				ms.GetFluentMappingBuilder()
+				new FluentMappingBuilder(ms)
 					.Entity<AllTypes2>()
 						.HasTableName("AllType2CreateTest")
 					.Build();

--- a/Tests/Linq/DataProvider/SqlServerTypesTests.cs
+++ b/Tests/Linq/DataProvider/SqlServerTypesTests.cs
@@ -454,14 +454,16 @@ namespace Tests.DataProvider
 
 			void Test<TValue>(DataType dataType, int precision, TValue value, TValue expected)
 			{
-				using var db = GetDataContext(context);
+				var ms = new MappingSchema();
 
-				db.GetFluentMappingBuilder()
+				new FluentMappingBuilder(ms)
 					.Entity<LiteralsTestTable<TValue>>()
 						.Property(e => e.Value)
 							.HasDataType(dataType)
 							.HasPrecision(precision)
 					.Build();
+
+				using var db = GetDataContext(context, ms);
 
 				db.AddInterceptor(interceptor);
 				

--- a/Tests/Linq/DataProvider/SybaseTests.cs
+++ b/Tests/Linq/DataProvider/SybaseTests.cs
@@ -1100,7 +1100,7 @@ namespace Tests.DataProvider
 		{
 			using (var db = GetDataConnection(context))
 			{
-				db.MappingSchema.GetFluentMappingBuilder()
+				new FluentMappingBuilder(db.MappingSchema)
 					.Entity<AllType>()
 						.HasTableName("AllTypeCreateTest")
 					.Build();

--- a/Tests/Linq/DataProvider/Types/TypeTestsBase.cs
+++ b/Tests/Linq/DataProvider/Types/TypeTestsBase.cs
@@ -84,7 +84,7 @@ namespace Tests.DataProvider
 			// setup test table mapping
 			var ms = new MappingSchema();
 
-			var ent = ms.GetFluentMappingBuilder().Entity<TypeTable<TType, TNullableType>>();
+			var ent = new FluentMappingBuilder(ms).Entity<TypeTable<TType, TNullableType>>();
 
 			var prop = ent.Property(e => e.Column).IsNullable(false);
 

--- a/Tests/Linq/Linq/AssociationTests.cs
+++ b/Tests/Linq/Linq/AssociationTests.cs
@@ -679,7 +679,7 @@ namespace Tests.Linq
 			var ids = new[] { 1, 5 };
 
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<Top>()
 				.Association( t => t.MiddleRuntime, (t, m) => t.ParentID == m!.ParentID && m.ChildID > 1 )
@@ -706,7 +706,7 @@ namespace Tests.Linq
 			var ids = new[] { 1, 5 };
 
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<Top>()
 				.Association( t => t.MiddlesRuntime, (t, m) => t.ParentID == m.ParentID && m.ChildID > 1 )
@@ -1183,7 +1183,7 @@ namespace Tests.Linq
 		public void Issue1711Test1([DataSources(TestProvName.AllAccess, TestProvName.AllClickHouse)] string context)
 		{
 			var ms = new MappingSchema();
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<Entity1711>()
 				.HasTableName("Entity1711")
 				.HasPrimaryKey(x => Sql.Property<long>(x, "Id"))
@@ -1204,7 +1204,7 @@ namespace Tests.Linq
 		public void Issue1711Test2([DataSources(TestProvName.AllAccess, TestProvName.AllClickHouse)] string context)
 		{
 			var ms = new MappingSchema();
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<Entity1711>()
 				.HasTableName("Entity1711")
 				.HasPrimaryKey(x => Sql.Property<long>(x, "Id"))

--- a/Tests/Linq/Linq/CompileTestsAsync.cs
+++ b/Tests/Linq/Linq/CompileTestsAsync.cs
@@ -162,7 +162,7 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context, new MappingSchema()))
 			using (var lt = db.CreateLocalTable(GenerateData()))
 			{
-				db.MappingSchema.GetFluentMappingBuilder()
+				new FluentMappingBuilder(db.MappingSchema)
 					.Entity<AsyncDataTable>()
 						.HasTableName(lt.TableName)
 					.Build();
@@ -212,7 +212,7 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context, new MappingSchema()))
 			using (var lt = db.CreateLocalTable(GenerateData()))
 			{
-				db.MappingSchema.GetFluentMappingBuilder()
+				new FluentMappingBuilder(db.MappingSchema)
 					.Entity<AsyncDataTable>()
 						.HasTableName(lt.TableName)
 					.Build();
@@ -327,7 +327,7 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context, new MappingSchema()))
 			using (var lt = db.CreateLocalTable(GenerateData()))
 			{
-				db.MappingSchema.GetFluentMappingBuilder()
+				new FluentMappingBuilder(db.MappingSchema)
 					.Entity<AsyncDataTable>()
 						.HasTableName(lt.TableName)
 					.Build();
@@ -347,7 +347,7 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context, new MappingSchema()))
 			using (var lt = db.CreateLocalTable(GenerateData()))
 			{
-				db.MappingSchema.GetFluentMappingBuilder()
+				new FluentMappingBuilder(db.MappingSchema)
 					.Entity<AsyncDataTable>()
 						.HasTableName(lt.TableName)
 					.Build();

--- a/Tests/Linq/Linq/ComplexTests2.cs
+++ b/Tests/Linq/Linq/ComplexTests2.cs
@@ -171,7 +171,7 @@ namespace Tests.Linq
 			var animalsTableName = "Animals" + cnt;
 			var eyeTableName     = "Eyes"    + cnt;
 
-			var mappingBuilder = ms.GetFluentMappingBuilder();
+			var mappingBuilder = new FluentMappingBuilder(ms);
 
 			mappingBuilder.Entity<Animal>()
 				.HasTableName(animalsTableName)

--- a/Tests/Linq/Linq/ConcurrencyTests.cs
+++ b/Tests/Linq/Linq/ConcurrencyTests.cs
@@ -40,7 +40,7 @@ namespace Tests.Linq
 			var skipCnt = context.IsAnyOf(TestProvName.AllClickHouse);
 			var ms      = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<ConcurrencyTable<int>>()
 					.HasTableName("ConcurrencyAutoIncrement")
 					.Property(e => e.Stamp)
@@ -108,7 +108,7 @@ namespace Tests.Linq
 			var skipCnt = context.IsAnyOf(TestProvName.AllClickHouse);
 			var ms      = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<ConcurrencyTable<int>>()
 					.HasTableName("ConcurrencyAutoIncrement")
 					.Property(e => e.Stamp)
@@ -176,7 +176,7 @@ namespace Tests.Linq
 			var skipCnt = context.IsAnyOf(TestProvName.AllClickHouse);
 			var ms      = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<ConcurrencyTable<int>>()
 					.HasTableName("ConcurrencyFiltered")
 					.Property(e => e.Stamp)
@@ -234,7 +234,7 @@ namespace Tests.Linq
 			var skipCnt = context.IsAnyOf(TestProvName.AllClickHouse);
 			var ms      = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<ConcurrencyTable<int>>()
 					.HasTableName("ConcurrencyFiltered")
 					.Property(e => e.Stamp)
@@ -292,7 +292,7 @@ namespace Tests.Linq
 			var skipCnt = context.IsAnyOf(TestProvName.AllClickHouse);
 			var ms      = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<ConcurrencyTable<Guid>>()
 					.HasTableName("ConcurrencyGuid")
 					.Property(e => e.Stamp)
@@ -366,7 +366,7 @@ namespace Tests.Linq
 			var skipCnt = context.IsAnyOf(TestProvName.AllClickHouse);
 			var ms      = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<ConcurrencyTable<string>>()
 					.HasTableName("ConcurrencyGuidString")
 					.Property(e => e.Stamp)
@@ -444,7 +444,7 @@ namespace Tests.Linq
 			var skipCnt = context.IsAnyOf(TestProvName.AllClickHouse);
 			var ms      = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<ConcurrencyTable<byte[]>>()
 					.HasTableName("ConcurrencyGuidBinary")
 					.Property(e => e.Stamp)
@@ -519,7 +519,7 @@ namespace Tests.Linq
 			var skipCnt = context.IsAnyOf(TestProvName.AllClickHouse);
 			var ms      = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<ConcurrencyTable<Guid>>()
 					.HasTableName("ConcurrencyGuid")
 					.Property(e => e.Stamp)
@@ -593,7 +593,7 @@ namespace Tests.Linq
 			var skipCnt = context.IsAnyOf(TestProvName.AllClickHouse);
 			var ms      = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<ConcurrencyTable<string>>()
 					.HasTableName("ConcurrencyCustom")
 					.Property(e => e.Stamp)
@@ -667,7 +667,7 @@ namespace Tests.Linq
 			var skipCnt = context.IsAnyOf(TestProvName.AllClickHouse);
 			var ms      = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<ConcurrencyTable<string>>()
 					.HasTableName("ConcurrencyCustom")
 					.Property(e => e.Stamp)
@@ -741,7 +741,7 @@ namespace Tests.Linq
 			var skipCnt = context.IsAnyOf(TestProvName.AllClickHouse);
 			var ms      = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<ConcurrencyTable<byte[]>>()
 					.Property(e => e.Stamp)
 						.HasAttribute(new OptimisticLockPropertyAttribute(VersionBehavior.Auto))
@@ -816,7 +816,7 @@ namespace Tests.Linq
 			var skipCnt = context.IsAnyOf(TestProvName.AllClickHouse);
 			var ms      = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<ConcurrencyTable<byte[]>>()
 					.Property(e => e.Stamp)
 						.HasAttribute(new OptimisticLockPropertyAttribute(VersionBehavior.Auto))

--- a/Tests/Linq/Linq/ContainsTests.cs
+++ b/Tests/Linq/Linq/ContainsTests.cs
@@ -14,7 +14,7 @@ namespace Tests.Linq
 	{
 		private TempTable<Src> SetupSrcTable(IDataContext db)
 		{
-			db.GetFluentMappingBuilder()
+			new FluentMappingBuilder(db.MappingSchema)
 				.Entity<Src>()
 					.Property(e => e.CEnum)
 						.HasDataType(DataType.VarChar)
@@ -38,7 +38,7 @@ namespace Tests.Linq
 			[Values]      bool   withNullCompares)
 		{
 			using var _   = new CompareNullsAsValuesOption(withNullCompares);
-			using var db  = GetDataContext(context);
+			using var db  = GetDataContext(context, new MappingSchema());
 			using var src = SetupSrcTable(db);
 
 			int? result;
@@ -68,7 +68,7 @@ namespace Tests.Linq
 			[Values]      bool   withNullCompares)
 		{
 			using var _   = new CompareNullsAsValuesOption(withNullCompares);
-			using var db  = GetDataContext(context);
+			using var db  = GetDataContext(context, new MappingSchema());
 			using var src = SetupSrcTable(db);
 
 			int? result;
@@ -98,7 +98,7 @@ namespace Tests.Linq
 			[Values]      bool   withNullCompares)
 		{
 			using var _   = new CompareNullsAsValuesOption(withNullCompares);
-			using var db  = GetDataContext(context);
+			using var db  = GetDataContext(context, new MappingSchema());
 			using var src = SetupSrcTable(db);
 
 			int? result;
@@ -128,7 +128,7 @@ namespace Tests.Linq
 			[Values]      bool   withNullCompares)
 		{
 			using var _   = new CompareNullsAsValuesOption(withNullCompares);
-			using var db  = GetDataContext(context);
+			using var db  = GetDataContext(context, new MappingSchema());
 			using var src = SetupSrcTable(db);
 
 			int count;
@@ -149,7 +149,7 @@ namespace Tests.Linq
 			[Values]      bool   withNullCompares)
 		{
 			using var _   = new CompareNullsAsValuesOption(withNullCompares);
-			using var db  = GetDataContext(context);
+			using var db  = GetDataContext(context, new MappingSchema());
 			using var src = SetupSrcTable(db);
 
 			int count;
@@ -170,7 +170,7 @@ namespace Tests.Linq
 			[Values]      bool   withNullCompares)
 		{
 			using var _   = new CompareNullsAsValuesOption(withNullCompares);
-			using var db  = GetDataContext(context);
+			using var db  = GetDataContext(context, new MappingSchema());
 			using var src = SetupSrcTable(db);
 
 			int count;
@@ -195,7 +195,7 @@ namespace Tests.Linq
 			[Values]                              bool   withNullCompares)
 		{
 			using var _   = new CompareNullsAsValuesOption(withNullCompares);
-			using var db  = GetDataContext(context);
+			using var db  = GetDataContext(context, new MappingSchema());
 			using var src = SetupSrcTable(db);
 
 			int count;
@@ -217,7 +217,7 @@ namespace Tests.Linq
 			[Values]                              bool   withNullCompares)
 		{
 			using var _   = new CompareNullsAsValuesOption(withNullCompares);
-			using var db  = GetDataContext(context);
+			using var db  = GetDataContext(context, new MappingSchema());
 			using var src = SetupSrcTable(db);
 
 			int count;
@@ -239,7 +239,7 @@ namespace Tests.Linq
 			[Values]                              bool   withNullCompares)
 		{
 			using var _   = new CompareNullsAsValuesOption(withNullCompares);
-			using var db  = GetDataContext(context);
+			using var db  = GetDataContext(context, new MappingSchema());
 			using var src = SetupSrcTable(db);
 
 			int count;

--- a/Tests/Linq/Linq/DynamicColumnsTests.cs
+++ b/Tests/Linq/Linq/DynamicColumnsTests.cs
@@ -424,7 +424,7 @@ namespace Tests.Linq
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<PersonWithDynamicStore>().HasTableName("Person")
 				.HasPrimaryKey(x => Sql.Property<int>(x, "ID"))
 				.Property(x => Sql.Property<string>(x, "FirstName")).IsNullable(false)
@@ -527,7 +527,7 @@ namespace Tests.Linq
 		public void TestConcatWithDynamic([IncludeDataSources(true, TestProvName.AllSQLiteClassic, TestProvName.AllClickHouse)] string context)
 		{
 			var mappingSchema = new MappingSchema();
-			var builder = mappingSchema.GetFluentMappingBuilder()
+			var builder = new FluentMappingBuilder(mappingSchema)
 				.Entity<SomeClassWithDynamic>();
 
 			builder.Property(x => x.Description).HasColumnName("F066_04");

--- a/Tests/Linq/Linq/FromSqlTests.cs
+++ b/Tests/Linq/Linq/FromSqlTests.cs
@@ -337,7 +337,7 @@ namespace Tests.Linq
 
 			var idFilter = 1;
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<SampleClass>()
 				.Association(x => x.AssociatedOne,
 					(x, db) => db.FromSql<SomeOtherClass>(someGeneratedSqlString, x.Id, idFilter))
@@ -370,7 +370,7 @@ namespace Tests.Linq
 
 				var idFilter = 1;
 
-				ms.GetFluentMappingBuilder()
+				new FluentMappingBuilder(ms)
 					.Entity<SampleClass>()
 						.Association(x => x.AssociatedOne, (x, db) => db.FromSql<SomeOtherClass>(someGeneratedSqlString, x.Id, idFilter))
 					.Build();

--- a/Tests/Linq/Linq/FullTextTests.SQLite.cs
+++ b/Tests/Linq/Linq/FullTextTests.SQLite.cs
@@ -31,7 +31,7 @@ namespace Tests.Linq
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<FtsTable>()
 				.HasTableName(type.ToString() + "_TABLE")
 				.HasColumn(t => t.text1)

--- a/Tests/Linq/Linq/MappingTests.cs
+++ b/Tests/Linq/Linq/MappingTests.cs
@@ -578,10 +578,11 @@ namespace Tests.Linq
 		public void TestRecordMapping([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
 		{
 			var ms = new MappingSchema();
-			ms.GetFluentMappingBuilder().Entity<Record>()
-				.Property(p => p.Id).IsPrimaryKey()
-				.Property(p => p.Value)
-				.Property(p => p.BaseValue)
+			new FluentMappingBuilder(ms)
+				.Entity<Record>()
+					.Property(p => p.Id).IsPrimaryKey()
+					.Property(p => p.Value)
+					.Property(p => p.BaseValue)
 				.Build();
 
 			using (var db = GetDataContext(context, ms))
@@ -616,10 +617,11 @@ namespace Tests.Linq
 		public void TestRecordLikeMapping([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
 		{
 			var ms = new MappingSchema();
-			ms.GetFluentMappingBuilder().Entity<RecordLike>()
-				.Property(p => p.Id).IsPrimaryKey()
-				.Property(p => p.Value)
-				.Property(p => p.BaseValue)
+			new FluentMappingBuilder(ms)
+				.Entity<RecordLike>()
+					.Property(p => p.Id).IsPrimaryKey()
+					.Property(p => p.Value)
+					.Property(p => p.BaseValue)
 				.Build();
 
 			using (var db = GetDataContext(context, ms))
@@ -654,9 +656,10 @@ namespace Tests.Linq
 		public void TestInitOnly([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
 		{
 			var ms = new MappingSchema();
-			ms.GetFluentMappingBuilder().Entity<WithInitOnly>()
-				.Property(p => p.Id).IsPrimaryKey()
-				.Property(p => p.Value)
+			new FluentMappingBuilder(ms)
+				.Entity<WithInitOnly>()
+					.Property(p => p.Id).IsPrimaryKey()
+					.Property(p => p.Value)
 				.Build();
 
 			using (var db = GetDataContext(context, ms))

--- a/Tests/Linq/Linq/QueryFilterTests.cs
+++ b/Tests/Linq/Linq/QueryFilterTests.cs
@@ -63,7 +63,7 @@ namespace Tests.Linq
 
 		static QueryFilterTests()
 		{
-			var builder = new MappingSchema().GetFluentMappingBuilder();
+			var builder = new FluentMappingBuilder(new MappingSchema());
 
 			builder.Entity<MasterClass>().HasQueryFilter((q, dc) => q.Where(e => !((DcParams)((MyDataContext)dc).Params).IsSoftDeleteFilterEnabled || !e.IsDeleted));
 
@@ -132,7 +132,7 @@ namespace Tests.Linq
 		{
 			var testData = GenerateTestData();
 
-			var builder = new MappingSchema().GetFluentMappingBuilder();
+			var builder = new FluentMappingBuilder(new MappingSchema());
 
 			builder.Entity<MasterClass>().HasQueryFilter<MyDataContext>((q, dc) => q.Where(e => !dc.IsSoftDeleteFilterEnabled || !e.IsDeleted));
 			builder.Entity<DetailClass>().HasQueryFilter<MyDataContext>((q, dc) => q.Where(e => !dc.IsSoftDeleteFilterEnabled || !e.IsDeleted));
@@ -219,7 +219,7 @@ namespace Tests.Linq
 		{
 			var testData = GenerateTestData();
 
-			var builder = new MappingSchema().GetFluentMappingBuilder();
+			var builder = new FluentMappingBuilder(new MappingSchema());
 
 			builder.Entity<MasterClass>().HasQueryFilter<MyDataContext>((q, dc) => q.Where(e => !dc.IsSoftDeleteFilterEnabled || !e.IsDeleted));
 			builder.Entity<DetailClass>().HasQueryFilter<MyDataContext>((q, dc) => q.Where(e => !dc.IsSoftDeleteFilterEnabled || !e.IsDeleted));
@@ -248,7 +248,7 @@ namespace Tests.Linq
 			var testData = GenerateTestData();
 
 			Expression<Func<ISoftDelete, MyDataContext, bool>> softDeleteCheck = (e, dc) => !dc.IsSoftDeleteFilterEnabled || !e.IsDeleted;
-			var builder = new MappingSchema().GetFluentMappingBuilder();
+			var builder = new FluentMappingBuilder(new MappingSchema());
 
 			builder.Entity<MasterClass>().HasQueryFilter<MyDataContext>((q, dc) => q.Where(e => softDeleteCheck.Compile()(e, dc)));
 			builder.Entity<DetailClass>().HasQueryFilter<MyDataContext>((q, dc) => q.Where(e => softDeleteCheck.Compile()(e, dc)));
@@ -292,7 +292,7 @@ namespace Tests.Linq
 		{
 			var testData = GenerateTestData();
 
-			var builder = new MappingSchema().GetFluentMappingBuilder();
+			var builder = new FluentMappingBuilder(new MappingSchema());
 
 			builder.Entity<MasterClass>().HasQueryFilter<MyDataContext>(FilterDeletedCondition);
 			builder.Entity<DetailClass>().HasQueryFilter<MyDataContext>(FilterDeletedCondition);

--- a/Tests/Linq/Linq/QueryableAssociationTests.cs
+++ b/Tests/Linq/Linq/QueryableAssociationTests.cs
@@ -167,7 +167,7 @@ namespace Tests.Linq
 
 		static MappingSchema GetMapping()
 		{
-			var builder = new MappingSchema().GetFluentMappingBuilder();
+			var builder = new FluentMappingBuilder(new MappingSchema());
 
 			builder.Entity<SomeEntity>().Association(e => e.OtherMapped,
 				(e, db) => db.GetTable<SomeOtherEntity>().With("NOLOCK").Where(se => se.Id == e.Id));

--- a/Tests/Linq/Linq/SelectTests.cs
+++ b/Tests/Linq/Linq/SelectTests.cs
@@ -666,7 +666,7 @@ namespace Tests.Linq
 		public void SelectComplex3([DataSources] string context)
 		{
 			var ms = new MappingSchema();
-			var b  = ms.GetFluentMappingBuilder();
+			var b  = new FluentMappingBuilder(ms);
 
 			b
 				.Entity<ComplexPerson3>()        .HasTableName ("Person")

--- a/Tests/Linq/Linq/TableOptionsTests.cs
+++ b/Tests/Linq/Linq/TableOptionsTests.cs
@@ -279,10 +279,10 @@ namespace Tests.Linq
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<TestTable>()
-				.HasIsTemporary()
-				.HasTableOptions(TableOptions.DropIfExists)
+					.HasIsTemporary()
+					.HasTableOptions(TableOptions.DropIfExists)
 				.Build();
 
 			using var db = GetDataContext(context, ms);

--- a/Tests/Linq/Linq/TestQueryCache.cs
+++ b/Tests/Linq/Linq/TestQueryCache.cs
@@ -145,7 +145,7 @@ namespace Tests.Linq
 		private static MappingSchema CreateMappingSchema(string columnName, string? schemaName = null)
 		{
 			var ms = new MappingSchema(schemaName);
-			var builder = ms.GetFluentMappingBuilder();
+			var builder = new FluentMappingBuilder(ms);
 
 			builder.Entity<SampleClass>()
 				.Property(e => e.Id).IsPrimaryKey()

--- a/Tests/Linq/Linq/ValueConversionTests.cs
+++ b/Tests/Linq/Linq/ValueConversionTests.cs
@@ -136,7 +136,7 @@ namespace Tests.Linq
 		private static MappingSchema CreateMappingSchema()
 		{
 			var ms = new MappingSchema();
-			var builder = ms.GetFluentMappingBuilder();
+			var builder = new FluentMappingBuilder(ms);
 
 			builder.Entity<MainClass>()
 				.Property(e => e.Value1)

--- a/Tests/Linq/Mapping/DynamicStoreTests.cs
+++ b/Tests/Linq/Mapping/DynamicStoreTests.cs
@@ -350,7 +350,7 @@ namespace Tests.Mapping
 		{
 			var ms = new MappingSchema();
 
-			var builder = ms.GetFluentMappingBuilder();
+			var builder = new FluentMappingBuilder(ms);
 			builder.Entity<FluentMetadataBasedStore>()
 				.HasColumn(e => e.Id)
 				.Property(x => Sql.Property<string>(x, "Name"))
@@ -379,7 +379,7 @@ namespace Tests.Mapping
 		{
 			var ms = new MappingSchema();
 
-			var builder = ms.GetFluentMappingBuilder();
+			var builder = new FluentMappingBuilder(ms);
 			builder.Entity<FluentMetadataBasedStore>()
 				.HasColumn(e => e.Id)
 				.DynamicColumnsStore(e => e.Values)
@@ -408,7 +408,7 @@ namespace Tests.Mapping
 		{
 			var ms = new MappingSchema();
 
-			var builder = ms.GetFluentMappingBuilder();
+			var builder = new FluentMappingBuilder(ms);
 			builder.Entity<FluentMetadataBasedStore>()
 				.HasColumn(e => e.Id)
 				.DynamicColumnsStore(e => e.Values)
@@ -440,7 +440,7 @@ namespace Tests.Mapping
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<AttributeMetadataBasedStore>()
 				.Property(x => Sql.Property<string>(x, "Name"))
 				.Build();
@@ -467,7 +467,7 @@ namespace Tests.Mapping
 		{
 			var ms = new MappingSchema();
 
-			var builder = ms.GetFluentMappingBuilder();
+			var builder = new FluentMappingBuilder(ms);
 			builder.Entity<FluentMetadataBasedStore>()
 				.HasColumn(e => e.Id)
 				.DynamicColumnsStore(e => e.Values)
@@ -495,7 +495,7 @@ namespace Tests.Mapping
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<InstanceGetterSetterMethods>()
 				.Property(x => Sql.Property<string>(x, "Name"))
 				.Build();
@@ -523,7 +523,7 @@ namespace Tests.Mapping
 			StaticGetterSetterMethods.InstanceValues.Clear();
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<StaticGetterSetterMethods>()
 				.Property(x => Sql.Property<string>(x, "Name"))
 				.Build();
@@ -556,7 +556,7 @@ namespace Tests.Mapping
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<InstanceGetterSetterExpressionMethods>()
 				.Property(x => Sql.Property<string>(x, "Name"))
 				.Build();
@@ -585,7 +585,7 @@ namespace Tests.Mapping
 
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<StaticGetterSetterExpressionMethods>()
 				.Property(x => Sql.Property<string>(x, "Name"))
 				.Build();
@@ -618,7 +618,7 @@ namespace Tests.Mapping
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<SQLiteInstanceGetterSetterMethods>()
 				.Property(x => Sql.Property<string>(x, "Name"))
 				.Build();
@@ -645,7 +645,7 @@ namespace Tests.Mapping
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<GetterSetterVsStorageMethods1>()
 				.Property(x => Sql.Property<string>(x, "Name"))
 				.Build();
@@ -672,7 +672,7 @@ namespace Tests.Mapping
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<GetterSetterVsStorageMethods2>()
 				.Property(x => Sql.Property<string>(x, "Name"))
 				.Build();
@@ -698,7 +698,7 @@ namespace Tests.Mapping
 		public void TestDynamicColumnStoreGetterSetterVsStorageMethodsConflict([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
 		{
 			var ms = new MappingSchema();
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<GetterSetterVsStorageMethodsConflict>()
 				.Property(x => Sql.Property<string>(x, "Name"))
 				.Build();
@@ -720,7 +720,7 @@ namespace Tests.Mapping
 			var storage = new Dictionary<int, Dictionary<string, object>>();
 
 			var ms = new MappingSchema();
-			var builder = ms.GetFluentMappingBuilder();
+			var builder = new FluentMappingBuilder(ms);
 
 			builder.Entity<CustomSetterGetterBase>()
 				.DynamicPropertyAccessors(
@@ -776,7 +776,7 @@ namespace Tests.Mapping
 			var ms = new MappingSchema();
 			ms.SetDefaultValue(typeof(string), "me_default");
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<AttributeMetadataBasedStore>()
 				.Property(x => Sql.Property<string>(x, "Name"))
 				.Build();
@@ -803,7 +803,7 @@ namespace Tests.Mapping
 			var ms = new MappingSchema();
 			ms.SetDefaultValue(typeof(string), "accessor_def");
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<InstanceGetterSetterMethods>()
 				.Property(x => Sql.Property<string>(x, "Name"))
 				.Build();
@@ -828,7 +828,7 @@ namespace Tests.Mapping
 		public void TestDynamicColumnStoreMultipleGetterSetters([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
 		{
 			var ms = new MappingSchema();
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<MultipleGetterSetterMethods>()
 				.Property(x => Sql.Property<string>(x, "Name"))
 				.Build();
@@ -848,7 +848,7 @@ namespace Tests.Mapping
 		public void TestDynamicColumnStoreNoGetterSetters([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
 		{
 			var ms = new MappingSchema();
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<NoGetterSetterMethods>()
 				.Property(x => Sql.Property<string>(x, "Name"))
 				.Build();

--- a/Tests/Linq/Mapping/FluentDynamicMappingTests.cs
+++ b/Tests/Linq/Mapping/FluentDynamicMappingTests.cs
@@ -38,7 +38,7 @@ namespace Tests.Mapping
 		public void HasAttribute1()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.HasAttribute<MyClass>(x => Sql.Property<int>(x, "ID"), new PrimaryKeyAttribute()).Build();
 
@@ -51,7 +51,7 @@ namespace Tests.Mapping
 		public void HasAttribute2()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.HasAttribute<MyClass>(x => Sql.Property<int>(x, "ID2"), new PrimaryKeyAttribute()).Build();
 
@@ -64,7 +64,7 @@ namespace Tests.Mapping
 		public void Property1()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<MyClass>()
 				.Property(x => Sql.Property<int>(x, "ID")).IsPrimaryKey()
@@ -79,7 +79,7 @@ namespace Tests.Mapping
 		public void Property2()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<MyClass>()
 				.Property(x => Sql.Property<int>(x, "ID2")).IsPrimaryKey()
@@ -94,7 +94,7 @@ namespace Tests.Mapping
 		public void Association1()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<MyClass>()
 				.Association(x => Sql.Property<MyClass>(x, "Parent"), x => Sql.Property<int>(x, "ID1"), x => Sql.Property<int>(x, "ID"))
@@ -111,7 +111,7 @@ namespace Tests.Mapping
 		public void Association2()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<MyClass>()
 				.Association(x => Sql.Property<MyClass>(x, "Parent2"), x => Sql.Property<int>(x, "ID2"), x => Sql.Property<int>(x, "ID3"))
@@ -128,7 +128,7 @@ namespace Tests.Mapping
 		public void HasPrimaryKey1()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<MyClass>()
 				.HasPrimaryKey(x => Sql.Property<int>(x, "ID"))
@@ -143,7 +143,7 @@ namespace Tests.Mapping
 		public void HasPrimaryKey2()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<MyClass>()
 				.HasPrimaryKey(x => Sql.Property<int>(x, "ID2"))
@@ -158,7 +158,7 @@ namespace Tests.Mapping
 		public void HasIdentity1()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<MyClass>()
 				.HasIdentity(x => Sql.Property<int>(x, "ID"))
@@ -173,7 +173,7 @@ namespace Tests.Mapping
 		public void HasIdentity2()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<MyClass>()
 				.HasIdentity(x => Sql.Property<int>(x, "ID2"))
@@ -188,7 +188,7 @@ namespace Tests.Mapping
 		public void HasColumn1()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<MyClass>()
 				.HasColumn(x => Sql.Property<int>(x, "ID"))
@@ -203,7 +203,7 @@ namespace Tests.Mapping
 		public void HasColumn2()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<MyClass>()
 				.HasColumn(x => Sql.Property<int>(x, "ID2"))
@@ -218,7 +218,7 @@ namespace Tests.Mapping
 		public void Ignore()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<MyClass>()
 				.Ignore(x => Sql.Property<int>(x, "ID"))
@@ -257,7 +257,7 @@ namespace Tests.Mapping
 		public void Inheritance1()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<MyClass>()
 				.Inheritance(x => Sql.Property<byte>(x, "RowType"), 1, typeof(MyClass2))
@@ -272,7 +272,7 @@ namespace Tests.Mapping
 		public void Inheritance2()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<MyClass>()
 				.Inheritance(x => Sql.Property<byte>(x, "RowType2"), 1, typeof(MyClass2))

--- a/Tests/Linq/Mapping/FluentMappingAliasTests.cs
+++ b/Tests/Linq/Mapping/FluentMappingAliasTests.cs
@@ -30,7 +30,7 @@ namespace Tests.Mapping
 		MappingSchema CreateMappingSchemaWithAlias()
 		{
 			var schema = new MappingSchema();
-			var fluent = schema.GetFluentMappingBuilder();
+			var fluent = new FluentMappingBuilder(schema);
 
 			fluent.Entity<InstanceClass>().IsColumnRequired()
 				.IsColumnRequired()

--- a/Tests/Linq/Mapping/FluentMappingExpressionMethodTests.cs
+++ b/Tests/Linq/Mapping/FluentMappingExpressionMethodTests.cs
@@ -22,7 +22,7 @@ namespace Tests.Mapping
 		MappingSchema CreateMappingSchema()
 		{
 			var schema = new MappingSchema();
-			var fluent = schema.GetFluentMappingBuilder();
+			var fluent = new FluentMappingBuilder(schema);
 
 			fluent.Entity<InstanceClass>().IsColumnRequired()
 				.IsColumnRequired()

--- a/Tests/Linq/Mapping/FluentMappingTests.cs
+++ b/Tests/Linq/Mapping/FluentMappingTests.cs
@@ -98,7 +98,7 @@ namespace Tests.Mapping
 		public void LowerCaseMappingTest()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			ms.EntityDescriptorCreatedCallback = (mappingSchema, entityDescriptor) =>
 			{
@@ -121,7 +121,7 @@ namespace Tests.Mapping
 		public void AddAttributeTest1()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.HasAttribute<MyClass>(new TableAttribute("NewName"))
 				.Build();
@@ -140,7 +140,7 @@ namespace Tests.Mapping
 		public void AddAttributeTest2()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.HasAttribute<MyClass>(new TableAttribute("NewName") { Configuration = "Test"}).Build();
 
@@ -153,7 +153,7 @@ namespace Tests.Mapping
 		public void HasPrimaryKey1()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<MyClass>().HasPrimaryKey(e => e.ID).Build();
 
@@ -166,7 +166,7 @@ namespace Tests.Mapping
 		public void HasPrimaryKey2()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<MyClass>().HasPrimaryKey(e => e.ID1, 3).Build();
 
@@ -180,7 +180,7 @@ namespace Tests.Mapping
 		public void HasPrimaryKey3()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<MyClass>().HasPrimaryKey(e => new { e.ID, e.ID1 }, 3).Build();
 
@@ -196,7 +196,7 @@ namespace Tests.Mapping
 		public void HasPrimaryKey4()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<MyClass>().Property(e => e.ID).IsPrimaryKey().Build();
 
@@ -209,7 +209,7 @@ namespace Tests.Mapping
 		public void IsPrimaryKeyIsIdentity()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<MyClass>()
 				.Property(e => e.ID)
@@ -227,7 +227,7 @@ namespace Tests.Mapping
 		public void TableNameAndSchema()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<MyClass>()
 				.HasTableName ("Table")
@@ -244,7 +244,7 @@ namespace Tests.Mapping
 		public void Association()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<MyClass>()
 				.Property(e => e.Parent)
@@ -261,7 +261,7 @@ namespace Tests.Mapping
 		{
 			var ms = new MappingSchema();
 
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<MyClass2>()
 				.Property(e => e.ID).IsPrimaryKey()
@@ -277,7 +277,7 @@ namespace Tests.Mapping
 		public void FluentAssociation1()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<MyClass>()
 				.Association( e => e.Parent, e => e.ID, o => o!.ID1 )
@@ -292,7 +292,7 @@ namespace Tests.Mapping
 		public void FluentAssociation2()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<MyClass>()
 				.Association( e => e.Parent, (e, o) => e.ID == o!.ID1 )
@@ -307,7 +307,7 @@ namespace Tests.Mapping
 		public void FluentAssociation3()
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<MyInheritedClass>()
 				.Association( e => e.Assosiations, (e, o) => e.Id == o.ID1 )
@@ -340,7 +340,7 @@ namespace Tests.Mapping
 		public void FluentInheritance([IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<TestInheritancePerson>()
 				.Inheritance(e => e.Gender, Gender.Male,   typeof(TestInheritanceMale))
@@ -366,7 +366,7 @@ namespace Tests.Mapping
 		public void FluentInheritance2([IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<TestInheritancePerson>()
 				.Inheritance(e => e.Gender, Gender.Male,   typeof(TestInheritanceMale))
@@ -409,7 +409,7 @@ namespace Tests.Mapping
 		public void FluentInheritanceExpression([IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.Entity<DescendantEntity>()
 				.Property(e => e.Value).IsExpression(e => e.Id + 100)
@@ -434,7 +434,7 @@ namespace Tests.Mapping
 		public void DoubleNameChangeTest()
 		{
 			var ms = new MappingSchema();
-			var b  = ms.GetFluentMappingBuilder();
+			var b  = new FluentMappingBuilder(ms);
 
 			b.Entity<MyClass>().HasTableName("Name1").Build();
 
@@ -453,7 +453,7 @@ namespace Tests.Mapping
 		public void AssociationInheritance()
 		{
 			var ms = new MappingSchema();
-			var b  = ms.GetFluentMappingBuilder();
+			var b  = new FluentMappingBuilder(ms);
 
 			b.Entity<MyInheritedClass>()
 				.Property(_ => _.Id)          .IsPrimaryKey()
@@ -469,7 +469,7 @@ namespace Tests.Mapping
 		public void AttributeInheritance()
 		{
 			var ms = new MappingSchema();
-			var b  = ms.GetFluentMappingBuilder();
+			var b  = new FluentMappingBuilder(ms);
 
 			b.Entity<MyBaseClass>()
 				.Property(_ => _.Id)          .IsPrimaryKey()
@@ -487,7 +487,7 @@ namespace Tests.Mapping
 		public void AttributeInheritance2()
 		{
 			var ms = new MappingSchema();
-			var b  = ms.GetFluentMappingBuilder();
+			var b  = new FluentMappingBuilder(ms);
 
 			b.Entity<MyInheritedClass>()
 				.Property(_ => _.Id)          .IsPrimaryKey()
@@ -509,7 +509,7 @@ namespace Tests.Mapping
 		public void InterfaceInheritance()
 		{
 			var ms = new MappingSchema();
-			var b  = ms.GetFluentMappingBuilder();
+			var b  = new FluentMappingBuilder(ms);
 
 			b.Entity<IInterfaceBase>()
 				.HasTableName(nameof(IInterfaceBase))
@@ -565,7 +565,7 @@ namespace Tests.Mapping
 		{
 			using (var db = GetDataContext(context, new MappingSchema()))
 			{
-				db.MappingSchema.GetFluentMappingBuilder()
+				new FluentMappingBuilder(db.MappingSchema)
 
 				   .Entity<BaseClass>().HasTableName("my_table")
 				   .HasAttribute(new LinqToDB.Mapping.InheritanceMappingAttribute()
@@ -608,7 +608,7 @@ namespace Tests.Mapping
 		{
 			using (var db = GetDataContext(context, new MappingSchema()))
 			{
-				db.MappingSchema.GetFluentMappingBuilder()
+				new FluentMappingBuilder(db.MappingSchema)
 				   .Entity<BaseClass>().HasTableName("my_table")
 				   .HasAttribute(new LinqToDB.Mapping.InheritanceMappingAttribute()
 				   {
@@ -689,7 +689,7 @@ namespace Tests.Mapping
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<PersonCustom>()
 				.Property(p => p.Money).IsExpression(p => Sql.AsSql(p.Age * Sql.AsSql(1000) + p.Name.Length * 10), true, "MONEY")
 				.Build();
@@ -728,7 +728,7 @@ namespace Tests.Mapping
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<SequenceTable>()
 				.Property(p => p.Id)
 				.UseSequence("sequencetestseq")
@@ -748,7 +748,7 @@ namespace Tests.Mapping
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<SequenceTable>()
 				.Property(p => p.Id)
 				.HasAttribute(new SequenceNameAttribute("sequencetestseq"))
@@ -782,7 +782,7 @@ namespace Tests.Mapping
 		public void MapValueTest([DataSources] string context)
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			mb.HasAttribute(typeof(GenderEnum).GetField(nameof(GenderEnum.Male))!,    new MapValueAttribute("M"));
 			mb.HasAttribute(typeof(GenderEnum).GetField(nameof(GenderEnum.Female))!,  new MapValueAttribute("F"));

--- a/Tests/Linq/Samples/DataContextDecoratorTests.cs
+++ b/Tests/Linq/Samples/DataContextDecoratorTests.cs
@@ -98,10 +98,6 @@ namespace Tests.Samples
 			public void RemoveInterceptor(IInterceptor interceptor) => _context.RemoveInterceptor(interceptor);
 
 			public IUnwrapDataObjectInterceptor? UnwrapDataObjectInterceptor { get; }
-			public FluentMappingBuilder          GetFluentMappingBuilder()
-			{
-				return MappingSchema.GetFluentMappingBuilder();
-			}
 		}
 
 		public class Entity
@@ -116,7 +112,7 @@ namespace Tests.Samples
 			using (var db = new DataConnection())
 			{
 				var ms = new MappingSchema();
-				var b  = ms.GetFluentMappingBuilder();
+				var b  = new FluentMappingBuilder(ms);
 				var dc = new DataContextDecorator(db, ms);
 
 				b.Entity<Entity>()

--- a/Tests/Linq/Update/BulkCopyTests.cs
+++ b/Tests/Linq/Update/BulkCopyTests.cs
@@ -441,7 +441,7 @@ namespace Tests.xUpdate
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<Inherited3>()
 				.Property(e => e.NullableBool)
 				.HasDataType(DataType.VarChar)

--- a/Tests/Linq/Update/CreateTableTests.cs
+++ b/Tests/Linq/Update/CreateTableTests.cs
@@ -26,7 +26,7 @@ namespace Tests.xUpdate
 		public void CreateTable1([DataSources] string context)
 		{
 			var ms = new MappingSchema();
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<TestTable>()
 					.Property(t => t.ID)
 						.IsIdentity()
@@ -50,7 +50,7 @@ namespace Tests.xUpdate
 		public async Task CreateTable1Async([DataSources] string context)
 		{
 			var ms = new MappingSchema();
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<TestTable>()
 					.Property(t => t.ID)
 						.IsIdentity()
@@ -74,7 +74,7 @@ namespace Tests.xUpdate
 		public void CreateLocalTempTable1([IncludeDataSources(TestProvName.AllSqlServer2008Plus/*, ProviderName.DB2*/)] string context)
 		{
 			var ms = new MappingSchema();
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<TestTable>()
 					.Property(t => t.Field1)
 						.HasLength(50)
@@ -125,7 +125,7 @@ namespace Tests.xUpdate
 			string context)
 		{
 			var ms = new MappingSchema();
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<TestTable>()
 					.Property(t => t.Field1)
 						.HasLength(50)
@@ -255,7 +255,7 @@ namespace Tests.xUpdate
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<Aa>()
 					.HasTableName("aa")
 					.Property(t => t.bb).IsPrimaryKey()

--- a/Tests/Linq/Update/CreateTableTypesTests.cs
+++ b/Tests/Linq/Update/CreateTableTypesTests.cs
@@ -171,7 +171,7 @@ namespace Tests.xUpdate
 			Query.ClearCaches();
 
 			var ms = new MappingSchema();
-			var entity = ms.GetFluentMappingBuilder()
+			var entity = new FluentMappingBuilder(ms)
 				.Entity<CreateTableTypes>()
 				.HasColumn(e => e.Id);
 

--- a/Tests/Linq/Update/CreateTempTableTests.cs
+++ b/Tests/Linq/Update/CreateTempTableTests.cs
@@ -68,7 +68,7 @@ namespace Tests.xUpdate
 		[Test]
 		public void CreateTable3([DataSources] string context)
 		{
-			using (var db = GetDataContext(context))
+			using (var db = GetDataContext(context, new MappingSchema()))
 			{
 				db.DropTable<int>("TempTable", throwExceptionIfNotExists:false);
 

--- a/Tests/Linq/Update/DynamicColumnsTests.cs
+++ b/Tests/Linq/Update/DynamicColumnsTests.cs
@@ -134,7 +134,7 @@ namespace Tests.xUpdate
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<MyClass>().HasTableName("Person")
 				.HasPrimaryKey(x => Sql.Property<int>(x, "ID"))
 				.Property(x => Sql.Property<string>(x, "FirstName")).IsNullable(false)

--- a/Tests/Linq/Update/MergeTests.DynamicColumns.cs
+++ b/Tests/Linq/Update/MergeTests.DynamicColumns.cs
@@ -27,7 +27,7 @@ namespace Tests.xUpdate
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<DynamicColumns1>().HasTableName("TestMerge1")
 					.HasPrimaryKey(x => Sql.Property<int>(x, "Id"))
 					.Property(x => Sql.Property<int?>(x, "Field1"))

--- a/Tests/Linq/Update/MergeTests.Issues.cs
+++ b/Tests/Linq/Update/MergeTests.Issues.cs
@@ -830,7 +830,7 @@ namespace Tests.xUpdate
 				PrepareData(db1);
 
 			var ms = new MappingSchema();
-			ms.GetFluentMappingBuilder().Entity<TestMapping1>().HasQueryFilter((t, _) => t.Where(_ => _.Id > 5)).Build();
+			new FluentMappingBuilder(ms).Entity<TestMapping1>().HasQueryFilter((t, _) => t.Where(_ => _.Id > 5)).Build();
 
 			using var db = GetDataContext(context, ms);
 

--- a/Tests/Linq/UserTests/Issue1128Tests.cs
+++ b/Tests/Linq/UserTests/Issue1128Tests.cs
@@ -34,7 +34,7 @@ namespace Tests.UserTests
 		{
 			var ms            = new MappingSchema();
 			var tableName     = nameof(AttributeBase);
-			var fluentBuilder = ms.GetFluentMappingBuilder();
+			var fluentBuilder = new FluentMappingBuilder(ms);
 
 			fluentBuilder.Entity<FluentBase>()
 				.HasTableName(tableName)

--- a/Tests/Linq/UserTests/Issue1268Tests.cs
+++ b/Tests/Linq/UserTests/Issue1268Tests.cs
@@ -34,7 +34,7 @@ namespace Tests.UserTests
 		public void InsertWithDynamicColumn([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
 		{
 			var ms = new MappingSchema();
-			var builder = ms.GetFluentMappingBuilder();
+			var builder = new FluentMappingBuilder(ms);
 			builder.Entity<RepresentTable>()
 				.Property(x => Sql.Property<bool>(x, "IsDeleted"))
 				.Build();

--- a/Tests/Linq/UserTests/Issue1305Tests.cs
+++ b/Tests/Linq/UserTests/Issue1305Tests.cs
@@ -97,7 +97,7 @@ namespace Tests.UserTests
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<FluentMapping>()
 				.Property(t => t.Audit1ID).HasOrder(-10)
 				.Property(t => t.Audit2ID).HasOrder(-1)

--- a/Tests/Linq/UserTests/Issue1307Tests.cs
+++ b/Tests/Linq/UserTests/Issue1307Tests.cs
@@ -55,11 +55,10 @@ namespace Tests.UserTests
 			[ValueSource(nameof(DateTimePairs))] Tuple<DateTimeQuantifiers, DateTimeQuantifiers> quantifiers)
 		{
 			var ms = new MappingSchema();
-			ms
-				.GetFluentMappingBuilder()
-					.Entity<DateTimeTestTable>()
-						.Property(t => t.DateTimeField)
-							.HasDbType($"datetime {GetQuantifierName(quantifiers.Item1)} to {GetQuantifierName(quantifiers.Item2)}")
+			new FluentMappingBuilder(ms)
+				.Entity<DateTimeTestTable>()
+					.Property(t => t.DateTimeField)
+						.HasDbType($"datetime {GetQuantifierName(quantifiers.Item1)} to {GetQuantifierName(quantifiers.Item2)}")
 				.Build();
 
 			var isIDS = IsIDSProvider(context);

--- a/Tests/Linq/UserTests/Issue1438Tests.cs
+++ b/Tests/Linq/UserTests/Issue1438Tests.cs
@@ -26,7 +26,7 @@ namespace Tests.UserTests
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<Client>()
 					.HasTableName("Issue1438")
 					.Property(x => x.Id)
@@ -58,7 +58,7 @@ namespace Tests.UserTests
 			var cs       = DataConnection.GetConnectionString(context);
 
 			var ms = new MappingSchema();
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<Client>()
 					.HasTableName("Issue1438")
 					.Property(x => x.Id)

--- a/Tests/Linq/UserTests/Issue1498Tests.cs
+++ b/Tests/Linq/UserTests/Issue1498Tests.cs
@@ -116,7 +116,7 @@ namespace Tests.UserTests
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<Topic>()
 					.Property(e => e.Id)
 					.Association(e => e.MessagesF1, (t, m) => t.Id == m.TopicId)
@@ -152,7 +152,7 @@ namespace Tests.UserTests
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<Topic>()
 					.Property(e => e.Id)
 					.Association(e => e.MessagesF2, t => t.Id, m => m.TopicId)
@@ -188,7 +188,7 @@ namespace Tests.UserTests
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<Topic>()
 					.Property(e => e.Id)
 					.Association(e => e.MessagesF3, (t, ctx) => ctx.GetTable<Message>().Where(m => m.TopicId == t.Id))
@@ -229,7 +229,7 @@ namespace Tests.UserTests
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<Topic>()
 					.Property(e => e.Id).IsPrimaryKey()
 					.Association(e => e.MessagesF3, (t, ctx) => ctx.GetTable<Message>().Where(m => m.TopicId == t.Id))

--- a/Tests/Linq/UserTests/Issue1554Tests.cs
+++ b/Tests/Linq/UserTests/Issue1554Tests.cs
@@ -453,7 +453,7 @@ namespace Tests.UserTests
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<PersonCacheFluent>()
 					.HasTableName("Issue1554FluentTable")
 					.Property(p => p.Id)

--- a/Tests/Linq/UserTests/Issue1585Tests.cs
+++ b/Tests/Linq/UserTests/Issue1585Tests.cs
@@ -17,7 +17,7 @@ namespace Tests.UserTests
 		{
 			var ms            = new MappingSchema();
 			var tableName     = nameof(Test1585);
-			var fluentBuilder = ms.GetFluentMappingBuilder();
+			var fluentBuilder = new FluentMappingBuilder(ms);
 
 			fluentBuilder.Entity<Test1585>()
 				.HasTableName(tableName)

--- a/Tests/Linq/UserTests/Issue1885Tests.cs
+++ b/Tests/Linq/UserTests/Issue1885Tests.cs
@@ -33,7 +33,7 @@ namespace Tests.UserTests
 		public void TestGenericAssociationRuntime([IncludeDataSources(ProviderName.SqlCe, TestProvName.AllSqlServer2008Plus)] string context)
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 
 			var values = new[] { 1, 5 };
 

--- a/Tests/Linq/UserTests/Issue2372Tests.cs
+++ b/Tests/Linq/UserTests/Issue2372Tests.cs
@@ -31,7 +31,7 @@ namespace Tests.UserTests
 			try
 			{
 				var ms1 = new MappingSchema();
-				var fmb1 = ms1.GetFluentMappingBuilder();
+				var fmb1 = new FluentMappingBuilder(ms1);
 				fmb1.Entity<InventoryResourceDTO>()
 				  .HasTableName("InventoryResource")
 				  .Property(e => e.Id).IsPrimaryKey()
@@ -52,7 +52,7 @@ namespace Tests.UserTests
 					return (InventoryResourceStatus)Enum.Parse(typeof(InventoryResourceStatus), txt, true);
 				});
 
-				var fmb2 = ms2.GetFluentMappingBuilder();
+				var fmb2 = new FluentMappingBuilder(ms2);
 				fmb2.Entity<InventoryResourceDTO>()
 				  .HasTableName("InventoryResource")
 				  .Property(e => e.Id).IsPrimaryKey()

--- a/Tests/Linq/UserTests/Issue2546Tests.cs
+++ b/Tests/Linq/UserTests/Issue2546Tests.cs
@@ -20,7 +20,7 @@ namespace Tests.UserTests
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<Issue2546Class>()
 				.Property(m => m.Value2)
 				.HasSkipOnInsert()

--- a/Tests/Linq/UserTests/Issue2564Tests.cs
+++ b/Tests/Linq/UserTests/Issue2564Tests.cs
@@ -25,7 +25,7 @@ namespace Tests.UserTests
 		{
 			var ms = new MappingSchema();
 
-			ms.GetFluentMappingBuilder()
+			new FluentMappingBuilder(ms)
 				.Entity<Issue2564Class>()
 				.HasTableName("Issue2564Table")
 				.Property(e => e.Id).IsPrimaryKey()

--- a/Tests/Linq/UserTests/Issue2566Tests.cs
+++ b/Tests/Linq/UserTests/Issue2566Tests.cs
@@ -101,7 +101,7 @@ namespace Tests.UserTests
 			};
 
 			var ms = new MappingSchema();
-			var builder = ms.GetFluentMappingBuilder();
+			var builder = new FluentMappingBuilder(ms);
 			builder.Entity<DataClass>().Property(e => e.Value).HasConversion(v => v!.Value, s => new AnredeAuswahlliste(s)).Build();
 
 			using (var db = GetDataContext(context, ms))

--- a/Tests/Linq/UserTests/Issue2800Tests.cs
+++ b/Tests/Linq/UserTests/Issue2800Tests.cs
@@ -33,7 +33,7 @@ namespace Tests.UserTests
 		[Test]
 		public void TestExpressionMethod([DataSources] string context)
 		{
-			var fluentMappingBuilder = new MappingSchema().GetFluentMappingBuilder();
+			var fluentMappingBuilder = new FluentMappingBuilder(new MappingSchema());
 
 			var carBuilder = fluentMappingBuilder.Entity<Car>();
 			carBuilder.Property(x => x.Id).IsPrimaryKey();

--- a/Tests/Linq/UserTests/Issue3056Tests.cs
+++ b/Tests/Linq/UserTests/Issue3056Tests.cs
@@ -16,7 +16,7 @@ namespace Tests.UserTests
 		public void DataModelDynamicTableTest2([IncludeDataSources(false, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
 		{
 			var mappingSchema = new MappingSchema();
-			var fm            = mappingSchema.GetFluentMappingBuilder();
+			var fm            = new FluentMappingBuilder(mappingSchema);
 
 			fm.Entity<DynamicTableRow>()
 				//.HasIdentity(x => Sql.Property<int>(x, "Id"))

--- a/Tests/Linq/UserTests/Issue3251Tests.cs
+++ b/Tests/Linq/UserTests/Issue3251Tests.cs
@@ -25,7 +25,7 @@ namespace Tests.UserTests
 		public void TestMappingCombine([IncludeDataSources(ProviderName.SQLiteMS, TestProvName.AllClickHouse)] string context)
 		{
 			var ms = new MappingSchema();
-			var mb = ms.GetFluentMappingBuilder();
+			var mb = new FluentMappingBuilder(ms);
 			mb.Entity<Class1>().HasTableName("Class1Table").Build();
 
 			using (var db = new DataConnection("SQLite.MS", ms))
@@ -37,7 +37,7 @@ namespace Tests.UserTests
 			}
 
 			var newMs = new MappingSchema(ms);
-			var mb2 = newMs.GetFluentMappingBuilder();
+			var mb2 = new FluentMappingBuilder(newMs);
 			mb2.Entity<Class2>().HasTableName("Class2Table").Build();
 			using (var db = new DataConnection("SQLite.MS", newMs))
 			{

--- a/Tests/Linq/UserTests/Issue3259Tests.cs
+++ b/Tests/Linq/UserTests/Issue3259Tests.cs
@@ -64,7 +64,7 @@ namespace Tests.UserTests
 		public void SubqueryAggregation([DataSources(ProviderName.SqlCe, TestProvName.AllSybase, TestProvName.AllClickHouse)] string context)
 		{
 			var ms      = new MappingSchema();
-			var builder = ms.GetFluentMappingBuilder();
+			var builder = new FluentMappingBuilder(ms);
 
 			builder.Entity<EmployeeTimeOffBalance>()
 				.HasPrimaryKey(x => x.Id)

--- a/Tests/Linq/UserTests/Issue3371Tests.cs
+++ b/Tests/Linq/UserTests/Issue3371Tests.cs
@@ -30,7 +30,7 @@ namespace Tests.UserTests
 		public void NullReferenceExceptionTest([IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
 		{
 			var ms      = new MappingSchema();
-			var builder = ms.GetFluentMappingBuilder();
+			var builder = new FluentMappingBuilder(ms);
 
 			builder.Entity<Employee>()
 				.Association(x => x.PayRate, x => x.PayRateId, x => x!.Id);

--- a/Tests/Linq/UserTests/Issue464Tests.cs
+++ b/Tests/Linq/UserTests/Issue464Tests.cs
@@ -30,7 +30,7 @@ namespace Tests.UserTests
 			schema.SetConvertExpression<decimal, MyInt>        (x => new MyInt { Value = (int)x }); //Oracle
 			schema.SetConvertExpression<MyInt,   DataParameter>(x => new DataParameter { DataType = DataType.Int32, Value = x.Value });
 
-			schema.GetFluentMappingBuilder()
+			new FluentMappingBuilder(schema)
 				  .Entity<Entity>()
 				  .HasTableName("Issue464")
 				  .HasColumn(x => x.Id)

--- a/Tests/Linq/UserTests/Issue548Tests.cs
+++ b/Tests/Linq/UserTests/Issue548Tests.cs
@@ -142,7 +142,7 @@ namespace Tests.UserTests
 			try
 			{
 				semaphore1.WaitOne();
-				var builder = ms.GetFluentMappingBuilder();
+				var builder = new FluentMappingBuilder(ms);
 
 				builder.Entity<TestEntity>().Property(_ => _.Id).IsColumn().Build();
 				semaphore2.WaitOne();
@@ -170,7 +170,7 @@ namespace Tests.UserTests
 			try
 			{
 				semaphore1.WaitOne();
-				var builder = ms.GetFluentMappingBuilder();
+				var builder = new FluentMappingBuilder(ms);
 
 				builder.Entity<TestEntity>().Property(_ => _.Value).IsColumn().Build();
 				semaphore2.WaitOne();

--- a/Tests/Linq/UserTests/SkipValuesOnInsertTest.cs
+++ b/Tests/Linq/UserTests/SkipValuesOnInsertTest.cs
@@ -229,7 +229,7 @@ namespace Tests.UserTests
 				// Change default value, so that null is not inserted as default.
 				db.MappingSchema.SetDefaultValue(typeof(int?), 0);
 
-				var mapping = db.MappingSchema.GetFluentMappingBuilder();
+				var mapping = new FluentMappingBuilder(db.MappingSchema);
 				mapping.Entity<TestTableFluent>().HasSkipValuesOnInsert(t => t.Age, 2, 5).Build();
 				using (db.CreateLocalTable<TestTableFluent>())
 				{

--- a/Tests/Linq/UserTests/SkipValuesOnUpdateTest.cs
+++ b/Tests/Linq/UserTests/SkipValuesOnUpdateTest.cs
@@ -186,7 +186,7 @@ namespace Tests.UserTests
 		public void TestSkipWithFluentBuilder([DataSources] string context)
 		{
 			var ms = new MappingSchema();
-			var mapping = ms.GetFluentMappingBuilder();
+			var mapping = new FluentMappingBuilder(ms);
 			mapping.Entity<TestTableFluent>().HasSkipValuesOnUpdate(t => t.Age, 2, 5).Build();
 
 			using (var db = GetDataContext(context, ms))


### PR DESCRIPTION
Otherwise users will not notice that they need to update their setup code...

Also it removes builder API from  data context. It was promoting context-level mapping configuration approach, which is not recommended due to performance concerns.

+ add locked mapping schema guard to TempTable APIs as it could use fluent mappings...