### PR TITLE
Failing test case for #3945

### DIFF
--- a/Source/LinqToDB/DataProvider/DB2/DB2SqlBuilderBase.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2SqlBuilderBase.cs
@@ -15,6 +15,8 @@ namespace LinqToDB.DataProvider.DB2
 
 	abstract partial class DB2SqlBuilderBase : BasicSqlBuilder<DB2Options>
 	{
+		public override bool CteFirst => false;
+
 		protected DB2SqlBuilderBase(IDataProvider? provider, MappingSchema mappingSchema, DataOptions dataOptions, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, dataOptions, sqlOptimizer, sqlProviderFlags)
 		{

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdSqlBuilder.cs
@@ -18,6 +18,8 @@ namespace LinqToDB.DataProvider.Firebird
 
 	public partial class FirebirdSqlBuilder : BasicSqlBuilder<FirebirdOptions>
 	{
+		public override bool CteFirst => false;
+
 		public FirebirdSqlBuilder(IDataProvider provider, MappingSchema mappingSchema, DataOptions dataOptions, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, dataOptions, sqlOptimizer, sqlProviderFlags)
 		{
@@ -336,18 +338,6 @@ namespace LinqToDB.DataProvider.Firebird
 			else
 			{
 				base.BuildDeleteQuery(deleteStatement);
-			}
-		}
-
-		protected override void BuildInsertQuery(SqlStatement statement, SqlInsertClause insertClause, bool addAlias)
-		{
-			if (statement is SqlStatementWithQueryBase withQuery && withQuery.With?.Clauses.Count > 0)
-			{
-				BuildInsertQuery2(statement, insertClause, addAlias);
-			}
-			else
-			{
-				base.BuildInsertQuery(statement, insertClause, addAlias);
 			}
 		}
 

--- a/Source/LinqToDB/DataProvider/Oracle/OracleSqlBuilderBase.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleSqlBuilderBase.cs
@@ -12,6 +12,8 @@ namespace LinqToDB.DataProvider.Oracle
 
 	abstract partial class OracleSqlBuilderBase : BasicSqlBuilder<OracleOptions>
 	{
+		public override bool CteFirst => false;
+
 		protected OracleSqlBuilderBase(IDataProvider? provider, MappingSchema mappingSchema, DataOptions dataOptions, ISqlOptimizer sqlOptimizer, SqlProviderFlags sqlProviderFlags)
 			: base(provider, mappingSchema, dataOptions, sqlOptimizer, sqlProviderFlags)
 		{
@@ -147,18 +149,6 @@ namespace LinqToDB.DataProvider.Oracle
 			else
 			{
 				base.BuildDeleteQuery(deleteStatement);
-			}
-		}
-
-		protected override void BuildInsertQuery(SqlStatement statement, SqlInsertClause insertClause, bool addAlias)
-		{
-			if (statement is SqlStatementWithQueryBase withQuery && withQuery.With?.Clauses.Count > 0)
-			{
-				BuildInsertQuery2(statement, insertClause, addAlias);
-			}
-			else
-			{
-				base.BuildInsertQuery(statement, insertClause, addAlias);
 			}
 		}
 

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -65,6 +65,14 @@ namespace LinqToDB.SqlProvider
 
 		public virtual bool IsNestedJoinSupported           => true;
 		public virtual bool IsNestedJoinParenthesisRequired => false;
+		/// <summary>
+		/// Identifies CTE clause location:
+		/// <list type="bullet">
+		/// <item><c>CteFirst = true</c> (default): WITH clause goes first in query</item>
+		/// <item><c>CteFirst = false</c>: WITH clause goes before SELECT</item>
+		/// </list>
+		/// </summary>
+		public virtual bool CteFirst                        => true;
 
 		/// <summary>
 		/// True if it is needed to wrap join condition with ()
@@ -390,6 +398,12 @@ namespace LinqToDB.SqlProvider
 
 		protected virtual void BuildInsertQuery(SqlStatement statement, SqlInsertClause insertClause, bool addAlias)
 		{
+			if (!CteFirst && statement is SqlStatementWithQueryBase withQuery && withQuery.With?.Clauses.Count > 0)
+			{
+				BuildInsertQuery2(statement, insertClause, addAlias);
+				return;
+			}
+
 			BuildStep = Step.Tag;          BuildTag(statement);
 			BuildStep = Step.WithClause;   BuildWithClause(statement.GetWithClause());
 			BuildStep = Step.InsertClause; BuildInsertClause(statement, insertClause, addAlias);
@@ -420,10 +434,10 @@ namespace LinqToDB.SqlProvider
 			BuildStep = Step.Tag;          BuildTag(statement);
 			BuildStep = Step.InsertClause; BuildInsertClause(statement, insertClause, addAlias);
 
-			AppendIndent().AppendLine("SELECT * FROM");
-			AppendIndent().AppendLine(OpenParens);
+			//AppendIndent().AppendLine("SELECT * FROM");
+			//AppendIndent().AppendLine(OpenParens);
 
-			++Indent;
+			//++Indent;
 
 			BuildStep = Step.WithClause;   BuildWithClause(statement.GetWithClause());
 
@@ -444,9 +458,9 @@ namespace LinqToDB.SqlProvider
 			else
 				BuildOutputSubclause(statement.GetOutputClause());
 
-			--Indent;
+			//--Indent;
 
-			AppendIndent().AppendLine(")");
+			//AppendIndent().AppendLine(")");
 		}
 
 		protected virtual void BuildMultiInsertQuery(SqlMultiInsertStatement statement)

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -434,11 +434,6 @@ namespace LinqToDB.SqlProvider
 			BuildStep = Step.Tag;          BuildTag(statement);
 			BuildStep = Step.InsertClause; BuildInsertClause(statement, insertClause, addAlias);
 
-			//AppendIndent().AppendLine("SELECT * FROM");
-			//AppendIndent().AppendLine(OpenParens);
-
-			//++Indent;
-
 			BuildStep = Step.WithClause;   BuildWithClause(statement.GetWithClause());
 
 			if (statement.QueryType == QueryType.Insert && statement.SelectQuery!.From.Tables.Count != 0)
@@ -457,10 +452,6 @@ namespace LinqToDB.SqlProvider
 				BuildGetIdentity(insertClause);
 			else
 				BuildOutputSubclause(statement.GetOutputClause());
-
-			//--Indent;
-
-			//AppendIndent().AppendLine(")");
 		}
 
 		protected virtual void BuildMultiInsertQuery(SqlMultiInsertStatement statement)

--- a/Source/LinqToDB/SqlProvider/BasicSqlOptimizer.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlOptimizer.cs
@@ -377,6 +377,14 @@ namespace LinqToDB.SqlProvider
 					Utils.MakeUniqueNames(ordered, null, static (n, a) => !ReservedWords.IsReserved(n), static c => c.Name, static (c, n, a) => c.Name = n,
 						static c => string.IsNullOrEmpty(c.Name) ? "CTE_1" : c.Name, StringComparer.OrdinalIgnoreCase);
 
+					// basic detection of non-recursive CTEs
+					// for more complex cases we will need dependency cycles detection
+					foreach (var kvp in cteHolder.WriteableValue)
+					{
+						if (kvp.Value.Count == 0)
+							kvp.Key.IsRecursive = false;
+					}
+
 					select.With = new SqlWithClause();
 					select.With.Clauses.AddRange(ordered);
 				}

--- a/Source/LinqToDB/SqlQuery/SelectQueryOptimizer.cs
+++ b/Source/LinqToDB/SqlQuery/SelectQueryOptimizer.cs
@@ -50,7 +50,7 @@ namespace LinqToDB.SqlQuery
 			FinalizeAndValidateInternal(isApplySupported);
 
 			//TODO: Why this is still needed
-			//ResolveFields();
+			ResolveFields();
 
 #if DEBUG
 			// ReSharper disable once RedundantAssignment
@@ -155,7 +155,7 @@ namespace LinqToDB.SqlQuery
 				{
 					var t = FindField(field, table);
 
-					if (t != null)
+					if (t != null && !FindField(q.Select.Columns, field))
 					{
 						var n   = q.Select.Columns.Count;
 						var idx = q.Select.Add(field);
@@ -172,18 +172,27 @@ namespace LinqToDB.SqlQuery
 			return null;
 		}
 
+		static bool FindField(List<SqlColumn> columns, SqlField field)
+		{
+			foreach (var column in columns)
+				if (column.Expression.Find(field, static (field, e) => field == e) != null)
+					return true;
+
+			return false;
+		}
+
 		static void ResolveFields(QueryData data)
 		{
 			if (data.Queries.Count == 0)
 				return;
 
-			var dic = new Dictionary<ISqlExpression,ISqlExpression>();
+			Dictionary<ISqlExpression,ISqlExpression>? dic = null;
 
 			foreach (var sqlExpression in data.Fields)
 			{
 				var field = (SqlField)sqlExpression;
 
-				if (dic.ContainsKey(field))
+				if (dic?.ContainsKey(field) == true)
 					continue;
 
 				var found = false;
@@ -201,11 +210,11 @@ namespace LinqToDB.SqlQuery
 					var expr = GetColumn(data, field);
 
 					if (expr != null)
-						dic.Add(field, expr);
+						(dic ??= new()).Add(field, expr);
 				}
 			}
 
-			if (dic.Count > 0)
+			if (dic != null)
 				data.Query.VisitParentFirst((dic, data), static (context, e) =>
 				{
 					ISqlExpression? ex;

--- a/Source/LinqToDB/SqlQuery/SelectQueryOptimizer.cs
+++ b/Source/LinqToDB/SqlQuery/SelectQueryOptimizer.cs
@@ -175,7 +175,7 @@ namespace LinqToDB.SqlQuery
 		static bool FindField(List<SqlColumn> columns, SqlField field)
 		{
 			foreach (var column in columns)
-				if (column.Expression.Find(field, static (field, e) => field == e) != null)
+				if (column.Expression != field && column.Expression.Find(field, static (field, e) => field == e) != null)
 					return true;
 
 			return false;

--- a/Source/LinqToDB/SqlQuery/SelectQueryOptimizer.cs
+++ b/Source/LinqToDB/SqlQuery/SelectQueryOptimizer.cs
@@ -50,7 +50,7 @@ namespace LinqToDB.SqlQuery
 			FinalizeAndValidateInternal(isApplySupported);
 
 			//TODO: Why this is still needed
-			ResolveFields();
+			//ResolveFields();
 
 #if DEBUG
 			// ReSharper disable once RedundantAssignment

--- a/Tests/Linq/Linq/CteTests.cs
+++ b/Tests/Linq/Linq/CteTests.cs
@@ -1396,7 +1396,7 @@ namespace Tests.Linq
 					   join parent in tb on child.ParentId equals parent.Id
 					   select new TestFolder
 					   {
-						   Id = Guid.NewGuid(),
+						   Id = TestData.Guid1,
 						   Label = parent.Label + "/" + child.Label,
 					   };
 			join.Insert(tb, x => x);

--- a/Tests/Linq/Linq/CteTests.cs
+++ b/Tests/Linq/Linq/CteTests.cs
@@ -1385,9 +1385,7 @@ namespace Tests.Linq
 			query.ToArray();
 		}
 
-		[Test(Description =
-			"Linq2db should not put a SELECT * FROM (..) around the query, " +
-			"as Oracle fails with ORA-00918 Column ambiguously defined.")]
+		[Test]
 		public void Issue3945([CteContextSource] string context)
 		{
 			using var db = GetDataContext(context);
@@ -1402,17 +1400,6 @@ namespace Tests.Linq
 						   Label = parent.Label + "/" + child.Label,
 					   };
 			join.Insert(tb, x => x);
-			// This test simply shouldn't crash with ORA-00918.
-			// As of linq2db 4.3.0, the generated SQL looks like this:
-			// INSERT ...
-			// SELECT * FROM (
-			//   WITH cte (..)
-			//   SELECT ..
-			//   FROM cte ..
-			//   JOIN parent ..
-			// )
-			// The SELECT * is the problem, and it is introduced when using a CTE + a join in query.
-			// It is useless as the same query without SELECT * works.
 		}
 	}
 }


### PR DESCRIPTION
Fix #3945 

Summary:
- remove not needed SELECT * wrapper around SELECT with CTE for insert queries
- fix DB2 CTE generation location
- added basic heuristics to detect that CTE created by `GetCte` API is not recursive
- "fixed" unnecessary column generation hack (whole hack will be gone in v6)