### PR TITLE
Add support for custom setters for associations storage members

### DIFF
--- a/Build/Azure/pipelines/templates/build-vars.yml
+++ b/Build/Azure/pipelines/templates/build-vars.yml
@@ -7,6 +7,6 @@ variables:
   build_configuration: 'Azure'
   assemblyVersion: 5.0.0
   ${{ if eq(variables['Build.SourceBranchName'], 'release') }}:
-    packageVersion: 5.0.0-rc.1
+    packageVersion: 5.0.0
   ${{ if ne(variables['Build.SourceBranchName'], 'release') }}:
     packageVersion: 5.0.0

--- a/Source/LinqToDB/Mapping/AssociationAttribute.cs
+++ b/Source/LinqToDB/Mapping/AssociationAttribute.cs
@@ -88,7 +88,7 @@ namespace LinqToDB.Mapping
 		/// <para>
 		/// <example>
 		/// <code>
-		/// var Expression&lt;Func&lt;SomeEntity, IDataContext, IQueryable&lt;SomeOtherEntity&gt;&gt;&gt; associationQuery;
+		/// Expression&lt;Func&lt;SomeEntity, IDataContext, IQueryable&lt;SomeOtherEntity&gt;&gt;&gt; associationQuery;
 		/// <para />
 		/// associationQuery = (e, db) =&gt; db.GetTable&lt;SomeOtherEntity&gt;().Where(se =&gt; se.Id == e.Id);
 		/// </code>
@@ -124,22 +124,22 @@ namespace LinqToDB.Mapping
 		/// </example>
 		/// </para>
 		/// </summary>
-		public string? SetExpressionMethod { get; set; }
+		public string? AssociationSetterExpressionMethod { get; set; }
 
 		/// <summary>
-		/// Specifies a set expression. If is set, it will be used to set the storage member when using LoadWith().
+		/// Specifies a setter expression. If is set, it will be used to set the storage member when using LoadWith().
 		/// Action takes two parameters: the storage member and the value to assign to it.
 		/// <para>
 		/// <example>
 		/// <code>
-		/// var Expression&lt;Action&lt;SomeContainerType,SomeOtherEntity&gt;&gt; setContainerValue;
+		/// Expression&lt;Action&lt;SomeContainerType,SomeOtherEntity&gt;&gt; setContainerValue;
 		/// <para />
 		/// setContainerValue = (container, value) =&gt; container.Value = value;
 		/// </code>
 		/// </example>
 		/// </para>
 		/// </summary>
-		public Expression? SetExpression { get; set; }
+		public Expression? AssociationSetterExpression { get; set; }
 
 		internal bool?      ConfiguredCanBeNull;
 		/// <summary>
@@ -175,7 +175,7 @@ namespace LinqToDB.Mapping
 
 		public override string GetObjectID()
 		{
-			return $".{Configuration}.{ThisKey}.{OtherKey}.{ExpressionPredicate}.{IdentifierBuilder.GetObjectID(Predicate)}.{QueryExpressionMethod}.{IdentifierBuilder.GetObjectID(QueryExpression)}.{Storage}.{SetExpressionMethod}.{IdentifierBuilder.GetObjectID(SetExpression)}.{(CanBeNull?1:0)}.{AliasName}.";
+			return $".{Configuration}.{ThisKey}.{OtherKey}.{ExpressionPredicate}.{IdentifierBuilder.GetObjectID(Predicate)}.{QueryExpressionMethod}.{IdentifierBuilder.GetObjectID(QueryExpression)}.{Storage}.{AssociationSetterExpressionMethod}.{IdentifierBuilder.GetObjectID(AssociationSetterExpression)}.{(CanBeNull?1:0)}.{AliasName}.";
 		}
 	}
 }

--- a/Source/LinqToDB/Mapping/AssociationAttribute.cs
+++ b/Source/LinqToDB/Mapping/AssociationAttribute.cs
@@ -103,6 +103,44 @@ namespace LinqToDB.Mapping
 		/// </summary>
 		public string?      Storage             { get; set; }
 
+		/// <summary>
+		/// Specifies static property or method without parameters, that returns a setter expression. 
+		/// If is set, it will be used to set the storage member when using LoadWith().
+		/// Result of method should be Action which takes two parameters: the storage member and the value to assign to it.
+		/// <para>
+		/// <example>
+		/// <code>
+		/// public class SomeEntity
+		/// {
+		///     [Association(SetExpressionMethod = nameof(OtherImpl), CanBeNull = true)]
+		///     public SomeOtherEntity Other { get; set; }
+		/// 
+		///     public static Expression&lt;Action&lt;SomeContainerType,SomeOtherEntity&gt;&gt; OtherImpl()
+		///     {
+		///         return (container, value) =&gt; container.Value = value;
+		///     }
+		/// }
+		/// </code>
+		/// </example>
+		/// </para>
+		/// </summary>
+		public string? SetExpressionMethod { get; set; }
+
+		/// <summary>
+		/// Specifies a set expression. If is set, it will be used to set the storage member when using LoadWith().
+		/// Action takes two parameters: the storage member and the value to assign to it.
+		/// <para>
+		/// <example>
+		/// <code>
+		/// var Expression&lt;Action&lt;SomeContainerType,SomeOtherEntity&gt;&gt; setContainerValue;
+		/// <para />
+		/// setContainerValue = (container, value) =&gt; container.Value = value;
+		/// </code>
+		/// </example>
+		/// </para>
+		/// </summary>
+		public Expression? SetExpression { get; set; }
+
 		internal bool?      ConfiguredCanBeNull;
 		/// <summary>
 		/// Defines type of join:
@@ -137,7 +175,7 @@ namespace LinqToDB.Mapping
 
 		public override string GetObjectID()
 		{
-			return $".{Configuration}.{ThisKey}.{OtherKey}.{ExpressionPredicate}.{IdentifierBuilder.GetObjectID(Predicate)}.{QueryExpressionMethod}.{IdentifierBuilder.GetObjectID(QueryExpression)}.{Storage}.{(CanBeNull?1:0)}.{AliasName}.";
+			return $".{Configuration}.{ThisKey}.{OtherKey}.{ExpressionPredicate}.{IdentifierBuilder.GetObjectID(Predicate)}.{QueryExpressionMethod}.{IdentifierBuilder.GetObjectID(QueryExpression)}.{Storage}.{SetExpressionMethod}.{IdentifierBuilder.GetObjectID(SetExpression)}.{(CanBeNull?1:0)}.{AliasName}.";
 		}
 	}
 }

--- a/Source/LinqToDB/Mapping/AssociationDescriptor.cs
+++ b/Source/LinqToDB/Mapping/AssociationDescriptor.cs
@@ -27,8 +27,8 @@ namespace LinqToDB.Mapping
 		/// <param name="expressionQueryMethod">Optional name of query method.</param>
 		/// <param name="expressionQuery">Optional query expression.</param>
 		/// <param name="storage">Optional association value storage field or property name.</param>
-		/// <param name="setExpressionMethod">Optional name of setter method.</param>
-		/// <param name="setExpression">Optional setter expression.</param>
+		/// <param name="associationSetterExpressionMethod">Optional name of setter method.</param>
+		/// <param name="associationSetterExpression">Optional setter expression.</param>
 		/// <param name="canBeNull">If <c>true</c>, association will generate outer join, otherwise - inner join.</param>
 		/// <param name="aliasName">Optional alias for representation in SQL.</param>
 		public AssociationDescriptor(
@@ -41,8 +41,8 @@ namespace LinqToDB.Mapping
 			string?     expressionQueryMethod,
 			Expression? expressionQuery,
 			string?     storage,
-			string?     setExpressionMethod,
-			Expression? setExpression,
+			string?     associationSetterExpressionMethod,
+			Expression? associationSetterExpression,
 			bool?       canBeNull,
 			string?     aliasName)
 		{
@@ -59,18 +59,18 @@ namespace LinqToDB.Mapping
 				throw new ArgumentException(
 					$"Association '{type.Name}.{memberInfo.Name}' has different number of keys for parent and child objects.");
 
-			MemberInfo            = memberInfo;
-			ThisKey               = thisKey;
-			OtherKey              = otherKey;
-			ExpressionPredicate   = expressionPredicate;
-			Predicate             = predicate;
-			ExpressionQueryMethod = expressionQueryMethod;
-			ExpressionQuery       = expressionQuery;
-			Storage               = storage;
-			SetExpressionMethod   = setExpressionMethod;
-			SetExpression         = setExpression;
-			CanBeNull             = canBeNull ?? AnalyzeCanBeNull();
-			AliasName             = aliasName;
+			MemberInfo                        = memberInfo;
+			ThisKey                           = thisKey;
+			OtherKey                          = otherKey;
+			ExpressionPredicate               = expressionPredicate;
+			Predicate                         = predicate;
+			ExpressionQueryMethod             = expressionQueryMethod;
+			ExpressionQuery                   = expressionQuery;
+			Storage                           = storage;
+			AssociationSetterExpressionMethod = associationSetterExpressionMethod;
+			AssociationSetterExpression       = associationSetterExpression;
+			CanBeNull                         = canBeNull ?? AnalyzeCanBeNull();
+			AliasName                         = aliasName;
 		}
 
 		/// <summary>
@@ -108,11 +108,11 @@ namespace LinqToDB.Mapping
 		/// <summary>
 		/// Gets optional setter method source property or method.
 		/// </summary>
-		public string? SetExpressionMethod { get; }
+		public string? AssociationSetterExpressionMethod { get; }
 		/// <summary>
 		/// Gets optional setter expression.
 		/// </summary>
-		public Expression? SetExpression { get; }
+		public Expression? AssociationSetterExpression { get; }
 		/// <summary>
 		/// Gets join type, generated for current association.
 		/// If <c>true</c>, association will generate outer join, otherwise - inner join.
@@ -324,21 +324,21 @@ namespace LinqToDB.Mapping
 			return lambda;
 		}
 
-		public bool HasSetterMethod()
+		public bool HasAssociationSetterMethod()
 		{
-			return SetExpression != null || !string.IsNullOrEmpty(SetExpressionMethod);
+			return AssociationSetterExpression != null || !string.IsNullOrEmpty(AssociationSetterExpressionMethod);
 		}
 
 		/// <summary>
-		/// Loads setter method expression from <see cref="SetExpression"/> member.
+		/// Loads setter method expression from <see cref="AssociationSetterExpression"/> member.
 		/// </summary>
 		/// <param name="memberType">Type of the storage member that declares association</param>
 		/// <param name="objectType">Type of object associated with setter method expression</param>
 		/// <returns><c>null</c> if association has no custom setter method expression specified
-		/// by <see cref="SetExpressionMethod"/> member.</returns>
-		public LambdaExpression? GetSetterMethod(Type memberType, Type objectType)
+		/// by <see cref="AssociationSetterExpressionMethod"/> member.</returns>
+		public LambdaExpression? GetAssociationSetterMethod(Type memberType, Type objectType)
 		{
-			if (!HasSetterMethod())
+			if (!HasAssociationSetterMethod())
 				return null;
 
 			Expression setExpression;
@@ -348,25 +348,25 @@ namespace LinqToDB.Mapping
 			if (type == null)
 				throw new ArgumentException($"Member '{MemberInfo.Name}' has no declaring type");
 
-			if (!string.IsNullOrEmpty(SetExpressionMethod))
-				setExpression = type.GetExpressionFromExpressionMember<Expression>(SetExpressionMethod!);
+			if (!string.IsNullOrEmpty(AssociationSetterExpressionMethod))
+				setExpression = type.GetExpressionFromExpressionMember<Expression>(AssociationSetterExpressionMethod!);
 			else
-				setExpression = SetExpression!;
+				setExpression = AssociationSetterExpression!;
 
 			var lambda = setExpression as LambdaExpression;
 			if (lambda == null || lambda.Parameters.Count != 2)
-				if (!string.IsNullOrEmpty(SetExpressionMethod))
+				if (!string.IsNullOrEmpty(AssociationSetterExpressionMethod))
 					throw new LinqToDBException(
-						$"Invalid set expression in {type.Name}.{SetExpressionMethod}. Expected: Expression<Action<{memberType.Name}, {objectType.Name}>>");
+						$"Invalid setter expression in {type.Name}.{AssociationSetterExpressionMethod}. Expected: Expression<Action<{memberType.Name}, {objectType.Name}>>");
 				else
 					throw new LinqToDBException(
-						$"Invalid set expression in {type.Name}. Expected: Expression<Action<{memberType.Name}, {objectType.Name}>>");
+						$"Invalid setter expression in {type.Name}. Expected: Expression<Action<{memberType.Name}, {objectType.Name}>>");
 
 			if (!lambda.Parameters[0].Type.IsSameOrParentOf(memberType))
-				throw new LinqToDBException($"First parameter of set expression should be '{memberType.Name}'");
+				throw new LinqToDBException($"First parameter of setter expression should be '{memberType.Name}'");
 
 			if (lambda.ReturnType != typeof(void))
-				throw new LinqToDBException("Result type of set expression should be 'void'");
+				throw new LinqToDBException("Result type of setter expression should be 'void'");
 
 			return lambda;
 		}

--- a/Source/LinqToDB/Mapping/EntityDescriptor.cs
+++ b/Source/LinqToDB/Mapping/EntityDescriptor.cs
@@ -213,8 +213,8 @@ namespace LinqToDB.Mapping
 						aa.QueryExpressionMethod, 
 						aa.QueryExpression,
 						aa.Storage,
-						aa.SetExpressionMethod,
-						aa.SetExpression,
+						aa.AssociationSetterExpressionMethod,
+						aa.AssociationSetterExpression,
 						aa.ConfiguredCanBeNull,
 						aa.AliasName));
 					continue;

--- a/Source/LinqToDB/Mapping/EntityDescriptor.cs
+++ b/Source/LinqToDB/Mapping/EntityDescriptor.cs
@@ -213,6 +213,8 @@ namespace LinqToDB.Mapping
 						aa.QueryExpressionMethod, 
 						aa.QueryExpression,
 						aa.Storage,
+						aa.SetExpressionMethod,
+						aa.SetExpression,
 						aa.ConfiguredCanBeNull,
 						aa.AliasName));
 					continue;

--- a/Tests/Linq/Linq/AssociationTests.cs
+++ b/Tests/Linq/Linq/AssociationTests.cs
@@ -665,7 +665,7 @@ namespace Tests.Linq
 
 		[Table("Child")]
 		[UsedImplicitly]
-		sealed class SetExpressionTestClass
+		sealed class AssociationSetterExpressionTestClass
 		{
 			[Column] public int ParentID;
 			[Column] public int ChildID;
@@ -689,12 +689,11 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SetExpressionTest([DataSources] string context)
+		public void AssociationSetterExpressionTest([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
-				var value = db.GetTable<SetExpressionTestClass>().LoadWith(x => x.Parent).First();
-				var value2 = db.GetTable<SetExpressionTestClass>().LoadWith(x => x.Parent).LoadWith(x => x.Parent2).First();
+				var value = db.GetTable<AssociationSetterExpressionTestClass>().LoadWith(x => x.Parent).First();
 
 				Assert.That(value.Parent, Is.Not.Null);
 			}

--- a/Tests/Linq/Linq/AssociationTests.cs
+++ b/Tests/Linq/Linq/AssociationTests.cs
@@ -672,12 +672,15 @@ namespace Tests.Linq
 
 			ParentContainer _parent = new ParentContainer();
 
-			[Association(ThisKey = "ParentID", OtherKey = "ParentID", CanBeNull = false, Storage = "_parent", SetExpressionMethod = nameof(SetParentValue))]
+			[Association(ThisKey = "ParentID", OtherKey = "ParentID", CanBeNull = false, Storage = "_parent", AssociationSetterExpressionMethod = nameof(SetParentValue))]
 			public Parent? Parent
 			{
 				get => _parent.Value;
 				set => throw new InvalidOperationException();
 			}
+
+			[Association(ThisKey = "Parent2ID", OtherKey = "ParentID", CanBeNull = false)]
+			public Parent? Parent2 { get; set; }
 
 			public static Expression<Action<ParentContainer, Parent>> SetParentValue()
 			{
@@ -691,6 +694,7 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 			{
 				var value = db.GetTable<SetExpressionTestClass>().LoadWith(x => x.Parent).First();
+				var value2 = db.GetTable<SetExpressionTestClass>().LoadWith(x => x.Parent).LoadWith(x => x.Parent2).First();
 
 				Assert.That(value.Parent, Is.Not.Null);
 			}


### PR DESCRIPTION
I'm not sure about the performance aspect, do you think I should cache the 
```
var setMethod = descriptor.GetSetterMethod(storageMember.Type, ex.Type)!;
```
or is it useless because the resulting expression is cached at a higher level?

Edit: fixes #3961
