### PR TITLE
DataOptions: fix equality operators nullability

### DIFF
--- a/Source/LinqToDB/Compatibility/System/Data/Linq/Binary.cs
+++ b/Source/LinqToDB/Compatibility/System/Data/Linq/Binary.cs
@@ -43,27 +43,15 @@ namespace System.Data.Linq
 
 		public static bool operator ==(Binary? binary1, Binary? binary2)
 		{
-			if (binary1 is null && binary2 is null)
+			if (ReferenceEquals(binary1, binary2))
 				return true;
 			if (binary1 is null || binary2 is null)
 				return false;
-			if (ReferenceEquals(binary1, binary2))
-				return true;
 
-			return binary1.EqualsTo(binary2);
+			return binary1.Equals(binary2);
 		}
 
-		public static bool operator !=(Binary? binary1, Binary? binary2)
-		{
-			if (binary1 is null && binary2 is null)
-				return false;
-			if (binary1 is null || binary2 is null)
-				return true;
-			if (ReferenceEquals(binary1, binary2))
-				return false;
-
-			return !binary1.EqualsTo(binary2);
-		}
+		public static bool operator !=(Binary? binary1, Binary? binary2) => !(binary1 == binary2);
 
 		public override bool Equals(object? obj) => EqualsTo(obj as Binary);
 

--- a/Source/LinqToDB/DataOptions.cs
+++ b/Source/LinqToDB/DataOptions.cs
@@ -160,14 +160,16 @@ namespace LinqToDB
 			return ((IConfigurationID)this).ConfigurationID;
 		}
 
-		public static bool operator ==(DataOptions t1, DataOptions t2)
+		public static bool operator ==(DataOptions? t1, DataOptions? t2)
 		{
+			if (ReferenceEquals(t1, t2))
+				return true;
+			if (t1 is null || t2 is null)
+				return false;
+
 			return t1.Equals(t2);
 		}
 
-		public static bool operator !=(DataOptions t1, DataOptions t2)
-		{
-			return !t1.Equals(t2);
-		}
+		public static bool operator !=(DataOptions? t1, DataOptions? t2) => !(t1 == t2);
 	}
 }


### PR DESCRIPTION
Discovered during ef.core extension migration:

- `DataOptions` equality operators doesn't work with null values
- `UseDB` configuration methods should have overloads without connection string to allow provider configuration without specifying connection string