### PR TITLE
Simplify IMetadataReader.GetAttributes API

### DIFF
--- a/Source/LinqToDB/Mapping/MappingSchema.cs
+++ b/Source/LinqToDB/Mapping/MappingSchema.cs
@@ -981,12 +981,7 @@ namespace LinqToDB.Mapping
 				}
 
 				if (readers != null)
-				{
-					if (readers.Count == 1)
-						Schemas[0].MetadataReader = readers[0];
-					else
-						Schemas[0].MetadataReader = new MetadataReader(readers.ToArray());
-				}
+					Schemas[0].MetadataReader = new MetadataReader(readers.ToArray());
 
 				void AddMetadataReaderInternal(IMetadataReader reader)
 				{
@@ -1013,18 +1008,18 @@ namespace LinqToDB.Mapping
 			lock (_syncRoot)
 			{
 				var currentReader = Schemas[0].MetadataReader;
-				if (currentReader is MetadataReader metadataReader)
+				if (currentReader != null)
 				{
-					var readers = new IMetadataReader[metadataReader.Readers.Count + 1];
+					var readers = new IMetadataReader[currentReader.Readers.Count + 1];
 
 					readers[0] = reader;
-					for (var i = 0; i < metadataReader.Readers.Count; i++)
-						readers[i + 1] = metadataReader.Readers[i];
+					for (var i = 0; i < currentReader.Readers.Count; i++)
+						readers[i + 1] = currentReader.Readers[i];
 
 					Schemas[0].MetadataReader = new MetadataReader(readers);
 				}
 				else
-					Schemas[0].MetadataReader = currentReader == null ? reader : new MetadataReader(reader, currentReader);
+					Schemas[0].MetadataReader = new MetadataReader(reader);
 
 				(_cache, _firstOnlyCache) = CreateAttributeCaches();
 
@@ -1358,7 +1353,7 @@ namespace LinqToDB.Mapping
 			{
 				public DefaultMappingSchemaInfo() : base("")
 				{
-					MetadataReader = Metadata.MetadataReader.Default;
+					MetadataReader = MetadataReader.Default;
 				}
 
 				protected override int GenerateID()

--- a/Source/LinqToDB/Mapping/MappingSchemaInfo.cs
+++ b/Source/LinqToDB/Mapping/MappingSchemaInfo.cs
@@ -22,9 +22,9 @@ namespace LinqToDB.Mapping
 		}
 
 		public  string           Configuration;
-		private IMetadataReader? _metadataReader;
+		private MetadataReader? _metadataReader;
 
-		public IMetadataReader? MetadataReader
+		public MetadataReader? MetadataReader
 		{
 			get => _metadataReader;
 			set
@@ -279,15 +279,7 @@ namespace LinqToDB.Mapping
 		/// <returns>
 		/// Returns array with all types, mapped by fluent mappings.
 		/// </returns>
-		public IEnumerable<Type> GetRegisteredTypes()
-		{
-			switch (MetadataReader)
-			{
-				case FluentMetadataReader fr : return fr.GetRegisteredTypes();
-				case MetadataReader mr       : return mr.GetRegisteredTypes();
-				default                      : return Array<Type>.Empty;
-			}
-		}
+		public IEnumerable<Type> GetRegisteredTypes() => MetadataReader?.GetRegisteredTypes() ?? Array<Type>.Empty;
 
 		#endregion
 

--- a/Source/LinqToDB/Metadata/AttributeInfo.cs
+++ b/Source/LinqToDB/Metadata/AttributeInfo.cs
@@ -44,7 +44,7 @@ namespace LinqToDB.Metadata
 										member,
 										Expression.Constant(Converter.ChangeType(k.Value, mtype), mtype));
 								})),
-							typeof(Attribute)));
+							typeof(MappingAttribute)));
 
 					_func = expr.CompileExpression();
 				}

--- a/Source/LinqToDB/Metadata/AttributeInfo.cs
+++ b/Source/LinqToDB/Metadata/AttributeInfo.cs
@@ -7,6 +7,7 @@ namespace LinqToDB.Metadata
 {
 	using Common;
 	using Extensions;
+	using LinqToDB.Mapping;
 
 	sealed class AttributeInfo
 	{
@@ -19,9 +20,9 @@ namespace LinqToDB.Metadata
 		public Type                       Type;
 		public Dictionary<string,object?> Values;
 
-		Func<Attribute>? _func;
+		Func<MappingAttribute>? _func;
 
-		public Attribute MakeAttribute()
+		public MappingAttribute MakeAttribute()
 		{
 			if (_func == null)
 			{
@@ -30,7 +31,7 @@ namespace LinqToDB.Metadata
 
 				if (ctor != null)
 				{
-					var expr = Expression.Lambda<Func<Attribute>>(
+					var expr = Expression.Lambda<Func<MappingAttribute>>(
 						Expression.Convert(
 							Expression.MemberInit(
 								Expression.New(ctor),

--- a/Source/LinqToDB/Metadata/AttributeInfo.cs
+++ b/Source/LinqToDB/Metadata/AttributeInfo.cs
@@ -7,7 +7,7 @@ namespace LinqToDB.Metadata
 {
 	using Common;
 	using Extensions;
-	using LinqToDB.Mapping;
+	using Mapping;
 
 	sealed class AttributeInfo
 	{

--- a/Source/LinqToDB/Metadata/AttributeReader.cs
+++ b/Source/LinqToDB/Metadata/AttributeReader.cs
@@ -18,13 +18,11 @@ namespace LinqToDB.Metadata
 				return res.Length == 0 ? Array<MappingAttribute>.Empty : res is MappingAttribute[] attrRes ? attrRes : res.Cast<MappingAttribute>().ToArray();
 			});
 
-		public T[] GetAttributes<T>(Type type)
-			where T : MappingAttribute
-			=> _cache.GetMappingAttributes<T>(type);
+		public MappingAttribute[] GetAttributes(Type type)
+			=> _cache.GetMappingAttributes<MappingAttribute>(type);
 
-		public T[] GetAttributes<T>(Type type, MemberInfo memberInfo)
-			where T : MappingAttribute
-			=> _cache.GetMappingAttributes<T>(type, memberInfo);
+		public MappingAttribute[] GetAttributes(Type type, MemberInfo memberInfo)
+			=> _cache.GetMappingAttributes<MappingAttribute>(type, memberInfo);
 
 		/// <inheritdoc cref="IMetadataReader.GetDynamicColumns"/>
 		public MemberInfo[] GetDynamicColumns(Type type) => Array<MemberInfo>.Empty;

--- a/Source/LinqToDB/Metadata/FluentMetadataReader.cs
+++ b/Source/LinqToDB/Metadata/FluentMetadataReader.cs
@@ -57,17 +57,15 @@ namespace LinqToDB.Metadata
 				return _members.TryGetValue((MemberInfo)attributeProvider, out var memberAttributes) ? memberAttributes : Array<MappingAttribute>.Empty;
 		}
 
-		public T[] GetAttributes<T>(Type type)
-			where T : MappingAttribute
-			=> _cache.GetMappingAttributes<T>(type);
+		public MappingAttribute[] GetAttributes(Type type)
+			=> _cache.GetMappingAttributes<MappingAttribute>(type);
 
-		public T[] GetAttributes<T>(Type type, MemberInfo memberInfo)
-			where T : MappingAttribute
+		public MappingAttribute[] GetAttributes(Type type, MemberInfo memberInfo)
 		{
 			if (memberInfo.ReflectedType != type)
 				memberInfo = type.GetMemberEx(memberInfo) ?? memberInfo;
 
-			return _cache.GetMappingAttributes<T>(type, memberInfo);
+			return _cache.GetMappingAttributes<MappingAttribute>(type, memberInfo);
 		}
 
 		/// <inheritdoc cref="IMetadataReader.GetDynamicColumns"/>

--- a/Source/LinqToDB/Metadata/IMetadataReader.cs
+++ b/Source/LinqToDB/Metadata/IMetadataReader.cs
@@ -11,26 +11,16 @@ namespace LinqToDB.Metadata
 		/// <summary>
 		/// Gets all mapping attributes on specified type.
 		/// </summary>
-		/// <typeparam name="T">Specify attribute base type, which should be implemented by returned attributes.</typeparam>
 		/// <param name="type">Attributes owner type.</param>
-		/// <returns>Array of attributes, derived from <typeparamref name="T"/> type.</returns>
-		/// <remarks>
-		/// Type parameter <typeparamref name="T"/> could specify <see cref="MappingAttribute"/> (base type for all attributes)
-		/// and metadata provider should return all supported mapping attributes for such requests.
-		/// </remarks>
-		T[] GetAttributes<T>(Type type                       ) where T : MappingAttribute;
+		/// <returns>Array of mapping attributes.</returns>
+		MappingAttribute[] GetAttributes(Type type);
 		/// <summary>
 		/// Gets all mapping attributes on specified type member.
 		/// </summary>
-		/// <typeparam name="T">Specify attribute base type, which should be implemented by returned attributes.</typeparam>
 		/// <param name="type">Member type. Could be used by some metadata providers to identify actual member owner type.</param>
 		/// <param name="memberInfo">Type member for which mapping attributes should be returned.</param>
-		/// <returns>Array of attributes, derived from <typeparamref name="T"/> type.</returns>
-		/// <remarks>
-		/// Type parameter <typeparamref name="T"/> could specify <see cref="MappingAttribute"/> (base type for all attributes)
-		/// and metadata provider should return all supported mapping attributes for such requests.
-		/// </remarks>
-		T[] GetAttributes<T>(Type type, MemberInfo memberInfo) where T : MappingAttribute;
+		/// <returns>Array of attributes.</returns>
+		MappingAttribute[] GetAttributes(Type type, MemberInfo memberInfo);
 
 		/// <summary>
 		/// Gets the dynamic columns defined on given type.

--- a/Source/LinqToDB/Metadata/MetaMemberInfo.cs
+++ b/Source/LinqToDB/Metadata/MetaMemberInfo.cs
@@ -13,10 +13,5 @@ namespace LinqToDB.Metadata
 
 		public string          Name;
 		public AttributeInfo[] Attributes;
-
-		public AttributeInfo[] GetAttribute(Type type)
-		{
-			return Attributes.Where(a => type.IsAssignableFrom(a.Type)).ToArray();
-		}
 	}
 }

--- a/Source/LinqToDB/Metadata/MetaTypeInfo.cs
+++ b/Source/LinqToDB/Metadata/MetaTypeInfo.cs
@@ -16,10 +16,5 @@ namespace LinqToDB.Metadata
 		public string                            Name;
 		public Dictionary<string,MetaMemberInfo> Members;
 		public AttributeInfo[]                   Attributes;
-
-		public AttributeInfo[] GetAttribute(Type type)
-		{
-			return Attributes.Where(a => type.IsAssignableFrom(a.Type)).ToArray();
-		}
 	}
 }

--- a/Source/LinqToDB/Metadata/MetadataReader.cs
+++ b/Source/LinqToDB/Metadata/MetadataReader.cs
@@ -45,29 +45,35 @@ namespace LinqToDB.Metadata
 						return Array<MappingAttribute>.Empty;
 					if (_readers.Length == 1)
 						if (type != null)
-							return _readers[0].GetAttributes<MappingAttribute>(type, (MemberInfo)source);
+							return _readers[0].GetAttributes(type, (MemberInfo)source);
 						else
-							return _readers[0].GetAttributes<MappingAttribute>((Type)source);
+							return _readers[0].GetAttributes((Type)source);
 
 					var attrs = new MappingAttribute[_readers.Length][];
 
 					for (var i = 0; i < _readers.Length; i++)
 						if (type != null)
-							attrs[i] = _readers[i].GetAttributes<MappingAttribute>(type, (MemberInfo)source);
+							attrs[i] = _readers[i].GetAttributes(type, (MemberInfo)source);
 						else
-							attrs[i] = _readers[i].GetAttributes<MappingAttribute>((Type)source);
+							attrs[i] = _readers[i].GetAttributes((Type)source);
 
 					return attrs.Flatten();
 				});
 		}
 
-		public T[] GetAttributes<T>(Type type)
+		internal T[] GetAttributes<T>(Type type)
 			where T : MappingAttribute
 			=> _cache.GetMappingAttributes<T>(type);
 
-		public T[] GetAttributes<T>(Type type, MemberInfo memberInfo)
-			where T : MappingAttribute
+		internal T[] GetAttributes<T>(Type type, MemberInfo memberInfo)
+			where T: MappingAttribute
 			=> _cache.GetMappingAttributes<T>(type, memberInfo);
+
+		MappingAttribute[] IMetadataReader.GetAttributes(Type type)
+			=> _cache.GetMappingAttributes<MappingAttribute>(type);
+
+		MappingAttribute[] IMetadataReader.GetAttributes(Type type, MemberInfo memberInfo)
+			=> _cache.GetMappingAttributes<MappingAttribute>(type, memberInfo);
 
 		/// <inheritdoc cref="IMetadataReader.GetDynamicColumns"/>
 		public MemberInfo[] GetDynamicColumns(Type type)

--- a/Source/LinqToDB/Metadata/SystemComponentModelDataAnnotationsSchemaAttributeReader.cs
+++ b/Source/LinqToDB/Metadata/SystemComponentModelDataAnnotationsSchemaAttributeReader.cs
@@ -16,63 +16,55 @@ namespace LinqToDB.Metadata
 	/// </summary>
 	public class SystemComponentModelDataAnnotationsSchemaAttributeReader : IMetadataReader
 	{
-		public T[] GetAttributes<T>(Type type)
-			where T : MappingAttribute
+		public MappingAttribute[] GetAttributes(Type type)
 		{
-			if (typeof(T).IsAssignableFrom(typeof(TableAttribute)))
+			var t = type.GetAttribute<System.ComponentModel.DataAnnotations.Schema.TableAttribute>();
+
+			if (t != null)
 			{
-				var t = type.GetAttribute<System.ComponentModel.DataAnnotations.Schema.TableAttribute>();
+				var attr = new TableAttribute();
 
-				if (t != null)
+				var name = t.Name;
+
+				if (name != null)
 				{
-					var attr = new TableAttribute();
+					var names = name.Replace("[", "").Replace("]", "").Split('.');
 
-					var name = t.Name;
-
-					if (name != null)
+					switch (names.Length)
 					{
-						var names = name.Replace("[", "").Replace("]", "").Split('.');
-
-						switch (names.Length)
-						{
-							case 0  : break;
-							case 1  : attr.Name = names[0]; break;
-							case 2  :
-								attr.Name   = names[0];
-								attr.Schema = names[1];
-								break;
-							default :
-								throw new MetadataException($"Invalid table name '{name}' of type '{type.FullName}'");
-						}
+						case 0: break;
+						case 1: attr.Name = names[0]; break;
+						case 2:
+							attr.Name   = names[0];
+							attr.Schema = names[1];
+							break;
+						default:
+							throw new MetadataException($"Invalid table name '{name}' of type '{type.FullName}'");
 					}
-
-					return new[] { (T)(Attribute)attr };
 				}
+
+				return new MappingAttribute[] { attr };
 			}
 
-			return Array<T>.Empty;
+			return Array<MappingAttribute>.Empty;
 		}
 
-		public T[] GetAttributes<T>(Type type, MemberInfo memberInfo)
-			where T : MappingAttribute
+		public MappingAttribute[] GetAttributes(Type type, MemberInfo memberInfo)
 		{
-			if (typeof(T).IsAssignableFrom(typeof(ColumnAttribute)))
+			var c = memberInfo.GetAttribute<System.ComponentModel.DataAnnotations.Schema.ColumnAttribute>();
+
+			if (c != null)
 			{
-				var c = memberInfo.GetAttribute<System.ComponentModel.DataAnnotations.Schema.ColumnAttribute>();
-
-				if (c != null)
+				var attr = new ColumnAttribute()
 				{
-					var attr = new ColumnAttribute()
-					{
-						Name   = c.Name,
-						DbType = c.TypeName
-					};
+					Name   = c.Name,
+					DbType = c.TypeName
+				};
 
-					return new[] { (T)(Attribute)attr };
-				}
+				return new MappingAttribute[] { attr };
 			}
 
-			return Array<T>.Empty;
+			return Array<MappingAttribute>.Empty;
 		}
 
 		/// <inheritdoc cref="IMetadataReader.GetDynamicColumns"/>

--- a/Source/LinqToDB/Metadata/XmlAttributeReader.cs
+++ b/Source/LinqToDB/Metadata/XmlAttributeReader.cs
@@ -254,27 +254,23 @@ namespace LinqToDB.Metadata
 			.ToDictionary(t => t.Name);
 		}
 
-		public T[] GetAttributes<T>(Type type)
-			where T : MappingAttribute
+		public MappingAttribute[] GetAttributes(Type type)
 		{
-			if (_types.TryGetValue(type.FullName!, out var t) || _types.TryGetValue(type.Name, out t))
-				return t.GetAttribute(typeof(T)).Select(a => (T)a.MakeAttribute()).ToArray();
+			if ((_types.TryGetValue(type.FullName!, out var t) || _types.TryGetValue(type.Name, out t)) && t.Attributes.Length > 0)
+				return t.Attributes.Select(a => a.MakeAttribute()).ToArray();
 
-			return Array<T>.Empty;
+			return Array<MappingAttribute>.Empty;
 		}
 
-		public T[] GetAttributes<T>(Type type, MemberInfo memberInfo)
-			where T : MappingAttribute
+		public MappingAttribute[] GetAttributes(Type type, MemberInfo memberInfo)
 		{
 			if (_types.TryGetValue(type.FullName!, out var t) || _types.TryGetValue(type.Name, out t))
 			{
-				if (t.Members.TryGetValue(memberInfo.Name, out var m))
-				{
-					return m.GetAttribute(typeof(T)).Select(a => (T)a.MakeAttribute()).ToArray();
-				}
+				if (t.Members.TryGetValue(memberInfo.Name, out var m) && m.Attributes.Length > 0)
+					return m.Attributes.Select(a => a.MakeAttribute()).ToArray();
 			}
 
-			return Array<T>.Empty;
+			return Array<MappingAttribute>.Empty;
 		}
 
 		/// <inheritdoc cref="IMetadataReader.GetDynamicColumns"/>

--- a/Tests/Linq/Metadata/AttributeReaderTests.cs
+++ b/Tests/Linq/Metadata/AttributeReaderTests.cs
@@ -1,4 +1,5 @@
-﻿using LinqToDB.Expressions;
+﻿using System.Linq;
+using LinqToDB.Expressions;
 using LinqToDB.Mapping;
 using LinqToDB.Metadata;
 
@@ -21,7 +22,8 @@ namespace Tests.Metadata
 		public void TypeAttribute()
 		{
 			var rd    = new AttributeReader();
-			var attrs = rd.GetAttributes<TableAttribute>(typeof(TestEntity));
+			var attrs = rd.GetAttributes(typeof(TestEntity))
+				.OfType<TableAttribute>().ToArray();
 
 			Assert.NotNull (attrs);
 			Assert.AreEqual(1, attrs.Length);
@@ -32,7 +34,8 @@ namespace Tests.Metadata
 		public void FieldAttribute()
 		{
 			var rd    = new AttributeReader();
-			var attrs = rd.GetAttributes<ColumnAttribute>(typeof(TestEntity), MemberHelper.MemberOf<TestEntity>(a => a.Field1));
+			var attrs = rd.GetAttributes(typeof(TestEntity), MemberHelper.MemberOf<TestEntity>(a => a.Field1))
+				.OfType<ColumnAttribute>().ToArray();
 
 			Assert.AreEqual(0, attrs.Length);
 		}
@@ -41,7 +44,8 @@ namespace Tests.Metadata
 		public void PropertyAttribute()
 		{
 			var rd    = new AttributeReader();
-			var attrs = rd.GetAttributes<ColumnAttribute>(typeof(TestEntity), MemberHelper.MemberOf<TestEntity>(a => a.Property1));
+			var attrs = rd.GetAttributes(typeof(TestEntity), MemberHelper.MemberOf<TestEntity>(a => a.Property1))
+				.OfType<ColumnAttribute>().ToArray();
 
 			Assert.NotNull (attrs);
 			Assert.AreEqual(1, attrs.Length);

--- a/Tests/Linq/Metadata/SystemDataLinqAttributeReaderTests.cs
+++ b/Tests/Linq/Metadata/SystemDataLinqAttributeReaderTests.cs
@@ -106,7 +106,8 @@ namespace Tests.Metadata
 		[Test]
 		public void ParseTableAttribute() {
 			var rd     = new SystemDataLinqAttributeReader();
-			var attrs = rd.GetAttributes<LinqToDB.Mapping.TableAttribute>(typeof(Shipper));
+			var attrs = rd.GetAttributes(typeof(Shipper))
+				.OfType<LinqToDB.Mapping.TableAttribute>().ToArray();
 
 			Assert.NotNull(attrs);
 			Assert.AreEqual(1, attrs.Length);

--- a/Tests/Linq/Metadata/XmlReaderTests.cs
+++ b/Tests/Linq/Metadata/XmlReaderTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Linq;
 using System.Text;
 
 using LinqToDB.Expressions;
@@ -54,7 +55,7 @@ namespace Tests.Metadata
 		public void TypeAttribute()
 		{
 			var rd    = new XmlAttributeReader(new MemoryStream(Encoding.UTF8.GetBytes(Data)));
-			var attrs = rd.GetAttributes<TableAttribute>(typeof(XmlReaderTests));
+			var attrs = rd.GetAttributes(typeof(XmlReaderTests)).OfType<TableAttribute>().ToArray();
 
 			Assert.NotNull (attrs);
 			Assert.AreEqual(1, attrs.Length);
@@ -67,7 +68,8 @@ namespace Tests.Metadata
 		public void FieldAttribute()
 		{
 			var rd    = new XmlAttributeReader(new MemoryStream(Encoding.UTF8.GetBytes(Data)));
-			var attrs = rd.GetAttributes<ColumnAttribute>(typeof(XmlReaderTests), MemberHelper.MemberOf<XmlReaderTests>(a => a.Field1));
+			var attrs = rd.GetAttributes(typeof(XmlReaderTests), MemberHelper.MemberOf<XmlReaderTests>(a => a.Field1))
+				.OfType<ColumnAttribute>().ToArray();
 
 			Assert.NotNull (attrs);
 			Assert.AreEqual(1, attrs.Length);
@@ -80,7 +82,8 @@ namespace Tests.Metadata
 		public void PropertyAttribute()
 		{
 			var rd    = new XmlAttributeReader(new MemoryStream(Encoding.UTF8.GetBytes(Data)));
-			var attrs = rd.GetAttributes<ColumnAttribute>(typeof(XmlReaderTests), MemberHelper.MemberOf<XmlReaderTests>(a => a.Property1));
+			var attrs = rd.GetAttributes(typeof(XmlReaderTests), MemberHelper.MemberOf<XmlReaderTests>(a => a.Property1))
+				.OfType<ColumnAttribute>().ToArray();
 
 			Assert.NotNull (attrs);
 			Assert.AreEqual(1, attrs.Length);


### PR DESCRIPTION
Fix #3981

After IMetadataReader refactoring [here](#3900) `GetAttributes` methods always called using `MappingAttribute` as type parameter, which makes it unnecessary and confusing.