### PR TITLE
Fix property/event attributes inheritance support

### DIFF
--- a/Build/BannedSymbols.txt
+++ b/Build/BannedSymbols.txt
@@ -77,3 +77,11 @@ M:System.Reflection.Module.GetCustomAttributes(System.Boolean); Use AttributesEx
 M:System.Reflection.Module.GetCustomAttributes(System.Type,System.Boolean); Use AttributesExtensions.GetAttributes<TAttribute>(bool inherit) extension
 M:System.Reflection.ParameterInfo.GetCustomAttributes(System.Boolean); Use AttributesExtensions.GetAttributes<TAttribute>(bool inherit) extension
 M:System.Reflection.ParameterInfo.GetCustomAttributes(System.Type,System.Boolean); Use AttributesExtensions.GetAttributes<TAttribute>(bool inherit) extension
+M:System.Attribute.IsDefined(System.Reflection.Assembly,System.Type); Use AttributesExtensions.HasAttribute<TAttribute>(bool inherit) extension
+M:System.Attribute.IsDefined(System.Reflection.Assembly,System.Type,System.Boolean); Use AttributesExtensions.HasAttribute<TAttribute>(bool inherit) extension
+M:System.Attribute.IsDefined(System.Reflection.MemberInfo,System.Type); Use AttributesExtensions.HasAttribute<TAttribute>(bool inherit) extension
+M:System.Attribute.IsDefined(System.Reflection.MemberInfo,System.Type,System.Boolean); Use AttributesExtensions.HasAttribute<TAttribute>(bool inherit) extension
+M:System.Attribute.IsDefined(System.Reflection.Module,System.Type); Use AttributesExtensions.HasAttribute<TAttribute>(bool inherit) extension
+M:System.Attribute.IsDefined(System.Reflection.Module,System.Type,System.Boolean); Use AttributesExtensions.HasAttribute<TAttribute>(bool inherit) extension
+M:System.Attribute.IsDefined(System.Reflection.ParameterInfo,System.Type); Use AttributesExtensions.HasAttribute<TAttribute>(bool inherit) extension
+M:System.Attribute.IsDefined(System.Reflection.ParameterInfo,System.Type,System.Boolean); Use AttributesExtensions.HasAttribute<TAttribute>(bool inherit) extension

--- a/Tests/Linq/Reflection/AttributesTests.cs
+++ b/Tests/Linq/Reflection/AttributesTests.cs
@@ -1,0 +1,51 @@
+﻿using System;
+
+using LinqToDB.Extensions;
+
+using NUnit.Framework;
+
+namespace Tests.Reflection
+{
+	[TestFixture]
+	public sealed class AttributesTests : TestBase
+	{
+		[Test]
+		public void PropertyAttributeInheritanceTest()
+		{
+			var prop = typeof(Derived).GetProperty(nameof(Base.Property))!;
+
+			Assert.False(prop.HasAttribute<MyAttribute>(false));
+			Assert.True(prop.HasAttribute<MyAttribute>(true));
+		}
+
+		[Test]
+		public void EventAttributeInheritanceTest()
+		{
+			var ev = typeof(Derived).GetEvent(nameof(Base.Event))!;
+
+			Assert.False(ev.HasAttribute<MyAttribute>(false));
+			Assert.True(ev.HasAttribute<MyAttribute>(true));
+		}
+
+		public class Base
+		{
+			[My]
+			public virtual bool Property { get; set; }
+
+			[My]
+			public virtual event Action Event { add { } remove { } }
+		}
+
+		public sealed class Derived : Base
+		{
+			public override bool Property { get; set; }
+
+			public override event Action Event { add { } remove { } }
+		}
+
+		[AttributeUsage(AttributeTargets.All)]
+		public sealed class MyAttribute : Attribute
+		{
+		}
+	}
+}


### PR DESCRIPTION
Discovered trying to use linq2db attribute cache in external project. Partial regression from v4