### PR TITLE
Fix test dependencies TFMs

### DIFF
--- a/Source/LinqToDB.AspNet/LinqToDB.AspNet.csproj
+++ b/Source/LinqToDB.AspNet/LinqToDB.AspNet.csproj
@@ -4,9 +4,14 @@
 
 		<AssemblyName>linq2db.AspNet</AssemblyName>
 		<RootNamespace>LinqToDB.AspNet</RootNamespace>
-		<TargetFrameworks>net45;netstandard2.0;net7.0</TargetFrameworks>
 
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\linq2db.AspNet.xml</DocumentationFile>
+
+		<!--published targets-->
+		<TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+		<!--add test-only targets separately for better visibility-->
+		<TargetFrameworks>$(TargetFrameworks);net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Source/LinqToDB.Remote.Grpc/LinqToDB.Remote.Grpc.csproj
+++ b/Source/LinqToDB.Remote.Grpc/LinqToDB.Remote.Grpc.csproj
@@ -5,7 +5,11 @@
 		<RootNamespace>LinqToDB.Remote.Grpc</RootNamespace>
 
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\linq2db.remote.grpc.xml</DocumentationFile>
+
+		<!--published targets-->
 		<TargetFrameworks>netstandard2.0;net7.0</TargetFrameworks>
+		<!--add test-only targets separately for better visibility-->
+		<TargetFrameworks>$(TargetFrameworks);net472;netcoreapp3.1;net6.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Source/LinqToDB.Tools/LinqToDB.Tools.csproj
+++ b/Source/LinqToDB.Tools/LinqToDB.Tools.csproj
@@ -5,7 +5,11 @@
 		<RootNamespace>LinqToDB.Tools</RootNamespace>
 
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\linq2db.Tools.xml</DocumentationFile>
-		<TargetFrameworks>net45;net46;netstandard2.0;net7.0</TargetFrameworks>
+		
+		<!--published targets-->
+		<TargetFrameworks>net45;net46;netstandard2.0</TargetFrameworks>
+		<!--add test-only targets separately for better visibility-->
+		<TargetFrameworks>$(TargetFrameworks);net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -16,7 +16,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\..\Source\LinqToDB\LinqToDB.csproj" />
 		<ProjectReference Include="..\..\Source\LinqToDB.Tools\LinqToDB.Tools.csproj" />
 	</ItemGroup>
 

--- a/Tests/Tests.Benchmarks/linq2db.Benchmarks.csproj
+++ b/Tests/Tests.Benchmarks/linq2db.Benchmarks.csproj
@@ -4,7 +4,6 @@
 	<PropertyGroup>
 		<AssemblyName>linq2db.Benchmarks</AssemblyName>
 		<RootNamespace>LinqToDB.Benchmarks</RootNamespace>
-		<TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<PlatformTarget>AnyCPU</PlatformTarget>
 		<!--<DefineConstants>JETBRAINS;$(DefineConstants)</DefineConstants>-->

--- a/Tests/linq2db.Providers.props
+++ b/Tests/linq2db.Providers.props
@@ -3,9 +3,6 @@
 	<PropertyGroup>
 		<MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);MSB3270;MSB3277;MSB3246</MSBuildWarningsAsMessages>
 		<NoWarn>$(NoWarn);CS8002</NoWarn>
-
-		<!--https://github.com/DarkWanderer/ClickHouse.Client/issues/238-->
-		<SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
because linq2db referenced from tests directly and as transitive dependency of other projects we end up with wrong linq2db binary in tests on build causing errors like this:

```
OneTimeSetUp: System.MissingMethodException : Method not found: 'LinqToDB.DataProvider.ClickHouse.ClickHouseOptions LinqToDB.DataProvider.ClickHouse.ClickHouseOptions.<Clone>$()'.
```