### PR TITLE
Improve interfaces support

### DIFF
--- a/Source/LinqToDB/Reflection/TypeAccessorT.cs
+++ b/Source/LinqToDB/Reflection/TypeAccessorT.cs
@@ -30,7 +30,7 @@ namespace LinqToDB.Reflection
 					Expression<Func<T>> mi;
 
 					if (type.IsAbstract) mi = () => ThrowAbstractException();
-					else                     mi = () => ThrowException();
+					else                 mi = () => ThrowException();
 
 					var body = Expression.Call(null, ((MethodCallExpression)mi.Body).Method);
 
@@ -42,33 +42,81 @@ namespace LinqToDB.Reflection
 				}
 			}
 
-			_members.AddRange(type.GetPublicInstanceValueMembers());
+			var interfaces = !type.IsInterface && !type.IsArray ? type.GetInterfaces() : Array<Type>.Empty;
 
-			// Add explicit interface implementation properties support
-			// Or maybe we should support all private fields/properties?
-			//
-			if (!type.IsInterface && !type.IsArray)
+			if (interfaces.Length == 0)
 			{
-				var interfaceMethods = type.GetInterfaces().SelectMany(ti => type.GetInterfaceMapEx(ti).TargetMethods)
-					.ToList();
+				_members.AddRange(type.GetPublicInstanceValueMembers());
+			}
+			else
+			{
+				// load properties takin into account explicit interface implementations
+				var interfacePropertiesList = new List<PropertyInfo>();
+				var interfaceProperties     = new HashSet<(Type? declaringType, string name, Type type)>();
 
-				if (interfaceMethods.Count > 0)
+				// as interface could be re-implemented multiple times, we should track which inteface property accessors
+				// are not mapped yet and reduce this list walking inheritance hierarchy from top to base type
+				HashSet<MethodInfo>? unmappedAccessors = null;
+
+				// fill unmappedAccessors with accessors, except those from public properties
+				foreach (var iface in type.GetInterfaces())
 				{
-					foreach (var pi in type.GetNonPublicPropertiesEx())
-					{
-						if (pi.GetIndexParameters().Length == 0)
-						{
-							var getMethod = pi.GetGetMethod(true);
-							var setMethod = pi.GetSetMethod(true);
+					var map = type.GetInterfaceMapEx(iface);
 
-							if ((getMethod == null || interfaceMethods.Contains(getMethod)) &&
-								(setMethod == null || interfaceMethods.Contains(setMethod)))
+					for (var i = 0; i < map.InterfaceMethods.Length; i++)
+					{
+						if (!map.InterfaceMethods[i].IsStatic)
+							(unmappedAccessors ??= new()).Add(map.InterfaceMethods[i]);
+					}
+				}
+
+				// go down in hierarchy and pick first found explicit implementation for interface properties
+				var implementor = type;
+				while (unmappedAccessors != null && unmappedAccessors.Count > 0)
+				{
+					Dictionary<MethodInfo, List<MethodInfo>>? methods = null;
+
+					foreach (var iface in implementor.GetInterfaces())
+					{
+						var map = implementor.GetInterfaceMapEx(iface);
+
+						for (var i = 0; i < map.InterfaceMethods.Length; i++)
+						{
+							if (map.InterfaceMethods[i].IsStatic)
+								continue;
+
+							methods ??= new();
+							if (methods.TryGetValue(map.TargetMethods[i], out var interfaceMethods))
+								interfaceMethods.Add(map.InterfaceMethods[i]);
+							else
+								methods.Add(map.TargetMethods[i], new List<MethodInfo>() { map.InterfaceMethods[i] });
+						}
+					}
+
+					if (methods != null)
+					{
+						foreach (var pi in implementor.GetDeclaredPropertiesEx())
+						{
+							if ((pi.GetMethod == null || (methods.TryGetValue(pi.GetMethod, out var ifaceGetters) && RemoveAll(unmappedAccessors, ifaceGetters))) &&
+								(pi.SetMethod == null || (methods.TryGetValue(pi.SetMethod, out var ifaceSetters) && RemoveAll(unmappedAccessors, ifaceSetters))))
 							{
-								_members.Add(pi);
+								interfacePropertiesList.Add(pi);
+								interfaceProperties.Add((pi.DeclaringType, pi.Name, pi.PropertyType));
 							}
 						}
 					}
+
+					if (implementor.BaseType == null || implementor.BaseType == typeof(object) || implementor.BaseType == typeof(ValueType))
+						break;
+
+					implementor = implementor.BaseType;
 				}
+
+				foreach (var mi in type.GetPublicInstanceValueMembers())
+					if (mi is not PropertyInfo pi || !interfaceProperties.Contains((pi.DeclaringType, pi.Name, pi.PropertyType)))
+						_members.Add(mi);
+
+				_members.AddRange(interfacePropertiesList);
 			}
 
 			// ObjectFactory
@@ -77,6 +125,15 @@ namespace LinqToDB.Reflection
 
 			if (attr != null)
 				_objectFactory = attr.ObjectFactory;
+
+			static bool RemoveAll(HashSet<MethodInfo> unmappedAccessors, List<MethodInfo> ifaceAccessors)
+			{
+				var removed = true;
+				foreach (var accessor in ifaceAccessors)
+					removed = unmappedAccessors.Remove(accessor) && removed;
+
+				return removed;
+			}
 		}
 
 		static T ThrowException()

--- a/Tests/Linq/Linq/InterfaceTests.cs
+++ b/Tests/Linq/Linq/InterfaceTests.cs
@@ -1,10 +1,13 @@
 ﻿using System.Linq;
+using FluentAssertions;
 using LinqToDB;
 using LinqToDB.Mapping;
 using NUnit.Framework;
 
 namespace Tests.Linq
 {
+	using Model;
+
 	[TestFixture]
 	public class InterfaceTests : TestBase
 	{
@@ -24,6 +27,254 @@ namespace Tests.Linq
 				var _ = q.ToList();
 			}
 		}
+
+		#region Issue 4031
+		[Table("Person")]
+		public class Issue4031BaseInternal
+		{
+			[Column("PersonID")] public int Id { get; set; }
+		}
+
+		[Table("Person")]
+		public class Issue4031BaseImplicit : IIssue4031
+		{
+			[Column("PersonID")] public int Id { get; set; }
+		}
+
+		[Table("Person")]
+		public class Issue4031BaseExplicit : IIssue4031
+		{
+			[Column("PersonID")] int IIssue4031.Id { get; set; }
+		}
+
+		[Table("Person")]
+		public class Issue4031BaseImplicitBad : IIssue4031
+		{
+			[Column("UNKNOWN")] public int Id { get; set; }
+		}
+
+		[Table("Person")]
+		public class Issue4031BaseExplicitBad : IIssue4031
+		{
+			[Column("UNKNOWN")] int IIssue4031.Id { get; set; }
+		}
+
+		public class Issue4031Case01 : Issue4031BaseExternal, IIssue4031
+		{
+		}
+
+		public class Issue4031Case02 : Issue4031BaseInternal, IIssue4031
+		{
+		}
+
+		public class Issue4031Case03 : Issue4031BaseImplicit
+		{
+		}
+
+		public class Issue4031Case04 : Issue4031BaseImplicit
+		{
+			[Column("UNKNOWN")] public new int Id { get; set; }
+		}
+
+		public class Issue4031Case05 : Issue4031BaseExplicit
+		{
+		}
+
+		public class Issue4031Case06 : Issue4031BaseExplicit
+		{
+			[Column("UNKNOWN")] public int Id { get; set; }
+		}
+
+		public class Issue4031Case07 : Issue4031BaseImplicit, IIssue4031
+		{
+		}
+
+		public class Issue4031Case08 : Issue4031BaseImplicit, IIssue4031
+		{
+			[Column("PersonID")] public new int Id { get; set; }
+		}
+
+		public class Issue4031Case09 : Issue4031BaseImplicitBad, IIssue4031
+		{
+			[Column("PersonID")] public new int Id { get; set; }
+		}
+
+		public class Issue4031Case10 : Issue4031BaseExplicit, IIssue4031
+		{
+		}
+
+		public class Issue4031Case11 : Issue4031BaseExplicit, IIssue4031
+		{
+			[Column("PersonID")] public int Id { get; set; }
+		}
+
+		public class Issue4031Case12 : Issue4031BaseExplicit, IIssue4031
+		{
+			[Column("PersonID")] int IIssue4031.Id { get; set; }
+		}
+
+		public class Issue4031Case13 : Issue4031BaseImplicit, IIssue4031
+		{
+		}
+
+		public class Issue4031Case14 : Issue4031BaseImplicitBad, IIssue4031
+		{
+			[Column("PersonID")] public new int Id { get; set; }
+		}
+
+		public class Issue4031Case15 : Issue4031BaseImplicitBad, IIssue4031
+		{
+			[Column("PersonID")] int IIssue4031.Id { get; set; }
+		}
+
+		public class Issue4031Case16 : Issue4031BaseExternal, IIssue4031<int>
+		{
+		}
+
+		[Test]
+		public void Issue4031_Case01([IncludeDataSources(ProviderName.SQLiteClassic)] string context)
+		{
+			Issue4031_Execute<Issue4031Case01>(context);
+		}
+
+		[Test]
+		public void Issue4031_Case02([IncludeDataSources(ProviderName.SQLiteClassic)] string context)
+		{
+			Issue4031_Execute<Issue4031Case02>(context);
+		}
+
+		[Test]
+		public void Issue4031_Case03([IncludeDataSources(ProviderName.SQLiteClassic)] string context)
+		{
+			Issue4031_Execute<Issue4031Case03>(context);
+		}
+
+		// unsuported case: two properties with same name (Id), which requires heavy EntityDescriptor refactoring (at least)
+		[Test, ActiveIssue]
+		public void Issue4031_Case04([IncludeDataSources(ProviderName.SQLiteClassic)] string context)
+		{
+			Issue4031_Execute_TwoFields<Issue4031Case04>(context);
+
+			using var db = GetDataContext(context);
+			var sql = db.GetTable<Issue4031Case15>().Where(c => c.Id == -1).Select(c => new { c.Id }).ToString();
+			Assert.That(sql, Is.Not.Contains("PersonID"));
+			sql.Should().Contain("UNKNOWN", Exactly.Twice());
+		}
+
+		[Test]
+		public void Issue4031_Case05([IncludeDataSources(ProviderName.SQLiteClassic)] string context)
+		{
+			Issue4031_Execute<Issue4031Case05>(context);
+		}
+
+		[Test]
+		public void Issue4031_Case06([IncludeDataSources(ProviderName.SQLiteClassic)] string context)
+		{
+			Issue4031_Execute_TwoFields<Issue4031Case06>(context);
+
+			using var db = GetDataContext(context);
+			var sql = db.GetTable<Issue4031Case15>().Where(c => c.Id == -1).Select(c => new { c.Id }).ToString();
+			Assert.That(sql, Is.Not.Contains("PersonID"));
+			sql.Should().Contain("UNKNOWN", Exactly.Twice());
+		}
+
+		[Test]
+		public void Issue4031_Case07([IncludeDataSources(ProviderName.SQLiteClassic)] string context)
+		{
+			Issue4031_Execute<Issue4031Case07>(context);
+		}
+
+		[Test]
+		public void Issue4031_Case08([IncludeDataSources(ProviderName.SQLiteClassic)] string context)
+		{
+			Issue4031_Execute<Issue4031Case08>(context);
+		}
+
+		[Test]
+		public void Issue4031_Case09([IncludeDataSources(ProviderName.SQLiteClassic)] string context)
+		{
+			Issue4031_Execute<Issue4031Case09>(context);
+		}
+
+		[Test]
+		public void Issue4031_Case10([IncludeDataSources(ProviderName.SQLiteClassic)] string context)
+		{
+			Issue4031_Execute<Issue4031Case10>(context);
+		}
+
+		[Test]
+		public void Issue4031_Case11([IncludeDataSources(ProviderName.SQLiteClassic)] string context)
+		{
+			Issue4031_Execute<Issue4031Case11>(context);
+		}
+
+		[Test]
+		public void Issue4031_Case12([IncludeDataSources(ProviderName.SQLiteClassic)] string context)
+		{
+			Issue4031_Execute<Issue4031Case12>(context);
+		}
+
+		[Test]
+		public void Issue4031_Case13([IncludeDataSources(ProviderName.SQLiteClassic)] string context)
+		{
+			Issue4031_Execute<Issue4031Case13>(context);
+		}
+
+		[Test]
+		public void Issue4031_Case14([IncludeDataSources(ProviderName.SQLiteClassic)] string context)
+		{
+			Issue4031_Execute<Issue4031Case14>(context);
+		}
+
+		[Test]
+		public void Issue4031_Case15([IncludeDataSources(ProviderName.SQLiteClassic)] string context)
+		{
+			Issue4031_Execute_TwoFields<Issue4031Case15>(context);
+
+			using var db = GetDataContext(context);
+			var sql = db.GetTable<Issue4031Case15>().Where(c => c.Id == -1).Select(c => new { c.Id }).ToString();
+			Assert.That(sql, Is.Not.Contains("PersonID"));
+			sql.Should().Contain("UNKNOWN", Exactly.Twice());
+		}
+
+		[Test]
+		public void Issue4031_Case16([IncludeDataSources(ProviderName.SQLiteClassic)] string context)
+		{
+			Issue4031_ExecuteT<Issue4031Case16>(context);
+		}
+
+		void Issue4031_ExecuteT<T>(string context) where T : class, IIssue4031<int>
+		{
+			using var db = GetDataContext(context);
+			db.GetTable<T>().Where(c => c.Id == -1).ToList();
+
+			var ed = db.MappingSchema.GetEntityDescriptor(typeof(T));
+			Assert.AreEqual(1, ed.Columns.Count);
+			Assert.AreEqual("PersonID", ed.Columns[0].ColumnName);
+		}
+
+		void Issue4031_Execute<T>(string context) where T : class, IIssue4031
+		{
+			using var db = GetDataContext(context);
+			db.GetTable<T>().Where(c => c.Id == -1).ToList();
+
+			var ed = db.MappingSchema.GetEntityDescriptor(typeof(T));
+			Assert.AreEqual(1, ed.Columns.Count);
+			Assert.AreEqual("PersonID", ed.Columns[0].ColumnName);
+		}
+
+		void Issue4031_Execute_TwoFields<T>(string context) where T : class, IIssue4031
+		{
+			using var db = GetDataContext(context);
+			db.GetTable<T>().Where(c => c.Id == -1).Select(c => new { c.Id }).ToList();
+
+			var ed = db.MappingSchema.GetEntityDescriptor(typeof(T));
+			Assert.AreEqual(2, ed.Columns.Count);
+			var columnNames = ed.Columns.Select(c => c.ColumnName).ToArray();
+			Assert.Contains("PersonID", columnNames);
+			Assert.Contains("UNKNOWN", columnNames);
+		}
+		#endregion
 
 		#region Issue 3034
 		interface IA

--- a/Tests/Linq/Update/MergeTests.Issues.cs
+++ b/Tests/Linq/Update/MergeTests.Issues.cs
@@ -668,7 +668,7 @@ namespace Tests.xUpdate
 					.Merge()
 					.Using(ReviewIndex.Data)
 					.OnTargetKey()
-					.UpdateWhenNotMatchedBySource(t =>  new ReviewIndex() { Id = 2, Value = "3"})
+					.UpdateWhenNotMatchedBySource(t =>  new ReviewIndex() { Id = 2, Value = "3" })
 					.Merge();
 			}
 		}

--- a/Tests/Model/Interfaces.cs
+++ b/Tests/Model/Interfaces.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using LinqToDB.Mapping;
+
+namespace Tests.Model
+{
+	public interface IIssue4031
+	{
+		public int Id { get; set; }
+	}
+
+	public interface IIssue4031<T>
+	{
+		public T Id { get; set; }
+	}
+
+	// must implement IIssue4031 without specifying IIssue4031 in implementation list
+	[Table("Person")]
+	public class Issue4031BaseExternal
+	{
+		[Column("PersonID")] public int Id { get; set; }
+	}
+}


### PR DESCRIPTION
Fix #4031

Original issue caused by C# compiler adding explicit getter/setter implementations without property implementation to class inheriting implementation from base class, located in another assembly.
I've added fix, but not happy with it so will appreciate better heuristics proposed.

Additional tests showed that we also doesn't handle inherited explicit interface implementations, so it makes sense to try and fix it too.

Additionally, added guard against static interface members