### PR TITLE
Fix eager load auto-transaction

### DIFF
--- a/Source/LinqToDB/Async/AsyncEnumeratorAsyncWrapper.cs
+++ b/Source/LinqToDB/Async/AsyncEnumeratorAsyncWrapper.cs
@@ -1,58 +1,37 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+#if !NATIVE_ASYNC
+using TASK  = System.Threading.Tasks.Task;
+using TASKB = System.Threading.Tasks.Task<bool>;
+#else
+using TASK  = System.Threading.Tasks.ValueTask;
+using TASKB = System.Threading.Tasks.ValueTask<bool>;
+#endif
 
 namespace LinqToDB.Async
 {
 	internal sealed class AsyncEnumeratorAsyncWrapper<T> : IAsyncEnumerator<T>
 	{
 		private IAsyncEnumerator<T>? _enumerator;
-#if !NATIVE_ASYNC
-		private readonly Func<Task<Tuple<IAsyncEnumerator<T>, IDisposable?>>> _init;
-		private IDisposable? _disposable;
-#else
 		private readonly Func<Task<Tuple<IAsyncEnumerator<T>, IAsyncDisposable?>>> _init;
 		private IAsyncDisposable? _disposable;
-#endif
 
-#if !NATIVE_ASYNC
-		public AsyncEnumeratorAsyncWrapper(Func<Task<Tuple<IAsyncEnumerator<T>, IDisposable?>>> init)
-#else
 		public AsyncEnumeratorAsyncWrapper(Func<Task<Tuple<IAsyncEnumerator<T>, IAsyncDisposable?>>> init)
-#endif
 		{
 			_init = init;
 		}
 
 		T IAsyncEnumerator<T>.Current => _enumerator!.Current;
 
-#if !NATIVE_ASYNC
-		async Task IAsyncDisposable.DisposeAsync()
-		{
-			await _enumerator!.DisposeAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
-			_disposable?.Dispose();
-		}
-
-		async Task<bool> IAsyncEnumerator<T>.MoveNextAsync()
-		{
-			if (_enumerator == null)
-			{
-				var tuple   = await _init().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
-				_enumerator = tuple.Item1;
-				_disposable = tuple.Item2;
-			}
-
-			return await _enumerator.MoveNextAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
-		}
-#else
-		async ValueTask IAsyncDisposable.DisposeAsync()
+		async TASK IAsyncDisposable.DisposeAsync()
 		{
 			await _enumerator!.DisposeAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 			if (_disposable != null)
 				await _disposable.DisposeAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
-		async ValueTask<bool> IAsyncEnumerator<T>.MoveNextAsync()
+		async TASKB IAsyncEnumerator<T>.MoveNextAsync()
 		{
 			if (_enumerator == null)
 			{
@@ -63,6 +42,5 @@ namespace LinqToDB.Async
 
 			return await _enumerator.MoveNextAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
-#endif
 	}
 }

--- a/Source/LinqToDB/Compatibility/System/IAsyncDisposableEmpty.cs
+++ b/Source/LinqToDB/Compatibility/System/IAsyncDisposableEmpty.cs
@@ -1,0 +1,20 @@
+﻿#if NATIVE_ASYNC
+using System;
+using System.Threading.Tasks;
+
+namespace LinqToDB
+{
+	/// <summary>
+	/// Helps leverage of pain to work with <c>await using nullable_value</c> code.
+	/// </summary>
+	internal static class EmptyIAsyncDisposable
+	{
+		public static readonly IAsyncDisposable Instance = new NoopImplementation();
+
+		private sealed class NoopImplementation : IAsyncDisposable
+		{
+			ValueTask IAsyncDisposable.DisposeAsync() => default;
+		}
+	}
+}
+#endif

--- a/Source/LinqToDB/DataContext.cs
+++ b/Source/LinqToDB/DataContext.cs
@@ -331,6 +331,7 @@ namespace LinqToDB
 					if (_dataConnection.QueryHints.    Count > 0) QueryHints.    AddRange(_queryHints!);
 					if (_dataConnection.NextQueryHints.Count > 0) NextQueryHints.AddRange(_nextQueryHints!);
 
+					_dataConnection.OnRemoveInterceptor -= RemoveInterceptor;
 					await _dataConnection.DisposeAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 					_dataConnection = null;
 				}
@@ -434,6 +435,7 @@ namespace LinqToDB
 				if (_dataConnection.QueryHints.    Count > 0) (_queryHints     ??= new ()).AddRange(_dataConnection.QueryHints);
 				if (_dataConnection.NextQueryHints.Count > 0) (_nextQueryHints ??= new ()).AddRange(_dataConnection.NextQueryHints);
 
+				_dataConnection.OnRemoveInterceptor -= RemoveInterceptor;
 				_dataConnection.Dispose();
 				_dataConnection = null;
 			}
@@ -451,6 +453,7 @@ namespace LinqToDB
 				if (_dataConnection.QueryHints.    Count > 0) (_queryHints     ??= new ()).AddRange(_dataConnection.QueryHints);
 				if (_dataConnection.NextQueryHints.Count > 0) (_nextQueryHints ??= new ()).AddRange(_dataConnection.NextQueryHints);
 
+				_dataConnection.OnRemoveInterceptor -= RemoveInterceptor;
 				await _dataConnection.DisposeAsync().ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 				_dataConnection = null;
 			}

--- a/Source/LinqToDB/Linq/QueryRunner.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.cs
@@ -564,8 +564,8 @@ namespace LinqToDB.Linq
 
 			public void Dispose()
 			{
-				_queryRunner?.Dispose();
 				_dataReader ?.Dispose();
+				_queryRunner?.Dispose();
 
 				_queryRunner = null;
 				_dataReader  = null;
@@ -577,11 +577,11 @@ namespace LinqToDB.Linq
 			public async ValueTask DisposeAsync()
 #endif
 			{
-				if (_queryRunner != null)
-					await _queryRunner.DisposeAsync().ConfigureAwait(Configuration.ContinueOnCapturedContext);
-
 				if (_dataReader != null)
 					await _dataReader.DisposeAsync().ConfigureAwait(Configuration.ContinueOnCapturedContext);
+
+				if (_queryRunner != null)
+					await _queryRunner.DisposeAsync().ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
 				_queryRunner = null;
 				_dataReader  = null;

--- a/Tests/Linq/Linq/EagerLoadingTests.cs
+++ b/Tests/Linq/Linq/EagerLoadingTests.cs
@@ -6,10 +6,12 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using LinqToDB;
 using LinqToDB.Async;
+using LinqToDB.Interceptors;
 using LinqToDB.Mapping;
 using LinqToDB.Tools;
 using LinqToDB.Tools.Comparers;
 using NUnit.Framework;
+using Tests.Model;
 
 namespace Tests.Linq
 {
@@ -1636,6 +1638,142 @@ FROM
 			using var table = db.CreateLocalTable<Test3799Item>(Test3799Item.TestData);
 
 			var result = table.Select(Test3799ItemModel.Selector).ToList();
+		}
+		#endregion
+
+		#region Issue 4057
+		[Test]
+		public async Task Issue4057_Async([DataSources] string context)
+		{
+			DataOptions options;
+
+			await using (var db = GetDataContext(context))
+			{
+				options = db.Options;
+				await db.GetTable<Parent>()
+					.LoadWith(x => x.Children)
+					.FirstOrDefaultAsync(x => x.ParentID == 3);
+			}
+
+			await using (var db = new DataContext(options))
+			{
+				db.KeepConnectionAlive = true;
+
+				await db.GetTable<Parent>()
+					.LoadWith(x => x.Children)
+					.FirstOrDefaultAsync(x => x.ParentID == 3);
+			}
+
+			await using (var db = new DataContext(options))
+			{
+				db.KeepConnectionAlive = false;
+
+				await db.GetTable<Parent>()
+					.LoadWith(x => x.Children)
+					.FirstOrDefaultAsync(x => x.ParentID == 3);
+			}
+		}
+
+		[Test]
+		public void Issue4057_Sync([DataSources] string context)
+		{
+			DataOptions options;
+			using (var db = GetDataContext(context))
+			{
+				options = db.Options;
+
+				db.GetTable<Parent>()
+					.LoadWith(x => x.Children)
+					.FirstOrDefault(x => x.ParentID == 3);
+			}
+
+			using (var db = new DataContext(options))
+			{
+				db.KeepConnectionAlive = true;
+
+				db.GetTable<Parent>()
+					.LoadWith(x => x.Children)
+					.FirstOrDefault(x => x.ParentID == 3);
+			}
+
+			using (var db = new DataContext(options))
+			{
+				db.KeepConnectionAlive = false;
+
+				db.GetTable<Parent>()
+					.LoadWith(x => x.Children)
+					.FirstOrDefault(x => x.ParentID == 3);
+			}
+		}
+
+		[Test]
+		public async Task Issue4057_Async_ExplicitTransaction([DataSources] string context)
+		{
+			DataOptions options;
+
+			await using (var db = GetDataContext(context))
+			{
+				using var _ = db.BeginTransaction();
+				options = db.Options;
+				await db.GetTable<Parent>()
+					.LoadWith(x => x.Children)
+					.FirstOrDefaultAsync(x => x.ParentID == 3);
+			}
+
+			await using (var db = new DataContext(options))
+			{
+				db.KeepConnectionAlive = true;
+
+				using var _ = db.BeginTransaction();
+				await db.GetTable<Parent>()
+					.LoadWith(x => x.Children)
+					.FirstOrDefaultAsync(x => x.ParentID == 3);
+			}
+
+			await using (var db = new DataContext(options))
+			{
+				db.KeepConnectionAlive = false;
+
+				using var _ = db.BeginTransaction();
+				await db.GetTable<Parent>()
+					.LoadWith(x => x.Children)
+					.FirstOrDefaultAsync(x => x.ParentID == 3);
+			}
+		}
+
+		[Test]
+		public void Issue4057_Sync_ExplicitTransaction([DataSources] string context)
+		{
+			DataOptions options;
+			using (var db = GetDataContext(context))
+			{
+				options = db.Options;
+
+				using var _ = db.BeginTransaction();
+				db.GetTable<Parent>()
+					.LoadWith(x => x.Children)
+					.FirstOrDefault(x => x.ParentID == 3);
+			}
+
+			using (var db = new DataContext(options))
+			{
+				db.KeepConnectionAlive = true;
+
+				using var _ = db.BeginTransaction();
+				db.GetTable<Parent>()
+					.LoadWith(x => x.Children)
+					.FirstOrDefault(x => x.ParentID == 3);
+			}
+
+			using (var db = new DataContext(options))
+			{
+				db.KeepConnectionAlive = false;
+
+				using var _ = db.BeginTransaction();
+				db.GetTable<Parent>()
+					.LoadWith(x => x.Children)
+					.FirstOrDefault(x => x.ParentID == 3);
+			}
 		}
 		#endregion
 	}

--- a/Tests/Model/Extensions.cs
+++ b/Tests/Model/Extensions.cs
@@ -6,11 +6,9 @@ namespace Tests.Model
 	{
 		public static DataConnectionTransaction? BeginTransaction(this ITestDataContext context)
 		{
-			if (context is DataConnection)
-				return ((DataConnection)context).BeginTransaction();
-			//else if (context is ServiceModelDataContext)
-			//	((ServiceModelDataContext)context).BeginBatch();
-			return null;
+			return context is DataConnection dc
+				? dc.BeginTransaction()
+				: null;
 		}
 	}
 }

--- a/Tests/Model/Extensions.cs
+++ b/Tests/Model/Extensions.cs
@@ -4,12 +4,13 @@ namespace Tests.Model
 {
 	public static class Extensions
 	{
-		public static void BeginTransaction(this ITestDataContext context)
+		public static DataConnectionTransaction? BeginTransaction(this ITestDataContext context)
 		{
 			if (context is DataConnection)
-				((DataConnection)context).BeginTransaction();
+				return ((DataConnection)context).BeginTransaction();
 			//else if (context is ServiceModelDataContext)
 			//	((ServiceModelDataContext)context).BeginBatch();
+			return null;
 		}
 	}
 }


### PR DESCRIPTION
Fix #4057

There were at least two bugs:
- for async enumeration we were disposing connection before data reader (in sync code disposal were done in different place with correct order) which raised exception in SqlClient when it tried to execute `Rollback Transaction` command on connection with already open data reader
- transaction rollback is actually another bug, affecting also sync code: because we open eager load transaction not on `DataContext` but on underlying `DataConnection` - `DataContext` with `KeepConnectionAlive = false` option set (default) doesn't know anything about it and close underlying connection after first eager load query for async code or don't close it at all for sync code (that's why there were no exception for sync code)
- also there were small issues with missing delegate unsubscribe + improved some async code
- [UPDATE] another issue with DataContext: context-id generation was incorrect, leading to false cache hits

In general it is caused by:
1. lack of `DataContext` testing. In general we test only `DataConnection` and remote context
2. access to `DataConnection` functionality directly, ignoring `DataContext` needs
