### PR TITLE
Fix ClickHouse primary key SQL spacing

### DIFF
--- a/Source/LinqToDB/DataProvider/ClickHouse/ClickHouseSqlBuilder.cs
+++ b/Source/LinqToDB/DataProvider/ClickHouse/ClickHouseSqlBuilder.cs
@@ -220,7 +220,7 @@ namespace LinqToDB.DataProvider.ClickHouse
 		{
 			AppendIndent();
 
-			StringBuilder.Append(" PRIMARY KEY (");
+			StringBuilder.Append("PRIMARY KEY (");
 
 			var first = true;
 			foreach (var fieldName in fieldNames)


### PR DESCRIPTION
cherry-picked from https://github.com/linq2db/linq2db/pull/4049 as it creates a lot of noise in baselines, making it hard to review