### PR TITLE
Fix outer apply columns nullability tracking

### DIFF
--- a/Source/LinqToDB/Linq/Builder/FirstSingleBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/FirstSingleBuilder.cs
@@ -136,10 +136,13 @@ namespace LinqToDB.Linq.Builder
 
 		public sealed class FirstSingleContext : SequenceContextBase
 		{
+			private readonly bool _orDefault;
+
 			public FirstSingleContext(IBuildContext? parent, IBuildContext sequence, MethodCallExpression methodCall)
 				: base(parent, sequence, null)
 			{
 				_methodCall = methodCall;
+				_orDefault  = _methodCall.Method.Name.Contains("OrDefault");
 			}
 
 			readonly MethodCallExpression _methodCall;
@@ -330,7 +333,7 @@ namespace LinqToDB.Linq.Builder
 
 						Expression defaultValue;
 
-						if (_methodCall.Method.Name.EndsWith("OrDefault"))
+						if (_orDefault)
 							defaultValue = Expression.Constant(expr.Type.GetDefaultValue(), expr.Type);
 						else
 							defaultValue = Expression.Convert(
@@ -367,6 +370,24 @@ namespace LinqToDB.Linq.Builder
 				}
 
 				throw new NotImplementedException();
+			}
+
+			public override int ConvertToParentIndex(int index, IBuildContext context)
+			{
+				if (!_orDefault || Parent == null || SelectQuery.Select.Columns[index].CanBeNull)
+					return base.ConvertToParentIndex(index, context);
+
+				var column = SelectQuery.Select.Columns[index];
+
+				var idx = Parent.ConvertToParentIndex(index, context);
+
+				foreach (var col in Parent.SelectQuery.Select.Columns)
+				{
+					if (col.Expression == column)
+						col.Expression = new SqlExpression(col.SystemType, "{0}", column.Precedence, column) { CanBeNull = true };
+				}
+
+				return idx;
 			}
 
 			public override SqlInfo[] ConvertToSql(Expression? expression, int level, ConvertFlags flags)

--- a/Source/LinqToDB/Linq/Builder/FirstSingleBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/FirstSingleBuilder.cs
@@ -269,10 +269,7 @@ namespace LinqToDB.Linq.Builder
 					_checkNullIndex = q.DefaultIfEmpty(-1).First();
 
 					if (_checkNullIndex < 0)
-					{
-						_checkNullIndex = SelectQuery.Select.Add(new SqlValue(1));
-						SelectQuery.Select.Columns[_checkNullIndex].RawAlias = "is_empty";
-					}
+						_checkNullIndex = SelectQuery.Select.AddNew(new SqlValue(1), "is_empty");
 
 					_checkNullIndex = ConvertToParentIndex(_checkNullIndex, this);
 				}

--- a/Tests/Linq/UserTests/Issue4090Tests.cs
+++ b/Tests/Linq/UserTests/Issue4090Tests.cs
@@ -96,8 +96,9 @@ namespace Tests.UserTests
 			});
 			using var tbl3 = db.CreateLocalTable(new[]
 			{
-				new Table3 { Id3 = 101, ParentId3 = 11, Name3 = "Nested1" },
-				new Table3 { Id3 = 102, ParentId3 = 12, Name3 = "Nested2" },
+				new Table3 { Id3 = 21, ParentId3 = 11, Name3 = "Child21" },
+				new Table3 { Id3 = 22, ParentId3 = 11, Name3 = "Child22" },
+				new Table3 { Id3 = 23, ParentId3 = 12, Name3 = "Child23" },
 			});
 			var ret = db.GetTable<Table1>()
 				.Select(t1 => new
@@ -190,8 +191,9 @@ namespace Tests.UserTests
 			});
 			using var tbl3 = db.CreateLocalTable(new[]
 			{
-				new Table3 { Id3 = 101, ParentId3 = 11, Name3 = "Nested1" },
-				new Table3 { Id3 = 102, ParentId3 = 12, Name3 = "Nested2" },
+				new Table3 { Id3 = 21, ParentId3 = 11, Name3 = "Child21" },
+				new Table3 { Id3 = 22, ParentId3 = 11, Name3 = "Child22" },
+				new Table3 { Id3 = 23, ParentId3 = 12, Name3 = "Child23" },
 			});
 			var ret = db.GetTable<Table1>()
 				.Select(t1 => new

--- a/Tests/Linq/UserTests/Issue4090Tests.cs
+++ b/Tests/Linq/UserTests/Issue4090Tests.cs
@@ -1,0 +1,225 @@
+﻿using System;
+using System.Linq;
+using FluentAssertions;
+using LinqToDB;
+using LinqToDB.Data;
+using LinqToDB.Mapping;
+using NUnit.Framework;
+
+namespace Tests.UserTests
+{
+	[TestFixture]
+	public class Issue4090Tests : TestBase
+	{
+		[Table("TABLE1")]
+		public partial class Table1
+		{
+			[Column("ID1"), PrimaryKey, NotNull] public int Id1 { get; set; }
+			[Column("NAME1"), Nullable] public string? Name1 { get; set; }
+		}
+
+		[Table("TABLE2")]
+		public partial class Table2
+		{
+			[Column("ID2"), PrimaryKey, NotNull] public int Id2 { get; set; }
+			[Column("PARENTID2"), NotNull] public int ParentId2 { get; set; }
+			[Column("NAME2"), Nullable] public string? Name2 { get; set; }
+		}
+
+		[Table("TABLE3")]
+		public partial class Table3
+		{
+			[Column("ID3"), PrimaryKey, NotNull] public int Id3 { get; set; }
+			[Column("PARENTID3"), NotNull] public int ParentId3 { get; set; }
+			[Column("NAME3"), Nullable] public string? Name3 { get; set; }
+		}
+
+		[Test]
+		public void WithIdFirst_NoData([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
+		{
+			using var db = GetDataContext(context);
+			using var tbl1 = db.CreateLocalTable(new[]
+			{
+				new Table1 { Id1 = 1, Name1 = "Some1" },
+				new Table1 { Id1 = 2, Name1 = "Some2" },
+			});
+			using var tbl2 = db.CreateLocalTable(new[]
+			{
+				new Table2 { Id2 = 11, ParentId2 = 1, Name2 = "Child11" },
+				new Table2 { Id2 = 12, ParentId2 = 1, Name2 = "Child12" },
+				new Table2 { Id2 = 13, ParentId2 = 2, Name2 = "Child13" },
+			});
+			using var tbl3 = db.CreateLocalTable(Array.Empty<Table3>());
+			var ret = db.GetTable<Table1>()
+				.Select(t1 => new
+				{
+					Name1 = t1.Name1,
+					Value1 = db.GetTable<Table2>()
+						.Where(x => x.ParentId2 == t1.Id1)
+						.Select(t2 => new
+						{
+							//first cross apply
+							Id2 = t2.Id2,
+							Value2 = db.GetTable<Table3>()
+								.Where(x => x.ParentId3 == t2.Id2)
+								.Select(t3 => new
+								{
+									//nested cross apply
+									Name3 = t3.Name3,
+									Value3 = t3.Id3
+								})
+								.FirstOrDefault(),
+							Name2 = t2.Name2
+						})
+						.FirstOrDefault()
+				})
+				.ToList();
+			Assert.That(ret.Count, Is.EqualTo(2));
+			Assert.That(ret[0].Value1, Is.Not.Null);
+			Assert.That(ret[0].Value1!.Value2, Is.Null);
+		}
+
+		[Test]
+		public void WithIdFirst_WithData([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
+		{
+			using var db = GetDataContext(context);
+			using var tbl1 = db.CreateLocalTable(new[]
+			{
+				new Table1 { Id1 = 1, Name1 = "Some1" },
+				new Table1 { Id1 = 2, Name1 = "Some2" },
+			});
+			using var tbl2 = db.CreateLocalTable(new[]
+			{
+				new Table2 { Id2 = 11, ParentId2 = 1, Name2 = "Child11" },
+				new Table2 { Id2 = 12, ParentId2 = 1, Name2 = "Child12" },
+				new Table2 { Id2 = 13, ParentId2 = 2, Name2 = "Child13" },
+			});
+			using var tbl3 = db.CreateLocalTable(new[]
+			{
+				new Table3 { Id3 = 101, ParentId3 = 11, Name3 = "Nested1" },
+				new Table3 { Id3 = 102, ParentId3 = 12, Name3 = "Nested2" },
+			});
+			var ret = db.GetTable<Table1>()
+				.Select(t1 => new
+				{
+					Name1 = t1.Name1,
+					Value1 = db.GetTable<Table2>()
+						.Where(x => x.ParentId2 == t1.Id1)
+						.Select(t2 => new
+						{
+							//first cross apply
+							Id2 = t2.Id2,
+							Value2 = db.GetTable<Table3>()
+								.Where(x => x.ParentId3 == t2.Id2)
+								.Select(t3 => new
+								{
+									//nested cross apply
+									Name3 = t3.Name3,
+									Value3 = t3.Id3
+								})
+								.FirstOrDefault(),
+							Name2 = t2.Name2
+						})
+						.FirstOrDefault()
+				})
+				.ToList();
+			Assert.That(ret.Count, Is.EqualTo(2));
+			Assert.That(ret[0].Value1, Is.Not.Null);
+			Assert.That(ret[0].Value1!.Value2, Is.Not.Null);
+		}
+
+		[Test]
+		public void WithIdAfter_NoData([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
+		{
+			using var db = GetDataContext(context);
+			using var tbl1 = db.CreateLocalTable(new[]
+			{
+				new Table1 { Id1 = 1, Name1 = "Some1" },
+				new Table1 { Id1 = 2, Name1 = "Some2" },
+			});
+			using var tbl2 = db.CreateLocalTable(new[]
+			{
+				new Table2 { Id2 = 11, ParentId2 = 1, Name2 = "Child11" },
+				new Table2 { Id2 = 12, ParentId2 = 1, Name2 = "Child12" },
+				new Table2 { Id2 = 13, ParentId2 = 2, Name2 = "Child13" },
+			});
+			using var tbl3 = db.CreateLocalTable(Array.Empty<Table3>());
+			var ret = db.GetTable<Table1>()
+				.Select(t1 => new
+				{
+					Name1 = t1.Name1,
+					Value1 = db.GetTable<Table2>()
+						.Where(x => x.ParentId2 == t1.Id1)
+						.Select(t2 => new
+						{
+							//first cross apply
+							Value2 = db.GetTable<Table3>()
+								.Where(x => x.ParentId3 == t2.Id2)
+								.Select(t3 => new
+								{
+									//nested cross apply
+									Name3 = t3.Name3,
+									Value3 = t3.Id3
+								})
+								.FirstOrDefault(),
+							Id2 = t2.Id2,
+							Name2 = t2.Name2
+						})
+						.FirstOrDefault()
+				})
+				.ToList();
+			Assert.That(ret.Count, Is.EqualTo(2));
+			Assert.That(ret[0].Value1, Is.Not.Null);
+			Assert.That(ret[0].Value1!.Value2, Is.Null);
+		}
+
+		[Test]
+		public void WithIdAfter_WithData([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
+		{
+			using var db = GetDataContext(context);
+			using var tbl1 = db.CreateLocalTable(new[]
+			{
+				new Table1 { Id1 = 1, Name1 = "Some1" },
+				new Table1 { Id1 = 2, Name1 = "Some2" },
+			});
+			using var tbl2 = db.CreateLocalTable(new[]
+			{
+				new Table2 { Id2 = 11, ParentId2 = 1, Name2 = "Child11" },
+				new Table2 { Id2 = 12, ParentId2 = 1, Name2 = "Child12" },
+				new Table2 { Id2 = 13, ParentId2 = 2, Name2 = "Child13" },
+			});
+			using var tbl3 = db.CreateLocalTable(new[]
+			{
+				new Table3 { Id3 = 101, ParentId3 = 11, Name3 = "Nested1" },
+				new Table3 { Id3 = 102, ParentId3 = 12, Name3 = "Nested2" },
+			});
+			var ret = db.GetTable<Table1>()
+				.Select(t1 => new
+				{
+					Name1 = t1.Name1,
+					Value1 = db.GetTable<Table2>()
+						.Where(x => x.ParentId2 == t1.Id1)
+						.Select(t2 => new
+						{
+							//first cross apply
+							Value2 = db.GetTable<Table3>()
+								.Where(x => x.ParentId3 == t2.Id2)
+								.Select(t3 => new
+								{
+									//nested cross apply
+									Name3 = t3.Name3,
+									Value3 = t3.Id3
+								})
+								.FirstOrDefault(),
+							Id2 = t2.Id2,
+							Name2 = t2.Name2
+						})
+						.FirstOrDefault()
+				})
+				.ToList();
+			Assert.That(ret.Count, Is.EqualTo(2));
+			Assert.That(ret[0].Value1, Is.Not.Null);
+			Assert.That(ret[0].Value1!.Value2, Is.Not.Null);
+		}
+	}
+}

--- a/Tests/Linq/UserTests/Issue4090Tests.cs
+++ b/Tests/Linq/UserTests/Issue4090Tests.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Linq;
+
 using FluentAssertions;
+
 using LinqToDB;
-using LinqToDB.Data;
 using LinqToDB.Mapping;
+
 using NUnit.Framework;
 
 namespace Tests.UserTests


### PR DESCRIPTION
Fix #4090 

The queries here were mostly copied from the tests for #3462 and although are not quite the same as in #4090, effectively demonstrate the bug.  Note that only when the nested OUTER APPLY has no data does the bug manifest itself, and only depending on the order of the columns selected.