### PR TITLE
Restore handling behavior of same-name properties/fields for entities with interfaces

### DIFF
--- a/Source/LinqToDB/Reflection/TypeAccessorT.cs
+++ b/Source/LinqToDB/Reflection/TypeAccessorT.cs
@@ -112,16 +112,18 @@ namespace LinqToDB.Reflection
 					implementor = implementor.BaseType;
 				}
 
+				var uniqueNames = new HashSet<string>();
 				foreach (var mi in type.GetPublicInstanceValueMembers())
 				{
 					if (mi is PropertyInfo pi && interfaceProperties.TryGetValue((pi.DeclaringType, pi.Name, pi.PropertyType), out var idx))
 						interfacePropertiesList[idx] = null;
 
-					_members.Add(mi);
+					if (uniqueNames.Add(mi.Name))
+						_members.Add(mi);
 				}
 
 				foreach (var pi in interfacePropertiesList)
-					if (pi != null)
+					if (pi != null && uniqueNames.Add(pi.Name))
 						_members.Add(pi);
 			}
 

--- a/Tests/Linq/Linq/InterfaceTests.cs
+++ b/Tests/Linq/Linq/InterfaceTests.cs
@@ -149,7 +149,9 @@ namespace Tests.Linq
 			Issue4031_Execute<Issue4031Case03>(context);
 		}
 
-		// unsuported case: two properties with same name (Id), which requires heavy EntityDescriptor refactoring (at least)
+		// unsuported case:
+		// we prefer member declared with "new" over interface implementation member for backward compatibility
+		// (see https://github.com/linq2db/linq2db/issues/4113)
 		[Test, ActiveIssue]
 		public void Issue4031_Case04([IncludeDataSources(ProviderName.SQLiteClassic)] string context)
 		{

--- a/Tests/Linq/Linq/MappingTests.cs
+++ b/Tests/Linq/Linq/MappingTests.cs
@@ -632,6 +632,114 @@ namespace Tests.Linq
 			}
 		}
 
-#endregion
+		#endregion
+
+		#region Issue 4113
+		public interface IInterface1
+		{
+		}
+
+		public interface IInterface2
+		{
+			Guid Id { get; set; }
+		}
+
+		public interface IInterface3
+		{
+			int Id { get; set; }
+		}
+
+		[Table("Person")]
+		public abstract class BaseModel1
+		{
+			[Column("UNKNOWN")] public virtual Guid Id { get; set; }
+		}
+
+		[Table("Person")]
+		public abstract class BaseModel2: IInterface2
+		{
+			[Column("UNKNOWN")] public virtual Guid Id { get; set; }
+		}
+
+		public sealed class NewModel1 : BaseModel1
+		{
+			[Column("PersonID")] public new int Id { get; set; }
+		}
+
+		public sealed class NewModel2 : BaseModel1, IInterface1
+		{
+			[Column("PersonID")] public new int Id { get; set; }
+		}
+
+		public sealed class NewModel3 : BaseModel2
+		{
+			[Column("PersonID")] public new int Id { get; set; }
+		}
+
+		public sealed class NewModel4 : BaseModel1, IInterface3
+		{
+			[Column("PersonID")] public new int Id { get; set; }
+		}
+
+		public sealed class NewModel5 : BaseModel2, IInterface3
+		{
+			[Column("PersonID")] public new int Id { get; set; }
+		}
+
+		[Test]
+		public void ColumnReplacedWithNew1([IncludeDataSources(true, ProviderName.SQLiteClassic)] string context)
+		{
+			using var db = GetDataContext(context);
+			db.GetTable<NewModel1>().Where(c => c.Id == -1).ToList();
+
+			var ed = db.MappingSchema.GetEntityDescriptor(typeof(NewModel1));
+			Assert.AreEqual(1, ed.Columns.Count);
+			Assert.AreEqual("PersonID", ed.Columns[0].ColumnName);
+		}
+
+		[Test]
+		public void ColumnReplacedWithNew2([IncludeDataSources(true, ProviderName.SQLiteClassic)] string context)
+		{
+			using var db = GetDataContext(context);
+			db.GetTable<NewModel2>().Where(c => c.Id == -1).ToList();
+
+			var ed = db.MappingSchema.GetEntityDescriptor(typeof(NewModel2));
+			Assert.AreEqual(1, ed.Columns.Count);
+			Assert.AreEqual("PersonID", ed.Columns[0].ColumnName);
+		}
+
+		[Test]
+		public void ColumnReplacedWithNew3([IncludeDataSources(true, ProviderName.SQLiteClassic)] string context)
+		{
+			using var db = GetDataContext(context);
+			db.GetTable<NewModel3>().Where(c => c.Id == -1).ToList();
+
+			var ed = db.MappingSchema.GetEntityDescriptor(typeof(NewModel3));
+			Assert.AreEqual(1, ed.Columns.Count);
+			Assert.AreEqual("PersonID", ed.Columns[0].ColumnName);
+		}
+
+		[Test]
+		public void ColumnReplacedWithNew4([IncludeDataSources(true, ProviderName.SQLiteClassic)] string context)
+		{
+			using var db = GetDataContext(context);
+			db.GetTable<NewModel4>().Where(c => c.Id == -1).ToList();
+
+			var ed = db.MappingSchema.GetEntityDescriptor(typeof(NewModel4));
+			Assert.AreEqual(1, ed.Columns.Count);
+			Assert.AreEqual("PersonID", ed.Columns[0].ColumnName);
+		}
+
+		[Test]
+		public void ColumnReplacedWithNew5([IncludeDataSources(true, ProviderName.SQLiteClassic)] string context)
+		{
+			using var db = GetDataContext(context);
+			db.GetTable<NewModel5>().Where(c => c.Id == -1).ToList();
+
+			var ed = db.MappingSchema.GetEntityDescriptor(typeof(NewModel5));
+			Assert.AreEqual(1, ed.Columns.Count);
+			Assert.AreEqual("PersonID", ed.Columns[0].ColumnName);
+		}
+		#endregion
 	}
 }


### PR DESCRIPTION
Fix #4113

