### PR TITLE
map mariadb provider name to mysqlconnector provider

### DIFF
--- a/Source/LinqToDB/DataProvider/MySql/MySqlTools.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlTools.cs
@@ -24,6 +24,7 @@ namespace LinqToDB.DataProvider.MySql
 			{
 				case ProviderName.MySqlOfficial                :
 				case MySqlProviderAdapter.MySqlDataAssemblyName: return _mySqlDataProvider.Value;
+				case ProviderName.MariaDB                      :
 				case ProviderName.MySqlConnector               : return _mySqlConnectorDataProvider.Value;
 
 				case ""                         :


### PR DESCRIPTION
Fix #4124

Since MySQL.Data doesn't support modern versions of MariaDB, we can map it to MySqlConnector directly