### PR TITLE
Optimized ConvertExpressionImpl method

### DIFF
--- a/Source/LinqToDB/DataProvider/Oracle/Oracle11SqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/Oracle11SqlOptimizer.cs
@@ -146,7 +146,10 @@ namespace LinqToDB.DataProvider.Oracle
 				{
 					case "Coalesce":
 					{
-						return ConvertCoalesceToBinaryFunc(func, "Nvl");
+						if (func.Parameters.Length == 2)
+							return ConvertCoalesceToBinaryFunc(func, "Nvl");
+							
+						return func;
 					}
 					case "Convert"        :
 					{


### PR DESCRIPTION
Fix #3273

Optimized ConvertExpressionImpl method to use nvl function for coalesce expressions with two parameters.