### PR TITLE
Fix MergeWithOutputInto with conditional in output expression

### DIFF
--- a/Source/LinqToDB/Linq/Builder/SingleExpressionContext.cs
+++ b/Source/LinqToDB/Linq/Builder/SingleExpressionContext.cs
@@ -61,17 +61,9 @@ namespace LinqToDB.Linq.Builder
 
 		public IsExpressionResult IsExpression(Expression? expression, int level, RequestFor requestFlag)
 		{
-			if (requestFlag != RequestFor.Field)
+			if (requestFlag != RequestFor.Field || expression == null)
 			{
 				return IsExpressionResult.False;
-			}
-
-			if (expression != null)
-			{
-				if (expression is ParameterExpression)
-				{
-					throw new NotImplementedException();
-				}
 			}
 
 			throw new NotImplementedException();

--- a/Tests/Linq/Update/MergeTests.WithOutput.cs
+++ b/Tests/Linq/Update/MergeTests.WithOutput.cs
@@ -339,6 +339,47 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
+		public void MergeWithOutputConditionalInto([IncludeDataSources(false, TestProvName.AllSqlServer2008Plus)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var temp = db.CreateTempTable<InsertTempTable>("#InsertTempTable");
+
+				PrepareData(db);
+
+				var table = GetTarget(db);
+
+				var affected = table
+					.Merge()
+					.Using(GetSource1(db).Where(_ => _.Id == 5))
+					.OnTargetKey()
+					.InsertWhenNotMatched()
+					.MergeWithOutputInto(temp,
+						(a, deleted, inserted, source) => new ()
+						{
+							Action    = a == "DELETE" ? "Row Deleted" : a == "INSERT" ? "Row Inserted" : "Row Updated",
+							NewId     = inserted.Id,
+							DeletedId = deleted.Id,
+							SourceId  = source.Id + 1
+						}
+					);
+
+				affected.Should().Be(1);
+
+				var result = temp.ToArray();
+
+				result.Should().HaveCount(1);
+
+				var record = result[0];
+
+				record.Action.   Should().Be("Row Inserted");
+				record.NewId.    Should().Be(5);
+				record.DeletedId.Should().BeNull();
+				record.SourceId. Should().Be(6);
+			}
+		}
+
+		[Test]
 		public void MergeWithOutputIntoTempTable([IncludeDataSources(false, TestProvName.AllSqlServer2008Plus)] string context)
 		{
 			using (var db = GetDataContext(context))


### PR DESCRIPTION
This makes the test included in the commit work instead of throwing a NotImplementedException.

I had a hard time figuring out what IsExpression is actually supposed to do. It asks whether an expression is an expression (?), and the comments are less than helpful. It's something about whether the (linq) expression can be turned into a valid SQL expression in the current context? - but then what does it mean when expression is null?

I figured the worst that can happen is that incorrect sql is produced now where it previously crashed with NotImplementedException. It at least makes this case work, and can't affect anything that didn't crash before.