### PR TITLE
mariadb.cmd simplify initialization

### DIFF
--- a/Data/Setup Scripts/mariadb.cmd
+++ b/Data/Setup Scripts/mariadb.cmd
@@ -6,10 +6,6 @@ docker rm -f mariadb
 
 REM use pull to get latest layers (run will use cached layers)
 docker pull mariadb:latest
-docker run -d --name mariadb -e MYSQL_ROOT_PASSWORD=root -p 3316:3306 mariadb:latest
+docker run -d --name mariadb -e MARIADB_ROOT_PASSWORD=root -e MARIADB_DATABSE=testdata -p 3316:3306 mariadb:latest
 
 call wait-err mariadb "3306  mariadb.org"
-
-REM create test database
-docker exec mariadb mariadb -e "CREATE DATABASE testdata DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;" -uroot -proot
-


### PR DESCRIPTION
Use MARIADB env names.

Created database has the right charset/collation by default.

test:
```
$ podman run --name mariadb -e MARIADB_ROOT_PASSWORD=root --env MARIADB_DATABASE=testdata -p 3316:3306 mariadb:latest
..
$ podman exec mariadb mariadb -proot  -e 'show create database testdata'
Database	Create Database
testdata	CREATE DATABASE `testdata` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci */
```