### PR TITLE
Fix table attributes ignored for output table when using MergeWithOutputInto

### DIFF
--- a/Source/LinqToDB/LinqExtensions.Merge.cs
+++ b/Source/LinqToDB/LinqExtensions.Merge.cs
@@ -1099,7 +1099,7 @@ namespace LinqToDB
 					null,
 					Methods.LinqToDB.Merge.MergeWithOutputInto.MakeGenericMethod(typeof(TTarget), typeof(TSource), typeof(TOutput)),
 					currentQuery.Expression,
-					Expression.Constant(outputTable),
+					((IQueryable<TOutput>)outputTable).Expression,
 					Expression.Quote(outputExpression)
 				)
 			);
@@ -1141,7 +1141,7 @@ namespace LinqToDB
 					null,
 					MergeWithOutputIntoSource.MakeGenericMethod(typeof(TTarget), typeof(TSource), typeof(TOutput)),
 					currentQuery.Expression,
-					Expression.Constant(outputTable),
+					((IQueryable<TOutput>)outputTable).Expression,
 					Expression.Quote(outputExpression)
 				)
 			);
@@ -1184,7 +1184,7 @@ namespace LinqToDB
 				null,
 				Methods.LinqToDB.Merge.MergeWithOutputInto.MakeGenericMethod(typeof(TTarget), typeof(TSource), typeof(TOutput)),
 				currentQuery.Expression,
-				Expression.Constant(outputTable),
+				((IQueryable<TOutput>)outputTable).Expression,
 				Expression.Quote(outputExpression)
 			);
 
@@ -1231,7 +1231,7 @@ namespace LinqToDB
 				null,
 				MergeWithOutputIntoSource.MakeGenericMethod(typeof(TTarget), typeof(TSource), typeof(TOutput)),
 				currentQuery.Expression,
-				Expression.Constant(outputTable),
+				((IQueryable<TOutput>)outputTable).Expression,
 				Expression.Quote(outputExpression)
 			);
 

--- a/Tests/Linq/Update/DeleteWithOutputTests.cs
+++ b/Tests/Linq/Update/DeleteWithOutputTests.cs
@@ -500,5 +500,135 @@ namespace Tests.xUpdate
 				target.ToArray(),
 				ComparerBuilder.GetEqualityComparer<DestinationTable>());
 		}
+
+		[Test]
+		public void DeleteWithOutputIntoTempTableProjByTableName([IncludeDataSources(FeatureDeleteOutputInto)] string context)
+		{
+			var sourceData    = GetSourceData();
+			using var db     = GetDataContext(context);
+			using var source = db.CreateLocalTable("TableWithData_source", sourceData);
+			using var target = db.CreateTempTable<DestinationTable>("DestinationTable_target");
+			var targetRef = db.GetTable<DestinationTable>()
+				.TableOptions(TableOptions.IsTemporary)
+				.TableName(target.TableName);
+
+			var expected = source
+				.Where(s => s.Id > 3)
+				.ToArray();
+
+			var param = 100500;
+			var output = source
+				.Where(s => s.Id > 3)
+				.DeleteWithOutputInto(
+					targetRef,
+					s => new DestinationTable()
+					{
+						Id       = s.Id       + param,
+						Value    = s.Value    + param,
+						ValueStr = s.ValueStr + param
+					});
+
+			AreEqual(
+				expected
+					.Select(s => new DestinationTable()
+					{
+						Id       = s.Id       + param,
+						Value    = s.Value    + param,
+						ValueStr = s.ValueStr + param,
+					}),
+				target.ToArray(),
+				ComparerBuilder.GetEqualityComparer<DestinationTable>());
+		}
+
+		[Test]
+		public async Task DeleteWithOutputIntoTempTableProjByTableNameAsync([IncludeDataSources(FeatureDeleteOutputInto)] string context)
+		{
+			var sourceData    = GetSourceData();
+			using var db     = GetDataContext(context);
+			using var source = db.CreateLocalTable("TableWithData_source", sourceData);
+			using var target = db.CreateTempTable<DestinationTable>("DestinationTable_target");
+			var targetRef = db.GetTable<DestinationTable>()
+				.TableOptions(TableOptions.IsTemporary)
+				.TableName(target.TableName);
+
+			var expected = source
+				.Where(s => s.Id > 3)
+				.ToArray();
+
+			var param = 100500;
+			var output = await source
+				.Where(s => s.Id > 3)
+				.DeleteWithOutputIntoAsync(
+					targetRef,
+					s => new DestinationTable()
+					{
+						Id       = s.Id       + param,
+						Value    = s.Value    + param,
+						ValueStr = s.ValueStr + param
+					});
+
+			AreEqual(
+				expected
+					.Select(s => new DestinationTable()
+					{
+						Id       = s.Id       + param,
+						Value    = s.Value    + param,
+						ValueStr = s.ValueStr + param,
+					}),
+				target.ToArray(),
+				ComparerBuilder.GetEqualityComparer<DestinationTable>());
+		}
+
+		[Test]
+		public void DeleteWithOutputIntoTempTableByTableName([IncludeDataSources(FeatureDeleteOutputInto)] string context)
+		{
+			var sourceData    = GetSourceData();
+			using var db     = GetDataContext(context);
+			using var source = db.CreateLocalTable("TableWithData_source", sourceData);
+			using var target = db.CreateTempTable<TableWithData>("TableWithData_target");
+			var targetRef = db.GetTable<TableWithData>()
+				.TableOptions(TableOptions.IsTemporary)
+				.TableName(target.TableName);
+
+			var expected = source
+				.Where(s => s.Id > 3)
+				.ToArray();
+
+			var output = source
+				.Where(s => s.Id > 3)
+				.DeleteWithOutputInto(
+					targetRef);
+
+			AreEqual(
+				expected,
+				target.ToArray(),
+				ComparerBuilder.GetEqualityComparer<TableWithData>());
+		}
+
+		[Test]
+		public async Task DeleteWithOutputIntoTempTableByTableNameAsync([IncludeDataSources(FeatureDeleteOutputInto)] string context)
+		{
+			var sourceData    = GetSourceData();
+			using var db     = GetDataContext(context);
+			using var source = db.CreateLocalTable("TableWithData_source", sourceData);
+			using var target = db.CreateTempTable<TableWithData>("TableWithData_target");
+			var targetRef = db.GetTable<TableWithData>()
+				.TableOptions(TableOptions.IsTemporary)
+				.TableName(target.TableName);
+
+			var expected = source
+				.Where(s => s.Id > 3)
+				.ToArray();
+
+			var output = await source
+				.Where(s => s.Id > 3)
+				.DeleteWithOutputIntoAsync(
+					targetRef);
+
+			AreEqual(
+				expected,
+				target.ToArray(),
+				ComparerBuilder.GetEqualityComparer<TableWithData>());
+		}
 	}
 }

--- a/Tests/Linq/Update/InsertWithOutputTests.cs
+++ b/Tests/Linq/Update/InsertWithOutputTests.cs
@@ -780,6 +780,446 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
+		public void InsertWithSetterWithOutputIntoTempTableByTableName([IncludeDataSources(FeatureInsertOutputInto)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				const int idsLimit = 1000;
+
+				try
+				{
+					var id = idsLimit + 1;
+
+					db.Child.Delete(c => c.ChildID > idsLimit);
+
+					var param = 10050;
+					using var t = db.CreateTempTable<Child>("TInserted");
+					var tRef = db.GetTable<Child>()
+						.TableOptions(TableOptions.IsTemporary)
+						.TableName(t.TableName);
+					var output =
+						db.Child
+							.Where(c => c.ChildID == 11)
+							.InsertWithOutputInto(
+								db.Child,
+								c => new Child()
+								{
+									ParentID = c.ParentID,
+									ChildID  = id + Sql.AsSql(param)
+								},
+								tRef);
+
+					Assert.AreEqual(1, output);
+
+					AreEqual(db.Child.Where(c => c.ChildID > idsLimit)
+						.Select(
+						c => new Child()
+						{
+							ParentID = c.ParentID,
+							ChildID  = c.ChildID
+						}),
+						t.Select(c => new Child()
+						{
+							ParentID = c.ParentID,
+							ChildID  = c.ChildID
+						}
+						)
+					);
+				}
+				finally
+				{
+					db.Child.Delete(c => c.ChildID > idsLimit);
+				}
+			}
+		}
+		
+		[Test]
+		public async Task InsertWithSetterWithOutputIntoTempTableByTableNameAsync([IncludeDataSources(FeatureInsertOutputInto)] string context)
+		{
+			using var db = GetDataContext(context);
+			const int idsLimit = 1000;
+
+			try
+			{
+				var id = idsLimit + 1;
+
+				db.Child.Delete(c => c.ChildID > idsLimit);
+
+				var param = 10050;
+				using var t = db.CreateTempTable<Child>("TInserted");
+				var tRef = db.GetTable<Child>()
+					.TableOptions(TableOptions.IsTemporary)
+					.TableName(t.TableName);
+				var output = await
+					db.Child
+						.Where(c => c.ChildID == 11)
+						.InsertWithOutputIntoAsync(
+							db.Child,
+							c => new Child()
+							{
+								ParentID = c.ParentID,
+								ChildID  = id + Sql.AsSql(param)
+							},
+							tRef);
+
+				Assert.AreEqual(1, output);
+
+				AreEqual(db.Child.Where(c => c.ChildID > idsLimit)
+					.Select(
+					c => new Child()
+					{
+						ParentID = c.ParentID,
+						ChildID  = c.ChildID
+					}),
+					t.Select(c => new Child()
+					{
+						ParentID = c.ParentID,
+						ChildID  = c.ChildID
+					}
+					)
+				);
+			}
+			finally
+			{
+				db.Child.Delete(c => c.ChildID > idsLimit);
+			}
+		}
+
+		[Test]
+		public void InsertSingleRowOutputIntoTempTableByTableName([IncludeDataSources(FeatureInsertOutputInto)] string context)
+		{
+			using var db     = GetDataContext(context);
+			using var source = db.CreateLocalTable<TableWithData>("TableWithData_source");
+			using var output = db.CreateTempTable<TableWithData>("TableWithData_output");
+			var outputRef = db.GetTable<TableWithData>()
+				.TableOptions(TableOptions.IsTemporary)
+				.TableName(output.TableName);
+
+			Expression<Func<TableWithData>> setter = () => new TableWithData
+			{
+				Value    = 42123,
+				Id       = 42,
+				ValueStr = "SomeStr"
+			};
+
+			var rowCount = source.InsertWithOutputInto(setter, outputRef);
+			Assert.AreEqual(1, rowCount);
+
+			var sourceData = source.ToArray();
+			Assert.AreEqual(1, sourceData.Length);
+			Assert.AreEqual(42, sourceData[0].Id);
+			Assert.AreEqual(42123, sourceData[0].Value);
+			Assert.AreEqual("SomeStr", sourceData[0].ValueStr);
+
+			var outputData = output.ToArray();
+			Assert.AreEqual(1, outputData.Length);
+			Assert.AreEqual(42, outputData[0].Id);
+			Assert.AreEqual(42123, outputData[0].Value);
+			Assert.AreEqual("SomeStr", outputData[0].ValueStr);
+		}
+		
+		[Test]
+		public async Task InsertSingleRowOutputIntoTempTableByTableNameAsync([IncludeDataSources(FeatureInsertOutputInto)] string context)
+		{
+			using var db     = GetDataContext(context);
+			using var source = db.CreateLocalTable<TableWithData>("TableWithData_source");
+			using var output = db.CreateTempTable<TableWithData>("TableWithData_output");
+			var outputRef = db.GetTable<TableWithData>()
+				.TableOptions(TableOptions.IsTemporary)
+				.TableName(output.TableName);
+
+			Expression<Func<TableWithData>> setter = () => new TableWithData
+			{
+				Value    = 42123,
+				Id       = 42,
+				ValueStr = "SomeStr"
+			};
+
+			var rowCount = await source.InsertWithOutputIntoAsync(setter, outputRef);
+			Assert.AreEqual(1, rowCount);
+
+			var sourceData = source.ToArray();
+			Assert.AreEqual(1, sourceData.Length);
+			Assert.AreEqual(42, sourceData[0].Id);
+			Assert.AreEqual(42123, sourceData[0].Value);
+			Assert.AreEqual("SomeStr", sourceData[0].ValueStr);
+
+			var outputData = output.ToArray();
+			Assert.AreEqual(1, outputData.Length);
+			Assert.AreEqual(42, outputData[0].Id);
+			Assert.AreEqual(42123, outputData[0].Value);
+			Assert.AreEqual("SomeStr", outputData[0].ValueStr);
+		}
+
+		[Test]
+		public void InsertSingleRowOutputIntoProjTempTableByTableName([IncludeDataSources(FeatureInsertOutputInto)] string context)
+		{
+			using var db     = GetDataContext(context);
+			using var source = db.CreateLocalTable<TableWithData>("TableWithData_source");
+			using var output = db.CreateTempTable<DestinationTable>("DestinationTable_output");
+			var outputRef = db.GetTable<DestinationTable>()
+				.TableOptions(TableOptions.IsTemporary)
+				.TableName(output.TableName);
+
+			Expression<Func<TableWithData>> setter = () => new TableWithData
+			{
+				Value    = 42123,
+				Id       = 42,
+				ValueStr = "SomeStr"
+			};
+
+			var rowCount = source.InsertWithOutputInto(setter, outputRef, v => new DestinationTable
+			{
+				Value = v.Value * 2,
+				Id = v.Id + 1,
+				ValueStr = "Foo" + v.ValueStr
+			});
+			Assert.AreEqual(1, rowCount);
+
+			var sourceData = source.ToArray();
+			Assert.AreEqual(1, sourceData.Length);
+			Assert.AreEqual(42, sourceData[0].Id);
+			Assert.AreEqual(42123, sourceData[0].Value);
+			Assert.AreEqual("SomeStr", sourceData[0].ValueStr);
+
+			var outputData = output.ToArray();
+			Assert.AreEqual(1, outputData.Length);
+			Assert.AreEqual(43, outputData[0].Id);
+			Assert.AreEqual(84246, outputData[0].Value);
+			Assert.AreEqual("FooSomeStr", outputData[0].ValueStr);
+		}
+
+		[Test]
+		public async Task InsertSingleRowOutputIntoProjTempTableByTableNameAsync([IncludeDataSources(FeatureInsertOutputInto)] string context)
+		{
+			using var db     = GetDataContext(context);
+			using var source = db.CreateLocalTable<TableWithData>("TableWithData_source");
+			using var output = db.CreateTempTable<DestinationTable>("DestinationTable_output");
+			var outputRef = db.GetTable<DestinationTable>()
+				.TableOptions(TableOptions.IsTemporary)
+				.TableName(output.TableName);
+
+			Expression<Func<TableWithData>> setter = () => new TableWithData
+			{
+				Value    = 42123,
+				Id       = 42,
+				ValueStr = "SomeStr"
+			};
+
+			var rowCount = await source.InsertWithOutputIntoAsync(setter, outputRef, v => new DestinationTable
+			{
+				Value = v.Value * 2,
+				Id = v.Id + 1,
+				ValueStr = "Foo" + v.ValueStr
+			});
+			Assert.AreEqual(1, rowCount);
+
+			var sourceData = source.ToArray();
+			Assert.AreEqual(1, sourceData.Length);
+			Assert.AreEqual(42, sourceData[0].Id);
+			Assert.AreEqual(42123, sourceData[0].Value);
+			Assert.AreEqual("SomeStr", sourceData[0].ValueStr);
+
+			var outputData = output.ToArray();
+			Assert.AreEqual(1, outputData.Length);
+			Assert.AreEqual(43, outputData[0].Id);
+			Assert.AreEqual(84246, outputData[0].Value);
+			Assert.AreEqual("FooSomeStr", outputData[0].ValueStr);
+		}
+
+		[Test]
+		public void InsertWithSetterWithOutputIntoProjTempTableByTableName([IncludeDataSources(FeatureInsertOutputInto)] string context)
+		{
+			using var db = GetDataContext(context);
+			const int idsLimit = 1000;
+			const int param = 4242;
+
+			try
+			{
+				var id = idsLimit + 1;
+
+				db.Child.Delete(c => c.ChildID > idsLimit);
+
+				using var t = db.CreateTempTable<Child>("TInserted");
+				var tRef = db.GetTable<Child>()
+					.TableOptions(TableOptions.IsTemporary)
+					.TableName(t.TableName);
+
+				var output =
+					db.Child
+						.Where(c => c.ChildID == 11)
+						.InsertWithOutputInto(db.Child, c => new Child
+							{
+								ParentID = c.ParentID,
+								ChildID  = id
+							},
+							tRef,
+							inserted =>
+								new Child
+								{
+									ChildID  = inserted.ChildID,
+									ParentID = inserted.ParentID + param
+								}
+						);
+
+				Assert.AreEqual(1, output);
+
+				AreEqual(db.Child.Where(c => c.ChildID > idsLimit).Select(c => new Child
+					{
+						ParentID = c.ParentID,
+						ChildID = c.ChildID
+					}),
+					t.Select(c => new Child
+					{
+						ParentID = c.ParentID - param,
+						ChildID = c.ChildID
+					}
+					)
+				);
+
+			}
+			finally
+			{
+				db.Child.Delete(c => c.ChildID > idsLimit);
+			}
+		}
+
+		[Test]
+		public async Task InsertWithSetterWithOutputIntoProjTempTableByTableNameAsync([IncludeDataSources(FeatureInsertOutputInto)] string context)
+		{
+			using var db = GetDataContext(context);
+			const int idsLimit = 1000;
+			const int param = 4242;
+
+			try
+			{
+				var id = idsLimit + 1;
+
+				db.Child.Delete(c => c.ChildID > idsLimit);
+
+				using var t = db.CreateTempTable<Child>("TInserted");
+				var tRef = db.GetTable<Child>()
+					.TableOptions(TableOptions.IsTemporary)
+					.TableName(t.TableName);
+
+				var output = await
+					db.Child
+						.Where(c => c.ChildID == 11)
+						.InsertWithOutputIntoAsync(db.Child, c => new Child
+							{
+								ParentID = c.ParentID,
+								ChildID  = id
+							},
+							tRef,
+							inserted =>
+								new Child
+								{
+									ChildID  = inserted.ChildID,
+									ParentID = inserted.ParentID + param
+								}
+						);
+
+				Assert.AreEqual(1, output);
+
+				AreEqual(db.Child.Where(c => c.ChildID > idsLimit).Select(c => new Child
+					{
+						ParentID = c.ParentID,
+						ChildID = c.ChildID
+					}),
+					t.Select(c => new Child
+					{
+						ParentID = c.ParentID - param,
+						ChildID = c.ChildID
+					}
+					)
+				);
+
+			}
+			finally
+			{
+				db.Child.Delete(c => c.ChildID > idsLimit);
+			}
+		}
+
+		[Test]
+		public void InsertWithConfiguredQueryIntoTempTableByTableName([IncludeDataSources(FeatureInsertOutputInto)] string context)
+		{
+			using var db     = GetDataContext(context);
+			using var target = db.CreateTempTable<TableWithData>("TableWithData_target");
+			var targetRef = db.GetTable<TableWithData>()
+				.TableOptions(TableOptions.IsTemporary)
+				.TableName(target.TableName);
+			using var output = db.CreateTempTable<TableWithData>("TableWithData_output");
+			var outputRef = db.GetTable<TableWithData>()
+				.TableOptions(TableOptions.IsTemporary)
+				.TableName(output.TableName);
+
+			var rowCount = db.Person
+				.Where(p => p.Gender == Gender.Female)
+				.Select(p => new TableWithData
+				{
+					Id = p.ID,
+					Value = p.ID * 10,
+					ValueStr = p.FirstName + " " + p.LastName
+				})
+				.Into(targetRef)
+				.InsertWithOutputInto(outputRef);
+
+			Assert.AreEqual(1, rowCount);
+
+			var targetData = target.ToArray();
+			Assert.AreEqual(1, targetData.Length);
+			Assert.AreEqual(3, targetData[0].Id);
+			Assert.AreEqual(30, targetData[0].Value);
+			Assert.AreEqual("Jane Doe", targetData[0].ValueStr);
+
+			var outputData = output.ToArray();
+			Assert.AreEqual(1, outputData.Length);
+			Assert.AreEqual(3, outputData[0].Id);
+			Assert.AreEqual(30, outputData[0].Value);
+			Assert.AreEqual("Jane Doe", outputData[0].ValueStr);
+		}
+
+		[Test]
+		public async Task InsertWithConfiguredQueryIntoTempTableByTableNameAsync([IncludeDataSources(FeatureInsertOutputInto)] string context)
+		{
+			using var db     = GetDataContext(context);
+			using var target = db.CreateTempTable<TableWithData>("TableWithData_target");
+			var targetRef = db.GetTable<TableWithData>()
+				.TableOptions(TableOptions.IsTemporary)
+				.TableName(target.TableName);
+			using var output = db.CreateTempTable<TableWithData>("TableWithData_output");
+			var outputRef = db.GetTable<TableWithData>()
+				.TableOptions(TableOptions.IsTemporary)
+				.TableName(output.TableName);
+
+			var rowCount = await db.Person
+				.Where(p => p.Gender == Gender.Female)
+				.Select(p => new TableWithData
+				{
+					Id = p.ID,
+					Value = p.ID * 10,
+					ValueStr = p.FirstName + " " + p.LastName
+				})
+				.Into(targetRef)
+				.InsertWithOutputIntoAsync(outputRef);
+
+			Assert.AreEqual(1, rowCount);
+
+			var targetData = target.ToArray();
+			Assert.AreEqual(1, targetData.Length);
+			Assert.AreEqual(3, targetData[0].Id);
+			Assert.AreEqual(30, targetData[0].Value);
+			Assert.AreEqual("Jane Doe", targetData[0].ValueStr);
+
+			var outputData = output.ToArray();
+			Assert.AreEqual(1, outputData.Length);
+			Assert.AreEqual(3, outputData[0].Id);
+			Assert.AreEqual(30, outputData[0].Value);
+			Assert.AreEqual("Jane Doe", outputData[0].ValueStr);
+		}
+
+		[Test]
 		public void InsertWithOutputWithSchema([IncludeDataSources(true, FeatureInsertOutputWithSchema)] string context, [Values(1, 2)] int value)
 		{
 			using (var db     = GetDataContext(context))

--- a/Tests/Linq/Update/MergeTests.WithOutput.cs
+++ b/Tests/Linq/Update/MergeTests.WithOutput.cs
@@ -337,6 +337,47 @@ namespace Tests.xUpdate
 				record.SourceId. Should().Be(6);
 			}
 		}
+		
+		[Test]
+		public async Task MergeWithOutputIntoWithSourceAsync([IncludeDataSources(false, TestProvName.AllSqlServer2008Plus)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var temp = db.CreateTempTable<InsertTempTable>("#InsertTempTable");
+
+				PrepareData(db);
+
+				var table = GetTarget(db);
+
+				var affected = await table
+					.Merge()
+					.Using(GetSource1(db).Where(_ => _.Id == 5))
+					.OnTargetKey()
+					.InsertWhenNotMatched()
+					.MergeWithOutputIntoAsync(temp,
+						(a, deleted, inserted, source) => new ()
+						{
+							Action    = a,
+							NewId     = inserted.Id,
+							DeletedId = deleted.Id,
+							SourceId  = source.Id + 1
+						}
+					);
+
+				affected.Should().Be(1);
+
+				var result = temp.ToArray();
+
+				result.Should().HaveCount(1);
+
+				var record = result[0];
+
+				record.Action.   Should().Be("INSERT");
+				record.NewId.    Should().Be(5);
+				record.DeletedId.Should().BeNull();
+				record.SourceId. Should().Be(6);
+			}
+		}
 
 		[Test]
 		public void MergeWithOutputIntoTempTable([IncludeDataSources(false, TestProvName.AllSqlServer2008Plus)] string context)
@@ -355,6 +396,45 @@ namespace Tests.xUpdate
 					.OnTargetKey()
 					.InsertWhenNotMatched()
 					.MergeWithOutputInto(temp,
+						(a, deleted, inserted) => new InsertTempTable { Action = a, NewId = inserted.Id, DeletedId = deleted.Id }
+					);
+
+				affected.Should().Be(1);
+
+				var result = temp.ToArray();
+
+				result.Should().HaveCount(1);
+				result.Should().HaveCount(1);
+
+				var record = result[0];
+
+				record.Action.Should().Be("INSERT");
+
+				record.NewId.Should().Be(5);
+				record.DeletedId.Should().BeNull();
+			}
+		}
+		
+		[Test]
+		public void MergeWithOutputIntoTempTableByTableName([IncludeDataSources(false, TestProvName.AllSqlServer2008Plus)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var temp = db.CreateTempTable<InsertTempTable>("InsertTempTable_42", tableOptions: TableOptions.IsTemporary);
+				var tempRef = db.GetTable<InsertTempTable>()
+					.TableOptions(TableOptions.IsTemporary)
+					.TableName(temp.TableName);
+
+				PrepareData(db);
+
+				var table = GetTarget(db);
+
+				var affected = table
+					.Merge()
+					.Using(GetSource1(db).Where(_ => _.Id == 5))
+					.OnTargetKey()
+					.InsertWhenNotMatched()
+					.MergeWithOutputInto(tempRef,
 						(a, deleted, inserted) => new InsertTempTable { Action = a, NewId = inserted.Id, DeletedId = deleted.Id }
 					);
 
@@ -445,5 +525,131 @@ namespace Tests.xUpdate
 			}
 		}
 
+		[Test]
+		public async Task MergeWithOutputIntoTempTableByTableNameAsync([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var temp = db.CreateTempTable<InsertTempTable>("InsertTempTable_42");
+				var tempRef = db.GetTable<InsertTempTable>()
+					.TableOptions(TableOptions.IsTemporary)
+					.TableName(temp.TableName);
+
+				PrepareData(db);
+
+				var table = GetTarget(db);
+
+				var affected = await table
+					.Merge()
+					.Using(GetSource1(db).Where(_ => _.Id == 5))
+					.OnTargetKey()
+					.InsertWhenNotMatched()
+					.MergeWithOutputIntoAsync(tempRef,
+						(a, deleted, inserted) => new InsertTempTable { Action = a, NewId = inserted.Id, DeletedId = deleted.Id }
+					);
+
+				affected.Should().Be(1);
+
+				var result = await temp.ToArrayAsync();
+
+				result.Should().HaveCount(1);
+				result.Should().HaveCount(1);
+
+				var record = result[0];
+
+				record.Action.Should().Be("INSERT");
+
+				record.NewId.Should().Be(5);
+				record.DeletedId.Should().BeNull();
+			}
+		}
+
+		[Test]
+		public void MergeWithOutputIntoTempTableByTableNameWithSource([IncludeDataSources(false, TestProvName.AllSqlServer2008Plus)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var temp = db.CreateTempTable<InsertTempTable>("InsertTempTable_42");
+				var tempRef = db.GetTable<InsertTempTable>()
+					.TableOptions(TableOptions.IsTemporary)
+					.TableName(temp.TableName);
+
+				PrepareData(db);
+
+				var table = GetTarget(db);
+
+				var affected = table
+					.Merge()
+					.Using(GetSource1(db).Where(_ => _.Id == 5))
+					.OnTargetKey()
+					.InsertWhenNotMatched()
+					.MergeWithOutputInto(tempRef,
+						(a, deleted, inserted, source) => new ()
+						{
+							Action    = a,
+							NewId     = inserted.Id,
+							DeletedId = deleted.Id,
+							SourceId  = source.Id + 1
+						}
+					);
+
+				affected.Should().Be(1);
+
+				var result = temp.ToArray();
+
+				result.Should().HaveCount(1);
+
+				var record = result[0];
+
+				record.Action.Should().Be("INSERT");
+				record.NewId.Should().Be(5);
+				record.DeletedId.Should().BeNull();
+				record.SourceId.Should().Be(6);
+			}
+		}
+
+		[Test]
+		public async Task MergeWithOutputIntoTempTableByTableNameWithSourceAsync([IncludeDataSources(false, TestProvName.AllSqlServer2008Plus)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var temp = db.CreateTempTable<InsertTempTable>("InsertTempTable_42");
+				var tempRef = db.GetTable<InsertTempTable>()
+					.TableOptions(TableOptions.IsTemporary)
+					.TableName(temp.TableName);
+
+				PrepareData(db);
+
+				var table = GetTarget(db);
+
+				var affected = await table
+					.Merge()
+					.Using(GetSource1(db).Where(_ => _.Id == 5))
+					.OnTargetKey()
+					.InsertWhenNotMatched()
+					.MergeWithOutputIntoAsync(tempRef,
+						(a, deleted, inserted, source) => new ()
+						{
+							Action    = a,
+							NewId     = inserted.Id,
+							DeletedId = deleted.Id,
+							SourceId  = source.Id + 1
+						}
+					);
+
+				affected.Should().Be(1);
+
+				var result = temp.ToArray();
+
+				result.Should().HaveCount(1);
+
+				var record = result[0];
+
+				record.Action.Should().Be("INSERT");
+				record.NewId.Should().Be(5);
+				record.DeletedId.Should().BeNull();
+				record.SourceId.Should().Be(6);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Referring to the outputTable using Expression.Constant results in TableAttributeBuilder not being used. Unfortunately TableBuilder.BuildSequence just returns a TableBuilder+TableContext which only bases its SqlTable on the original type without taking modified attributes into account. So in order to make the modified attributes take effect the full expression from outputTable must be used rather than just embedding it in a ConstantExpression (alternatively should the logic in TableBuilder be changed so the SqlTable is generated with the changed attributes)