### PR TITLE
BUG: GroupBy with subquery.

### DIFF
--- a/Source/LinqToDB/SqlQuery/SelectQueryOptimizer.cs
+++ b/Source/LinqToDB/SqlQuery/SelectQueryOptimizer.cs
@@ -1508,13 +1508,18 @@ namespace LinqToDB.SqlQuery
 		{
 			CorrectCrossJoinQuery(_selectQuery);
 
-			for (var i = 0; i < _selectQuery.From.Tables.Count; i++)
-			{
-				var table = OptimizeSubQuery(_selectQuery, _selectQuery.From.Tables[i], true, false, isApplySupported, true, null);
+			var tableSources = _selectQuery.From.Tables;
 
-				if (table != _selectQuery.From.Tables[i])
+			for (var i = 0; i < tableSources.Count; i++)
+			{
+				if (tableSources.Count > 1 && tableSources[i] is { Source: SelectQuery { GroupBy.IsEmpty: false }})
+					continue;
+
+				var table = OptimizeSubQuery(_selectQuery, tableSources[i], true, false, isApplySupported, true, null);
+
+				if (table != tableSources[i])
 				{
-					if (_selectQuery.From.Tables[i].Source is SelectQuery sql)
+					if (tableSources[i].Source is SelectQuery sql)
 					{
 						ApplySubQueryExtensions(_selectQuery, sql);
 
@@ -1522,7 +1527,7 @@ namespace LinqToDB.SqlQuery
 							ApplySubsequentOrder(_selectQuery, sql);
 					}
 
-					_selectQuery.From.Tables[i] = table;
+					tableSources[i] = table;
 				}
 			}
 

--- a/Source/LinqToDB/SqlQuery/SelectQueryOptimizer.cs
+++ b/Source/LinqToDB/SqlQuery/SelectQueryOptimizer.cs
@@ -1512,6 +1512,8 @@ namespace LinqToDB.SqlQuery
 
 			for (var i = 0; i < tableSources.Count; i++)
 			{
+				// #4204 fix.
+				//
 				if (tableSources.Count > 1 && tableSources[i] is { Source: SelectQuery { GroupBy.IsEmpty: false }})
 					continue;
 

--- a/Tests/Linq/Linq/GroupByTests.cs
+++ b/Tests/Linq/Linq/GroupByTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using FluentAssertions;
 
 using LinqToDB;
-using LinqToDB.DataProvider.SqlServer;
 using LinqToDB.Linq;
 using LinqToDB.Mapping;
 using LinqToDB.SqlQuery;
@@ -2710,7 +2709,7 @@ namespace Tests.Linq
 		#endregion
 
 		[Test]
-		public void GroupSubqueryTest([DataSources] string context)
+		public void GroupSubqueryTest1([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 
@@ -2718,16 +2717,49 @@ namespace Tests.Linq
 			(
 				from pmp in
 				(
-					from p  in db.Parent
-					join ins in db.Person on p.ParentID equals ins.ID
 					from pmp  in db.Child
-					group pmp by new { ID = ins.ID, pmp.ParentID, pmp } into g
-					select new { g.Key.ID, g.Key.ParentID, Field1 = g.Max(x => x.ChildID) }
+					group pmp by pmp.ParentID into g
+					select g.Key
 				)
-				//.AsSubQuery()
 				from pmp1 in db.Child
-				group pmp1 by pmp.ID into g
-				select new { g.Key, Field1 = g.Max(x => x.ChildID )}
+				select new { pmp1.ChildID }
+			)
+			.ToList();
+		}
+
+		[Test]
+		public void GroupSubqueryTest2([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			_ =
+			(
+				from pmp1 in db.Child
+				from pmp in
+				(
+					from pmp  in db.Child
+					group pmp by pmp.ParentID into g
+					select g.Key
+				)
+				select new { pmp1.ChildID }
+			)
+			.ToList();
+		}
+
+		[Test]
+		public void GroupSubqueryTest3([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			_ =
+			(
+				from pmp in
+				(
+					from pmp  in db.Child
+					group pmp by pmp.ParentID into g
+					select g.Key
+				)
+				select new { pmp }
 			)
 			.ToList();
 		}

--- a/Tests/Linq/Linq/GroupByTests.cs
+++ b/Tests/Linq/Linq/GroupByTests.cs
@@ -2713,8 +2713,7 @@ namespace Tests.Linq
 		{
 			using var db = GetDataContext(context);
 
-			_ =
-			(
+			AssertQuery(
 				from pmp in
 				(
 					from pmp  in db.Child
@@ -2722,9 +2721,7 @@ namespace Tests.Linq
 					select g.Key
 				)
 				from pmp1 in db.Child
-				select new { pmp1.ChildID }
-			)
-			.ToList();
+				select new { pmp1.ChildID });
 		}
 
 		[Test]
@@ -2732,8 +2729,7 @@ namespace Tests.Linq
 		{
 			using var db = GetDataContext(context);
 
-			_ =
-			(
+			AssertQuery(
 				from pmp1 in db.Child
 				from pmp in
 				(
@@ -2741,9 +2737,7 @@ namespace Tests.Linq
 					group pmp by pmp.ParentID into g
 					select g.Key
 				)
-				select new { pmp1.ChildID }
-			)
-			.ToList();
+				select new { pmp1.ChildID });
 		}
 
 		[Test]
@@ -2751,17 +2745,14 @@ namespace Tests.Linq
 		{
 			using var db = GetDataContext(context);
 
-			_ =
-			(
+			AssertQuery(
 				from pmp in
 				(
 					from pmp  in db.Child
 					group pmp by pmp.ParentID into g
 					select g.Key
 				)
-				select new { pmp }
-			)
-			.ToList();
+				select new { pmp });
 		}
 	}
 }


### PR DESCRIPTION
The following code 

```c#
from pmp in
(
	from pmp  in db.Child
	group pmp by pmp.ParentID into g
	select g.Key
)
from pmp1 in db.Child
select new { pmp1.ChildID }
```

generates wrong SQL

```sql
SELECT
	[pmp1].[ChildID]
FROM
	[Child] [pmp],
	[Child] [pmp1]
GROUP BY
	[pmp].[ParentID]
```

should be 

```sql
SELECT
	[pmp1].[ChildID]
FROM
	(
		SELECT
			[t1].[ParentID]
		FROM
			[Child] [t1]
		GROUP BY
			[t1].[ParentID]
	) [pmp],
	[Child] [pmp1]
```