### PR TITLE
Disable long parameter names for oracle12 dialect

### DIFF
--- a/Source/LinqToDB/DataProvider/Oracle/Oracle11ParametersNormalizer.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/Oracle11ParametersNormalizer.cs
@@ -1,6 +1,6 @@
 ﻿namespace LinqToDB.DataProvider.Oracle
 {
-	public sealed class Oracle11ParametersNormalizer : Oracle12ParametersNormalizer
+	public sealed class Oracle11ParametersNormalizer : Oracle122ParametersNormalizer
 	{
 		protected override int MaxLength => 30;
 	}

--- a/Source/LinqToDB/DataProvider/Oracle/Oracle122ParametersNormalizer.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/Oracle122ParametersNormalizer.cs
@@ -2,7 +2,7 @@
 
 namespace LinqToDB.DataProvider.Oracle
 {
-	public class Oracle12ParametersNormalizer : UniqueParametersNormalizer
+	public class Oracle122ParametersNormalizer : UniqueParametersNormalizer
 	{
 		protected override bool IsReserved(string name) => ReservedWords.IsReserved(name, ProviderName.Oracle);
 	}

--- a/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleDataProvider.cs
@@ -168,9 +168,11 @@ namespace LinqToDB.DataProvider.Oracle
 
 		public override IQueryParametersNormalizer GetQueryParameterNormalizer()
 		{
-			return Version == OracleVersion.v11
-				? new Oracle11ParametersNormalizer()
-				: new Oracle12ParametersNormalizer();
+			// TODO: versioning support
+			// currently we cannot enable Oracle122ParametersNormalizer
+			// as we don't have Version for Oracle 12.2 or higher
+			// also see https://github.com/linq2db/linq2db/issues/4219
+			return new Oracle11ParametersNormalizer();
 		}
 
 		public override void SetParameter(DataConnection dataConnection, DbParameter parameter, string name, DbDataType dataType, object? value)


### PR DESCRIPTION
Fix #4219

We could reenable them when we will add more dialects to Oracle provider. Parameter names longer 30 characters doesn't sound right thing to require new dialect support.