### PR TITLE
Remove netcoreapp3.1 test builds (to gain space on CI agents)

### DIFF
--- a/Build/Azure/pipelines/templates/build-job.yml
+++ b/Build/Azure/pipelines/templates/build-job.yml
@@ -43,15 +43,11 @@ jobs:
   - task: CmdLine@2
     inputs:
       script: |
-        dotnet publish Tests\Linq\Tests.csproj -f netcoreapp3.1 -c $(build_configuration)
-        if %errorlevel% neq 0 exit
         dotnet publish Tests\Linq\Tests.csproj -f net6.0 -c $(build_configuration)
         if %errorlevel% neq 0 exit
         dotnet publish Tests\Linq\Tests.csproj -f net7.0 -c $(build_configuration)
         if %errorlevel% neq 0 exit
         dotnet publish Tests\Linq\Tests.csproj -f net472 -c $(build_configuration) -a x64 /p:X86=SET -o Tests\Linq\bin\$(build_configuration)\net472\publishx64
-        if %errorlevel% neq 0 exit
-        dotnet publish Tests\Linq\Tests.csproj -f netcoreapp3.1 -c $(build_configuration) -a x86 /p:X86=SET -o Tests\Linq\bin\$(build_configuration)\netcoreapp3.1\publishx86
         if %errorlevel% neq 0 exit
         dotnet publish Tests\Linq\Tests.csproj -f net6.0 -c $(build_configuration) -a x86 /p:X86=SET -o Tests\Linq\bin\$(build_configuration)\net6.0\publishx86
         if %errorlevel% neq 0 exit
@@ -60,8 +56,6 @@ jobs:
         mkdir testing
         if %errorlevel% neq 0 exit
         xcopy /i /s Tests\Linq\bin\$(build_configuration)\net472 testing\net472
-        if %errorlevel% neq 0 exit
-        xcopy /i /s Tests\Linq\bin\$(build_configuration)\netcoreapp3.1\publish testing\netcore31
         if %errorlevel% neq 0 exit
         xcopy /i /s Tests\Linq\bin\$(build_configuration)\net6.0\publish testing\net60
         if %errorlevel% neq 0 exit
@@ -72,8 +66,6 @@ jobs:
         xcopy /i /s testing\net472\runtimes testing\net472x64\runtimes
         if %errorlevel% neq 0 exit
         xcopy /i /s /y testing\net472\x64 testing\net472x64\x64
-        if %errorlevel% neq 0 exit
-        xcopy /i /s Tests\Linq\bin\$(build_configuration)\netcoreapp3.1\publishx86 testing\netcore31x86
         if %errorlevel% neq 0 exit
         xcopy /i /s Tests\Linq\bin\$(build_configuration)\net6.0\publishx86 testing\net60x86
         if %errorlevel% neq 0 exit


### PR DESCRIPTION
Again, oracle test agents run out of space..