### PR TITLE
Change WriteTraceLineConnection accessibility level to protected

### DIFF
--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -633,7 +633,7 @@ namespace LinqToDB.Data
 		/// Defaults to <see cref="WriteTraceLine"/>.
 		/// Used for the current instance.
 		/// </summary>
-		public Action<string?,string?,TraceLevel> WriteTraceLineConnection { get; private set; } = WriteTraceLine;
+		public Action<string?, string?, TraceLevel> WriteTraceLineConnection { get; protected set; } = WriteTraceLine;
 
 		#endregion
 


### PR DESCRIPTION
Reasoning: the property is supposed to be overridable (why would a global static one be overridable then?) but for some reason it's not outside of the base class which is often inheritable. 