### PR TITLE
EntityDescriptor optimizations

### DIFF
--- a/Source/LinqToDB.Tools/Comparers/ComparerBuilder.cs
+++ b/Source/LinqToDB.Tools/Comparers/ComparerBuilder.cs
@@ -37,7 +37,7 @@ namespace LinqToDB.Tools.Comparers
 		/// <typeparam name="T">The type of objects to compare.</typeparam>
 		[Pure]
 		public static Func<T,T,bool> GetEqualsFunc<T>([InstantHandle] IEnumerable<MemberAccessor> members)
-			=> CreateEqualsFunc<T>(members.Select(m => m.GetterExpression));
+			=> CreateEqualsFunc<T>(members.Select(m => (Func<Expression, Expression>)m.GetGetterExpression));
 
 		/// <summary>
 		/// Returns GetEqualsFunc function for provided members for type T to compare.
@@ -47,7 +47,7 @@ namespace LinqToDB.Tools.Comparers
 		/// <typeparam name="T">The type of objects to compare.</typeparam>
 		[Pure]
 		public static Func<T,T,bool> GetEqualsFunc<T>(params Expression<Func<T,object?>>[] members)
-			=> CreateEqualsFunc<T>(members);
+			=> CreateEqualsFunc<T>(members.Select(e => (Func<Expression, Expression>)e.GetBody));
 
 		/// <summary>
 		/// Returns GetHashCode function for type T to compare.
@@ -68,7 +68,7 @@ namespace LinqToDB.Tools.Comparers
 		/// <typeparam name="T">The type of objects to compare.</typeparam>
 		[Pure]
 		public static Func<T,int> GetGetHashCodeFunc<T>([InstantHandle] IEnumerable<MemberAccessor> members)
-			=> CreateGetHashCodeFunc<T>(members.Select(m => m.GetterExpression));
+			=> CreateGetHashCodeFunc<T>(members.Select(m => (Func<Expression, Expression>)m.GetGetterExpression));
 
 		/// <summary>
 		/// Returns GetHashCode function for provided members for type T to compare.
@@ -78,7 +78,7 @@ namespace LinqToDB.Tools.Comparers
 		/// <typeparam name="T">The type of objects to compare.</typeparam>
 		[Pure]
 		public static Func<T,int> GetGetHashCodeFunc<T>(params Expression<Func<T, object?>>[] members)
-			=> CreateGetHashCodeFunc<T>(members);
+			=> CreateGetHashCodeFunc<T>(members.Select(e => (Func<Expression, Expression>)e.GetBody));
 
 		sealed class Comparer<T> : EqualityComparer<T>
 		{
@@ -129,7 +129,7 @@ namespace LinqToDB.Tools.Comparers
 		public static IEqualityComparer<T> GetEqualityComparer<T>(params Expression<Func<T,object?>>[] membersToCompare)
 		{
 			if (membersToCompare == null) throw new ArgumentNullException(nameof(membersToCompare));
-			return new Comparer<T>(CreateEqualsFunc<T>(membersToCompare), CreateGetHashCodeFunc<T>(membersToCompare));
+			return new Comparer<T>(CreateEqualsFunc<T>(membersToCompare.Select(e => (Func<Expression, Expression>)e.GetBody)), CreateGetHashCodeFunc<T>(membersToCompare.Select(e => (Func<Expression, Expression>)e.GetBody)));
 		}
 
 		/// <summary>
@@ -177,15 +177,15 @@ namespace LinqToDB.Tools.Comparers
 		}
 
 		[Pure]
-		static Func<T,T,bool> CreateEqualsFunc<T>(IEnumerable<LambdaExpression> membersToCompare)
+		static Func<T,T,bool> CreateEqualsFunc<T>(IEnumerable<Func<Expression, Expression>> membersToCompare)
 		{
 			var x = Expression.Parameter(typeof(T), "x");
 			var y = Expression.Parameter(typeof(T), "y");
 
 			var expressions = membersToCompare.Select(me =>
 			{
-				var arg0 = RemoveCastToObject(me.GetBody(x));
-				var arg1 = RemoveCastToObject(me.GetBody(y));
+				var arg0 = RemoveCastToObject(me(x));
+				var arg1 = RemoveCastToObject(me(y));
 				var eq   = GetEqualityComparerExpression(arg1.Type);
 				var mi   = eq.Type.GetMethods().Single(m => m.IsPublic && m.Name == "Equals" && m.GetParameters().Length == 2);
 
@@ -234,14 +234,14 @@ namespace LinqToDB.Tools.Comparers
 		}
 
 		[Pure]
-		static Func<T,int> CreateGetHashCodeFunc<T>(IEnumerable<LambdaExpression> membersToCompare)
+		static Func<T,int> CreateGetHashCodeFunc<T>(IEnumerable<Func<Expression, Expression>> membersToCompare)
 		{
 			var parameter  = Expression.Parameter(typeof(T), "parameter");
 			var expression = membersToCompare.Aggregate(
 				(Expression)Expression.Constant(_randomSeed),
 				(e, me) =>
 				{
-					var ma = RemoveCastToObject(me.GetBody(parameter));
+					var ma = RemoveCastToObject(me(parameter));
 					var eq = GetEqualityComparerExpression(ma.Type);
 					var mi = eq.Type.GetMethods().Single(m => m.IsPublic && m.Name == "GetHashCode" && m.GetParameters().Length == 1);
 

--- a/Source/LinqToDB.Tools/EntityServices/EntityMap.cs
+++ b/Source/LinqToDB.Tools/EntityServices/EntityMap.cs
@@ -91,7 +91,7 @@ namespace LinqToDB.Tools.EntityServices
 					_mapper = v =>
 					{
 						var e = entityDesc.TypeAccessor.CreateInstanceEx();
-						_keyColumns![0].Setter!(e, v);
+						_keyColumns![0].SetValue(e, v);
 						return (T)e;
 					};
 				}

--- a/Source/LinqToDB.Tools/Mapper/ExpressionBuilder.cs
+++ b/Source/LinqToDB.Tools/Mapper/ExpressionBuilder.cs
@@ -151,7 +151,7 @@ namespace LinqToDB.Tools.Mapper
 					{
 						if (item.Item1.Length == 1 && item.Item1[0] == toMember.MemberInfo)
 						{
-							binds.Add(BuildAssignment(item.Item2, fromExpression, item.Item2.Type, toMember));
+							binds.Add(BuildAssignment(item.Item2.GetBody, fromExpression, item.Item2.Type, toMember));
 							processed = true;
 							break;
 						}
@@ -178,19 +178,17 @@ namespace LinqToDB.Tools.Mapper
 				if (fromMember == null || !fromMember.HasGetter)
 					continue;
 
-				var getter = fromMember.GetterExpression;
-
 				if (_mapperBuilder.MappingSchema.IsScalarType(fromMember.Type) || _mapperBuilder.MappingSchema.IsScalarType(toMember.Type))
 				{
-					binds.Add(BuildAssignment(getter, fromExpression, fromMember.Type, toMember));
+					binds.Add(BuildAssignment(fromMember.GetGetterExpression, fromExpression, fromMember.Type, toMember));
 				}
 				else if (fromMember.Type == toMember.Type && _mapperBuilder.DeepCopy == false)
 				{
-					binds.Add(Bind(toMember.MemberInfo, getter.GetBody(fromExpression)));
+					binds.Add(Bind(toMember.MemberInfo, fromMember.GetGetterExpression(fromExpression)));
 				}
 				else
 				{
-					var getValue = getter.GetBody(fromExpression);
+					var getValue = fromMember.GetGetterExpression(fromExpression);
 					var exExpr   = GetExpressionImpl(getValue, toMember.Type);
 
 					if (_data.IsRestart)
@@ -277,12 +275,12 @@ namespace LinqToDB.Tools.Mapper
 		}
 
 		MemberAssignment BuildAssignment(
-			LambdaExpression getter,
-			Expression       fromExpression,
-			Type             fromMemberType,
-			MemberAccessor   toMember)
+			Func<Expression, Expression> getter,
+			Expression                   fromExpression,
+			Type                         fromMemberType,
+			MemberAccessor               toMember)
 		{
-			var getValue = getter.GetBody(fromExpression);
+			var getValue = getter(fromExpression);
 			var expr     = _mapperBuilder.MappingSchema.GetConvertExpression(fromMemberType, toMember.Type)!;
 			var convert  = expr.GetBody(getValue);
 
@@ -424,8 +422,6 @@ namespace LinqToDB.Tools.Mapper
 					if (!toMember.HasSetter)
 						continue;
 
-					var setter = toMember.SetterExpression;
-
 					if (_builder._data.MemberMappers != null)
 					{
 						var processed = false;
@@ -434,7 +430,7 @@ namespace LinqToDB.Tools.Mapper
 						{
 							if (item.Item1.Length == 1 && item.Item1[0] == toMember.MemberInfo)
 							{
-								_expressions.Add(BuildAssignment(item.Item2, setter, item.Item2.Type, _localObject, toMember));
+								_expressions.Add(BuildAssignment(item.Item2.GetBody, toMember.GetSetterExpression, item.Item2.Type, _localObject, toMember));
 								processed = true;
 								break;
 							}
@@ -461,31 +457,29 @@ namespace LinqToDB.Tools.Mapper
 					if (fromMember == null || !fromMember.HasGetter)
 						continue;
 
-					var getter = fromMember.GetterExpression;
-
 					if (_builder._mapperBuilder.MappingSchema.IsScalarType(fromMember.Type) ||
 						_builder._mapperBuilder.MappingSchema.IsScalarType(toMember.Type))
 					{
-						_expressions.Add(BuildAssignment(getter, setter, fromMember.Type, _localObject, toMember));
+						_expressions.Add(BuildAssignment(fromMember.GetGetterExpression, fromMember.GetSetterExpression, fromMember.Type, _localObject, toMember));
 					}
 					else if (fromMember.Type == toMember.Type && _builder._mapperBuilder.DeepCopy == false)
 					{
-						_expressions.Add(setter.GetBody(_localObject, getter.GetBody(_fromExpression)));
+						_expressions.Add(fromMember.GetSetterExpression(_localObject, fromMember.GetGetterExpression(_fromExpression)));
 					}
 					else
 					{
-						var getValue = getter.GetBody(_fromExpression);
+						var getValue = fromMember.GetGetterExpression(_fromExpression);
 						var expr     = IfThenElse(
 							// if (from == null)
 							Equal(getValue, Constant(_builder._mapperBuilder.MappingSchema.GetDefaultValue(getValue.Type), getValue.Type)),
 							//   localObject = null;
-							setter.GetBody(
+							fromMember.GetSetterExpression(
 								_localObject,
 								Constant(_builder._mapperBuilder.MappingSchema.GetDefaultValue(toMember.Type), toMember.Type)),
 							// else
 							toMember.HasGetter ?
-								setter.GetBody(_localObject, BuildClassMapper(getValue, toMember)) :
-								setter.GetBody(_localObject, _builder.GetExpressionImpl(getValue, toMember.Type)!));
+								fromMember.GetSetterExpression(_localObject, BuildClassMapper(getValue, toMember)) :
+								fromMember.GetSetterExpression(_localObject, _builder.GetExpressionImpl(getValue, toMember.Type)!));
 
 						_expressions.Add(expr);
 					}
@@ -497,7 +491,7 @@ namespace LinqToDB.Tools.Mapper
 				var key   = Tuple.Create(_fromExpression.Type, toMember.Type);
 				var pFrom = Parameter(getValue.Type, "pFrom");
 				var pTo   = Parameter(toMember.Type, "pTo");
-				var toObj = toMember.GetterExpression.GetBody(_localObject);
+				var toObj = toMember.GetGetterExpression(_localObject);
 
 				ParameterExpression? nullPrm = null;
 
@@ -609,17 +603,17 @@ namespace LinqToDB.Tools.Mapper
 			}
 
 			Expression BuildAssignment(
-				LambdaExpression getter,
-				LambdaExpression setter,
-				Type             fromMemberType,
-				Expression       toExpression,
-				MemberAccessor   toMember)
+				Func<Expression, Expression>             getter,
+				Func<Expression, Expression, Expression> setter,
+				Type                                     fromMemberType,
+				Expression                               toExpression,
+				MemberAccessor                           toMember)
 			{
-				var getValue = getter.GetBody(_fromExpression);
+				var getValue = getter(_fromExpression);
 				var expr     = _builder._mapperBuilder.MappingSchema.GetConvertExpression(fromMemberType, toMember.Type)!;
 				var convert  = expr.GetBody(getValue);
 
-				return setter.GetBody(toExpression, convert);
+				return setter(toExpression, convert);
 			}
 		}
 

--- a/Source/LinqToDB.Tools/Mapper/ExpressionBuilder.cs
+++ b/Source/LinqToDB.Tools/Mapper/ExpressionBuilder.cs
@@ -460,11 +460,11 @@ namespace LinqToDB.Tools.Mapper
 					if (_builder._mapperBuilder.MappingSchema.IsScalarType(fromMember.Type) ||
 						_builder._mapperBuilder.MappingSchema.IsScalarType(toMember.Type))
 					{
-						_expressions.Add(BuildAssignment(fromMember.GetGetterExpression, fromMember.GetSetterExpression, fromMember.Type, _localObject, toMember));
+						_expressions.Add(BuildAssignment(fromMember.GetGetterExpression, toMember.GetSetterExpression, fromMember.Type, _localObject, toMember));
 					}
 					else if (fromMember.Type == toMember.Type && _builder._mapperBuilder.DeepCopy == false)
 					{
-						_expressions.Add(fromMember.GetSetterExpression(_localObject, fromMember.GetGetterExpression(_fromExpression)));
+						_expressions.Add(toMember.GetSetterExpression(_localObject, fromMember.GetGetterExpression(_fromExpression)));
 					}
 					else
 					{
@@ -473,13 +473,13 @@ namespace LinqToDB.Tools.Mapper
 							// if (from == null)
 							Equal(getValue, Constant(_builder._mapperBuilder.MappingSchema.GetDefaultValue(getValue.Type), getValue.Type)),
 							//   localObject = null;
-							fromMember.GetSetterExpression(
+							toMember.GetSetterExpression(
 								_localObject,
 								Constant(_builder._mapperBuilder.MappingSchema.GetDefaultValue(toMember.Type), toMember.Type)),
 							// else
 							toMember.HasGetter ?
-								fromMember.GetSetterExpression(_localObject, BuildClassMapper(getValue, toMember)) :
-								fromMember.GetSetterExpression(_localObject, _builder.GetExpressionImpl(getValue, toMember.Type)!));
+								toMember.GetSetterExpression(_localObject, BuildClassMapper(getValue, toMember)) :
+								toMember.GetSetterExpression(_localObject, _builder.GetExpressionImpl(getValue, toMember.Type)!));
 
 						_expressions.Add(expr);
 					}

--- a/Source/LinqToDB/Concurrency/ConcurrencyExtensions.cs
+++ b/Source/LinqToDB/Concurrency/ConcurrencyExtensions.cs
@@ -27,7 +27,7 @@ namespace LinqToDB.Concurrency
 			{
 				var equality = Expression.Equal(
 					Expression.MakeMemberAccess(param, cd.MemberInfo),
-					cd.MemberAccessor.GetterExpression.GetBody(instance));
+					cd.MemberAccessor.GetGetterExpression(instance));
 
 				predicate = predicate == null ? equality : Expression.AndAlso(predicate, equality);
 			}
@@ -100,7 +100,7 @@ namespace LinqToDB.Concurrency
 						continue;
 				}
 				else
-					valueExpression = Expression.Lambda(cd.MemberAccessor.GetterExpression.GetBody(instance), param);
+					valueExpression = Expression.Lambda(cd.MemberAccessor.GetGetterExpression(instance), param);
 
 				updatable = (IUpdatable<T>)updateMethod.Invoke(null, new object[] { updatable, propExpression, valueExpression })!;
 			}

--- a/Source/LinqToDB/Concurrency/OptimisticLockPropertyAttribute.cs
+++ b/Source/LinqToDB/Concurrency/OptimisticLockPropertyAttribute.cs
@@ -44,7 +44,7 @@ namespace LinqToDB.Concurrency
 
 				case VersionBehavior.AutoIncrement:
 					return Expression.Lambda(
-						Expression.Add(column.MemberAccessor.GetterExpression.GetBody(record), ExpressionInstances.Constant1),
+						Expression.Add(column.MemberAccessor.GetGetterExpression(record), ExpressionInstances.Constant1),
 						record);
 
 				case VersionBehavior.Guid:

--- a/Source/LinqToDB/Data/RecordReaderBuilder.cs
+++ b/Source/LinqToDB/Data/RecordReaderBuilder.cs
@@ -162,7 +162,7 @@ namespace LinqToDB.Data
 				{
 					if (m.column.MemberAccessor.IsComplex)
 					{
-						exprs.Add(m.column.MemberAccessor.SetterExpression.GetBody(obj, m.expr));
+						exprs.Add(m.column.MemberAccessor.GetSetterExpression(obj, m.expr));
 					}
 				}
 

--- a/Source/LinqToDB/Linq/Builder/TableBuilder.TableContext.cs
+++ b/Source/LinqToDB/Linq/Builder/TableBuilder.TableContext.cs
@@ -206,9 +206,9 @@ namespace LinqToDB.Linq.Builder
 						if (member.Info.MemberInfo.IsDynamicColumnPropertyEx())
 						{
 							var typeAcc = TypeAccessor.GetAccessor(member.Info.MemberInfo.ReflectedType!);
-							var setter  = new MemberAccessor(typeAcc, member.Info.MemberInfo, EntityDescriptor).SetterExpression;
+							var setter  = new MemberAccessor(typeAcc, member.Info.MemberInfo, EntityDescriptor).GetSetterExpression(parentObject, ex);
 
-							exprs.Add(Expression.Invoke(setter, parentObject, ex));
+							exprs.Add(setter);
 						}
 						else
 						{
@@ -369,7 +369,7 @@ namespace LinqToDB.Linq.Builder
 					if (hasComplex)
 						foreach (var (column, _, exp) in members)
 							if (column.MemberAccessor.IsComplex)
-								exprs.Add(column.MemberAccessor.SetterExpression.GetBody(obj, exp));
+								exprs.Add(column.MemberAccessor.GetSetterExpression(obj, exp));
 
 					if (loadWith != null)
 						SetLoadWithBindings(objectType, obj, exprs);

--- a/Source/LinqToDB/Mapping/ColumnDescriptor.cs
+++ b/Source/LinqToDB/Mapping/ColumnDescriptor.cs
@@ -517,7 +517,7 @@ namespace LinqToDB.Mapping
 				return _getOriginalValueLambda;
 
 			var objParam   = Expression.Parameter(MemberAccessor.TypeAccessor.Type, "obj");
-			var getterExpr = MemberAccessor.GetterExpression.GetBody(objParam);
+			var getterExpr = MemberAccessor.GetGetterExpression(objParam);
 
 			_getOriginalValueLambda = Expression.Lambda(getterExpr, objParam);
 			return _getOriginalValueLambda;
@@ -582,7 +582,7 @@ namespace LinqToDB.Mapping
 				return _getDbParamLambda;
 
 			var objParam   = Expression.Parameter(MemberAccessor.TypeAccessor.Type, "obj");
-			var getterExpr = MemberAccessor.GetterExpression.GetBody(objParam);
+			var getterExpr = MemberAccessor.GetGetterExpression(objParam);
 			var dbDataType = GetDbDataType(true);
 
 			if (IsDiscriminator && MemberAccessor.HasSetter)

--- a/Source/LinqToDB/Mapping/EntityDescriptor.cs
+++ b/Source/LinqToDB/Mapping/EntityDescriptor.cs
@@ -444,13 +444,16 @@ namespace LinqToDB.Mapping
 		private void InitializeDynamicColumnsAccessors(bool hasInheritanceMapping)
 		{
 			// initialize dynamic columns store accessors
-			var dynamicStoreAttributes = new List<MappingAttribute>();
+			List<MappingAttribute>?                                   dynamicStoreAttributes = null;
+			Dictionary<DynamicColumnsStoreAttribute, MemberAccessor>? storeMembers           = null;
+
 			var accessors = MappingSchema.GetAttribute<DynamicColumnAccessorAttribute>(TypeAccessor.Type);
 			if (accessors != null)
 			{
-				dynamicStoreAttributes.Add(accessors);
+#pragma warning disable CA1508 // Avoid dead conditional code : analyzer bug
+				(dynamicStoreAttributes ??= new()).Add(accessors);
+#pragma warning restore CA1508 // Avoid dead conditional code
 			}
-			var storeMembers = new Dictionary<DynamicColumnsStoreAttribute, MemberAccessor>();
 
 			foreach (var member in TypeAccessor.Members)
 			{
@@ -459,12 +462,12 @@ namespace LinqToDB.Mapping
 
 				if (dcsProp != null)
 				{
-					dynamicStoreAttributes.Add(dcsProp);
-					storeMembers.Add(dcsProp, member);
+					(dynamicStoreAttributes ??= new()).Add(dcsProp);
+					(storeMembers ??= new()).Add(dcsProp, member);
 				}
 			}
 
-			if (dynamicStoreAttributes.Count > 0)
+			if (dynamicStoreAttributes != null)
 			{
 				MappingAttribute dynamicStoreAttribute;
 				if (dynamicStoreAttributes.Count > 1)
@@ -486,7 +489,7 @@ namespace LinqToDB.Mapping
 
 				if (dynamicStoreAttribute is DynamicColumnsStoreAttribute storeAttribute)
 				{
-					var member          = storeMembers[storeAttribute];
+					var member          = storeMembers![storeAttribute];
 					DynamicColumnsStore = new ColumnDescriptor(MappingSchema, this, new ColumnAttribute(member.Name), member, hasInheritanceMapping);
 
 					// getter expression

--- a/Source/LinqToDB/Mapping/MappingSchema.cs
+++ b/Source/LinqToDB/Mapping/MappingSchema.cs
@@ -1720,7 +1720,7 @@ namespace LinqToDB.Mapping
 		/// </summary>
 		public static Action<MappingSchema, IEntityChangeDescriptor>? EntityDescriptorCreatedCallback { get; set; }
 
-		internal static MemoryCache<(Type entityType, int schemaId),EntityDescriptor> EntityDescriptorsCache { get; } = new (new ());
+		private static MemoryCache<(Type entityType, int schemaId),EntityDescriptor> EntityDescriptorsCache { get; } = new (new ());
 
 		/// <summary>
 		/// Returns mapped entity descriptor.

--- a/Source/LinqToDB/Mapping/SkipValuesByListAttribute.cs
+++ b/Source/LinqToDB/Mapping/SkipValuesByListAttribute.cs
@@ -35,7 +35,7 @@ namespace LinqToDB.Mapping
 		/// <returns><c>true</c> if object should be skipped for the operation.</returns>
 		public override bool ShouldSkip(object obj, EntityDescriptor entityDescriptor, ColumnDescriptor columnDescriptor)
 		{
-			return Values?.Contains(columnDescriptor.MemberAccessor.Getter!(obj)) ?? false;
+			return Values?.Contains(columnDescriptor.MemberAccessor.GetValue(obj)) ?? false;
 		}
 
 		public override string GetObjectID()

--- a/Source/LinqToDB/Reflection/MemberAccessor.cs
+++ b/Source/LinqToDB/Reflection/MemberAccessor.cs
@@ -93,13 +93,15 @@ namespace LinqToDB.Reflection
 						expr = Expression.MakeMemberAccess(expr, info.member);
 				}
 
-				GetterExpression = Expression.Lambda(expr, objParam);
+				_getterArguments  = new[] { objParam };
+				_getterExpression = expr;
 
 				// Build setter.
 				//
 				HasSetter = !infos.Any(info => info.member is PropertyInfo pi && pi.GetSetMethod(true) == null);
 
-				var valueParam = Expression.Parameter(Type, "value");
+				var valueParam   = Expression.Parameter(Type, "value");
+				_setterArguments = new[] { objParam, valueParam };
 
 				if (HasSetter)
 				{
@@ -154,18 +156,15 @@ namespace LinqToDB.Reflection
 						expr = Expression.Assign(expr, valueParam);
 					}
 
-					SetterExpression = Expression.Lambda(expr, objParam, valueParam);
+					_setterExpression = expr;
 				}
 				else
 				{
 					var fakeParam = Expression.Parameter(typeof(int));
 
-					SetterExpression = Expression.Lambda(
-						Expression.Block(
-							new[] { fakeParam },
-							Expression.Assign(fakeParam, ExpressionInstances.Constant0)),
-						objParam,
-						valueParam);
+					_setterExpression = Expression.Block(
+						new[] { fakeParam },
+						Expression.Assign(fakeParam, ExpressionInstances.Constant0));
 				}
 			}
 
@@ -181,7 +180,7 @@ namespace LinqToDB.Reflection
 		}
 
 #pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
-		[MemberNotNull(nameof(Type), nameof(MemberInfo), nameof(GetterExpression), nameof(SetterExpression))]
+		[MemberNotNull(nameof(Type), nameof(MemberInfo), nameof(_getterExpression), nameof(_getterArguments), nameof(_setterExpression), nameof(_setterArguments))]
 #pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant
 		void SetSimple(MemberInfo memberInfo, EntityDescriptor? ed)
 		{
@@ -201,8 +200,8 @@ namespace LinqToDB.Reflection
 
 			var objParam   = Expression.Parameter(TypeAccessor.Type, "obj");
 			var valueParam = Expression.Parameter(Type, "value");
-			var getterType = typeof(Func<,>).MakeGenericType(TypeAccessor.Type, Type);
-			var setterType = typeof(Action<,>).MakeGenericType(TypeAccessor.Type, Type);
+
+			_getterArguments = new[] { objParam };
 
 			if (HasGetter && memberInfo.IsDynamicColumnPropertyEx())
 			{
@@ -210,99 +209,81 @@ namespace LinqToDB.Reflection
 
 				if (ed?.DynamicColumnGetter != null)
 				{
-					GetterExpression = Expression.Lambda(
-						getterType,
-						Expression.Convert(
-							ed.DynamicColumnGetter.GetBody(
-								objParam,
-								Expression.Constant(memberInfo.Name),
-								Expression.Convert(new DefaultValueExpression(ed.MappingSchema, Type), typeof(object))),
-							Type),
-						objParam);
+					_getterExpression = Expression.Convert(
+						ed.DynamicColumnGetter.GetBody(
+							objParam,
+							Expression.Constant(memberInfo.Name),
+							Expression.Convert(new DefaultValueExpression(ed.MappingSchema, Type), typeof(object))),
+						Type);
 				}
 				else
 					// dynamic columns store was not provided, throw exception when accessed
 					// @mace_windu: why not throw it immediately? Fail fast
-					GetterExpression = Expression.Lambda(
-						getterType,
-						Expression.Call(_throwOnDynamicStoreMissingMethod.MakeGenericMethod(Type)),
-						objParam);
+					_getterExpression = Expression.Call(_throwOnDynamicStoreMissingMethod.MakeGenericMethod(Type));
 			}
 			else if (HasGetter)
-				GetterExpression = Expression.Lambda(getterType, Expression.MakeMemberAccess(objParam, memberInfo), objParam);
+				_getterExpression = Expression.MakeMemberAccess(objParam, memberInfo);
 			else
-				GetterExpression = Expression.Lambda(getterType, new DefaultValueExpression(ed?.MappingSchema ?? MappingSchema.Default, Type), objParam);
+				_getterExpression = new DefaultValueExpression(ed?.MappingSchema ?? MappingSchema.Default, Type);
 
+			_setterArguments = new[] { objParam, valueParam };
 			if (HasSetter && memberInfo.IsDynamicColumnPropertyEx())
 			{
 				IsComplex = true;
 
 				if (ed?.DynamicColumnSetter != null)
 				{
-					SetterExpression = Expression.Lambda(
-						setterType,
-						ed.DynamicColumnSetter.GetBody(
-							objParam,
-							Expression.Constant(memberInfo.Name),
-							valueParam),
+					_setterExpression = ed.DynamicColumnSetter.GetBody(
 						objParam,
+						Expression.Constant(memberInfo.Name),
 						valueParam);
 				}
 				else
 					// dynamic columns store was not provided, throw exception when accessed
 					// @mace_windu: why not throw it immediately? Fail fast
-					SetterExpression = Expression.Lambda(
-						setterType,
-						Expression.Block(
-							Expression.Throw(
-								Expression.New(
-									ArgumentExceptionConstructorInfo,
-									Expression.Constant("Tried setting dynamic column value, without setting dynamic column store on type."))),
-							Expression.Constant(DefaultValue.GetValue(valueParam.Type), valueParam.Type)
-						),
-						objParam,
-						valueParam);
+					_setterExpression = Expression.Block(
+						Expression.Throw(
+							Expression.New(
+								ArgumentExceptionConstructorInfo,
+								Expression.Constant("Tried setting dynamic column value, without setting dynamic column store on type."))),
+						Expression.Constant(DefaultValue.GetValue(valueParam.Type), valueParam.Type));
 
 			}
 			else if (HasSetter)
-				SetterExpression = Expression.Lambda(
-					setterType,
-					Expression.Assign(Expression.MakeMemberAccess(objParam, memberInfo), valueParam),
-					objParam,
-					valueParam);
+				_setterExpression = Expression.Assign(Expression.MakeMemberAccess(objParam, memberInfo), valueParam);
 			else
 			{
 				var fakeParam = Expression.Parameter(typeof(int));
 
-				SetterExpression = Expression.Lambda(
-					setterType,
-					Expression.Block(
-						new[] { fakeParam },
-						new Expression[] { Expression.Assign(fakeParam, ExpressionInstances.Constant0) }),
-					objParam,
-					valueParam);
+				_setterExpression = Expression.Block(
+					new[] { fakeParam },
+					new Expression[] { Expression.Assign(fakeParam, ExpressionInstances.Constant0) });
 			}
 		}
 
 		void SetExpressions()
 		{
-			var objParam   = Expression.Parameter(typeof(object), "obj");
-			var getterExpr = GetterExpression.GetBody(Expression.Convert(objParam, TypeAccessor.Type));
-			var getter     = Expression.Lambda<Func<object,object?>>(Expression.Convert(getterExpr, typeof(object)), objParam);
-
-			Getter = getter.CompileExpression();
-
-			var valueParam = Expression.Parameter(typeof(object), "value");
-
-			if (SetterExpression != null)
+			// lazy init as those delegates used in rare cases and compilation is expensive
+			_getter = new Lazy<Func<object, object?>>(() =>
 			{
-				var setterExpr = SetterExpression.GetBody(
+				var objParam   = Expression.Parameter(typeof(object), "obj");
+				var getterExpr = GetGetterExpression(Expression.Convert(objParam, TypeAccessor.Type));
+				var getter     = Expression.Lambda<Func<object,object?>>(Expression.Convert(getterExpr, typeof(object)), objParam);
+
+				return getter.CompileExpression();
+			});
+
+			_setter = new Lazy<Action<object, object?>>(() =>
+			{
+				var objParam   = Expression.Parameter(typeof(object), "obj");
+				var valueParam = Expression.Parameter(typeof(object), "value");
+				var setterExpr = GetSetterExpression(
 					Expression.Convert(objParam, TypeAccessor.Type),
 					Expression.Convert(valueParam, Type));
 				var setter = Expression.Lambda<Action<object, object?>>(setterExpr, objParam, valueParam);
 
-				Setter = setter.CompileExpression();
-			}
+				return setter.CompileExpression();
+			});
 		}
 
 		static readonly MethodInfo _throwOnDynamicStoreMissingMethod = MemberHelper.MethodOf(() => ThrowOnDynamicStoreMissing<int>()).GetGenericMethodDefinition();
@@ -319,10 +300,6 @@ namespace LinqToDB.Reflection
 		public bool                    HasSetter        { get; private set; }
 		public Type                    Type             { get; private set; }
 		public bool                    IsComplex        { get; private set; }
-		public LambdaExpression        GetterExpression { get; private set; }
-		public LambdaExpression        SetterExpression { get; private set; }
-		public Func  <object,object?>? Getter           { get; private set; }
-		public Action<object,object?>? Setter           { get; private set; }
 
 		public string Name
 		{
@@ -332,15 +309,48 @@ namespace LinqToDB.Reflection
 		#endregion
 
 		#region Set/Get Value
+		[Obsolete($"Use {nameof(GetGetterExpression)} method instead")]
+		public LambdaExpression        GetterExpression => Expression.Lambda(_getterExpression, _getterArguments);
+		[Obsolete($"Use {nameof(GetSetterExpression)} method instead")]
+		public LambdaExpression        SetterExpression => Expression.Lambda(_setterExpression, _setterArguments);
+		[Obsolete($"Use {nameof(GetValue)} method instead")]
+		public Func  <object,object?>? Getter           => _getter?.Value;
+		[Obsolete($"Use {nameof(SetValue)} method instead")]
+		public Action<object,object?>? Setter           => _setter?.Value;
+
+		private Lazy<Func<object, object?>>?   _getter;
+		private Lazy<Action<object, object?>>? _setter;
+
+		private Expression            _getterExpression;
+		private ParameterExpression[] _getterArguments;
+
+		private Expression            _setterExpression;
+		private ParameterExpression[] _setterArguments;
+
+		public Expression GetGetterExpression(Expression instance)
+		{
+			return _getterExpression.Transform(
+				(parameters: _getterArguments, instance),
+				static (context, e) => e == context.parameters[0] ? context.instance : e);
+		}
+
+		public Expression GetSetterExpression(Expression instance, Expression value)
+		{
+			return _setterExpression.Transform(
+				(parameters: _setterArguments, instance, value),
+				static (context, e) =>
+					e == context.parameters[0] ? context.instance :
+					e == context.parameters[1] ? context.value : e);
+		}
 
 		public virtual object? GetValue(object o)
 		{
-			return Getter!(o);
+			return _getter!.Value(o);
 		}
 
 		public virtual void SetValue(object o, object? value)
 		{
-			Setter!(o, value);
+			_setter!.Value(o, value);
 		}
 
 		#endregion

--- a/Source/LinqToDB/SqlQuery/SqlObjectExpression.cs
+++ b/Source/LinqToDB/SqlQuery/SqlObjectExpression.cs
@@ -27,7 +27,7 @@ namespace LinqToDB.SqlQuery
 
 			var ta        = TypeAccessor.GetAccessor(mi.DeclaringType!);
 			var valueType = mi.GetMemberType();
-			var value     = ta[mi.Name].Getter!(obj);
+			var value     = ta[mi.Name].GetValue(obj);
 
 			return MappingSchema.GetSqlValue(valueType, value);
 		}


### PR DESCRIPTION
Fix #4275

This PR address performance issues in `EntityDescriptor` construction. It is not an issue for majority of use-cases, but in situations, when you want to prebuild big datamodel it results in quite big delays. See #4275 for details on specific use case.

I've used following model to test:
- entity with 1 PK field, 4 FK fields, 40 regular fields and 8 associations

Tested models: 150 entities and 1500 entities (to detect bottlenecks, not visible enough on smaller model)

### Test scenario

1. model build: create single instance of `FluentMappingBuilder` and populate it with mappings in single thread
2. model pregeneration: create entity descriptor for each registered entity using `MappingSchema.GetEntityDescriptor` call in single thread

### Results

Version: 5.2.2 vs this PR
150 items: 0.5 + 4 seconds => 0.5 + 0.7 seconds
1500 items: 4.7 + 44 seconds => 4.7 + 7 seconds

There is no performance gains for model build stage as I didn't see any explicit area for optimization.
For ED pregeneration I observe ~x6 performance boost

### Implemented optimizations

there are 3 optimizations and small memory fix in `EntityDescriptor.InitializeDynamicColumnsAccessors` method (delayed collections initialization)

#### Fix 1: memoise ReflectionExtensions.GetMemberEx reflection helper results

This method was called a lot with same arguments and perform a lot of reflection work

#### Fix 2: Use lazy compilation of MemberAccessor.Getter/Setter delegates

This not only speed-up `EntityDescriptor` creation by delaying expensive compilation operation but also avoids it in cases when those delegates are not used. And they are not used for most of use-cases as we use them only for some rartere operations and only on some entity members.

#### Fix 3: Dont' generate LambdaExpression for MemberAccessor.[Getter/Setter]Expression expressions

While `LambdaExpression` looks good encapsulation for expression body and parameters, I've discovered that in most of cases we just extract back body expression from it. What surprised me is that `Expression.Lambda` is very heavy method so it makes sense to eview use of it in other places in future.