### PR TITLE
Fix postgresql identifiers quotation

### DIFF
--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLIdentifierQuoteMode.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLIdentifierQuoteMode.cs
@@ -14,7 +14,8 @@
 		/// </summary>
 		Quote,
 		/// <summary>
-		/// Quote identifiers only when it is required according to PostgreSQL identifier quotation rules:
+		/// Quote identifiers only when it is required according to PostgreSQL identifier quotation rules
+		/// (except uppercase letters, for that look at <see cref="Auto"/> mode):
 		/// <list type="bullet">
 		/// <item>identifier use reserved word</item>
 		/// <item>identifier contains whitespace character(s)</item>
@@ -25,9 +26,9 @@
 		/// Quote identifiers only when it is required according to PostgreSQL identifier quotation rules:
 		/// <list type="bullet">
 		/// <item>identifier use reserved word</item>
-		/// <item>identifier constains whitespace character(s)</item>
+		/// <item>identifier constains prohibited character(s)</item>
+		/// <item>identifier constains upper-case letter(s)</item>
 		/// </list>
-		/// or when identifier starts with upper-case letter.
 		/// </summary>
 		Auto
 	}

--- a/Tests/Base/BaselinesWriter.cs
+++ b/Tests/Base/BaselinesWriter.cs
@@ -51,6 +51,7 @@ namespace Tests
 			// " used in each test name, for now we just remove it
 			return name
 				.Replace("\"", string.Empty)
+				.Replace("\\" , $"0x{(ushort)'\\':X4}")
 				.Replace(">" , $"0x{(ushort)'>':X4}")
 				.Replace("<" , $"0x{(ushort)'<':X4}")
 				.Replace("/" , $"0x{(ushort)'/':X4}")

--- a/Tests/Linq/DataProvider/PostgreSQLTests.cs
+++ b/Tests/Linq/DataProvider/PostgreSQLTests.cs
@@ -2485,8 +2485,7 @@ namespace Tests.DataProvider
 			throw new InvalidOperationException();
 		}
 
-		// TODO: function names should be escaped by linq2db, but it is not implemented yet
-		[Sql.TableFunction("\"TestTableFunctionSchema\"")]
+		[Sql.TableFunction("TestTableFunctionSchema")]
 		public LinqToDB.ITable<PostgreSQLTests.AllTypes> GetAllTypes()
 		{
 			var methodInfo = typeof(TestPgFunctions).GetMethod("GetAllTypes", Array<Type>.Empty)!;
@@ -2494,13 +2493,14 @@ namespace Tests.DataProvider
 			return _ctx.GetTable<PostgreSQLTests.AllTypes>(this, methodInfo);
 		}
 
+		// TODO: function names should be escaped by linq2db, but it is not implemented yet
 		[Sql.Function("\"TestFunctionParameters\"", ServerSideOnly = true)]
 		public static TestParametersResult TestParameters(int? param1, int? param2)
 		{
 			throw new InvalidOperationException();
 		}
 
-		[Sql.TableFunction("\"TestTableFunction\"")]
+		[Sql.TableFunction("TestTableFunction")]
 		public LinqToDB.ITable<TestScalarTableFunctionResult> TestScalarTableFunction(int? param1)
 		{
 			var methodInfo = typeof(TestPgFunctions).GetMethod("TestScalarTableFunction", new[] { typeof(int?) })!;
@@ -2508,7 +2508,7 @@ namespace Tests.DataProvider
 			return _ctx.GetTable<TestScalarTableFunctionResult>(this, methodInfo, param1);
 		}
 
-		[Sql.TableFunction("\"TestTableFunction1\"")]
+		[Sql.TableFunction("TestTableFunction1")]
 		public LinqToDB.ITable<TestRecordTableFunctionResult> TestRecordTableFunction(int? param1, int? param2)
 		{
 			var methodInfo = typeof(TestPgFunctions).GetMethod("TestRecordTableFunction", new[] { typeof(int?), typeof(int?) })!;


### PR DESCRIPTION
Fix #4285

- fix validation of allowed characters
- add `"` escaping
- remove legacy logic to skip quotation when identifier starts from `"`. User should fix their mappings or use `PostgreSQLIdentifierQuoteMode.None` mode