### PR TITLE
Add test for #4284

### DIFF
--- a/Tests/Linq/Linq/SelectQueryTests.cs
+++ b/Tests/Linq/Linq/SelectQueryTests.cs
@@ -172,5 +172,26 @@ namespace Tests.Linq
 			}
 		}
 
+		[ActiveIssue(4284)]
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4284")]
+		public void Select_GroupBy_SelectAgain([DataSources(TestProvName.AllSqlServer2017)] string context)
+		{
+			using (var db = GetDataContext(context))
+			{
+				var query = db.Person
+					.GroupBy(g => g.LastName)
+					.Select(group => new
+					{
+						LastName         = group.Key,
+						Count            = group.Count(),
+						HighestFirstName = group.Max(x => x.FirstName)
+					})
+					.Where(summary => summary.Count > 5)
+					.Skip(1).Take(1)
+					.Select(x => new { Count = Sql.Ext.Count().Over().ToValue(), Value = x });
+
+				query.ToArray();
+			}
+		}
 	}
 }


### PR DESCRIPTION
Adds test for #4284

We don't plan to fix it for now:
- it is already fixed in new parser
- fix could be too complex with current parser
- issue could be workarounded