### PR TITLE
Workaround NativeAOT issue with GetInterfaceMap  method

### DIFF
--- a/Source/LinqToDB/Extensions/ReflectionExtensions.cs
+++ b/Source/LinqToDB/Extensions/ReflectionExtensions.cs
@@ -308,41 +308,28 @@ namespace LinqToDB.Extensions
 			return type.GetMember(name);
 		}
 
-// TODO: V6: reenable TFM filtering after NativeAOT testing added
-//#if NETSTANDARD2_0
-		private static Func<Type, Type, InterfaceMapping>? _getInterfaceMap;
-//#endif
+		// GetInterfaceMap could fail in AOT builds
+		// - CoreRT runtime could miss this method implementation
+		// - NativeAOT builds at least up to .NET 8 doesn't support interfaces with statics or/and default implementations
+		// for such cases we return empty stub
 		public static InterfaceMapping GetInterfaceMapEx(this Type type, Type interfaceType)
 		{
-			// native UWP builds (corert) had no GetInterfaceMap() implementation
-			// (added here https://github.com/dotnet/corert/pull/8144)
-//#if NETSTANDARD2_0
-			if (_getInterfaceMap == null)
+			try
 			{
-				_getInterfaceMap = (t, i) => t.GetInterfaceMap(i);
-				try
-				{
-					return _getInterfaceMap(type, interfaceType);
-				}
-				//catch (PlatformNotSupportedException)
-				catch (Exception ex) when (ex is NotSupportedException or PlatformNotSupportedException)
-				{
-					// porting of https://github.com/dotnet/corert/pull/8144 is not possible as it requires access
-					// to non-public runtime data and reflection doesn't work in corert
-					_getInterfaceMap = (t, i) => new InterfaceMapping()
-					{
-						TargetType       = t,
-						InterfaceType    = i,
-						TargetMethods    = Array<MethodInfo>.Empty,
-						InterfaceMethods = Array<MethodInfo>.Empty
-					};
-				}
+				return type.GetInterfaceMap(interfaceType);
 			}
-
-			return _getInterfaceMap(type, interfaceType);
-//#else
-//			return type.GetInterfaceMap(interfaceType);
-//#endif
+			// PNSE: corert
+			// NSE: NativeAOUT
+			catch (Exception ex) when (ex is NotSupportedException or PlatformNotSupportedException)
+			{
+				return new InterfaceMapping()
+				{
+					TargetType = type,
+					InterfaceType = interfaceType,
+					TargetMethods = Array<MethodInfo>.Empty,
+					InterfaceMethods = Array<MethodInfo>.Empty
+				};
+			}
 		}
 
 		/// <summary>

--- a/Source/LinqToDB/Extensions/ReflectionExtensions.cs
+++ b/Source/LinqToDB/Extensions/ReflectionExtensions.cs
@@ -15,6 +15,7 @@ using JetBrains.Annotations;
 
 namespace LinqToDB.Extensions
 {
+	using Common;
 	using Reflection;
 
 	[PublicAPI]
@@ -332,8 +333,8 @@ namespace LinqToDB.Extensions
 					{
 						TargetType       = t,
 						InterfaceType    = i,
-						TargetMethods    = Array.Empty<MethodInfo>(),
-						InterfaceMethods = Array.Empty<MethodInfo>()
+						TargetMethods    = Array<MethodInfo>.Empty,
+						InterfaceMethods = Array<MethodInfo>.Empty
 					};
 				}
 			}

--- a/Source/LinqToDB/Extensions/ReflectionExtensions.cs
+++ b/Source/LinqToDB/Extensions/ReflectionExtensions.cs
@@ -307,14 +307,15 @@ namespace LinqToDB.Extensions
 			return type.GetMember(name);
 		}
 
-#if NETSTANDARD2_0
+// TODO: V6: reenable TFM filtering after NativeAOT testing added
+//#if NETSTANDARD2_0
 		private static Func<Type, Type, InterfaceMapping>? _getInterfaceMap;
-#endif
+//#endif
 		public static InterfaceMapping GetInterfaceMapEx(this Type type, Type interfaceType)
 		{
 			// native UWP builds (corert) had no GetInterfaceMap() implementation
 			// (added here https://github.com/dotnet/corert/pull/8144)
-#if NETSTANDARD2_0
+//#if NETSTANDARD2_0
 			if (_getInterfaceMap == null)
 			{
 				_getInterfaceMap = (t, i) => t.GetInterfaceMap(i);
@@ -322,7 +323,8 @@ namespace LinqToDB.Extensions
 				{
 					return _getInterfaceMap(type, interfaceType);
 				}
-				catch (PlatformNotSupportedException)
+				//catch (PlatformNotSupportedException)
+				catch (Exception ex) when (ex is NotSupportedException or PlatformNotSupportedException)
 				{
 					// porting of https://github.com/dotnet/corert/pull/8144 is not possible as it requires access
 					// to non-public runtime data and reflection doesn't work in corert
@@ -337,9 +339,9 @@ namespace LinqToDB.Extensions
 			}
 
 			return _getInterfaceMap(type, interfaceType);
-#else
-			return type.GetInterfaceMap(interfaceType);
-#endif
+//#else
+//			return type.GetInterfaceMap(interfaceType);
+//#endif
 		}
 
 		/// <summary>


### PR DESCRIPTION
Fix #4267 - adds workaround for runtime issue

We already have workaround code for CoreRT, but looks like NativeAOT have issue with `GetInterfaceMap` code erasure : https://github.com/dotnet/runtime/issues/89157

Problem with this workaround is tha it only suppress exception, not reintroduce required functionality, so it will not work properly for mappings with interfaces.

For v6 release I plan to add proper NativeAOT testing to ensure that we can work there.