### PR TITLE
Improve `IAsyncEnumerable` usage

### DIFF
--- a/Source/LinqToDB/Data/CommandInfo.cs
+++ b/Source/LinqToDB/Data/CommandInfo.cs
@@ -262,24 +262,28 @@ namespace LinqToDB.Data
 		/// </summary>
 		/// <typeparam name="T">Result record type.</typeparam>
 		/// <param name="objectReader">Record mapping function from data reader.</param>
-		/// <param name="cancellationToken">Asynchronous operation cancellation token.</param>
 		/// <returns>Async sequence of records returned by the query.</returns>
-		public async IAsyncEnumerable<T> QueryToAsyncEnumerable<T>(Func<DbDataReader, T> objectReader, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		public IAsyncEnumerable<T> QueryToAsyncEnumerable<T>(Func<DbDataReader, T> objectReader)
 		{
-			await DataConnection.EnsureConnectionAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
+			return Impl(objectReader);
 
-			InitCommand();
-
-			await using ((DataConnection.DataProvider.ExecuteScope(DataConnection) ?? EmptyIAsyncDisposable.Instance).ConfigureAwait(Configuration.ContinueOnCapturedContext))
+			async IAsyncEnumerable<T> Impl(Func<DbDataReader, T> objectReader, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 			{
+				await DataConnection.EnsureConnectionAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
+
+				InitCommand();
+
+				await using ((DataConnection.DataProvider.ExecuteScope(DataConnection) ?? EmptyIAsyncDisposable.Instance).ConfigureAwait(Configuration.ContinueOnCapturedContext))
+				{
 #if NETSTANDARD2_1PLUS
-				var rd = await DataConnection.ExecuteDataReaderAsync(GetCommandBehavior(), cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
-				await using (rd.ConfigureAwait(Configuration.ContinueOnCapturedContext))
+					var rd = await DataConnection.ExecuteDataReaderAsync(GetCommandBehavior(), cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
+					await using (rd.ConfigureAwait(Configuration.ContinueOnCapturedContext))
 #else
-				using (var rd = await DataConnection.ExecuteDataReaderAsync(GetCommandBehavior(), cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
+					using (var rd = await DataConnection.ExecuteDataReaderAsync(GetCommandBehavior(), cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 #endif
-					while (await rd.DataReader!.ReadAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
-						yield return objectReader(rd.DataReader!);
+						while (await rd.DataReader!.ReadAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
+							yield return objectReader(rd.DataReader!);
+				}
 			}
 		}
 #endif
@@ -503,51 +507,55 @@ namespace LinqToDB.Data
 		/// Executes command asynchronously and apply provided action to each record.
 		/// </summary>
 		/// <typeparam name="T">Result record type.</typeparam>
-		/// <param name="cancellationToken">Asynchronous operation cancellation token.</param>
 		/// <returns>Async sequence of records returned by the query.</returns>
-		public async IAsyncEnumerable<T> QueryToAsyncEnumerable<T>([EnumeratorCancellation] CancellationToken cancellationToken = default)
+		public IAsyncEnumerable<T> QueryToAsyncEnumerable<T>()
 		{
-			await DataConnection.EnsureConnectionAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
+			return Impl();
 
-			InitCommand();
-
-			await using ((DataConnection.DataProvider.ExecuteScope(DataConnection) ?? EmptyIAsyncDisposable.Instance).ConfigureAwait(Configuration.ContinueOnCapturedContext))
+			async IAsyncEnumerable<T> Impl([EnumeratorCancellation] CancellationToken cancellationToken = default)
 			{
-#if NETSTANDARD2_1PLUS
-				var rd = await DataConnection.ExecuteDataReaderAsync(GetCommandBehavior(), cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
-				await using (rd.ConfigureAwait(Configuration.ContinueOnCapturedContext))
-#else
-				using (var rd = await DataConnection.ExecuteDataReaderAsync(GetCommandBehavior(), cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
-#endif
+				await DataConnection.EnsureConnectionAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
+
+				InitCommand();
+
+				await using ((DataConnection.DataProvider.ExecuteScope(DataConnection) ?? EmptyIAsyncDisposable.Instance).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 				{
-					if (await rd.DataReader!.ReadAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
+#if NETSTANDARD2_1PLUS
+					var rd = await DataConnection.ExecuteDataReaderAsync(GetCommandBehavior(), cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
+					await using (rd.ConfigureAwait(Configuration.ContinueOnCapturedContext))
+#else
+					using (var rd = await DataConnection.ExecuteDataReaderAsync(GetCommandBehavior(), cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
+#endif
 					{
-						var additionalKey = GetCommandAdditionalKey(rd.DataReader!, typeof(T));
-						var reader        = ((IDataContext)DataConnection).UnwrapDataObjectInterceptor?.UnwrapDataReader(DataConnection, rd.DataReader!) ?? rd.DataReader!;
-						var objectReader  = GetObjectReader<T>(DataConnection, reader, CommandText, additionalKey);
-						var isFaulted     = false;
-
-						do
+						if (await rd.DataReader!.ReadAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 						{
-							T result;
+							var additionalKey = GetCommandAdditionalKey(rd.DataReader!, typeof(T));
+							var reader        = ((IDataContext)DataConnection).UnwrapDataObjectInterceptor?.UnwrapDataReader(DataConnection, rd.DataReader!) ?? rd.DataReader!;
+							var objectReader  = GetObjectReader<T>(DataConnection, reader, CommandText, additionalKey);
+							var isFaulted     = false;
 
-							try
+							do
 							{
-								result = objectReader(reader);
-							}
-							catch (InvalidCastException)
-							{
-								if (isFaulted)
-									throw;
+								T result;
 
-								isFaulted = true;
-								objectReader = GetObjectReader2<T>(DataConnection, reader, CommandText, additionalKey);
-								result = objectReader(reader);
-							}
+								try
+								{
+									result = objectReader(reader);
+								}
+								catch (InvalidCastException)
+								{
+									if (isFaulted)
+										throw;
 
-							yield return result;
+									isFaulted = true;
+									objectReader = GetObjectReader2<T>(DataConnection, reader, CommandText, additionalKey);
+									result = objectReader(reader);
+								}
 
-						} while (await rd.DataReader!.ReadAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext));
+								yield return result;
+
+							} while (await rd.DataReader!.ReadAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext));
+						}
 					}
 				}
 			}
@@ -1387,35 +1395,40 @@ namespace LinqToDB.Data
 		}
 
 #if NATIVE_ASYNC
-		internal async IAsyncEnumerable<T> ExecuteQueryAsync<T>(DbDataReader rd, string sql, [EnumeratorCancellation] CancellationToken cancellationToken)
+		internal IAsyncEnumerable<T> ExecuteQueryAsync<T>(DbDataReader rd, string sql)
 		{
-			if (await rd.ReadAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
+			return Impl(rd, sql);
+
+			async IAsyncEnumerable<T> Impl(DbDataReader rd, string sql, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 			{
-				var additionalKey = GetCommandAdditionalKey(rd, typeof(T));
-				var objectReader  = GetObjectReader<T>(DataConnection, rd, sql, additionalKey);
-				var isFaulted     = false;
-
-				do
+				if (await rd.ReadAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 				{
-					T result;
+					var additionalKey = GetCommandAdditionalKey(rd, typeof(T));
+					var objectReader  = GetObjectReader<T>(DataConnection, rd, sql, additionalKey);
+					var isFaulted     = false;
 
-					try
+					do
 					{
-						result = objectReader(rd);
-					}
-					catch (InvalidCastException)
-					{
-						if (isFaulted)
-							throw;
+						T result;
 
-						isFaulted = true;
-						objectReader = GetObjectReader2<T>(DataConnection, rd, sql, additionalKey);
-						result = objectReader(rd);
-					}
+						try
+						{
+							result = objectReader(rd);
+						}
+						catch (InvalidCastException)
+						{
+							if (isFaulted)
+								throw;
 
-					yield return result;
+							isFaulted = true;
+							objectReader = GetObjectReader2<T>(DataConnection, rd, sql, additionalKey);
+							result = objectReader(rd);
+						}
 
-				} while (await rd.ReadAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext));
+						yield return result;
+
+					} while (await rd.ReadAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext));
+				}
 			}
 		}
 #endif

--- a/Source/LinqToDB/Data/CommandInfo.cs
+++ b/Source/LinqToDB/Data/CommandInfo.cs
@@ -256,7 +256,7 @@ namespace LinqToDB.Data
 			}
 		}
 
-#if NETSTANDARD2_1PLUS
+#if NATIVE_ASYNC
 		/// <summary>
 		/// Executes command asynchronously and apply provided action to each record, mapped using provided mapping function.
 		/// </summary>
@@ -272,8 +272,12 @@ namespace LinqToDB.Data
 
 			await using ((DataConnection.DataProvider.ExecuteScope(DataConnection) ?? EmptyIAsyncDisposable.Instance).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 			{
+#if NETSTANDARD2_1PLUS
 				var rd = await DataConnection.ExecuteDataReaderAsync(GetCommandBehavior(), cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 				await using (rd.ConfigureAwait(Configuration.ContinueOnCapturedContext))
+#else
+				using (var rd = await DataConnection.ExecuteDataReaderAsync(GetCommandBehavior(), cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
+#endif
 					while (await rd.DataReader!.ReadAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 						yield return objectReader(rd.DataReader!);
 			}
@@ -494,7 +498,7 @@ namespace LinqToDB.Data
 			}
 		}
 
-#if NETSTANDARD2_1PLUS
+#if NATIVE_ASYNC
 		/// <summary>
 		/// Executes command asynchronously and apply provided action to each record.
 		/// </summary>
@@ -509,8 +513,12 @@ namespace LinqToDB.Data
 
 			await using ((DataConnection.DataProvider.ExecuteScope(DataConnection) ?? EmptyIAsyncDisposable.Instance).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 			{
+#if NETSTANDARD2_1PLUS
 				var rd = await DataConnection.ExecuteDataReaderAsync(GetCommandBehavior(), cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 				await using (rd.ConfigureAwait(Configuration.ContinueOnCapturedContext))
+#else
+				using (var rd = await DataConnection.ExecuteDataReaderAsync(GetCommandBehavior(), cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
+#endif
 				{
 					if (await rd.DataReader!.ReadAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 					{
@@ -672,11 +680,11 @@ namespace LinqToDB.Data
 #else
 				using (var rd = await DataConnection.ExecuteDataReaderAsync(GetCommandBehavior(), cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))
 #endif
-			{
-					result = await ReadMultipleResultSetsAsync<T>(rd.DataReader!, cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
+				{
+						result = await ReadMultipleResultSetsAsync<T>(rd.DataReader!, cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext);
 
-					SetRebindParameters(rd);
-			}
+						SetRebindParameters(rd);
+				}
 			}
 
 			return result;
@@ -1378,7 +1386,7 @@ namespace LinqToDB.Data
 			}
 		}
 
-#if NETSTANDARD2_1PLUS
+#if NATIVE_ASYNC
 		internal async IAsyncEnumerable<T> ExecuteQueryAsync<T>(DbDataReader rd, string sql, [EnumeratorCancellation] CancellationToken cancellationToken)
 		{
 			if (await rd.ReadAsync(cancellationToken).ConfigureAwait(Configuration.ContinueOnCapturedContext))

--- a/Source/LinqToDB/Data/CommandInfo.cs
+++ b/Source/LinqToDB/Data/CommandInfo.cs
@@ -485,9 +485,9 @@ namespace LinqToDB.Data
 								if (isFaulted)
 									throw;
 
-								isFaulted = true;
+								isFaulted    = true;
 								objectReader = GetObjectReader2<T>(DataConnection, reader, CommandText, additionalKey);
-								result = objectReader(reader);
+								result       = objectReader(reader);
 							}
 
 							action(result);
@@ -1375,9 +1375,9 @@ namespace LinqToDB.Data
 						if (isFaulted)
 							throw;
 
-						isFaulted = true;
+						isFaulted    = true;
 						objectReader = GetObjectReader2<T>(DataConnection, rd, sql, additionalKey);
-						result = objectReader(rd);
+						result       = objectReader(rd);
 					}
 
 					action(result);

--- a/Source/LinqToDB/Data/DataConnectionExtensions.cs
+++ b/Source/LinqToDB/Data/DataConnectionExtensions.cs
@@ -483,7 +483,7 @@ namespace LinqToDB.Data
 		}
 #endif
 
-#endregion
+		#endregion
 
 		#region Query
 
@@ -1389,7 +1389,7 @@ namespace LinqToDB.Data
 		}
 #endif
 
-#endregion
+		#endregion
 
 		#region Query with template
 
@@ -2746,6 +2746,6 @@ namespace LinqToDB.Data
 		}
 
 #endif
-#endregion
+		#endregion
 	}
 }

--- a/Source/LinqToDB/Data/DataConnectionExtensions.cs
+++ b/Source/LinqToDB/Data/DataConnectionExtensions.cs
@@ -275,7 +275,7 @@ namespace LinqToDB.Data
 			return new CommandInfo(connection, sql).QueryToArrayAsync(objectReader, cancellationToken);
 		}
 
-#if NETSTANDARD2_1PLUS
+#if NATIVE_ASYNC
 		/// <summary>
 		/// Executes command asynchronously and returns async sequence of values, mapped using provided mapping function.
 		/// </summary>
@@ -348,7 +348,7 @@ namespace LinqToDB.Data
 			return new CommandInfo(connection, sql, parameters).QueryToArrayAsync(objectReader, cancellationToken);
 		}
 
-#if NETSTANDARD2_1PLUS
+#if NATIVE_ASYNC
 		/// <summary>
 		/// Executes command asynchronously and returns array of values, mapped using provided mapping function.
 		/// </summary>
@@ -458,7 +458,7 @@ namespace LinqToDB.Data
 			return new CommandInfo(connection, sql, parameters).QueryToArrayAsync(objectReader, cancellationToken);
 		}
 
-#if NETSTANDARD2_1PLUS
+#if NATIVE_ASYNC
 		/// <summary>
 		/// Executes command asynchronously and returns array of values, mapped using provided mapping function.
 		/// </summary>
@@ -1123,7 +1123,7 @@ namespace LinqToDB.Data
 			return new CommandInfo(connection, sql).QueryToArrayAsync<T>(cancellationToken);
 		}
 
-#if NETSTANDARD2_1PLUS
+#if NATIVE_ASYNC
 		/// <summary>
 		/// Executes command asynchronously and returns array of values.
 		/// </summary>
@@ -1191,7 +1191,7 @@ namespace LinqToDB.Data
 			return new CommandInfo(connection, sql, parameters).QueryToArrayAsync<T>(cancellationToken);
 		}
 
-#if NETSTANDARD2_1PLUS
+#if NATIVE_ASYNC
 		/// <summary>
 		/// Executes command asynchronously and returns array of values.
 		/// </summary>
@@ -1260,7 +1260,7 @@ namespace LinqToDB.Data
 			return new CommandInfo(connection, sql, parameter).QueryToArrayAsync<T>(cancellationToken);
 		}
 
-#if NETSTANDARD2_1PLUS
+#if NATIVE_ASYNC
 		/// <summary>
 		/// Executes command asynchronously and returns array of values.
 		/// </summary>
@@ -1365,7 +1365,7 @@ namespace LinqToDB.Data
 			return new CommandInfo(connection, sql, parameters).QueryToArrayAsync<T>(cancellationToken);
 		}
 
-#if NETSTANDARD2_1PLUS
+#if NATIVE_ASYNC
 		/// <summary>
 		/// Executes command asynchronously and returns array of values.
 		/// </summary>
@@ -1582,7 +1582,7 @@ namespace LinqToDB.Data
 			return new CommandInfo(connection, sql, parameters).QueryToArrayAsync<T>(cancellationToken);
 		}
 
-#if NETSTANDARD2_1PLUS
+#if NATIVE_ASYNC
 		/// <summary>
 		/// Executes command asynchronously and returns array of values of specified type.
 		/// </summary>
@@ -1692,7 +1692,7 @@ namespace LinqToDB.Data
 			return new CommandInfo(connection, sql, parameters).QueryToArrayAsync<T>(cancellationToken);
 		}
 
-#if NETSTANDARD2_1PLUS
+#if NATIVE_ASYNC
 		/// <summary>
 		/// Executes command asynchronously and returns array of values of specified type.
 		/// </summary>

--- a/Source/LinqToDB/Data/DataConnectionExtensions.cs
+++ b/Source/LinqToDB/Data/DataConnectionExtensions.cs
@@ -275,6 +275,21 @@ namespace LinqToDB.Data
 			return new CommandInfo(connection, sql).QueryToArrayAsync(objectReader, cancellationToken);
 		}
 
+#if NETSTANDARD2_1PLUS
+		/// <summary>
+		/// Executes command asynchronously and returns async sequence of values, mapped using provided mapping function.
+		/// </summary>
+		/// <typeparam name="T">Result record type.</typeparam>
+		/// <param name="connection">Database connection.</param>
+		/// <param name="objectReader">Record mapping function from data reader.</param>
+		/// <param name="sql">Command text.</param>
+		/// <returns>Async sequence of records returned by the query.</returns>
+		public static IAsyncEnumerable<T> QueryToAsyncEnumerable<T>(this DataConnection connection, Func<DbDataReader, T> objectReader, string sql)
+		{
+			return new CommandInfo(connection, sql).QueryToAsyncEnumerable(objectReader);
+		}
+#endif
+
 		/// <summary>
 		/// Executes command asynchronously and returns list of values, mapped using provided mapping function.
 		/// </summary>
@@ -332,6 +347,22 @@ namespace LinqToDB.Data
 		{
 			return new CommandInfo(connection, sql, parameters).QueryToArrayAsync(objectReader, cancellationToken);
 		}
+
+#if NETSTANDARD2_1PLUS
+		/// <summary>
+		/// Executes command asynchronously and returns array of values, mapped using provided mapping function.
+		/// </summary>
+		/// <typeparam name="T">Result record type.</typeparam>
+		/// <param name="connection">Database connection.</param>
+		/// <param name="objectReader">Record mapping function from data reader.</param>
+		/// <param name="sql">Command text.</param>
+		/// <param name="parameters">Command parameters.</param>
+		/// <returns>Async sequence of records returned by the query.</returns>
+		public static IAsyncEnumerable<T> QueryToAsyncEnumerable<T>(this DataConnection connection, Func<DbDataReader, T> objectReader, string sql, params DataParameter[] parameters)
+		{
+			return new CommandInfo(connection, sql, parameters).QueryToAsyncEnumerable(objectReader);
+		}
+#endif
 
 		/// <summary>
 		/// Executes command asynchronously and returns list of values, mapped using provided mapping function.
@@ -427,7 +458,32 @@ namespace LinqToDB.Data
 			return new CommandInfo(connection, sql, parameters).QueryToArrayAsync(objectReader, cancellationToken);
 		}
 
-		#endregion
+#if NETSTANDARD2_1PLUS
+		/// <summary>
+		/// Executes command asynchronously and returns array of values, mapped using provided mapping function.
+		/// </summary>
+		/// <typeparam name="T">Result record type.</typeparam>
+		/// <param name="connection">Database connection.</param>
+		/// <param name="objectReader">Record mapping function from data reader.</param>
+		/// <param name="sql">Command text.</param>
+		/// <param name="parameters">Command parameters. Supported values:
+		/// <para> - <c>null</c> for command without parameters;</para>
+		/// <para> - single <see cref="DataParameter"/> instance;</para>
+		/// <para> - array of <see cref="DataParameter"/> parameters;</para>
+		/// <para> - mapping class entity.</para>
+		/// <para>Last case will convert all mapped columns to <see cref="DataParameter"/> instances using following logic:</para>
+		/// <para> - if column is of <see cref="DataParameter"/> type, column value will be used. If parameter name (<see cref="DataParameter.Name"/>) is not set, column name will be used;</para>
+		/// <para> - if converter from column type to <see cref="DataParameter"/> is defined in mapping schema, it will be used to create parameter with column name passed to converter;</para>
+		/// <para> - otherwise column value will be converted to <see cref="DataParameter"/> using column name as parameter name and column value will be converted to parameter value using conversion, defined by mapping schema.</para>
+		/// </param>
+		/// <returns>Async sequence of records returned by the query.</returns>
+		public static IAsyncEnumerable<T> QueryToAsyncEnumerable<T>(this DataConnection connection, Func<DbDataReader, T> objectReader, string sql, object? parameters)
+		{
+			return new CommandInfo(connection, sql, parameters).QueryToAsyncEnumerable(objectReader);
+		}
+#endif
+
+#endregion
 
 		#region Query
 
@@ -1067,6 +1123,20 @@ namespace LinqToDB.Data
 			return new CommandInfo(connection, sql).QueryToArrayAsync<T>(cancellationToken);
 		}
 
+#if NETSTANDARD2_1PLUS
+		/// <summary>
+		/// Executes command asynchronously and returns array of values.
+		/// </summary>
+		/// <typeparam name="T">Result record type.</typeparam>
+		/// <param name="connection">Database connection.</param>
+		/// <param name="sql">Command text.</param>
+		/// <returns>Async sequence of records returned by the query.</returns>
+		public static IAsyncEnumerable<T> QueryToAsyncEnumerable<T>(this DataConnection connection, string sql)
+		{
+			return new CommandInfo(connection, sql).QueryToAsyncEnumerable<T>();
+		}
+#endif
+
 		/// <summary>
 		/// Executes command asynchronously and returns list of values.
 		/// </summary>
@@ -1121,6 +1191,21 @@ namespace LinqToDB.Data
 			return new CommandInfo(connection, sql, parameters).QueryToArrayAsync<T>(cancellationToken);
 		}
 
+#if NETSTANDARD2_1PLUS
+		/// <summary>
+		/// Executes command asynchronously and returns array of values.
+		/// </summary>
+		/// <typeparam name="T">Result record type.</typeparam>
+		/// <param name="connection">Database connection.</param>
+		/// <param name="sql">Command text.</param>
+		/// <param name="parameters">Command parameters.</param>
+		/// <returns>Async sequence of records returned by the query.</returns>
+		public static IAsyncEnumerable<T> QueryToAsyncEnumerable<T>(this DataConnection connection, string sql, params DataParameter[] parameters)
+		{
+			return new CommandInfo(connection, sql, parameters).QueryToAsyncEnumerable<T>();
+		}
+#endif
+
 		/// <summary>
 		/// Executes command asynchronously and returns list of values.
 		/// </summary>
@@ -1174,6 +1259,21 @@ namespace LinqToDB.Data
 		{
 			return new CommandInfo(connection, sql, parameter).QueryToArrayAsync<T>(cancellationToken);
 		}
+
+#if NETSTANDARD2_1PLUS
+		/// <summary>
+		/// Executes command asynchronously and returns array of values.
+		/// </summary>
+		/// <typeparam name="T">Result record type.</typeparam>
+		/// <param name="connection">Database connection.</param>
+		/// <param name="sql">Command text.</param>
+		/// <param name="parameter">Command parameter.</param>
+		/// <returns>Async sequence of records returned by the query.</returns>
+		public static IAsyncEnumerable<T> QueryToAsyncEnumerable<T>(this DataConnection connection, string sql, DataParameter parameter)
+		{
+			return new CommandInfo(connection, sql, parameter).QueryToAsyncEnumerable<T>();
+		}
+#endif
 
 		/// <summary>
 		/// Executes command asynchronously and returns list of values.
@@ -1265,7 +1365,31 @@ namespace LinqToDB.Data
 			return new CommandInfo(connection, sql, parameters).QueryToArrayAsync<T>(cancellationToken);
 		}
 
-		#endregion
+#if NETSTANDARD2_1PLUS
+		/// <summary>
+		/// Executes command asynchronously and returns array of values.
+		/// </summary>
+		/// <typeparam name="T">Result record type.</typeparam>
+		/// <param name="connection">Database connection.</param>
+		/// <param name="sql">Command text.</param>
+		/// <param name="parameters">Command parameters. Supported values:
+		/// <para> - <c>null</c> for command without parameters;</para>
+		/// <para> - single <see cref="DataParameter"/> instance;</para>
+		/// <para> - array of <see cref="DataParameter"/> parameters;</para>
+		/// <para> - mapping class entity.</para>
+		/// <para>Last case will convert all mapped columns to <see cref="DataParameter"/> instances using following logic:</para>
+		/// <para> - if column is of <see cref="DataParameter"/> type, column value will be used. If parameter name (<see cref="DataParameter.Name"/>) is not set, column name will be used;</para>
+		/// <para> - if converter from column type to <see cref="DataParameter"/> is defined in mapping schema, it will be used to create parameter with column name passed to converter;</para>
+		/// <para> - otherwise column value will be converted to <see cref="DataParameter"/> using column name as parameter name and column value will be converted to parameter value using conversion, defined by mapping schema.</para>
+		/// </param>
+		/// <returns>Async sequence of records returned by the query.</returns>
+		public static IAsyncEnumerable<T> QueryToAsyncEnumerable<T>(this DataConnection connection, string sql, object? parameters)
+		{
+			return new CommandInfo(connection, sql, parameters).QueryToAsyncEnumerable<T>();
+		}
+#endif
+
+#endregion
 
 		#region Query with template
 
@@ -1458,6 +1582,22 @@ namespace LinqToDB.Data
 			return new CommandInfo(connection, sql, parameters).QueryToArrayAsync<T>(cancellationToken);
 		}
 
+#if NETSTANDARD2_1PLUS
+		/// <summary>
+		/// Executes command asynchronously and returns array of values of specified type.
+		/// </summary>
+		/// <typeparam name="T">Result record type.</typeparam>
+		/// <param name="connection">Database connection.</param>
+		/// <param name="template">This value used only for <typeparamref name="T"/> parameter type inference, which makes this method usable with anonymous types.</param>
+		/// <param name="sql">Command text.</param>
+		/// <param name="parameters">Command parameters.</param>
+		/// <returns>Async sequence of records returned by the query.</returns>
+		public static IAsyncEnumerable<T> QueryToAsyncEnumerable<T>(this DataConnection connection, T template, string sql, params DataParameter[] parameters)
+		{
+			return new CommandInfo(connection, sql, parameters).QueryToAsyncEnumerable<T>();
+		}
+#endif
+
 		/// <summary>
 		/// Executes command asynchronously and returns list of values of specified type.
 		/// </summary>
@@ -1551,6 +1691,31 @@ namespace LinqToDB.Data
 		{
 			return new CommandInfo(connection, sql, parameters).QueryToArrayAsync<T>(cancellationToken);
 		}
+
+#if NETSTANDARD2_1PLUS
+		/// <summary>
+		/// Executes command asynchronously and returns array of values of specified type.
+		/// </summary>
+		/// <typeparam name="T">Result record type.</typeparam>
+		/// <param name="connection">Database connection.</param>
+		/// <param name="template">This value used only for <typeparamref name="T"/> parameter type inference, which makes this method usable with anonymous types.</param>
+		/// <param name="sql">Command text.</param>
+		/// <param name="parameters">Command parameters. Supported values:
+		/// <para> - <c>null</c> for command without parameters;</para>
+		/// <para> - single <see cref="DataParameter"/> instance;</para>
+		/// <para> - array of <see cref="DataParameter"/> parameters;</para>
+		/// <para> - mapping class entity.</para>
+		/// <para>Last case will convert all mapped columns to <see cref="DataParameter"/> instances using following logic:</para>
+		/// <para> - if column is of <see cref="DataParameter"/> type, column value will be used. If parameter name (<see cref="DataParameter.Name"/>) is not set, column name will be used;</para>
+		/// <para> - if converter from column type to <see cref="DataParameter"/> is defined in mapping schema, it will be used to create parameter with column name passed to converter;</para>
+		/// <para> - otherwise column value will be converted to <see cref="DataParameter"/> using column name as parameter name and column value will be converted to parameter value using conversion, defined by mapping schema.</para>
+		/// </param>
+		/// <returns>Async sequence of records returned by the query.</returns>
+		public static IAsyncEnumerable<T> QueryToAsyncEnumerable<T>(this DataConnection connection, T template, string sql, object? parameters)
+		{
+			return new CommandInfo(connection, sql, parameters).QueryToAsyncEnumerable<T>();
+		}
+#endif
 
 		#endregion
 
@@ -2581,6 +2746,6 @@ namespace LinqToDB.Data
 		}
 
 #endif
-		#endregion
+#endregion
 	}
 }

--- a/Source/LinqToDB/Data/DataReaderAsync.cs
+++ b/Source/LinqToDB/Data/DataReaderAsync.cs
@@ -125,7 +125,7 @@ namespace LinqToDB.Data
 				action(objectReader(Reader));
 		}
 
-#if NETSTANDARD2_1PLUS
+#if NATIVE_ASYNC
 		public async IAsyncEnumerable<T> QueryToAsyncEnumerable<T>(Func<DbDataReader, T> objectReader, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			while (await Reader!.ReadAsync(cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
@@ -177,7 +177,7 @@ namespace LinqToDB.Data
 			await CommandInfo!.ExecuteQueryAsync(Reader!, CommandInfo.CommandText + "$$$" + ReadNumber, action, cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 		}
 
-#if NETSTANDARD2_1PLUS
+#if NATIVE_ASYNC
 		public async IAsyncEnumerable<T> QueryToAsyncEnumerable<T>([EnumeratorCancellation] CancellationToken cancellationToken)
 		{
 			if (ReadNumber != 0)
@@ -229,7 +229,7 @@ namespace LinqToDB.Data
 			return QueryForEachAsync(action, cancellationToken);
 		}
 
-#if NETSTANDARD2_1PLUS
+#if NATIVE_ASYNC
 		public IAsyncEnumerable<T> QueryForEachAsync<T>(T template, CancellationToken cancellationToken)
 		{
 			return QueryToAsyncEnumerable<T>(cancellationToken);

--- a/Source/LinqToDB/Data/DataReaderAsync.cs
+++ b/Source/LinqToDB/Data/DataReaderAsync.cs
@@ -178,7 +178,7 @@ namespace LinqToDB.Data
 		}
 
 #if NATIVE_ASYNC
-		public async IAsyncEnumerable<T> QueryToAsyncEnumerable<T>([EnumeratorCancellation] CancellationToken cancellationToken)
+		public async IAsyncEnumerable<T> QueryToAsyncEnumerable<T>([EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
 			if (ReadNumber != 0)
 				if (!await Reader!.NextResultAsync(cancellationToken).ConfigureAwait(Common.Configuration.ContinueOnCapturedContext))
@@ -230,9 +230,9 @@ namespace LinqToDB.Data
 		}
 
 #if NATIVE_ASYNC
-		public IAsyncEnumerable<T> QueryForEachAsync<T>(T template, CancellationToken cancellationToken)
+		public IAsyncEnumerable<T> QueryToAsyncEnumerable<T>(T template)
 		{
-			return QueryToAsyncEnumerable<T>(cancellationToken);
+			return QueryToAsyncEnumerable<T>();
 		}
 #endif
 		

--- a/Source/LinqToDB/LinqExtensions.Insert.cs
+++ b/Source/LinqToDB/LinqExtensions.Insert.cs
@@ -596,9 +596,9 @@ namespace LinqToDB
 							Expression<Func<TTarget, TOutput>> outputExpression)
 			where TTarget : notnull
 		{
-			if (source == null) throw new ArgumentNullException(nameof(source));
-			if (target == null) throw new ArgumentNullException(nameof(target));
-			if (setter == null) throw new ArgumentNullException(nameof(setter));
+			if (source           == null) throw new ArgumentNullException(nameof(source));
+			if (target           == null) throw new ArgumentNullException(nameof(target));
+			if (setter           == null) throw new ArgumentNullException(nameof(setter));
 			if (outputExpression == null) throw new ArgumentNullException(nameof(outputExpression));
 
 			var currentSource = ProcessSourceQueryable?.Invoke(source) ?? source;

--- a/Source/LinqToDB/LinqExtensions.Merge.cs
+++ b/Source/LinqToDB/LinqExtensions.Merge.cs
@@ -928,7 +928,7 @@ namespace LinqToDB
 		/// <param name="merge">Merge command definition.</param>
 		/// <param name="outputExpression">Output record constructor expression.
 		/// Expression supports only record new expression with field initializers.</param>
-		/// <returns>Returns number of target table records, affected by merge command.</returns>
+		/// <returns>Sequence of records returned by output.</returns>
 		/// <remarks>
 		/// Database support:
 		/// <list type="bullet">
@@ -964,7 +964,7 @@ namespace LinqToDB
 		/// <param name="merge">Merge command definition.</param>
 		/// <param name="outputExpression">Output record constructor expression.
 		/// Expression supports only record new expression with field initializers.</param>
-		/// <returns>Returns number of target table records, affected by merge command.</returns>
+		/// <returns>Sequence of records returned by output.</returns>
 		/// <remarks>
 		/// Database support:
 		/// <list type="bullet">
@@ -1000,7 +1000,7 @@ namespace LinqToDB
 		/// <param name="merge">Merge command definition.</param>
 		/// <param name="outputExpression">Output record constructor expression.
 		/// Expression supports only record new expression with field initializers.</param>
-		/// <returns>Returns number of target table records, affected by merge command.</returns>
+		/// <returns>Async sequence of records returned by output.</returns>
 		/// <remarks>
 		/// Database support:
 		/// <list type="bullet">
@@ -1036,7 +1036,7 @@ namespace LinqToDB
 		/// <param name="merge">Merge command definition.</param>
 		/// <param name="outputExpression">Output record constructor expression.
 		/// Expression supports only record new expression with field initializers.</param>
-		/// <returns>Returns number of target table records, affected by merge command.</returns>
+		/// <returns>Async sequence of records returned by output.</returns>
 		/// <remarks>
 		/// Database support:
 		/// <list type="bullet">

--- a/Source/LinqToDB/LinqExtensions.Update.cs
+++ b/Source/LinqToDB/LinqExtensions.Update.cs
@@ -170,9 +170,9 @@ namespace LinqToDB
 							Expression<Func<TSource, TTarget, TTarget, TOutput>> outputExpression)
 			where TTarget : class
 		{
-			if (source == null) throw new ArgumentNullException(nameof(source));
-			if (target == null) throw new ArgumentNullException(nameof(target));
-			if (setter == null) throw new ArgumentNullException(nameof(setter));
+			if (source           == null) throw new ArgumentNullException(nameof(source));
+			if (target           == null) throw new ArgumentNullException(nameof(target));
+			if (setter           == null) throw new ArgumentNullException(nameof(setter));
 			if (outputExpression == null) throw new ArgumentNullException(nameof(outputExpression));
 
 			var currentSource = ProcessSourceQueryable?.Invoke(source) ?? source;
@@ -566,9 +566,9 @@ namespace LinqToDB
 			[InstantHandle] Expression<Func<TSource, TTarget>> setter,
 							Expression<Func<TSource, TTarget, TTarget, TOutput>> outputExpression)
 		{
-			if (source == null) throw new ArgumentNullException(nameof(source));
-			if (target == null) throw new ArgumentNullException(nameof(target));
-			if (setter == null) throw new ArgumentNullException(nameof(setter));
+			if (source           == null) throw new ArgumentNullException(nameof(source));
+			if (target           == null) throw new ArgumentNullException(nameof(target));
+			if (setter           == null) throw new ArgumentNullException(nameof(setter));
 			if (outputExpression == null) throw new ArgumentNullException(nameof(outputExpression));
 
 			var currentSource = ProcessSourceQueryable?.Invoke(source) ?? source;
@@ -938,8 +938,8 @@ namespace LinqToDB
 			[InstantHandle] Expression<Func<T, T>> setter,
 							Expression<Func<T, T, TOutput>> outputExpression)
 		{
-			if (source == null) throw new ArgumentNullException(nameof(source));
-			if (setter == null) throw new ArgumentNullException(nameof(setter));
+			if (source           == null) throw new ArgumentNullException(nameof(source));
+			if (setter           == null) throw new ArgumentNullException(nameof(setter));
 			if (outputExpression == null) throw new ArgumentNullException(nameof(outputExpression));
 
 			var currentSource = ProcessSourceQueryable?.Invoke(source) ?? source;
@@ -1272,7 +1272,7 @@ namespace LinqToDB
 					   this IUpdatable<T> source,
 							Expression<Func<T, T, TOutput>> outputExpression)
 		{
-			if (source == null) throw new ArgumentNullException(nameof(source));
+			if (source           == null) throw new ArgumentNullException(nameof(source));
 			if (outputExpression == null) throw new ArgumentNullException(nameof(outputExpression));
 
 			var query = ((Updatable<T>)source).Query;

--- a/Source/LinqToDB/LinqExtensions.Update.cs
+++ b/Source/LinqToDB/LinqExtensions.Update.cs
@@ -153,8 +153,7 @@ namespace LinqToDB
 		/// <param name="outputExpression">Output record constructor expression.
 		/// Parameters passed are as follows: (<typeparamref name="TSource"/> source, <typeparamref name="TTarget"/> deleted, <typeparamref name="TTarget"/> inserted).
 		/// Expression supports only record new expression with field initializers.</param>
-		/// <param name="token">Optional asynchronous operation cancellation token.</param>
-		/// <returns>Output values from the update statement.</returns>
+		/// <returns>Async sequence of records returned by output.</returns>
 		/// <remarks>
 		/// Database support:
 		/// <list type="bullet">
@@ -164,17 +163,16 @@ namespace LinqToDB
 		/// <item>SQLite 3.35+  (doesn't support old data; database limitation)</item>
 		/// </list>
 		/// </remarks>
-		public static Task<TOutput[]> UpdateWithOutputAsync<TSource,TTarget,TOutput>(
-			                this IQueryable<TSource>                          source,
-			                ITable<TTarget>                                   target,
-			[InstantHandle] Expression<Func<TSource,TTarget>>                 setter,
-			                Expression<Func<TSource,TTarget,TTarget,TOutput>> outputExpression,
-			                CancellationToken                                 token = default)
+		public static IAsyncEnumerable<TOutput> UpdateWithOutputAsync<TSource, TTarget, TOutput>(
+							this IQueryable<TSource> source,
+							ITable<TTarget> target,
+			[InstantHandle] Expression<Func<TSource, TTarget>> setter,
+							Expression<Func<TSource, TTarget, TTarget, TOutput>> outputExpression)
 			where TTarget : class
 		{
-			if (source ==           null) throw new ArgumentNullException(nameof(source));
-			if (target ==           null) throw new ArgumentNullException(nameof(target));
-			if (setter ==           null) throw new ArgumentNullException(nameof(setter));
+			if (source == null) throw new ArgumentNullException(nameof(source));
+			if (target == null) throw new ArgumentNullException(nameof(target));
+			if (setter == null) throw new ArgumentNullException(nameof(setter));
 			if (outputExpression == null) throw new ArgumentNullException(nameof(outputExpression));
 
 			var currentSource = ProcessSourceQueryable?.Invoke(source) ?? source;
@@ -187,6 +185,42 @@ namespace LinqToDB
 					((IQueryable<TTarget>)target).Expression,
 					Expression.Quote(setter),
 					Expression.Quote(outputExpression)))
+				.AsAsyncEnumerable();
+		}
+
+		/// <summary>
+		/// Executes update-from-source operation against target table.
+		/// </summary>
+		/// <typeparam name="TSource">Source query record type.</typeparam>
+		/// <typeparam name="TTarget">Target table mapping class.</typeparam>
+		/// <typeparam name="TOutput">Output table record type.</typeparam>
+		/// <param name="source">Source data query.</param>
+		/// <param name="target">Target table.</param>
+		/// <param name="setter">Update expression. Uses record from source query as parameter. Expression supports only target table record new expression with field initializers.</param>
+		/// <param name="outputExpression">Output record constructor expression.
+		/// Parameters passed are as follows: (<typeparamref name="TSource"/> source, <typeparamref name="TTarget"/> deleted, <typeparamref name="TTarget"/> inserted).
+		/// Expression supports only record new expression with field initializers.</param>
+		/// <param name="token">Optional asynchronous operation cancellation token.</param>
+		/// <returns>Sequence of records returned by output.</returns>
+		/// <remarks>
+		/// Database support:
+		/// <list type="bullet">
+		/// <item>SQL Server 2005+</item>
+		/// <item>Firebird 2.5+ (doesn't support more than one record; database limitation)</item>
+		/// <item>PostgreSQL (doesn't support old data; database limitation)</item>
+		/// <item>SQLite 3.35+  (doesn't support old data; database limitation)</item>
+		/// </list>
+		/// </remarks>
+		[Obsolete("Will be removed in l2db 7.0")]
+		public static Task<TOutput[]> UpdateWithOutputAsync<TSource, TTarget, TOutput>(
+							this IQueryable<TSource> source,
+							ITable<TTarget> target,
+			[InstantHandle] Expression<Func<TSource, TTarget>> setter,
+							Expression<Func<TSource, TTarget, TTarget, TOutput>> outputExpression,
+							CancellationToken token)
+			where TTarget : class
+		{
+			return UpdateWithOutputAsync(source, target, setter, outputExpression)
 				.ToArrayAsync(token);
 		}
 
@@ -516,8 +550,7 @@ namespace LinqToDB
 		/// <param name="outputExpression">Output record constructor expression.
 		/// Parameters passed are as follows: (<typeparamref name="TSource"/> source, <typeparamref name="TTarget"/> deleted, <typeparamref name="TTarget"/> inserted).
 		/// Expression supports only record new expression with field initializers.</param>
-		/// <param name="token">Optional asynchronous operation cancellation token.</param>
-		/// <returns>Output values from the update statement.</returns>
+		/// <returns>Async sequence of records returned by output.</returns>
 		/// <remarks>
 		/// Database support:
 		/// <list type="bullet">
@@ -527,16 +560,15 @@ namespace LinqToDB
 		/// <item>SQLite 3.35+  (doesn't support old data; database limitation)</item>
 		/// </list>
 		/// </remarks>
-		public static Task<TOutput[]> UpdateWithOutputAsync<TSource,TTarget,TOutput>(
-			                this IQueryable<TSource>                          source,
-			                Expression<Func<TSource,TTarget>>                 target,
-			[InstantHandle] Expression<Func<TSource,TTarget>>                 setter,
-							Expression<Func<TSource,TTarget,TTarget,TOutput>> outputExpression,
-							CancellationToken                                 token = default)
+		public static IAsyncEnumerable<TOutput> UpdateWithOutputAsync<TSource, TTarget, TOutput>(
+							this IQueryable<TSource> source,
+							Expression<Func<TSource, TTarget>> target,
+			[InstantHandle] Expression<Func<TSource, TTarget>> setter,
+							Expression<Func<TSource, TTarget, TTarget, TOutput>> outputExpression)
 		{
-			if (source ==           null) throw new ArgumentNullException(nameof(source));
-			if (target ==           null) throw new ArgumentNullException(nameof(target));
-			if (setter ==           null) throw new ArgumentNullException(nameof(setter));
+			if (source == null) throw new ArgumentNullException(nameof(source));
+			if (target == null) throw new ArgumentNullException(nameof(target));
+			if (setter == null) throw new ArgumentNullException(nameof(setter));
 			if (outputExpression == null) throw new ArgumentNullException(nameof(outputExpression));
 
 			var currentSource = ProcessSourceQueryable?.Invoke(source) ?? source;
@@ -549,6 +581,41 @@ namespace LinqToDB
 					Expression.Quote(target),
 					Expression.Quote(setter),
 					Expression.Quote(outputExpression)))
+				.AsAsyncEnumerable();
+		}
+
+		/// <summary>
+		/// Executes update-from-source operation against target table.
+		/// </summary>
+		/// <typeparam name="TSource">Source query record type.</typeparam>
+		/// <typeparam name="TTarget">Target table mapping class.</typeparam>
+		/// <typeparam name="TOutput">Output table record type.</typeparam>
+		/// <param name="source">Source data query.</param>
+		/// <param name="target">Target table.</param>
+		/// <param name="setter">Update expression. Uses record from source query as parameter. Expression supports only target table record new expression with field initializers.</param>
+		/// <param name="outputExpression">Output record constructor expression.
+		/// Parameters passed are as follows: (<typeparamref name="TSource"/> source, <typeparamref name="TTarget"/> deleted, <typeparamref name="TTarget"/> inserted).
+		/// Expression supports only record new expression with field initializers.</param>
+		/// <param name="token">Optional asynchronous operation cancellation token.</param>
+		/// <returns>Sequence of records returned by output.</returns>
+		/// <remarks>
+		/// Database support:
+		/// <list type="bullet">
+		/// <item>SQL Server 2005+</item>
+		/// <item>Firebird 2.5+ (doesn't support more than one record; database limitation)</item>
+		/// <item>PostgreSQL (doesn't support old data; database limitation)</item>
+		/// <item>SQLite 3.35+  (doesn't support old data; database limitation)</item>
+		/// </list>
+		/// </remarks>
+		[Obsolete("Will be removed in l2db 7.0")]
+		public static Task<TOutput[]> UpdateWithOutputAsync<TSource, TTarget, TOutput>(
+							this IQueryable<TSource> source,
+							Expression<Func<TSource, TTarget>> target,
+			[InstantHandle] Expression<Func<TSource, TTarget>> setter,
+							Expression<Func<TSource, TTarget, TTarget, TOutput>> outputExpression,
+							CancellationToken token)
+		{
+			return UpdateWithOutputAsync(source, target, setter, outputExpression)
 				.ToArrayAsync(token);
 		}
 
@@ -856,8 +923,7 @@ namespace LinqToDB
 		/// <param name="outputExpression">Output record constructor expression.
 		/// Parameters passed are as follows: (<typeparamref name="T"/> deleted, <typeparamref name="T"/> inserted).
 		/// Expression supports only record new expression with field initializers.</param>
-		/// <param name="token">Optional asynchronous operation cancellation token.</param>
-		/// <returns>Output values from the update statement.</returns>
+		/// <returns>Async sequence of records returned by output.</returns>
 		/// <remarks>
 		/// Database support:
 		/// <list type="bullet">
@@ -867,14 +933,13 @@ namespace LinqToDB
 		/// <item>SQLite 3.35+  (doesn't support old data; database limitation)</item>
 		/// </list>
 		/// </remarks>
-		public static Task<TOutput[]> UpdateWithOutputAsync<T,TOutput>(
-			           this IQueryable<T>                 source,
-			[InstantHandle] Expression<Func<T,T>>         setter,
-			                Expression<Func<T,T,TOutput>> outputExpression,
-			                CancellationToken             token = default)
+		public static IAsyncEnumerable<TOutput> UpdateWithOutputAsync<T, TOutput>(
+					   this IQueryable<T> source,
+			[InstantHandle] Expression<Func<T, T>> setter,
+							Expression<Func<T, T, TOutput>> outputExpression)
 		{
-			if (source ==           null) throw new ArgumentNullException(nameof(source));
-			if (setter ==           null) throw new ArgumentNullException(nameof(setter));
+			if (source == null) throw new ArgumentNullException(nameof(source));
+			if (setter == null) throw new ArgumentNullException(nameof(setter));
 			if (outputExpression == null) throw new ArgumentNullException(nameof(outputExpression));
 
 			var currentSource = ProcessSourceQueryable?.Invoke(source) ?? source;
@@ -885,6 +950,38 @@ namespace LinqToDB
 					MethodHelper.GetMethodInfo(UpdateWithOutput, source, setter, outputExpression),
 					currentSource.Expression, Expression.Quote(setter),
 					Expression.Quote(outputExpression)))
+				.AsAsyncEnumerable();
+		}
+
+		/// <summary>
+		/// Executes update operation using source query as record filter.
+		/// </summary>
+		/// <typeparam name="T">Updated table record type.</typeparam>
+		/// <typeparam name="TOutput">Output table record type.</typeparam>
+		/// <param name="source">Source data query.</param>
+		/// <param name="setter">Update expression. Uses updated record as parameter. Expression supports only target table record new expression with field initializers.</param>
+		/// <param name="outputExpression">Output record constructor expression.
+		/// Parameters passed are as follows: (<typeparamref name="T"/> deleted, <typeparamref name="T"/> inserted).
+		/// Expression supports only record new expression with field initializers.</param>
+		/// <param name="token">Optional asynchronous operation cancellation token.</param>
+		/// <returns>Sequence of records returned by output.</returns>
+		/// <remarks>
+		/// Database support:
+		/// <list type="bullet">
+		/// <item>SQL Server 2005+</item>
+		/// <item>Firebird 2.5+ (doesn't support more than one record; database limitation)</item>
+		/// <item>PostgreSQL (doesn't support old data; database limitation)</item>
+		/// <item>SQLite 3.35+  (doesn't support old data; database limitation)</item>
+		/// </list>
+		/// </remarks>
+		[Obsolete("Will be removed in l2db 7.0")]
+		public static Task<TOutput[]> UpdateWithOutputAsync<T, TOutput>(
+					   this IQueryable<T> source,
+			[InstantHandle] Expression<Func<T, T>> setter,
+							Expression<Func<T, T, TOutput>> outputExpression,
+							CancellationToken token)
+		{
+			return UpdateWithOutputAsync(source, setter, outputExpression)
 				.ToArrayAsync(token);
 		}
 
@@ -1161,8 +1258,7 @@ namespace LinqToDB
 		/// <param name="outputExpression">Output record constructor expression.
 		/// Parameters passed are as follows: (<typeparamref name="T"/> deleted, <typeparamref name="T"/> inserted).
 		/// Expression supports only record new expression with field initializers.</param>
-		/// <param name="token">Optional asynchronous operation cancellation token.</param>
-		/// <returns>Output values from the update statement.</returns>
+		/// <returns>Async sequence of records returned by output.</returns>
 		/// <remarks>
 		/// Database support:
 		/// <list type="bullet">
@@ -1172,12 +1268,11 @@ namespace LinqToDB
 		/// <item>SQLite 3.35+  (doesn't support old data; database limitation)</item>
 		/// </list>
 		/// </remarks>
-		public static Task<TOutput[]> UpdateWithOutputAsync<T,TOutput>(
-			           this IUpdatable<T>                 source,
-			                Expression<Func<T,T,TOutput>> outputExpression,
-			                CancellationToken             token = default)
+		public static IAsyncEnumerable<TOutput> UpdateWithOutputAsync<T, TOutput>(
+					   this IUpdatable<T> source,
+							Expression<Func<T, T, TOutput>> outputExpression)
 		{
-			if (source ==           null) throw new ArgumentNullException(nameof(source));
+			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (outputExpression == null) throw new ArgumentNullException(nameof(outputExpression));
 
 			var query = ((Updatable<T>)source).Query;
@@ -1189,6 +1284,36 @@ namespace LinqToDB
 					MethodHelper.GetMethodInfo(UpdateWithOutput, source, outputExpression),
 					currentSource.Expression,
 					Expression.Quote(outputExpression)))
+				.AsAsyncEnumerable();
+		}
+
+		/// <summary>
+		/// Executes update operation using source query as record filter.
+		/// </summary>
+		/// <typeparam name="T">Updated table record type.</typeparam>
+		/// <typeparam name="TOutput">Output table record type.</typeparam>
+		/// <param name="source">Source data query.</param>
+		/// <param name="outputExpression">Output record constructor expression.
+		/// Parameters passed are as follows: (<typeparamref name="T"/> deleted, <typeparamref name="T"/> inserted).
+		/// Expression supports only record new expression with field initializers.</param>
+		/// <param name="token">Optional asynchronous operation cancellation token.</param>
+		/// <returns>Output values from the update statement.</returns>
+		/// <remarks>
+		/// Database support:
+		/// <list type="bullet">
+		/// <item>SQL Server 2005+</item>
+		/// <item>Firebird 2.5+ (doesn't support more than one record; database limitation)</item>
+		/// <item>PostgreSQL (doesn't support old data; database limitation)</item>
+		/// <item>SQLite 3.35+  (doesn't support old data; database limitation)</item>
+		/// </list>
+		/// </remarks>
+		[Obsolete("Will be removed in l2db 7.0")]
+		public static Task<TOutput[]> UpdateWithOutputAsync<T, TOutput>(
+					   this IUpdatable<T> source,
+							Expression<Func<T, T, TOutput>> outputExpression,
+							CancellationToken token)
+		{
+			return UpdateWithOutputAsync(source, outputExpression)
 				.ToArrayAsync(token);
 		}
 

--- a/Tests/Linq/DataProvider/Types/TypeTestsBase.cs
+++ b/Tests/Linq/DataProvider/Types/TypeTestsBase.cs
@@ -165,13 +165,6 @@ namespace Tests.DataProvider
 			await table.DeleteAsync();
 			await db.BulkCopyAsync(options, data);
 			AssertData(table, value, nullableValue, skipNullable, filterByValue, filterByNullableValue, getExpectedValue, getExpectedNullableValue);
-
-#if NATIVE_ASYNC
-			options = GetDefaultBulkCopyOptions(context) with { BulkCopyType = BulkCopyType.ProviderSpecific };
-			await table.DeleteAsync();
-			await db.BulkCopyAsync(options, data);
-			AssertData(table, value, nullableValue, skipNullable, filterByValue, filterByNullableValue, getExpectedValue, getExpectedNullableValue);
-#endif
 		}
 
 		/// <summary>

--- a/Tests/Linq/Linq/AsyncTests.cs
+++ b/Tests/Linq/Linq/AsyncTests.cs
@@ -126,7 +126,6 @@ namespace Tests.Linq
 			}
 		}
 
-#if NETSTANDARD2_1PLUS
 		[Test]
 		public async Task TestQueryToAsyncEnumerable([DataSources(false)] string context)
 		{
@@ -149,7 +148,6 @@ namespace Tests.Linq
 				Assert.That(list[0], Is.EqualTo("John"));
 			}
 		}
-#endif
 
 		[Test]
 		public async Task FirstAsyncTest([DataSources] string context)

--- a/Tests/Linq/Update/DeleteWithOutputTests.cs
+++ b/Tests/Linq/Update/DeleteWithOutputTests.cs
@@ -103,13 +103,17 @@ namespace Tests.xUpdate
 			await using var db     = GetDataContext(context);
 			await using var source = db.CreateLocalTable(sourceData);
 
+			var expected = source
+				.Where(s => s.Id > 3)
+				.ToList();
+
 			var output = await source
 				.Where(s => s.Id > 3)
 				.DeleteWithOutputAsync()
 				.ToListAsync();
 
 			AreEqual(
-				source.Where(s => s.Id > 3).ToList(),
+				expected,
 				output,
 				ComparerBuilder.GetEqualityComparer<TableWithData>());
 		}

--- a/Tests/Linq/Update/DeleteWithOutputTests.cs
+++ b/Tests/Linq/Update/DeleteWithOutputTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using LinqToDB;
+using LinqToDB.Async;
 using LinqToDB.Mapping;
 using LinqToDB.Tools.Comparers;
 
@@ -102,9 +103,14 @@ namespace Tests.xUpdate
 			await using var db     = GetDataContext(context);
 			await using var source = db.CreateLocalTable(sourceData);
 
+			var output = await source
+				.Where(s => s.Id > 3)
+				.DeleteWithOutputAsync()
+				.ToListAsync();
+
 			AreEqual(
 				source.Where(s => s.Id > 3).ToList(),
-				await source.Where(s => s.Id > 3).DeleteWithOutputAsync(),
+				output,
 				ComparerBuilder.GetEqualityComparer<TableWithData>());
 		}
 
@@ -121,7 +127,8 @@ namespace Tests.xUpdate
 
 				var output = await source
 					.Where(s => s.Id == 3)
-					.DeleteWithOutputAsync();
+					.DeleteWithOutputAsync()
+					.ToListAsync();
 
 				AreEqual(
 					expected,
@@ -212,7 +219,8 @@ namespace Tests.xUpdate
 						{
 							Id       = Sql.AsSql(deleted.Id       + 1),
 							ValueStr = Sql.AsSql(deleted.ValueStr + 1),
-						});
+						})
+					.ToListAsync();
 
 				AreEqual(
 					expected
@@ -243,7 +251,8 @@ namespace Tests.xUpdate
 						{
 							Id       = Sql.AsSql(deleted.Id       + 1),
 							ValueStr = Sql.AsSql(deleted.ValueStr + 1),
-						});
+						})
+					.ToListAsync();
 
 				AreEqual(
 					expected
@@ -345,7 +354,8 @@ namespace Tests.xUpdate
 							Id       = s.Id       + param,
 							Value    = s.Value    + param,
 							ValueStr = s.ValueStr + param
-						});
+						})
+					.ToListAsync();
 
 				AreEqual(
 					expected
@@ -379,7 +389,8 @@ namespace Tests.xUpdate
 							Id       = s.Id       + param,
 							Value    = s.Value    + param,
 							ValueStr = s.ValueStr + param
-						});
+						})
+					.ToListAsync();
 
 				AreEqual(
 					expected

--- a/Tests/Linq/Update/InsertWithOutputTests.cs
+++ b/Tests/Linq/Update/InsertWithOutputTests.cs
@@ -13,6 +13,8 @@ using LinqToDB.Common;
 
 namespace Tests.xUpdate
 {
+	using LinqToDB.Async;
+
 	using Model;
 
 	[TestFixture]
@@ -166,7 +168,8 @@ namespace Tests.xUpdate
 							Id       = s.Id       + param,
 							Value    = s.Value    + param,
 							ValueStr = s.ValueStr + param
-						});
+						})
+					.ToListAsync();
 
 				AreEqual(source.Where(s => s.Id > 3).Select(s => new DestinationTable
 				{
@@ -195,7 +198,8 @@ namespace Tests.xUpdate
 							Id       = s.Id       + param,
 							Value    = s.Value    + param,
 							ValueStr = s.ValueStr + param
-						});
+						})
+					.ToListAsync();
 
 				AreEqual(source.Where(s => s.Id == 3).Select(s => new DestinationTable
 				{

--- a/Tests/Linq/Update/UpdateWithOutputTests.cs
+++ b/Tests/Linq/Update/UpdateWithOutputTests.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 using LinqToDB;
+using LinqToDB.Async;
 using LinqToDB.Mapping;
 using LinqToDB.Tools.Comparers;
 
@@ -433,7 +434,8 @@ namespace Tests.xUpdate
 							SourceStr = source.s.ValueStr,
 							DeletedValue = deleted.Value,
 							InsertedValue = inserted.Value,
-						});
+						})
+					.ToListAsync();
 
 				AreEqual(
 					expected,
@@ -467,7 +469,8 @@ namespace Tests.xUpdate
 						{
 							DeletedValue = deleted.Value,
 							InsertedValue = inserted.Value,
-						});
+						})
+					.ToListAsync();
 
 				AreEqual(
 					expected,
@@ -503,7 +506,8 @@ namespace Tests.xUpdate
 						{
 							DeletedValue = deleted.Value,
 							InsertedValue = inserted.Value,
-						});
+						})
+					.ToListAsync();
 
 				AreEqual(
 					expected,
@@ -537,7 +541,8 @@ namespace Tests.xUpdate
 						{
 							SourceStr     = source.s.ValueStr,
 							InsertedValue = inserted.Value,
-						});
+						})
+					.ToListAsync();
 
 				AreEqual(
 					expected,
@@ -569,7 +574,8 @@ namespace Tests.xUpdate
 						(source, deleted, inserted) => new
 						{
 							InsertedValue = inserted.Value,
-						});
+						})
+					.ToListAsync();
 
 				AreEqual(
 					expected,
@@ -603,7 +609,8 @@ namespace Tests.xUpdate
 						(source, deleted, inserted) => new
 						{
 							InsertedValue = inserted.Value,
-						});
+						})
+					.ToListAsync();
 
 				AreEqual(
 					expected,
@@ -1213,7 +1220,8 @@ namespace Tests.xUpdate
 							SourceStr = source.s.ValueStr,
 							DeletedValue = deleted.Value,
 							InsertedValue = inserted.Value,
-						});
+						})
+					.ToListAsync();
 
 				AreEqual(
 					expected,
@@ -1247,7 +1255,8 @@ namespace Tests.xUpdate
 						{
 							DeletedValue = deleted.Value,
 							InsertedValue = inserted.Value,
-						});
+						})
+					.ToListAsync();
 
 				AreEqual(
 					expected,
@@ -1283,7 +1292,8 @@ namespace Tests.xUpdate
 						{
 							DeletedValue = deleted.Value,
 							InsertedValue = inserted.Value,
-						});
+						})
+					.ToListAsync();
 
 				AreEqual(
 					expected,
@@ -1317,7 +1327,8 @@ namespace Tests.xUpdate
 						{
 							SourceStr     = source.s.ValueStr,
 							InsertedValue = inserted.Value,
-						});
+						})
+					.ToListAsync();
 
 				AreEqual(
 					expected,
@@ -1349,7 +1360,8 @@ namespace Tests.xUpdate
 						(source, deleted, inserted) => new
 						{
 							InsertedValue = inserted.Value,
-						});
+						})
+					.ToListAsync();
 
 				AreEqual(
 					expected,
@@ -1383,7 +1395,8 @@ namespace Tests.xUpdate
 						(source, deleted, inserted) => new
 						{
 							InsertedValue = inserted.Value,
-						});
+						})
+					.ToListAsync();
 
 				AreEqual(
 					expected,
@@ -1879,7 +1892,8 @@ namespace Tests.xUpdate
 					.Where(s => s.Id > 3)
 					.UpdateWithOutputAsync(
 						s => new TableWithData { Id = s.Id, Value = s.Value + 1, ValueStr = s.ValueStr + "Upd", },
-						(deleted, inserted) => new { DeletedValue = deleted.Value, InsertedValue = inserted.Value, });
+						(deleted, inserted) => new { DeletedValue = deleted.Value, InsertedValue = inserted.Value, })
+					.ToListAsync();
 
 				AreEqual(
 					expected,
@@ -1907,7 +1921,8 @@ namespace Tests.xUpdate
 					.Where(s => s.Id == 3)
 					.UpdateWithOutputAsync(
 						s => new TableWithData { Id = s.Id, Value = s.Value + 1, ValueStr = s.ValueStr + "Upd", },
-						(deleted, inserted) => new { DeletedValue = deleted.Value, InsertedValue = inserted.Value, });
+						(deleted, inserted) => new { DeletedValue = deleted.Value, InsertedValue = inserted.Value, })
+					.ToListAsync();
 
 				AreEqual(
 					expected,
@@ -1934,7 +1949,8 @@ namespace Tests.xUpdate
 					.Where(s => s.Id > 3)
 					.UpdateWithOutputAsync(
 						s => new TableWithData { Id = s.Id, Value = s.Value + 1, ValueStr = s.ValueStr + "Upd", },
-						(deleted, inserted) => new { InsertedValue = inserted.Value, });
+						(deleted, inserted) => new { InsertedValue = inserted.Value, })
+					.ToListAsync();
 
 				AreEqual(
 					expected,
@@ -1961,7 +1977,8 @@ namespace Tests.xUpdate
 					.Where(s => s.Id == 3)
 					.UpdateWithOutputAsync(
 						s => new TableWithData { Id = s.Id, Value = s.Value + 1, ValueStr = s.ValueStr + "Upd", },
-						(deleted, inserted) => new { InsertedValue = inserted.Value, });
+						(deleted, inserted) => new { InsertedValue = inserted.Value, })
+					.ToListAsync();
 
 				AreEqual(
 					expected,
@@ -2459,7 +2476,8 @@ namespace Tests.xUpdate
 					.Set(s => s.Value, s => s.Value + 1)
 					.Set(s => s.ValueStr, s => s.ValueStr + "Upd")
 					.UpdateWithOutputAsync(
-						(deleted, inserted) => new { DeletedValue = deleted.Value, InsertedValue = inserted.Value, });
+						(deleted, inserted) => new { DeletedValue = deleted.Value, InsertedValue = inserted.Value, })
+					.ToListAsync();
 
 				AreEqual(
 					expected,
@@ -2489,7 +2507,8 @@ namespace Tests.xUpdate
 					.Set(s => s.Value, s => s.Value + 1)
 					.Set(s => s.ValueStr, s => s.ValueStr + "Upd")
 					.UpdateWithOutputAsync(
-						(deleted, inserted) => new { DeletedValue = deleted.Value, InsertedValue = inserted.Value, });
+						(deleted, inserted) => new { DeletedValue = deleted.Value, InsertedValue = inserted.Value, })
+					.ToListAsync();
 
 				AreEqual(
 					expected,
@@ -2518,7 +2537,8 @@ namespace Tests.xUpdate
 					.Set(s => s.Value, s => s.Value + 1)
 					.Set(s => s.ValueStr, s => s.ValueStr + "Upd")
 					.UpdateWithOutputAsync(
-						(deleted, inserted) => new { InsertedValue = inserted.Value, });
+						(deleted, inserted) => new { InsertedValue = inserted.Value, })
+					.ToListAsync();
 
 				AreEqual(
 					expected,
@@ -2547,7 +2567,8 @@ namespace Tests.xUpdate
 					.Set(s => s.Value, s => s.Value + 1)
 					.Set(s => s.ValueStr, s => s.ValueStr + "Upd")
 					.UpdateWithOutputAsync(
-						(deleted, inserted) => new { InsertedValue = inserted.Value, });
+						(deleted, inserted) => new { InsertedValue = inserted.Value, })
+					.ToListAsync();
 
 				AreEqual(
 					expected,


### PR DESCRIPTION
This PR does two things:
* Updates `InsertWithOutputAsync`, `UpdateWithOutputAsync`, and `DeleteWithOutputAsync` to return `IAsyncEnumerable` properly. This is a binary-compatible change, as the existing methods are kept. However, these methods are now marked with `[Obsolete]` to encourage source migration to the newer `IAsyncEnumerable` method. 
* Adds `QueryToAsyncEnumerable` in places where `QueryToArrayAsync` and `QueryToListAsync` are provided. This allows consumers to use `IAsyncEnumerable` if desired. No obsoletions are planned here, though consumers are allowed and encouraged to upgrade if the query has many rows. 
  > [!NOTE]
  > This change only applies to `NATIVE_ASYNC`.

## 💣 Breaking Change
* The new versions of `XxxWithOutputAsync` are not source compatible, so this is a v6.0 breaking change. Consumers will need to add `.ToListAsync()` or similar to address this change. This is to restore consistency between `InsertWithOutputAsync`/`UpdateWithOutputAsync`/`DeleteWithOutputAsync` with `MergeWithOutputAsync`; this consistency has been chosen to use the more flexible and modern approach.