### PR TITLE
Add a concurrency check to inform users of invalid use

### DIFF
--- a/Source/LinqToDB/Common/Internal/ConcurrencyDetector.cs
+++ b/Source/LinqToDB/Common/Internal/ConcurrencyDetector.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Threading;
+
+namespace LinqToDB.Common.Internal
+{
+	using Linq;
+
+	internal sealed class ConcurrencyDetector
+	{
+		private const string ConcurrentExecutionMessage = "A second operation was started on this context instance before a previous operation completed. This is usually caused by different threads concurrently using the same instance of DbContext.";
+
+		private int _inCriticalSection;
+		private int _currentContextRefCount;
+
+		public IDisposable EnterCriticalSection()
+		{
+			if (Interlocked.CompareExchange(ref _inCriticalSection, 1, 0) == 1)
+			{
+				throw new LinqException(ConcurrentExecutionMessage);
+			}
+
+			_currentContextRefCount++;
+			return new CurrencyDetectorDisposer(this);
+		}
+
+		/// <summary>
+		///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+		///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+		///     any release. You should only use it directly in your code with extreme caution and knowing that
+		///     doing so can result in application failures when updating to a new Entity Framework Core release.
+		/// </summary>
+		private void ExitCriticalSection()
+		{
+			if (--_currentContextRefCount == 0)
+			{
+				_inCriticalSection = 0;
+			}
+		}
+
+		private class CurrencyDetectorDisposer(ConcurrencyDetector detector) : IDisposable
+		{
+			public void Dispose() => detector.ExitCriticalSection();
+		}
+	}
+}

--- a/Source/LinqToDB/Data/DataConnection.Async.cs
+++ b/Source/LinqToDB/Data/DataConnection.Async.cs
@@ -554,7 +554,7 @@ namespace LinqToDB.Data
 
 			if (_commandInterceptor != null)
 				await using (ActivityService.StartAndConfigureAwait(ActivityID.CommandInterceptorExecuteReaderAsync))
-					result = await _commandInterceptor.ExecuteReaderAsync(new (this), CurrentCommand!, commandBehavior, result, cancellationToken)
+					result = await _commandInterceptor.ExecuteReaderAsync(new (this), _command!, commandBehavior, result, cancellationToken)
 						.ConfigureAwait(Common.Configuration.ContinueOnCapturedContext);
 
 			DbDataReader? dr;
@@ -570,8 +570,10 @@ namespace LinqToDB.Data
 				using (ActivityService.Start(ActivityID.CommandInterceptorAfterExecuteReader))
 					_commandInterceptor.AfterExecuteReader(new (this), _command!, commandBehavior, dr);
 
-			var wrapper = new DataReaderWrapper(this, dr, CurrentCommand);
-			_command    = null;
+			var wrapper = new DataReaderWrapper(this, dr, _command!, _concurrencyToken!);
+
+			_command          = null;
+			_concurrencyToken = null;
 
 			return wrapper;
 		}

--- a/Tests/Linq/Common/ConcurrencyTests.cs
+++ b/Tests/Linq/Common/ConcurrencyTests.cs
@@ -1,0 +1,49 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+
+using LinqToDB;
+using LinqToDB.Linq;
+
+using NUnit.Framework;
+
+namespace Tests.Common
+{
+	[TestFixture]
+	public class ConcurrencyTests : TestBase
+	{
+		[Test]
+		public void SequentialUsagesDoNotThrow([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			_ = db.Parent.ToList();
+			_ = db.Parent.ToList();
+		}
+
+		[Test]
+		public async Task ConcurrentUsageMultipleThreadsThrows([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			await using var enum1 = db.Parent.AsAsyncEnumerable().GetAsyncEnumerator();
+			await enum1.MoveNextAsync();
+
+			Assert.ThrowsAsync<LinqException>(async () =>
+				await Task.Run(() => db.Parent.ToListAsync()));
+		}
+
+		[Test]
+		public void ConcurrentUsageSameThreadThrows([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			using var enum1 = db.Parent.GetEnumerator();
+			enum1.MoveNext();
+
+			using var enum2 = db.Parent.GetEnumerator();
+
+			Assert.Throws<LinqException>(
+				() => enum2.MoveNext());
+		}
+	}
+}


### PR DESCRIPTION
Adds a concurrency detector, which will throw when the `DataConnection` has been used on multiple threads or in simultaneous situations incorrectly.

Fixes #4405