### PR TITLE
Fix rare NRE in tracing due to race-conditions

### DIFF
--- a/Source/LinqToDB/Data/DataConnection.Async.cs
+++ b/Source/LinqToDB/Data/DataConnection.Async.cs
@@ -349,7 +349,7 @@ namespace LinqToDB.Data
 						TraceLevel    = TraceLevel.Info,
 						CommandText   = sql,
 						StartTime     = now,
-						ExecutionTime = sw!.Elapsed
+						ExecutionTime = sw?.Elapsed
 					});
 				}
 

--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -1385,7 +1385,7 @@ namespace LinqToDB.Data
 						TraceLevel    = TraceLevel.Info,
 						CommandText   = sql,
 						StartTime     = now,
-						ExecutionTime = sw!.Elapsed
+						ExecutionTime = sw?.Elapsed
 					});
 				}
 


### PR DESCRIPTION
more or less easily reproduced using following code:

```cs
for (var i = 0; i < 190000; i++)
{
	DataConnection.TurnTraceSwitchOn(System.Diagnostics.TraceLevel.Info);
	DataConnection.TurnTraceSwitchOn(System.Diagnostics.TraceLevel.Warning);
	Task.Run(() =>
	{
		using var db = new DataConnection(SqlServerTools.GetDataProvider(provider: SqlServerProvider.MicrosoftDataSqlClient), "Server=.\\SQL2019;Initial Catalog=DesignerDB;User=sa;Password=p@zzw0rd;Encrypt=true;TrustServerCertificate=true");
		using var _ = db.BeginTransaction(System.Data.IsolationLevel.ReadCommitted);

	});
	DataConnection.TurnTraceSwitchOn(System.Diagnostics.TraceLevel.Info);
	DataConnection.TurnTraceSwitchOn(System.Diagnostics.TraceLevel.Warning);

}
```