### PR TITLE
SQLite database file extension can now be passed to SQLiteTools.CreateDatabase (parameter has ".sqlite" default value for backward compatibility)

### DIFF
--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteExtensions.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteExtensions.cs
@@ -43,7 +43,7 @@ namespace LinqToDB.DataProvider.SQLite
 		}
 
 		/// <summary>
-		/// Performs full-text search query against against speficied table and returns search results.
+		/// Performs full-text search query against specified table and returns search results.
 		/// Example: "table('search query')".
 		/// </summary>
 		/// <typeparam name="TEntity">Queried table mapping class.</typeparam>

--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteTools.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteTools.cs
@@ -125,12 +125,12 @@ namespace LinqToDB.DataProvider.SQLite
 
 		#endregion
 
-		public static void CreateDatabase(string databaseName, bool deleteIfExists = false)
+		public static void CreateDatabase(string databaseName, bool deleteIfExists = false, string extension = ".sqlite")
 		{
 			if (databaseName == null) throw new ArgumentNullException(nameof(databaseName));
 
 			DataTools.CreateFileDatabase(
-				databaseName, deleteIfExists, ".sqlite",
+				databaseName, deleteIfExists, extension,
 				dbName =>
 				{
 					// don't use CreateFile method of System.Data.Sqlite as it just creates empty file


### PR DESCRIPTION
CreateDatabase helper method exists in AccessTools, SqlCeTools and SQLiteTools.
MS Access most common database file extension is ".mdb", SQL Server Compact - ".sdf". 
Unlike them SQLite has many commonly used extensions (".sqlite", ".sqlite3", ".db", etc.).
SQLite database file extension can now be passed to SQLiteTools.CreateDatabase (parameter has ".sqlite" default value for backward compatibility)
