### PR TITLE
PostgreSQLBulkCopy - replaced GetNativeType by pre calculated npgsqlType

### DIFF
--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
@@ -164,10 +164,9 @@ namespace LinqToDB.DataProvider.PostgreSQL
 					for (var i = 0; i < columns.Length; i++)
 					{
 						// DBNull.Value : https://github.com/npgsql/npgsql/issues/5330
-						var value = _provider.NormalizeTimeStamp(pgOptions, columns[i].GetProviderValue(item!) ?? DBNull.Value, columnTypes[i]);
-						var dataType = columnTypes[i];
+						var value = _provider.NormalizeTimeStamp(pgOptions, columns[i].GetProviderValue(item!) ?? DBNull.Value, columnTypes[i], npgsqlTypes[i]);
 
-						if (_provider.GetNativeType(dataType.DbType) == NpgsqlProviderAdapter.NpgsqlDbType.TimeTZ && value is DateTimeOffset dto)
+						if (value is DateTimeOffset dto && npgsqlTypes[i] == NpgsqlProviderAdapter.NpgsqlDbType.TimeTZ)
 						{
 							// https://github.com/npgsql/npgsql/issues/5332
 							// reset date
@@ -291,10 +290,9 @@ namespace LinqToDB.DataProvider.PostgreSQL
 					for (var i = 0; i < columns.Length; i++)
 					{
 						// DBNull.Value : https://github.com/npgsql/npgsql/issues/5330
-						var value = _provider.NormalizeTimeStamp(pgOptions, columns[i].GetProviderValue(item!) ?? DBNull.Value, columnTypes[i]);
-						var dataType = columnTypes[i];
-
-						if (_provider.GetNativeType(dataType.DbType) == NpgsqlProviderAdapter.NpgsqlDbType.TimeTZ && value is DateTimeOffset dto)
+						var value = _provider.NormalizeTimeStamp(pgOptions, columns[i].GetProviderValue(item!) ?? DBNull.Value, columnTypes[i], npgsqlTypes[i]);
+						
+						if (value is DateTimeOffset dto && npgsqlTypes[i] == NpgsqlProviderAdapter.NpgsqlDbType.TimeTZ)
 						{
 							// https://github.com/npgsql/npgsql/issues/5332
 							// reset date
@@ -415,10 +413,9 @@ namespace LinqToDB.DataProvider.PostgreSQL
 					for (var i = 0; i < columns.Length; i++)
 					{
 						// DBNull.Value : https://github.com/npgsql/npgsql/issues/5330
-						var value = _provider.NormalizeTimeStamp(pgOptions, columns[i].GetProviderValue(item!) ?? DBNull.Value, columnTypes[i]);
-						var dataType = columnTypes[i];
+						var value = _provider.NormalizeTimeStamp(pgOptions, columns[i].GetProviderValue(item!) ?? DBNull.Value, columnTypes[i], npgsqlTypes[i]);
 
-						if (_provider.GetNativeType(dataType.DbType) == NpgsqlProviderAdapter.NpgsqlDbType.TimeTZ && value is DateTimeOffset dto)
+						if (value is DateTimeOffset dto && npgsqlTypes[i] == NpgsqlProviderAdapter.NpgsqlDbType.TimeTZ)
 						{
 							// https://github.com/npgsql/npgsql/issues/5332
 							// reset date

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
@@ -234,14 +234,16 @@ namespace LinqToDB.DataProvider.PostgreSQL
 				else if (value is DateTime dt)
 				{
 					// timestamptz should have UTC Kind
-					if (dt.Kind != DateTimeKind.Utc && (dataType.DataType == DataType.DateTimeOffset || npgsqlType == NpgsqlProviderAdapter.NpgsqlDbType.TimestampTZ))
+					if (dataType.DataType == DataType.DateTimeOffset || npgsqlType == NpgsqlProviderAdapter.NpgsqlDbType.TimestampTZ)
 					{
-						value = DateTime.SpecifyKind(dt, DateTimeKind.Utc);
+						if (dt.Kind != DateTimeKind.Utc)
+							value = DateTime.SpecifyKind(dt, DateTimeKind.Utc);
 					}
 					// timestamp should have non-UTC Kind (Unspecified used by default by npgsql)
-					else if (dt.Kind == DateTimeKind.Utc && (dataType.DataType == DataType.DateTime2 || npgsqlType == NpgsqlProviderAdapter.NpgsqlDbType.Timestamp))
+					else if (dataType.DataType == DataType.DateTime2 || npgsqlType == NpgsqlProviderAdapter.NpgsqlDbType.Timestamp)
 					{
-						value = DateTime.SpecifyKind(dt, DateTimeKind.Unspecified);
+						if (dt.Kind == DateTimeKind.Utc)
+							value = DateTime.SpecifyKind(dt, DateTimeKind.Unspecified);
 					}
 				}
 			}


### PR DESCRIPTION
Fix #4445

Good afternoon.

`NormalizeTimeStamp` now accepts the parameter `NpgsqlProviderAdapter.NpgsqlDbType?`, the responsibility for calculating it has been transferred to the following methods:
 - `setParameter` - as before, GetNativeType(data type.DbType) is simply called without parameters.
 - `ProviderSpecificCopySyncImpl<T>` - now gets `NpgsqlProviderAdapter.NpgsqlDbType?` from the `npgsqlTypes` array.
 - `ProviderSpecificCopyImplAsync<T>` - now gets `NpgsqlProviderAdapter.NpgsqlDbType?` from the `npgsqlTypes` array.
 - `ProviderSpecificCopyImplAsync<T> with NATIVE_ASYNC` - now gets `NpgsqlProviderAdapter.NpgsqlDbType?` from the `npgsqlTypes` array.

The `ProviderSpecificCopy*` methods already had a calculated `npgsqlTypes` array, so I just deleted the `GetNativeType` calls. The main difference is that `npgsqlTypes` is calculated as `GetNativeType(DbType, true)`, and in the `ProviderSpecificCopy*` methods it was called as `GetNativeType(DbType, false)`.  Unfortunately, I do not know if this change is critical.

Half of the tests are not work locally in Rider, both before and after these changes. And in the pull request, I can't run tests. Therefore, I am not sure that my solution is working.

It would be ideal to build a nuget package from this branch and I could check the fix. https://github.com/linq2db/linq2db/issues/4445 , but now azure does not push packages from the branch.

I'm sorry if I didn't fully figure it out somewhere.