### PR TITLE
Improve InList values conversion logic

### DIFF
--- a/Source/LinqToDB/Linq/Builder/ParametersContext.cs
+++ b/Source/LinqToDB/Linq/Builder/ParametersContext.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -34,9 +35,19 @@ namespace LinqToDB.Linq.Builder
 		public IDataContext                      DataContext          { get; }
 		public MappingSchema                     MappingSchema        => DataContext.MappingSchema;
 
-		static ParameterExpression[] AccessorParameters =
+		static readonly ParameterExpression ItemParameter = Expression.Parameter(typeof(object));
+
+		static readonly ParameterExpression[] AccessorParameters =
 		{
 			ExpressionBuilder.ExpressionParam,
+			ExpressionConstants.DataContextParam,
+			ExpressionBuilder.ParametersParam
+		};
+
+		static ParameterExpression[] DbTypeAccessorParameters =
+		{
+			ExpressionBuilder.ExpressionParam,
+			ItemParameter,
 			ExpressionConstants.DataContextParam,
 			ExpressionBuilder.ParametersParam
 		};
@@ -222,117 +233,137 @@ namespace LinqToDB.Linq.Builder
 
 		ParameterAccessor? PrepareConvertersAndCreateParameter(ValueTypeExpression newExpr, Expression valueExpression, string? name, ColumnDescriptor? columnDescriptor, bool doNotCheckCompatibility, BuildParameterType buildParameterType)
 		{
-			var originalAccessor = newExpr.ValueExpression;
-			if (buildParameterType != BuildParameterType.InPredicate)
+			Type?       elementType   = null;
+			var buildElementConverter = buildParameterType == BuildParameterType.InPredicate;
+
+			if (buildElementConverter)
 			{
-				if (!newExpr.IsDataParameter)
+				elementType = newExpr.ValueExpression.Type.GetItemType()
+					?? newExpr.ValueExpression.UnwrapConvert().Type.GetItemType()
+					?? columnDescriptor?.MemberType
+					?? typeof(object);
+			}
+
+			var originalAccessor = newExpr.ValueExpression;
+			var valueType        = elementType ?? newExpr.ValueExpression.Type;
+			var valueGetter      = buildElementConverter ? ItemParameter : newExpr.ValueExpression;
+
+			if (!newExpr.IsDataParameter)
+			{
+				if (columnDescriptor != null && originalAccessor is not BinaryExpression)
 				{
-					if (columnDescriptor != null && originalAccessor is not BinaryExpression)
+					newExpr.DataType = columnDescriptor
+						.GetDbDataType(true)
+						.WithSystemType(valueType);
+
+					if (valueType != columnDescriptor.MemberType)
 					{
-						newExpr.DataType = columnDescriptor.GetDbDataType(true)
-							.WithSystemType(newExpr.ValueExpression.Type);
+						var memberType = columnDescriptor.MemberType;
+						var noConvert  = valueGetter.UnwrapConvert();
 
-						if (newExpr.ValueExpression.Type != columnDescriptor.MemberType)
+						if (noConvert.Type != typeof(object))
+							valueGetter = noConvert;
+						else if (!buildElementConverter && valueGetter.Type != valueExpression.Type)
+							valueGetter = Expression.Convert(noConvert, valueExpression.Type);
+						else if (valueGetter.Type == typeof(object))
+							valueGetter = Expression.Convert(noConvert, memberType);
+
+						if (valueGetter.Type != memberType
+							&& !(valueGetter.Type.IsNullable() && valueGetter.Type.ToNullableUnderlying() == memberType.ToNullableUnderlying()))
 						{
-							var memberType = columnDescriptor.MemberType;
-							var noConvert  = newExpr.ValueExpression.UnwrapConvert();
-							if (noConvert.Type != typeof(object))
-								newExpr.ValueExpression = noConvert;
-							else if (newExpr.ValueExpression.Type != valueExpression.Type)
-								newExpr.ValueExpression = Expression.Convert(noConvert, valueExpression.Type);
-							else if (newExpr.ValueExpression.Type == typeof(object))
-								newExpr.ValueExpression = Expression.Convert(noConvert, memberType);
-
-							if (newExpr.ValueExpression.Type != memberType 
-							    && !(newExpr.ValueExpression.Type.IsNullable() && newExpr.ValueExpression.Type.ToNullableUnderlying() == memberType.ToNullableUnderlying()))
+							if (memberType.IsValueType ||
+								!memberType.IsSameOrParentOf(valueGetter.Type))
 							{
-								if (memberType.IsValueType ||
-								    !memberType.IsSameOrParentOf(newExpr.ValueExpression.Type))
+								var convertLambda = MappingSchema.GetConvertExpression(valueGetter.Type, memberType, checkNull: true, createDefault: false);
+								if (convertLambda != null)
 								{
-									var convertLambda = MappingSchema.GetConvertExpression(newExpr.ValueExpression.Type, memberType, checkNull: true, createDefault: false);
-									if (convertLambda != null)
-									{
-										newExpr.ValueExpression = InternalExtensions.ApplyLambdaToExpression(convertLambda, newExpr.ValueExpression);
-									}
-								}
-
-								if (newExpr.ValueExpression.Type.IsNullable() && newExpr.ValueExpression.Type.ToNullableUnderlying() != memberType)
-								{
-									var convertLambda = MappingSchema.GenerateSafeConvert(newExpr.ValueExpression.Type, memberType);
-									newExpr.ValueExpression = InternalExtensions.ApplyLambdaToExpression(convertLambda, newExpr.ValueExpression);
-								}
-
-								if (newExpr.ValueExpression.Type != memberType)
-								{
-									newExpr.ValueExpression = Expression.Convert(newExpr.ValueExpression, memberType);
+									valueGetter = InternalExtensions.ApplyLambdaToExpression(convertLambda, valueGetter);
 								}
 							}
+
+							if (valueGetter.Type.IsNullable() && valueGetter.Type.ToNullableUnderlying() != memberType)
+							{
+								var convertLambda = MappingSchema.GenerateSafeConvert(valueGetter.Type, memberType);
+								valueGetter = InternalExtensions.ApplyLambdaToExpression(convertLambda, valueGetter);
+							}
+
+							if (valueGetter.Type != memberType)
+							{
+								valueGetter = Expression.Convert(valueGetter, memberType);
+							}
 						}
+					}
+					else if (valueType != valueGetter.Type)
+					{
+						valueGetter = Expression.Convert(valueGetter, valueType);
+					}
 
-						newExpr.ValueExpression = columnDescriptor.ApplyConversions(newExpr.ValueExpression, newExpr.DataType, true);
+					valueGetter = columnDescriptor.ApplyConversions(valueGetter, newExpr.DataType, true);
 
-						newExpr.DbDataTypeExpression = Expression.Constant(newExpr.DataType);
+					newExpr.DbDataTypeExpression = Expression.Constant(newExpr.DataType);
 
-						if (name == null)
-						{
-							if (columnDescriptor.MemberName.Contains("."))
-								name = columnDescriptor.ColumnName;
-							else
-								name = columnDescriptor.MemberName;
+					if (name == null)
+					{
+						if (columnDescriptor.MemberName.Contains("."))
+							name = columnDescriptor.ColumnName;
+						else
+							name = columnDescriptor.MemberName;
 
-						}
+					}
+				}
+				else
+				{
+					if (buildParameterType == BuildParameterType.Bool)
+					{
+						// right now, do nothing
 					}
 					else
 					{
-						if (buildParameterType == BuildParameterType.Bool)
+						// Try GetConvertExpression<.., DataParameter>() first.
+						//
+						if (valueGetter.Type != typeof(DataParameter))
 						{
-							// right now, do nothing
+							LambdaExpression? convertExpr = null;
+							if (buildParameterType == BuildParameterType.Default
+								&& !HasDbMapping(MappingSchema, valueGetter.Type, out convertExpr))
+							{
+								if (!doNotCheckCompatibility)
+									return null;
+							}
+
+							valueGetter = convertExpr != null
+								? InternalExtensions.ApplyLambdaToExpression(convertExpr, valueGetter)
+								: ColumnDescriptor.ApplyConversions(MappingSchema, valueGetter, newExpr.DataType, null, true);
 						}
 						else
 						{
-							// Try GetConvertExpression<.., DataParameter>() first.
-							//
-							if (newExpr.ValueExpression.Type != typeof(DataParameter))
-							{
-								LambdaExpression? convertExpr = null;
-								if (buildParameterType == BuildParameterType.Default
-									&& !HasDbMapping(MappingSchema, newExpr.ValueExpression.Type, out convertExpr))
-								{
-									if (!doNotCheckCompatibility)
-										return null;
-								}
-
-								newExpr.ValueExpression = convertExpr != null
-									? InternalExtensions.ApplyLambdaToExpression(convertExpr, newExpr.ValueExpression)
-									: ColumnDescriptor.ApplyConversions(MappingSchema, newExpr.ValueExpression, newExpr.DataType, null, true);
-							}
-							else
-							{
-								newExpr.ValueExpression = ColumnDescriptor.ApplyConversions(MappingSchema, newExpr.ValueExpression, newExpr.DataType, null, true);
-							}
+							valueGetter = ColumnDescriptor.ApplyConversions(MappingSchema, valueGetter, newExpr.DataType, null, true);
 						}
 					}
 				}
-
-				if (typeof(DataParameter).IsSameOrParentOf(newExpr.ValueExpression.Type))
-				{
-					newExpr.DbDataTypeExpression = Expression.Property(newExpr.ValueExpression, Methods.LinqToDB.DataParameter.DbDataType);
-
-					if (columnDescriptor != null)
-					{
-						var dbDataType = columnDescriptor.GetDbDataType(false);
-						newExpr.DbDataTypeExpression = Expression.Call(Expression.Constant(dbDataType),
-							DbDataType.WithSetValuesMethodInfo, newExpr.DbDataTypeExpression);
-					}
-
-					newExpr.ValueExpression = Expression.Property(newExpr.ValueExpression, Methods.LinqToDB.DataParameter.Value);
-				}
 			}
+
+			if (typeof(DataParameter).IsSameOrParentOf(valueGetter.Type))
+			{
+				newExpr.DbDataTypeExpression = Expression.Property(valueGetter, Methods.LinqToDB.DataParameter.DbDataType);
+
+				if (columnDescriptor != null)
+				{
+					var dbDataType = columnDescriptor.GetDbDataType(false);
+					newExpr.DbDataTypeExpression = Expression.Call(Expression.Constant(dbDataType),
+						DbDataType.WithSetValuesMethodInfo, newExpr.DbDataTypeExpression);
+				}
+
+				valueGetter = Expression.Property(valueGetter, Methods.LinqToDB.DataParameter.Value);
+			}
+
+			if (!buildElementConverter)
+				newExpr.ValueExpression = valueGetter;
 
 			name ??= columnDescriptor?.MemberName;
 
 			var p = CreateParameterAccessor(
-				DataContext, newExpr.ValueExpression, originalAccessor, newExpr.DbDataTypeExpression, valueExpression, ParametersExpression, name);
+				DataContext, newExpr.ValueExpression, buildElementConverter ? valueGetter : null, newExpr.DbDataTypeExpression, valueExpression, ParametersExpression, name);
 
 			return p;
 		}
@@ -477,13 +508,13 @@ namespace LinqToDB.Linq.Builder
 		#endregion
 
 		internal static ParameterAccessor CreateParameterAccessor(
-			IDataContext        dataContext,
-			Expression          accessorExpression,
-			Expression          originalAccessorExpression,
-			Expression          dbDataTypeAccessorExpression,
-			Expression          expression,
-			Expression?         parametersExpression,
-			string?             name)
+			IDataContext         dataContext,
+			Expression           accessorExpression,
+			Expression?          itemAccessorExpression,
+			Expression           dbDataTypeAccessorExpression,
+			Expression           expression,
+			Expression?          parametersExpression,
+			string?              name)
 		{
 			// Extracting name for parameter
 			//
@@ -497,31 +528,35 @@ namespace LinqToDB.Linq.Builder
 			name ??= "p";
 
 			// see #820
-			accessorExpression = CorrectAccessorExpression(accessorExpression, dataContext);
-			originalAccessorExpression   = CorrectAccessorExpression(originalAccessorExpression, dataContext);
+			accessorExpression           = CorrectAccessorExpression(accessorExpression, dataContext);
 			dbDataTypeAccessorExpression = CorrectAccessorExpression(dbDataTypeAccessorExpression, dataContext);
 
 			var mapper = Expression.Lambda<Func<Expression,IDataContext?,object?[]?,object?>>(
 				Expression.Convert(accessorExpression, typeof(object)),
 				AccessorParameters);
 
-			var original = Expression.Lambda<Func<Expression,IDataContext?,object?[]?,object?>>(
-				Expression.Convert(originalAccessorExpression, typeof(object)),
-				AccessorParameters);
+			// TODO: it make sense to use cache for item converter
+			var itemMapper = itemAccessorExpression == null
+				? null
+				: Expression.Lambda<Func<object?,object?>>(
+					Expression.Convert(itemAccessorExpression, typeof(object)),
+					ItemParameter);
 
-			var dbDataTypeAccessor = Expression.Lambda<Func<Expression,IDataContext?,object?[]?,DbDataType>>(
+			var dbDataTypeAccessor = Expression.Lambda<Func<Expression,object?,IDataContext?,object?[]?,DbDataType>>(
 				Expression.Convert(dbDataTypeAccessorExpression, typeof(DbDataType)),
-				AccessorParameters);
+				DbTypeAccessorParameters);
 
 			var dataTypeAccessor = dbDataTypeAccessor.CompileExpression();
 
-			var parameterType = parametersExpression == null
-				? new DbDataType(accessorExpression.Type)
-				: dataTypeAccessor(parametersExpression, dataContext, null);
+			var parameterType = itemAccessorExpression != null
+				? new DbDataType(itemAccessorExpression.Type)
+				: parametersExpression == null
+					? new DbDataType(accessorExpression.Type)
+					: dataTypeAccessor(parametersExpression, null, dataContext, null);
 
 			return new ParameterAccessor(
 					mapper.CompileExpression(),
-					original.CompileExpression(),
+					itemMapper?.CompileExpression(),
 					dataTypeAccessor,
 					new SqlParameter(parameterType, name, null)
 					{
@@ -530,7 +565,8 @@ namespace LinqToDB.Linq.Builder
 				)
 #if DEBUG
 				{
-					AccessorExpr = mapper
+					AccessorExpr     = mapper,
+					ItemAccessorExpr = itemMapper
 				}
 #endif
 				;
@@ -596,7 +632,7 @@ namespace LinqToDB.Linq.Builder
 
 		public List<Expression>?                   GetParameterized()  => _parameterized;
 
-		public List<(Func<Expression, IDataContext?, object?[]?, object?> main, Func<Expression, IDataContext?, object?[]?, object?> substituted)>? GetParameterDuplicates() 
+		public List<(Func<Expression, IDataContext?, object?[]?, object?> main, Func<Expression, IDataContext?, object?[]?, object?> substituted)>? GetParameterDuplicates()
 			=> _parametersDuplicateCheck;
 
 		public List<(Expression used, MappingSchema mappingSchema, Func<IDataContext, MappingSchema, Expression> accessorFunc)>? GetDynamicAccessors() => _dynamicAccessors?.Values.ToList();

--- a/Source/LinqToDB/Linq/Builder/TakeSkipBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/TakeSkipBuilder.cs
@@ -28,7 +28,7 @@ namespace LinqToDB.Linq.Builder
 
 			ISqlExpression expr;
 
-            var linqOptions = builder.DataContext.Options.LinqOptions;
+			var linqOptions = builder.DataContext.Options.LinqOptions;
 			var parameterize = !buildInfo.IsSubQuery && linqOptions.ParameterizeTakeSkip;
 
 			if (arg.NodeType == ExpressionType.Lambda)

--- a/Source/LinqToDB/Linq/Query.cs
+++ b/Source/LinqToDB/Linq/Query.cs
@@ -650,22 +650,23 @@ namespace LinqToDB.Linq
 	{
 		public ParameterAccessor(
 			Func<Expression,IDataContext?,object?[]?,object?>    valueAccessor,
-			Func<Expression,IDataContext?,object?[]?,object?>    originalAccessor,
-			Func<Expression,IDataContext?,object?[]?,DbDataType> dbDataTypeAccessor,
+			Func<object?,object?>?                               itemAccessor,
+			Func<Expression,object?,IDataContext?,object?[]?,DbDataType> dbDataTypeAccessor,
 			SqlParameter                                         sqlParameter)
 		{
 			ValueAccessor      = valueAccessor;
-			OriginalAccessor   = originalAccessor;
+			ItemAccessor       = itemAccessor;
 			DbDataTypeAccessor = dbDataTypeAccessor;
 			SqlParameter       = sqlParameter;
 		}
 
-		public readonly Func<Expression,IDataContext?,object?[]?,object?>     ValueAccessor;
-		public readonly Func<Expression,IDataContext?,object?[]?,object?>     OriginalAccessor;
-		public readonly Func<Expression,IDataContext?,object?[]?,DbDataType>  DbDataTypeAccessor;
-		public readonly SqlParameter                                          SqlParameter;
+		public readonly Func<Expression,IDataContext?,object?[]?,object?>             ValueAccessor;
+		public readonly Func<object?,object?>?                                        ItemAccessor;
+		public readonly Func<Expression,object?,IDataContext?,object?[]?,DbDataType>  DbDataTypeAccessor;
+		public readonly SqlParameter                                                  SqlParameter;
 #if DEBUG
 		public Expression<Func<Expression,IDataContext?,object?[]?,object?>>? AccessorExpr;
+		public Expression<Func<object?,object?>>?                             ItemAccessorExpr;
 #endif
 	}
 }

--- a/Source/LinqToDB/Mapping/MappingSchema.cs
+++ b/Source/LinqToDB/Mapping/MappingSchema.cs
@@ -539,6 +539,7 @@ namespace LinqToDB.Mapping
 		/// Wrapper will be added only if source type can have <c>null</c> values and conversion expression doesn't use
 		/// default value provider.
 		/// See <see cref="DefaultValue{T}"/> and <see cref="DefaultValue"/> types for more details.
+		/// This parameter is ignored for conversions to <see cref="DataParameter"/> and treated as <c>false</c>.
 		/// </param>
 		/// <param name="conversionType">Conversion type. See <see cref="ConversionType"/> for more details.</param>
 		public MappingSchema SetConvertExpression(
@@ -552,7 +553,7 @@ namespace LinqToDB.Mapping
 			if (toType   == null) throw new ArgumentNullException(nameof(toType));
 			if (expr     == null) throw new ArgumentNullException(nameof(expr));
 
-			var ex = addNullCheck && Converter.IsDefaultValuePlaceHolderVisitor.Find(expr) == null?
+			var ex = addNullCheck && toType != typeof(DataParameter) && Converter.IsDefaultValuePlaceHolderVisitor.Find(expr) == null?
 				AddNullCheck(expr) :
 				expr;
 
@@ -575,6 +576,7 @@ namespace LinqToDB.Mapping
 		/// Wrapper will be added only if source type can have <c>null</c> values and conversion expression doesn't use
 		/// default value provider.
 		/// See <see cref="DefaultValue{T}"/> and <see cref="DefaultValue"/> types for more details.
+		/// This parameter is ignored for conversions to <see cref="DataParameter"/> and treated as <c>false</c>.
 		/// </param>
 		/// <param name="conversionType">Conversion type. See <see cref="ConversionType"/> for more details.</param>
 		public MappingSchema SetConvertExpression(
@@ -586,7 +588,7 @@ namespace LinqToDB.Mapping
 		{
 			if (expr == null) throw new ArgumentNullException(nameof(expr));
 
-			var ex = addNullCheck && Converter.IsDefaultValuePlaceHolderVisitor.Find(expr) == null?
+			var ex = addNullCheck && toType.SystemType != typeof(DataParameter) && Converter.IsDefaultValuePlaceHolderVisitor.Find(expr) == null?
 				AddNullCheck(expr) :
 				expr;
 
@@ -609,6 +611,7 @@ namespace LinqToDB.Mapping
 		/// Wrapper will be added only if source type can have <c>null</c> values and conversion expression doesn't use
 		/// default value provider.
 		/// See <see cref="DefaultValue{T}"/> and <see cref="DefaultValue"/> types for more details.
+		/// This parameter is ignored for conversions to <see cref="DataParameter"/> and treated as <c>false</c>.
 		/// </param>
 		/// <param name="conversionType">Conversion type. See <see cref="ConversionType"/> for more details.</param>
 		public MappingSchema SetConvertExpression<TFrom,TTo>(
@@ -618,7 +621,7 @@ namespace LinqToDB.Mapping
 		{
 			if (expr == null) throw new ArgumentNullException(nameof(expr));
 
-			var ex = addNullCheck && Converter.IsDefaultValuePlaceHolderVisitor.Find(expr) == null?
+			var ex = addNullCheck && typeof(TTo) != typeof(DataParameter) && Converter.IsDefaultValuePlaceHolderVisitor.Find(expr) == null?
 				AddNullCheck(expr) :
 				expr;
 

--- a/Tests/Linq/Data/DataExtensionsTests.cs
+++ b/Tests/Linq/Data/DataExtensionsTests.cs
@@ -303,12 +303,9 @@ namespace Tests.Data
 			ms.SetConvertExpression<TwoValues,DataParameter>(tv => new DataParameter { Value = (long)tv.Value1 << 32 | tv.Value2 });
 #pragma warning restore CS0675
 
-			using (var conn = (DataConnection)GetDataContext(context, ms))
-			{
-				var n = conn.Execute<long?>("SELECT @p", new { p = (TwoValues?)null });
+			using var conn = (DataConnection)GetDataContext(context, ms);
 
-				Assert.That(n, Is.EqualTo(null));
-			}
+			Assert.That(() => conn.Execute<long?>("SELECT @p", new { p = (TwoValues?)null }), Throws.TypeOf<NullReferenceException>());
 		}
 
 		[ActiveIssue("Poor parameters support", Configuration = ProviderName.ClickHouseClient)]

--- a/Tests/Linq/Linq/MappingTests.cs
+++ b/Tests/Linq/Linq/MappingTests.cs
@@ -893,7 +893,7 @@ namespace Tests.Linq
 
 			var cnt = db.GetTable<RecordTable>().Where(i => i.Value1!.Value == tenderIds[0] || i.Value1!.Value == tenderIds[1] || i.Value1!.Value == tenderIds[2] || i.Value1!.Value == tenderIds[3]).Count();
 
-			Assert.That(cnt, Is.EqualTo(mapNull && !(useExpressions && addNullCheck) ? 3 : 4));
+			Assert.That(cnt, Is.EqualTo(mapNull ? 3 : 4));
 		}
 
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4539")]
@@ -905,7 +905,7 @@ namespace Tests.Linq
 
 			var cnt = db.GetTable<RecordTable>().Where(i => i.Value1!.Value == tenderIds[0] || i.Value1!.Value == tenderIds[1] || i.Value1!.Value == tenderIds[2] || i.Value1!.Value == tenderIds[3]).Count();
 
-			Assert.That(cnt, Is.EqualTo(mapNull && !(useExpressions && addNullCheck) ? 3 : 4));
+			Assert.That(cnt, Is.EqualTo(mapNull ? 3 : 4));
 		}
 
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4539")]
@@ -917,7 +917,7 @@ namespace Tests.Linq
 
 			var cnt = db.GetTable<RecordTable>().Where(i => tenderIds.Contains(i.Value1!.Value)).Count();
 
-			Assert.That(cnt, Is.EqualTo(mapNull && !(useExpressions && addNullCheck) ? 3 : 4));
+			Assert.That(cnt, Is.EqualTo(mapNull ? 3 : 4));
 		}
 
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4539")]
@@ -965,11 +965,10 @@ namespace Tests.Linq
 
 			var cnt = db.GetTable<RecordTable>().Where(i => tenderIds.Contains(i.Value1!.Value)).Count();
 
-			Assert.That(cnt, Is.EqualTo(mapNull && !(useExpressions && addNullCheck) ? 3 : 4));
+			Assert.That(cnt, Is.EqualTo(mapNull ? 3 : 4));
 		}
 
 
-		[ActiveIssue("Not supported case")]
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4539")]
 		public void StructMapping_Enumerable_IntList([IncludeDataSources(TestProvName.AllSQLite)] string context, [Values] bool useExpressions, [Values] bool addNullCheck, [Values] bool mapNull)
 		{
@@ -977,9 +976,8 @@ namespace Tests.Linq
 
 			var tenderIds = new ArrayList() { 5, 3, 4, null };
 
-			var cnt = db.GetTable<RecordTable>().Where(i => tenderIds.Contains(i.Value1!.Value)).Count();
-
-			Assert.That(cnt, Is.EqualTo(mapNull && !(useExpressions && addNullCheck) ? 3 : 4));
+			// not supported case
+			Assert.That(() => db.GetTable<RecordTable>().Where(i => tenderIds.Contains(i.Value1!.Value)).Count(), Throws.TypeOf<InvalidCastException>());
 		}
 
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4539")]
@@ -994,7 +992,6 @@ namespace Tests.Linq
 			Assert.That(cnt, Is.EqualTo(0));
 		}
 
-		[ActiveIssue("Not supported case")]
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4539")]
 		public void StructMapping_MixedEnumerable([IncludeDataSources(TestProvName.AllSQLite)] string context, [Values] bool useExpressions, [Values] bool addNullCheck, [Values] bool mapNull)
 		{
@@ -1002,9 +999,8 @@ namespace Tests.Linq
 
 			var tenderIds = new ArrayList() { new RecordId(5), 3, new RecordId(4), null };
 
-			var cnt = db.GetTable<RecordTable>().Where(i => tenderIds.Contains(i.Value1!.Value)).Count();
-
-			Assert.That(cnt, Is.EqualTo(mapNull && !(useExpressions && addNullCheck) ? 3 : 4));
+			// not supported case
+			Assert.That(() => db.GetTable<RecordTable>().Where(i => tenderIds.Contains(i.Value1!.Value)).Count(), Throws.TypeOf<InvalidCastException>());
 		}
 	}
 }


### PR DESCRIPTION
Fix #4539

Summary:
- improve collection-based parameters handling (currently used by `In/Contains` predicates with client-side collection) to use same parameter conversion generation logic as other parameters (original issue)
- (semi-breaking change) fix long standing issue with `SetConvertExpression(addNullCheck=true)` creating invalid conversion expression to `DataParameter` : `dp != null ? dp : default` as it later used to extract value and type from it leading to bad extractors like `(dp != null ? dp : default).Value/DbType`. As it was generated bad expression, I wouldn't expect anyone being broken by this change.