### PR TITLE
Remove tfm from generator binaries path

### DIFF
--- a/Source/CodeGenerators/Directory.Build.props
+++ b/Source/CodeGenerators/Directory.Build.props
@@ -8,7 +8,7 @@
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
 		<ArtifactsPath>$(MSBuildThisFileDirectory)..\..\.build</ArtifactsPath>
-		<ArtifactsPivots>$(Configuration)\$(TargetFramework)</ArtifactsPivots>
+		<ArtifactsPivots>$(Configuration)</ArtifactsPivots>
 
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 


### PR DESCRIPTION
or roslyn will not be able to locate them