### PR TITLE
CI Fixes

### DIFF
--- a/Build/Azure/README.md
+++ b/Build/Azure/README.md
@@ -64,7 +64,7 @@ Legend:
 - `netfx`: .NET Framework (4.6.2)
 - `netcore`: .NET 6 OR .NET 8
 - :door: - Windows 2022
-- :penguin: - Linux (Ununtu 22.04)
+- :penguin: - Linux (Ununtu 24.04)
 - :green_apple: - MacOS 13 (MacOS testing currently disabled)
 
 | Database (version): provider \ Target framework (OS) | netfx :door: | netcore :door: | netcore :penguin: | netcore :green_apple: |

--- a/Build/Azure/pipelines/templates/build-job.yml
+++ b/Build/Azure/pipelines/templates/build-job.yml
@@ -1,6 +1,8 @@
 parameters:
   for_nuget: false
   for_tests: false
+  with_analyzers: true
+  with_examples: true
 
 jobs:
 - job: build_job
@@ -45,10 +47,11 @@ jobs:
 
   - task: DotNetCoreCLI@2
     inputs:
-      command: 'build'
+      command: build
       projects: 'Examples/Examples.sln'
       arguments: '--configuration Debug'
     displayName: Build Examples (verify)
+    condition: and(succeeded(), ${{ parameters.with_examples }})
 
   - task: DotNetCoreCLI@2
     inputs:
@@ -129,7 +132,7 @@ jobs:
     inputs:
       command: build
       projects: $(solution)
-      arguments: -property:ContinuousIntegrationBuild=true --configuration $(release_configuration)
+      arguments: -property:ContinuousIntegrationBuild=true -property:RunAnalyzersDuringBuild=$(with_analyzers) --configuration $(release_configuration)
     displayName: Build Solution for Release and Nuget
 
   - task: PublishPipelineArtifact@1

--- a/Build/Azure/pipelines/templates/test-jobs.yml
+++ b/Build/Azure/pipelines/templates/test-jobs.yml
@@ -163,11 +163,11 @@ jobs:
       with_baselines: ${{ parameters.with_baselines }}
 
 ########################
-#  Tests: Ubuntu 22.04 #
+#  Tests: Ubuntu 24.04 #
 ########################
 - job: test_ubuntu_job
   pool:
-    vmImage: 'ubuntu-22.04'
+    vmImage: 'ubuntu-24.04'
   timeoutInMinutes: 90 # default: 60, max: 360
   displayName: 'Tests: Linux'
   dependsOn: create_baselines_branch

--- a/Build/Azure/pipelines/templates/test-matrix.yml
+++ b/Build/Azure/pipelines/templates/test-matrix.yml
@@ -41,7 +41,7 @@ parameters:
 
 # OPERATION SYSTEM SELECTORS
 # - enable_os_windows  (true/false string) : enables testrun for windows 2022 image (windows-2022)
-# - enable_os_ubuntu   (true/false string) : enables testrun for Ubuntu 22.04 image (ubuntu-22.04)
+# - enable_os_ubuntu   (true/false string) : enables testrun for Ubuntu 24.04 image (ubuntu-24.04)
 # - enable_os_macos    (true/false string) : enables testrun for Mac OS image (macOS-13)
 
 # TARGET FRAMEWORK SELECTORS

--- a/Build/Azure/pipelines/templates/test-workflow-linux.yml
+++ b/Build/Azure/pipelines/templates/test-workflow-linux.yml
@@ -77,6 +77,13 @@ steps:
   condition: and(variables.title, eq(variables.net60, 'true'), succeeded())
   displayName: 'EF.Core Tests (NET60): $(title)'
 
+- task: UseDotNet@2
+  displayName: 'Use .NET 8'
+  inputs:
+    packageType: sdk
+    version: 8.x
+  condition: and(variables.title, eq(variables.net80, 'true'), succeeded())
+
 - task: CmdLine@2
   inputs:
     script: '$(System.DefaultWorkingDirectory)/scripts/$(script_local)'

--- a/Build/Azure/pipelines/templates/test-workflow-linux.yml
+++ b/Build/Azure/pipelines/templates/test-workflow-linux.yml
@@ -4,7 +4,14 @@ parameters:
 steps:
 - checkout: none
 
-# .NET 6/8 SDK already installed https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
+# .NET 8 SDK already installed https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
+
+- task: UseDotNet@2
+  displayName: 'Install .NET 6'
+  inputs:
+    packageType: sdk
+    version: 6.x
+  condition: and(variables.title, eq(variables.net60, 'true'), succeeded())
 
 - task: CmdLine@2
   inputs:

--- a/Build/Azure/pipelines/testing.yml
+++ b/Build/Azure/pipelines/testing.yml
@@ -18,8 +18,8 @@ stages:
     parameters:
       for_nuget: false
       for_tests: true
-      with_analyzers: true
-      with_examples: true
+      with_analyzers: false
+      with_examples: false
 
 #############
 # TEST JOBS #

--- a/Build/Azure/pipelines/testing.yml
+++ b/Build/Azure/pipelines/testing.yml
@@ -18,6 +18,8 @@ stages:
     parameters:
       for_nuget: false
       for_tests: true
+      with_analyzers: true
+      with_examples: true
 
 #############
 # TEST JOBS #

--- a/Build/Azure/scripts/sqlserver.2017.sh
+++ b/Build/Azure/scripts/sqlserver.2017.sh
@@ -1,28 +1,19 @@
 #!/bin/bash
 
-docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=Password12!' -p 1433:1433 -h mssql --name=mssql -d mcr.microsoft.com/mssql/server:2017-latest
-# with FTS
-#docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=Password12!' -p 1433:1433 -h mssql --name=mssql -d marvalsoftware/sqlserverfts:latest
+docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=Password12!' -p 1433:1433 -h mssql --name=mssql -d linq2db/linq2db:mssql-2017
 docker ps -a
 
 # Wait for start
 echo "Waiting for SQL Server to accept connections"
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "SELECT 1"
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q "SELECT 1"
 is_up=$?
 while [ $is_up -ne 0 ] ; do
-    docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "SELECT 1"
+    docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q "SELECT 1"
     is_up=$?
 done
 echo "SQL Server is operational"
 
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'SELECT @@Version'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'SELECT @@Version'
 
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestData;'
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataMS;'
-
-#docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'CREATE DATABASE Northwind;'
-#docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'CREATE DATABASE NorthwindMS;'
-#docker cp scripts/northwind.sql mssql:/northwind.sql
-#docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -d Northwind -i /northwind.sql
-#docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -d NorthwindMS -i /northwind.sql
-
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestData;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataMS;'

--- a/Build/Azure/scripts/sqlserver.2019.sh
+++ b/Build/Azure/scripts/sqlserver.2019.sh
@@ -5,30 +5,30 @@ docker ps -a
 
 # Wait for start
 echo "Waiting for SQL Server to accept connections"
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "SELECT 1"
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q "SELECT 1"
 is_up=$?
 while [ $is_up -ne 0 ] ; do
-    docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "SELECT 1"
+    docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q "SELECT 1"
     is_up=$?
 done
 echo "SQL Server is operational"
 
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'SELECT @@Version'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'SELECT @@Version'
 
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestData COLLATE Latin1_General_CS_AS WITH CATALOG_COLLATION = SQL_Latin1_General_CP1_CI_AS;;'
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataMS COLLATE Latin1_General_CS_AS WITH CATALOG_COLLATION = SQL_Latin1_General_CP1_CI_AS;;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestData COLLATE Latin1_General_CS_AS WITH CATALOG_COLLATION = SQL_Latin1_General_CP1_CI_AS;;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataMS COLLATE Latin1_General_CS_AS WITH CATALOG_COLLATION = SQL_Latin1_General_CP1_CI_AS;;'
 
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataSA;'
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataMSSA;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataSA;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataMSSA;'
 
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'sp_configure '"'"'contained database authentication'"'"', 1;'
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'RECONFIGURE;'
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataContained CONTAINMENT = PARTIAL;'
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataMSContained CONTAINMENT = PARTIAL;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'sp_configure '"'"'contained database authentication'"'"', 1;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'RECONFIGURE;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataContained CONTAINMENT = PARTIAL;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataMSContained CONTAINMENT = PARTIAL;'
 
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'CREATE DATABASE Northwind;'
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'CREATE DATABASE NorthwindMS;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE Northwind;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE NorthwindMS;'
 
 docker cp northwind.sql mssql:/northwind.sql
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -d Northwind -i /northwind.sql
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -d NorthwindMS -i /northwind.sql
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -d Northwind -i /northwind.sql
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -d NorthwindMS -i /northwind.sql

--- a/Build/Azure/scripts/sqlserver.2019.sh
+++ b/Build/Azure/scripts/sqlserver.2019.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-#docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=Password12!' -p 1433:1433 -h mssql --name=mssql -d mcr.microsoft.com/mssql/server:2019-latest
-docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=Password12!' -p 1433:1433 -h mssql --name=mssql -d huyttq/sqlserver-2019-with-fts:2019
+docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=Password12!' -p 1433:1433 -h mssql --name=mssql -d linq2db/linq2db:mssql-2019-fts
 docker ps -a
 
 # Wait for start

--- a/Build/Azure/scripts/sqlserver.extras.sh
+++ b/Build/Azure/scripts/sqlserver.extras.sh
@@ -1,25 +1,24 @@
 #!/bin/bash
 
-#docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=Password12!' -p 1433:1433 -h mssql --name=mssql -d mcr.microsoft.com/mssql/server:2019-latest
-docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=Password12!' -p 1433:1433 -h mssql --name=mssql -d huyttq/sqlserver-2019-with-fts:2019
+docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=Password12!' -p 1433:1433 -h mssql --name=mssql -d linq2db/linq2db:mssql-2019-fts
 docker ps -a
 
 # Wait for start
 echo "Waiting for SQL Server to accept connections"
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "SELECT 1"
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q "SELECT 1"
 is_up=$?
 while [ $is_up -ne 0 ] ; do
-    docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "SELECT 1"
+    docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q "SELECT 1"
     is_up=$?
 done
 echo "SQL Server is operational"
 
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'SELECT @@Version'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'SELECT @@Version'
 
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataSA;'
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataMSSA;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataSA;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataMSSA;'
 
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'sp_configure '"'"'contained database authentication'"'"', 1;'
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'RECONFIGURE;'
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataContained CONTAINMENT = PARTIAL;'
-docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataMSContained CONTAINMENT = PARTIAL;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'sp_configure '"'"'contained database authentication'"'"', 1;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'RECONFIGURE;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataContained CONTAINMENT = PARTIAL;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataMSContained CONTAINMENT = PARTIAL;'

--- a/Data/Setup Scripts/sqlserver2017.cmd
+++ b/Data/Setup Scripts/sqlserver2017.cmd
@@ -5,12 +5,12 @@ docker stop sql2017
 docker rm -f sql2017
 
 REM use pull to get latest layers (run will use cached layers)
-docker pull mcr.microsoft.com/mssql/server:2017-latest
-docker run -e ACCEPT_EULA=Y -e SA_PASSWORD=Password12! -p 1417:1433 --name sql2017 -d mcr.microsoft.com/mssql/server:2017-latest
+docker pull linq2db/linq2db:mssql-2017
+docker run -e ACCEPT_EULA=Y -e SA_PASSWORD=Password12! -p 1417:1433 --name sql2017 -d linq2db/linq2db:mssql-2017
 
 call wait sql2017 "Recovery is complete"
 
 REM create test databases
-docker exec sql2017 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData;"
-docker exec sql2017 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS;"
+docker exec sql2017 /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData;"
+docker exec sql2017 /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS;"
 

--- a/Data/Setup Scripts/sqlserver2019.cmd
+++ b/Data/Setup Scripts/sqlserver2019.cmd
@@ -5,34 +5,32 @@ docker stop sql2019
 docker rm -f sql2019
 
 REM use pull to get latest layers (run will use cached layers)
-REM docker pull mcr.microsoft.com/mssql/server:2019-latest
-REM docker run -e ACCEPT_EULA=Y -e SA_PASSWORD=Password12! -p 1419:1433 --name sql2019 -d mcr.microsoft.com/mssql/server:2019-latest
-docker pull huyttq/sqlserver-2019-with-fts:2019
-docker run -e ACCEPT_EULA=Y -e SA_PASSWORD=Password12! -p 1419:1433 --name sql2019 -d huyttq/sqlserver-2019-with-fts:2019
+REM docker pull linq2db/linq2db:mssql-2019-fts
+docker run -e ACCEPT_EULA=Y -e SA_PASSWORD=Password12! -p 1419:1433 --name sql2019 -d linq2db/linq2db:mssql-2019-fts
 
 call wait sql2019 "Recovery is complete"
 
 REM create test databases
-REM docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData;"
-REM docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS;"
+REM docker exec sql2019 /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData;"
+REM docker exec sql2019 /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS;"
 
-docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData COLLATE Latin1_General_CS_AS WITH CATALOG_COLLATION = SQL_Latin1_General_CP1_CI_AS;"
-docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS COLLATE Latin1_General_CS_AS WITH CATALOG_COLLATION = SQL_Latin1_General_CP1_CI_AS;"
+docker exec sql2019 /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData COLLATE Latin1_General_CS_AS WITH CATALOG_COLLATION = SQL_Latin1_General_CP1_CI_AS;"
+docker exec sql2019 /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS COLLATE Latin1_General_CS_AS WITH CATALOG_COLLATION = SQL_Latin1_General_CP1_CI_AS;"
 
-docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataSA;"
-docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMSSA;"
+docker exec sql2019 /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataSA;"
+docker exec sql2019 /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMSSA;"
 
-docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "sp_configure 'contained database authentication', 1;"
-docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "RECONFIGURE;"
-docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataContained CONTAINMENT = PARTIAL;"
-docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMSContained CONTAINMENT = PARTIAL;"
+docker exec sql2019 /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q "sp_configure 'contained database authentication', 1;"
+docker exec sql2019 /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q "RECONFIGURE;"
+docker exec sql2019 /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataContained CONTAINMENT = PARTIAL;"
+docker exec sql2019 /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMSContained CONTAINMENT = PARTIAL;"
 
-docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE Northwind;"
-docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE NorthwindMS;"
+docker exec sql2019 /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q "CREATE DATABASE Northwind;"
+docker exec sql2019 /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q "CREATE DATABASE NorthwindMS;"
 
 docker cp "../Create Scripts/Northwind.sql" sql2019:/northwind.sql
 
-docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -d Northwind -i /northwind.sql
-docker exec sql2019 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Password12! -d NorthwindMS -i /northwind.sql
+docker exec sql2019 /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -d Northwind -i /northwind.sql
+docker exec sql2019 /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -d NorthwindMS -i /northwind.sql
 
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -123,7 +123,7 @@
 </ItemGroup>
 	
 	<ItemGroup Label="Testing" Condition=" '$(TargetFramework)' == 'net462' ">
-		<PackageVersion Include="System.Text.Json"                                      Version="8.0.4"                 />
+		<PackageVersion Include="System.Text.Json"                                      Version="8.0.5"                 />
 	</ItemGroup>
 
 	<ItemGroup Label="Benchmarks">


### PR DESCRIPTION
As ubuntu 22.04 kernel update broke existing sql server 2017/2019 images, I think it's a good time to look into 24.04 migration and replacing some 3rd-party images with our own.

- [x] Switch to own SQL 2017 Linux image
- [x] Switch to own SQL 2019 + FTS Linux image
- [ ] Switch to own Sybase ASE Linux image with UTF-8 support enabled
- [x] Run analyzers and examples only for default pipeline
- [x] Bump STJ version to avoid build nagging
