### PR TITLE
Add `ToSqlQuery` API

### DIFF
--- a/NuGet/README.EF.md
+++ b/NuGet/README.EF.md
@@ -138,7 +138,7 @@ using (var ctx = CreateAdventureWorksContext())
     var items2 = await neededRecords.ToLinqToDB().ToArrayAsync(); 
     
     // and simple bonus - how to generate SQL
-    var sql = neededRecords.ToLinqToDB().ToString();
+    var command = neededRecords.ToLinqToDB().ToSqlQuery();
 }
 ```
 

--- a/Source/LinqToDB.EntityFrameworkCore/Internal/LinqToDBForEFQueryProvider.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/Internal/LinqToDBForEFQueryProvider.cs
@@ -27,7 +27,7 @@ namespace LinqToDB.EntityFrameworkCore.Internal
 	///		It may change or be removed without further notice.
 	/// </summary>
 	/// <typeparam name="T">Type of query element.</typeparam>
-	public class LinqToDBForEFQueryProvider<T> : IAsyncQueryProvider, IQueryProviderAsync, IQueryable<T>, IAsyncEnumerable<T>
+	public class LinqToDBForEFQueryProvider<T> : IAsyncQueryProvider, IQueryProviderAsync, IQueryable<T>, IAsyncEnumerable<T>, IExpressionQuery
 	{
 		/// <summary>
 		/// Creates instance of adapter.
@@ -185,5 +185,16 @@ namespace LinqToDB.EntityFrameworkCore.Internal
 		{
 			return QueryProvider.ToString();
 		}
+
+		#region IExpressionQuery
+
+		Expression IExpressionQuery.Expression => ((IExpressionQuery)QueryProvider).Expression;
+
+		IDataContext IExpressionQuery.DataContext => ((IExpressionQuery)QueryProvider).DataContext;
+
+		IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options) =>
+			((IExpressionQuery)QueryProvider).GetSqlQueries(options);
+
+		#endregion
 	}
 }

--- a/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
+++ b/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
@@ -71,13 +71,8 @@ namespace LinqToDB.Data
 				}
 			}
 
-			public override IReadOnlyList<QuerySql> GetSqlText(SqlGenerationOptions? options)
+			public override IReadOnlyList<QuerySql> GetSqlText()
 			{
-				var oldInline = _dataConnection.InlineParameters;
-
-				if (options?.InlineParameters != null)
-					_dataConnection.InlineParameters = options.InlineParameters.Value;
-
 				SetCommand(true);
 
 				var queries = new QuerySql[_executionQuery!.PreparedQuery.Commands.Length];
@@ -112,8 +107,6 @@ namespace LinqToDB.Data
 
 					queries[index] = new QuerySql(sql, parameters);
 				}
-
-				_dataConnection.InlineParameters = oldInline;
 
 				return queries;
 			}

--- a/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
+++ b/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
@@ -71,8 +71,13 @@ namespace LinqToDB.Data
 				}
 			}
 
-			public override IReadOnlyList<QuerySql> GetSqlText()
+			public override IReadOnlyList<QuerySql> GetSqlText(SqlGenerationOptions? options)
 			{
+				var oldInline = _dataConnection.InlineParameters;
+
+				if (options?.InlineParameters != null)
+					_dataConnection.InlineParameters = options.InlineParameters.Value;
+
 				SetCommand(true);
 
 				var queries = new QuerySql[_executionQuery!.PreparedQuery.Commands.Length];
@@ -107,6 +112,8 @@ namespace LinqToDB.Data
 
 					queries[index] = new QuerySql(sql, parameters);
 				}
+
+				_dataConnection.InlineParameters = oldInline;
 
 				return queries;
 			}

--- a/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
+++ b/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
@@ -71,59 +71,44 @@ namespace LinqToDB.Data
 				}
 			}
 
-			public override string GetSqlText()
+			public override IReadOnlyList<QuerySql> GetSqlText()
 			{
 				SetCommand(true);
 
-				var sqlProvider = _dataConnection.DataProvider.CreateSqlBuilder(_dataConnection.MappingSchema, _dataConnection.Options);
-
-				using var sbv = Pools.StringBuilder.Allocate();
-				var sb = sbv.Value;
-
-				sb.Append("-- ").Append(_dataConnection.ConfigurationString);
-
-				if (_dataConnection.ConfigurationString != _dataConnection.DataProvider.Name)
-					sb.Append(' ').Append(_dataConnection.DataProvider.Name);
-
-				if (_dataConnection.DataProvider.Name != sqlProvider.Name)
-					sb.Append(' ').Append(sqlProvider.Name);
-
-				sb.AppendLine();
-
-				var isFirst = true;
+				var queries = new QuerySql[_executionQuery!.PreparedQuery.Commands.Length];
 
 				for (var index = 0; index < _executionQuery!.PreparedQuery.Commands.Length; index++)
 				{
-					var queryCommand = _executionQuery.PreparedQuery.Commands[index];
-					sqlProvider.PrintParameters(_dataConnection, sb, _executionQuery.CommandsParameters[index]);
+					var queryCommand    = _executionQuery.PreparedQuery.Commands[index];
+					var queryParameters = _executionQuery.CommandsParameters[index];
 
-					sb.AppendLine(queryCommand.Command);
+					var parameters = queryParameters == null || queryParameters.Length == 0
+						? Array.Empty<DataParameter>()
+						: new DataParameter[queryParameters.Length];
 
-					if (isFirst && _executionQuery.PreparedQuery.QueryHints != null)
+					if (queryParameters != null)
 					{
-						isFirst = false;
+						for (var i = 0; i < queryParameters.Length; i++)
+						{
+							var p            = queryParameters[i];
+							var sqlParameter = queryCommand.SqlParameters[i];
 
-						while (sb[sb.Length - 1] == '\n' || sb[sb.Length - 1] == '\r')
-							sb.Length--;
+							parameters[i] = new DataParameter(p.ParameterName, p.Value, sqlParameter.Type);
+						}
+					}
 
-						sb.AppendLine();
+					var sql = queryCommand.Command;
 
-						var sql = sb.ToString();
-
+					if (index == 0 && _executionQuery.PreparedQuery.QueryHints != null)
+					{
 						var sqlBuilder = _dataConnection.DataProvider.CreateSqlBuilder(_dataConnection.MappingSchema, _dataConnection.Options);
 						sql = sqlBuilder.ApplyQueryHints(sql, _executionQuery.PreparedQuery.QueryHints);
-
-						sb.Length = 0;
-						sb.Append(sql);
 					}
+
+					queries[index] = new QuerySql(sql, parameters);
 				}
 
-				while (sb[sb.Length - 1] == '\n' || sb[sb.Length - 1] == '\r')
-					sb.Length--;
-
-				sb.AppendLine();
-
-				return sb.ToString();
+				return queries;
 			}
 
 			public override void Dispose()

--- a/Source/LinqToDB/DataContext.cs
+++ b/Source/LinqToDB/DataContext.cs
@@ -571,9 +571,9 @@ namespace LinqToDB
 				return _queryRunner!.ExecuteNonQueryAsync(cancellationToken);
 			}
 
-			public IReadOnlyList<QuerySql> GetSqlText()
+			public IReadOnlyList<QuerySql> GetSqlText(SqlGenerationOptions? options)
 			{
-				return _queryRunner!.GetSqlText();
+				return _queryRunner!.GetSqlText(options);
 			}
 
 			public IDataContext      DataContext      => _dataContext!;

--- a/Source/LinqToDB/DataContext.cs
+++ b/Source/LinqToDB/DataContext.cs
@@ -571,7 +571,7 @@ namespace LinqToDB
 				return _queryRunner!.ExecuteNonQueryAsync(cancellationToken);
 			}
 
-			public string GetSqlText()
+			public IReadOnlyList<QuerySql> GetSqlText()
 			{
 				return _queryRunner!.GetSqlText();
 			}

--- a/Source/LinqToDB/DataContext.cs
+++ b/Source/LinqToDB/DataContext.cs
@@ -571,9 +571,9 @@ namespace LinqToDB
 				return _queryRunner!.ExecuteNonQueryAsync(cancellationToken);
 			}
 
-			public IReadOnlyList<QuerySql> GetSqlText(SqlGenerationOptions? options)
+			public IReadOnlyList<QuerySql> GetSqlText()
 			{
-				return _queryRunner!.GetSqlText(options);
+				return _queryRunner!.GetSqlText();
 			}
 
 			public IDataContext      DataContext      => _dataContext!;

--- a/Source/LinqToDB/DataProvider/DatabaseSpecificTable.cs
+++ b/Source/LinqToDB/DataProvider/DatabaseSpecificTable.cs
@@ -33,10 +33,10 @@ namespace LinqToDB.DataProvider
 
 		public Expression Expression => _table.Expression;
 
-		IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQuery() => _table.GetSqlQuery();
-		public IDataContext   DataContext                      => _table.DataContext;
-		public Type           ElementType                      => _table.ElementType;
-		public IQueryProvider Provider                         => _table.Provider;
+		IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options) => _table.GetSqlQueries(options);
+		public IDataContext   DataContext                                                     => _table.DataContext;
+		public Type           ElementType                                                     => _table.ElementType;
+		public IQueryProvider Provider                                                        => _table.Provider;
 
 		public IQueryable CreateQuery(Expression expression)
 		{

--- a/Source/LinqToDB/DataProvider/DatabaseSpecificTable.cs
+++ b/Source/LinqToDB/DataProvider/DatabaseSpecificTable.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 namespace LinqToDB.DataProvider
 {
 	using Async;
+	using Linq;
 
 	abstract class DatabaseSpecificTable<TSource> : ITable<TSource>
 		where TSource : notnull
@@ -32,10 +33,10 @@ namespace LinqToDB.DataProvider
 
 		public Expression Expression => _table.Expression;
 
-		public string         SqlText     => _table.SqlText;
-		public IDataContext   DataContext => _table.DataContext;
-		public Type           ElementType => _table.ElementType;
-		public IQueryProvider Provider    => _table.Provider;
+		IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQuery() => _table.GetSqlQuery();
+		public IDataContext   DataContext                      => _table.DataContext;
+		public Type           ElementType                      => _table.ElementType;
+		public IQueryProvider Provider                         => _table.Provider;
 
 		public IQueryable CreateQuery(Expression expression)
 		{

--- a/Source/LinqToDB/DataProvider/Informix/InformixSqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixSqlOptimizer.cs
@@ -58,24 +58,12 @@ namespace LinqToDB.DataProvider.Informix
 			}
 		}
 
-		static void ClearQueryParameter(IQueryElement element)
-		{
-			if (element is SqlParameter p && p.IsQueryParameter)
-				p.IsQueryParameter = false;
-		}
-
 		public override SqlStatement Finalize(MappingSchema mappingSchema, SqlStatement statement, DataOptions dataOptions)
 		{
 			statement.VisitAll(SetQueryParameter);
 
 			// Informix doesn't support parameters in select list
-			var ignore = statement.QueryType == QueryType.Insert && statement.SelectQuery!.From.Tables.Count == 0;
-			if (!ignore)
-				statement.VisitAll(static e =>
-				{
-					if (e is SqlSelectClause select)
-						select.VisitAll(ClearQueryParameter);
-				});
+			new ClearColumParametersVisitor().Visit(statement);
 
 			return base.Finalize(mappingSchema, statement, dataOptions);
 		}

--- a/Source/LinqToDB/DataProvider/SqlCe/SqlCeSqlOptimizer.cs
+++ b/Source/LinqToDB/DataProvider/SqlCe/SqlCeSqlOptimizer.cs
@@ -100,17 +100,7 @@ namespace LinqToDB.DataProvider.SqlCe
 			//
 			if (statement.IsInsert())
 			{
-				var query = statement.SelectQuery;
-				if (query != null)
-				{
-					foreach (var column in query.Select.Columns)
-					{
-						if (column.Expression is SqlParameter parameter)
-						{
-							parameter.IsQueryParameter = false;
-						}
-					}
-				}
+				new ClearColumParametersVisitor().Visit(statement);
 			}
 		}
 

--- a/Source/LinqToDB/IDataContext.cs
+++ b/Source/LinqToDB/IDataContext.cs
@@ -106,7 +106,7 @@ namespace LinqToDB
 		/// <param name="queryNumber">Index of query in query batch.</param>
 		/// <param name="expressions">Query results mapping expressions.</param>
 		/// <param name="parameters">Query parameters.</param>
-		/// <param name="preambles">Query preambles</param>
+		/// <param name="preambles">Query preambles.</param>
 		/// <returns>Query runner service.</returns>
 		IQueryRunner GetQueryRunner(Query query, IDataContext parametersContext, int queryNumber, IQueryExpressions expressions, object?[]? parameters, object?[]? preambles);
 

--- a/Source/LinqToDB/Linq/ExpressionQuery.cs
+++ b/Source/LinqToDB/Linq/ExpressionQuery.cs
@@ -59,11 +59,11 @@ namespace LinqToDB.Linq
 			return sqlText;
 		}
 
-		public virtual QueryDebugView DebugView 
+		public virtual QueryDebugView DebugView
 			=> new(
-				() => new ExpressionPrinter().PrintExpression(Expression), 
-				() => ((IExpressionQuery)this).GetSqlQuery().Single().Sql,
-				() => ((IExpressionQuery)this).GetSqlQuery().Single().Sql // TODO: Inline parameters
+				() => new ExpressionPrinter().PrintExpression(Expression),
+				() => ((IExpressionQuery)this).GetSqlQueries(null)[0].Sql,
+				() => ((IExpressionQuery)this).GetSqlQueries(new () { InlineParameters = false })[0].Sql
 				);
 
 		#endregion

--- a/Source/LinqToDB/Linq/ExpressionQuery.cs
+++ b/Source/LinqToDB/Linq/ExpressionQuery.cs
@@ -43,7 +43,7 @@ namespace LinqToDB.Linq
 
 		#region Public Members
 
-		IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQuery()
+		IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options)
 		{
 			var expression  = Expression;
 			var expressions = (IQueryExpressions)new RuntimeExpressionsContainer(expression);
@@ -54,7 +54,7 @@ namespace LinqToDB.Linq
 				Expression = expressions.MainExpression;
 			}
 
-			var sqlText    = QueryRunner.GetSqlText(info, DataContext, expressions, Parameters, Preambles);
+			var sqlText    = QueryRunner.GetSqlText(info, DataContext, expressions, Parameters, Preambles, options);
 
 			return sqlText;
 		}
@@ -272,7 +272,7 @@ namespace LinqToDB.Linq
 		Type           IQueryable.ElementType => typeof(T);
 
 		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
-		Expression IQueryable.Expression  => Expression;
+		Expression     IQueryable.Expression  => Expression;
 		
 		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 		IQueryProvider IQueryable.Provider    => this;

--- a/Source/LinqToDB/Linq/ExpressionQuery.cs
+++ b/Source/LinqToDB/Linq/ExpressionQuery.cs
@@ -41,26 +41,23 @@ namespace LinqToDB.Linq
 		//
 		[JetBrains.Annotations.UsedImplicitly]
 		// ReSharper disable once InconsistentNaming
-		public string _sqlText => SqlText;
+		public IReadOnlyList<QuerySql> _sqlText => ((IExpressionQuery)this).GetSqlQuery();
 #endif
 
-		public string SqlText
+		IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQuery()
 		{
-			get
+			var expression  = Expression;
+			var expressions = (IQueryExpressions)new RuntimeExpressionsContainer(expression);
+			var info        = GetQuery(ref expressions, true, out var dependsOnParameters);
+
+			if (!dependsOnParameters)
 			{
-				var expression  = Expression;
-				var expressions = (IQueryExpressions)new RuntimeExpressionsContainer(expression);
-				var info        = GetQuery(ref expressions, true, out var dependsOnParameters);
-
-				if (!dependsOnParameters)
-				{
-					Expression = expressions.MainExpression;
-				}
-
-				var sqlText    = QueryRunner.GetSqlText(info, DataContext, expressions, Parameters, Preambles);
-
-				return sqlText;
+				Expression = expressions.MainExpression;
 			}
+
+			var sqlText    = QueryRunner.GetSqlText(info, DataContext, expressions, Parameters, Preambles);
+
+			return sqlText;
 		}
 
 		#endregion

--- a/Source/LinqToDB/Linq/ExpressionQuery.cs
+++ b/Source/LinqToDB/Linq/ExpressionQuery.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -14,6 +15,7 @@ namespace LinqToDB.Linq
 	using Extensions;
 	using Tools;
 	using Internal;
+	using LinqToDB.Expressions;
 
 	abstract class ExpressionQuery<T> : IExpressionQuery<T>, IAsyncEnumerable<T>
 	{
@@ -28,21 +30,18 @@ namespace LinqToDB.Linq
 		public Expression   Expression  { get; set; } = null!;
 		public IDataContext DataContext { get; set; } = null!;
 
+		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 		internal Query<T>?  Info;
+
+		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 		internal object?[]? Parameters;
+
+		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 		internal object?[]? Preambles;
 
 		#endregion
 
 		#region Public Members
-
-#if DEBUG
-		// This property is helpful in Debug Mode.
-		//
-		[JetBrains.Annotations.UsedImplicitly]
-		// ReSharper disable once InconsistentNaming
-		public IReadOnlyList<QuerySql> _sqlText => ((IExpressionQuery)this).GetSqlQuery();
-#endif
 
 		IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQuery()
 		{
@@ -59,6 +58,13 @@ namespace LinqToDB.Linq
 
 			return sqlText;
 		}
+
+		public virtual QueryDebugView DebugView 
+			=> new(
+				() => new ExpressionPrinter().PrintExpression(Expression), 
+				() => ((IExpressionQuery)this).GetSqlQuery().Single().Sql,
+				() => ((IExpressionQuery)this).GetSqlQuery().Single().Sql // TODO: Inline parameters
+				);
 
 		#endregion
 
@@ -262,8 +268,13 @@ namespace LinqToDB.Linq
 
 		#region IQueryable Members
 
+		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 		Type           IQueryable.ElementType => typeof(T);
-		Expression     IQueryable.Expression  => Expression;
+
+		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
+		Expression IQueryable.Expression  => Expression;
+		
+		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 		IQueryProvider IQueryable.Provider    => this;
 
 		#endregion

--- a/Source/LinqToDB/Linq/ExpressionQueryImpl.cs
+++ b/Source/LinqToDB/Linq/ExpressionQueryImpl.cs
@@ -10,11 +10,6 @@ namespace LinqToDB.Linq
 		{
 			Init(dataContext, expression);
 		}
-
-		public override string ToString()
-		{
-			return SqlText;
-		}
 	}
 
 	static class ExpressionQueryImpl

--- a/Source/LinqToDB/Linq/IExpressionQuery.cs
+++ b/Source/LinqToDB/Linq/IExpressionQuery.cs
@@ -1,11 +1,13 @@
-﻿using System.Linq.Expressions;
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
 
 namespace LinqToDB.Linq
 {
 	public interface IExpressionQuery
 	{
 		Expression   Expression  { get; }
-		string       SqlText     { get; }
 		IDataContext DataContext { get; }
+
+		IReadOnlyList<QuerySql> GetSqlQuery();
 	}
 }

--- a/Source/LinqToDB/Linq/IExpressionQuery.cs
+++ b/Source/LinqToDB/Linq/IExpressionQuery.cs
@@ -8,6 +8,6 @@ namespace LinqToDB.Linq
 		Expression   Expression  { get; }
 		IDataContext DataContext { get; }
 
-		IReadOnlyList<QuerySql> GetSqlQuery();
+		IReadOnlyList<QuerySql> GetSqlQueries(SqlGenerationOptions? options);
 	}
 }

--- a/Source/LinqToDB/Linq/IQueryRunner.cs
+++ b/Source/LinqToDB/Linq/IQueryRunner.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -45,10 +46,10 @@ namespace LinqToDB.Linq
 		Task<IDataReaderAsync> ExecuteReaderAsync  (CancellationToken cancellationToken);
 
 		/// <summary>
-		/// Returns SQL text for query.
+		/// Returns SQL text with parameters for query.
 		/// </summary>
-		/// <returns>Query SQL text.</returns>
-		string                 GetSqlText          ();
+		/// <returns>Query SQL text with parameters.</returns>
+		IReadOnlyList<QuerySql> GetSqlText();
 		
 		IQueryExpressions Expressions      { get; }
 		IDataContext      DataContext      { get; }

--- a/Source/LinqToDB/Linq/IQueryRunner.cs
+++ b/Source/LinqToDB/Linq/IQueryRunner.cs
@@ -49,7 +49,7 @@ namespace LinqToDB.Linq
 		/// Returns SQL text with parameters for query.
 		/// </summary>
 		/// <returns>Query SQL text with parameters.</returns>
-		IReadOnlyList<QuerySql> GetSqlText(SqlGenerationOptions? options);
+		IReadOnlyList<QuerySql> GetSqlText();
 		
 		IQueryExpressions Expressions      { get; }
 		IDataContext      DataContext      { get; }

--- a/Source/LinqToDB/Linq/IQueryRunner.cs
+++ b/Source/LinqToDB/Linq/IQueryRunner.cs
@@ -49,7 +49,7 @@ namespace LinqToDB.Linq
 		/// Returns SQL text with parameters for query.
 		/// </summary>
 		/// <returns>Query SQL text with parameters.</returns>
-		IReadOnlyList<QuerySql> GetSqlText();
+		IReadOnlyList<QuerySql> GetSqlText(SqlGenerationOptions? options);
 		
 		IQueryExpressions Expressions      { get; }
 		IDataContext      DataContext      { get; }

--- a/Source/LinqToDB/Linq/PersistentTableT.cs
+++ b/Source/LinqToDB/Linq/PersistentTableT.cs
@@ -30,10 +30,10 @@ namespace LinqToDB.Linq
 
 		public Expression Expression => _query.Expression;
 
-		IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQuery() => Array.Empty<QuerySql>();
-		public IDataContext   DataContext                      => null!;
-		public Type           ElementType                      => _query.ElementType;
-		public IQueryProvider Provider                         => _query.Provider;
+		IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options) => Array.Empty<QuerySql>();
+		public IDataContext   DataContext                                                     => null!;
+		public Type           ElementType                                                     => _query.ElementType;
+		public IQueryProvider Provider                                                        => _query.Provider;
 
 		public IQueryable CreateQuery(Expression expression)
 		{

--- a/Source/LinqToDB/Linq/PersistentTableT.cs
+++ b/Source/LinqToDB/Linq/PersistentTableT.cs
@@ -30,10 +30,10 @@ namespace LinqToDB.Linq
 
 		public Expression Expression => _query.Expression;
 
-		public string         SqlText     { get; } = null!;
-		public IDataContext   DataContext => null!;
-		public Type           ElementType => _query.ElementType;
-		public IQueryProvider Provider    => _query.Provider;
+		IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQuery() => Array.Empty<QuerySql>();
+		public IDataContext   DataContext                      => null!;
+		public Type           ElementType                      => _query.ElementType;
+		public IQueryProvider Provider                         => _query.Provider;
 
 		public IQueryable CreateQuery(Expression expression)
 		{

--- a/Source/LinqToDB/Linq/QueryDebugView.cs
+++ b/Source/LinqToDB/Linq/QueryDebugView.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace LinqToDB.Linq
+{
+	public class QueryDebugView
+	{
+		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
+		private readonly Func<string> _toExpressionString;
+
+		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
+		private readonly Func<string> _toQueryString;
+
+		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
+		private readonly Func<string> _toQueryStringNoParams;
+
+		public QueryDebugView(
+			Func<string> toExpressionString,
+			Func<string> toQueryString,
+			Func<string> toQueryStringNoParams
+			)
+		{
+			_toExpressionString    = toExpressionString;
+			_toQueryString         = toQueryString;
+			_toQueryStringNoParams = toQueryStringNoParams;
+		}
+
+		public virtual string Expression
+		{
+			get
+			{
+				try
+				{
+					return _toExpressionString();
+				}
+				catch (Exception exception)
+				{
+					return "Error creating query expression: " + exception;
+				}
+			}
+		}
+
+		public virtual string Query
+		{
+			get
+			{
+				try
+				{
+					return _toQueryString();
+				}
+				catch (Exception exception)
+				{
+					return "Error creating query string: " + exception;
+				}
+			}
+		}
+
+		public virtual string QueryNoParams
+		{
+			get
+			{
+				try
+				{
+					return _toQueryStringNoParams();
+				}
+				catch (Exception exception)
+				{
+					return "Error creating query string: " + exception;
+				}
+			}
+		}
+	}
+}

--- a/Source/LinqToDB/Linq/QueryRunner.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.cs
@@ -995,11 +995,12 @@ namespace LinqToDB.Linq
 
 		#region GetSqlText
 
-		public static IReadOnlyList<QuerySql> GetSqlText(Query query, IDataContext dataContext, IQueryExpressions expressions, object?[]? parameters, object?[]? preambles)
+		public static IReadOnlyList<QuerySql> GetSqlText(Query query, IDataContext dataContext, IQueryExpressions expressions, object?[]? parameters, object?[]? preambles, SqlGenerationOptions? options)
 		{
 			using var m      = ActivityService.Start(ActivityID.GetSqlText);
+
 			using var runner = dataContext.GetQueryRunner(query, dataContext, 0, expressions, parameters, preambles);
-			return runner.GetSqlText();
+			return runner.GetSqlText(options);
 		}
 
 		#endregion

--- a/Source/LinqToDB/Linq/QueryRunner.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.cs
@@ -995,12 +995,12 @@ namespace LinqToDB.Linq
 
 		#region GetSqlText
 
-		public static IReadOnlyList<QuerySql> GetSqlText(Query query, IDataContext dataContext, IQueryExpressions expressions, object?[]? parameters, object?[]? preambles, SqlGenerationOptions? options)
+		public static IReadOnlyList<QuerySql> GetSqlText(Query query, IDataContext dataContext, IQueryExpressions expressions, object?[]? parameters, object?[]? preambles)
 		{
 			using var m      = ActivityService.Start(ActivityID.GetSqlText);
 
 			using var runner = dataContext.GetQueryRunner(query, dataContext, 0, expressions, parameters, preambles);
-			return runner.GetSqlText(options);
+			return runner.GetSqlText();
 		}
 
 		#endregion

--- a/Source/LinqToDB/Linq/QueryRunner.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.cs
@@ -995,7 +995,7 @@ namespace LinqToDB.Linq
 
 		#region GetSqlText
 
-		public static string GetSqlText(Query query, IDataContext dataContext, IQueryExpressions expressions, object?[]? parameters, object?[]? preambles)
+		public static IReadOnlyList<QuerySql> GetSqlText(Query query, IDataContext dataContext, IQueryExpressions expressions, object?[]? parameters, object?[]? preambles)
 		{
 			using var m      = ActivityService.Start(ActivityID.GetSqlText);
 			using var runner = dataContext.GetQueryRunner(query, dataContext, 0, expressions, parameters, preambles);

--- a/Source/LinqToDB/Linq/QueryRunnerBase.cs
+++ b/Source/LinqToDB/Linq/QueryRunnerBase.cs
@@ -65,6 +65,6 @@ namespace LinqToDB.Linq
 
 		protected abstract void SetQuery(IReadOnlyParameterValues parameterValues, bool forGetSqlText);
 
-		public    abstract IReadOnlyList<QuerySql> GetSqlText(SqlGenerationOptions? options);
+		public    abstract IReadOnlyList<QuerySql> GetSqlText();
 	}
 }

--- a/Source/LinqToDB/Linq/QueryRunnerBase.cs
+++ b/Source/LinqToDB/Linq/QueryRunnerBase.cs
@@ -1,11 +1,10 @@
-﻿using System;
+﻿using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace LinqToDB.Linq
 {
-	using Common.Internal;
 	using Data;
 	using SqlQuery;
 
@@ -66,6 +65,6 @@ namespace LinqToDB.Linq
 
 		protected abstract void SetQuery(IReadOnlyParameterValues parameterValues, bool forGetSqlText);
 
-		public    abstract string GetSqlText();
+		public    abstract IReadOnlyList<QuerySql> GetSqlText();
 	}
 }

--- a/Source/LinqToDB/Linq/QueryRunnerBase.cs
+++ b/Source/LinqToDB/Linq/QueryRunnerBase.cs
@@ -65,6 +65,6 @@ namespace LinqToDB.Linq
 
 		protected abstract void SetQuery(IReadOnlyParameterValues parameterValues, bool forGetSqlText);
 
-		public    abstract IReadOnlyList<QuerySql> GetSqlText();
+		public    abstract IReadOnlyList<QuerySql> GetSqlText(SqlGenerationOptions? options);
 	}
 }

--- a/Source/LinqToDB/Linq/QuerySql.cs
+++ b/Source/LinqToDB/Linq/QuerySql.cs
@@ -4,5 +4,18 @@ using LinqToDB.Data;
 
 namespace LinqToDB.Linq
 {
-	public sealed record QuerySql(string Sql, IReadOnlyList<DataParameter> Parameters);
+	/// <summary>
+	/// Command SQL, generated from linq query.
+	/// </summary>
+	public sealed class QuerySql(string sql, IReadOnlyList<DataParameter> parameters)
+	{
+		/// <summary>
+		/// Command SQL text.
+		/// </summary>
+		public string                       Sql        => sql;
+		/// <summary>
+		/// Command parameters with values.
+		/// </summary>
+		public IReadOnlyList<DataParameter> Parameters => parameters;
+	}
 }

--- a/Source/LinqToDB/Linq/QuerySql.cs
+++ b/Source/LinqToDB/Linq/QuerySql.cs
@@ -1,0 +1,8 @@
+﻿using System.Collections.Generic;
+
+using LinqToDB.Data;
+
+namespace LinqToDB.Linq
+{
+	public sealed record QuerySql(string Sql, IReadOnlyList<DataParameter> Parameters);
+}

--- a/Source/LinqToDB/Linq/SqlGenerationOptions.cs
+++ b/Source/LinqToDB/Linq/SqlGenerationOptions.cs
@@ -1,0 +1,14 @@
+﻿namespace LinqToDB.Linq
+{
+	/// <summary>
+	/// SQL generation options for <see cref="LinqExtensions.ToSqlQuery{T}(System.Linq.IQueryable{T}, SqlGenerationOptions?)"/> group of APIs.
+	/// </summary>
+	public sealed class SqlGenerationOptions
+	{
+		/// <summary>
+		/// Enforce parameters inlining into SQL as literals.
+		/// When not set, current context settings used.
+		/// </summary>
+		public bool? InlineParameters { get; set; }
+	}
+}

--- a/Source/LinqToDB/LinqExtensions.LoadWith.cs
+++ b/Source/LinqToDB/LinqExtensions.LoadWith.cs
@@ -78,9 +78,9 @@ namespace LinqToDB
 
 			public IQueryable<TEntity> Query { get; }
 
-			Expression              IExpressionQuery.Expression    => Query.Expression;
-			IDataContext            IExpressionQuery.DataContext   => ((IExpressionQuery)Query.GetLinqToDBSource()).DataContext;
-			IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQuery() => ((IExpressionQuery)Query.GetLinqToDBSource()).GetSqlQuery();
+			Expression              IExpressionQuery.Expression                                   => Query.Expression;
+			IDataContext            IExpressionQuery.DataContext                                  => ((IExpressionQuery)Query.GetLinqToDBSource()).DataContext;
+			IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options) => ((IExpressionQuery)Query.GetLinqToDBSource()).GetSqlQueries(options);
 		}
 
 		sealed class LoadWithQueryable<TEntity, TProperty> : LoadWithQueryableBase<TEntity>, ILoadWithQueryable<TEntity, TProperty>

--- a/Source/LinqToDB/LinqExtensions.LoadWith.cs
+++ b/Source/LinqToDB/LinqExtensions.LoadWith.cs
@@ -64,28 +64,42 @@ namespace LinqToDB
 			return newTable;
 		}
 
-		sealed class LoadWithQueryable<TEntity, TProperty> : ILoadWithQueryable<TEntity, TProperty>, IExpressionQuery
+		abstract class LoadWithQueryableBase<TEntity> : IExpressionQuery
 		{
-			private readonly IQueryable<TEntity> _query;
-
-			public LoadWithQueryable(IQueryable<TEntity> query)
+			public LoadWithQueryableBase(IQueryable<TEntity> query)
 			{
-				_query = query;
+				Query = query;
 			}
 
-			public IEnumerator<TEntity> GetEnumerator() => _query.GetEnumerator();
-			IEnumerator IEnumerable.GetEnumerator()     => GetEnumerator();
+			//IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQuery() => (_query as IExpressionQuery)?.GetSqlQuery() ?? Array.Empty<QuerySql>();
+			//public IDataContext DataContext => ;
+			//public Type ElementType => _query.ElementType;
+			//public IQueryProvider Provider => _query.Provider;
+
+			public IQueryable<TEntity> Query { get; }
+
+			Expression              IExpressionQuery.Expression    => Query.Expression;
+			IDataContext            IExpressionQuery.DataContext   => ((IExpressionQuery)Query.GetLinqToDBSource()).DataContext;
+			IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQuery() => ((IExpressionQuery)Query.GetLinqToDBSource()).GetSqlQuery();
+		}
+
+		sealed class LoadWithQueryable<TEntity, TProperty> : LoadWithQueryableBase<TEntity>, ILoadWithQueryable<TEntity, TProperty>
+		{
+			public LoadWithQueryable(IQueryable<TEntity> query)
+				: base(query)
+			{
+			}
+
+			Type           IQueryable.ElementType => Query.ElementType;
+			Expression     IQueryable.Expression  => Query.Expression;
+			IQueryProvider IQueryable.Provider    => Query.Provider;
 
 			IAsyncEnumerator<TEntity> IAsyncEnumerable<TEntity>.GetAsyncEnumerator(CancellationToken cancellationToken) =>
-				((IAsyncEnumerable<TEntity>)_query).GetAsyncEnumerator(cancellationToken);
+				((IAsyncEnumerable<TEntity>)Query).GetAsyncEnumerator(cancellationToken);
 
-			public Expression     Expression  => _query.Expression;
-			public string         SqlText     => (_query as IExpressionQuery)?.SqlText ?? string.Empty;
-			public IDataContext   DataContext => (_query as IExpressionQuery)?.DataContext!;
-			public Type           ElementType => _query.ElementType;
-			public IQueryProvider Provider    => _query.Provider;
+			IEnumerator<TEntity> IEnumerable<TEntity>.GetEnumerator() => Query.GetEnumerator();
 
-			public override string ToString() => _query.ToString()!;
+			IEnumerator IEnumerable.GetEnumerator() => Query.GetEnumerator();
 		}
 
 		/// <summary>

--- a/Source/LinqToDB/LinqExtensions.MultiInsert.cs
+++ b/Source/LinqToDB/LinqExtensions.MultiInsert.cs
@@ -275,7 +275,7 @@ namespace LinqToDB
 		public interface IMultiInsertElse<TSource>
 		{ }
 
-		private sealed class MultiInsertQuery<TSource> : IMultiInsertSource<TSource>
+		internal sealed class MultiInsertQuery<TSource> : IMultiInsertSource<TSource>
 		{
 			public readonly IQueryable<TSource> Query;
 

--- a/Source/LinqToDB/LinqExtensions.cs
+++ b/Source/LinqToDB/LinqExtensions.cs
@@ -4018,84 +4018,79 @@ namespace LinqToDB
 		/// Convert Linq To DB query to SQL command with parameters.
 		/// </summary>
 		/// <remarks>Eager load queries currently return only SQL for main query.</remarks>
-		public static QuerySql ToSqlQuery<T>(this IQueryable<T> query)
+		public static QuerySql ToSqlQuery<T>(this IQueryable<T> query, SqlGenerationOptions? options = null)
 		{
 			if (query is LoadWithQueryableBase<T> loadWith)
 				query = loadWith.Query;
 
 			var expressionQuery = (IExpressionQuery)query.GetLinqToDBSource();
 
-			// query not expected to have multiple commands currently
-			return expressionQuery.GetSqlQuery().Single();
+			// currently we have only non-linq APIs that could generate multiple commands like
+			// InsertOrReplace, CreateTable, DropTable
+			return expressionQuery.GetSqlQueries(options)[0];
 		}
 
 		/// <summary>
 		/// Convert Linq To DB query to SQL command with parameters.
 		/// </summary>
-		public static QuerySql ToSqlQuery<T>(this IUpdatable<T> query)
+		public static QuerySql ToSqlQuery<T>(this IUpdatable<T> query, SqlGenerationOptions? options = null)
 		{
 			var expressionQuery = (IExpressionQuery)((Updatable<T>)query).Query.GetLinqToDBSource();
 
-			// query not expected to have multiple commands currently
-			return expressionQuery.GetSqlQuery().Single();
+			return expressionQuery.GetSqlQueries(options)[0];
 		}
 
 		/// <summary>
 		/// Convert Linq To DB query to SQL command with parameters.
 		/// </summary>
-		public static QuerySql ToSqlQuery<T>(this IValueInsertable<T> query)
+		public static QuerySql ToSqlQuery<T>(this IValueInsertable<T> query, SqlGenerationOptions? options = null)
 		{
 			var expressionQuery = (IExpressionQuery)((ValueInsertable<T>)query).Query.GetLinqToDBSource();
 
-			// query not expected to have multiple commands currently
-			return expressionQuery.GetSqlQuery().Single();
+			return expressionQuery.GetSqlQueries(options)[0];
 		}
 
 		/// <summary>
 		/// Convert Linq To DB query to SQL command with parameters.
 		/// </summary>
-		public static QuerySql ToSqlQuery<TSource, TTarget>(this ISelectInsertable<TSource, TTarget> query)
+		public static QuerySql ToSqlQuery<TSource, TTarget>(this ISelectInsertable<TSource, TTarget> query, SqlGenerationOptions? options = null)
 		{
 			var expressionQuery = (IExpressionQuery)((SelectInsertable<TSource, TTarget>)query).Query.GetLinqToDBSource();
 
-			// query not expected to have multiple commands currently
-			return expressionQuery.GetSqlQuery().Single();
+			return expressionQuery.GetSqlQueries(options)[0];
 		}
 
 		/// <summary>
 		/// Convert Linq To DB query to SQL command with parameters.
 		/// </summary>
 		/// <remarks>Eager load queries currently return only SQL for main query.</remarks>
-		public static QuerySql ToSqlQuery<TSource>(this IMultiInsertInto<TSource> query)
+		public static QuerySql ToSqlQuery<TSource>(this IMultiInsertInto<TSource> query, SqlGenerationOptions? options = null)
 		{
 			var expressionQuery = (IExpressionQuery)((MultiInsertQuery<TSource>)query).Query.GetLinqToDBSource();
 
-			// query not expected to have multiple commands currently
-			return expressionQuery.GetSqlQuery().Single();
+			return expressionQuery.GetSqlQueries(options)[0];
 		}
 
 		/// <summary>
 		/// Convert Linq To DB query to SQL command with parameters.
 		/// </summary>
 		/// <remarks>Eager load queries currently return only SQL for main query.</remarks>
-		public static QuerySql ToSqlQuery<TSource>(this IMultiInsertElse<TSource> query)
+		public static QuerySql ToSqlQuery<TSource>(this IMultiInsertElse<TSource> query, SqlGenerationOptions? options = null)
 		{
 			var expressionQuery = (IExpressionQuery)((MultiInsertQuery<TSource>)query).Query.GetLinqToDBSource();
 
-			// query not expected to have multiple commands currently
-			return expressionQuery.GetSqlQuery().Single();
+			return expressionQuery.GetSqlQueries(options)[0];
 		}
 
 		/// <summary>
 		/// Convert Linq To DB query to SQL command with parameters.
 		/// </summary>
 		/// <remarks>Eager load queries currently return only SQL for main query.</remarks>
-		public static QuerySql ToSqlQuery<TSource, TTarget>(this IMergeable<TSource, TTarget> query)
+		public static QuerySql ToSqlQuery<TSource, TTarget>(this IMergeable<TSource, TTarget> query, SqlGenerationOptions? options = null)
 		{
 			var expressionQuery = (IExpressionQuery)((MergeQuery<TSource, TTarget>)query).Query.GetLinqToDBSource();
 
-			// query not expected to have multiple commands currently
-			return expressionQuery.GetSqlQuery().Single();
+			return expressionQuery.GetSqlQueries(options)[0];
 		}
 		#endregion
 	}

--- a/Source/LinqToDB/LinqExtensions.cs
+++ b/Source/LinqToDB/LinqExtensions.cs
@@ -13,12 +13,15 @@ using JetBrains.Annotations;
 namespace LinqToDB
 {
 	using Async;
+	using Data;
 	using DataProvider;
 	using Expressions;
 	using Linq;
 	using Linq.Builder;
 	using Reflection;
 	using SqlProvider;
+
+	using static MultiInsertExtensions;
 
 	/// <summary>
 	/// Contains extension methods for LINQ queries.
@@ -59,7 +62,7 @@ namespace LinqToDB
 			where T : notnull
 		{
 			if (table == null) throw new ArgumentNullException(nameof(table));
-			if (name  == null) throw new ArgumentNullException(nameof(name));
+			if (name == null) throw new ArgumentNullException(nameof(name));
 
 			var result = ((ITableMutable<T>)table).ChangeTableName(name);
 			return result;
@@ -169,8 +172,8 @@ namespace LinqToDB
 		/// <returns>Table-like query source with table hints.</returns>
 		[LinqTunnel, Pure, IsQueryable]
 		[Sql.QueryExtension(ProviderName.Oracle, Sql.QueryExtensionScope.TableHint, typeof(TableSpecHintExtensionBuilder))]
-		[Sql.QueryExtension(ProviderName.MySql,  Sql.QueryExtensionScope.TableHint, typeof(TableSpecHintExtensionBuilder))]
-		[Sql.QueryExtension(null,                Sql.QueryExtensionScope.TableHint, typeof(HintExtensionBuilder))]
+		[Sql.QueryExtension(ProviderName.MySql, Sql.QueryExtensionScope.TableHint, typeof(TableSpecHintExtensionBuilder))]
+		[Sql.QueryExtension(null, Sql.QueryExtensionScope.TableHint, typeof(HintExtensionBuilder))]
 		public static ITable<TSource> With<TSource>(this ITable<TSource> table, [SqlQueryDependent] string hint)
 			where TSource : notnull
 		{
@@ -193,8 +196,8 @@ namespace LinqToDB
 		/// <returns>Table-like query source with table hints.</returns>
 		[LinqTunnel, Pure, IsQueryable]
 		[Sql.QueryExtension(ProviderName.Oracle, Sql.QueryExtensionScope.TableHint, typeof(TableSpecHintExtensionBuilder))]
-		[Sql.QueryExtension(ProviderName.MySql,  Sql.QueryExtensionScope.TableHint, typeof(TableSpecHintExtensionBuilder))]
-		[Sql.QueryExtension(null,                Sql.QueryExtensionScope.TableHint, typeof(HintExtensionBuilder))]
+		[Sql.QueryExtension(ProviderName.MySql, Sql.QueryExtensionScope.TableHint, typeof(TableSpecHintExtensionBuilder))]
+		[Sql.QueryExtension(null, Sql.QueryExtensionScope.TableHint, typeof(HintExtensionBuilder))]
 		public static ITable<TSource> TableHint<TSource>(this ITable<TSource> table, [SqlQueryDependent] string hint)
 			where TSource : notnull
 		{
@@ -219,10 +222,10 @@ namespace LinqToDB
 		/// <returns>Table-like query source with table hints.</returns>
 		[LinqTunnel, Pure, IsQueryable]
 		[Sql.QueryExtension(ProviderName.Oracle, Sql.QueryExtensionScope.TableHint, typeof(TableSpecHintExtensionBuilder))]
-		[Sql.QueryExtension(ProviderName.MySql,  Sql.QueryExtensionScope.TableHint, typeof(TableSpecHintExtensionBuilder))]
-		[Sql.QueryExtension(null,                Sql.QueryExtensionScope.TableHint, typeof(HintWithParameterExtensionBuilder))]
-		public static ITable<TSource> TableHint<TSource,TParam>(
-			this ITable<TSource>       table,
+		[Sql.QueryExtension(ProviderName.MySql, Sql.QueryExtensionScope.TableHint, typeof(TableSpecHintExtensionBuilder))]
+		[Sql.QueryExtension(null, Sql.QueryExtensionScope.TableHint, typeof(HintWithParameterExtensionBuilder))]
+		public static ITable<TSource> TableHint<TSource, TParam>(
+			this ITable<TSource> table,
 			[SqlQueryDependent] string hint,
 			[SqlQueryDependent] TParam hintParameter)
 			where TSource : notnull
@@ -248,11 +251,11 @@ namespace LinqToDB
 		/// <returns>Table-like query source with table hints.</returns>
 		[LinqTunnel, Pure, IsQueryable]
 		[Sql.QueryExtension(ProviderName.Oracle, Sql.QueryExtensionScope.TableHint, typeof(TableSpecHintExtensionBuilder), " ", " ")]
-		[Sql.QueryExtension(ProviderName.MySql,  Sql.QueryExtensionScope.TableHint, typeof(TableSpecHintExtensionBuilder), " ", ", ")]
-		[Sql.QueryExtension(null,                Sql.QueryExtensionScope.TableHint, typeof(HintWithParametersExtensionBuilder))]
-		public static ITable<TSource> TableHint<TSource,TParam>(
-			this ITable<TSource>                table,
-			[SqlQueryDependent] string          hint,
+		[Sql.QueryExtension(ProviderName.MySql, Sql.QueryExtensionScope.TableHint, typeof(TableSpecHintExtensionBuilder), " ", ", ")]
+		[Sql.QueryExtension(null, Sql.QueryExtensionScope.TableHint, typeof(HintWithParametersExtensionBuilder))]
+		public static ITable<TSource> TableHint<TSource, TParam>(
+			this ITable<TSource> table,
+			[SqlQueryDependent] string hint,
 			[SqlQueryDependent] params TParam[] hintParameters)
 			where TSource : notnull
 		{
@@ -281,8 +284,8 @@ namespace LinqToDB
 		/// <returns>Query source with table hints.</returns>
 		[LinqTunnel, Pure, IsQueryable]
 		[Sql.QueryExtension(ProviderName.Oracle, Sql.QueryExtensionScope.TablesInScopeHint, typeof(TableSpecHintExtensionBuilder))]
-		[Sql.QueryExtension(ProviderName.MySql,  Sql.QueryExtensionScope.TablesInScopeHint, typeof(TableSpecHintExtensionBuilder))]
-		[Sql.QueryExtension(null,                Sql.QueryExtensionScope.TablesInScopeHint, typeof(HintExtensionBuilder))]
+		[Sql.QueryExtension(ProviderName.MySql, Sql.QueryExtensionScope.TablesInScopeHint, typeof(TableSpecHintExtensionBuilder))]
+		[Sql.QueryExtension(null, Sql.QueryExtensionScope.TablesInScopeHint, typeof(HintExtensionBuilder))]
 		public static IQueryable<TSource> TablesInScopeHint<TSource>(this IQueryable<TSource> source, [SqlQueryDependent] string hint)
 			where TSource : notnull
 		{
@@ -307,9 +310,9 @@ namespace LinqToDB
 		/// <returns>Query source with table hints.</returns>
 		[LinqTunnel, Pure, IsQueryable]
 		[Sql.QueryExtension(ProviderName.Oracle, Sql.QueryExtensionScope.TablesInScopeHint, typeof(TableSpecHintExtensionBuilder))]
-		[Sql.QueryExtension(ProviderName.MySql,  Sql.QueryExtensionScope.TablesInScopeHint, typeof(TableSpecHintExtensionBuilder))]
-		[Sql.QueryExtension(null,                Sql.QueryExtensionScope.TablesInScopeHint, typeof(HintWithParameterExtensionBuilder))]
-		public static IQueryable<TSource> TablesInScopeHint<TSource,TParam>(
+		[Sql.QueryExtension(ProviderName.MySql, Sql.QueryExtensionScope.TablesInScopeHint, typeof(TableSpecHintExtensionBuilder))]
+		[Sql.QueryExtension(null, Sql.QueryExtensionScope.TablesInScopeHint, typeof(HintWithParameterExtensionBuilder))]
+		public static IQueryable<TSource> TablesInScopeHint<TSource, TParam>(
 			this IQueryable<TSource> source,
 			[SqlQueryDependent] string hint,
 			[SqlQueryDependent] TParam hintParameter)
@@ -335,8 +338,8 @@ namespace LinqToDB
 		/// <returns>Query source with table hints.</returns>
 		[LinqTunnel, Pure, IsQueryable]
 		[Sql.QueryExtension(ProviderName.Oracle, Sql.QueryExtensionScope.TablesInScopeHint, typeof(TableSpecHintExtensionBuilder), " ", " ")]
-		[Sql.QueryExtension(ProviderName.MySql,  Sql.QueryExtensionScope.TablesInScopeHint, typeof(TableSpecHintExtensionBuilder), " ", ", ")]
-		[Sql.QueryExtension(null,                Sql.QueryExtensionScope.TablesInScopeHint, typeof(HintWithParametersExtensionBuilder))]
+		[Sql.QueryExtension(ProviderName.MySql, Sql.QueryExtensionScope.TablesInScopeHint, typeof(TableSpecHintExtensionBuilder), " ", ", ")]
+		[Sql.QueryExtension(null, Sql.QueryExtensionScope.TablesInScopeHint, typeof(HintWithParametersExtensionBuilder))]
 		public static IQueryable<TSource> TablesInScopeHint<TSource>(
 			this IQueryable<TSource> source,
 			[SqlQueryDependent] string hint,
@@ -368,8 +371,8 @@ namespace LinqToDB
 		/// <returns>Table-like query source with index hints.</returns>
 		[LinqTunnel, Pure, IsQueryable]
 		[Sql.QueryExtension(ProviderName.Oracle, Sql.QueryExtensionScope.IndexHint, typeof(TableSpecHintExtensionBuilder))]
-		[Sql.QueryExtension(ProviderName.MySql,  Sql.QueryExtensionScope.IndexHint, typeof(HintExtensionBuilder))]
-		[Sql.QueryExtension(null,                Sql.QueryExtensionScope.IndexHint, typeof(HintExtensionBuilder))]
+		[Sql.QueryExtension(ProviderName.MySql, Sql.QueryExtensionScope.IndexHint, typeof(HintExtensionBuilder))]
+		[Sql.QueryExtension(null, Sql.QueryExtensionScope.IndexHint, typeof(HintExtensionBuilder))]
 		public static ITable<TSource> IndexHint<TSource>(this ITable<TSource> table, [SqlQueryDependent] string hint)
 			where TSource : notnull
 		{
@@ -394,10 +397,10 @@ namespace LinqToDB
 		/// <returns>Table-like query source with index hints.</returns>
 		[LinqTunnel, Pure, IsQueryable]
 		[Sql.QueryExtension(ProviderName.Oracle, Sql.QueryExtensionScope.IndexHint, typeof(TableSpecHintExtensionBuilder))]
-		[Sql.QueryExtension(ProviderName.MySql,  Sql.QueryExtensionScope.IndexHint, typeof(HintWithParameterExtensionBuilder))]
-		[Sql.QueryExtension(null,                Sql.QueryExtensionScope.IndexHint, typeof(HintWithParameterExtensionBuilder))]
-		public static ITable<TSource> IndexHint<TSource,TParam>(
-			this ITable<TSource>       table,
+		[Sql.QueryExtension(ProviderName.MySql, Sql.QueryExtensionScope.IndexHint, typeof(HintWithParameterExtensionBuilder))]
+		[Sql.QueryExtension(null, Sql.QueryExtensionScope.IndexHint, typeof(HintWithParameterExtensionBuilder))]
+		public static ITable<TSource> IndexHint<TSource, TParam>(
+			this ITable<TSource> table,
 			[SqlQueryDependent] string hint,
 			[SqlQueryDependent] TParam hintParameter)
 			where TSource : notnull
@@ -423,11 +426,11 @@ namespace LinqToDB
 		/// <returns>Table-like query source with index hints.</returns>
 		[LinqTunnel, Pure, IsQueryable]
 		[Sql.QueryExtension(ProviderName.Oracle, Sql.QueryExtensionScope.IndexHint, typeof(TableSpecHintExtensionBuilder), " ", " ")]
-		[Sql.QueryExtension(ProviderName.MySql,  Sql.QueryExtensionScope.IndexHint, typeof(HintWithParametersExtensionBuilder))]
-		[Sql.QueryExtension(null,                Sql.QueryExtensionScope.IndexHint, typeof(HintWithParametersExtensionBuilder))]
-		public static ITable<TSource> IndexHint<TSource,TParam>(
-			this ITable<TSource>                table,
-			[SqlQueryDependent] string          hint,
+		[Sql.QueryExtension(ProviderName.MySql, Sql.QueryExtensionScope.IndexHint, typeof(HintWithParametersExtensionBuilder))]
+		[Sql.QueryExtension(null, Sql.QueryExtensionScope.IndexHint, typeof(HintWithParametersExtensionBuilder))]
+		public static ITable<TSource> IndexHint<TSource, TParam>(
+			this ITable<TSource> table,
+			[SqlQueryDependent] string hint,
 			[SqlQueryDependent] params TParam[] hintParameters)
 			where TSource : notnull
 		{
@@ -506,8 +509,8 @@ namespace LinqToDB
 		/// <returns>Query source with hints.</returns>
 		[LinqTunnel, Pure, IsQueryable]
 		[Sql.QueryExtension(null, Sql.QueryExtensionScope.SubQueryHint, typeof(HintWithParameterExtensionBuilder))]
-		public static IQueryable<TSource> SubQueryHint<TSource,TParam>(
-			this IQueryable<TSource>   source,
+		public static IQueryable<TSource> SubQueryHint<TSource, TParam>(
+			this IQueryable<TSource> source,
 			[SqlQueryDependent] string hint,
 			[SqlQueryDependent] TParam hintParameter)
 			where TSource : notnull
@@ -536,7 +539,7 @@ namespace LinqToDB
 		[LinqTunnel, Pure, IsQueryable]
 		[Sql.QueryExtension(null, Sql.QueryExtensionScope.SubQueryHint, typeof(HintWithParametersExtensionBuilder))]
 		public static IQueryable<TSource> SubQueryHint<TSource, TParam>(
-			this IQueryable<TSource>   source,
+			this IQueryable<TSource> source,
 			[SqlQueryDependent] string hint,
 			[SqlQueryDependent] params TParam[] hintParameters)
 			where TSource : notnull
@@ -590,7 +593,7 @@ namespace LinqToDB
 		/// <returns>Query source with hints.</returns>
 		[LinqTunnel, Pure, IsQueryable]
 		[Sql.QueryExtension(null, Sql.QueryExtensionScope.QueryHint, typeof(HintWithParameterExtensionBuilder))]
-		public static IQueryable<TSource> QueryHint<TSource,TParam>(
+		public static IQueryable<TSource> QueryHint<TSource, TParam>(
 			this IQueryable<TSource> source,
 			[SqlQueryDependent] string hint,
 			[SqlQueryDependent] TParam hintParameter)
@@ -619,7 +622,7 @@ namespace LinqToDB
 		/// <returns>Table-like query source with hints.</returns>
 		[LinqTunnel, Pure, IsQueryable]
 		[Sql.QueryExtension(ProviderName.Oracle, Sql.QueryExtensionScope.QueryHint, typeof(HintWithParametersExtensionBuilder), " ")]
-		[Sql.QueryExtension(null,                Sql.QueryExtensionScope.QueryHint, typeof(HintWithParametersExtensionBuilder))]
+		[Sql.QueryExtension(null, Sql.QueryExtensionScope.QueryHint, typeof(HintWithParametersExtensionBuilder))]
 		public static IQueryable<TSource> QueryHint<TSource, TParam>(
 			this IQueryable<TSource> source,
 			[SqlQueryDependent] string hint,
@@ -652,11 +655,11 @@ namespace LinqToDB
 		/// <returns>Requested value.</returns>
 		[Pure]
 		public static T Select<T>(
-			                this IDataContext   dataContext,
+							this IDataContext dataContext,
 			[InstantHandle] Expression<Func<T>> selector)
 		{
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
-			if (selector    == null) throw new ArgumentNullException(nameof(selector));
+			if (selector == null) throw new ArgumentNullException(nameof(selector));
 
 			var q = new ExpressionQueryImpl<T>(dataContext, selector);
 
@@ -677,12 +680,12 @@ namespace LinqToDB
 		/// <returns>Requested value.</returns>
 		[Pure]
 		public static async Task<T> SelectAsync<T>(
-			                this IDataContext   dataContext,
+							this IDataContext dataContext,
 			[InstantHandle] Expression<Func<T>> selector,
-			                CancellationToken token = default)
+							CancellationToken token = default)
 		{
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
-			if (selector    == null) throw new ArgumentNullException(nameof(selector));
+			if (selector == null) throw new ArgumentNullException(nameof(selector));
 
 			var q = new ExpressionQueryImpl<T>(dataContext, selector);
 
@@ -755,10 +758,10 @@ namespace LinqToDB
 		/// <param name="predicate">Filter expression, to specify what records from source should be deleted.</param>
 		/// <returns>Number of deleted records.</returns>
 		public static int Delete<T>(
-			                this IQueryable<T>       source,
-			[InstantHandle] Expression<Func<T,bool>> predicate)
+							this IQueryable<T> source,
+			[InstantHandle] Expression<Func<T, bool>> predicate)
 		{
-			if (source    == null) throw new ArgumentNullException(nameof(source));
+			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (predicate == null) throw new ArgumentNullException(nameof(predicate));
 
 			var currentSource = source.GetLinqToDBSource();
@@ -780,11 +783,11 @@ namespace LinqToDB
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Number of deleted records.</returns>
 		public static Task<int> DeleteAsync<T>(
-			           this IQueryable<T>            source,
-			[InstantHandle] Expression<Func<T,bool>> predicate,
-			CancellationToken                        token = default)
+					   this IQueryable<T> source,
+			[InstantHandle] Expression<Func<T, bool>> predicate,
+			CancellationToken token = default)
 		{
-			if (source    == null) throw new ArgumentNullException(nameof(source));
+			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (predicate == null) throw new ArgumentNullException(nameof(predicate));
 
 			var currentSource = source.GetLinqToDBSource();
@@ -812,10 +815,10 @@ namespace LinqToDB
 		/// <returns>Number of updated records.</returns>
 		// TODO: remove in v7
 		[Obsolete($"Use overload with lambda argument for target parameter")]
-		public static int Update<TSource,TTarget>(
-			                this IQueryable<TSource>          source,
-			                ITable<TTarget>                   target,
-			[InstantHandle] Expression<Func<TSource,TTarget>> setter)
+		public static int Update<TSource, TTarget>(
+							this IQueryable<TSource> source,
+							ITable<TTarget> target,
+			[InstantHandle] Expression<Func<TSource, TTarget>> setter)
 			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
@@ -844,11 +847,11 @@ namespace LinqToDB
 		/// <returns>Number of updated records.</returns>
 		// TODO: remove in v7
 		[Obsolete($"Use overload with lambda argument for target parameter")]
-		public static Task<int> UpdateAsync<TSource,TTarget>(
-			                this IQueryable<TSource>          source,
-			                ITable<TTarget>                   target,
-			[InstantHandle] Expression<Func<TSource,TTarget>> setter,
-			CancellationToken                                 token = default)
+		public static Task<int> UpdateAsync<TSource, TTarget>(
+							this IQueryable<TSource> source,
+							ITable<TTarget> target,
+			[InstantHandle] Expression<Func<TSource, TTarget>> setter,
+			CancellationToken token = default)
 			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
@@ -872,7 +875,7 @@ namespace LinqToDB
 		/// <param name="source">Source data query.</param>
 		/// <param name="setter">Update expression. Uses updated record as parameter. Expression supports only target table record new expression with field initializers.</param>
 		/// <returns>Number of updated records.</returns>
-		public static int Update<T>(this IQueryable<T> source, [InstantHandle] Expression<Func<T,T>> setter)
+		public static int Update<T>(this IQueryable<T> source, [InstantHandle] Expression<Func<T, T>> setter)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (setter == null) throw new ArgumentNullException(nameof(setter));
@@ -896,9 +899,9 @@ namespace LinqToDB
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Number of updated records.</returns>
 		public static Task<int> UpdateAsync<T>(
-			           this IQueryable<T>         source,
-			[InstantHandle] Expression<Func<T,T>> setter,
-			CancellationToken                     token = default)
+					   this IQueryable<T> source,
+			[InstantHandle] Expression<Func<T, T>> setter,
+			CancellationToken token = default)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (setter == null) throw new ArgumentNullException(nameof(setter));
@@ -922,13 +925,13 @@ namespace LinqToDB
 		/// <param name="setter">Update expression. Uses updated record as parameter. Expression supports only target table record new expression with field initializers.</param>
 		/// <returns>Number of updated records.</returns>
 		public static int Update<T>(
-			                this IQueryable<T>       source,
-			[InstantHandle] Expression<Func<T,bool>> predicate,
-			[InstantHandle] Expression<Func<T,T>>    setter)
+							this IQueryable<T> source,
+			[InstantHandle] Expression<Func<T, bool>> predicate,
+			[InstantHandle] Expression<Func<T, T>> setter)
 		{
-			if (source    == null) throw new ArgumentNullException(nameof(source));
+			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (predicate == null) throw new ArgumentNullException(nameof(predicate));
-			if (setter    == null) throw new ArgumentNullException(nameof(setter));
+			if (setter == null) throw new ArgumentNullException(nameof(setter));
 
 			var currentSource = source.GetLinqToDBSource();
 
@@ -950,14 +953,14 @@ namespace LinqToDB
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Number of updated records.</returns>
 		public static Task<int> UpdateAsync<T>(
-			           this IQueryable<T>            source,
-			[InstantHandle] Expression<Func<T,bool>> predicate,
-			[InstantHandle] Expression<Func<T,T>>    setter,
-			CancellationToken                        token = default)
+					   this IQueryable<T> source,
+			[InstantHandle] Expression<Func<T, bool>> predicate,
+			[InstantHandle] Expression<Func<T, T>> setter,
+			CancellationToken token = default)
 		{
-			if (source    == null) throw new ArgumentNullException(nameof(source));
+			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (predicate == null) throw new ArgumentNullException(nameof(predicate));
-			if (setter    == null) throw new ArgumentNullException(nameof(setter));
+			if (setter == null) throw new ArgumentNullException(nameof(setter));
 
 			var currentSource = source.GetLinqToDBSource();
 
@@ -1024,10 +1027,10 @@ namespace LinqToDB
 		/// <param name="target">Target table selection expression.</param>
 		/// <param name="setter">Update expression. Uses record from source query as parameter. Expression supports only target table record new expression with field initializers.</param>
 		/// <returns>Number of updated records.</returns>
-		public static int Update<TSource,TTarget>(
-			                this IQueryable<TSource>          source,
-			[InstantHandle] Expression<Func<TSource,TTarget>> target,
-			[InstantHandle] Expression<Func<TSource,TTarget>> setter)
+		public static int Update<TSource, TTarget>(
+							this IQueryable<TSource> source,
+			[InstantHandle] Expression<Func<TSource, TTarget>> target,
+			[InstantHandle] Expression<Func<TSource, TTarget>> setter)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (target == null) throw new ArgumentNullException(nameof(target));
@@ -1054,11 +1057,11 @@ namespace LinqToDB
 		/// <param name="setter">Update expression. Uses record from source query as parameter. Expression supports only target table record new expression with field initializers.</param>
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Number of updated records.</returns>
-		public static Task<int> UpdateAsync<TSource,TTarget>(
-			                this IQueryable<TSource>          source,
-			[InstantHandle] Expression<Func<TSource,TTarget>> target,
-			[InstantHandle] Expression<Func<TSource,TTarget>> setter,
-			CancellationToken                                 token = default)
+		public static Task<int> UpdateAsync<TSource, TTarget>(
+							this IQueryable<TSource> source,
+			[InstantHandle] Expression<Func<TSource, TTarget>> target,
+			[InstantHandle] Expression<Func<TSource, TTarget>> setter,
+			CancellationToken token = default)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (target == null) throw new ArgumentNullException(nameof(target));
@@ -1082,11 +1085,6 @@ namespace LinqToDB
 			}
 
 			public IQueryable<T> Query;
-
-			public override string ToString()
-			{
-				return Query.ToString()!;
-			}
 		}
 
 		/// <summary>
@@ -1099,7 +1097,7 @@ namespace LinqToDB
 		[Pure]
 		public static IUpdatable<T> AsUpdatable<T>(this IQueryable<T> source)
 		{
-			if (source  == null) throw new ArgumentNullException(nameof(source));
+			if (source == null) throw new ArgumentNullException(nameof(source));
 
 			var currentSource = source.ProcessIQueryable();
 
@@ -1123,14 +1121,14 @@ namespace LinqToDB
 		/// <returns><see cref="IUpdatable{T}"/> query.</returns>
 		[LinqTunnel]
 		[Pure]
-		public static IUpdatable<T> Set<T,TV>(
-			                this IQueryable<T>     source,
-			[InstantHandle] Expression<Func<T,TV>> extract,
-			[InstantHandle] Expression<Func<T,TV>> update)
+		public static IUpdatable<T> Set<T, TV>(
+							this IQueryable<T> source,
+			[InstantHandle] Expression<Func<T, TV>> extract,
+			[InstantHandle] Expression<Func<T, TV>> update)
 		{
-			if (source  == null) throw new ArgumentNullException(nameof(source));
+			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (extract == null) throw new ArgumentNullException(nameof(extract));
-			if (update  == null) throw new ArgumentNullException(nameof(update));
+			if (update == null) throw new ArgumentNullException(nameof(update));
 
 			var currentSource = source.ProcessIQueryable();
 
@@ -1154,14 +1152,14 @@ namespace LinqToDB
 		/// <returns><see cref="IUpdatable{T}"/> query.</returns>
 		[LinqTunnel]
 		[Pure]
-		public static IUpdatable<T> Set<T,TV>(
-			                this IUpdatable<T>     source,
-			[InstantHandle] Expression<Func<T,TV>> extract,
-			[InstantHandle] Expression<Func<T,TV>> update)
+		public static IUpdatable<T> Set<T, TV>(
+							this IUpdatable<T> source,
+			[InstantHandle] Expression<Func<T, TV>> extract,
+			[InstantHandle] Expression<Func<T, TV>> update)
 		{
-			if (source  == null) throw new ArgumentNullException(nameof(source));
+			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (extract == null) throw new ArgumentNullException(nameof(extract));
-			if (update  == null) throw new ArgumentNullException(nameof(update));
+			if (update == null) throw new ArgumentNullException(nameof(update));
 
 			var query = ((Updatable<T>)source).Query;
 
@@ -1185,14 +1183,14 @@ namespace LinqToDB
 		/// <returns><see cref="IUpdatable{T}"/> query.</returns>
 		[LinqTunnel]
 		[Pure]
-		public static IUpdatable<T> Set<T,TV>(
-			                this IQueryable<T>     source,
-			[InstantHandle] Expression<Func<T,TV>> extract,
-			[InstantHandle] Expression<Func<TV>>   update)
+		public static IUpdatable<T> Set<T, TV>(
+							this IQueryable<T> source,
+			[InstantHandle] Expression<Func<T, TV>> extract,
+			[InstantHandle] Expression<Func<TV>> update)
 		{
-			if (source  == null) throw new ArgumentNullException(nameof(source));
+			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (extract == null) throw new ArgumentNullException(nameof(extract));
-			if (update  == null) throw new ArgumentNullException(nameof(update));
+			if (update == null) throw new ArgumentNullException(nameof(update));
 
 			var query = source.Provider.CreateQuery<T>(
 				Expression.Call(
@@ -1214,14 +1212,14 @@ namespace LinqToDB
 		/// <returns><see cref="IUpdatable{T}"/> query.</returns>
 		[LinqTunnel]
 		[Pure]
-		public static IUpdatable<T> Set<T,TV>(
-			                this IUpdatable<T>     source,
-			[InstantHandle] Expression<Func<T,TV>> extract,
-			[InstantHandle] Expression<Func<TV>>   update)
+		public static IUpdatable<T> Set<T, TV>(
+							this IUpdatable<T> source,
+			[InstantHandle] Expression<Func<T, TV>> extract,
+			[InstantHandle] Expression<Func<TV>> update)
 		{
-			if (source  == null) throw new ArgumentNullException(nameof(source));
+			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (extract == null) throw new ArgumentNullException(nameof(extract));
-			if (update  == null) throw new ArgumentNullException(nameof(update));
+			if (update == null) throw new ArgumentNullException(nameof(update));
 
 			var query = ((Updatable<T>)source).Query;
 
@@ -1245,12 +1243,12 @@ namespace LinqToDB
 		/// <returns><see cref="IUpdatable{T}"/> query.</returns>
 		[LinqTunnel]
 		[Pure]
-		public static IUpdatable<T> Set<T,TV>(
-			                 this IQueryable<T>     source,
-			[InstantHandle]  Expression<Func<T,TV>> extract,
-			[SkipIfConstant] TV                     value)
+		public static IUpdatable<T> Set<T, TV>(
+							 this IQueryable<T> source,
+			[InstantHandle] Expression<Func<T, TV>> extract,
+			[SkipIfConstant] TV value)
 		{
-			if (source  == null) throw new ArgumentNullException(nameof(source));
+			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (extract == null) throw new ArgumentNullException(nameof(extract));
 
 			var currentSource = source.ProcessIQueryable();
@@ -1276,12 +1274,12 @@ namespace LinqToDB
 		/// <returns><see cref="IUpdatable{T}"/> query.</returns>
 		[LinqTunnel]
 		[Pure]
-		public static IUpdatable<T> Set<T,TV>(
-			                 this IUpdatable<T>     source,
-			[InstantHandle]  Expression<Func<T,TV>> extract,
-			[SkipIfConstant] TV                     value)
+		public static IUpdatable<T> Set<T, TV>(
+							 this IUpdatable<T> source,
+			[InstantHandle] Expression<Func<T, TV>> extract,
+			[SkipIfConstant] TV value)
 		{
-			if (source  == null) throw new ArgumentNullException(nameof(source));
+			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (extract == null) throw new ArgumentNullException(nameof(extract));
 
 			var query = ((Updatable<T>)source).Query;
@@ -1313,10 +1311,10 @@ namespace LinqToDB
 		[LinqTunnel]
 		[Pure]
 		public static IUpdatable<T> Set<T>(
-			                this IQueryable<T>         source,
-			[InstantHandle] Expression<Func<T,string>> setExpression)
+							this IQueryable<T> source,
+			[InstantHandle] Expression<Func<T, string>> setExpression)
 		{
-			if (source        == null) throw new ArgumentNullException(nameof(source));
+			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (setExpression == null) throw new ArgumentNullException(nameof(setExpression));
 
 			var currentSource = source.ProcessIQueryable();
@@ -1349,10 +1347,10 @@ namespace LinqToDB
 		[LinqTunnel]
 		[Pure]
 		public static IUpdatable<T> Set<T>(
-			                this IUpdatable<T>         source,
-			[InstantHandle] Expression<Func<T,string>> setExpression)
+							this IUpdatable<T> source,
+			[InstantHandle] Expression<Func<T, string>> setExpression)
 		{
-			if (source        == null) throw new ArgumentNullException(nameof(source));
+			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (setExpression == null) throw new ArgumentNullException(nameof(setExpression));
 
 			var query = ((Updatable<T>)source).Query;
@@ -1378,7 +1376,7 @@ namespace LinqToDB
 		/// <param name="setter">Insert expression. Expression supports only target table record new expression with field initializers.</param>
 		/// <returns>Number of affected records.</returns>
 		public static int Insert<T>(
-			                this ITable<T>      target,
+							this ITable<T> target,
 			[InstantHandle] Expression<Func<T>> setter)
 			where T : notnull
 		{
@@ -1404,9 +1402,9 @@ namespace LinqToDB
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Number of affected records.</returns>
 		public static Task<int> InsertAsync<T>(
-			                this ITable<T>      target,
+							this ITable<T> target,
 			[InstantHandle] Expression<Func<T>> setter,
-			CancellationToken                   token = default)
+			CancellationToken token = default)
 			where T : notnull
 		{
 			if (target == null) throw new ArgumentNullException(nameof(target));
@@ -1430,7 +1428,7 @@ namespace LinqToDB
 		/// <param name="setter">Insert expression. Expression supports only target table record new expression with field initializers.</param>
 		/// <returns>Inserted record's identity value.</returns>
 		public static object InsertWithIdentity<T>(
-			                this ITable<T>      target,
+							this ITable<T> target,
 			[InstantHandle] Expression<Func<T>> setter)
 			where T : notnull
 		{
@@ -1455,7 +1453,7 @@ namespace LinqToDB
 		/// <param name="setter">Insert expression. Expression supports only target table record new expression with field initializers.</param>
 		/// <returns>Inserted record's identity value.</returns>
 		public static int InsertWithInt32Identity<T>(
-			                this ITable<T>      target,
+							this ITable<T> target,
 			[InstantHandle] Expression<Func<T>> setter)
 			where T : notnull
 		{
@@ -1470,7 +1468,7 @@ namespace LinqToDB
 		/// <param name="setter">Insert expression. Expression supports only target table record new expression with field initializers.</param>
 		/// <returns>Inserted record's identity value.</returns>
 		public static long InsertWithInt64Identity<T>(
-			                this ITable<T>      target,
+							this ITable<T> target,
 			[InstantHandle] Expression<Func<T>> setter)
 			where T : notnull
 		{
@@ -1485,7 +1483,7 @@ namespace LinqToDB
 		/// <param name="setter">Insert expression. Expression supports only target table record new expression with field initializers.</param>
 		/// <returns>Inserted record's identity value.</returns>
 		public static decimal InsertWithDecimalIdentity<T>(
-			                this ITable<T>      target,
+							this ITable<T> target,
 			[InstantHandle] Expression<Func<T>> setter)
 			where T : notnull
 		{
@@ -1501,9 +1499,9 @@ namespace LinqToDB
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Inserted record's identity value.</returns>
 		public static Task<object> InsertWithIdentityAsync<T>(
-			                this ITable<T>      target,
+							this ITable<T> target,
 			[InstantHandle] Expression<Func<T>> setter,
-			CancellationToken                   token = default)
+			CancellationToken token = default)
 			where T : notnull
 		{
 			if (target == null) throw new ArgumentNullException(nameof(target));
@@ -1528,9 +1526,9 @@ namespace LinqToDB
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Inserted record's identity value.</returns>
 		public static async Task<int> InsertWithInt32IdentityAsync<T>(
-			                this ITable<T>      target,
+							this ITable<T> target,
 			[InstantHandle] Expression<Func<T>> setter,
-			CancellationToken                   token = default)
+			CancellationToken token = default)
 			where T : notnull
 		{
 			return target.DataContext.MappingSchema.ChangeTypeTo<int>(
@@ -1547,9 +1545,9 @@ namespace LinqToDB
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Inserted record's identity value.</returns>
 		public static async Task<long> InsertWithInt64IdentityAsync<T>(
-			                this ITable<T>      target,
+							this ITable<T> target,
 			[InstantHandle] Expression<Func<T>> setter,
-			CancellationToken                   token = default)
+			CancellationToken token = default)
 			where T : notnull
 		{
 			return target.DataContext.MappingSchema.ChangeTypeTo<long>(
@@ -1566,9 +1564,9 @@ namespace LinqToDB
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Inserted record's identity value.</returns>
 		public static async Task<decimal> InsertWithDecimalIdentityAsync<T>(
-			                this ITable<T>      target,
+							this ITable<T> target,
 			[InstantHandle] Expression<Func<T>> setter,
-			CancellationToken                   token = default)
+			CancellationToken token = default)
 			where T : notnull
 		{
 			return target.DataContext.MappingSchema.ChangeTypeTo<decimal>(
@@ -1586,11 +1584,6 @@ namespace LinqToDB
 			}
 
 			public IQueryable<T> Query;
-
-			public override string ToString()
-			{
-				return Query.ToString()!;
-			}
 		}
 
 		/// <summary>
@@ -1651,15 +1644,15 @@ namespace LinqToDB
 		/// <returns>Insert query.</returns>
 		[LinqTunnel]
 		[Pure]
-		public static IValueInsertable<T> Value<T,TV>(
-			                this ITable<T>         source,
-			[InstantHandle] Expression<Func<T,TV>> field,
-			[InstantHandle] Expression<Func<TV>>   value)
+		public static IValueInsertable<T> Value<T, TV>(
+							this ITable<T> source,
+			[InstantHandle] Expression<Func<T, TV>> field,
+			[InstantHandle] Expression<Func<TV>> value)
 			where T : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
-			if (field  == null) throw new ArgumentNullException(nameof(field));
-			if (value  == null) throw new ArgumentNullException(nameof(value));
+			if (field == null) throw new ArgumentNullException(nameof(field));
+			if (value == null) throw new ArgumentNullException(nameof(value));
 
 			var currentSource = source.ProcessIQueryable();
 
@@ -1683,14 +1676,14 @@ namespace LinqToDB
 		/// <returns>Insert query.</returns>
 		[LinqTunnel]
 		[Pure]
-		public static IValueInsertable<T> Value<T,TV>(
-			                 this ITable<T>         source,
-			[InstantHandle]  Expression<Func<T,TV>> field,
-			[SkipIfConstant] TV                     value)
+		public static IValueInsertable<T> Value<T, TV>(
+							 this ITable<T> source,
+			[InstantHandle] Expression<Func<T, TV>> field,
+			[SkipIfConstant] TV value)
 			where T : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
-			if (field  == null) throw new ArgumentNullException(nameof(field));
+			if (field == null) throw new ArgumentNullException(nameof(field));
 
 			var currentSource = source.ProcessIQueryable();
 
@@ -1714,14 +1707,14 @@ namespace LinqToDB
 		/// <returns>Insert query.</returns>
 		[LinqTunnel]
 		[Pure]
-		public static IValueInsertable<T> Value<T,TV>(
-			                this IValueInsertable<T> source,
-			[InstantHandle] Expression<Func<T,TV>>   field,
-			[InstantHandle] Expression<Func<TV>>     value)
+		public static IValueInsertable<T> Value<T, TV>(
+							this IValueInsertable<T> source,
+			[InstantHandle] Expression<Func<T, TV>> field,
+			[InstantHandle] Expression<Func<TV>> value)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
-			if (field  == null) throw new ArgumentNullException(nameof(field));
-			if (value  == null) throw new ArgumentNullException(nameof(value));
+			if (field == null) throw new ArgumentNullException(nameof(field));
+			if (value == null) throw new ArgumentNullException(nameof(value));
 
 			var query = ((ValueInsertable<T>)source).Query;
 
@@ -1745,13 +1738,13 @@ namespace LinqToDB
 		/// <returns>Insert query.</returns>
 		[LinqTunnel]
 		[Pure]
-		public static IValueInsertable<T> Value<T,TV>(
-			                 this IValueInsertable<T> source,
-			[InstantHandle]  Expression<Func<T,TV>>   field,
-			[SkipIfConstant] TV                       value)
+		public static IValueInsertable<T> Value<T, TV>(
+							 this IValueInsertable<T> source,
+			[InstantHandle] Expression<Func<T, TV>> field,
+			[SkipIfConstant] TV value)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
-			if (field  == null) throw new ArgumentNullException(nameof(field));
+			if (field == null) throw new ArgumentNullException(nameof(field));
 
 			var query = ((ValueInsertable<T>)source).Query;
 
@@ -1792,7 +1785,7 @@ namespace LinqToDB
 		/// <param name="source">Insert query.</param>
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Number of affected records.</returns>
-		public static Task<int> InsertAsync<T>( this IValueInsertable<T> source, CancellationToken token = default)
+		public static Task<int> InsertAsync<T>(this IValueInsertable<T> source, CancellationToken token = default)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
@@ -1835,7 +1828,7 @@ namespace LinqToDB
 		/// <typeparam name="T">Target table record type.</typeparam>
 		/// <param name="source">Insert query.</param>
 		/// <returns>Inserted record's identity value.</returns>
-		public static int? InsertWithInt32Identity<T>( this IValueInsertable<T> source)
+		public static int? InsertWithInt32Identity<T>(this IValueInsertable<T> source)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
@@ -1848,7 +1841,7 @@ namespace LinqToDB
 		/// <typeparam name="T">Target table record type.</typeparam>
 		/// <param name="source">Insert query.</param>
 		/// <returns>Inserted record's identity value.</returns>
-		public static long? InsertWithInt64Identity<T>( this IValueInsertable<T> source)
+		public static long? InsertWithInt64Identity<T>(this IValueInsertable<T> source)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
@@ -1861,7 +1854,7 @@ namespace LinqToDB
 		/// <typeparam name="T">Target table record type.</typeparam>
 		/// <param name="source">Insert query.</param>
 		/// <returns>Inserted record's identity value.</returns>
-		public static decimal? InsertWithDecimalIdentity<T>( this IValueInsertable<T> source)
+		public static decimal? InsertWithDecimalIdentity<T>(this IValueInsertable<T> source)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
@@ -1953,10 +1946,10 @@ namespace LinqToDB
 		/// <param name="setter">Inserted record constructor expression.
 		/// Expression supports only target table record new expression with field initializers.</param>
 		/// <returns>Number of affected records.</returns>
-		public static int Insert<TSource,TTarget>(
-			                this IQueryable<TSource>          source,
-			                ITable<TTarget>                   target,
-			[InstantHandle] Expression<Func<TSource,TTarget>> setter)
+		public static int Insert<TSource, TTarget>(
+							this IQueryable<TSource> source,
+							ITable<TTarget> target,
+			[InstantHandle] Expression<Func<TSource, TTarget>> setter)
 			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
@@ -1984,11 +1977,11 @@ namespace LinqToDB
 		/// Expression supports only target table record new expression with field initializers.</param>
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Number of affected records.</returns>
-		public static Task<int> InsertAsync<TSource,TTarget>(
-			                this IQueryable<TSource>          source,
-			                ITable<TTarget>                   target,
-			[InstantHandle] Expression<Func<TSource,TTarget>> setter,
-			CancellationToken                                 token = default)
+		public static Task<int> InsertAsync<TSource, TTarget>(
+							this IQueryable<TSource> source,
+							ITable<TTarget> target,
+			[InstantHandle] Expression<Func<TSource, TTarget>> setter,
+			CancellationToken token = default)
 			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
@@ -2015,10 +2008,10 @@ namespace LinqToDB
 		/// <param name="setter">Inserted record constructor expression.
 		/// Expression supports only target table record new expression with field initializers.</param>
 		/// <returns>Last inserted record's identity value.</returns>
-		public static object InsertWithIdentity<TSource,TTarget>(
-			                this IQueryable<TSource>          source,
-			                ITable<TTarget>                   target,
-			[InstantHandle] Expression<Func<TSource,TTarget>> setter)
+		public static object InsertWithIdentity<TSource, TTarget>(
+							this IQueryable<TSource> source,
+							ITable<TTarget> target,
+			[InstantHandle] Expression<Func<TSource, TTarget>> setter)
 			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
@@ -2045,10 +2038,10 @@ namespace LinqToDB
 		/// <param name="setter">Inserted record constructor expression.
 		/// Expression supports only target table record new expression with field initializers.</param>
 		/// <returns>Last inserted record's identity value.</returns>
-		public static int? InsertWithInt32Identity<TSource,TTarget>(
-			                this IQueryable<TSource>          source,
-			                ITable<TTarget>                   target,
-			[InstantHandle] Expression<Func<TSource,TTarget>> setter)
+		public static int? InsertWithInt32Identity<TSource, TTarget>(
+							this IQueryable<TSource> source,
+							ITable<TTarget> target,
+			[InstantHandle] Expression<Func<TSource, TTarget>> setter)
 			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
@@ -2071,10 +2064,10 @@ namespace LinqToDB
 		/// <param name="setter">Inserted record constructor expression.
 		/// Expression supports only target table record new expression with field initializers.</param>
 		/// <returns>Last inserted record's identity value.</returns>
-		public static long? InsertWithInt64Identity<TSource,TTarget>(
-			                this IQueryable<TSource>          source,
-			                ITable<TTarget>                   target,
-			[InstantHandle] Expression<Func<TSource,TTarget>> setter)
+		public static long? InsertWithInt64Identity<TSource, TTarget>(
+							this IQueryable<TSource> source,
+							ITable<TTarget> target,
+			[InstantHandle] Expression<Func<TSource, TTarget>> setter)
 			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
@@ -2097,10 +2090,10 @@ namespace LinqToDB
 		/// <param name="setter">Inserted record constructor expression.
 		/// Expression supports only target table record new expression with field initializers.</param>
 		/// <returns>Last inserted record's identity value.</returns>
-		public static decimal? InsertWithDecimalIdentity<TSource,TTarget>(
-			                this IQueryable<TSource>          source,
-			                ITable<TTarget>                   target,
-			[InstantHandle] Expression<Func<TSource,TTarget>> setter)
+		public static decimal? InsertWithDecimalIdentity<TSource, TTarget>(
+							this IQueryable<TSource> source,
+							ITable<TTarget> target,
+			[InstantHandle] Expression<Func<TSource, TTarget>> setter)
 			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
@@ -2124,11 +2117,11 @@ namespace LinqToDB
 		/// Expression supports only target table record new expression with field initializers.</param>
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Last inserted record's identity value.</returns>
-		public static Task<object> InsertWithIdentityAsync<TSource,TTarget>(
-			                this IQueryable<TSource>          source,
-			                ITable<TTarget>                   target,
-			[InstantHandle] Expression<Func<TSource,TTarget>> setter,
-			CancellationToken                                 token = default)
+		public static Task<object> InsertWithIdentityAsync<TSource, TTarget>(
+							this IQueryable<TSource> source,
+							ITable<TTarget> target,
+			[InstantHandle] Expression<Func<TSource, TTarget>> setter,
+			CancellationToken token = default)
 			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
@@ -2156,11 +2149,11 @@ namespace LinqToDB
 		/// Expression supports only target table record new expression with field initializers.</param>
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Last inserted record's identity value.</returns>
-		public static async Task<int?> InsertWithInt32IdentityAsync<TSource,TTarget>(
-			                this IQueryable<TSource>          source,
-			                ITable<TTarget>                   target,
-			[InstantHandle] Expression<Func<TSource,TTarget>> setter,
-			CancellationToken                                 token = default)
+		public static async Task<int?> InsertWithInt32IdentityAsync<TSource, TTarget>(
+							this IQueryable<TSource> source,
+							ITable<TTarget> target,
+			[InstantHandle] Expression<Func<TSource, TTarget>> setter,
+			CancellationToken token = default)
 			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
@@ -2184,11 +2177,11 @@ namespace LinqToDB
 		/// Expression supports only target table record new expression with field initializers.</param>
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Last inserted record's identity value.</returns>
-		public static async Task<long?> InsertWithInt64IdentityAsync<TSource,TTarget>(
-			                this IQueryable<TSource>          source,
-			                ITable<TTarget>                   target,
-			[InstantHandle] Expression<Func<TSource,TTarget>> setter,
-			CancellationToken                                 token = default)
+		public static async Task<long?> InsertWithInt64IdentityAsync<TSource, TTarget>(
+							this IQueryable<TSource> source,
+							ITable<TTarget> target,
+			[InstantHandle] Expression<Func<TSource, TTarget>> setter,
+			CancellationToken token = default)
 			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
@@ -2212,11 +2205,11 @@ namespace LinqToDB
 		/// Expression supports only target table record new expression with field initializers.</param>
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Last inserted record's identity value.</returns>
-		public static async Task<decimal?> InsertWithDecimalIdentityAsync<TSource,TTarget>(
-			                this IQueryable<TSource>          source,
-			                ITable<TTarget>                   target,
-			[InstantHandle] Expression<Func<TSource,TTarget>> setter,
-			CancellationToken                                 token = default)
+		public static async Task<decimal?> InsertWithDecimalIdentityAsync<TSource, TTarget>(
+							this IQueryable<TSource> source,
+							ITable<TTarget> target,
+			[InstantHandle] Expression<Func<TSource, TTarget>> setter,
+			CancellationToken token = default)
 			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
@@ -2229,7 +2222,7 @@ namespace LinqToDB
 				await InsertWithIdentityAsync(currentSource, target, setter, token).ConfigureAwait(false));
 		}
 
-		internal sealed class SelectInsertable<T,TT> : ISelectInsertable<T,TT>
+		internal sealed class SelectInsertable<T, TT> : ISelectInsertable<T, TT>
 		{
 			public SelectInsertable(IQueryable<T> query)
 			{
@@ -2237,11 +2230,6 @@ namespace LinqToDB
 			}
 
 			public IQueryable<T> Query;
-
-			public override string ToString()
-			{
-				return Query.ToString()!;
-			}
 		}
 
 		/// <summary>
@@ -2254,9 +2242,9 @@ namespace LinqToDB
 		/// <returns>Insertable source query.</returns>
 		[LinqTunnel]
 		[Pure]
-		public static ISelectInsertable<TSource,TTarget> Into<TSource,TTarget>(
+		public static ISelectInsertable<TSource, TTarget> Into<TSource, TTarget>(
 			 this IQueryable<TSource> source,
-			 ITable<TTarget>          target)
+			 ITable<TTarget> target)
 			where TTarget : notnull
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
@@ -2270,7 +2258,7 @@ namespace LinqToDB
 				currentSource.Expression, ((IQueryable<TTarget>)target).Expression);
 
 			var q = currentSource.Provider.CreateQuery<TSource>(expr);
-			return new SelectInsertable<TSource,TTarget>(q);
+			return new SelectInsertable<TSource, TTarget>(q);
 		}
 
 		/// <summary>
@@ -2285,14 +2273,14 @@ namespace LinqToDB
 		/// <returns>Insert query.</returns>
 		[LinqTunnel]
 		[Pure]
-		public static ISelectInsertable<TSource,TTarget> Value<TSource,TTarget,TValue>(
-			                this ISelectInsertable<TSource,TTarget> source,
-			[InstantHandle] Expression<Func<TTarget,TValue>>        field,
-			[InstantHandle] Expression<Func<TSource,TValue>>        value)
+		public static ISelectInsertable<TSource, TTarget> Value<TSource, TTarget, TValue>(
+							this ISelectInsertable<TSource, TTarget> source,
+			[InstantHandle] Expression<Func<TTarget, TValue>> field,
+			[InstantHandle] Expression<Func<TSource, TValue>> value)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
-			if (field  == null) throw new ArgumentNullException(nameof(field));
-			if (value  == null) throw new ArgumentNullException(nameof(value));
+			if (field == null) throw new ArgumentNullException(nameof(field));
+			if (value == null) throw new ArgumentNullException(nameof(value));
 
 			var query = ((SelectInsertable<TSource,TTarget>)source).Query;
 
@@ -2302,7 +2290,7 @@ namespace LinqToDB
 				query.Expression, Expression.Quote(field), Expression.Quote(value));
 
 			var q = query.Provider.CreateQuery<TSource>(expr);
-			return new SelectInsertable<TSource,TTarget>(q);
+			return new SelectInsertable<TSource, TTarget>(q);
 		}
 
 		/// <summary>
@@ -2317,14 +2305,14 @@ namespace LinqToDB
 		/// <returns>Insert query.</returns>
 		[LinqTunnel]
 		[Pure]
-		public static ISelectInsertable<TSource,TTarget> Value<TSource,TTarget,TValue>(
-			                this ISelectInsertable<TSource,TTarget> source,
-			[InstantHandle] Expression<Func<TTarget,TValue>>        field,
-			[InstantHandle] Expression<Func<TValue>>                value)
+		public static ISelectInsertable<TSource, TTarget> Value<TSource, TTarget, TValue>(
+							this ISelectInsertable<TSource, TTarget> source,
+			[InstantHandle] Expression<Func<TTarget, TValue>> field,
+			[InstantHandle] Expression<Func<TValue>> value)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
-			if (field  == null) throw new ArgumentNullException(nameof(field));
-			if (value  == null) throw new ArgumentNullException(nameof(value));
+			if (field == null) throw new ArgumentNullException(nameof(field));
+			if (value == null) throw new ArgumentNullException(nameof(value));
 
 			var query = ((SelectInsertable<TSource,TTarget>)source).Query;
 			var expr = Expression.Call(
@@ -2333,7 +2321,7 @@ namespace LinqToDB
 					query.Expression, Expression.Quote(field), Expression.Quote(value));
 
 			var q = query.Provider.CreateQuery<TSource>(expr);
-			return new SelectInsertable<TSource,TTarget>(q);
+			return new SelectInsertable<TSource, TTarget>(q);
 		}
 
 		/// <summary>
@@ -2348,13 +2336,13 @@ namespace LinqToDB
 		/// <returns>Insert query.</returns>
 		[LinqTunnel]
 		[Pure]
-		public static ISelectInsertable<TSource,TTarget> Value<TSource,TTarget,TValue>(
-			                this ISelectInsertable<TSource,TTarget> source,
-			[InstantHandle] Expression<Func<TTarget,TValue>>        field,
-			TValue                                                  value)
+		public static ISelectInsertable<TSource, TTarget> Value<TSource, TTarget, TValue>(
+							this ISelectInsertable<TSource, TTarget> source,
+			[InstantHandle] Expression<Func<TTarget, TValue>> field,
+			TValue value)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
-			if (field  == null) throw new ArgumentNullException(nameof(field));
+			if (field == null) throw new ArgumentNullException(nameof(field));
 
 			var query = ((SelectInsertable<TSource,TTarget>)source).Query;
 
@@ -2364,7 +2352,7 @@ namespace LinqToDB
 				query.Expression, Expression.Quote(field), Expression.Constant(value, typeof(TValue)));
 
 			var q = query.Provider.CreateQuery<TSource>(expr);
-			return new SelectInsertable<TSource,TTarget>(q);
+			return new SelectInsertable<TSource, TTarget>(q);
 		}
 
 		/// <summary>
@@ -2374,7 +2362,7 @@ namespace LinqToDB
 		/// <typeparam name="TTarget">Target table record type.</typeparam>
 		/// <param name="source">Insert query.</param>
 		/// <returns>Number of affected records.</returns>
-		public static int Insert<TSource,TTarget>(this ISelectInsertable<TSource,TTarget> source)
+		public static int Insert<TSource, TTarget>(this ISelectInsertable<TSource, TTarget> source)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
@@ -2397,8 +2385,8 @@ namespace LinqToDB
 		/// <param name="source">Insert query.</param>
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Number of affected records.</returns>
-		public static Task<int> InsertAsync<TSource,TTarget>(
-			 this ISelectInsertable<TSource,TTarget> source, CancellationToken token = default)
+		public static Task<int> InsertAsync<TSource, TTarget>(
+			 this ISelectInsertable<TSource, TTarget> source, CancellationToken token = default)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
@@ -2420,7 +2408,7 @@ namespace LinqToDB
 		/// <typeparam name="TTarget">Target table record type.</typeparam>
 		/// <param name="source">Insert query.</param>
 		/// <returns>Number of affected records.</returns>
-		public static object InsertWithIdentity<TSource,TTarget>( this ISelectInsertable<TSource,TTarget> source)
+		public static object InsertWithIdentity<TSource, TTarget>(this ISelectInsertable<TSource, TTarget> source)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
@@ -2442,11 +2430,11 @@ namespace LinqToDB
 		/// <typeparam name="TTarget">Target table record type.</typeparam>
 		/// <param name="source">Insert query.</param>
 		/// <returns>Number of affected records.</returns>
-		public static int? InsertWithInt32Identity<TSource,TTarget>( this ISelectInsertable<TSource,TTarget> source)
+		public static int? InsertWithInt32Identity<TSource, TTarget>(this ISelectInsertable<TSource, TTarget> source)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
-			return ((ExpressionQuery<TSource>)((SelectInsertable<TSource,TTarget>)source).Query).DataContext.MappingSchema.ChangeTypeTo<int?>(
+			return ((ExpressionQuery<TSource>)((SelectInsertable<TSource, TTarget>)source).Query).DataContext.MappingSchema.ChangeTypeTo<int?>(
 				InsertWithIdentity(source));
 		}
 
@@ -2457,11 +2445,11 @@ namespace LinqToDB
 		/// <typeparam name="TTarget">Target table record type.</typeparam>
 		/// <param name="source">Insert query.</param>
 		/// <returns>Number of affected records.</returns>
-		public static long? InsertWithInt64Identity<TSource,TTarget>( this ISelectInsertable<TSource,TTarget> source)
+		public static long? InsertWithInt64Identity<TSource, TTarget>(this ISelectInsertable<TSource, TTarget> source)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
-			return ((ExpressionQuery<TSource>)((SelectInsertable<TSource,TTarget>)source).Query).DataContext.MappingSchema.ChangeTypeTo<long?>(
+			return ((ExpressionQuery<TSource>)((SelectInsertable<TSource, TTarget>)source).Query).DataContext.MappingSchema.ChangeTypeTo<long?>(
 				InsertWithIdentity(source));
 		}
 
@@ -2472,11 +2460,11 @@ namespace LinqToDB
 		/// <typeparam name="TTarget">Target table record type.</typeparam>
 		/// <param name="source">Insert query.</param>
 		/// <returns>Number of affected records.</returns>
-		public static decimal? InsertWithDecimalIdentity<TSource,TTarget>( this ISelectInsertable<TSource,TTarget> source)
+		public static decimal? InsertWithDecimalIdentity<TSource, TTarget>(this ISelectInsertable<TSource, TTarget> source)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
-			return ((ExpressionQuery<TSource>)((SelectInsertable<TSource,TTarget>)source).Query).DataContext.MappingSchema.ChangeTypeTo<decimal?>(
+			return ((ExpressionQuery<TSource>)((SelectInsertable<TSource, TTarget>)source).Query).DataContext.MappingSchema.ChangeTypeTo<decimal?>(
 				InsertWithIdentity(source));
 		}
 
@@ -2488,8 +2476,8 @@ namespace LinqToDB
 		/// <param name="source">Insert query.</param>
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Number of affected records.</returns>
-		public static Task<object> InsertWithIdentityAsync<TSource,TTarget>(
-			 this ISelectInsertable<TSource,TTarget> source, CancellationToken token = default)
+		public static Task<object> InsertWithIdentityAsync<TSource, TTarget>(
+			 this ISelectInsertable<TSource, TTarget> source, CancellationToken token = default)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
@@ -2512,12 +2500,12 @@ namespace LinqToDB
 		/// <param name="source">Insert query.</param>
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Number of affected records.</returns>
-		public static async Task<int?> InsertWithInt32IdentityAsync<TSource,TTarget>(
-			 this ISelectInsertable<TSource,TTarget> source, CancellationToken token = default)
+		public static async Task<int?> InsertWithInt32IdentityAsync<TSource, TTarget>(
+			 this ISelectInsertable<TSource, TTarget> source, CancellationToken token = default)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
-			return ((ExpressionQuery<TSource>)((SelectInsertable<TSource,TTarget>)source).Query).DataContext.MappingSchema.ChangeTypeTo<int?>(
+			return ((ExpressionQuery<TSource>)((SelectInsertable<TSource, TTarget>)source).Query).DataContext.MappingSchema.ChangeTypeTo<int?>(
 				await InsertWithIdentityAsync(source, token).ConfigureAwait(false));
 		}
 
@@ -2529,12 +2517,12 @@ namespace LinqToDB
 		/// <param name="source">Insert query.</param>
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Number of affected records.</returns>
-		public static async Task<long?> InsertWithInt64IdentityAsync<TSource,TTarget>(
-			 this ISelectInsertable<TSource,TTarget> source, CancellationToken token = default)
+		public static async Task<long?> InsertWithInt64IdentityAsync<TSource, TTarget>(
+			 this ISelectInsertable<TSource, TTarget> source, CancellationToken token = default)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
-			return ((ExpressionQuery<TSource>)((SelectInsertable<TSource,TTarget>)source).Query).DataContext.MappingSchema.ChangeTypeTo<long?>(
+			return ((ExpressionQuery<TSource>)((SelectInsertable<TSource, TTarget>)source).Query).DataContext.MappingSchema.ChangeTypeTo<long?>(
 				await InsertWithIdentityAsync(source, token).ConfigureAwait(false));
 		}
 
@@ -2546,12 +2534,12 @@ namespace LinqToDB
 		/// <param name="source">Insert query.</param>
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Number of affected records.</returns>
-		public static async Task<decimal?> InsertWithDecimalIdentityAsync<TSource,TTarget>(
-			 this ISelectInsertable<TSource,TTarget> source, CancellationToken token = default)
+		public static async Task<decimal?> InsertWithDecimalIdentityAsync<TSource, TTarget>(
+			 this ISelectInsertable<TSource, TTarget> source, CancellationToken token = default)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
-			return ((ExpressionQuery<TSource>)((SelectInsertable<TSource,TTarget>)source).Query).DataContext.MappingSchema.ChangeTypeTo<decimal?>(
+			return ((ExpressionQuery<TSource>)((SelectInsertable<TSource, TTarget>)source).Query).DataContext.MappingSchema.ChangeTypeTo<decimal?>(
 				await InsertWithIdentityAsync(source, token).ConfigureAwait(false));
 		}
 
@@ -2578,13 +2566,13 @@ namespace LinqToDB
 		/// Accepts updated record as parameter.</param>
 		/// <returns>Number of affected records.</returns>
 		public static int InsertOrUpdate<T>(
-			                this ITable<T>          target,
-			[InstantHandle] Expression<Func<T>>     insertSetter,
-			[InstantHandle] Expression<Func<T,T?>>? onDuplicateKeyUpdateSetter)
+							this ITable<T> target,
+			[InstantHandle] Expression<Func<T>> insertSetter,
+			[InstantHandle] Expression<Func<T, T?>>? onDuplicateKeyUpdateSetter)
 			where T : notnull
 		{
-			if (target                     == null) throw new ArgumentNullException(nameof(target));
-			if (insertSetter               == null) throw new ArgumentNullException(nameof(insertSetter));
+			if (target == null) throw new ArgumentNullException(nameof(target));
+			if (insertSetter == null) throw new ArgumentNullException(nameof(insertSetter));
 
 			var currentSource = target.GetLinqToDBSource();
 
@@ -2612,14 +2600,14 @@ namespace LinqToDB
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Number of affected records.</returns>
 		public static Task<int> InsertOrUpdateAsync<T>(
-			                this ITable<T>          target,
-			[InstantHandle] Expression<Func<T>>     insertSetter,
-			[InstantHandle] Expression<Func<T,T?>>? onDuplicateKeyUpdateSetter,
-			CancellationToken                       token = default)
+							this ITable<T> target,
+			[InstantHandle] Expression<Func<T>> insertSetter,
+			[InstantHandle] Expression<Func<T, T?>>? onDuplicateKeyUpdateSetter,
+			CancellationToken token = default)
 			where T : notnull
 		{
-			if (target                     == null) throw new ArgumentNullException(nameof(target));
-			if (insertSetter               == null) throw new ArgumentNullException(nameof(insertSetter));
+			if (target == null) throw new ArgumentNullException(nameof(target));
+			if (insertSetter == null) throw new ArgumentNullException(nameof(insertSetter));
 
 			var currentSource = target.GetLinqToDBSource();
 
@@ -2650,15 +2638,15 @@ namespace LinqToDB
 		/// Expression supports only target table record new expression with field initializers for each key field. Assigned key field value will be used as key value by operation type selector.</param>
 		/// <returns>Number of affected records.</returns>
 		public static int InsertOrUpdate<T>(
-			                this ITable<T>          target,
-			[InstantHandle] Expression<Func<T>>     insertSetter,
-			[InstantHandle] Expression<Func<T,T?>>? onDuplicateKeyUpdateSetter,
-			[InstantHandle] Expression<Func<T>>     keySelector)
+							this ITable<T> target,
+			[InstantHandle] Expression<Func<T>> insertSetter,
+			[InstantHandle] Expression<Func<T, T?>>? onDuplicateKeyUpdateSetter,
+			[InstantHandle] Expression<Func<T>> keySelector)
 			where T : notnull
 		{
-			if (target                     == null) throw new ArgumentNullException(nameof(target));
-			if (insertSetter               == null) throw new ArgumentNullException(nameof(insertSetter));
-			if (keySelector                == null) throw new ArgumentNullException(nameof(keySelector));
+			if (target == null) throw new ArgumentNullException(nameof(target));
+			if (insertSetter == null) throw new ArgumentNullException(nameof(insertSetter));
+			if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
 			var currentSource = target.GetLinqToDBSource();
 
@@ -2690,16 +2678,16 @@ namespace LinqToDB
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Number of affected records.</returns>
 		public static Task<int> InsertOrUpdateAsync<T>(
-			                this ITable<T>          target,
-			[InstantHandle] Expression<Func<T>>     insertSetter,
-			[InstantHandle] Expression<Func<T,T?>>? onDuplicateKeyUpdateSetter,
-			[InstantHandle] Expression<Func<T>>     keySelector,
-			CancellationToken                       token = default)
+							this ITable<T> target,
+			[InstantHandle] Expression<Func<T>> insertSetter,
+			[InstantHandle] Expression<Func<T, T?>>? onDuplicateKeyUpdateSetter,
+			[InstantHandle] Expression<Func<T>> keySelector,
+			CancellationToken token = default)
 			where T : notnull
 		{
-			if (target                     == null) throw new ArgumentNullException(nameof(target));
-			if (insertSetter               == null) throw new ArgumentNullException(nameof(insertSetter));
-			if (keySelector                == null) throw new ArgumentNullException(nameof(keySelector));
+			if (target == null) throw new ArgumentNullException(nameof(target));
+			if (insertSetter == null) throw new ArgumentNullException(nameof(insertSetter));
+			if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
 			var currentSource = target.GetLinqToDBSource();
 
@@ -2730,7 +2718,7 @@ namespace LinqToDB
 		/// Tracked by <a href="https://github.com/linq2db/linq2db/issues/798">issue</a>.
 		/// Default value: <c>true</c>.</param>
 		/// <returns>Number of affected records. Usually <c>-1</c> as it is not data modification operation.</returns>
-		public static int Drop<T>( this ITable<T> target, bool throwExceptionIfNotExists = true)
+		public static int Drop<T>(this ITable<T> target, bool throwExceptionIfNotExists = true)
 			where T : notnull
 		{
 			if (target == null) throw new ArgumentNullException(nameof(target));
@@ -2765,8 +2753,8 @@ namespace LinqToDB
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Number of affected records. Usually <c>-1</c> as it is not data modification operation.</returns>
 		public static async Task<int> DropAsync<T>(
-			this ITable<T>    target,
-			bool              throwExceptionIfNotExists = true,
+			this ITable<T> target,
+			bool throwExceptionIfNotExists = true,
 			CancellationToken token = default)
 			where T : notnull
 		{
@@ -2803,7 +2791,7 @@ namespace LinqToDB
 		/// <param name="target">Truncated table.</param>
 		/// <param name="resetIdentity">Performs reset identity column.</param>
 		/// <returns>Number of affected records. Usually <c>-1</c> as it is not data modification operation.</returns>
-		public static int Truncate<T>( this ITable<T> target, bool resetIdentity = true)
+		public static int Truncate<T>(this ITable<T> target, bool resetIdentity = true)
 			where T : notnull
 		{
 			if (target == null) throw new ArgumentNullException(nameof(target));
@@ -2827,9 +2815,9 @@ namespace LinqToDB
 		/// <param name="token">Optional asynchronous operation cancellation token.</param>
 		/// <returns>Number of affected records. Usually <c>-1</c> as it is not data modification operation.</returns>
 		public static Task<int> TruncateAsync<T>(
-			this ITable<T>    target,
-			bool              resetIdentity = true,
-			CancellationToken token         = default)
+			this ITable<T> target,
+			bool resetIdentity = true,
+			CancellationToken token = default)
 			where T : notnull
 		{
 			if (target == null) throw new ArgumentNullException(nameof(target));
@@ -2860,11 +2848,11 @@ namespace LinqToDB
 		[LinqTunnel]
 		[Pure]
 		public static IQueryable<TSource> Take<TSource>(
-			           this IQueryable<TSource>   source,
+					   this IQueryable<TSource> source,
 			[InstantHandle] Expression<Func<int>> count)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
-			if (count  == null) throw new ArgumentNullException(nameof(count));
+			if (count == null) throw new ArgumentNullException(nameof(count));
 
 			var currentSource = source.ProcessIQueryable();
 
@@ -2890,12 +2878,12 @@ namespace LinqToDB
 		[LinqTunnel]
 		[Pure]
 		public static IQueryable<TSource> Take<TSource>(
-			                    this IQueryable<TSource>   source,
-			[InstantHandle]          Expression<Func<int>> count,
-			[SqlQueryDependent]      TakeHints             hints)
+								this IQueryable<TSource> source,
+			[InstantHandle] Expression<Func<int>> count,
+			[SqlQueryDependent] TakeHints hints)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
-			if (count  == null) throw new ArgumentNullException(nameof(count));
+			if (count == null) throw new ArgumentNullException(nameof(count));
 
 			var currentSource = source.ProcessIQueryable();
 
@@ -2921,9 +2909,9 @@ namespace LinqToDB
 		[LinqTunnel]
 		[Pure]
 		public static IQueryable<TSource> Take<TSource>(
-			      this IQueryable<TSource> source,
-			                    int                 count,
-			[SqlQueryDependent] TakeHints           hints)
+				  this IQueryable<TSource> source,
+								int count,
+			[SqlQueryDependent] TakeHints hints)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
@@ -2949,11 +2937,11 @@ namespace LinqToDB
 		[LinqTunnel]
 		[Pure]
 		public static IQueryable<TSource> Skip<TSource>(
-			           this IQueryable<TSource>   source,
+					   this IQueryable<TSource> source,
 			[InstantHandle] Expression<Func<int>> count)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
-			if (count  == null) throw new ArgumentNullException(nameof(count));
+			if (count == null) throw new ArgumentNullException(nameof(count));
 
 			var currentSource = source.ProcessIQueryable();
 
@@ -2976,11 +2964,11 @@ namespace LinqToDB
 		/// <returns>Record at specified position.</returns>
 		[Pure]
 		public static TSource ElementAt<TSource>(
-			           this IQueryable<TSource>   source,
+					   this IQueryable<TSource> source,
 			[InstantHandle] Expression<Func<int>> index)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
-			if (index  == null) throw new ArgumentNullException(nameof(index));
+			if (index == null) throw new ArgumentNullException(nameof(index));
 
 			var currentSource = source.GetLinqToDBSource();
 
@@ -3004,12 +2992,12 @@ namespace LinqToDB
 		/// <returns>Record at specified position.</returns>
 		[Pure]
 		public static Task<TSource> ElementAtAsync<TSource>(
-			           this IQueryable<TSource>   source,
+					   this IQueryable<TSource> source,
 			[InstantHandle] Expression<Func<int>> index,
-			CancellationToken                     token = default)
+			CancellationToken token = default)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
-			if (index  == null) throw new ArgumentNullException(nameof(index));
+			if (index == null) throw new ArgumentNullException(nameof(index));
 
 			var currentSource = source.GetLinqToDBSource();
 
@@ -3032,11 +3020,11 @@ namespace LinqToDB
 		/// <returns>Record at specified position or default value, if source query doesn't have record with such index.</returns>
 		[Pure]
 		public static TSource ElementAtOrDefault<TSource>(
-			           this IQueryable<TSource>   source,
+					   this IQueryable<TSource> source,
 			[InstantHandle] Expression<Func<int>> index)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
-			if (index  == null) throw new ArgumentNullException(nameof(index));
+			if (index == null) throw new ArgumentNullException(nameof(index));
 
 			var currentSource = source.GetLinqToDBSource();
 
@@ -3058,12 +3046,12 @@ namespace LinqToDB
 		/// <returns>Record at specified position or default value, if source query doesn't have record with such index.</returns>
 		[Pure]
 		public static Task<TSource> ElementAtOrDefaultAsync<TSource>(
-			           this IQueryable<TSource>   source,
+					   this IQueryable<TSource> source,
 			[InstantHandle] Expression<Func<int>> index,
-			                CancellationToken     token = default)
+							CancellationToken token = default)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
-			if (index  == null) throw new ArgumentNullException(nameof(index));
+			if (index == null) throw new ArgumentNullException(nameof(index));
 
 			var currentSource = source.GetLinqToDBSource();
 
@@ -3095,10 +3083,10 @@ namespace LinqToDB
 		[LinqTunnel]
 		[Pure]
 		public static IQueryable<TSource> Having<TSource>(
-			                this IQueryable<TSource>       source,
-			[InstantHandle] Expression<Func<TSource,bool>> predicate)
+							this IQueryable<TSource> source,
+			[InstantHandle] Expression<Func<TSource, bool>> predicate)
 		{
-			if (source    == null) throw new ArgumentNullException(nameof(source));
+			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (predicate == null) throw new ArgumentNullException(nameof(predicate));
 
 			var currentSource = source.ProcessIQueryable();
@@ -3127,10 +3115,10 @@ namespace LinqToDB
 		[LinqTunnel]
 		[Pure]
 		public static IOrderedQueryable<TSource> ThenOrBy<TSource, TKey>(
-			           this IQueryable<TSource>            source,
-			[InstantHandle] Expression<Func<TSource,TKey>> keySelector)
+					   this IQueryable<TSource> source,
+			[InstantHandle] Expression<Func<TSource, TKey>> keySelector)
 		{
-			if (source      == null) throw new ArgumentNullException(nameof(source));
+			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
 			var currentSource = source.ProcessIQueryable();
@@ -3155,10 +3143,10 @@ namespace LinqToDB
 		[LinqTunnel]
 		[Pure]
 		public static IOrderedQueryable<TSource> ThenOrByDescending<TSource, TKey>(
-			           this IQueryable<TSource>             source,
+					   this IQueryable<TSource> source,
 			[InstantHandle] Expression<Func<TSource, TKey>> keySelector)
 		{
-			if (source      == null) throw new ArgumentNullException(nameof(source));
+			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
 			var currentSource = source.ProcessIQueryable();
@@ -3196,7 +3184,7 @@ namespace LinqToDB
 
 		#region Stub helpers
 
-		internal static TOutput AsQueryable<TOutput,TInput>(TInput source)
+		internal static TOutput AsQueryable<TOutput, TInput>(TInput source)
 		{
 			throw new InvalidOperationException();
 		}
@@ -3216,11 +3204,11 @@ namespace LinqToDB
 		[Pure]
 		[LinqTunnel]
 		public static IQueryable<TSource> Join<TSource>(
-			           this     IQueryable<TSource>             source,
-			[SqlQueryDependent] SqlJoinType                     joinType,
-			[InstantHandle]     Expression<Func<TSource, bool>> predicate)
+					   this IQueryable<TSource> source,
+			[SqlQueryDependent] SqlJoinType joinType,
+			[InstantHandle] Expression<Func<TSource, bool>> predicate)
 		{
-			if (source    == null) throw new ArgumentNullException(nameof(source));
+			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (predicate == null) throw new ArgumentNullException(nameof(predicate));
 
 			var currentSource = source.ProcessIQueryable();
@@ -3250,15 +3238,15 @@ namespace LinqToDB
 		[Pure]
 		[LinqTunnel]
 		public static IQueryable<TResult> Join<TOuter, TInner, TResult>(
-			               this IQueryable<TOuter>                        outer,
-			                    IQueryable<TInner>                        inner,
-			[SqlQueryDependent] SqlJoinType                               joinType,
-			[InstantHandle]     Expression<Func<TOuter, TInner, bool>>    predicate,
-			[InstantHandle]     Expression<Func<TOuter, TInner, TResult>> resultSelector)
+						   this IQueryable<TOuter> outer,
+								IQueryable<TInner> inner,
+			[SqlQueryDependent] SqlJoinType joinType,
+			[InstantHandle] Expression<Func<TOuter, TInner, bool>> predicate,
+			[InstantHandle] Expression<Func<TOuter, TInner, TResult>> resultSelector)
 		{
-			if (outer          == null) throw new ArgumentNullException(nameof(outer));
-			if (inner          == null) throw new ArgumentNullException(nameof(inner));
-			if (predicate      == null) throw new ArgumentNullException(nameof(predicate));
+			if (outer == null) throw new ArgumentNullException(nameof(outer));
+			if (inner == null) throw new ArgumentNullException(nameof(inner));
+			if (predicate == null) throw new ArgumentNullException(nameof(predicate));
 			if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
 			var currentSource = outer.ProcessIQueryable();
@@ -3285,7 +3273,7 @@ namespace LinqToDB
 		[Pure]
 		[LinqTunnel]
 		public static IQueryable<TSource> InnerJoin<TSource>(
-			           this IQueryable<TSource>             source,
+					   this IQueryable<TSource> source,
 			[InstantHandle] Expression<Func<TSource, bool>> predicate)
 		{
 			return Join(source, SqlJoinType.Inner, predicate);
@@ -3305,9 +3293,9 @@ namespace LinqToDB
 		[Pure]
 		[LinqTunnel]
 		public static IQueryable<TResult> InnerJoin<TOuter, TInner, TResult>(
-			           this IQueryable<TOuter>                        outer,
-			                IQueryable<TInner>                        inner,
-			[InstantHandle] Expression<Func<TOuter, TInner, bool>>    predicate,
+					   this IQueryable<TOuter> outer,
+							IQueryable<TInner> inner,
+			[InstantHandle] Expression<Func<TOuter, TInner, bool>> predicate,
 			[InstantHandle] Expression<Func<TOuter, TInner, TResult>> resultSelector)
 		{
 			return Join(outer, inner, SqlJoinType.Inner, predicate, resultSelector);
@@ -3323,7 +3311,7 @@ namespace LinqToDB
 		[Pure]
 		[LinqTunnel]
 		public static IQueryable<TSource> LeftJoin<TSource>(
-			           this IQueryable<TSource>             source,
+					   this IQueryable<TSource> source,
 			[InstantHandle] Expression<Func<TSource, bool>> predicate)
 		{
 			return Join(source, SqlJoinType.Left, predicate);
@@ -3343,9 +3331,9 @@ namespace LinqToDB
 		[Pure]
 		[LinqTunnel]
 		public static IQueryable<TResult> LeftJoin<TOuter, TInner, TResult>(
-			           this IQueryable<TOuter>                        outer,
-			                IQueryable<TInner>                        inner,
-			[InstantHandle] Expression<Func<TOuter, TInner, bool>>    predicate,
+					   this IQueryable<TOuter> outer,
+							IQueryable<TInner> inner,
+			[InstantHandle] Expression<Func<TOuter, TInner, bool>> predicate,
 			[InstantHandle] Expression<Func<TOuter, TInner, TResult>> resultSelector)
 		{
 			return Join(outer, inner, SqlJoinType.Left, predicate, resultSelector);
@@ -3361,7 +3349,7 @@ namespace LinqToDB
 		[Pure]
 		[LinqTunnel]
 		public static IQueryable<TSource> RightJoin<TSource>(
-			           this IQueryable<TSource>             source,
+					   this IQueryable<TSource> source,
 			[InstantHandle] Expression<Func<TSource, bool>> predicate)
 		{
 			return Join(source, SqlJoinType.Right, predicate);
@@ -3381,9 +3369,9 @@ namespace LinqToDB
 		[Pure]
 		[LinqTunnel]
 		public static IQueryable<TResult> RightJoin<TOuter, TInner, TResult>(
-			           this IQueryable<TOuter>                        outer,
-			                IQueryable<TInner>                        inner,
-			[InstantHandle] Expression<Func<TOuter, TInner, bool>>    predicate,
+					   this IQueryable<TOuter> outer,
+							IQueryable<TInner> inner,
+			[InstantHandle] Expression<Func<TOuter, TInner, bool>> predicate,
 			[InstantHandle] Expression<Func<TOuter, TInner, TResult>> resultSelector)
 		{
 			return Join(outer, inner, SqlJoinType.Right, predicate, resultSelector);
@@ -3399,7 +3387,7 @@ namespace LinqToDB
 		[Pure]
 		[LinqTunnel]
 		public static IQueryable<TSource> FullJoin<TSource>(
-			           this IQueryable<TSource>             source,
+					   this IQueryable<TSource> source,
 			[InstantHandle] Expression<Func<TSource, bool>> predicate)
 		{
 			return Join(source, SqlJoinType.Full, predicate);
@@ -3419,9 +3407,9 @@ namespace LinqToDB
 		[Pure]
 		[LinqTunnel]
 		public static IQueryable<TResult> FullJoin<TOuter, TInner, TResult>(
-			           this IQueryable<TOuter>                        outer,
-			                IQueryable<TInner>                        inner,
-			[InstantHandle] Expression<Func<TOuter, TInner, bool>>    predicate,
+					   this IQueryable<TOuter> outer,
+							IQueryable<TInner> inner,
+			[InstantHandle] Expression<Func<TOuter, TInner, bool>> predicate,
 			[InstantHandle] Expression<Func<TOuter, TInner, TResult>> resultSelector)
 		{
 			return Join(outer, inner, SqlJoinType.Full, predicate, resultSelector);
@@ -3440,12 +3428,12 @@ namespace LinqToDB
 		[Pure]
 		[LinqTunnel]
 		public static IQueryable<TResult> CrossJoin<TOuter, TInner, TResult>(
-			           this IQueryable<TOuter>                        outer,
-			                IQueryable<TInner>                        inner,
+					   this IQueryable<TOuter> outer,
+							IQueryable<TInner> inner,
 			[InstantHandle] Expression<Func<TOuter, TInner, TResult>> resultSelector)
 		{
-			if (outer          == null) throw new ArgumentNullException(nameof(outer));
-			if (inner          == null) throw new ArgumentNullException(nameof(inner));
+			if (outer == null) throw new ArgumentNullException(nameof(outer));
+			if (inner == null) throw new ArgumentNullException(nameof(inner));
 			if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
 			var currentSource = outer.ProcessIQueryable();
@@ -3502,7 +3490,7 @@ namespace LinqToDB
 		[LinqTunnel]
 		public static IQueryable<TSource> AsCte<TSource>(
 			this IQueryable<TSource> source,
-			string?                  name)
+			string? name)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
@@ -3529,9 +3517,9 @@ namespace LinqToDB
 		/// <paramref name="source" /> is <see langword="null" />.</exception>
 		public static IQueryable<TElement> AsQueryable<TElement>(
 			this IEnumerable<TElement> source,
-			IDataContext               dataContext)
+			IDataContext dataContext)
 		{
-			if (source      == null) throw new ArgumentNullException(nameof(source));
+			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (dataContext == null) throw new ArgumentNullException(nameof(dataContext));
 
 			if (source is IQueryable<TElement> already)
@@ -3582,7 +3570,7 @@ namespace LinqToDB
 		/// <returns>Query converted into sub-query.</returns>
 		[Pure]
 		[LinqTunnel]
-		public static IQueryable<TKey> AsSubQuery<TKey, TElement>(this IQueryable<IGrouping<TKey,TElement>> grouping)
+		public static IQueryable<TKey> AsSubQuery<TKey, TElement>(this IQueryable<IGrouping<TKey, TElement>> grouping)
 		{
 			if (grouping == null) throw new ArgumentNullException(nameof(grouping));
 
@@ -3630,7 +3618,7 @@ namespace LinqToDB
 		/// <returns>Query converted into sub-query.</returns>
 		[Pure]
 		[LinqTunnel]
-		public static IQueryable<TKey> AsSubQuery<TKey, TElement>(this IQueryable<IGrouping<TKey,TElement>> grouping, [SqlQueryDependent] string queryName)
+		public static IQueryable<TKey> AsSubQuery<TKey, TElement>(this IQueryable<IGrouping<TKey, TElement>> grouping, [SqlQueryDependent] string queryName)
 		{
 			if (grouping == null) throw new ArgumentNullException(nameof(grouping));
 
@@ -3683,7 +3671,7 @@ namespace LinqToDB
 		/// <returns>Query converted into sub-query.</returns>
 		[Pure]
 		[LinqTunnel]
-		public static IQueryable<TKey> QueryName<TKey,TElement>(this IQueryable<IGrouping<TKey,TElement>> grouping, [SqlQueryDependent] string queryName)
+		public static IQueryable<TKey> QueryName<TKey, TElement>(this IQueryable<IGrouping<TKey, TElement>> grouping, [SqlQueryDependent] string queryName)
 		{
 			if (grouping == null) throw new ArgumentNullException(nameof(grouping));
 
@@ -3742,7 +3730,7 @@ namespace LinqToDB
 			if (grouping == null) throw new ArgumentNullException(nameof(grouping));
 
 			var currentSource = grouping.ProcessIQueryable();
-			
+
 			var expr = Expression.Call(
 				null,
 				MethodHelper.GetMethodInfo(DisableGuard, grouping),
@@ -3766,10 +3754,10 @@ namespace LinqToDB
 		[Pure]
 		[LinqTunnel]
 		public static IQueryable<TSource> HasUniqueKey<TSource, TKey>(
-			 this IQueryable<TSource>             source,
-			      Expression<Func<TSource, TKey>> keySelector)
+			 this IQueryable<TSource> source,
+				  Expression<Func<TSource, TKey>> keySelector)
 		{
-			if (source      == null) throw new ArgumentNullException(nameof(source));
+			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
 			var currentSource = source.ProcessIQueryable();
@@ -3791,7 +3779,7 @@ namespace LinqToDB
 		{
 			if (source is IQueryable<TSource> queryable)
 				return queryable.Expression;
-			return Expression.Constant(source, typeof (IEnumerable<TSource>));
+			return Expression.Constant(source, typeof(IEnumerable<TSource>));
 		}
 
 		/// <summary>Concatenates two sequences, similar to <see cref="Queryable.Concat{TSource}"/>.</summary>
@@ -3802,8 +3790,8 @@ namespace LinqToDB
 		/// <exception cref="ArgumentNullException">
 		/// <paramref name="source1" /> or <paramref name="source2" /> is <see langword="null" />.</exception>
 		public static IQueryable<TSource> UnionAll<TSource>(
-			 this IQueryable<TSource>  source1,
-			      IEnumerable<TSource> source2)
+			 this IQueryable<TSource> source1,
+				  IEnumerable<TSource> source2)
 		{
 			if (source1 == null) throw new ArgumentNullException(nameof(source1));
 			if (source2 == null) throw new ArgumentNullException(nameof(source2));
@@ -3819,8 +3807,8 @@ namespace LinqToDB
 		/// <exception cref="ArgumentNullException">
 		/// <paramref name="source1" /> or <paramref name="source2" /> is <see langword="null" />.</exception>
 		public static IQueryable<TSource> ExceptAll<TSource>(
-			 this IQueryable<TSource>  source1,
-			      IEnumerable<TSource> source2)
+			 this IQueryable<TSource> source1,
+				  IEnumerable<TSource> source2)
 		{
 			if (source1 == null) throw new ArgumentNullException(nameof(source1));
 			if (source2 == null) throw new ArgumentNullException(nameof(source2));
@@ -3844,8 +3832,8 @@ namespace LinqToDB
 		/// <exception cref="ArgumentNullException">
 		/// <paramref name="source1" /> or <paramref name="source2" /> is <see langword="null" />.</exception>
 		public static IQueryable<TSource> IntersectAll<TSource>(
-			 this IQueryable<TSource>  source1,
-			      IEnumerable<TSource> source2)
+			 this IQueryable<TSource> source1,
+				  IEnumerable<TSource> source2)
 		{
 			if (source1 == null) throw new ArgumentNullException(nameof(source1));
 			if (source2 == null) throw new ArgumentNullException(nameof(source2));
@@ -3912,7 +3900,7 @@ namespace LinqToDB
 		/// Gets or sets callback for preprocessing query before execution.
 		/// Useful for intercepting queries.
 		/// </summary>
-		public static Func<IQueryable,IQueryable>? ProcessSourceQueryable { get; set; }
+		public static Func<IQueryable, IQueryable>? ProcessSourceQueryable { get; set; }
 
 		public static IExtensionsAdapter? ExtensionsAdapter { get; set; }
 
@@ -4022,6 +4010,92 @@ namespace LinqToDB
 		private static IQueryProviderAsync ThrowInvalidSource(string? method)
 		{
 			throw new LinqToDBException($"LinqToDB method '{method}' called on non-LinqToDB IQueryable.");
+		}
+		#endregion
+
+		#region ToSqlQuery
+		/// <summary>
+		/// Convert Linq To DB query to SQL command with parameters.
+		/// </summary>
+		/// <remarks>Eager load queries currently return only SQL for main query.</remarks>
+		public static QuerySql ToSqlQuery<T>(this IQueryable<T> query)
+		{
+			if (query is LoadWithQueryableBase<T> loadWith)
+				query = loadWith.Query;
+
+			var expressionQuery = (IExpressionQuery)query.GetLinqToDBSource();
+
+			// query not expected to have multiple commands currently
+			return expressionQuery.GetSqlQuery().Single();
+		}
+
+		/// <summary>
+		/// Convert Linq To DB query to SQL command with parameters.
+		/// </summary>
+		public static QuerySql ToSqlQuery<T>(this IUpdatable<T> query)
+		{
+			var expressionQuery = (IExpressionQuery)((Updatable<T>)query).Query.GetLinqToDBSource();
+
+			// query not expected to have multiple commands currently
+			return expressionQuery.GetSqlQuery().Single();
+		}
+
+		/// <summary>
+		/// Convert Linq To DB query to SQL command with parameters.
+		/// </summary>
+		public static QuerySql ToSqlQuery<T>(this IValueInsertable<T> query)
+		{
+			var expressionQuery = (IExpressionQuery)((ValueInsertable<T>)query).Query.GetLinqToDBSource();
+
+			// query not expected to have multiple commands currently
+			return expressionQuery.GetSqlQuery().Single();
+		}
+
+		/// <summary>
+		/// Convert Linq To DB query to SQL command with parameters.
+		/// </summary>
+		public static QuerySql ToSqlQuery<TSource, TTarget>(this ISelectInsertable<TSource, TTarget> query)
+		{
+			var expressionQuery = (IExpressionQuery)((SelectInsertable<TSource, TTarget>)query).Query.GetLinqToDBSource();
+
+			// query not expected to have multiple commands currently
+			return expressionQuery.GetSqlQuery().Single();
+		}
+
+		/// <summary>
+		/// Convert Linq To DB query to SQL command with parameters.
+		/// </summary>
+		/// <remarks>Eager load queries currently return only SQL for main query.</remarks>
+		public static QuerySql ToSqlQuery<TSource>(this IMultiInsertInto<TSource> query)
+		{
+			var expressionQuery = (IExpressionQuery)((MultiInsertQuery<TSource>)query).Query.GetLinqToDBSource();
+
+			// query not expected to have multiple commands currently
+			return expressionQuery.GetSqlQuery().Single();
+		}
+
+		/// <summary>
+		/// Convert Linq To DB query to SQL command with parameters.
+		/// </summary>
+		/// <remarks>Eager load queries currently return only SQL for main query.</remarks>
+		public static QuerySql ToSqlQuery<TSource>(this IMultiInsertElse<TSource> query)
+		{
+			var expressionQuery = (IExpressionQuery)((MultiInsertQuery<TSource>)query).Query.GetLinqToDBSource();
+
+			// query not expected to have multiple commands currently
+			return expressionQuery.GetSqlQuery().Single();
+		}
+
+		/// <summary>
+		/// Convert Linq To DB query to SQL command with parameters.
+		/// </summary>
+		/// <remarks>Eager load queries currently return only SQL for main query.</remarks>
+		public static QuerySql ToSqlQuery<TSource, TTarget>(this IMergeable<TSource, TTarget> query)
+		{
+			var expressionQuery = (IExpressionQuery)((MergeQuery<TSource, TTarget>)query).Query.GetLinqToDBSource();
+
+			// query not expected to have multiple commands currently
+			return expressionQuery.GetSqlQuery().Single();
 		}
 		#endregion
 	}

--- a/Source/LinqToDB/Remote/RemoteDataContextBase.QueryRunner.cs
+++ b/Source/LinqToDB/Remote/RemoteDataContextBase.QueryRunner.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Data.Common;
 using System.Globalization;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,8 +14,8 @@ namespace LinqToDB.Remote
 {
 	using Common.Internal;
 	using Data;
-	using Linq;
 	using DataProvider;
+	using Linq;
 	using SqlProvider;
 	using SqlQuery;
 
@@ -47,18 +47,19 @@ namespace LinqToDB.Remote
 				_evaluationContext = new EvaluationContext(parameterValues);
 			}
 
-#region GetSqlText
+			#region GetSqlText
 
-			public override string GetSqlText()
+			public override IReadOnlyList<QuerySql> GetSqlText()
 			{
 				SetCommand(true);
 
-				using var sb               = Pools.StringBuilder.Allocate();
 				var query                  = Query.Queries[QueryNumber];
 				var sqlBuilder             = DataContext.CreateSqlProvider();
 				var sqlOptimizer           = DataContext.GetSqlOptimizer(DataContext.Options);
 				using var sqlStringBuilder = Pools.StringBuilder.Allocate();
 				var cc                     = sqlBuilder.CommandCount(query.Statement);
+
+				var queries = new QuerySql[cc];
 
 				for (var i = 0; i < cc; i++)
 				{
@@ -71,7 +72,7 @@ namespace LinqToDB.Remote
 						DataContext.MappingSchema,
 						sqlOptimizer.CreateOptimizerVisitor(false),
 						sqlOptimizer.CreateConvertVisitor(false),
-						isParameterOrderDepended : false,
+						isParameterOrderDepended : DataContext.SqlProviderFlags.IsParameterOrderDependent,
 						isAlreadyOptimizedAndConverted : true,
 						static () => NoopQueryParametersNormalizer.Instance);
 
@@ -84,70 +85,36 @@ namespace LinqToDB.Remote
 						var queryHints = DataContext.GetNextCommandHints(false);
 						if (queryHints != null)
 						{
-							var sql = sqlStringBuilder.Value.ToString();
+							var querySql = sqlStringBuilder.Value.ToString();
 
-							sql = sqlBuilder.ApplyQueryHints(sql, queryHints);
+							querySql = sqlBuilder.ApplyQueryHints(querySql, queryHints);
 
-							sqlStringBuilder.Value.Append(sql);
+							sqlStringBuilder.Value.Append(querySql);
 						}
 					}
 
-					sb.Value
-						.Append("-- ")
-						.Append("ServiceModel")
-						.Append(' ')
-						.Append(DataContext.ContextName)
-						.Append(' ')
-						.Append(sqlBuilder.Name)
-						.AppendLine();
+					DataParameter[]? parameters = null;
+					var sql                     = sqlStringBuilder.Value.ToString();
+
+					sqlStringBuilder.Value.Length = 0;
 
 					if (optimizationContext.HasParameters())
 					{
 						var sqlParameters = optimizationContext.GetParameters();
-						foreach (var p in sqlParameters)
+						parameters        = new DataParameter[sqlParameters.Count];
+
+						for (var pIdx = 0; pIdx < sqlParameters.Count; pIdx++)
 						{
+							var p              = sqlParameters[pIdx];
 							var parameterValue = p.GetParameterValue(_evaluationContext.ParameterValues);
-
-							var value = parameterValue.ProviderValue;
-
-							sb.Value
-								.Append("-- DECLARE ")
-								.Append(p.Name)
-								.Append(' ')
-								.Append(value == null ? parameterValue.DbDataType.SystemType.ToString() : value.GetType().Name)
-								.AppendLine();
+							parameters[pIdx]   = new DataParameter(p.Name, parameterValue.ProviderValue, parameterValue.DbDataType);
 						}
-
-						sb.Value.AppendLine();
-
-						foreach (var p in sqlParameters)
-						{
-							var parameterValue = p.GetParameterValue(_evaluationContext.ParameterValues);
-
-							var value = parameterValue.ProviderValue;
-
-							value = value switch
-							{
-								string str => FormattableString.Invariant($"'{str.Replace("'", "''")}'"),
-								char chr   => FormattableString.Invariant($"'{(chr == '\'' ? "''" : chr)}'"),
-								_ => value
-							};
-
-							sb.Value.AppendLine(CultureInfo.InvariantCulture, $"-- SET {p.Name} = {value}");
-						}
-
-						sb.Value.AppendLine();
 					}
 
-#if NET6_0_OR_GREATER
-					sb.Value.Append(sqlStringBuilder.Value);
-#else
-					sb.Value.Append(sqlStringBuilder.Value.ToString());
-#endif
-					sqlStringBuilder.Value.Length = 0;
+					queries[i] = new QuerySql(sql, parameters ?? Array.Empty<DataParameter>());
 				}
 
-				return sb.Value.ToString();
+				return queries;
 			}
 
 #endregion

--- a/Source/LinqToDB/Remote/RemoteDataContextBase.QueryRunner.cs
+++ b/Source/LinqToDB/Remote/RemoteDataContextBase.QueryRunner.cs
@@ -49,13 +49,8 @@ namespace LinqToDB.Remote
 
 			#region GetSqlText
 
-			public override IReadOnlyList<QuerySql> GetSqlText(SqlGenerationOptions? options)
+			public override IReadOnlyList<QuerySql> GetSqlText()
 			{
-				var oldInline = _dataContext.InlineParameters;
-
-				if (options?.InlineParameters != null)
-					_dataContext.InlineParameters = options.InlineParameters.Value;
-
 				SetCommand(true);
 
 				var query                  = Query.Queries[QueryNumber];
@@ -118,8 +113,6 @@ namespace LinqToDB.Remote
 
 					queries[i] = new QuerySql(sql, parameters ?? Array.Empty<DataParameter>());
 				}
-
-				_dataContext.InlineParameters = oldInline;
 
 				return queries;
 			}

--- a/Source/LinqToDB/Remote/RemoteDataContextBase.QueryRunner.cs
+++ b/Source/LinqToDB/Remote/RemoteDataContextBase.QueryRunner.cs
@@ -49,8 +49,13 @@ namespace LinqToDB.Remote
 
 			#region GetSqlText
 
-			public override IReadOnlyList<QuerySql> GetSqlText()
+			public override IReadOnlyList<QuerySql> GetSqlText(SqlGenerationOptions? options)
 			{
+				var oldInline = _dataContext.InlineParameters;
+
+				if (options?.InlineParameters != null)
+					_dataContext.InlineParameters = options.InlineParameters.Value;
+
 				SetCommand(true);
 
 				var query                  = Query.Queries[QueryNumber];
@@ -113,6 +118,8 @@ namespace LinqToDB.Remote
 
 					queries[i] = new QuerySql(sql, parameters ?? Array.Empty<DataParameter>());
 				}
+
+				_dataContext.InlineParameters = oldInline;
 
 				return queries;
 			}

--- a/Source/LinqToDB/SqlProvider/BasicSqlOptimizer.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlOptimizer.cs
@@ -2067,5 +2067,36 @@ namespace LinqToDB.SqlProvider
 			return statement;
 		}
 
+		#region Visitors
+		protected sealed class ClearColumParametersVisitor : SqlQueryVisitor
+		{
+			bool _disableParameters;
+
+			public ClearColumParametersVisitor() : base(VisitMode.Modify, null)
+			{
+			}
+
+			protected override ISqlExpression VisitSqlColumnExpression(SqlColumn column, ISqlExpression expression)
+			{
+				var old            = _disableParameters;
+				_disableParameters = true;
+
+				var result         = base.VisitSqlColumnExpression(column, expression);
+
+				_disableParameters = old;
+
+				return result;
+			}
+
+			protected override IQueryElement VisitSqlParameter(SqlParameter sqlParameter)
+			{
+				if (_disableParameters)
+					sqlParameter.IsQueryParameter = false;
+
+				return base.VisitSqlParameter(sqlParameter);
+			}
+		}
+		#endregion
+
 	}
 }

--- a/Source/LinqToDB/TempTable.cs
+++ b/Source/LinqToDB/TempTable.cs
@@ -715,8 +715,8 @@ namespace LinqToDB
 		/// </summary>
 		public IDataContext DataContext => _table.DataContext;
 
-		IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQuery() => _table.GetSqlQuery();
-		Expression              IExpressionQuery.Expression    => ((IExpressionQuery)_table).Expression;
+		IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options) => _table.GetSqlQueries(options);
+		Expression              IExpressionQuery.Expression                                   => ((IExpressionQuery)_table).Expression;
 
 		#endregion
 

--- a/Source/LinqToDB/TempTable.cs
+++ b/Source/LinqToDB/TempTable.cs
@@ -715,8 +715,8 @@ namespace LinqToDB
 		/// </summary>
 		public IDataContext DataContext => _table.DataContext;
 
-		string       IExpressionQuery.SqlText    => _table.SqlText;
-		Expression   IExpressionQuery.Expression => ((IExpressionQuery)_table).Expression;
+		IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQuery() => _table.GetSqlQuery();
+		Expression              IExpressionQuery.Expression    => ((IExpressionQuery)_table).Expression;
 
 		#endregion
 

--- a/Tests/Base/ProviderNameHelpers.cs
+++ b/Tests/Base/ProviderNameHelpers.cs
@@ -14,7 +14,7 @@ namespace Tests
 		/// <param name="providers">List of test providers to check against. Each entry could be provider name or comma-separated list of providers.</param>
 		public static bool IsAnyOf(this string context, params string[] providers)
 		{
-			var providerName = context.Replace(TestBase.LinqServiceSuffix, string.Empty);
+			var providerName = context.StripRemote();
 			foreach (var provider in providers)
 			{
 				if (provider.Split(',').Any(p => p == providerName))
@@ -22,6 +22,16 @@ namespace Tests
 			}
 
 			return false;
+		}
+
+		public static bool IsUseParameters(this string context)
+		{
+			return !context.IsAnyOf(TestProvName.AllClickHouse);
+		}
+
+		public static bool IsUsePositionalParameters(this string context)
+		{
+			return context.IsAnyOf(TestProvName.AllSapHana, TestProvName.AllAccessOdbc);
 		}
 
 		/// <summary>

--- a/Tests/Base/QueryUtils.cs
+++ b/Tests/Base/QueryUtils.cs
@@ -24,7 +24,7 @@ namespace Tests
 
 		private static void InitParameters<T>(IExpressionQuery eq, Query<T> info, IQueryExpressions expressions)
 		{
-			eq.DataContext.GetQueryRunner(info, eq.DataContext, 0, expressions, null, null).GetSqlText(null);
+			eq.DataContext.GetQueryRunner(info, eq.DataContext, 0, expressions, null, null).GetSqlText();
 		}
 
 		public static SelectQuery GetSelectQuery<T>(this IQueryable<T> query)

--- a/Tests/Base/QueryUtils.cs
+++ b/Tests/Base/QueryUtils.cs
@@ -24,7 +24,7 @@ namespace Tests
 
 		private static void InitParameters<T>(IExpressionQuery eq, Query<T> info, IQueryExpressions expressions)
 		{
-			eq.DataContext.GetQueryRunner(info, eq.DataContext, 0, expressions, null, null).GetSqlText();
+			eq.DataContext.GetQueryRunner(info, eq.DataContext, 0, expressions, null, null).GetSqlText(null);
 		}
 
 		public static SelectQuery GetSelectQuery<T>(this IQueryable<T> query)

--- a/Tests/EntityFrameworkCore/Tests/ToolsTests.cs
+++ b/Tests/EntityFrameworkCore/Tests/ToolsTests.cs
@@ -228,8 +228,6 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 
 			query = query.ToLinqToDB();
 
-			var str = query.ToString();
-
 			var items = query.ToArray();
 		}
 
@@ -776,7 +774,7 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 			var resultEF = query.ToArray();
 			var result = query.ToLinqToDB().ToArray();
 
-			var str = query.ToLinqToDB().ToString();
+			var str = query.ToLinqToDB().ToSqlQuery().Sql;
 
 			AreEqual(resultEF, result);
 

--- a/Tests/FSharp/SelectTest.fs
+++ b/Tests/FSharp/SelectTest.fs
@@ -13,7 +13,7 @@ let SelectField (db : IDataContext) =
         select p.LastName
     }
 
-    let sql = "" + q.ToString()
+    let sql = q.ToSqlQuery().Sql
     Assert.That(sql.IndexOf("First"), Is.LessThan 0)
     Assert.That(sql.IndexOf("LastName"), Is.GreaterThan 0)
 
@@ -24,7 +24,7 @@ let SelectFieldDeeplyComplexPerson (db : IDataContext) =
         select p.Name.LastName.Value
     }
 
-    let sql = "" + q.ToString()
+    let sql = q.ToSqlQuery().Sql
     Assert.That(sql.IndexOf("First"), Is.LessThan 0)
     Assert.That(sql.IndexOf("LastName"), Is.GreaterThan 0)
 

--- a/Tests/FSharp/SelectTest.fs
+++ b/Tests/FSharp/SelectTest.fs
@@ -13,6 +13,8 @@ let SelectField (db : IDataContext) =
         select p.LastName
     }
 
+    q.ToArray |> ignore
+
     let sql = q.ToSqlQuery().Sql
     Assert.That(sql.IndexOf("First"), Is.LessThan 0)
     Assert.That(sql.IndexOf("LastName"), Is.GreaterThan 0)
@@ -23,6 +25,8 @@ let SelectFieldDeeplyComplexPerson (db : IDataContext) =
         for p in persons do
         select p.Name.LastName.Value
     }
+
+    q.ToArray |> ignore
 
     let sql = q.ToSqlQuery().Sql
     Assert.That(sql.IndexOf("First"), Is.LessThan 0)

--- a/Tests/Linq/Data/DataExtensionsTests.cs
+++ b/Tests/Linq/Data/DataExtensionsTests.cs
@@ -129,7 +129,7 @@ namespace Tests.Data
 			using (var conn = GetDataConnection(context))
 			{
 				conn.InlineParameters = true;
-				var sql = conn.Person.Where(p => p.ID == 1).Select(p => p.FirstName).Take(1).ToString()!;
+				var sql = conn.Person.Where(p => p.ID == 1).Select(p => p.FirstName).Take(1).ToSqlQuery().Sql;
 				sql = string.Join(Environment.NewLine, sql.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
 					.Where(line => !line.StartsWith("--")));
 				var res = conn.Execute<string>(sql);

--- a/Tests/Linq/Data/DataExtensionsTests.cs
+++ b/Tests/Linq/Data/DataExtensionsTests.cs
@@ -130,8 +130,6 @@ namespace Tests.Data
 			{
 				conn.InlineParameters = true;
 				var sql = conn.Person.Where(p => p.ID == 1).Select(p => p.FirstName).Take(1).ToSqlQuery().Sql;
-				sql = string.Join(Environment.NewLine, sql.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-					.Where(line => !line.StartsWith("--")));
 				var res = conn.Execute<string>(sql);
 
 				Assert.That(res, Is.EqualTo("John"));

--- a/Tests/Linq/Data/TraceTests.cs
+++ b/Tests/Linq/Data/TraceTests.cs
@@ -166,7 +166,7 @@ namespace Tests.Data
 
 			using (var db = GetDataConnection(context))
 			{
-				var sql = db.GetTable<Northwind.Category>().SqlText;
+				var sql = db.GetTable<Northwind.Category>().ToSqlQuery().Sql;
 				db.OnTraceConnection = e =>
 				{
 					events[e.TraceInfoStep] = e;
@@ -206,7 +206,7 @@ namespace Tests.Data
 
 			using (var db = GetDataConnection(context))
 			{
-				var sql = db.GetTable<Northwind.Category>().SqlText;
+				var sql = db.GetTable<Northwind.Category>().ToSqlQuery().Sql;
 				db.OnTraceConnection = e =>
 				{
 					events[e.TraceInfoStep] = e;
@@ -246,7 +246,7 @@ namespace Tests.Data
 
 			using (var db = new DataConnection(context))
 			{
-				var sql = db.GetTable<Northwind.Category>().SqlText;
+				var sql = db.GetTable<Northwind.Category>().ToSqlQuery().Sql;
 				db.OnTraceConnection = e =>
 				{
 					events[e.TraceInfoStep] = e;
@@ -284,7 +284,7 @@ namespace Tests.Data
 
 			using (var db = new DataConnection(context))
 			{
-				var sql = db.GetTable<Northwind.Category>().SqlText;
+				var sql = db.GetTable<Northwind.Category>().ToSqlQuery().Sql;
 				db.OnTraceConnection = e =>
 				{
 					events[e.TraceInfoStep] = e;
@@ -482,7 +482,7 @@ namespace Tests.Data
 
 			using (var db = new DataConnection(context))
 			{
-				var sql = db.GetTable<Northwind.Category>().SqlText;
+				var sql = db.GetTable<Northwind.Category>().ToSqlQuery().Sql;
 				db.OnTraceConnection = e =>
 				{
 					events[e.TraceInfoStep] = e;

--- a/Tests/Linq/DataProvider/AccessTests.cs
+++ b/Tests/Linq/DataProvider/AccessTests.cs
@@ -117,18 +117,13 @@ namespace Tests.DataProvider
 
 					var sql = string.Format(CultureInfo.InvariantCulture, "SELECT {0}({1})", sqlType, sqlValue);
 
-					Debug.WriteLine(sql + " -> " + typeof(T));
-
 					Assert.That(conn.Execute<T>(sql), Is.EqualTo(expectedValue));
 				}
 
 			var querySql = isODBCNull ? $"SELECT CVar({param})" : $"SELECT {param}";
 
-			Debug.WriteLine("{0} -> DataType.{1}", typeof(T), dataType);
 			Assert.That(conn.Execute<T>(querySql, new DataParameter { Name = "p", DataType = dataType, Value = expectedValue }), Is.EqualTo(expectedValue));
-			Debug.WriteLine("{0} -> auto", typeof(T));
 			Assert.That(conn.Execute<T>(querySql, new DataParameter { Name = "p", Value = expectedValue }), Is.EqualTo(expectedValue));
-			Debug.WriteLine("{0} -> new", typeof(T));
 			Assert.That(conn.Execute<T>(querySql, new { p = expectedValue }), Is.EqualTo(expectedValue));
 		}
 

--- a/Tests/Linq/DataProvider/DB2Tests.cs
+++ b/Tests/Linq/DataProvider/DB2Tests.cs
@@ -135,17 +135,12 @@ namespace Tests.DataProvider
 
 				var sql = string.Format(CultureInfo.InvariantCulture, "SELECT Cast({0} as {1}) FROM SYSIBM.SYSDUMMY1", sqlValue ?? "NULL", sqlType);
 
-				Debug.WriteLine(sql + " -> " + typeof(T));
-
 				Assert.That(conn.Execute<T>(sql), Is.EqualTo(expectedValue));
 			}
 
 			// [IBM][DB2/LINUXX8664] SQL0418N  The statement was not processed because the statement contains an invalid use of one of the following: an untyped parameter marker, the DEFAULT keyword, or a null value.
-//			Debug.WriteLine("{0} -> DataType.{1}",  typeof(T), dataType);
 //			Assert.That(conn.Execute<T>("SELECT @p FROM SYSIBM.SYSDUMMY1", new DataParameter { Name = "p", DataType = dataType, Value = expectedValue }), Is.EqualTo(expectedValue));
-//			Debug.WriteLine("{0} -> auto", typeof(T));
 //			Assert.That(conn.Execute<T>("SELECT @p FROM SYSIBM.SYSDUMMY1", new DataParameter { Name = "p", Value = expectedValue }), Is.EqualTo(expectedValue));
-//			Debug.WriteLine("{0} -> new",  typeof(T));
 //			Assert.That(conn.Execute<T>("SELECT @p FROM SYSIBM.SYSDUMMY1", new { p = expectedValue }), Is.EqualTo(expectedValue));
 		}
 
@@ -454,7 +449,6 @@ namespace Tests.DataProvider
 							MaxBatchSize       = maxSize,
 							BulkCopyType       = bulkCopyType,
 							NotifyAfter        = 10000,
-							RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied)
 						},
 						Enumerable.Range(0, batchSize).Select(n =>
 							new ALLTYPE
@@ -501,7 +495,6 @@ namespace Tests.DataProvider
 							MaxBatchSize       = maxSize,
 							BulkCopyType       = bulkCopyType,
 							NotifyAfter        = 10000,
-							RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied)
 						},
 						Enumerable.Range(0, batchSize).Select(n =>
 							new ALLTYPE

--- a/Tests/Linq/DataProvider/FirebirdTests.cs
+++ b/Tests/Linq/DataProvider/FirebirdTests.cs
@@ -109,8 +109,6 @@ namespace Tests.DataProvider
 					"SELECT NULL FROM \"Dual\"" :
 					string.Format(CultureInfo.InvariantCulture, "SELECT Cast({0} as {1}) FROM \"Dual\"", sqlValue, sqlType);
 
-				Debug.WriteLine(sql + " -> " + typeof(T));
-
 				Assert.That(conn.Execute<T>(sql), Is.EqualTo(expectedValue));
 			}
 
@@ -132,17 +130,14 @@ namespace Tests.DataProvider
 					dataType == DataType.SmallMoney ? "SELECT Cast(@p as decimal(18)) FROM \"Dual\"" :
 													  "SELECT @p                      FROM \"Dual\"";
 
-				Debug.WriteLine("{0} -> DataType.{1}",  typeof(T), dataType);
 				var value = conn.Execute<T>(sql, new DataParameter { Name = "p", DataType = dataType, Value = expectedValue });
 				if (!(value is double))
 					Assert.That(value, Is.EqualTo(expectedValue));
 
-				Debug.WriteLine("{0} -> auto", typeof(T));
 				value = conn.Execute<T>(sql, new DataParameter { Name = "p", Value = expectedValue });
 				if (!(value is double))
 					Assert.That(value, Is.EqualTo(expectedValue));
 
-				Debug.WriteLine("{0} -> new",  typeof(T));
 				value = conn.Execute<T>(sql, new { p = expectedValue });
 				if (!(value is double))
 					Assert.That(value, Is.EqualTo(expectedValue));

--- a/Tests/Linq/DataProvider/InformixTests.cs
+++ b/Tests/Linq/DataProvider/InformixTests.cs
@@ -240,7 +240,6 @@ namespace Tests.DataProvider
 						new BulkCopyOptions
 						{
 							BulkCopyType       = BulkCopyType.MultipleRows,
-							RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied)
 						},
 						Enumerable.Range(0, 10).Select(n =>
 							new DataTypes
@@ -277,7 +276,6 @@ namespace Tests.DataProvider
 						new BulkCopyOptions
 						{
 							BulkCopyType       = BulkCopyType.MultipleRows,
-							RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied)
 						},
 						Enumerable.Range(0, 10).Select(n =>
 							new DataTypes
@@ -314,7 +312,6 @@ namespace Tests.DataProvider
 						new BulkCopyOptions
 						{
 							BulkCopyType       = BulkCopyType.ProviderSpecific,
-							RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied)
 						},
 						Enumerable.Range(0, 10).Select(n =>
 							new DataTypes
@@ -351,7 +348,6 @@ namespace Tests.DataProvider
 						new BulkCopyOptions
 						{
 							BulkCopyType       = BulkCopyType.ProviderSpecific,
-							RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied)
 						},
 						Enumerable.Range(0, 10).Select(n =>
 							new DataTypes
@@ -394,7 +390,6 @@ namespace Tests.DataProvider
 						new BulkCopyOptions
 						{
 							BulkCopyType       = bulkCopyType,
-							RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied),
 							KeepIdentity       = keepIdentity
 						},
 						_allTypeses);
@@ -432,7 +427,6 @@ namespace Tests.DataProvider
 						new BulkCopyOptions
 						{
 							BulkCopyType = bulkCopyType,
-							RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied),
 							KeepIdentity = keepIdentity
 						},
 						_allTypeses);

--- a/Tests/Linq/DataProvider/MySqlTests.cs
+++ b/Tests/Linq/DataProvider/MySqlTests.cs
@@ -956,7 +956,6 @@ namespace Tests.DataProvider
 					KeepIdentity = true,
 					BulkCopyType = bulkCopyType,
 					NotifyAfter = 3,
-					RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied)
 				};
 
 				db.BulkCopy(options, data.RetrieveIdentity(db));
@@ -987,7 +986,6 @@ namespace Tests.DataProvider
 					KeepIdentity = true,
 					BulkCopyType = bulkCopyType,
 					NotifyAfter = 3,
-					RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied)
 				};
 
 				await db.BulkCopyAsync(options, data.RetrieveIdentity(db));

--- a/Tests/Linq/DataProvider/OracleTests.cs
+++ b/Tests/Linq/DataProvider/OracleTests.cs
@@ -191,16 +191,11 @@ namespace Tests.DataProvider
 
 				var sql = string.Format(CultureInfo.InvariantCulture, "SELECT Cast({0} as {1}) FROM sys.dual", sqlValue ?? "NULL", sqlType);
 
-				Debug.WriteLine(sql + " -> " + typeof(T));
-
 				Assert.That(conn.Execute<T>(sql), Is.EqualTo(expectedValue));
 			}
 
-			Debug.WriteLine("{0} -> DataType.{1}",  typeof(T), dataType);
 			Assert.That(conn.Execute<T>(PathThroughSql, new DataParameter { Name = "p", DataType = dataType, Value = expectedValue }), Is.EqualTo(expectedValue));
-			Debug.WriteLine("{0} -> auto", typeof(T));
 			Assert.That(conn.Execute<T>(PathThroughSql, new DataParameter { Name = "p", Value = expectedValue }), Is.EqualTo(expectedValue));
-			Debug.WriteLine("{0} -> new",  typeof(T));
 			Assert.That(conn.Execute<T>(PathThroughSql, new { p = expectedValue }), Is.EqualTo(expectedValue));
 		}
 
@@ -876,8 +871,7 @@ namespace Tests.DataProvider
 
 				db.AddMappingSchema(ms);
 
-				var res = db.GetTable<AllTypes>().Where(e => e.datetime2DataType == TestData.DateTime).ToList();
-				Debug.WriteLine(res.Count);
+				db.GetTable<AllTypes>().Where(e => e.datetime2DataType == TestData.DateTime).ToList();
 			}
 		}
 
@@ -1336,7 +1330,6 @@ namespace Tests.DataProvider
 					KeepIdentity       = bulkCopyType != BulkCopyType.RowByRow,
 					BulkCopyType       = bulkCopyType,
 					NotifyAfter        = 3,
-					RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied)
 				};
 
 				db.BulkCopy(options, data.RetrieveIdentity(db));
@@ -1371,7 +1364,6 @@ namespace Tests.DataProvider
 					KeepIdentity       = bulkCopyType != BulkCopyType.RowByRow,
 					BulkCopyType       = bulkCopyType,
 					NotifyAfter        = 3,
-					RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied)
 				};
 
 				await db.BulkCopyAsync(options, data.RetrieveIdentity(db));
@@ -1418,7 +1410,6 @@ namespace Tests.DataProvider
 					MaxBatchSize = 5,
 					BulkCopyType = bulkCopyType,
 					NotifyAfter  = 3,
-					RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied)
 				};
 
 				db.BulkCopy(options, data);
@@ -1448,7 +1439,6 @@ namespace Tests.DataProvider
 					MaxBatchSize = 5,
 					BulkCopyType = bulkCopyType,
 					NotifyAfter  = 3,
-					RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied)
 				};
 
 				await db.BulkCopyAsync(options, data);

--- a/Tests/Linq/DataProvider/PostgreSQLTests.cs
+++ b/Tests/Linq/DataProvider/PostgreSQLTests.cs
@@ -2263,7 +2263,7 @@ namespace Tests.DataProvider
 						StringValue = TestPgFunctions.Unnest(t.StringArray)
 					};
 
-				var str = query.ToString();
+				var str = query.ToSqlQuery().Sql;
 				TestContext.Out.WriteLine(str);
 			}
 		}
@@ -2280,7 +2280,7 @@ namespace Tests.DataProvider
 						StringValue = TestPgFunctions.Unnest(t.StringArray)
 					};
 
-				var str = query.ToString();
+				var str = query.ToSqlQuery().Sql;
 				TestContext.Out.WriteLine(str);
 			}
 		}

--- a/Tests/Linq/DataProvider/PostgreSQLTests.cs
+++ b/Tests/Linq/DataProvider/PostgreSQLTests.cs
@@ -240,16 +240,11 @@ namespace Tests.DataProvider
 
 				var sql = string.Format("SELECT Cast({0} as {1})", sqlValue ?? "NULL", sqlType);
 
-				Debug.WriteLine(sql + " -> " + typeof(T));
-
 				Assert.That(conn.Execute<T>(sql), Is.EqualTo(expectedValue));
 			}
 
-			Debug.WriteLine("{0} -> DataType.{1}", typeof(T), dataType);
 			Assert.That(conn.Execute<T>("SELECT :p", new DataParameter { Name = "p", DataType = dataType, Value = expectedValue }), Is.EqualTo(expectedValue));
-			Debug.WriteLine("{0} -> auto", typeof(T));
 			Assert.That(conn.Execute<T>("SELECT :p", new DataParameter { Name = "p", Value = expectedValue }), Is.EqualTo(expectedValue));
-			Debug.WriteLine("{0} -> new", typeof(T));
 			Assert.That(conn.Execute<T>("SELECT :p", new { p = expectedValue }), Is.EqualTo(expectedValue));
 		}
 
@@ -2247,7 +2242,7 @@ namespace Tests.DataProvider
 
 		sealed class TableWithArray
 		{
-			[Column]
+			[Column(DbType = "text[]")]
 			public string[] StringArray { get; set; } = null!;
 		}
 
@@ -2255,34 +2250,32 @@ namespace Tests.DataProvider
 		public void UnnestTest([IncludeDataSources(TestProvName.AllPostgreSQL)]
 			string context)
 		{
-			using (var db = GetDataContext(context))
-			{
-				var query = from t in db.GetTable<TableWithArray>()
-					select new
-					{
-						StringValue = TestPgFunctions.Unnest(t.StringArray)
-					};
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<TableWithArray>();
 
-				var str = query.ToSqlQuery().Sql;
-				TestContext.Out.WriteLine(str);
-			}
+			var query = from t in db.GetTable<TableWithArray>()
+				select new
+				{
+					StringValue = TestPgFunctions.Unnest(t.StringArray)
+				};
+
+			query.ToArray();
 		}
 
 		[Test]
 		public void UnnestTest2([IncludeDataSources(TestProvName.AllPostgreSQL)]
 			string context)
 		{
-			using (var db = GetDataContext(context))
-			{
-				var query = from t in db.GetTable<TableWithArray>()
-					select new
-					{
-						StringValue = TestPgFunctions.Unnest(t.StringArray)
-					};
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<TableWithArray>();
 
-				var str = query.ToSqlQuery().Sql;
-				TestContext.Out.WriteLine(str);
-			}
+			var query = from t in db.GetTable<TableWithArray>()
+				select new
+				{
+					StringValue = TestPgFunctions.Unnest(t.StringArray)
+				};
+
+			query.ToArray();
 		}
 
 		public class DataTypeBinaryMapping

--- a/Tests/Linq/DataProvider/SQLiteParameterTests.cs
+++ b/Tests/Linq/DataProvider/SQLiteParameterTests.cs
@@ -60,7 +60,7 @@ namespace Tests.DataProvider
 					Assert.That(query.GetStatement().CollectParameters(), Is.Empty);
 #pragma warning restore CS0618 // Type or member is obsolete
 
-					Assert.That(query.ToString(), Does.Not.Contain("DateTime("));
+					Assert.That(query.ToSqlQuery().Sql, Does.Not.Contain("DateTime("));
 				});
 			}
 		}

--- a/Tests/Linq/DataProvider/SQLiteParameterTests.cs
+++ b/Tests/Linq/DataProvider/SQLiteParameterTests.cs
@@ -46,23 +46,24 @@ namespace Tests.DataProvider
 			ms.SetConverter<long, DateTime>(ticks => new DateTime(ticks, DateTimeKind.Unspecified));
 			ms.SetConverter<DateTime, DataParameter>(d => new DataParameter("", d.Ticks, DataType.Long));
 
-			using (var db = GetDataContext(context, ms))
+			using var db = GetDataContext(context, ms);
+			using var tb = db.CreateLocalTable<ClassWithIntDate>();
+			db.InlineParameters = true;
+
+			var query = from t in db.GetTable<ClassWithIntDate>()
+						where t.Value > TestData.DateTime
+						select t;
+
+			query.ToArray();
+
+			Assert.Multiple(() =>
 			{
-				db.InlineParameters = true;
-
-				var query = from t in db.GetTable<ClassWithIntDate>()
-							where t.Value > TestData.DateTime
-							select t;
-
-				Assert.Multiple(() =>
-				{
 #pragma warning disable CS0618 // Type or member is obsolete
-					Assert.That(query.GetStatement().CollectParameters(), Is.Empty);
+				Assert.That(query.GetStatement().CollectParameters(), Is.Empty);
 #pragma warning restore CS0618 // Type or member is obsolete
 
-					Assert.That(query.ToSqlQuery().Sql, Does.Not.Contain("DateTime("));
-				});
-			}
+				Assert.That(query.ToSqlQuery().Sql, Does.Not.Contain("DateTime("));
+			});
 		}
 
 		[Test]

--- a/Tests/Linq/DataProvider/SQLiteTests.cs
+++ b/Tests/Linq/DataProvider/SQLiteTests.cs
@@ -137,11 +137,8 @@ namespace Tests.DataProvider
 
 			conn.InlineParameters = false;
 
-			Debug.WriteLine("{0} -> DataType.{1}",  typeof(T), dataType);
 			Assert.That(conn.Execute<T>("SELECT @p", new DataParameter { Name = "p", DataType = dataType, Value = expectedValue }), Is.EqualTo(expectedValue));
-			Debug.WriteLine("{0} -> auto", typeof(T));
 			Assert.That(conn.Execute<T>("SELECT @p", new DataParameter { Name = "p", Value = expectedValue }), Is.EqualTo(expectedValue));
-			Debug.WriteLine("{0} -> new",  typeof(T));
 			Assert.That(conn.Execute<T>("SELECT @p", new { p = expectedValue }), Is.EqualTo(expectedValue));
 		}
 

--- a/Tests/Linq/DataProvider/SapHanaTests.cs
+++ b/Tests/Linq/DataProvider/SapHanaTests.cs
@@ -715,6 +715,10 @@ namespace Tests.DataProvider
 			{
 				var query1 = ctx.CaParamTest(10, 10.01, "mandatory1", null, null, "optional1");
 				var query2 = ctx.CaParamTest(100, 100.001, "mandatory2", null, 10.1, "optional2");
+
+				query1.ToArray();
+				query2.ToArray();
+
 				Assert.That(query1.ToSqlQuery().Sql, Is.Not.EqualTo(query2.ToSqlQuery().Sql));
 			}
 		}

--- a/Tests/Linq/DataProvider/SapHanaTests.cs
+++ b/Tests/Linq/DataProvider/SapHanaTests.cs
@@ -715,7 +715,7 @@ namespace Tests.DataProvider
 			{
 				var query1 = ctx.CaParamTest(10, 10.01, "mandatory1", null, null, "optional1");
 				var query2 = ctx.CaParamTest(100, 100.001, "mandatory2", null, 10.1, "optional2");
-				Assert.That(query1.SqlText, Is.Not.EqualTo(query2.SqlText));
+				Assert.That(query1.ToSqlQuery().Sql, Is.Not.EqualTo(query2.ToSqlQuery().Sql));
 			}
 		}
 

--- a/Tests/Linq/DataProvider/SqlCeTests.cs
+++ b/Tests/Linq/DataProvider/SqlCeTests.cs
@@ -102,16 +102,11 @@ namespace Tests.DataProvider
 
 				var sql = string.Format(CultureInfo.InvariantCulture, "SELECT Cast({0} as {1})", sqlValue ?? "NULL", sqlType);
 
-				Debug.WriteLine(sql + " -> " + typeof(T));
-
 				Assert.That(conn.Execute<T>(sql), Is.EqualTo(expectedValue));
 			}
 
-			Debug.WriteLine("{0} -> DataType.{1}",  typeof(T), dataType);
 			Assert.That(conn.Execute<T>("SELECT @p + 0", new DataParameter { Name = "p", DataType = dataType, Value = expectedValue }), Is.EqualTo(expectedValue));
-			Debug.WriteLine("{0} -> auto", typeof(T));
 			Assert.That(conn.Execute<T>("SELECT @p + 0", new DataParameter { Name = "p", Value = expectedValue }), Is.EqualTo(expectedValue));
-			Debug.WriteLine("{0} -> new",  typeof(T));
 			Assert.That(conn.Execute<T>("SELECT @p + 0", new { p = expectedValue }), Is.EqualTo(expectedValue));
 		}
 

--- a/Tests/Linq/DataProvider/SqlServerTests.cs
+++ b/Tests/Linq/DataProvider/SqlServerTests.cs
@@ -154,16 +154,11 @@ namespace Tests.DataProvider
 
 				var sql = string.Format(CultureInfo.InvariantCulture, "SELECT Cast({0} as {1})", sqlValue ?? "NULL", sqlType);
 
-				Debug.WriteLine(sql + " -> " + typeof(T));
-
 				Assert.That(conn.Execute<T>(sql), Is.EqualTo(expectedValue));
 			}
 
-			Debug.WriteLine("{0} -> DataType.{1}",  typeof(T), dataType);
 			Assert.That(conn.Execute<T>("SELECT @p", new DataParameter { Name = "p", DataType = dataType, Value = expectedValue }), Is.EqualTo(expectedValue));
-			Debug.WriteLine("{0} -> auto", typeof(T));
 			Assert.That(conn.Execute<T>("SELECT @p", new DataParameter { Name = "p", Value = expectedValue }), Is.EqualTo(expectedValue));
-			Debug.WriteLine("{0} -> new",  typeof(T));
 			Assert.That(conn.Execute<T>("SELECT @p", new { p = expectedValue }), Is.EqualTo(expectedValue));
 		}
 
@@ -895,7 +890,6 @@ namespace Tests.DataProvider
 						new BulkCopyOptions
 						{
 							BulkCopyType       = BulkCopyType.MultipleRows,
-							RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied)
 						},
 						Enumerable.Range(0, 10).Select(n =>
 							new DataTypes
@@ -927,7 +921,6 @@ namespace Tests.DataProvider
 						new BulkCopyOptions
 						{
 							BulkCopyType       = BulkCopyType.MultipleRows,
-							RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied)
 						},
 						Enumerable.Range(0, 10).Select(n =>
 							new DataTypes
@@ -959,7 +952,6 @@ namespace Tests.DataProvider
 						new BulkCopyOptions
 						{
 							BulkCopyType       = BulkCopyType.ProviderSpecific,
-							RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied)
 						},
 						Enumerable.Range(0, 10).Select(n =>
 							new DataTypes
@@ -991,7 +983,6 @@ namespace Tests.DataProvider
 						new BulkCopyOptions
 						{
 							BulkCopyType       = BulkCopyType.ProviderSpecific,
-							RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied)
 						},
 						Enumerable.Range(0, 10).Select(n =>
 							new DataTypes
@@ -1141,7 +1132,6 @@ namespace Tests.DataProvider
 						new BulkCopyOptions
 						{
 							BulkCopyType       = bulkCopyType,
-							RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied),
 							KeepIdentity       = true,
 						},
 						_allTypeses);
@@ -1176,7 +1166,6 @@ namespace Tests.DataProvider
 						new BulkCopyOptions
 						{
 							BulkCopyType       = bulkCopyType,
-							RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied),
 							KeepIdentity       = true,
 						},
 						_allTypeses);
@@ -1302,7 +1291,6 @@ namespace Tests.DataProvider
 					new BulkCopyOptions
 					{
 						BulkCopyType       = bulkCopyType,
-						RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied),
 						KeepIdentity       = true,
 					},
 					allTypes2);
@@ -1332,7 +1320,6 @@ namespace Tests.DataProvider
 					new BulkCopyOptions
 					{
 						BulkCopyType       = bulkCopyType,
-						RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied),
 						KeepIdentity       = true,
 					},
 					allTypes2);

--- a/Tests/Linq/DataProvider/SybaseTests.cs
+++ b/Tests/Linq/DataProvider/SybaseTests.cs
@@ -127,8 +127,6 @@ namespace Tests.DataProvider
 
 				var sql = string.Format(CultureInfo.InvariantCulture, "SELECT Cast({0} as {1})", sqlValue ?? "NULL", sqlType);
 
-				Debug.WriteLine(sql + " -> " + typeof(T));
-
 				Assert.That(conn.Execute<T>(sql), Is.EqualTo(expectedValue));
 			}
 
@@ -137,11 +135,8 @@ namespace Tests.DataProvider
 					"SELECT Cast(@p as decimal(38))" :
 					"SELECT @p";
 
-				Debug.WriteLine("{0} -> DataType.{1}",  typeof(T), dataType);
 				Assert.That(conn.Execute<T>(sql, new DataParameter { Name = "p", DataType = dataType, Value = expectedValue }), Is.EqualTo(expectedValue));
-				Debug.WriteLine("{0} -> auto", typeof(T));
 				Assert.That(conn.Execute<T>(sql, new DataParameter { Name = "p", Value = expectedValue }), Is.EqualTo(expectedValue));
-				Debug.WriteLine("{0} -> new",  typeof(T));
 				Assert.That(conn.Execute<T>(sql, new { p = expectedValue }), Is.EqualTo(expectedValue));
 			}
 		}
@@ -875,7 +870,6 @@ namespace Tests.DataProvider
 						new BulkCopyOptions
 						{
 							BulkCopyType = BulkCopyType.MultipleRows,
-							RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied)
 						},
 						Enumerable.Range(0, 10).Select(n =>
 							new DataTypes
@@ -912,7 +906,6 @@ namespace Tests.DataProvider
 						new BulkCopyOptions
 						{
 							BulkCopyType = BulkCopyType.MultipleRows,
-							RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied)
 						},
 						Enumerable.Range(0, 10).Select(n =>
 							new DataTypes
@@ -949,7 +942,6 @@ namespace Tests.DataProvider
 						new BulkCopyOptions
 						{
 							BulkCopyType = BulkCopyType.ProviderSpecific,
-							RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied)
 						},
 						Enumerable.Range(0, 10).Select(n =>
 							new DataTypes
@@ -986,7 +978,6 @@ namespace Tests.DataProvider
 						new BulkCopyOptions
 						{
 							BulkCopyType = BulkCopyType.ProviderSpecific,
-							RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied)
 						},
 						Enumerable.Range(0, 10).Select(n =>
 							new DataTypes
@@ -1027,7 +1018,6 @@ namespace Tests.DataProvider
 						new BulkCopyOptions
 						{
 							BulkCopyType       = bulkCopyType,
-							RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied),
 							KeepIdentity       = true,
 						},
 						_allTypeses);
@@ -1063,7 +1053,6 @@ namespace Tests.DataProvider
 						new BulkCopyOptions
 						{
 							BulkCopyType = bulkCopyType,
-							RowsCopiedCallback = copied => Debug.WriteLine(copied.RowsCopied),
 							KeepIdentity = true,
 						},
 						_allTypeses);

--- a/Tests/Linq/Extensions/QueryExtensionTests.cs
+++ b/Tests/Linq/Extensions/QueryExtensionTests.cs
@@ -38,9 +38,10 @@ namespace Tests.Extensions
 		}
 
 		[Test]
-		public void SelfJoinWithDifferentHintTest2([NorthwindDataContext] string context)
+		public void SelfJoinWithDifferentHintTest2([NorthwindDataContext(true)] string context)
 		{
 			using var db = new NorthwindDB(context);
+			using var tb = db.CreateLocalTable<JoinOptimizeTests.AdressEntity>();
 
 			var query =
 				from p in db.GetTable<JoinOptimizeTests.AdressEntity>().TableHint("NOLOCK")
@@ -48,7 +49,7 @@ namespace Tests.Extensions
 					on p.Id equals a.Id //PK column
 				select p;
 
-			Debug.WriteLine(query);
+			query.ToArray();
 
 			Assert.That(query.GetTableSource().Joins, Has.Count.EqualTo(1));
 		}

--- a/Tests/Linq/Extensions/QueryHintsTests.cs
+++ b/Tests/Linq/Extensions/QueryHintsTests.cs
@@ -25,7 +25,7 @@ namespace Tests.Extensions
 
 				var str = q.ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(str);
+				BaselinesManager.LogQuery(str);
 
 				Assert.That(str, Contains.Substring("---"));
 				Assert.That(str, Contains.Substring("----"));
@@ -42,7 +42,7 @@ namespace Tests.Extensions
 
 				str = q.ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(str);
+				BaselinesManager.LogQuery(str);
 
 				Assert.That(str, Contains.Substring("---"));
 				Assert.That(str, Is.Not.Contains("----"));

--- a/Tests/Linq/Extensions/QueryHintsTests.cs
+++ b/Tests/Linq/Extensions/QueryHintsTests.cs
@@ -23,7 +23,7 @@ namespace Tests.Extensions
 
 				var q = db.Parent.Select(p => p);
 
-				var str = q.ToString();
+				var str = q.ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(str);
 
@@ -40,7 +40,7 @@ namespace Tests.Extensions
 					Assert.That(ctx.LastQuery, Contains.Substring("----"));
 				}
 
-				str = q.ToString();
+				str = q.ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(str);
 
@@ -84,7 +84,7 @@ namespace Tests.Extensions
 				db.NextQueryHints.Add(oneTimeHint);
 
 				var query = db.Parent.Where(r => r.ParentID == 11);
-				var sql = db is DataConnection ? null : query.ToString();
+				var sql = db is DataConnection ? null : query.ToSqlQuery().Sql;
 				await query.ToListAsync();
 				if (db is DataConnection dc) sql = dc.LastQuery!;
 
@@ -93,7 +93,7 @@ namespace Tests.Extensions
 				Assert.That(sql, Does.Contain(oneTimeHint), $"(1) expected {oneTimeHint}. Has alien hint: {sql.Contains("once")}");
 
 				query = db.Parent.Where(r => r.ParentID == 11);
-				sql = db is DataConnection ? null : query.ToString();
+				sql = db is DataConnection ? null : query.ToSqlQuery().Sql;
 				await query.ToListAsync();
 				if (db is DataConnection dc2) sql = dc2.LastQuery!;
 

--- a/Tests/Linq/Extensions/SqlServerTests.cs
+++ b/Tests/Linq/Extensions/SqlServerTests.cs
@@ -70,7 +70,7 @@ namespace Tests.Extensions
 
 			_ = q.ToList();
 
-			Assert.That(q.ToString(), Contains.Substring($"WITH ({hint})"));
+			Assert.That(q.ToSqlQuery().Sql, Contains.Substring($"WITH ({hint})"));
 		}
 
 		[Test]

--- a/Tests/Linq/Infrastructure/DataOptionsTests.cs
+++ b/Tests/Linq/Infrastructure/DataOptionsTests.cs
@@ -312,7 +312,7 @@ namespace Tests.Infrastructure
 				// global handler set
 				using (var db = GetDataContext(context))
 				{
-					db.GetTable<EntityDescriptorTable>().ToString();
+					_ = db.GetTable<EntityDescriptorTable>().ToSqlQuery().Sql;
 				}
 
 				Assert.Multiple(() =>
@@ -329,7 +329,7 @@ namespace Tests.Infrastructure
 					localTriggrered = true;
 				})))
 				{
-					db.GetTable<EntityDescriptorTable>().ToString();
+					_ = db.GetTable<EntityDescriptorTable>().ToSqlQuery().Sql;
 				}
 
 				Assert.Multiple(() =>
@@ -342,7 +342,7 @@ namespace Tests.Infrastructure
 				// descriptor cached
 				using (var db = GetDataContext(context))
 				{
-					db.GetTable<EntityDescriptorTable>().ToString();
+					_ = db.GetTable<EntityDescriptorTable>().ToSqlQuery().Sql;
 				}
 
 				Assert.Multiple(() =>
@@ -354,7 +354,7 @@ namespace Tests.Infrastructure
 				// cache miss
 				using (var db = GetDataContext(context, new MappingSchema("name1")))
 				{
-					db.GetTable<EntityDescriptorTable>().ToString();
+					_ = db.GetTable<EntityDescriptorTable>().ToSqlQuery().Sql;
 				}
 
 				Assert.Multiple(() =>
@@ -368,7 +368,7 @@ namespace Tests.Infrastructure
 				MappingSchema.EntityDescriptorCreatedCallback = null;
 				using (var db = GetDataContext(context, new MappingSchema("name2")))
 				{
-					db.GetTable<EntityDescriptorTable>().ToString();
+					_ = db.GetTable<EntityDescriptorTable>().ToSqlQuery().Sql;
 				}
 
 				Assert.Multiple(() =>

--- a/Tests/Linq/Infrastructure/DataOptionsTests.cs
+++ b/Tests/Linq/Infrastructure/DataOptionsTests.cs
@@ -312,7 +312,7 @@ namespace Tests.Infrastructure
 				// global handler set
 				using (var db = GetDataContext(context))
 				{
-					_ = db.GetTable<EntityDescriptorTable>().ToSqlQuery().Sql;
+					_ = db.GetTable<EntityDescriptorTable>().ToSqlQuery();
 				}
 
 				Assert.Multiple(() =>
@@ -329,7 +329,7 @@ namespace Tests.Infrastructure
 					localTriggrered = true;
 				})))
 				{
-					_ = db.GetTable<EntityDescriptorTable>().ToSqlQuery().Sql;
+					_ = db.GetTable<EntityDescriptorTable>().ToSqlQuery();
 				}
 
 				Assert.Multiple(() =>
@@ -342,7 +342,7 @@ namespace Tests.Infrastructure
 				// descriptor cached
 				using (var db = GetDataContext(context))
 				{
-					_ = db.GetTable<EntityDescriptorTable>().ToSqlQuery().Sql;
+					_ = db.GetTable<EntityDescriptorTable>().ToSqlQuery();
 				}
 
 				Assert.Multiple(() =>
@@ -354,7 +354,7 @@ namespace Tests.Infrastructure
 				// cache miss
 				using (var db = GetDataContext(context, new MappingSchema("name1")))
 				{
-					_ = db.GetTable<EntityDescriptorTable>().ToSqlQuery().Sql;
+					_ = db.GetTable<EntityDescriptorTable>().ToSqlQuery();
 				}
 
 				Assert.Multiple(() =>
@@ -368,7 +368,7 @@ namespace Tests.Infrastructure
 				MappingSchema.EntityDescriptorCreatedCallback = null;
 				using (var db = GetDataContext(context, new MappingSchema("name2")))
 				{
-					_ = db.GetTable<EntityDescriptorTable>().ToSqlQuery().Sql;
+					_ = db.GetTable<EntityDescriptorTable>().ToSqlQuery();
 				}
 
 				Assert.Multiple(() =>

--- a/Tests/Linq/Linq/AnalyticTests.cs
+++ b/Tests/Linq/Linq/AnalyticTests.cs
@@ -1341,9 +1341,6 @@ namespace Tests.Linq
 						MaxValue = Sql.Ext.Min(q.MaxValue).Over().PartitionBy(q.ParentID).ToValue(),
 					};
 
-				TestContext.Out.WriteLine(q1.ToSqlQuery().Sql);
-				TestContext.Out.WriteLine(q2.ToSqlQuery().Sql);
-
 				Assert.Multiple(() =>
 				{
 					Assert.That(q1.EnumQueries().Count(), Is.EqualTo(2));

--- a/Tests/Linq/Linq/AnalyticTests.cs
+++ b/Tests/Linq/Linq/AnalyticTests.cs
@@ -1341,8 +1341,8 @@ namespace Tests.Linq
 						MaxValue = Sql.Ext.Min(q.MaxValue).Over().PartitionBy(q.ParentID).ToValue(),
 					};
 
-				TestContext.Out.WriteLine(q1.ToString());
-				TestContext.Out.WriteLine(q2.ToString());
+				TestContext.Out.WriteLine(q1.ToSqlQuery().Sql);
+				TestContext.Out.WriteLine(q2.ToSqlQuery().Sql);
 
 				Assert.Multiple(() =>
 				{

--- a/Tests/Linq/Linq/AsyncTests.cs
+++ b/Tests/Linq/Linq/AsyncTests.cs
@@ -87,10 +87,7 @@ namespace Tests.Linq
 					.Where(p => p.ID == 1)
 					.Select(p => p.FirstName)
 					.Take(1)
-					.ToString()!;
-
-				sql = string.Join(Environment.NewLine, sql.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-					.Where(line => !line.StartsWith("--")));
+					.ToSqlQuery().Sql;
 
 				var res = await conn.SetCommand(sql).ExecuteAsync<string>();
 
@@ -109,7 +106,7 @@ namespace Tests.Linq
 					.Where(p => p.ID == 1)
 					.Select(p => p.FirstName)
 					.Take(1)
-					.ToString()!;
+					.ToSqlQuery().Sql;
 
 				sql = string.Join(Environment.NewLine, sql.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
 					.Where(line => !line.StartsWith("--")));
@@ -136,7 +133,7 @@ namespace Tests.Linq
 					.Where(p => p.ID == 1)
 					.Select(p => p.FirstName)
 					.Take(1)
-					.ToString()!;
+					.ToSqlQuery().Sql;
 
 				sql = string.Join(Environment.NewLine, sql.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
 					.Where(line => !line.StartsWith("--")));
@@ -162,7 +159,7 @@ namespace Tests.Linq
 			{
 				conn.InlineParameters = true;
 
-				var sql = conn.Person.Where(p => p.ID == 1).Select(p => p.Name).Take(1).ToString()!;
+				var sql = conn.Person.Where(p => p.ID == 1).Select(p => p.Name).Take(1).ToSqlQuery().Sql;
 				sql = string.Join(Environment.NewLine, sql.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
 					.Where(line => !line.StartsWith("--")));
 

--- a/Tests/Linq/Linq/AsyncTests.cs
+++ b/Tests/Linq/Linq/AsyncTests.cs
@@ -108,9 +108,6 @@ namespace Tests.Linq
 					.Take(1)
 					.ToSqlQuery().Sql;
 
-				sql = string.Join(Environment.NewLine, sql.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-					.Where(line => !line.StartsWith("--")));
-
 				var res = conn.SetCommand(sql).ExecuteAsync<string>().Result;
 
 				Assert.That(res, Is.EqualTo("John"));
@@ -135,9 +132,6 @@ namespace Tests.Linq
 					.Take(1)
 					.ToSqlQuery().Sql;
 
-				sql = string.Join(Environment.NewLine, sql.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-					.Where(line => !line.StartsWith("--")));
-
 				await using (var rd = await conn.SetCommand(sql).ExecuteReaderAsync())
 				{
 					var list = await rd.QueryToArrayAsync<string>();
@@ -160,8 +154,6 @@ namespace Tests.Linq
 				conn.InlineParameters = true;
 
 				var sql = conn.Person.Where(p => p.ID == 1).Select(p => p.Name).Take(1).ToSqlQuery().Sql;
-				sql = string.Join(Environment.NewLine, sql.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-					.Where(line => !line.StartsWith("--")));
 
 				var list = await conn.SetCommand(sql)
 					.QueryToAsyncEnumerable<string>()

--- a/Tests/Linq/Linq/CachingTests.cs
+++ b/Tests/Linq/Linq/CachingTests.cs
@@ -64,7 +64,7 @@ namespace Tests.Linq
 						Aggregate = AggregateFunc(funcName, fieldName)
 					};
 
-				var sql = query.ToString();
+				var sql = query.ToSqlQuery().Sql;
 				TestContext.Out.WriteLine(sql);
 
 				Assert.That(sql, Contains.Substring(funcName).And.Contains(fieldName));
@@ -117,7 +117,7 @@ namespace Tests.Linq
 					)
 					select cc;
 
-				var sql = query.ToString()!;
+				var sql = query.ToSqlQuery().Sql;
 				TestContext.Out.WriteLine(sql);
 
 				Assert.Multiple(() =>
@@ -149,7 +149,7 @@ namespace Tests.Linq
 					)
 					select cc;
 
-				var sql = query.ToString()!;
+				var sql = query.ToSqlQuery().Sql;
 				TestContext.Out.WriteLine(sql);
 
 				Assert.Multiple(() =>
@@ -176,7 +176,7 @@ namespace Tests.Linq
 					from c2 in db.Child.Take(10, takeHint)
 					select new {c1, c2};
 
-				var sql = query.ToString();
+				var sql = query.ToSqlQuery().Sql;
 				TestContext.Out.WriteLine(sql);
 
 				if (takeHint.HasFlag(TakeHints.Percent))

--- a/Tests/Linq/Linq/CommonTests.cs
+++ b/Tests/Linq/Linq/CommonTests.cs
@@ -584,7 +584,7 @@ namespace Tests.Linq
 					.Where(user =>
 						user.Status == status &&
 						(string.IsNullOrEmpty(firstName) || user.FirstName!.Contains(firstName)))
-					.ToString();
+					.ToSqlQuery().Sql;
 
 				Debug.WriteLine(str);
 			}

--- a/Tests/Linq/Linq/CommonTests.cs
+++ b/Tests/Linq/Linq/CommonTests.cs
@@ -575,19 +575,17 @@ namespace Tests.Linq
 		[Test]
 		public void Issue191Test([DataSources] string context)
 		{
-			using (var db = GetDataContext(context))
-			{
-				string? firstName = null;
-				int?    status    = null;
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<User>();
 
-				var str = db.GetTable<User>()
-					.Where(user =>
-						user.Status == status &&
-						(string.IsNullOrEmpty(firstName) || user.FirstName!.Contains(firstName)))
-					.ToSqlQuery().Sql;
+			string? firstName = null;
+			int?    status    = null;
 
-				Debug.WriteLine(str);
-			}
+			db.GetTable<User>()
+				.Where(user =>
+					user.Status == status &&
+					(string.IsNullOrEmpty(firstName) || user.FirstName!.Contains(firstName)))
+				.ToArray();
 		}
 	}
 

--- a/Tests/Linq/Linq/ConcatUnionTests.cs
+++ b/Tests/Linq/Linq/ConcatUnionTests.cs
@@ -688,10 +688,7 @@ namespace Tests.Linq
 
 				var q = q1.Union(q2).Take(5);
 
-				foreach (var item in q)
-				{
-					TestContext.Out.WriteLine(item);
-				}
+				q.ToArray();
 			}
 		}
 
@@ -699,40 +696,35 @@ namespace Tests.Linq
 		public class TestEntity2 { public int Id; public string? Field1; }
 
 		[Test]
-		public void Concat90()
+		public void Concat90([DataSources] string context)
 		{
-			using(var context = new DataConnection())
-			{
-				var join1 =
-					from t1 in context.GetTable<TestEntity1>()
-					join t2 in context.GetTable<TestEntity2>()
+			using var db = GetDataContext(context);
+			using var tb1 = db.CreateLocalTable<TestEntity1>();
+			using var tb2 = db.CreateLocalTable<TestEntity2>();
+			var join1 =
+					from t1 in db.GetTable<TestEntity1>()
+					join t2 in db.GetTable<TestEntity2>()
 						on t1.Id equals t2.Id
 					into tmp
 					from t2 in tmp.DefaultIfEmpty()
 					select new { t1, t2 };
 
-				var join1Sql = join1.ToSqlQuery().Sql;
-				Assert.That(join1Sql, Is.Not.Null);
+			join1.ToArray();
 
-				var join2 =
-					from t2 in context.GetTable<TestEntity2>()
-					join t1 in context.GetTable<TestEntity1>()
+			var join2 =
+					from t2 in db.GetTable<TestEntity2>()
+					join t1 in db.GetTable<TestEntity1>()
 						on t2.Id equals t1.Id
 					into tmp
 					from t1 in tmp.DefaultIfEmpty()
 					where t1 == null
 					select new { t1, t2 };
 
-				var join2Sql = join2.ToSqlQuery().Sql;
-				Assert.That(join2Sql, Is.Not.Null);
+			join2.ToArray();
 
-				var fullJoin = join1.Concat(join2);
+			var fullJoin = join1.Concat(join2);
 
-				var fullJoinSql = fullJoin.ToSqlQuery().Sql; // exception : Types in Concat are constructed incompatibly.
-				Assert.That(fullJoinSql, Is.Not.Null);
-
-				TestContext.Out.Write(fullJoinSql);
-			}
+			fullJoin.ToArray();
 		}
 
 		[Test]

--- a/Tests/Linq/Linq/ConcatUnionTests.cs
+++ b/Tests/Linq/Linq/ConcatUnionTests.cs
@@ -711,7 +711,7 @@ namespace Tests.Linq
 					from t2 in tmp.DefaultIfEmpty()
 					select new { t1, t2 };
 
-				var join1Sql = join1.ToString();
+				var join1Sql = join1.ToSqlQuery().Sql;
 				Assert.That(join1Sql, Is.Not.Null);
 
 				var join2 =
@@ -723,12 +723,12 @@ namespace Tests.Linq
 					where t1 == null
 					select new { t1, t2 };
 
-				var join2Sql = join2.ToString();
+				var join2Sql = join2.ToSqlQuery().Sql;
 				Assert.That(join2Sql, Is.Not.Null);
 
 				var fullJoin = join1.Concat(join2);
 
-				var fullJoinSql = fullJoin.ToString(); // exception : Types in Concat are constructed incompatibly.
+				var fullJoinSql = fullJoin.ToSqlQuery().Sql; // exception : Types in Concat are constructed incompatibly.
 				Assert.That(fullJoinSql, Is.Not.Null);
 
 				TestContext.Out.Write(fullJoinSql);
@@ -1887,7 +1887,7 @@ namespace Tests.Linq
 				.OrderBy(i => i.ID))
 				.Union((from item in db.Person select item));
 
-			var sql = query.ToString()!;
+			var sql = query.ToSqlQuery().Sql;
 
 			sql.Should().NotContain("ORDER BY");
 
@@ -1903,7 +1903,7 @@ namespace Tests.Linq
 				.Union((from item in db.Person select item)
 				.OrderBy(i => i.ID));
 
-			var sql = query.ToString()!;
+			var sql = query.ToSqlQuery().Sql;
 
 			sql.Should().NotContain("ORDER BY");
 
@@ -1920,7 +1920,7 @@ namespace Tests.Linq
 				.OrderBy(i => i.ID))
 				.UnionAll((from item in db.Person select item));
 
-			var sql = query.ToString()!;
+			var sql = query.ToSqlQuery().Sql;
 
 			sql.Should().Contain("ORDER BY", Exactly.Once());
 			sql.Substring(sql.IndexOf("ORDER BY")).Should().Contain("UNION", Exactly.Once());
@@ -1938,7 +1938,7 @@ namespace Tests.Linq
 				.UnionAll((from item in db.Person select item)
 				.OrderBy(i => i.ID));
 
-			var sql = query.ToString()!;
+			var sql = query.ToSqlQuery().Sql;
 
 			sql.Should().Contain("ORDER BY", Exactly.Once());
 			sql.Should().Contain("UNION", Exactly.Once());

--- a/Tests/Linq/Linq/ConvertTests.cs
+++ b/Tests/Linq/Linq/ConvertTests.cs
@@ -735,8 +735,8 @@ namespace Tests.Linq
 					select
 						Sql.AsSql(od.UnitPrice * od.Quantity * (decimal)(1 - od.Discount));
 
-				var sqlActual   = qActual.  ToString();
-				var sqlExpected = qExpected.ToString();
+				var sqlActual   = qActual.ToSqlQuery().Sql;
+				var sqlExpected = qExpected.ToSqlQuery().Sql;
 
 				Assert.Multiple(() =>
 				{

--- a/Tests/Linq/Linq/CteTests.cs
+++ b/Tests/Linq/Linq/CteTests.cs
@@ -102,9 +102,6 @@ namespace Tests.Linq
 					from c4 in db.Child.Where(c4 => c4.ParentID % 2 == 0).InnerJoin(c4 => c4.ParentID == c3.ParentID)
 					select c3;
 
-				var expectedStr = expected.ToSqlQuery().Sql;
-				var resultdStr  = result.ToSqlQuery().Sql;
-
 				// Looks like we do not populate needed field for CTE. It is aproblem that needs to be solved
 				AreEqual(expected, result);
 			}
@@ -205,9 +202,6 @@ namespace Tests.Linq
 					orderby p.CategoryName, p.UnitPrice, p.ProductName
 					select p;
 
-				var expectedStr = expected.ToSqlQuery().Sql;
-				var resultdStr  = result.ToSqlQuery().Sql;
-
 				AreEqual(expected, result);
 			}
 		}
@@ -246,9 +240,6 @@ namespace Tests.Linq
 						p.CategoryName,
 						p.UnitPrice
 					};
-
-				var expectedStr = expected.ToSqlQuery().Sql;
-				var resultdStr  = result.ToSqlQuery().Sql;
 
 				AreEqual(expected, result);
 			}
@@ -296,9 +287,6 @@ namespace Tests.Linq
 						p.ProductName,
 						p.UnitPrice
 					};
-
-				var expectedStr = expected.ToSqlQuery().Sql;
-				var resultdStr  = result.ToSqlQuery().Sql;
 
 				AreEqual(expected, result);
 			}
@@ -408,8 +396,6 @@ namespace Tests.Linq
 					orderby eh.HierarchyLevel, eh.LastName, eh.FirstName
 					select eh;
 
-				var resultdStr  = result.ToSqlQuery().Sql;
-
 				var data = result.ToArray();
 			}
 		}
@@ -428,9 +414,6 @@ namespace Tests.Linq
 				var expected = from p in _cte1
 					from c4 in db.Child.Where(c4 => c4.ParentID % 2 == 0).InnerJoin(c4 => c4.ParentID == p.ParentID)
 					select c4;
-
-				var expectedStr = expected.ToSqlQuery().Sql;
-				var resultdStr  = result.ToSqlQuery().Sql;
 
 				AreEqual(expected, result);
 			}
@@ -569,7 +552,7 @@ namespace Tests.Linq
 				var query = cte.Where(t => t.ChildID == var3 || var3 == null);
 				var str = query.ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(str);
+				query.ToArray();
 
 				Assert.That(str.Contains("WITH"), Is.EqualTo(true));
 			}
@@ -695,7 +678,6 @@ namespace Tests.Linq
 						)
 					, "MY_CTE");
 
-				var str = cteRecursive.ToSqlQuery().Sql;
 				var result = cteRecursive.ToArray();
 			}
 		}
@@ -868,7 +850,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void RecursiveDeepNesting([CteContextSource(true, ProviderName.DB2)] string context)
+		public void RecursiveDeepNesting([CteContextSource(true, TestProvName.AllDB2, TestProvName.AllSapHana)] string context)
 		{
 			using (var db   = GetDataContext(context))
 			using (var tree = db.CreateLocalTable<HierarchyTree>())
@@ -886,7 +868,7 @@ namespace Tests.Linq
 						q.Level
 					};
 
-				Assert.DoesNotThrow(() => TestContext.Out.WriteLine(query.ToSqlQuery().Sql));
+				query.ToArray();
 			}
 		}
 
@@ -1039,8 +1021,8 @@ namespace Tests.Linq
 					from ct in children.LeftJoin(ct => c.ChildID == ct.ChildID)
 					select c;
 
+				query.ToArray();
 				var sql = query.ToSqlQuery().Sql;
-				TestContext.Out.WriteLine(sql);
 
 				Assert.That(sql, Is.Not.Contains("WITH"));
 			}
@@ -1177,6 +1159,8 @@ namespace Tests.Linq
 				var ncCodeBo = "NCCodeBO:8110,SETUP_OSCILLOSCO";
 
 				var result = from item in wipCte.AllowedNcCode() where item.NcCodeBo == ncCodeBo select item;
+				result.ToArray();
+
 				var sql = result.ToSqlQuery().Sql;
 
 				Assert.That(sql.Replace("\"", "").Replace("`", "").Replace("[", "").Replace("]", "").ToLowerInvariant(), Does.Contain("WITH AllowedNcCode (NcCodeBo, NcCode, NcCodeDescription)".ToLowerInvariant()));

--- a/Tests/Linq/Linq/CteTests.cs
+++ b/Tests/Linq/Linq/CteTests.cs
@@ -102,8 +102,8 @@ namespace Tests.Linq
 					from c4 in db.Child.Where(c4 => c4.ParentID % 2 == 0).InnerJoin(c4 => c4.ParentID == c3.ParentID)
 					select c3;
 
-				var expectedStr = expected.ToString();
-				var resultdStr  = result.ToString();
+				var expectedStr = expected.ToSqlQuery().Sql;
+				var resultdStr  = result.ToSqlQuery().Sql;
 
 				// Looks like we do not populate needed field for CTE. It is aproblem that needs to be solved
 				AreEqual(expected, result);
@@ -205,8 +205,8 @@ namespace Tests.Linq
 					orderby p.CategoryName, p.UnitPrice, p.ProductName
 					select p;
 
-				var expectedStr = expected.ToString();
-				var resultdStr  = result.ToString();
+				var expectedStr = expected.ToSqlQuery().Sql;
+				var resultdStr  = result.ToSqlQuery().Sql;
 
 				AreEqual(expected, result);
 			}
@@ -247,8 +247,8 @@ namespace Tests.Linq
 						p.UnitPrice
 					};
 
-				var expectedStr = expected.ToString();
-				var resultdStr  = result.ToString();
+				var expectedStr = expected.ToSqlQuery().Sql;
+				var resultdStr  = result.ToSqlQuery().Sql;
 
 				AreEqual(expected, result);
 			}
@@ -297,8 +297,8 @@ namespace Tests.Linq
 						p.UnitPrice
 					};
 
-				var expectedStr = expected.ToString();
-				var resultdStr  = result.ToString();
+				var expectedStr = expected.ToSqlQuery().Sql;
+				var resultdStr  = result.ToSqlQuery().Sql;
 
 				AreEqual(expected, result);
 			}
@@ -408,7 +408,7 @@ namespace Tests.Linq
 					orderby eh.HierarchyLevel, eh.LastName, eh.FirstName
 					select eh;
 
-				var resultdStr  = result.ToString();
+				var resultdStr  = result.ToSqlQuery().Sql;
 
 				var data = result.ToArray();
 			}
@@ -429,8 +429,8 @@ namespace Tests.Linq
 					from c4 in db.Child.Where(c4 => c4.ParentID % 2 == 0).InnerJoin(c4 => c4.ParentID == p.ParentID)
 					select c4;
 
-				var expectedStr = expected.ToString();
-				var resultdStr  = result.ToString();
+				var expectedStr = expected.ToSqlQuery().Sql;
+				var resultdStr  = result.ToSqlQuery().Sql;
 
 				AreEqual(expected, result);
 			}
@@ -567,7 +567,7 @@ namespace Tests.Linq
 				var cte = db.GetTable<Child>().AsCte();
 
 				var query = cte.Where(t => t.ChildID == var3 || var3 == null);
-				var str = query.ToString()!;
+				var str = query.ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(str);
 
@@ -695,7 +695,7 @@ namespace Tests.Linq
 						)
 					, "MY_CTE");
 
-				var str = cteRecursive.ToString();
+				var str = cteRecursive.ToSqlQuery().Sql;
 				var result = cteRecursive.ToArray();
 			}
 		}
@@ -886,7 +886,7 @@ namespace Tests.Linq
 						q.Level
 					};
 
-				Assert.DoesNotThrow(() => TestContext.Out.WriteLine(query.ToString()));
+				Assert.DoesNotThrow(() => TestContext.Out.WriteLine(query.ToSqlQuery().Sql));
 			}
 		}
 
@@ -1039,7 +1039,7 @@ namespace Tests.Linq
 					from ct in children.LeftJoin(ct => c.ChildID == ct.ChildID)
 					select c;
 
-				var sql = query.ToString();
+				var sql = query.ToSqlQuery().Sql;
 				TestContext.Out.WriteLine(sql);
 
 				Assert.That(sql, Is.Not.Contains("WITH"));
@@ -1177,7 +1177,7 @@ namespace Tests.Linq
 				var ncCodeBo = "NCCodeBO:8110,SETUP_OSCILLOSCO";
 
 				var result = from item in wipCte.AllowedNcCode() where item.NcCodeBo == ncCodeBo select item;
-				var sql = ((IExpressionQuery)result).SqlText;
+				var sql = result.ToSqlQuery().Sql;
 
 				Assert.That(sql.Replace("\"", "").Replace("`", "").Replace("[", "").Replace("]", "").ToLowerInvariant(), Does.Contain("WITH AllowedNcCode (NcCodeBo, NcCode, NcCodeDescription)".ToLowerInvariant()));
 			}

--- a/Tests/Linq/Linq/DataContextTests.cs
+++ b/Tests/Linq/Linq/DataContextTests.cs
@@ -50,13 +50,13 @@ namespace Tests.Linq
 		{
 			using (var ctx = new DataContext(context))
 			{
-				NUnit.Framework.TestContext.Out.WriteLine(ctx.GetTable<Person>().ToSqlQuery().Sql);
+				ctx.GetTable<Person>().ToArray();
 
 				var q =
 					from s in ctx.GetTable<Person>()
 					select s.FirstName;
 
-				NUnit.Framework.TestContext.Out.WriteLine(q.ToSqlQuery().Sql);
+				q.ToArray();
 			}
 		}
 

--- a/Tests/Linq/Linq/DataContextTests.cs
+++ b/Tests/Linq/Linq/DataContextTests.cs
@@ -50,13 +50,13 @@ namespace Tests.Linq
 		{
 			using (var ctx = new DataContext(context))
 			{
-				NUnit.Framework.TestContext.Out.WriteLine(ctx.GetTable<Person>().ToString());
+				NUnit.Framework.TestContext.Out.WriteLine(ctx.GetTable<Person>().ToSqlQuery().Sql);
 
 				var q =
 					from s in ctx.GetTable<Person>()
 					select s.FirstName;
 
-				NUnit.Framework.TestContext.Out.WriteLine(q.ToString());
+				NUnit.Framework.TestContext.Out.WriteLine(q.ToSqlQuery().Sql);
 			}
 		}
 

--- a/Tests/Linq/Linq/EagerLoadingTests.cs
+++ b/Tests/Linq/Linq/EagerLoadingTests.cs
@@ -337,7 +337,10 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 			{
-				var sql = db.Parent.LoadWith(p => p.Children).ToSqlQuery().Sql;
+				var query = db.Parent.LoadWith(p => p.Children);
+				query.ToArray();
+
+				var sql = query.ToSqlQuery().Sql;
 
 				Assert.That(sql, Does.Not.Contain("LoadWithQueryable"));
 
@@ -356,8 +359,9 @@ FROM
 			using var db = GetDataContext(context);
 
 			var query = db.Person.LoadWith(p => p.Patient).AsQueryable();
-			var sql   = query.ToSqlQuery().Sql;
-			TestContext.Out.WriteLine(sql);
+			query.ToArray();
+
+			var sql = query.ToSqlQuery().Sql;
 
 			sql.Should().NotContain("LoadWithQueryable");
 

--- a/Tests/Linq/Linq/EagerLoadingTests.cs
+++ b/Tests/Linq/Linq/EagerLoadingTests.cs
@@ -337,7 +337,7 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 			{
-				var sql = db.Parent.LoadWith(p => p.Children).ToString()!;
+				var sql = db.Parent.LoadWith(p => p.Children).ToSqlQuery().Sql;
 
 				Assert.That(sql, Does.Not.Contain("LoadWithQueryable"));
 
@@ -356,7 +356,7 @@ FROM
 			using var db = GetDataContext(context);
 
 			var query = db.Person.LoadWith(p => p.Patient).AsQueryable();
-			var sql   = query.ToString()!;
+			var sql   = query.ToSqlQuery().Sql;
 			TestContext.Out.WriteLine(sql);
 
 			sql.Should().NotContain("LoadWithQueryable");

--- a/Tests/Linq/Linq/EnumMappingTests.cs
+++ b/Tests/Linq/Linq/EnumMappingTests.cs
@@ -1246,7 +1246,7 @@ namespace Tests.Linq
 					where (t.IntValue & TestFlag.Value1) != 0
 					select t;
 
-				var sql = result.ToString();
+				var sql = result.ToSqlQuery().Sql;
 
 				Assert.That(sql, Is.Not.Contains("Convert").And.Not.Contains("Int(").And.Not.Contains("Cast"));
 			}

--- a/Tests/Linq/Linq/EnumMappingTests.cs
+++ b/Tests/Linq/Linq/EnumMappingTests.cs
@@ -1246,6 +1246,8 @@ namespace Tests.Linq
 					where (t.IntValue & TestFlag.Value1) != 0
 					select t;
 
+				result.ToArray();
+
 				var sql = result.ToSqlQuery().Sql;
 
 				Assert.That(sql, Is.Not.Contains("Convert").And.Not.Contains("Int(").And.Not.Contains("Cast"));

--- a/Tests/Linq/Linq/EnumerableSourceTests.cs
+++ b/Tests/Linq/Linq/EnumerableSourceTests.cs
@@ -195,7 +195,7 @@ namespace Tests.Linq
 					select p;
 
 				var result = q.ToList();
-				var sql    = q.ToString();
+				var sql    = q.ToSqlQuery().Sql;
 
 				if (iteration > 1)
 					Query<Person>.CacheMissCount.Should().Be(cacheMiss);

--- a/Tests/Linq/Linq/ExpandTests.cs
+++ b/Tests/Linq/Linq/ExpandTests.cs
@@ -90,7 +90,7 @@ namespace Tests.Linq
 
 				//DO NOT REMOVE, it forces caching query
 				var str = query.ToSqlQuery().Sql;
-				TestContext.Out.WriteLine(str);
+				BaselinesManager.LogQuery(str);
 
 				var expected = from t in sampleData
 					from t2 in sampleData.Where(predicate.Compile())

--- a/Tests/Linq/Linq/ExpandTests.cs
+++ b/Tests/Linq/Linq/ExpandTests.cs
@@ -89,7 +89,7 @@ namespace Tests.Linq
 					select t;
 
 				//DO NOT REMOVE, it forces caching query
-				var str = query.ToString();
+				var str = query.ToSqlQuery().Sql;
 				TestContext.Out.WriteLine(str);
 
 				var expected = from t in sampleData

--- a/Tests/Linq/Linq/FullTextTests.SQLite.cs
+++ b/Tests/Linq/Linq/FullTextTests.SQLite.cs
@@ -62,7 +62,7 @@ namespace Tests.Linq
 				}
 				else
 				{
-					var sql = query.ToString()!;
+					var sql = query.ToSqlQuery().Sql;
 
 					TestContext.Out.WriteLine(sql);
 
@@ -129,7 +129,7 @@ namespace Tests.Linq
 				}
 				else
 				{
-					var sql = query.ToString()!;
+					var sql = query.ToSqlQuery().Sql;
 					Assert.That(sql, Does.Contain("[r].[text1] MATCH 'found'"));
 				}
 			}
@@ -142,7 +142,7 @@ namespace Tests.Linq
 			{
 				var query = Sql.Ext.SQLite().MatchTable(db.GetTable<FtsTable>(), "found");
 
-				var sql = query.ToString()!;
+				var sql = query.ToSqlQuery().Sql;
 				Assert.That(sql, Does.Contain(" = 'found'"));
 				Assert.That(sql, Does.Contain("[FTS5_TABLE](@"));
 			}
@@ -167,7 +167,7 @@ namespace Tests.Linq
 				}
 				else
 				{
-					var sql = query.ToString()!;
+					var sql = query.ToSqlQuery().Sql;
 					Assert.That(sql, Does.Contain("[r].[rowid] = 3"));
 				}
 			}
@@ -180,7 +180,7 @@ namespace Tests.Linq
 			{
 				var query = db.GetTable<FtsTable>().OrderBy(r => Sql.Ext.SQLite().Rank(r));
 
-				var sql = query.ToString()!;
+				var sql = query.ToSqlQuery().Sql;
 				Assert.That(sql, Does.Contain("ORDER BY"));
 				Assert.That(sql, Does.Contain("[t1].[rank]"));
 			}
@@ -337,7 +337,7 @@ namespace Tests.Linq
 			{
 				var query = db.GetTable<FtsTable>().Select(r => Sql.Ext.SQLite().FTS5bm25(r));
 
-				var sql = query.ToString()!;
+				var sql = query.ToSqlQuery().Sql;
 				Assert.That(sql, Does.Contain("bm25([r].[FTS5_TABLE])"));
 			}
 		}
@@ -349,7 +349,7 @@ namespace Tests.Linq
 			{
 				var query = db.GetTable<FtsTable>().Select(r => Sql.Ext.SQLite().FTS5bm25(r, 1.4, 5.6));
 
-				var sql = query.ToString()!;
+				var sql = query.ToSqlQuery().Sql;
 				Assert.That(sql, Does.Contain("bm25([r].[FTS5_TABLE], 1.3999999999999999, 5.5999999999999996)"));
 			}
 		}
@@ -361,7 +361,7 @@ namespace Tests.Linq
 			{
 				var query = db.GetTable<FtsTable>().Select(r => Sql.Ext.SQLite().FTS5Highlight(r, 2, "start", "end"));
 
-				var sql = query.ToString()!;
+				var sql = query.ToSqlQuery().Sql;
 				Assert.That(sql, Does.Contain("highlight([r].[FTS5_TABLE], 2, 'start', 'end')"));
 			}
 		}
@@ -373,7 +373,7 @@ namespace Tests.Linq
 			{
 				var query = db.GetTable<FtsTable>().Select(r => Sql.Ext.SQLite().FTS5Snippet(r, 1, "->", "<-", "zzz", 4));
 
-				var sql = query.ToString()!;
+				var sql = query.ToSqlQuery().Sql;
 				Assert.That(sql, Does.Contain("snippet([r].[FTS5_TABLE], 1, '->', '<-', 'zzz', 4)"));
 			}
 		}

--- a/Tests/Linq/Linq/FullTextTests.SQLite.cs
+++ b/Tests/Linq/Linq/FullTextTests.SQLite.cs
@@ -62,9 +62,12 @@ namespace Tests.Linq
 				}
 				else
 				{
+					// FTS5 required
+					//query.ToArray();
+
 					var sql = query.ToSqlQuery().Sql;
 
-					TestContext.Out.WriteLine(sql);
+					BaselinesManager.LogQuery(sql);
 
 					Assert.That(sql, Does.Contain("[r].[FTS5_TABLE] MATCH 'something'"));
 				}
@@ -129,6 +132,9 @@ namespace Tests.Linq
 				}
 				else
 				{
+					// FTS5 required
+					//query.ToArray();
+
 					var sql = query.ToSqlQuery().Sql;
 					Assert.That(sql, Does.Contain("[r].[text1] MATCH 'found'"));
 				}
@@ -142,9 +148,13 @@ namespace Tests.Linq
 			{
 				var query = Sql.Ext.SQLite().MatchTable(db.GetTable<FtsTable>(), "found");
 
-				var sql = query.ToSqlQuery().Sql;
-				Assert.That(sql, Does.Contain(" = 'found'"));
-				Assert.That(sql, Does.Contain("[FTS5_TABLE](@"));
+				// FTS5 required
+				//query.ToArray();
+
+				var command = query.ToSqlQuery();
+				Assert.That(command.Sql, Does.Contain("[FTS5_TABLE](@"));
+				Assert.That(command.Parameters, Has.Length.EqualTo(1));
+				Assert.That(command.Parameters[0].Value, Is.EqualTo("found"));
 			}
 		}
 
@@ -167,6 +177,9 @@ namespace Tests.Linq
 				}
 				else
 				{
+					// FTS5 required
+					//query.ToArray();
+
 					var sql = query.ToSqlQuery().Sql;
 					Assert.That(sql, Does.Contain("[r].[rowid] = 3"));
 				}
@@ -179,6 +192,9 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context, SetupFtsMapping(SQLiteFTS.FTS5)))
 			{
 				var query = db.GetTable<FtsTable>().OrderBy(r => Sql.Ext.SQLite().Rank(r));
+
+				// FTS5 required
+				//query.ToArray();
 
 				var sql = query.ToSqlQuery().Sql;
 				Assert.That(sql, Does.Contain("ORDER BY"));
@@ -337,6 +353,9 @@ namespace Tests.Linq
 			{
 				var query = db.GetTable<FtsTable>().Select(r => Sql.Ext.SQLite().FTS5bm25(r));
 
+				// FTS5 required
+				//query.ToArray();
+
 				var sql = query.ToSqlQuery().Sql;
 				Assert.That(sql, Does.Contain("bm25([r].[FTS5_TABLE])"));
 			}
@@ -348,6 +367,9 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context, SetupFtsMapping(SQLiteFTS.FTS5)))
 			{
 				var query = db.GetTable<FtsTable>().Select(r => Sql.Ext.SQLite().FTS5bm25(r, 1.4, 5.6));
+
+				// FTS5 required
+				//query.ToArray();
 
 				var sql = query.ToSqlQuery().Sql;
 				Assert.That(sql, Does.Contain("bm25([r].[FTS5_TABLE], 1.3999999999999999, 5.5999999999999996)"));
@@ -361,6 +383,9 @@ namespace Tests.Linq
 			{
 				var query = db.GetTable<FtsTable>().Select(r => Sql.Ext.SQLite().FTS5Highlight(r, 2, "start", "end"));
 
+				// FTS5 required
+				//query.ToArray();
+
 				var sql = query.ToSqlQuery().Sql;
 				Assert.That(sql, Does.Contain("highlight([r].[FTS5_TABLE], 2, 'start', 'end')"));
 			}
@@ -372,6 +397,9 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context, SetupFtsMapping(SQLiteFTS.FTS5)))
 			{
 				var query = db.GetTable<FtsTable>().Select(r => Sql.Ext.SQLite().FTS5Snippet(r, 1, "->", "<-", "zzz", 4));
+
+				// FTS5 required
+				//query.ToArray();
 
 				var sql = query.ToSqlQuery().Sql;
 				Assert.That(sql, Does.Contain("snippet([r].[FTS5_TABLE], 1, '->', '<-', 'zzz', 4)"));

--- a/Tests/Linq/Linq/FullTextTests.SqlServer.cs
+++ b/Tests/Linq/Linq/FullTextTests.SqlServer.cs
@@ -2120,6 +2120,9 @@ namespace Tests.Linq
 					orderby c.CategoryID descending
 					select c;
 
+				// TODO: FTS not configured properly
+				//q.ToArray();
+
 				q.ToSqlQuery().Sql.Should().Contain("CONTAINS(PROPERTY([c_1].[Description], N'title'), N'bread')");
 			}
 		}
@@ -2135,6 +2138,9 @@ namespace Tests.Linq
 					orderby c.CategoryID descending
 					select c;
 
+				// TODO: FTS not configured properly
+				//q.ToArray();
+
 				q.ToSqlQuery().Sql.Should().Contain("CONTAINS(PROPERTY([c_1].[Description], N'Title'), N'dry & bread', LANGUAGE N'English')");
 			}
 		}
@@ -2149,6 +2155,9 @@ namespace Tests.Linq
 					where Sql.Ext.SqlServer().ContainsPropertyWithLanguage(c.CategoryName, "Title", "candy | meat", 1033)
 					orderby c.CategoryID descending
 					select c;
+
+				// TODO: FTS not configured properly
+				//q.ToArray();
 
 				q.ToSqlQuery().Sql.Should().Contain("CONTAINS(PROPERTY([c_1].[CategoryName], N'Title'), N'candy | meat', LANGUAGE 1033)");
 			}
@@ -2167,6 +2176,9 @@ namespace Tests.Linq
 					where Sql.Ext.SqlServer().ContainsProperty(c.Description, property, search)
 					orderby c.CategoryID descending
 					select c;
+
+				// TODO: FTS not configured properly
+				//q.ToArray();
 
 				q.ToSqlQuery().Sql.Should().Contain($"CONTAINS(PROPERTY([c_1].[Description], @property), @search)");
 			}
@@ -2187,6 +2199,9 @@ namespace Tests.Linq
 					orderby c.CategoryID descending
 					select c;
 
+				// TODO: FTS not configured properly
+				//q.ToArray();
+
 				q.ToSqlQuery().Sql.Should().Contain($"CONTAINS(PROPERTY([c_1].[Description], @property), @search, LANGUAGE @lang)");
 			}
 		}
@@ -2205,6 +2220,9 @@ namespace Tests.Linq
 					where Sql.Ext.SqlServer().ContainsPropertyWithLanguage(c.CategoryName, property, search, lang)
 					orderby c.CategoryID descending
 					select c;
+
+				// TODO: FTS not configured properly
+				//q.ToArray();
 
 				q.ToSqlQuery().Sql.Should().Contain($"CONTAINS(PROPERTY([c_1].[CategoryName], @property), @search, LANGUAGE @lang)");
 			}

--- a/Tests/Linq/Linq/FullTextTests.SqlServer.cs
+++ b/Tests/Linq/Linq/FullTextTests.SqlServer.cs
@@ -2120,7 +2120,7 @@ namespace Tests.Linq
 					orderby c.CategoryID descending
 					select c;
 
-				q.ToString()!.Should().Contain("CONTAINS(PROPERTY([c_1].[Description], N'title'), N'bread')");
+				q.ToSqlQuery().Sql.Should().Contain("CONTAINS(PROPERTY([c_1].[Description], N'title'), N'bread')");
 			}
 		}
 
@@ -2135,7 +2135,7 @@ namespace Tests.Linq
 					orderby c.CategoryID descending
 					select c;
 
-				q.ToString()!.Should().Contain("CONTAINS(PROPERTY([c_1].[Description], N'Title'), N'dry & bread', LANGUAGE N'English')");
+				q.ToSqlQuery().Sql.Should().Contain("CONTAINS(PROPERTY([c_1].[Description], N'Title'), N'dry & bread', LANGUAGE N'English')");
 			}
 		}
 
@@ -2150,7 +2150,7 @@ namespace Tests.Linq
 					orderby c.CategoryID descending
 					select c;
 
-				q.ToString()!.Should().Contain("CONTAINS(PROPERTY([c_1].[CategoryName], N'Title'), N'candy | meat', LANGUAGE 1033)");
+				q.ToSqlQuery().Sql.Should().Contain("CONTAINS(PROPERTY([c_1].[CategoryName], N'Title'), N'candy | meat', LANGUAGE 1033)");
 			}
 		}
 
@@ -2168,7 +2168,7 @@ namespace Tests.Linq
 					orderby c.CategoryID descending
 					select c;
 
-				q.ToString()!.Should().Contain($"CONTAINS(PROPERTY([c_1].[Description], @property), @search)");
+				q.ToSqlQuery().Sql.Should().Contain($"CONTAINS(PROPERTY([c_1].[Description], @property), @search)");
 			}
 		}
 
@@ -2187,7 +2187,7 @@ namespace Tests.Linq
 					orderby c.CategoryID descending
 					select c;
 
-				q.ToString()!.Should().Contain($"CONTAINS(PROPERTY([c_1].[Description], @property), @search, LANGUAGE @lang)");
+				q.ToSqlQuery().Sql.Should().Contain($"CONTAINS(PROPERTY([c_1].[Description], @property), @search, LANGUAGE @lang)");
 			}
 		}
 
@@ -2206,7 +2206,7 @@ namespace Tests.Linq
 					orderby c.CategoryID descending
 					select c;
 
-				q.ToString()!.Should().Contain($"CONTAINS(PROPERTY([c_1].[CategoryName], @property), @search, LANGUAGE @lang)");
+				q.ToSqlQuery().Sql.Should().Contain($"CONTAINS(PROPERTY([c_1].[CategoryName], @property), @search, LANGUAGE @lang)");
 			}
 		}
 		#endregion

--- a/Tests/Linq/Linq/FunctionTests.cs
+++ b/Tests/Linq/Linq/FunctionTests.cs
@@ -607,7 +607,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void MatchFtsTest([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
+		public void MatchFtsTest([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -615,8 +615,11 @@ namespace Tests.Linq
 					where SqlLite.MatchFts(c, "some*")
 					select c;
 
+				// FTS5 required
+				//q.ToArray();
+
 				var str = q.ToSqlQuery().Sql;
-				Assert.That(str, Does.Contain(" matches "));
+				Assert.That(str, Does.Contain(" MATCH "));
 			}
 		}
 
@@ -653,13 +656,13 @@ namespace Tests.Linq
 					return;
 				}
 
-				var newField = new SqlAnchor(srcExpr, SqlAnchor.AnchorKindEnum.TableAsSelfColumn);
+				var newField = new SqlAnchor(srcExpr, SqlAnchor.AnchorKindEnum.TableName);
 
 				builder.AddParameter("table_field", newField);
 			}
 		}
 
-		[Sql.Extension("{table_field} matches {match}", BuilderType = typeof(MatchBuilder), IsPredicate = true)]
+		[Sql.Extension("{table_field} MATCH {match}", BuilderType = typeof(MatchBuilder), IsPredicate = true)]
 		public static bool MatchFts<TEntity>(TEntity src, [ExprParameter]string match)
 		{
 			throw new InvalidOperationException();

--- a/Tests/Linq/Linq/FunctionTests.cs
+++ b/Tests/Linq/Linq/FunctionTests.cs
@@ -615,7 +615,7 @@ namespace Tests.Linq
 					where SqlLite.MatchFts(c, "some*")
 					select c;
 
-				var str = q.ToString()!;
+				var str = q.ToSqlQuery().Sql;
 				Assert.That(str, Does.Contain(" matches "));
 			}
 		}

--- a/Tests/Linq/Linq/GroupByTests.cs
+++ b/Tests/Linq/Linq/GroupByTests.cs
@@ -3060,10 +3060,9 @@ namespace Tests.Linq
 					First = cItems.OrderBy(x => x.Count).ThenBy(x => x.Id).FirstOrDefault()
 				};
 
+			query.ToArray();
+
 			var selectQuery = query.GetSelectQuery();
-
-			TestContext.Out.WriteLine(query.ToSqlQuery().Sql);
-
 
 			// We check that grouping is left in the subquery
 

--- a/Tests/Linq/Linq/GroupByTests.cs
+++ b/Tests/Linq/Linq/GroupByTests.cs
@@ -3062,7 +3062,7 @@ namespace Tests.Linq
 
 			var selectQuery = query.GetSelectQuery();
 
-			TestContext.Out.WriteLine(query.ToString());
+			TestContext.Out.WriteLine(query.ToSqlQuery().Sql);
 
 
 			// We check that grouping is left in the subquery

--- a/Tests/Linq/Linq/IdlTests.cs
+++ b/Tests/Linq/Linq/IdlTests.cs
@@ -422,8 +422,8 @@ namespace Tests.Linq
 						Name = p.FirstName
 					};
 
-				var sql1 = (from p in people where p.Id       == 1 select p).ToString();
-				var sql2 = (from p in people where p.Id.Value == 1 select p).ToString();
+				var sql1 = (from p in people where p.Id       == 1 select p).ToSqlQuery().Sql;
+				var sql2 = (from p in people where p.Id.Value == 1 select p).ToSqlQuery().Sql;
 
 				Assert.That(sql1, Is.EqualTo(sql2));
 			}
@@ -685,7 +685,7 @@ namespace Tests.Linq
 						from p in db.Person
 						select new { Rank = p.ID, p.FirstName, p.LastName });
 
-				var resultquery = (from x in query2 orderby x.Rank, x.FirstName, x.LastName select x).ToString()!;
+				var resultquery = (from x in query2 orderby x.Rank, x.FirstName, x.LastName select x).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(resultquery);
 

--- a/Tests/Linq/Linq/IdlTests.cs
+++ b/Tests/Linq/Linq/IdlTests.cs
@@ -422,8 +422,14 @@ namespace Tests.Linq
 						Name = p.FirstName
 					};
 
-				var sql1 = (from p in people where p.Id       == 1 select p).ToSqlQuery().Sql;
-				var sql2 = (from p in people where p.Id.Value == 1 select p).ToSqlQuery().Sql;
+				var query1 = from p in people where p.Id       == 1 select p;
+				var query2 = from p in people where p.Id.Value == 1 select p;
+
+				query1.ToArray();
+				query2.ToArray();
+
+				var sql1 = query1.ToSqlQuery().Sql;
+				var sql2 = query2.ToSqlQuery().Sql;
 
 				Assert.That(sql1, Is.EqualTo(sql2));
 			}
@@ -685,12 +691,13 @@ namespace Tests.Linq
 						from p in db.Person
 						select new { Rank = p.ID, p.FirstName, p.LastName });
 
-				var resultquery = (from x in query2 orderby x.Rank, x.FirstName, x.LastName select x).ToSqlQuery().Sql;
+				var resultquery = from x in query2 orderby x.Rank, x.FirstName, x.LastName select x;
+				resultquery.ToArray();
 
-				TestContext.Out.WriteLine(resultquery);
+				var sql = resultquery.ToSqlQuery().Sql;
 
-				var rqr = resultquery.LastIndexOf("ORDER BY", StringComparison.OrdinalIgnoreCase);
-				var rqp = (resultquery.Substring(rqr + "ORDER BY".Length).Split(',')).Select(p => p.Trim()).ToArray();
+				var rqr = sql.LastIndexOf("ORDER BY", StringComparison.OrdinalIgnoreCase);
+				var rqp = (sql.Substring(rqr + "ORDER BY".Length).Split(',')).Select(p => p.Trim()).ToArray();
 
 				Assert.That(rqp, Has.Length.EqualTo(3));
 			}

--- a/Tests/Linq/Linq/InSubqueryTests.cs
+++ b/Tests/Linq/Linq/InSubqueryTests.cs
@@ -59,7 +59,7 @@ namespace Tests.Linq
 
 			AssertQuery(query);
 
-			var sqlStr = query.ToString();
+			var sqlStr = query.ToSqlQuery().Sql;
 
 			preferExists = preferExists || db.SqlProviderFlags.IsExistsPreferableForContains;
 

--- a/Tests/Linq/Linq/InheritanceTests.cs
+++ b/Tests/Linq/Linq/InheritanceTests.cs
@@ -284,16 +284,14 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void InheritanceMappingIssueTest()
+		public void InheritanceMappingIssueTest([DataSources] string context)
 		{
-			using (var db = new DataConnection())
-			{
-				var q1 = db.GetTable<Parent222>();
-				var q  = q1.Where(_ => _.Value.ID == 1);
+			using var db = GetDataContext(context);
 
-				var sql = q.ToSqlQuery().Sql;
-				Assert.That(sql, Is.Not.Empty);
-			}
+			var q1 = db.GetTable<Parent222>();
+			var q  = q1.Where(_ => _.Value.ID == 1);
+
+			q.ToArray();
 		}
 
 		[Table(Name = "Child", IsColumnAttributeRequired = false)]

--- a/Tests/Linq/Linq/InheritanceTests.cs
+++ b/Tests/Linq/Linq/InheritanceTests.cs
@@ -291,7 +291,7 @@ namespace Tests.Linq
 				var q1 = db.GetTable<Parent222>();
 				var q  = q1.Where(_ => _.Value.ID == 1);
 
-				var sql = ((IExpressionQuery<Parent222>)q).SqlText;
+				var sql = q.ToSqlQuery().Sql;
 				Assert.That(sql, Is.Not.Empty);
 			}
 		}

--- a/Tests/Linq/Linq/InterfaceTests.cs
+++ b/Tests/Linq/Linq/InterfaceTests.cs
@@ -164,7 +164,7 @@ namespace Tests.Linq
 			Issue4031_Execute_TwoFields<Issue4031Case04>(context);
 
 			using var db = GetDataContext(context);
-			var sql = db.GetTable<Issue4031Case15>().Where(c => c.Id == -1).Select(c => new { c.Id }).ToString();
+			var sql = db.GetTable<Issue4031Case15>().Where(c => c.Id == -1).Select(c => new { c.Id }).ToSqlQuery().Sql;
 			Assert.That(sql, Is.Not.Contains("PersonID"));
 			sql.Should().Contain("UNKNOWN", Exactly.Twice());
 		}
@@ -181,7 +181,7 @@ namespace Tests.Linq
 			Issue4031_Execute_TwoFields<Issue4031Case06>(context);
 
 			using var db = GetDataContext(context);
-			var sql = db.GetTable<Issue4031Case15>().Where(c => c.Id == -1).Select(c => new { c.Id }).ToString();
+			var sql = db.GetTable<Issue4031Case15>().Where(c => c.Id == -1).Select(c => new { c.Id }).ToSqlQuery().Sql;
 			Assert.That(sql, Is.Not.Contains("PersonID"));
 			sql.Should().Contain("UNKNOWN", Exactly.Twice());
 		}
@@ -240,7 +240,7 @@ namespace Tests.Linq
 			Issue4031_Execute_TwoFields<Issue4031Case15>(context);
 
 			using var db = GetDataContext(context);
-			var sql = db.GetTable<Issue4031Case15>().Where(c => c.Id == -1).Select(c => new { c.Id }).ToString();
+			var sql = db.GetTable<Issue4031Case15>().Where(c => c.Id == -1).Select(c => new { c.Id }).ToSqlQuery().Sql;
 			Assert.That(sql, Is.Not.Contains("PersonID"));
 			sql.Should().Contain("UNKNOWN", Exactly.Twice());
 		}

--- a/Tests/Linq/Linq/InterfaceTests.cs
+++ b/Tests/Linq/Linq/InterfaceTests.cs
@@ -164,7 +164,11 @@ namespace Tests.Linq
 			Issue4031_Execute_TwoFields<Issue4031Case04>(context);
 
 			using var db = GetDataContext(context);
-			var sql = db.GetTable<Issue4031Case15>().Where(c => c.Id == -1).Select(c => new { c.Id }).ToSqlQuery().Sql;
+
+			var query = db.GetTable<Issue4031Case15>().Where(c => c.Id == -1).Select(c => new { c.Id });
+			query.ToArray();
+
+			var sql = query.ToSqlQuery().Sql;
 			Assert.That(sql, Is.Not.Contains("PersonID"));
 			sql.Should().Contain("UNKNOWN", Exactly.Twice());
 		}
@@ -181,7 +185,13 @@ namespace Tests.Linq
 			Issue4031_Execute_TwoFields<Issue4031Case06>(context);
 
 			using var db = GetDataContext(context);
-			var sql = db.GetTable<Issue4031Case15>().Where(c => c.Id == -1).Select(c => new { c.Id }).ToSqlQuery().Sql;
+
+			var query = db.GetTable<Issue4031Case15>().Where(c => c.Id == -1).Select(c => new { c.Id });
+
+			var sql = query.ToSqlQuery().Sql;
+
+			BaselinesManager.LogQuery(sql);
+
 			Assert.That(sql, Is.Not.Contains("PersonID"));
 			sql.Should().Contain("UNKNOWN", Exactly.Twice());
 		}
@@ -240,7 +250,13 @@ namespace Tests.Linq
 			Issue4031_Execute_TwoFields<Issue4031Case15>(context);
 
 			using var db = GetDataContext(context);
-			var sql = db.GetTable<Issue4031Case15>().Where(c => c.Id == -1).Select(c => new { c.Id }).ToSqlQuery().Sql;
+
+			var query = db.GetTable<Issue4031Case15>().Where(c => c.Id == -1).Select(c => new { c.Id });
+
+			var sql = query.ToSqlQuery().Sql;
+
+			BaselinesManager.LogQuery(sql);
+
 			Assert.That(sql, Is.Not.Contains("PersonID"));
 			sql.Should().Contain("UNKNOWN", Exactly.Twice());
 		}

--- a/Tests/Linq/Linq/IsNullTests.SqlServer.cs
+++ b/Tests/Linq/Linq/IsNullTests.SqlServer.cs
@@ -27,7 +27,7 @@ namespace Tests.Linq
 			{
 				var query = (from c in db.Category
 							 select Sql.Ext.SqlServer().IsNull(c.CategoryName, defaultCategory));
-				Assert.That(query.ToString()!, Does.Contain(statement));
+				Assert.That(query.ToSqlQuery().Sql, Does.Contain(statement));
 
 				var results = await query.ToListAsync();
 				Assert.Multiple(() =>
@@ -47,7 +47,7 @@ namespace Tests.Linq
 			using (var db = new NorthwindDB(context))
 			{
 				var supplierQuery =  GetSupplierIdWithMaxUnitPrice(categoryId, db);
-				Assert.That(supplierQuery.ToString()!, Does.Contain(statement));
+				Assert.That(supplierQuery.ToSqlQuery().Sql, Does.Contain(statement));
 
 				var results = await supplierQuery.ToListAsync();
 				Assert.Multiple(() =>

--- a/Tests/Linq/Linq/IssueTests.cs
+++ b/Tests/Linq/Linq/IssueTests.cs
@@ -245,7 +245,7 @@ namespace Tests.Linq
 
 				AreEqual(rr, r);
 
-				var sql = r.ToString()!;
+				var sql = r.ToSqlQuery().Sql;
 				Assert.That(sql.IndexOf("INNER", 1), Is.GreaterThan(0), sql);
 			}
 		}

--- a/Tests/Linq/Linq/IssueTests.cs
+++ b/Tests/Linq/Linq/IssueTests.cs
@@ -36,8 +36,6 @@ namespace Tests.Linq
 				var sql = ((TestDataConnection)db).LastQuery;
 
 				Assert.That(sql, Is.Not.Contains("INNER JOIN"));
-
-				Debug.WriteLine(sql);
 			}
 		}
 
@@ -246,7 +244,7 @@ namespace Tests.Linq
 				AreEqual(rr, r);
 
 				var sql = r.ToSqlQuery().Sql;
-				Assert.That(sql.IndexOf("INNER", 1), Is.GreaterThan(0), sql);
+				Assert.That(sql, Does.Contain("INNER"));
 			}
 		}
 

--- a/Tests/Linq/Linq/JoinOptimizeTests.cs
+++ b/Tests/Linq/Linq/JoinOptimizeTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Linq;
+﻿using System.Linq;
 
 using LinqToDB;
 using LinqToDB.Mapping;
@@ -9,7 +8,6 @@ using NUnit.Framework;
 
 namespace Tests.Linq
 {
-
 	using Model;
 
 	[TestFixture]
@@ -83,9 +81,6 @@ namespace Tests.Linq
 						OrderID3 = o3.OrderID,
 					};
 
-
-				var sql = q.ToSqlQuery().Sql;
-
 				var q2 = from od in dd.OrderDetail
 					join o1 in dd.Order on od.OrderID equals o1.OrderID
 					join o2 in dd.Order on new {od.OrderID, od.ProductID} equals new {OrderID = o2.OrderID, ProductID = 1}
@@ -110,7 +105,7 @@ namespace Tests.Linq
 				});
 
 				var proj1 = q.Select(v => v.OrderID);
-				TestContext.Out.WriteLine(proj1.ToSqlQuery().Sql);
+				proj1.ToArray();
 				var sq1 = proj1.GetSelectQuery();
 				Assert.Multiple(() =>
 				{
@@ -119,7 +114,7 @@ namespace Tests.Linq
 				});
 
 				var proj2 = q.Select(v => v.OrderDate);
-				TestContext.Out.WriteLine(proj2.ToSqlQuery().Sql);
+				proj2.ToArray();
 				var sq2 = proj2.GetSelectQuery();
 				Assert.Multiple(() =>
 				{
@@ -148,8 +143,6 @@ namespace Tests.Linq
 						OrderID1 = o1.OrderID,
 						OrderID2 = od2.OrderID,
 					};
-
-				var str = q.ToSqlQuery().Sql;
 
 				var q2 = from od in dd.OrderDetail
 					join o1 in dd.Order on od.OrderID equals o1.OrderID
@@ -201,8 +194,6 @@ namespace Tests.Linq
 						OrderID3 = o3 == null ? 0 : o3.OrderID,
 						OrderID4 = o4 == null ? 0 : o4.OrderID,
 					};
-
-				var str = q.ToSqlQuery().Sql;
 
 				var q2 = from od in dd.OrderDetail
 					join o1 in dd.Order on new {od.OrderID, od.ProductID} equals new {o1.OrderID, ProductID = 39}
@@ -282,7 +273,7 @@ namespace Tests.Linq
 					join o1 in db.Order on e.OrderID equals o1.OrderID
 					select e;
 
-				TestContext.Out.WriteLine(q2.ToSqlQuery().Sql);
+				q2.ToArray();
 				var ts = q2.GetTableSource();
 				Assert.That(ts.Joins, Has.Count.EqualTo(1));
 			}
@@ -307,11 +298,12 @@ namespace Tests.Linq
 						OrderID3 = o3.OrderID,
 					};
 
-				var str = q.ToSqlQuery().Sql;
+				q.ToArray();
 
 				Assert.That(q.GetTableSource().Joins, Has.Count.EqualTo(1));
 
 				var proj1 = q.Select(v => v.OrderID);
+				proj1.ToArray();
 				Assert.That(proj1.GetTableSource().Joins, Has.Count.EqualTo(1));
 			}
 		}
@@ -337,11 +329,11 @@ namespace Tests.Linq
 						OrderID4 = o4.OrderID,
 					};
 
-				TestContext.Out.WriteLine(q.ToSqlQuery().Sql);
+				q.ToArray();
 				Assert.That(q.GetTableSource().Joins, Has.Count.EqualTo(1));
 
 				var proj1 = q.Select(v => v.OrderID);
-				TestContext.Out.WriteLine(proj1.ToSqlQuery().Sql);
+				proj1.ToArray();
 				Assert.That(proj1.GetTableSource().Joins, Has.Count.EqualTo(1));
 			}
 		}
@@ -512,7 +504,7 @@ namespace Tests.Linq
 						OrderID2 = o2.OrderID,
 					};
 
-				TestContext.Out.WriteLine(q.ToSqlQuery().Sql);
+				q.ToArray();
 
 				Assert.That(q.GetTableSource().Joins, Has.Count.EqualTo(1), "Join not optimized");
 
@@ -522,7 +514,7 @@ namespace Tests.Linq
 #pragma warning disable CS0472 // comparison of int with null
 				var qw = q.Where(v => v.OrderID1 != null);
 #pragma warning restore CS0472
-				var str = qw.ToSqlQuery().Sql;
+				qw.ToArray();
 				Assert.That(qw.GetTableSource().Joins, Has.Count.EqualTo(2), "If LEFT join is used in where condition - it can not be optimized");
 
 				var proj1 = q.Select(v => v.OrderID1);

--- a/Tests/Linq/Linq/JoinOptimizeTests.cs
+++ b/Tests/Linq/Linq/JoinOptimizeTests.cs
@@ -84,7 +84,7 @@ namespace Tests.Linq
 					};
 
 
-				var sql = q.ToString();
+				var sql = q.ToSqlQuery().Sql;
 
 				var q2 = from od in dd.OrderDetail
 					join o1 in dd.Order on od.OrderID equals o1.OrderID
@@ -110,7 +110,7 @@ namespace Tests.Linq
 				});
 
 				var proj1 = q.Select(v => v.OrderID);
-				TestContext.Out.WriteLine(proj1.ToString());
+				TestContext.Out.WriteLine(proj1.ToSqlQuery().Sql);
 				var sq1 = proj1.GetSelectQuery();
 				Assert.Multiple(() =>
 				{
@@ -119,7 +119,7 @@ namespace Tests.Linq
 				});
 
 				var proj2 = q.Select(v => v.OrderDate);
-				TestContext.Out.WriteLine(proj2.ToString());
+				TestContext.Out.WriteLine(proj2.ToSqlQuery().Sql);
 				var sq2 = proj2.GetSelectQuery();
 				Assert.Multiple(() =>
 				{
@@ -149,7 +149,7 @@ namespace Tests.Linq
 						OrderID2 = od2.OrderID,
 					};
 
-				var str = q.ToString();
+				var str = q.ToSqlQuery().Sql;
 
 				var q2 = from od in dd.OrderDetail
 					join o1 in dd.Order on od.OrderID equals o1.OrderID
@@ -202,7 +202,7 @@ namespace Tests.Linq
 						OrderID4 = o4 == null ? 0 : o4.OrderID,
 					};
 
-				var str = q.ToString();
+				var str = q.ToSqlQuery().Sql;
 
 				var q2 = from od in dd.OrderDetail
 					join o1 in dd.Order on new {od.OrderID, od.ProductID} equals new {o1.OrderID, ProductID = 39}
@@ -282,7 +282,7 @@ namespace Tests.Linq
 					join o1 in db.Order on e.OrderID equals o1.OrderID
 					select e;
 
-				TestContext.Out.WriteLine(q2.ToString());
+				TestContext.Out.WriteLine(q2.ToSqlQuery().Sql);
 				var ts = q2.GetTableSource();
 				Assert.That(ts.Joins, Has.Count.EqualTo(1));
 			}
@@ -307,7 +307,7 @@ namespace Tests.Linq
 						OrderID3 = o3.OrderID,
 					};
 
-				var str = q.ToString();
+				var str = q.ToSqlQuery().Sql;
 
 				Assert.That(q.GetTableSource().Joins, Has.Count.EqualTo(1));
 
@@ -337,11 +337,11 @@ namespace Tests.Linq
 						OrderID4 = o4.OrderID,
 					};
 
-				TestContext.Out.WriteLine(q.ToString());
+				TestContext.Out.WriteLine(q.ToSqlQuery().Sql);
 				Assert.That(q.GetTableSource().Joins, Has.Count.EqualTo(1));
 
 				var proj1 = q.Select(v => v.OrderID);
-				TestContext.Out.WriteLine(proj1.ToString());
+				TestContext.Out.WriteLine(proj1.ToSqlQuery().Sql);
 				Assert.That(proj1.GetTableSource().Joins, Has.Count.EqualTo(1));
 			}
 		}
@@ -512,7 +512,7 @@ namespace Tests.Linq
 						OrderID2 = o2.OrderID,
 					};
 
-				TestContext.Out.WriteLine(q.ToString());
+				TestContext.Out.WriteLine(q.ToSqlQuery().Sql);
 
 				Assert.That(q.GetTableSource().Joins, Has.Count.EqualTo(1), "Join not optimized");
 
@@ -522,7 +522,7 @@ namespace Tests.Linq
 #pragma warning disable CS0472 // comparison of int with null
 				var qw = q.Where(v => v.OrderID1 != null);
 #pragma warning restore CS0472
-				var str = qw.ToString();
+				var str = qw.ToSqlQuery().Sql;
 				Assert.That(qw.GetTableSource().Joins, Has.Count.EqualTo(2), "If LEFT join is used in where condition - it can not be optimized");
 
 				var proj1 = q.Select(v => v.OrderID1);

--- a/Tests/Linq/Linq/MappingTests.cs
+++ b/Tests/Linq/Linq/MappingTests.cs
@@ -385,15 +385,12 @@ namespace Tests.Linq
 		public class     Document : Entity, IDocument { }
 
 		[Test]
-		public void TestMethod()
+		public void TestMethod([DataSources] string context)
 		{
-			using (var db = new TestDataConnection())
-			{
-				IQueryable<IDocument> query = db.GetTable<Document>();
-				var idsQuery = query.Select(s => s.Id);
-				var str = idsQuery.ToSqlQuery().Sql; // Exception
-				Assert.That(str, Is.Not.Null);
-			}
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<Document>();
+
+			var query = db.GetTable<Document>().Select(s => s.Id).ToArray();
 		}
 
 		[Table("Person")]

--- a/Tests/Linq/Linq/MappingTests.cs
+++ b/Tests/Linq/Linq/MappingTests.cs
@@ -391,7 +391,7 @@ namespace Tests.Linq
 			{
 				IQueryable<IDocument> query = db.GetTable<Document>();
 				var idsQuery = query.Select(s => s.Id);
-				var str = idsQuery.ToString(); // Exception
+				var str = idsQuery.ToSqlQuery().Sql; // Exception
 				Assert.That(str, Is.Not.Null);
 			}
 		}

--- a/Tests/Linq/Linq/OptimizerTests.cs
+++ b/Tests/Linq/Linq/OptimizerTests.cs
@@ -107,7 +107,7 @@ namespace Tests.Linq
 						s
 					};
 
-				TestContext.Out.WriteLine(query.ToString());
+				TestContext.Out.WriteLine(query.ToSqlQuery().Sql);
 				Assert.That(query.EnumQueries().Count(), Is.EqualTo(2));
 
 				// test that optimizer removes subquery
@@ -123,7 +123,7 @@ namespace Tests.Linq
 						s
 					};
 
-				TestContext.Out.WriteLine(queryOptimized.ToString());
+				TestContext.Out.WriteLine(queryOptimized.ToSqlQuery().Sql);
 				Assert.That(queryOptimized.EnumQueries().Count(), Is.EqualTo(1));
 			}
 		}
@@ -186,11 +186,11 @@ namespace Tests.Linq
 						d
 					};
 
-				TestContext.Out.WriteLine(query.ToString());
+				TestContext.Out.WriteLine(query.ToSqlQuery().Sql);
 				Assert.That(query.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(1));
 
 				var projected = query.Select(p => p.s);
-				TestContext.Out.WriteLine(projected.ToString());
+				TestContext.Out.WriteLine(projected.ToSqlQuery().Sql);
 				Assert.That(projected.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(0));
 			}
 		}
@@ -227,11 +227,11 @@ namespace Tests.Linq
 						MNUCount = nu.Count
 					};
 
-				TestContext.Out.WriteLine(query.ToString());
+				TestContext.Out.WriteLine(query.ToSqlQuery().Sql);
 				Assert.That(query.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(2));
 
 				var projected = query.Select(p => p.s);
-				TestContext.Out.WriteLine(projected.ToString());
+				TestContext.Out.WriteLine(projected.ToSqlQuery().Sql);
 				Assert.That(projected.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(1));
 			}
 		}
@@ -255,11 +255,11 @@ namespace Tests.Linq
 						d
 					};
 
-				TestContext.Out.WriteLine(query.ToString());
+				TestContext.Out.WriteLine(query.ToSqlQuery().Sql);
 				Assert.That(query.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(1));
 
 				var projected = query.Select(p => p.s);
-				TestContext.Out.WriteLine(projected.ToString());
+				TestContext.Out.WriteLine(projected.ToSqlQuery().Sql);
 				Assert.That(projected.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(opimizerSwitch ? 0 : 1));
 			}
 		}
@@ -289,11 +289,11 @@ namespace Tests.Linq
 						First = a
 					};
 
-				TestContext.Out.WriteLine(query1.ToString());
+				TestContext.Out.WriteLine(query1.ToSqlQuery().Sql);
 				Assert.That(query1.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(1));
 
 				var projected1 = query1.Select(p => p.Second);
-				TestContext.Out.WriteLine(projected1.ToString());
+				TestContext.Out.WriteLine(projected1.ToSqlQuery().Sql);
 				Assert.That(projected1.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(opimizerSwitch ? 0 : 1));
 
 				// With two keys
@@ -307,11 +307,11 @@ namespace Tests.Linq
 						First = a
 					};
 
-				TestContext.Out.WriteLine(query2.ToString());
+				TestContext.Out.WriteLine(query2.ToSqlQuery().Sql);
 				Assert.That(query2.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(1));
 
 				var projected2 = query2.Select(p => p.Second);
-				TestContext.Out.WriteLine(projected2.ToString());
+				TestContext.Out.WriteLine(projected2.ToSqlQuery().Sql);
 				Assert.That(projected2.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(opimizerSwitch ? 0 : 1));
 
 				// With three keys
@@ -325,11 +325,11 @@ namespace Tests.Linq
 						First = a
 					};
 
-				TestContext.Out.WriteLine(query3.ToString());
+				TestContext.Out.WriteLine(query3.ToSqlQuery().Sql);
 				Assert.That(query3.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(1));
 
 				var projected3 = query3.Select(p => p.Second);
-				TestContext.Out.WriteLine(projected3.ToString());
+				TestContext.Out.WriteLine(projected3.ToSqlQuery().Sql);
 				Assert.That(projected3.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(opimizerSwitch ? 0 : 1));
 
 			}
@@ -369,7 +369,7 @@ namespace Tests.Linq
 						FF3 = ff3,
 					};
 
-				TestContext.Out.WriteLine(query.ToString());
+				TestContext.Out.WriteLine(query.ToSqlQuery().Sql);
 				Assert.That(query.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(opimizerSwitch ? 4 : 8));
 
 			}
@@ -400,7 +400,7 @@ namespace Tests.Linq
 						F = f
 					};
 
-				TestContext.Out.WriteLine(query.ToString());
+				TestContext.Out.WriteLine(query.ToSqlQuery().Sql);
 
 				var selectQuery = query.EnumQueries().Single();
 				var table = selectQuery.From.Tables[0];
@@ -442,7 +442,7 @@ namespace Tests.Linq
 						F2 = f2,
 					};
 
-				var sqlString = query.ToString();
+				var sqlString = query.ToSqlQuery().Sql;
 				TestContext.Out.WriteLine(sqlString);
 
 				var selectQuery = query.EnumQueries().First();
@@ -450,7 +450,7 @@ namespace Tests.Linq
 				Assert.That(table.Joins, Has.Count.EqualTo(2));
 
 				var smallProjection = query.Select(q => q.S);
-				TestContext.Out.WriteLine(smallProjection.ToString());
+				TestContext.Out.WriteLine(smallProjection.ToSqlQuery().Sql);
 
 				var selectQuery2 = smallProjection.EnumQueries().First();
 				var table2 = selectQuery2.From.Tables[0];

--- a/Tests/Linq/Linq/OptimizerTests.cs
+++ b/Tests/Linq/Linq/OptimizerTests.cs
@@ -107,7 +107,7 @@ namespace Tests.Linq
 						s
 					};
 
-				TestContext.Out.WriteLine(query.ToSqlQuery().Sql);
+				query.ToArray();
 				Assert.That(query.EnumQueries().Count(), Is.EqualTo(2));
 
 				// test that optimizer removes subquery
@@ -123,7 +123,7 @@ namespace Tests.Linq
 						s
 					};
 
-				TestContext.Out.WriteLine(queryOptimized.ToSqlQuery().Sql);
+				queryOptimized.ToArray();
 				Assert.That(queryOptimized.EnumQueries().Count(), Is.EqualTo(1));
 			}
 		}
@@ -186,11 +186,11 @@ namespace Tests.Linq
 						d
 					};
 
-				TestContext.Out.WriteLine(query.ToSqlQuery().Sql);
+				query.ToArray();
 				Assert.That(query.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(1));
 
 				var projected = query.Select(p => p.s);
-				TestContext.Out.WriteLine(projected.ToSqlQuery().Sql);
+				projected.ToArray();
 				Assert.That(projected.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(0));
 			}
 		}
@@ -227,11 +227,11 @@ namespace Tests.Linq
 						MNUCount = nu.Count
 					};
 
-				TestContext.Out.WriteLine(query.ToSqlQuery().Sql);
+				query.ToArray();
 				Assert.That(query.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(2));
 
 				var projected = query.Select(p => p.s);
-				TestContext.Out.WriteLine(projected.ToSqlQuery().Sql);
+				projected.ToArray();
 				Assert.That(projected.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(1));
 			}
 		}
@@ -255,11 +255,11 @@ namespace Tests.Linq
 						d
 					};
 
-				TestContext.Out.WriteLine(query.ToSqlQuery().Sql);
+				query.ToArray();
 				Assert.That(query.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(1));
 
 				var projected = query.Select(p => p.s);
-				TestContext.Out.WriteLine(projected.ToSqlQuery().Sql);
+				projected.ToArray();
 				Assert.That(projected.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(opimizerSwitch ? 0 : 1));
 			}
 		}
@@ -289,11 +289,11 @@ namespace Tests.Linq
 						First = a
 					};
 
-				TestContext.Out.WriteLine(query1.ToSqlQuery().Sql);
+				query1.ToArray();
 				Assert.That(query1.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(1));
 
 				var projected1 = query1.Select(p => p.Second);
-				TestContext.Out.WriteLine(projected1.ToSqlQuery().Sql);
+				projected1.ToArray();
 				Assert.That(projected1.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(opimizerSwitch ? 0 : 1));
 
 				// With two keys
@@ -307,11 +307,11 @@ namespace Tests.Linq
 						First = a
 					};
 
-				TestContext.Out.WriteLine(query2.ToSqlQuery().Sql);
+				query2.ToArray();
 				Assert.That(query2.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(1));
 
 				var projected2 = query2.Select(p => p.Second);
-				TestContext.Out.WriteLine(projected2.ToSqlQuery().Sql);
+				projected2.ToArray();
 				Assert.That(projected2.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(opimizerSwitch ? 0 : 1));
 
 				// With three keys
@@ -325,11 +325,11 @@ namespace Tests.Linq
 						First = a
 					};
 
-				TestContext.Out.WriteLine(query3.ToSqlQuery().Sql);
+				query3.ToArray();
 				Assert.That(query3.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(1));
 
 				var projected3 = query3.Select(p => p.Second);
-				TestContext.Out.WriteLine(projected3.ToSqlQuery().Sql);
+				projected3.ToArray();
 				Assert.That(projected3.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(opimizerSwitch ? 0 : 1));
 
 			}
@@ -369,7 +369,7 @@ namespace Tests.Linq
 						FF3 = ff3,
 					};
 
-				TestContext.Out.WriteLine(query.ToSqlQuery().Sql);
+				query.ToArray();
 				Assert.That(query.EnumQueries().SelectMany(q => q.EnumJoins()).Count(), Is.EqualTo(opimizerSwitch ? 4 : 8));
 
 			}
@@ -400,7 +400,7 @@ namespace Tests.Linq
 						F = f
 					};
 
-				TestContext.Out.WriteLine(query.ToSqlQuery().Sql);
+				query.ToArray();
 
 				var selectQuery = query.EnumQueries().Single();
 				var table = selectQuery.From.Tables[0];
@@ -416,7 +416,7 @@ namespace Tests.Linq
 
 
 		[Test]
-		public void UniqueKeysAndSubqueries([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context, [Values] bool opimizerSwitch)
+		public void UniqueKeysAndSubqueries([IncludeDataSources(true, TestProvName.AllSQLite)] string context, [Values] bool opimizerSwitch)
 		{
 			var testData = GenerateTestData();
 
@@ -442,15 +442,14 @@ namespace Tests.Linq
 						F2 = f2,
 					};
 
-				var sqlString = query.ToSqlQuery().Sql;
-				TestContext.Out.WriteLine(sqlString);
+				query.ToArray();
 
 				var selectQuery = query.EnumQueries().First();
 				var table = selectQuery.From.Tables[0];
 				Assert.That(table.Joins, Has.Count.EqualTo(2));
 
 				var smallProjection = query.Select(q => q.S);
-				TestContext.Out.WriteLine(smallProjection.ToSqlQuery().Sql);
+				smallProjection.ToArray();
 
 				var selectQuery2 = smallProjection.EnumQueries().First();
 				var table2 = selectQuery2.From.Tables[0];

--- a/Tests/Linq/Linq/OrderByTests.cs
+++ b/Tests/Linq/Linq/OrderByTests.cs
@@ -396,7 +396,7 @@ namespace Tests.Linq
 					orderby pp.ParentID
 					select p;
 
-				TestContext.Out.WriteLine(secondOrder.ToSqlQuery().Sql);
+				secondOrder.ToArray();
 
 				var selectQuery = secondOrder.GetSelectQuery();
 				Assert.That(selectQuery.OrderBy.Items, Has.Count.EqualTo(2));
@@ -422,7 +422,7 @@ namespace Tests.Linq
 					orderby p.ParentID descending
 					select p;
 
-				TestContext.Out.WriteLine(secondOrder.ToSqlQuery().Sql);
+				secondOrder.ToArray();
 			
 				var selectQuery = secondOrder.GetSelectQuery();
 				Assert.That(selectQuery.OrderBy.Items, Has.Count.EqualTo(1));

--- a/Tests/Linq/Linq/OrderByTests.cs
+++ b/Tests/Linq/Linq/OrderByTests.cs
@@ -396,7 +396,7 @@ namespace Tests.Linq
 					orderby pp.ParentID
 					select p;
 
-				TestContext.Out.WriteLine(secondOrder.ToString());
+				TestContext.Out.WriteLine(secondOrder.ToSqlQuery().Sql);
 
 				var selectQuery = secondOrder.GetSelectQuery();
 				Assert.That(selectQuery.OrderBy.Items, Has.Count.EqualTo(2));
@@ -422,7 +422,7 @@ namespace Tests.Linq
 					orderby p.ParentID descending
 					select p;
 
-				TestContext.Out.WriteLine(secondOrder.ToString());
+				TestContext.Out.WriteLine(secondOrder.ToSqlQuery().Sql);
 			
 				var selectQuery = secondOrder.GetSelectQuery();
 				Assert.That(selectQuery.OrderBy.Items, Has.Count.EqualTo(1));

--- a/Tests/Linq/Linq/ParameterTests.FSharp.cs
+++ b/Tests/Linq/Linq/ParameterTests.FSharp.cs
@@ -40,7 +40,7 @@ namespace Tests.Linq
 			using (var db = GetDataConnection(context))
 			{
 				var p   = "abc";
-				var sql = db.GetTable<Person>().Where(t => t.FirstName == p).ToString();
+				var sql = db.GetTable<Person>().Where(t => t.FirstName == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 

--- a/Tests/Linq/Linq/ParameterTests.FSharp.cs
+++ b/Tests/Linq/Linq/ParameterTests.FSharp.cs
@@ -40,9 +40,9 @@ namespace Tests.Linq
 			using (var db = GetDataConnection(context))
 			{
 				var p   = "abc";
-				var sql = db.GetTable<Person>().Where(t => t.FirstName == p).ToSqlQuery().Sql;
+				db.GetTable<Person>().Where(t => t.FirstName == p).ToArray();
 
-				TestContext.Out.WriteLine(sql);
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("(3)").Or.Contains("(4000)"));
 			}

--- a/Tests/Linq/Linq/ParameterTests.SqlServer.cs
+++ b/Tests/Linq/Linq/ParameterTests.SqlServer.cs
@@ -166,7 +166,7 @@ namespace Tests.Linq
 			using (var db = GetDataConnection(context))
 			{
 				var p = "abc";
-				var sql = db.GetTable<Person>().Where(t => t.FirstName == p).ToString();
+				var sql = db.GetTable<Person>().Where(t => t.FirstName == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -180,7 +180,7 @@ namespace Tests.Linq
 			using (var db = GetDataConnection(context))
 			{
 				var p = "abc";
-				var sql = db.GetTable<AllTypes>().Where(t => t.VarcharDataType == p).ToString();
+				var sql = db.GetTable<AllTypes>().Where(t => t.VarcharDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -194,7 +194,7 @@ namespace Tests.Linq
 			using (var db = GetDataConnection(context))
 			{
 				var p = new byte[] { 1 };
-				var sql = db.GetTable<AllTypes>().Where(t => t.VarBinaryDataType == p).ToString();
+				var sql = db.GetTable<AllTypes>().Where(t => t.VarBinaryDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -208,7 +208,7 @@ namespace Tests.Linq
 			using (var db = GetDataConnection(context))
 			{
 				var p = "abc";
-				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.NVarcharDataType == p).ToString();
+				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.NVarcharDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -222,7 +222,7 @@ namespace Tests.Linq
 			using (var db = GetDataConnection(context))
 			{
 				var p = "abc";
-				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.VarcharDataType == p).ToString();
+				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.VarcharDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -236,7 +236,7 @@ namespace Tests.Linq
 			using (var db = GetDataConnection(context))
 			{
 				var p = new byte[] { 1 };
-				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.VarBinaryDataType == p).ToString();
+				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.VarBinaryDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -250,7 +250,7 @@ namespace Tests.Linq
 			using (var db = GetDataConnection(context))
 			{
 				var p = "abcdeabcdeabcdeabcde1";
-				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.NVarcharDataType == p).ToString();
+				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.NVarcharDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -264,7 +264,7 @@ namespace Tests.Linq
 			using (var db = GetDataConnection(context))
 			{
 				var p = "abcdeabcdeabcdeabcde1";
-				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.VarcharDataType == p).ToString();
+				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.VarcharDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -278,7 +278,7 @@ namespace Tests.Linq
 			using (var db = GetDataConnection(context))
 			{
 				var p = new byte[] { 1, 2 };
-				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.VarBinaryDataType == p).ToString();
+				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.VarBinaryDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -293,7 +293,7 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema);
 				var p = new NVarChar() { Value = "abc" };
-				var sql = db.GetTable<AllTypesCustom>().Where(t => t.NVarcharDataType == p).ToString();
+				var sql = db.GetTable<AllTypesCustom>().Where(t => t.NVarcharDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -308,7 +308,7 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema);
 				var p = new VarChar() { Value = "abc" };
-				var sql = db.GetTable<AllTypesCustom>().Where(t => t.VarcharDataType == p).ToString();
+				var sql = db.GetTable<AllTypesCustom>().Where(t => t.VarcharDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -323,7 +323,7 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema);
 				var p = new VarBinary() { Value = new byte[] { 1 } };
-				var sql = db.GetTable<AllTypesCustom>().Where(t => t.VarBinaryDataType == p).ToString();
+				var sql = db.GetTable<AllTypesCustom>().Where(t => t.VarBinaryDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -338,7 +338,7 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema);
 				var p = new NVarChar() { Value = "abc" };
-				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.NVarcharDataType == p).ToString();
+				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.NVarcharDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -353,7 +353,7 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema);
 				var p = new VarChar() { Value = "abc" };
-				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarcharDataType == p).ToString();
+				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarcharDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -368,7 +368,7 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema);
 				var p = new VarBinary() { Value = new byte[] { 1 } };
-				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarBinaryDataType == p).ToString();
+				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarBinaryDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -383,7 +383,7 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema);
 				var p = new NVarChar() { Value = "abcdeabcdeabcdeabcde1" };
-				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.NVarcharDataType == p).ToString();
+				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.NVarcharDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -398,7 +398,7 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema);
 				var p = new VarChar() { Value = "abcdeabcdeabcdeabcde1" };
-				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarcharDataType == p).ToString();
+				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarcharDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -413,7 +413,7 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema);
 				var p = new VarBinary() { Value = new byte[] { 1, 2 } };
-				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarBinaryDataType == p).ToString();
+				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarBinaryDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -437,7 +437,7 @@ namespace Tests.Linq
 
 					var records = table.ToList();
 					var p = new NVarChar() { Value = value };
-					var sql = table.Where(t => t.NVarChar == p).ToString()!;
+					var sql = table.Where(t => t.NVarChar == p).ToSqlQuery().Sql;
 
 					Assert.That(records, Has.Count.EqualTo(1));
 					Assert.That(records[0].NVarChar, Is.Not.Null);
@@ -466,7 +466,7 @@ namespace Tests.Linq
 
 					var records = table.ToList();
 					var p = new VarChar() { Value = value };
-					var sql = table.Where(t => t.VarChar == p).ToString();
+					var sql = table.Where(t => t.VarChar == p).ToSqlQuery().Sql;
 
 					Assert.That(records, Has.Count.EqualTo(1));
 					Assert.That(records[0].VarChar, Is.Not.Null);
@@ -498,7 +498,7 @@ namespace Tests.Linq
 
 					var records = table.ToList();
 					var p = new VarBinary() { Value = value };
-					var sql = table.Where(t => t.VarBinary == p).ToString()!;
+					var sql = table.Where(t => t.VarBinary == p).ToSqlQuery().Sql;
 
 					Assert.That(records, Has.Count.EqualTo(1));
 					Assert.That(records[0].VarBinary, Is.Not.Null);
@@ -518,7 +518,7 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema, true);
 				var p = new NVarChar() { Value = "abc" };
-				var sql = db.GetTable<AllTypesCustom>().Where(t => t.NVarcharDataType == p).ToString();
+				var sql = db.GetTable<AllTypesCustom>().Where(t => t.NVarcharDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -533,7 +533,7 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema, true);
 				var p = new VarChar() { Value = "abc" };
-				var sql = db.GetTable<AllTypesCustom>().Where(t => t.VarcharDataType == p).ToString();
+				var sql = db.GetTable<AllTypesCustom>().Where(t => t.VarcharDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -548,7 +548,7 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema, true);
 				var p = new VarBinary() { Value = new byte[] { 1 } };
-				var sql = db.GetTable<AllTypesCustom>().Where(t => t.VarBinaryDataType == p).ToString();
+				var sql = db.GetTable<AllTypesCustom>().Where(t => t.VarBinaryDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -563,7 +563,7 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema, true);
 				var p = new NVarChar() { Value = "abc" };
-				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.NVarcharDataType == p).ToString();
+				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.NVarcharDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -578,7 +578,7 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema, true);
 				var p = new VarChar() { Value = "abc" };
-				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarcharDataType == p).ToString();
+				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarcharDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -593,7 +593,7 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema, true);
 				var p = new VarBinary() { Value = new byte[] { 1 } };
-				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarBinaryDataType == p).ToString();
+				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarBinaryDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -608,7 +608,7 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema, true);
 				var p = new NVarChar() { Value = "abcdeabcdeabcdeabcde1" };
-				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.NVarcharDataType == p).ToString();
+				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.NVarcharDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -623,7 +623,7 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema, true);
 				var p = new VarChar() { Value = "abcdeabcdeabcdeabcde1" };
-				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarcharDataType == p).ToString();
+				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarcharDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -638,7 +638,7 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema, true);
 				var p = new VarBinary() { Value = new byte[] { 1, 2 } };
-				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarBinaryDataType == p).ToString();
+				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarBinaryDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -663,7 +663,7 @@ namespace Tests.Linq
 
 					var records = table.ToList();
 					var p = new NVarChar() { Value = value };
-					var sql = table.Where(t => t.NVarChar == p).ToString()!;
+					var sql = table.Where(t => t.NVarChar == p).ToSqlQuery().Sql;
 
 					Assert.That(records, Has.Count.EqualTo(1));
 					Assert.That(records[0].NVarChar, Is.Not.Null);
@@ -692,7 +692,7 @@ namespace Tests.Linq
 
 					var records = table.ToList();
 					var p = new VarChar() { Value = value };
-					var sql = table.Where(t => t.VarChar == p).ToString()!;
+					var sql = table.Where(t => t.VarChar == p).ToSqlQuery().Sql;
 
 					Assert.That(records, Has.Count.EqualTo(1));
 					Assert.That(records[0].VarChar, Is.Not.Null);
@@ -724,7 +724,7 @@ namespace Tests.Linq
 
 					var records = table.ToList();
 					var p = new VarBinary() { Value = value };
-					var sql = table.Where(t => t.VarBinary == p).ToString()!;
+					var sql = table.Where(t => t.VarBinary == p).ToSqlQuery().Sql;
 
 					Assert.That(records, Has.Count.EqualTo(1));
 					Assert.That(records[0].VarBinary, Is.Not.Null);

--- a/Tests/Linq/Linq/ParameterTests.SqlServer.cs
+++ b/Tests/Linq/Linq/ParameterTests.SqlServer.cs
@@ -166,9 +166,10 @@ namespace Tests.Linq
 			using (var db = GetDataConnection(context))
 			{
 				var p = "abc";
-				var sql = db.GetTable<Person>().Where(t => t.FirstName == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query =  db.GetTable<Person>().Where(t => t.FirstName == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("(4000)"));
 			}
@@ -180,9 +181,10 @@ namespace Tests.Linq
 			using (var db = GetDataConnection(context))
 			{
 				var p = "abc";
-				var sql = db.GetTable<AllTypes>().Where(t => t.VarcharDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query =  db.GetTable<AllTypes>().Where(t => t.VarcharDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("(8000)"));
 			}
@@ -194,9 +196,10 @@ namespace Tests.Linq
 			using (var db = GetDataConnection(context))
 			{
 				var p = new byte[] { 1 };
-				var sql = db.GetTable<AllTypes>().Where(t => t.VarBinaryDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query =  db.GetTable<AllTypes>().Where(t => t.VarBinaryDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("(8000)"));
 			}
@@ -208,9 +211,10 @@ namespace Tests.Linq
 			using (var db = GetDataConnection(context))
 			{
 				var p = "abc";
-				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.NVarcharDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query =  db.GetTable<AllTypesWithLength>().Where(t => t.NVarcharDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("(20)"));
 			}
@@ -222,9 +226,10 @@ namespace Tests.Linq
 			using (var db = GetDataConnection(context))
 			{
 				var p = "abc";
-				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.VarcharDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query =  db.GetTable<AllTypesWithLength>().Where(t => t.VarcharDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("(20)"));
 			}
@@ -236,9 +241,10 @@ namespace Tests.Linq
 			using (var db = GetDataConnection(context))
 			{
 				var p = new byte[] { 1 };
-				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.VarBinaryDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query =  db.GetTable<AllTypesWithLength>().Where(t => t.VarBinaryDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("(1)"));
 			}
@@ -250,9 +256,10 @@ namespace Tests.Linq
 			using (var db = GetDataConnection(context))
 			{
 				var p = "abcdeabcdeabcdeabcde1";
-				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.NVarcharDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query =  db.GetTable<AllTypesWithLength>().Where(t => t.NVarcharDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("(4000)"));
 			}
@@ -264,9 +271,10 @@ namespace Tests.Linq
 			using (var db = GetDataConnection(context))
 			{
 				var p = "abcdeabcdeabcdeabcde1";
-				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.VarcharDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query =  db.GetTable<AllTypesWithLength>().Where(t => t.VarcharDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("(8000)"));
 			}
@@ -278,9 +286,10 @@ namespace Tests.Linq
 			using (var db = GetDataConnection(context))
 			{
 				var p = new byte[] { 1, 2 };
-				var sql = db.GetTable<AllTypesWithLength>().Where(t => t.VarBinaryDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query =  db.GetTable<AllTypesWithLength>().Where(t => t.VarBinaryDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("(8000)"));
 			}
@@ -293,9 +302,10 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema);
 				var p = new NVarChar() { Value = "abc" };
-				var sql = db.GetTable<AllTypesCustom>().Where(t => t.NVarcharDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query =  db.GetTable<AllTypesCustom>().Where(t => t.NVarcharDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("NVarChar -- String"));
 			}
@@ -308,9 +318,10 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema);
 				var p = new VarChar() { Value = "abc" };
-				var sql = db.GetTable<AllTypesCustom>().Where(t => t.VarcharDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query =  db.GetTable<AllTypesCustom>().Where(t => t.VarcharDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring(" VarChar -- AnsiString"));
 			}
@@ -323,9 +334,10 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema);
 				var p = new VarBinary() { Value = new byte[] { 1 } };
-				var sql = db.GetTable<AllTypesCustom>().Where(t => t.VarBinaryDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query =  db.GetTable<AllTypesCustom>().Where(t => t.VarBinaryDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("VarBinary -- Binary"));
 			}
@@ -338,9 +350,10 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema);
 				var p = new NVarChar() { Value = "abc" };
-				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.NVarcharDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query =  db.GetTable<AllTypesCustomWithLength>().Where(t => t.NVarcharDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("NVarChar -- String"));
 			}
@@ -353,9 +366,10 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema);
 				var p = new VarChar() { Value = "abc" };
-				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarcharDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query =  db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarcharDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring(" VarChar -- AnsiString"));
 			}
@@ -368,9 +382,10 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema);
 				var p = new VarBinary() { Value = new byte[] { 1 } };
-				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarBinaryDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query =  db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarBinaryDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("VarBinary -- Binary"));
 			}
@@ -383,9 +398,10 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema);
 				var p = new NVarChar() { Value = "abcdeabcdeabcdeabcde1" };
-				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.NVarcharDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query =  db.GetTable<AllTypesCustomWithLength>().Where(t => t.NVarcharDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("NVarChar -- String"));
 			}
@@ -398,9 +414,10 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema);
 				var p = new VarChar() { Value = "abcdeabcdeabcdeabcde1" };
-				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarcharDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query =  db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarcharDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring(" VarChar -- AnsiString"));
 			}
@@ -413,9 +430,10 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema);
 				var p = new VarBinary() { Value = new byte[] { 1, 2 } };
-				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarBinaryDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query =  db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarBinaryDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("VarBinary -- Binary"));
 			}
@@ -437,7 +455,10 @@ namespace Tests.Linq
 
 					var records = table.ToList();
 					var p = new NVarChar() { Value = value };
-					var sql = table.Where(t => t.NVarChar == p).ToSqlQuery().Sql;
+
+					var query =  table.Where(t => t.NVarChar == p);
+					query.ToArray();
+					var sql = GetCurrentBaselines();
 
 					Assert.That(records, Has.Count.EqualTo(1));
 					Assert.That(records[0].NVarChar, Is.Not.Null);
@@ -466,7 +487,10 @@ namespace Tests.Linq
 
 					var records = table.ToList();
 					var p = new VarChar() { Value = value };
-					var sql = table.Where(t => t.VarChar == p).ToSqlQuery().Sql;
+
+					var query =  table.Where(t => t.VarChar == p);
+					query.ToArray();
+					var sql = GetCurrentBaselines();
 
 					Assert.That(records, Has.Count.EqualTo(1));
 					Assert.That(records[0].VarChar, Is.Not.Null);
@@ -498,7 +522,10 @@ namespace Tests.Linq
 
 					var records = table.ToList();
 					var p = new VarBinary() { Value = value };
-					var sql = table.Where(t => t.VarBinary == p).ToSqlQuery().Sql;
+
+					var query =  table.Where(t => t.VarBinary == p);
+					query.ToArray();
+					var sql = GetCurrentBaselines();
 
 					Assert.That(records, Has.Count.EqualTo(1));
 					Assert.That(records[0].VarBinary, Is.Not.Null);
@@ -518,9 +545,10 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema, true);
 				var p = new NVarChar() { Value = "abc" };
-				var sql = db.GetTable<AllTypesCustom>().Where(t => t.NVarcharDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query = db.GetTable<AllTypesCustom>().Where(t => t.NVarcharDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("(4000)"));
 			}
@@ -533,9 +561,10 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema, true);
 				var p = new VarChar() { Value = "abc" };
-				var sql = db.GetTable<AllTypesCustom>().Where(t => t.VarcharDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query = db.GetTable<AllTypesCustom>().Where(t => t.VarcharDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("(8000)"));
 			}
@@ -548,9 +577,10 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema, true);
 				var p = new VarBinary() { Value = new byte[] { 1 } };
-				var sql = db.GetTable<AllTypesCustom>().Where(t => t.VarBinaryDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query = db.GetTable<AllTypesCustom>().Where(t => t.VarBinaryDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("(8000)"));
 			}
@@ -563,9 +593,10 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema, true);
 				var p = new NVarChar() { Value = "abc" };
-				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.NVarcharDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query = db.GetTable<AllTypesCustomWithLength>().Where(t => t.NVarcharDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("(20)"));
 			}
@@ -578,9 +609,10 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema, true);
 				var p = new VarChar() { Value = "abc" };
-				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarcharDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarcharDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("(20)"));
 			}
@@ -593,9 +625,10 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema, true);
 				var p = new VarBinary() { Value = new byte[] { 1 } };
-				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarBinaryDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarBinaryDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("(1)"));
 			}
@@ -608,9 +641,10 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema, true);
 				var p = new NVarChar() { Value = "abcdeabcdeabcdeabcde1" };
-				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.NVarcharDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query = db.GetTable<AllTypesCustomWithLength>().Where(t => t.NVarcharDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("(4000)"));
 			}
@@ -623,9 +657,10 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema, true);
 				var p = new VarChar() { Value = "abcdeabcdeabcdeabcde1" };
-				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarcharDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarcharDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("(8000)"));
 			}
@@ -638,9 +673,10 @@ namespace Tests.Linq
 			{
 				SetupCustomTypes(db.MappingSchema, true);
 				var p = new VarBinary() { Value = new byte[] { 1, 2 } };
-				var sql = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarBinaryDataType == p).ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
+				var query = db.GetTable<AllTypesCustomWithLength>().Where(t => t.VarBinaryDataType == p);
+				query.ToArray();
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("(8000)"));
 			}
@@ -663,7 +699,10 @@ namespace Tests.Linq
 
 					var records = table.ToList();
 					var p = new NVarChar() { Value = value };
-					var sql = table.Where(t => t.NVarChar == p).ToSqlQuery().Sql;
+
+					var query = table.Where(t => t.NVarChar == p);
+					query.ToArray();
+					var sql = GetCurrentBaselines();
 
 					Assert.That(records, Has.Count.EqualTo(1));
 					Assert.That(records[0].NVarChar, Is.Not.Null);
@@ -692,7 +731,10 @@ namespace Tests.Linq
 
 					var records = table.ToList();
 					var p = new VarChar() { Value = value };
-					var sql = table.Where(t => t.VarChar == p).ToSqlQuery().Sql;
+
+					var query = table.Where(t => t.VarChar == p);
+					query.ToArray();
+					var sql = GetCurrentBaselines();
 
 					Assert.That(records, Has.Count.EqualTo(1));
 					Assert.That(records[0].VarChar, Is.Not.Null);
@@ -724,7 +766,10 @@ namespace Tests.Linq
 
 					var records = table.ToList();
 					var p = new VarBinary() { Value = value };
-					var sql = table.Where(t => t.VarBinary == p).ToSqlQuery().Sql;
+
+					var query = table.Where(t => t.VarBinary == p);
+					query.ToArray();
+					var sql = GetCurrentBaselines();
 
 					Assert.That(records, Has.Count.EqualTo(1));
 					Assert.That(records[0].VarBinary, Is.Not.Null);

--- a/Tests/Linq/Linq/ParameterTests.cs
+++ b/Tests/Linq/Linq/ParameterTests.cs
@@ -223,7 +223,7 @@ namespace Tests.Linq
 			using (var db = GetDataConnection(context))
 			{
 				var p   = 123.456m;
-				var sql = db.GetTable<AllTypes>().Where(t => t.DecimalDataType == p).ToString();
+				var sql = db.GetTable<AllTypes>().Where(t => t.DecimalDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -238,7 +238,7 @@ namespace Tests.Linq
 			using (var db = GetDataConnection(context))
 			{
 				var p   = new byte[] { 0, 1, 2 };
-				var sql = db.GetTable<AllTypes>().Where(t => t.BinaryDataType == p).ToString();
+				var sql = db.GetTable<AllTypes>().Where(t => t.BinaryDataType == p).ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 

--- a/Tests/Linq/Linq/ParameterTests.cs
+++ b/Tests/Linq/Linq/ParameterTests.cs
@@ -216,31 +216,31 @@ namespace Tests.Linq
 			public string? VarcharDataType;
 		}
 
-		// Excluded providers inline such parameter
+		// Excluded providers inline such parameter or miss mappings
 		[Test]
-		public void ExposeSqlDecimalParameter([DataSources(false, TestProvName.AllInformix, TestProvName.AllClickHouse)] string context)
+		public void ExposeSqlDecimalParameter([DataSources(false, ProviderName.SqlCe, TestProvName.AllSybase, TestProvName.AllSapHana, TestProvName.AllPostgreSQL, TestProvName.AllOracle, TestProvName.AllDB2, TestProvName.AllFirebird, TestProvName.AllInformix, TestProvName.AllClickHouse)] string context)
 		{
 			using (var db = GetDataConnection(context))
 			{
 				var p   = 123.456m;
-				var sql = db.GetTable<AllTypes>().Where(t => t.DecimalDataType == p).ToSqlQuery().Sql;
+				db.GetTable<AllTypes>().Where(t => t.DecimalDataType == p).ToArray();
 
-				TestContext.Out.WriteLine(sql);
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("(6, 3)"));
 			}
 		}
 
-		// DB2: see DB2SqlOptimizer.SetQueryParameter - binary parameters inlined for DB2
+		// Excluded providers inline such parameter or miss mappings
 		[Test]
-		public void ExposeSqlBinaryParameter([DataSources(false, TestProvName.AllClickHouse)] string context)
+		public void ExposeSqlBinaryParameter([DataSources(false, ProviderName.SqlCe, TestProvName.AllSybase, TestProvName.AllDB2, TestProvName.AllSapHana, TestProvName.AllPostgreSQL, TestProvName.AllOracle, TestProvName.AllInformix, TestProvName.AllFirebird, TestProvName.AllClickHouse)] string context)
 		{
 			using (var db = GetDataConnection(context))
 			{
 				var p   = new byte[] { 0, 1, 2 };
-				var sql = db.GetTable<AllTypes>().Where(t => t.BinaryDataType == p).ToSqlQuery().Sql;
+				db.GetTable<AllTypes>().Where(t => t.BinaryDataType == p).ToArray();
 
-				TestContext.Out.WriteLine(sql);
+				var sql = GetCurrentBaselines();
 
 				Assert.That(sql, Contains.Substring("(3)").Or.Contains("Blob").Or.Contains("(8000)"));
 			}
@@ -563,12 +563,12 @@ namespace Tests.Linq
 			}
 		}
 
-		IQueryable<Person> GetParsons(ITestDataContext db, int personId)
+		IQueryable<Person> GetPersons(ITestDataContext db, int personId)
 		{
 			return db.Person.Where(p => p.ID == personId);
 		}
 
-		IQueryable<Person> GetParsons2(ITestDataContext db, int? personId)
+		IQueryable<Person> GetPersons2(ITestDataContext db, int? personId)
 		{
 			return db.Person.Where(p => p.ID == personId!.Value);
 		}
@@ -586,8 +586,8 @@ namespace Tests.Linq
 				var ctn = new { personId = 1 };
 
 				var query =
-					from p in GetParsons(db, personId)
-					from p2 in GetParsons2(db, personId).Where(p2 => p2.ID == p.ID)
+					from p in GetPersons(db, personId)
+					from p2 in GetPersons2(db, personId).Where(p2 => p2.ID == p.ID)
 					where p.ID == ctn.personId
 					select new { p, p2 };
 
@@ -609,8 +609,8 @@ namespace Tests.Linq
 				var ctn = new { personId = 2 };
 
 				var query =
-					from p in GetParsons(db, personId)
-					from p2 in GetParsons2(db, personId).Where(p2 => p2.ID == p.ID)
+					from p in GetPersons(db, personId)
+					from p2 in GetPersons2(db, personId).Where(p2 => p2.ID == p.ID)
 					where p.ID == ctn.personId
 					select new { p, p2 };
 
@@ -1731,7 +1731,7 @@ namespace Tests.Linq
 
 			// check only one parameter generated
 			if(!context.IsAnyOf(TestProvName.AllClickHouse))
-				GetCurrentBaselines().Should().Contain("DECLARE", Exactly.Once());
+				Assert.That(query1.ToSqlQuery().Parameters, Has.Count.EqualTo(1));
 
 			id = 2;
 
@@ -1744,7 +1744,7 @@ namespace Tests.Linq
 
 			// check only one parameter generated (1+2+1=4)
 			if (!context.IsAnyOf(TestProvName.AllClickHouse))
-				GetCurrentBaselines().Should().Contain("DECLARE", Exactly.Times(4));
+				Assert.That(query1.ToSqlQuery().Parameters, Has.Count.EqualTo(1));
 		}
 
 

--- a/Tests/Linq/Linq/QueryGenerationTests.cs
+++ b/Tests/Linq/Linq/QueryGenerationTests.cs
@@ -1,0 +1,575 @@
+﻿using System;
+using System.Linq;
+
+using LinqToDB;
+using LinqToDB.Data;
+using LinqToDB.Mapping;
+
+using NUnit.Framework;
+
+namespace Tests.Linq
+{
+	using FluentAssertions;
+
+	using Model;
+
+	using xUpdate;
+
+	using static Tests.xUpdate.MergeTests;
+	using static xUpdate.MultiInsertTests;
+
+	[TestFixture]
+	public class QueryGenerationTests : TestBase
+	{
+		[Table("TableWithIdentitySrc")]
+		sealed class TableWithIdentitySource
+		{
+			[PrimaryKey, Identity] public int Id { get; set; }
+			[Column] public int Value { get; set; }
+		}
+
+		[Table("TableWithIdentity")]
+		sealed class TableWithIdentity
+		{
+			[PrimaryKey, Identity] public int Id { get; set; }
+			[Column] public int Value { get; set; }
+		}
+
+		[Test]
+		public void ToSqlQuery_NotLinqQuery()
+		{
+			Assert.That(() => Array.Empty<string>().AsQueryable().ToSqlQuery(), Throws.InstanceOf<LinqToDBException>().With.Message.EqualTo("LinqToDB method 'ToSqlQuery' called on non-LinqToDB IQueryable."));
+		}
+
+		[Test]
+		public void ToString_Default([IncludeDataSources(ProviderName.SQLiteClassic)] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var query = db.Person;
+
+			var toString = query.Where(r => r.ID == 1).ToString();
+
+			Assert.That(toString, Is.EqualTo("LinqToDB.Linq.ExpressionQueryImpl`1[Tests.Model.Person]"));
+		}
+
+		[Test]
+		public void ToSqlQuery_Table([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var query = db.Person;
+
+			var command = query.ToSqlQuery();
+
+			using var dc = GetDataConnection(context.StripRemote());
+			var bySql = dc.Query<Person>(command.Sql).ToArray();
+			var expected = query.ToArray();
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(command.Sql, Does.Contain("SELECT"));
+				Assert.That(command.Parameters, Has.Count.EqualTo(0));
+				Assert.That(bySql, Has.Length.EqualTo(expected.Length));
+			});
+		}
+
+		[ActiveIssue("Final aliases break by-name mapping for raw SQL (not an issue?)", Configuration = ProviderName.SqlCe)]
+		[Test]
+		public void ToSqlQuery_SimpleQuery([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var query = db.Person.Where(p => p.ID == 1);
+
+			var command = query.ToSqlQuery();
+
+			using var dc = GetDataConnection(context.StripRemote());
+			var person = dc.Query<Person>(command.Sql).ToArray();
+			var expected = query.Single();
+
+			Assert.That(person, Has.Length.EqualTo(1));
+			Assert.Multiple(() =>
+			{
+				Assert.That(command.Sql, Does.Contain("SELECT"));
+				Assert.That(command.Parameters, Has.Count.EqualTo(0));
+				Assert.That(person[0].ID, Is.EqualTo(expected.ID));
+				Assert.That(person[0].FirstName, Is.EqualTo(expected.FirstName));
+				Assert.That(person[0].MiddleName, Is.EqualTo(expected.MiddleName));
+				Assert.That(person[0].LastName, Is.EqualTo(expected.LastName));
+				Assert.That(person[0].Gender, Is.EqualTo(expected.Gender));
+			});
+		}
+
+		[ActiveIssue("Final aliases break by-name mapping for raw SQL (not an issue?)", Configuration = ProviderName.SqlCe)]
+		[Test]
+		public void ToSqlQuery_WithParameters([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var id = 1;
+
+			var query = db.Person.Where(p => p.ID == id);
+
+			var command = query.ToSqlQuery();
+
+			using var dc = GetDataConnection(context.StripRemote());
+
+			var person = dc.Query<Person>(command.Sql, command.Parameters).ToArray();
+			var expected = query.Single();
+
+			var expectedParams = context.IsUseParameters()
+					? 1
+					: 0;
+
+			Assert.That(person, Has.Length.EqualTo(1));
+			Assert.Multiple(() =>
+			{
+				Assert.That(command.Sql, Does.Contain("SELECT"));
+				Assert.That(command.Parameters, Has.Count.EqualTo(expectedParams));
+				Assert.That(person[0].ID, Is.EqualTo(expected.ID));
+				Assert.That(person[0].FirstName, Is.EqualTo(expected.FirstName));
+				Assert.That(person[0].MiddleName, Is.EqualTo(expected.MiddleName));
+				Assert.That(person[0].LastName, Is.EqualTo(expected.LastName));
+				Assert.That(person[0].Gender, Is.EqualTo(expected.Gender));
+			});
+		}
+
+		[ActiveIssue("Final aliases break by-name mapping for raw SQL (not an issue?)", Configuration = ProviderName.SqlCe)]
+		[Test]
+		public void ToSqlQuery_WithParametersDeduplication([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var firstName = "John";
+
+			var query = db.Person.Where(p => p.FirstName == firstName || p.LastName == firstName);
+
+			var command = query.ToSqlQuery();
+
+			using var dc = GetDataConnection(context.StripRemote());
+
+			var person = dc.Query<Person>(command.Sql, command.Parameters).ToArray();
+			var expected = query.Single();
+
+			var expectedParams = context.IsUseParameters()
+					? context.IsUsePositionalParameters()
+						? 2 : 1
+					: 0;
+
+			Assert.That(person, Has.Length.EqualTo(1));
+			Assert.Multiple(() =>
+			{
+				Assert.That(command.Sql, Does.Contain("SELECT"));
+				Assert.That(command.Parameters, Has.Count.EqualTo(expectedParams));
+				Assert.That(person[0].ID, Is.EqualTo(expected.ID));
+				Assert.That(person[0].FirstName, Is.EqualTo(expected.FirstName));
+				Assert.That(person[0].MiddleName, Is.EqualTo(expected.MiddleName));
+				Assert.That(person[0].LastName, Is.EqualTo(expected.LastName));
+				Assert.That(person[0].Gender, Is.EqualTo(expected.Gender));
+			});
+		}
+
+		[ActiveIssue("Final aliases break by-name mapping for raw SQL (not an issue?)", Configuration = ProviderName.SqlCe)]
+		[Test]
+		public void ToSqlQuery_WithNullableParameters([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			string? middleName = null;
+
+			var query = db.Person.Where(p => p.MiddleName != middleName);
+
+			var command = query.ToSqlQuery();
+
+			using var dc = GetDataConnection(context.StripRemote());
+
+			var person = dc.Query<Person>(command.Sql).ToArray();
+			var expected = query.Single();
+
+			Assert.That(person, Has.Length.EqualTo(1));
+			Assert.Multiple(() =>
+			{
+				Assert.That(command.Sql, Does.Contain("SELECT"));
+				Assert.That(command.Parameters, Has.Count.EqualTo(0));
+				Assert.That(person[0].ID, Is.EqualTo(expected.ID));
+				Assert.That(person[0].FirstName, Is.EqualTo(expected.FirstName));
+				Assert.That(person[0].MiddleName, Is.EqualTo(expected.MiddleName));
+				Assert.That(person[0].LastName, Is.EqualTo(expected.LastName));
+				Assert.That(person[0].Gender, Is.EqualTo(expected.Gender));
+			});
+		}
+
+		[Test]
+		public void ToSqlQuery_EagerLoad([DataSources] string context)
+		{
+			// currently preambule queries not exposed by API
+			using var db = GetDataContext(context);
+
+			var id = 2;
+
+			var query = db.Parent.Where(p => p.ParentID == id).Select(p => new { Parent = p, Children = p.Children.ToArray() });
+
+			var command = query.ToSqlQuery();
+
+			using var dc = GetDataConnection(context.StripRemote());
+
+			var parent = dc.Query<Parent>(command.Sql, command.Parameters).ToArray();
+			var expected = db.Person.Where(p => p.ID == id).Single();
+
+			Assert.That(parent, Has.Length.EqualTo(1));
+			Assert.Multiple(() =>
+			{
+				Assert.That(command.Sql, Does.Contain("SELECT"));
+				Assert.That(command.Parameters, Has.Count.EqualTo(context.IsUseParameters() ? 1 : 0));
+				Assert.That(parent[0].ParentID, Is.EqualTo(expected.ID));
+			});
+		}
+
+		[Test]
+		public void ToSqlQuery_IUpdatable([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<TableWithIdentity>();
+
+			var newValue = 123;
+			var query = tb.Set(r => r.Value, r => newValue);
+
+			var command = query.ToSqlQuery();
+
+			using var dc = GetDataConnection(context.StripRemote());
+			dc.Insert(new TableWithIdentity() { Value = 1 });
+			dc.Execute(command.Sql, command.Parameters);
+
+			var record = dc.GetTable<TableWithIdentity>().Single();
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(command.Sql, Does.Contain("UPDATE"));
+				Assert.That(command.Parameters, Has.Count.EqualTo(context.IsUseParameters() ? 1 : 0));
+				Assert.That(record.Value, Is.EqualTo(newValue));
+			});
+		}
+
+		[Test]
+		public void ToSqlQuery_IUpdatable_ClientIdentiy([DataSources(ProviderName.SqlCe, TestProvName.AllAccess, TestProvName.AllInformix, TestProvName.AllClickHouse, TestProvName.AllSqlServer, TestProvName.AllDB2, TestProvName.AllSybase)] string context)
+		{
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<TableWithIdentity>();
+
+			var newValue = 123;
+			var query = tb
+				.Set(r => r.Id, r => 492)
+				.Set(r => r.Value, r => newValue);
+
+			var command = query.ToSqlQuery();
+
+			using var dc = GetDataConnection(context.StripRemote());
+			dc.Insert(new TableWithIdentity() { Value = 1 });
+			dc.Execute(command.Sql, command.Parameters);
+
+			var record = dc.GetTable<TableWithIdentity>().Single();
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(command.Sql, Does.Contain("UPDATE"));
+				Assert.That(command.Parameters, Has.Count.EqualTo(context.IsUseParameters() ? 1 : 0));
+				Assert.That(record.Value, Is.EqualTo(newValue));
+			});
+		}
+
+		[Test]
+		public void ToSqlQuery_IValueInsertable([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<TableWithIdentity>();
+
+			var value = 123;
+			var query = tb.Value(r => r.Value, () => value);
+
+			var command = query.ToSqlQuery();
+
+			using var dc = GetDataConnection(context.StripRemote());
+
+			dc.Execute(command.Sql, command.Parameters);
+
+			var record = dc.GetTable<TableWithIdentity>().Single();
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(command.Sql, Does.Contain("INSERT"));
+				Assert.That(command.Parameters, Has.Count.EqualTo(context.IsUseParameters() ? 1 : 0));
+				Assert.That(record.Value, Is.EqualTo(value));
+			});
+		}
+
+		[Test]
+		public void ToSqlQuery_IValueInsertable_ClientIdentity([DataSources(ProviderName.SqlCe, TestProvName.AllSqlServer, TestProvName.AllDB2, TestProvName.AllSybase)] string context)
+		{
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<TableWithIdentity>();
+
+			var value = 123;
+			var query = tb
+				.Value(r => r.Id, () => 543)
+				.Value(r => r.Value, () => value);
+
+			var command = query.ToSqlQuery();
+
+			using var dc = GetDataConnection(context.StripRemote());
+
+			dc.Execute(command.Sql, command.Parameters);
+
+			var record = dc.GetTable<TableWithIdentity>().Single();
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(command.Sql, Does.Contain("INSERT"));
+				Assert.That(command.Parameters, Has.Count.EqualTo(context.IsUseParameters() ? 1 : 0));
+				Assert.That(record.Value, Is.EqualTo(value));
+			});
+		}
+
+		[Test]
+		public void ToSqlQuery_ISelectInsertable([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+			using var ts = db.CreateLocalTable<TableWithIdentitySource>();
+			using var td = db.CreateLocalTable<TableWithIdentity>();
+
+			var addition = 123;
+			var query = ts.Into(td).Value(r => r.Value, r => r.Value + addition);
+
+			var command = query.ToSqlQuery();
+
+			using var dc = GetDataConnection(context.StripRemote());
+			dc.Insert(new TableWithIdentitySource() { Value = 1 });
+
+			dc.Execute(command.Sql, command.Parameters);
+
+			var records = dc.GetTable<TableWithIdentity>().ToArray();
+
+			Assert.That(records, Has.Length.EqualTo(1));
+			Assert.Multiple(() =>
+			{
+				Assert.That(command.Sql, Does.Contain("INSERT"));
+				Assert.That(command.Sql, Does.Contain("SELECT"));
+				Assert.That(command.Parameters, Has.Count.EqualTo(context.IsUseParameters() ? 1 : 0));
+				Assert.That(records.Count(r => r.Value == 1 + addition), Is.EqualTo(1));
+			});
+		}
+
+		[Test]
+		public void ToSqlQuery_ISelectInsertable_ClientIdentity([DataSources(ProviderName.SqlCe, TestProvName.AllDB2, TestProvName.AllSqlServer, TestProvName.AllSybase)] string context)
+		{
+			using var db = GetDataContext(context);
+			using var ts = db.CreateLocalTable<TableWithIdentitySource>();
+			using var td = db.CreateLocalTable<TableWithIdentity>();
+
+			var addition = 123;
+			var query = ts.Into(td)
+				.Value(r => r.Id, r => 345)
+				.Value(r => r.Value, r => r.Value + addition);
+
+			var command = query.ToSqlQuery();
+
+			using var dc = GetDataConnection(context.StripRemote());
+			dc.Insert(new TableWithIdentitySource() { Value = 1 });
+
+			dc.Execute(command.Sql, command.Parameters);
+
+			var records = dc.GetTable<TableWithIdentity>().ToArray();
+
+			Assert.That(records, Has.Length.EqualTo(1));
+			Assert.Multiple(() =>
+			{
+				Assert.That(command.Sql, Does.Contain("INSERT"));
+				Assert.That(command.Sql, Does.Contain("SELECT"));
+				Assert.That(command.Parameters, Has.Count.EqualTo(context.IsUseParameters() ? 1 : 0));
+				Assert.That(records.Count(r => r.Value == 1 + addition), Is.EqualTo(1));
+			});
+		}
+
+		[Test]
+		public void ToSqlQuery_ILoadWithQueryable([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var query = db.Parent.Where(p => p.ParentID == 1).LoadWith(p => p.Children);
+
+			var command = query.ToSqlQuery();
+
+			using var dc = GetDataConnection(context.StripRemote());
+			var parent = dc.Query<Parent>(command.Sql).ToArray();
+			var expected = query.Single();
+
+			Assert.That(parent, Has.Length.EqualTo(1));
+			Assert.Multiple(() =>
+			{
+				Assert.That(command.Sql, Does.Contain("SELECT"));
+				Assert.That(command.Parameters, Has.Count.EqualTo(0));
+				Assert.That(parent[0].ParentID, Is.EqualTo(expected.ParentID));
+			});
+		}
+
+		[Test]
+		public void ToSqlQuery_IMultiInsertInto([IncludeDataSources(true, TestProvName.AllOracle)] string context)
+		{
+			using var db = GetDataContext(context);
+			using var dest1 = db.CreateLocalTable<MultiInsertTests.Dest1>();
+			using var dest2 = db.CreateLocalTable<MultiInsertTests.Dest2>();
+
+			var query = db
+				.SelectQuery(() => new { ID = 1000, N = (short)42 })
+				.MultiInsert()
+				.Into(
+					dest1,
+					x => new MultiInsertTests.Dest1 { ID = x.ID + 1, Value = x.N }
+				)
+				.Into(
+					dest1,
+					x => new MultiInsertTests.Dest1 { ID = x.ID + 2, Value = x.N }
+				)
+				.Into(
+					dest2,
+					x => new MultiInsertTests.Dest2 { ID = x.ID + 3, Int = x.ID + 1 }
+				);
+
+			var command = query.ToSqlQuery();
+
+			using var dc = GetDataConnection(context.StripRemote());
+			var count = dc.Execute(command.Sql);
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(command.Sql, Does.Contain("INSERT ALL"));
+				Assert.That(command.Parameters, Has.Count.EqualTo(0));
+				Assert.That(count, Is.EqualTo(3));
+				Assert.That(dest1.Count(), Is.EqualTo(2));
+				Assert.That(dest2.Count(x => x.ID == 1003), Is.EqualTo(1));
+			});
+		}
+
+		[Test]
+		public void ToSqlQuery_IMultiInsertElse([IncludeDataSources(true, TestProvName.AllOracle)] string context)
+		{
+			using var db = GetDataContext(context);
+			using var dest1 = db.CreateLocalTable<Dest1>();
+			using var dest2 = db.CreateLocalTable<Dest2>();
+
+			var query = db
+				.SelectQuery(() => new { ID = 1000, N = (short)42 })
+				.MultiInsert()
+				.When(
+					x => x.N > 40,
+					dest1,
+					x => new Dest1 { ID = x.ID + 1, Value = x.N }
+				)
+				.When(
+					x => x.N < 40,
+					dest1,
+					x => new Dest1 { ID = x.ID + 2, Value = x.N }
+				)
+				.When(
+					x => true,
+					dest2,
+					x => new Dest2 { ID = x.ID + 3, Int = x.ID + 1 }
+				);
+
+			var command = query.ToSqlQuery();
+
+			using var dc = GetDataConnection(context.StripRemote());
+			var count = dc.Execute(command.Sql);
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(command.Sql, Does.Contain("INSERT ALL"));
+				Assert.That(command.Sql, Does.Contain("WHEN"));
+				Assert.That(command.Parameters, Has.Count.EqualTo(0));
+
+				Assert.That(count, Is.EqualTo(2));
+				Assert.That(dest1.Count(), Is.EqualTo(1));
+				Assert.That(dest1.Count(x => x.ID == 1001), Is.EqualTo(1));
+				Assert.That(dest2.Count(x => x.ID == 1003), Is.EqualTo(1));
+			});
+		}
+
+		[Test]
+		public void ToSqlQuery_IMergeable([MergeDataContextSource] string context)
+		{
+			using var db = GetDataContext(context);
+
+			PrepareData(db);
+
+			var table = GetTarget(db);
+
+			var query = table
+					.Merge()
+					.Using(GetSource1(db))
+					.OnTargetKey()
+					.UpdateWhenMatched()
+					.InsertWhenNotMatched();
+
+			var command = query.ToSqlQuery();
+
+			using var dc = GetDataConnection(context.StripRemote());
+			var count = dc.Execute(command.Sql);
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(command.Sql, Does.Contain("MERGE"));
+				Assert.That(command.Parameters, Has.Count.EqualTo(0));
+			});
+		}
+
+		[Test]
+		public void ToSqlQuery_IMergeable_WithIdentity([IdentityInsertMergeDataContextSource] string context)
+		{
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<TableWithIdentity>();
+
+			var query = tb
+					.Merge()
+					.Using(new [] { new TableWithIdentity() { Id = 1, Value = 2 } })
+					.OnTargetKey()
+					.UpdateWhenMatched()
+					.InsertWhenNotMatched();
+
+			var command = query.ToSqlQuery();
+
+			using var dc = GetDataConnection(context.StripRemote());
+			var count = dc.Execute(command.Sql);
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(command.Sql, Does.Contain("MERGE"));
+				Assert.That(command.Parameters, Has.Count.EqualTo(0));
+			});
+		}
+
+		[Test]
+		public void ToSqlQuery_IMergeable_WithIdentity_ClientValue([IdentityInsertMergeDataContextSource] string context)
+		{
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<TableWithIdentity>();
+
+			var query = tb
+					.Merge()
+					.Using(new [] { new TableWithIdentity() { Id = 1, Value = 2 } })
+					.OnTargetKey()
+					.UpdateWhenMatched()
+					.InsertWhenNotMatched(s => new TableWithIdentity() { Id = 123, Value = 321 });
+
+			var command = query.ToSqlQuery();
+
+			using var dc = GetDataConnection(context.StripRemote());
+			var count = dc.Execute(command.Sql);
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(command.Sql, Does.Contain("MERGE"));
+				Assert.That(command.Parameters, Has.Count.EqualTo(0));
+			});
+		}
+	}
+}

--- a/Tests/Linq/Linq/QueryableAssociationTests.cs
+++ b/Tests/Linq/Linq/QueryableAssociationTests.cs
@@ -483,8 +483,7 @@ WHERE
 		}
 
 		[Test]
-		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllClickHouse, ErrorMessage = ErrorHelper.Error_Correlated_Subqueries)]
-		public void AssociationFromSqlTest([IncludeDataSources(TestProvName.AllSqlServer2008Plus, TestProvName.AllClickHouse)] string context)
+		public void AssociationFromSqlTest([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
 		{
 			using (var db = (DataConnection)GetDataContext(context, GetMapping()))
 			using (db.CreateLocalTable<FewNumberEntity>())
@@ -503,7 +502,7 @@ WHERE
 					x.SomeValue.Value
 				});
 
-				TestContext.Out.WriteLine(q.ToSqlQuery().Sql);
+				q.ToArray();
 
 				var select = q.GetSelectQuery();
 

--- a/Tests/Linq/Linq/QueryableAssociationTests.cs
+++ b/Tests/Linq/Linq/QueryableAssociationTests.cs
@@ -503,7 +503,7 @@ WHERE
 					x.SomeValue.Value
 				});
 
-				TestContext.Out.WriteLine(q.ToString());
+				TestContext.Out.WriteLine(q.ToSqlQuery().Sql);
 
 				var select = q.GetSelectQuery();
 

--- a/Tests/Linq/Linq/SelectQueryTests.cs
+++ b/Tests/Linq/Linq/SelectQueryTests.cs
@@ -170,7 +170,7 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 			{
-				var sql = db.Child.Where(child => child.ChildID == -1).ToString();
+				var sql = db.Child.Where(child => child.ChildID == -1).ToSqlQuery().Sql;
 				Assert.That(sql, Does.Contain("child_1"));
 			}
 		}

--- a/Tests/Linq/Linq/SelectQueryTests.cs
+++ b/Tests/Linq/Linq/SelectQueryTests.cs
@@ -170,7 +170,9 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 			{
-				var sql = db.Child.Where(child => child.ChildID == -1).ToSqlQuery().Sql;
+				var query = db.Child.Where(child => child.ChildID == -1);
+				query.ToArray();
+				var sql = query.ToSqlQuery().Sql;
 				Assert.That(sql, Does.Contain("child_1"));
 			}
 		}

--- a/Tests/Linq/Linq/SelectTests.cs
+++ b/Tests/Linq/Linq/SelectTests.cs
@@ -674,18 +674,19 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SelectField()
+		public void SelectField([DataSources] string context)
 		{
-			using (var db = new DataConnection())
-			{
-				var q =
+			using var db = GetDataContext(context);
+
+			var q =
 					from p in db.GetTable<TestParent>()
 					select p.Value1_;
 
-				var sql = q.ToSqlQuery().Sql;
+			q.ToArray();
 
-				Assert.That(sql.IndexOf("ParentID_"), Is.LessThan(0));
-			}
+			var sql = q.ToSqlQuery().Sql;
+
+			Assert.That(sql, Does.Not.Contain("ParentID_"));
 		}
 
 		[Test]
@@ -697,14 +698,14 @@ namespace Tests.Linq
 					from p in db.GetTable<ComplexPerson>()
 					select p.Name.LastName;
 
-				var sql = q.ToSqlQuery().Sql;
+				q.ToArray();
 
-				TestContext.Out.WriteLine(sql);
+				var sql = q.ToSqlQuery().Sql;
 
 				Assert.Multiple(() =>
 				{
-					Assert.That(sql.IndexOf("First"), Is.LessThan(0));
-					Assert.That(sql.IndexOf("LastName"), Is.GreaterThan(0));
+					Assert.That(sql, Does.Not.Contain("First"));
+					Assert.That(sql, Does.Contain("LastName"));
 				});
 			}
 		}
@@ -1716,11 +1717,14 @@ namespace Tests.Linq
 					where p.ParentID == id
 					select p;
 
-				var sql1 = query.ToSqlQuery().Sql;
+				var sql1 = query.ToSqlQuery(new SqlGenerationOptions() { InlineParameters = true }).Sql;
 
 				id = 2;
 
-				var sql2 = query.ToSqlQuery().Sql;
+				var sql2 = query.ToSqlQuery(new SqlGenerationOptions() { InlineParameters = true }).Sql;
+
+				BaselinesManager.LogQuery(sql1);
+				BaselinesManager.LogQuery(sql2);
 
 				Assert.That(sql1, Is.Not.EqualTo(sql2));
 			}

--- a/Tests/Linq/Linq/SelectTests.cs
+++ b/Tests/Linq/Linq/SelectTests.cs
@@ -682,7 +682,7 @@ namespace Tests.Linq
 					from p in db.GetTable<TestParent>()
 					select p.Value1_;
 
-				var sql = q.ToString()!;
+				var sql = q.ToSqlQuery().Sql;
 
 				Assert.That(sql.IndexOf("ParentID_"), Is.LessThan(0));
 			}
@@ -697,7 +697,7 @@ namespace Tests.Linq
 					from p in db.GetTable<ComplexPerson>()
 					select p.Name.LastName;
 
-				var sql = q.ToString()!;
+				var sql = q.ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -1716,11 +1716,11 @@ namespace Tests.Linq
 					where p.ParentID == id
 					select p;
 
-				var sql1 = query.ToString();
+				var sql1 = query.ToSqlQuery().Sql;
 
 				id = 2;
 
-				var sql2 = query.ToString();
+				var sql2 = query.ToSqlQuery().Sql;
 
 				Assert.That(sql1, Is.Not.EqualTo(sql2));
 			}

--- a/Tests/Linq/Linq/SqlExtensionsTests.cs
+++ b/Tests/Linq/Linq/SqlExtensionsTests.cs
@@ -122,7 +122,7 @@ namespace Tests.Linq
 						TableName_Database = Sql.TableName(t, Sql.TableQualification.DatabaseName),
 					};
 
-				TestContext.Out.WriteLine(query.ToString());
+				TestContext.Out.WriteLine(query.ToSqlQuery().Sql);
 
 				var ast = query.GetSelectQuery();
 
@@ -194,7 +194,7 @@ namespace Tests.Linq
 						TableName_Database = Sql.TableExpr(t, Sql.TableQualification.DatabaseName),
 					};
 
-				TestContext.Out.WriteLine(query.ToString());
+				TestContext.Out.WriteLine(query.ToSqlQuery().Sql);
 
 				var ast = query.GetSelectQuery();
 
@@ -258,7 +258,7 @@ namespace Tests.Linq
 						.InnerJoin(ft => ft.Key == t.Id)
 					select t;
 
-				var query1Str = query1.ToString();
+				var query1Str = query1.ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(query1Str);
 
@@ -268,7 +268,7 @@ namespace Tests.Linq
 						.InnerJoin(ft => ft.Key == t.Id)
 					select t;
 
-				var query2Str = query2.ToString();
+				var query2Str = query2.ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(query2Str);
 
@@ -276,7 +276,7 @@ namespace Tests.Linq
 				var query3 = db.FromSql<FreeTextKey<int>>(
 					$"FREETEXTTABLE({Sql.TableExpr(table)}, {Sql.FieldExpr(table, t => t.Value)}, {queryText})");
 
-				var query3Str = query3.ToString();
+				var query3Str = query3.ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(query3Str);
 

--- a/Tests/Linq/Linq/SqlExtensionsTests.cs
+++ b/Tests/Linq/Linq/SqlExtensionsTests.cs
@@ -72,7 +72,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void TableNameTests1([IncludeDataSources(true, TestProvName.AllSqlServer2012)] string context)
+		public void TableNameTests1([IncludeDataSources(true, TestProvName.AllSqlServer2012Plus)] string context)
 		{
 			using (var db = GetDataContext(context))
 			using (var table = db.CreateLocalTable<SampleClass>("sample_table_temp", new[]{new SampleClass{Id = 1, Value = 2} }))
@@ -105,7 +105,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void TableNameTests2([IncludeDataSources(true, TestProvName.AllSqlServer2012)] string context)
+		public void TableNameTests2([IncludeDataSources(true, TestProvName.AllSqlServer2012Plus)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -144,7 +144,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void TableExprTests1([IncludeDataSources(true, TestProvName.AllSqlServer2012)] string context)
+		public void TableExprTests1([IncludeDataSources(true, TestProvName.AllSqlServer2012Plus)] string context)
 		{
 			using (var db = GetDataContext(context))
 			using (var table = db.CreateLocalTable<SampleClass>("sample_table_temp", new[]{new SampleClass{Id = 1, Value = 2} }))
@@ -177,7 +177,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void TableExprTests2([IncludeDataSources(true, TestProvName.AllSqlServer2012)] string context)
+		public void TableExprTests2([IncludeDataSources(true, TestProvName.AllSqlServer2012Plus)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -244,7 +244,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void FreeTextTableTest([IncludeDataSources(true, TestProvName.AllSqlServer2012)] string context)
+		public void FreeTextTableTest([IncludeDataSources(true, TestProvName.AllSqlServer2012Plus)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{

--- a/Tests/Linq/Linq/SqlExtensionsTests.cs
+++ b/Tests/Linq/Linq/SqlExtensionsTests.cs
@@ -122,7 +122,7 @@ namespace Tests.Linq
 						TableName_Database = Sql.TableName(t, Sql.TableQualification.DatabaseName),
 					};
 
-				TestContext.Out.WriteLine(query.ToSqlQuery().Sql);
+				BaselinesManager.LogQuery(query.ToSqlQuery().Sql);
 
 				var ast = query.GetSelectQuery();
 
@@ -194,7 +194,7 @@ namespace Tests.Linq
 						TableName_Database = Sql.TableExpr(t, Sql.TableQualification.DatabaseName),
 					};
 
-				TestContext.Out.WriteLine(query.ToSqlQuery().Sql);
+				BaselinesManager.LogQuery(query.ToSqlQuery().Sql);
 
 				var ast = query.GetSelectQuery();
 
@@ -260,7 +260,7 @@ namespace Tests.Linq
 
 				var query1Str = query1.ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(query1Str);
+				BaselinesManager.LogQuery(query1Str);
 
 				var query2 = from t in table
 					from ft in db.FromSql<FreeTextKey<int>>(
@@ -270,7 +270,7 @@ namespace Tests.Linq
 
 				var query2Str = query2.ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(query2Str);
+				BaselinesManager.LogQuery(query2Str);
 
 
 				var query3 = db.FromSql<FreeTextKey<int>>(
@@ -278,7 +278,7 @@ namespace Tests.Linq
 
 				var query3Str = query3.ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(query3Str);
+				BaselinesManager.LogQuery(query3Str);
 
 				Assert.Multiple(() =>
 				{

--- a/Tests/Linq/Linq/StringFunctionTests.cs
+++ b/Tests/Linq/Linq/StringFunctionTests.cs
@@ -1069,11 +1069,14 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void Stuff2([IncludeDataSources(TestProvName.AllSqlServer2008Plus, TestProvName.AllClickHouse)] string context)
+		public void Stuff2([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
 		{
-			using (var db = GetDataContext(context))
-			{
-				var q =
+			using var db = GetDataContext(context);
+			using var t1 = db.CreateLocalTable<Task>();
+			using var t2 = db.CreateLocalTable<TaskCategory>();
+			using var t3 = db.CreateLocalTable<Category>();
+
+			var q =
 					from t in db.GetTable<Task>()
 					join tc in db.GetTable<TaskCategory>() on t.Id equals tc.TaskId into g
 					from tc in g.DefaultIfEmpty()
@@ -1087,8 +1090,7 @@ namespace Tests.Linq
 							select "," + c.Name, 1, 1, "")
 					};
 
-				TestContext.Out.WriteLine(q.ToSqlQuery().Sql);
-			}
+			_ = q.ToArray();
 		}
 
 		[Test]

--- a/Tests/Linq/Linq/StringFunctionTests.cs
+++ b/Tests/Linq/Linq/StringFunctionTests.cs
@@ -1087,7 +1087,7 @@ namespace Tests.Linq
 							select "," + c.Name, 1, 1, "")
 					};
 
-				TestContext.Out.WriteLine(q.ToString());
+				TestContext.Out.WriteLine(q.ToSqlQuery().Sql);
 			}
 		}
 

--- a/Tests/Linq/Linq/TakeSkipTests.cs
+++ b/Tests/Linq/Linq/TakeSkipTests.cs
@@ -749,7 +749,7 @@ namespace Tests.Linq
 
 				Assert.That(q, Is.Not.Empty);
 
-				var qry = q.ToString()!;
+				var qry = q.ToSqlQuery().Sql;
 				Assert.That(qry, Does.Contain("PERCENT"));
 				CheckTakeGlobalParams(db);
 			}
@@ -765,7 +765,7 @@ namespace Tests.Linq
 
 				Assert.That(q, Is.Not.Empty);
 
-				var qry = q.ToString()!;
+				var qry = q.ToSqlQuery().Sql;
 				Assert.That(qry, Does.Contain("PERCENT"));
 			}
 
@@ -780,7 +780,7 @@ namespace Tests.Linq
 
 				Assert.That(q, Is.Not.Empty);
 
-				var qry = q.ToString()!;
+				var qry = q.ToSqlQuery().Sql;
 				Assert.That(qry, Does.Contain("PERCENT"));
 				Assert.That(qry, Does.Contain("WITH"));
 				CheckTakeGlobalParams(db);
@@ -797,7 +797,7 @@ namespace Tests.Linq
 
 				Assert.That(q, Is.Not.Empty);
 
-				var qry = q.ToString()!;
+				var qry = q.ToSqlQuery().Sql;
 				Assert.That(qry, Does.Contain("PERCENT"));
 				Assert.That(qry, Does.Contain("WITH"));
 			}

--- a/Tests/Linq/Linq/TakeSkipTests.cs
+++ b/Tests/Linq/Linq/TakeSkipTests.cs
@@ -749,8 +749,8 @@ namespace Tests.Linq
 
 				Assert.That(q, Is.Not.Empty);
 
-				var qry = q.ToSqlQuery().Sql;
-				Assert.That(qry, Does.Contain("PERCENT"));
+				var sql = q.ToSqlQuery().Sql;
+				Assert.That(sql, Does.Contain("PERCENT"));
 				CheckTakeGlobalParams(db);
 			}
 
@@ -765,8 +765,8 @@ namespace Tests.Linq
 
 				Assert.That(q, Is.Not.Empty);
 
-				var qry = q.ToSqlQuery().Sql;
-				Assert.That(qry, Does.Contain("PERCENT"));
+				var sql = q.ToSqlQuery().Sql;
+				Assert.That(sql, Does.Contain("PERCENT"));
 			}
 
 		}
@@ -780,9 +780,9 @@ namespace Tests.Linq
 
 				Assert.That(q, Is.Not.Empty);
 
-				var qry = q.ToSqlQuery().Sql;
-				Assert.That(qry, Does.Contain("PERCENT"));
-				Assert.That(qry, Does.Contain("WITH"));
+				var sql = q.ToSqlQuery().Sql;
+				Assert.That(sql, Does.Contain("PERCENT"));
+				Assert.That(sql, Does.Contain("WITH"));
 				CheckTakeGlobalParams(db);
 			}
 
@@ -797,9 +797,9 @@ namespace Tests.Linq
 
 				Assert.That(q, Is.Not.Empty);
 
-				var qry = q.ToSqlQuery().Sql;
-				Assert.That(qry, Does.Contain("PERCENT"));
-				Assert.That(qry, Does.Contain("WITH"));
+				var sql = q.ToSqlQuery().Sql;
+				Assert.That(sql, Does.Contain("PERCENT"));
+				Assert.That(sql, Does.Contain("WITH"));
 			}
 
 		}

--- a/Tests/Linq/Linq/TemporalTableTests.cs
+++ b/Tests/Linq/Linq/TemporalTableTests.cs
@@ -225,7 +225,7 @@ namespace Tests.Linq
 					.DefaultIfEmpty()
 				select t;
 
-			TestContext.Out.WriteLine(q.ToSqlQuery().Sql);
+			_ = q.ToSqlQuery();
 
 			var selectQuery = q.GetSelectQuery();
 

--- a/Tests/Linq/Linq/TemporalTableTests.cs
+++ b/Tests/Linq/Linq/TemporalTableTests.cs
@@ -225,7 +225,7 @@ namespace Tests.Linq
 					.DefaultIfEmpty()
 				select t;
 
-			TestContext.Out.WriteLine(q.ToString());
+			TestContext.Out.WriteLine(q.ToSqlQuery().Sql);
 
 			var selectQuery = q.GetSelectQuery();
 

--- a/Tests/Linq/Linq/TestQueryCache.cs
+++ b/Tests/Linq/Linq/TestQueryCache.cs
@@ -186,7 +186,7 @@ namespace Tests.Linq
 						.GetTable<ManyFields>()
 						.Where(x => Helper.GetField(x, i) == i);
 
-					var sqlStr = test.ToString();
+					var sqlStr = test.ToSqlQuery().Sql;
 					TestContext.Out.WriteLine(sqlStr);
 				}
 
@@ -200,7 +200,7 @@ namespace Tests.Linq
 						.GetTable<ManyFields>()
 						.Where(x => Helper.GetField(x, i) == i);
 
-					var sqlStr = test.ToString();
+					var sqlStr = test.ToSqlQuery().Sql;
 				}
 
 				Assert.That(Query<ManyFields>.CacheMissCount, Is.EqualTo(currentMiss));

--- a/Tests/Linq/Linq/TestQueryCache.cs
+++ b/Tests/Linq/Linq/TestQueryCache.cs
@@ -186,8 +186,7 @@ namespace Tests.Linq
 						.GetTable<ManyFields>()
 						.Where(x => Helper.GetField(x, i) == i);
 
-					var sqlStr = test.ToSqlQuery().Sql;
-					TestContext.Out.WriteLine(sqlStr);
+					_ = test.ToSqlQuery();
 				}
 
 				Assert.That(Query<ManyFields>.CacheMissCount - currentMiss, Is.EqualTo(5));
@@ -200,7 +199,7 @@ namespace Tests.Linq
 						.GetTable<ManyFields>()
 						.Where(x => Helper.GetField(x, i) == i);
 
-					var sqlStr = test.ToSqlQuery().Sql;
+					_ = test.ToSqlQuery();
 				}
 
 				Assert.That(Query<ManyFields>.CacheMissCount, Is.EqualTo(currentMiss));

--- a/Tests/Linq/Linq/VisualBasicTests.cs
+++ b/Tests/Linq/Linq/VisualBasicTests.cs
@@ -28,8 +28,9 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 			{
 				var query = (IQueryable<Person>)CompilerServices.CompareString(db);
+				query.ToArray();
+
 				var str   = query.ToSqlQuery().Sql;
-				TestContext.Out.WriteLine(str);
 				Assert.That(str, Does.Not.Contain("CASE"));
 			}
 		}
@@ -162,7 +163,7 @@ namespace Tests.Linq
 					LastChild = data.Grouped.Max(f => f.ChildID)
 				});
 
-				var str = q1.ToSqlQuery().Sql;
+				_ = q1.ToArray();
 			}
 		}
 

--- a/Tests/Linq/Linq/VisualBasicTests.cs
+++ b/Tests/Linq/Linq/VisualBasicTests.cs
@@ -28,7 +28,7 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 			{
 				var query = (IQueryable<Person>)CompilerServices.CompareString(db);
-				var str   = query.ToString();
+				var str   = query.ToSqlQuery().Sql;
 				TestContext.Out.WriteLine(str);
 				Assert.That(str, Does.Not.Contain("CASE"));
 			}
@@ -162,7 +162,7 @@ namespace Tests.Linq
 					LastChild = data.Grouped.Max(f => f.ChildID)
 				});
 
-				var str = q1.ToString();
+				var str = q1.ToSqlQuery().Sql;
 			}
 		}
 

--- a/Tests/Linq/Linq/WhereTests.cs
+++ b/Tests/Linq/Linq/WhereTests.cs
@@ -1622,8 +1622,6 @@ namespace Tests.Linq
 
 				var sql = results.ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(sql);
-
 				AreEqual(
 					from c in db.Parent.AsEnumerable()
 					where c.ParentID == id
@@ -1632,9 +1630,7 @@ namespace Tests.Linq
 					results,
 					true);
 
-				// remote context doesn't have access to final SQL
-				if (!context.IsRemote())
-					Assert.That(Regex.Matches(sql, " AND "), Has.Count.EqualTo(flag == null ? 0 : 1));
+				Assert.That(Regex.Matches(sql, " AND "), Has.Count.EqualTo(flag == null ? 0 : 1));
 			}
 		}
 
@@ -1658,9 +1654,7 @@ namespace Tests.Linq
 					results,
 					true);
 
-				// remote context doesn't have access to final SQL
-				if (!context.IsRemote())
-					Assert.That(Regex.Matches(sql, " AND "), Has.Count.EqualTo(flag == null ? 0 : 1));
+				Assert.That(Regex.Matches(sql, " AND "), Has.Count.EqualTo(flag == null ? 0 : 1));
 			}
 		}
 

--- a/Tests/Linq/Linq/WhereTests.cs
+++ b/Tests/Linq/Linq/WhereTests.cs
@@ -1893,7 +1893,6 @@ namespace Tests.Linq
 			}
 		}
 
-
 		#region issue 2424
 		sealed class Isue2424Table
 		{

--- a/Tests/Linq/Linq/WhereTests.cs
+++ b/Tests/Linq/Linq/WhereTests.cs
@@ -1437,7 +1437,7 @@ namespace Tests.Linq
 				var exp = expected.Where(predicate.CompileExpression());
 				var act = actual.  Where(predicate);
 				AreEqual(exp, act, WhereCases.Comparer);
-				Assert.That(act.ToString(), Does.Not.Contain("<>"));
+				Assert.That(act.ToSqlQuery().Sql, Does.Not.Contain("<>"));
 
 				var notPredicate = Expression.Lambda<Func<WhereCases, bool>>(
 					Expression.Not(predicate.Body), predicate.Parameters);
@@ -1447,14 +1447,14 @@ namespace Tests.Linq
 				var actNot      = actNotQuery.ToArray();
 				AreEqual(expNot, actNot, WhereCases.Comparer);
 
-				Assert.That(actNotQuery.ToString(), Does.Not.Contain("<>"));
+				Assert.That(actNotQuery.ToSqlQuery().Sql, Does.Not.Contain("<>"));
 			}
 
 			void AreEqualLocalPredicate(IEnumerable<WhereCases> expected, IQueryable<WhereCases> actual, Expression<Func<WhereCases, bool>> predicate, Expression<Func<WhereCases, bool>> localPredicate)
 			{
 				var actualQuery = actual.Where(predicate);
 				AreEqual(expected.Where(localPredicate.CompileExpression()), actualQuery, WhereCases.Comparer);
-				Assert.That(actualQuery.ToString(), Does.Not.Contain("<>"));
+				Assert.That(actualQuery.ToSqlQuery().Sql, Does.Not.Contain("<>"));
 
 				var notLocalPredicate = Expression.Lambda<Func<WhereCases, bool>>(
 					Expression.Not(localPredicate.Body), localPredicate.Parameters);
@@ -1468,7 +1468,7 @@ namespace Tests.Linq
 				var actNot = actualNotQuery.ToArray();
 				AreEqual(expNot, actNot, WhereCases.Comparer);
 
-				Assert.That(actualNotQuery.ToString(), Does.Not.Contain("<>"));
+				Assert.That(actualNotQuery.ToSqlQuery().Sql, Does.Not.Contain("<>"));
 			}
 
 			using (var db = GetDataContext(context))
@@ -1620,7 +1620,7 @@ namespace Tests.Linq
 								   && (!flag.HasValue || flag.Value && c.Value1 == null || !flag.Value && c.Value1 != null)
 							   select c);
 
-				var sql = results.ToString()!;
+				var sql = results.ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(sql);
 
@@ -1648,7 +1648,7 @@ namespace Tests.Linq
 								   && (flag == null || flag.Value && c.Value1 == null || !flag.Value && c.Value1 != null)
 							   select c);
 
-				var sql = results.ToString()!;
+				var sql = results.ToSqlQuery().Sql;
 
 				AreEqual(
 					from c in db.Parent.AsEnumerable()
@@ -1866,7 +1866,7 @@ namespace Tests.Linq
 
 				var result = query.ToArray();
 
-				var str = query.ToString();
+				var str = query.ToSqlQuery().Sql;
 
 				str.Should().Contain("IS NOT NULL");
 			}
@@ -1984,7 +1984,7 @@ namespace Tests.Linq
 					db.Parent.AsEnumerable().Where(p => p.Value1 != null && p.Value1 != 1),
 					query);
 
-				var sql = query.ToString()!;
+				var sql = query.ToSqlQuery().Sql;
 				Assert.Multiple(() =>
 				{
 					Assert.That(sql, Does.Not.Contain("IS NULL"), sql);
@@ -2005,7 +2005,7 @@ namespace Tests.Linq
 					db.Parent.AsEnumerable().Where(p => p.Value1 == null || p.Value1 != 1),
 					query);
 
-				var sql = query.ToString()!;
+				var sql = query.ToSqlQuery().Sql;
 				Assert.Multiple(() =>
 				{
 					Assert.That(Regex.Matches(sql, "IS NULL"), Has.Count.EqualTo(1), sql);

--- a/Tests/Linq/Mapping/ConversionTypeTests.cs
+++ b/Tests/Linq/Mapping/ConversionTypeTests.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.Diagnostics;
-using System.Linq;
+﻿using System.Linq;
 
 using LinqToDB;
 using LinqToDB.Common;
 using LinqToDB.Data;
 using LinqToDB.Mapping;
-using LinqToDB.Tools;
 
 using NUnit.Framework;
 
@@ -44,8 +41,6 @@ namespace Tests.Mapping
 
 			t.Insert(() => new TrimTestTable { ID = 3, Data = "VVV" });
 
-			Debug.WriteLine(t.ToDiagnosticString());
-
 			AreEqual(
 				[
 					new { ID = 1, Data = "OOO" },
@@ -55,8 +50,6 @@ namespace Tests.Mapping
 				t.OrderBy(r => r.ID).Select(r => new { r.ID, r.Data }));
 
 			using var db1 = GetDataContext(context);
-
-			Debug.WriteLine(db1.GetTable<TrimTestTable>().ToDiagnosticString());
 
 			AreEqual(
 				[
@@ -96,9 +89,6 @@ namespace Tests.Mapping
 					inserted => new { inserted.ID, inserted.Data })
 				.ToList();
 
-			Debug.WriteLine(o.ToDiagnosticString());
-			Debug.WriteLine(t.ToDiagnosticString());
-
 			AreEqual([new { ID = 2, Data = "HHH" }], o.OrderBy(r => r.ID));
 
 			AreEqual(
@@ -109,8 +99,6 @@ namespace Tests.Mapping
 				t.OrderBy(r => r.ID).Select(r => new { r.ID, r.Data}));
 
 			using var db1 = GetDataContext(context);
-
-			Debug.WriteLine(db1.GetTable<TrimTestTable>().ToDiagnosticString());
 
 			AreEqual(
 				[
@@ -130,15 +118,11 @@ namespace Tests.Mapping
 
 			t.BulkCopy([new TrimTestTable { ID = 1, Data = "OOO" }]);
 
-			Debug.WriteLine(t.ToDiagnosticString());
-
 			AreEqual(
 				[ new { ID = 1, Data = "OOO"} ],
 				t.OrderBy(r => r.ID).Select(r => new { r.ID, r.Data}));
 
 			using var db1 = GetDataContext(context);
-
-			Debug.WriteLine(db1.GetTable<TrimTestTable>().ToDiagnosticString());
 
 			AreEqual(
 				[ new { ID = 1, Data = "***OOO***"} ],
@@ -173,8 +157,6 @@ namespace Tests.Mapping
 				.Set(t => t.Data, "SSS")
 				.Update();
 
-			Debug.WriteLine(t.ToDiagnosticString());
-
 			AreEqual(
 				[
 					new { ID = 1, Data = "OOO"},
@@ -184,8 +166,6 @@ namespace Tests.Mapping
 				t.OrderBy(r => r.ID).Select(r => new { r.ID, r.Data}));
 
 			using var db1 = GetDataContext(context);
-
-			Debug.WriteLine(db1.GetTable<TrimTestTable>().ToDiagnosticString());
 
 			AreEqual(
 				[
@@ -233,13 +213,11 @@ namespace Tests.Mapping
 				;
 
 #pragma warning disable CS0618 // Type or member is obsolete
-				t.Merge(
+			t.Merge(
 				[
 					new TrimTestTable { ID = 3, Data = "III" }
 				]);
 #pragma warning restore CS0618 // Type or member is obsolete
-
-				Debug.WriteLine(t.ToDiagnosticString());
 
 			AreEqual(
 				[
@@ -250,8 +228,6 @@ namespace Tests.Mapping
 				t.OrderBy(r => r.ID).Select(r => new { r.ID, r.Data}));
 
 			using var db1 = GetDataContext(context);
-
-			Debug.WriteLine(db1.GetTable<TrimTestTable>().ToDiagnosticString());
 
 			AreEqual(
 				[

--- a/Tests/Linq/Mapping/FluentMappingTests.cs
+++ b/Tests/Linq/Mapping/FluentMappingTests.cs
@@ -706,7 +706,7 @@ namespace Tests.Mapping
 
 				var query = db.GetTable<PersonCustom>().Where(p => p.Name != "");
 				var sql1 = query.ToSqlQuery().Sql;
-				TestContext.Out.WriteLine(sql1);
+				BaselinesManager.LogQuery(sql1);
 
 				if (finalAliases)
 					Assert.That(sql1, Does.Contain("[AGE]"));
@@ -714,7 +714,7 @@ namespace Tests.Mapping
 					Assert.That(sql1, Does.Not.Contain("[AGE]"));
 
 				var sql2 = query.Select(q => new { q.Name, q.Age }).ToSqlQuery().Sql;
-				TestContext.Out.WriteLine(sql2);
+				BaselinesManager.LogQuery(sql2);
 
 				if (finalAliases)
 					Assert.That(sql2, Does.Contain("[AGE]"));
@@ -739,7 +739,7 @@ namespace Tests.Mapping
 
 				var query = db.GetTable<PersonCustom>().Where(p => p.Name != "");
 				var sql1 = query.ToSqlQuery().Sql;
-				TestContext.Out.WriteLine(sql1);
+				BaselinesManager.LogQuery(sql1);
 
 				if (finalAliases)
 					Assert.That(sql1, Does.Contain("[MONEY]"));
@@ -747,7 +747,7 @@ namespace Tests.Mapping
 					Assert.That(sql1, Does.Not.Contain("[MONEY]"));
 
 				var sql2 = query.Select(q => new { q.Name, q.Money }).ToSqlQuery().Sql;
-				TestContext.Out.WriteLine(sql2);
+				BaselinesManager.LogQuery(sql2);
 
 				if (finalAliases)
 					Assert.That(sql2, Does.Contain("[MONEY]"));

--- a/Tests/Linq/Mapping/FluentMappingTests.cs
+++ b/Tests/Linq/Mapping/FluentMappingTests.cs
@@ -705,7 +705,7 @@ namespace Tests.Mapping
 				Query.ClearCaches();
 
 				var query = db.GetTable<PersonCustom>().Where(p => p.Name != "");
-				var sql1 = query.ToString();
+				var sql1 = query.ToSqlQuery().Sql;
 				TestContext.Out.WriteLine(sql1);
 
 				if (finalAliases)
@@ -713,7 +713,7 @@ namespace Tests.Mapping
 				else
 					Assert.That(sql1, Does.Not.Contain("[AGE]"));
 
-				var sql2 = query.Select(q => new { q.Name, q.Age }).ToString();
+				var sql2 = query.Select(q => new { q.Name, q.Age }).ToSqlQuery().Sql;
 				TestContext.Out.WriteLine(sql2);
 
 				if (finalAliases)
@@ -738,7 +738,7 @@ namespace Tests.Mapping
 				Query.ClearCaches();
 
 				var query = db.GetTable<PersonCustom>().Where(p => p.Name != "");
-				var sql1 = query.ToString();
+				var sql1 = query.ToSqlQuery().Sql;
 				TestContext.Out.WriteLine(sql1);
 
 				if (finalAliases)
@@ -746,7 +746,7 @@ namespace Tests.Mapping
 				else
 					Assert.That(sql1, Does.Not.Contain("[MONEY]"));
 
-				var sql2 = query.Select(q => new { q.Name, q.Money }).ToString();
+				var sql2 = query.Select(q => new { q.Name, q.Money }).ToSqlQuery().Sql;
 				TestContext.Out.WriteLine(sql2);
 
 				if (finalAliases)

--- a/Tests/Linq/Samples/JoinOperatorTests.cs
+++ b/Tests/Linq/Samples/JoinOperatorTests.cs
@@ -20,10 +20,7 @@ namespace Tests.Samples
 					where !p.Discontinued
 					select c;
 
-				foreach (var category in query)
-				{
-					TestContext.Out.WriteLine(category.CategoryID);
-				}
+				query.ToArray();
 			}
 		}
 

--- a/Tests/Linq/Tools/ToDiagnosticStringTests.cs
+++ b/Tests/Linq/Tools/ToDiagnosticStringTests.cs
@@ -14,8 +14,6 @@ namespace Tests.Tools
 		{
 			var str = new[] { 1, 2, 222 }.ToDiagnosticString();
 
-			TestContext.Out.Write(str);
-
 			Assert.That(@"Count : 3
 +-------+
 | Value |
@@ -44,8 +42,6 @@ namespace Tests.Tools
 				new TestDiagnostic { StringValue = "dakasdlkjjkasd  djkadlskdj ", DateTimeValue = new DateTime(2016, 11, 22), DecimalValue = 111.3m },
 				new TestDiagnostic { StringValue = "dkjdkdjkl102398 3 1231233",   DateTimeValue = new DateTime(2016, 10, 23), DecimalValue = 1111111 },
 			}.ToDiagnosticString();
-
-			TestContext.Out.Write(str);
 
 			Assert.That(@"Count : 4
 +---------------------+--------------+-----------------------------+

--- a/Tests/Linq/Update/InsertTests.cs
+++ b/Tests/Linq/Update/InsertTests.cs
@@ -321,15 +321,12 @@ namespace Tests.xUpdate
 				var id = 1;
 
 				var insertable = db.Child
-					.Where(c => c.ChildID == 11)
+					.Where(c => c.ChildID == 111)
 					.Into(db.Child)
 					.Value(c => c.ParentID, c => c.ParentID)
 					.Value(c => c.ChildID, () => id);
 
-				var sql = insertable.ToSqlQuery().Sql;
-				TestContext.Out.WriteLine(sql);
-
-				Assert.That(sql, Does.Contain("INSERT"));
+				var sql = insertable.Insert();
 			}
 		}
 

--- a/Tests/Linq/Update/InsertTests.cs
+++ b/Tests/Linq/Update/InsertTests.cs
@@ -326,7 +326,7 @@ namespace Tests.xUpdate
 					.Value(c => c.ParentID, c => c.ParentID)
 					.Value(c => c.ChildID, () => id);
 
-				var sql = insertable.ToString();
+				var sql = insertable.ToSqlQuery().Sql;
 				TestContext.Out.WriteLine(sql);
 
 				Assert.That(sql, Does.Contain("INSERT"));

--- a/Tests/Linq/Update/MergeTests.ApiParametersValidation.cs
+++ b/Tests/Linq/Update/MergeTests.ApiParametersValidation.cs
@@ -190,13 +190,13 @@ namespace Tests.xUpdate
 		sealed class FakeTable<TEntity> : ITable<TEntity>
 			where TEntity : notnull
 		{
-			IDataContext            IExpressionQuery.   DataContext   => throw new NotImplementedException();
-			Expression              IExpressionQuery.   Expression    => throw new NotImplementedException();
-			IReadOnlyList<QuerySql> IExpressionQuery.   GetSqlQuery() => throw new NotImplementedException();
-			Type                    IQueryable.         ElementType   => throw new NotImplementedException();
-			Expression              IQueryable.         Expression    => throw new NotImplementedException();
-			IQueryProvider          IQueryable.         Provider      => new FakeQueryProvider();
-			Expression              IQueryProviderAsync.Expression    => throw new NotImplementedException();
+			IDataContext            IExpressionQuery.   DataContext                                  => throw new NotImplementedException();
+			Expression              IExpressionQuery.   Expression                                   => throw new NotImplementedException();
+			IReadOnlyList<QuerySql> IExpressionQuery.   GetSqlQueries(SqlGenerationOptions? options) => throw new NotImplementedException();
+			Type                    IQueryable.         ElementType                                  => throw new NotImplementedException();
+			Expression              IQueryable.         Expression                                   => throw new NotImplementedException();
+			IQueryProvider          IQueryable.         Provider                                     => new FakeQueryProvider();
+			Expression              IQueryProviderAsync.Expression                                   => throw new NotImplementedException();
 
 			Expression IExpressionQuery<TEntity>.Expression => Expression.Constant((ITable<TEntity>)this);
 

--- a/Tests/Linq/Update/MergeTests.ApiParametersValidation.cs
+++ b/Tests/Linq/Update/MergeTests.ApiParametersValidation.cs
@@ -190,13 +190,13 @@ namespace Tests.xUpdate
 		sealed class FakeTable<TEntity> : ITable<TEntity>
 			where TEntity : notnull
 		{
-			IDataContext   IExpressionQuery.   DataContext => throw new NotImplementedException();
-			Expression     IExpressionQuery.   Expression  => throw new NotImplementedException();
-			string         IExpressionQuery.   SqlText     => throw new NotImplementedException();
-			Type           IQueryable.         ElementType => throw new NotImplementedException();
-			Expression     IQueryable.         Expression  => throw new NotImplementedException();
-			IQueryProvider IQueryable.         Provider    => new FakeQueryProvider();
-			Expression     IQueryProviderAsync.Expression  => throw new NotImplementedException();
+			IDataContext            IExpressionQuery.   DataContext   => throw new NotImplementedException();
+			Expression              IExpressionQuery.   Expression    => throw new NotImplementedException();
+			IReadOnlyList<QuerySql> IExpressionQuery.   GetSqlQuery() => throw new NotImplementedException();
+			Type                    IQueryable.         ElementType   => throw new NotImplementedException();
+			Expression              IQueryable.         Expression    => throw new NotImplementedException();
+			IQueryProvider          IQueryable.         Provider      => new FakeQueryProvider();
+			Expression              IQueryProviderAsync.Expression    => throw new NotImplementedException();
 
 			Expression IExpressionQuery<TEntity>.Expression => Expression.Constant((ITable<TEntity>)this);
 

--- a/Tests/Linq/Update/MergeTests.cs
+++ b/Tests/Linq/Update/MergeTests.cs
@@ -146,12 +146,12 @@ namespace Tests.xUpdate
 			public int OtherFake;
 		}
 
-		private static ITable<TestMapping1> GetTarget(IDataContext db)
+		internal static ITable<TestMapping1> GetTarget(IDataContext db)
 		{
 			return db.GetTable<TestMapping1>().TableName("TestMerge1");
 		}
 
-		private static ITable<TestMapping1> GetSource1(IDataContext db)
+		internal static ITable<TestMapping1> GetSource1(IDataContext db)
 		{
 			return db.GetTable<TestMapping1>().TableName("TestMerge2");
 		}
@@ -174,7 +174,7 @@ namespace Tests.xUpdate
 			});
 		}
 
-		private void PrepareData(IDataContext db)
+		internal static void PrepareData(IDataContext db)
 		{
 			using (new DisableLogging())
 			{

--- a/Tests/Linq/Update/MergeTests.cs
+++ b/Tests/Linq/Update/MergeTests.cs
@@ -146,12 +146,16 @@ namespace Tests.xUpdate
 			public int OtherFake;
 		}
 
+#pragma warning disable NUnit1028 // The non-test method is public
 		internal static ITable<TestMapping1> GetTarget(IDataContext db)
+#pragma warning restore NUnit1028 // The non-test method is public
 		{
 			return db.GetTable<TestMapping1>().TableName("TestMerge1");
 		}
 
+#pragma warning disable NUnit1028 // The non-test method is public
 		internal static ITable<TestMapping1> GetSource1(IDataContext db)
+#pragma warning restore NUnit1028 // The non-test method is public
 		{
 			return db.GetTable<TestMapping1>().TableName("TestMerge2");
 		}
@@ -174,7 +178,9 @@ namespace Tests.xUpdate
 			});
 		}
 
+#pragma warning disable NUnit1028 // The non-test method is public
 		internal static void PrepareData(IDataContext db)
+#pragma warning restore NUnit1028 // The non-test method is public
 		{
 			using (new DisableLogging())
 			{

--- a/Tests/Linq/Update/MultiInsertTests.cs
+++ b/Tests/Linq/Update/MultiInsertTests.cs
@@ -573,14 +573,14 @@ namespace Tests.xUpdate
 			public short N  { get; set; }
 		}
 
-		sealed class Dest1
+		public sealed class Dest1
 		{
 			public int     ID          { get; set; }
 			public short?  Value       { get; set; }
 			public string? StringValue { get; set; }
 		}
 
-		sealed class Dest2
+		public sealed class Dest2
 		{
 			public int ID    { get; set; }
 			public int Int   { get; set; }

--- a/Tests/Linq/Update/UpdateTests.cs
+++ b/Tests/Linq/Update/UpdateTests.cs
@@ -155,10 +155,7 @@ namespace Tests.xUpdate
 						.Where(c => c.ChildID == id && c.Parent!.Value1 == 1)
 						.Set(c => c.ChildID, c => c.ChildID + 1);
 
-				var sql = updatable.ToSqlQuery().Sql;
-				TestContext.Out.WriteLine(sql);
-
-				Assert.That(sql, Does.Contain("UPDATE"));
+				updatable.Update();
 			}
 		}
 

--- a/Tests/Linq/Update/UpdateTests.cs
+++ b/Tests/Linq/Update/UpdateTests.cs
@@ -155,7 +155,7 @@ namespace Tests.xUpdate
 						.Where(c => c.ChildID == id && c.Parent!.Value1 == 1)
 						.Set(c => c.ChildID, c => c.ChildID + 1);
 
-				var sql = updatable.ToString();
+				var sql = updatable.ToSqlQuery().Sql;
 				TestContext.Out.WriteLine(sql);
 
 				Assert.That(sql, Does.Contain("UPDATE"));

--- a/Tests/Linq/UserTests/CompareNullableCharTests.cs
+++ b/Tests/Linq/UserTests/CompareNullableCharTests.cs
@@ -39,7 +39,7 @@ namespace Tests.UserTests
 					where current.Foeld2 == previous.Foeld2
 					select new { current.Field1, Field2 = previous.Field1 };
 
-				var sql = q.ToString();
+				var sql = q.ToSqlQuery().Sql;
 			}
 		}
 	}

--- a/Tests/Linq/UserTests/CompareNullableCharTests.cs
+++ b/Tests/Linq/UserTests/CompareNullableCharTests.cs
@@ -15,32 +15,23 @@ namespace Tests.UserTests
 		sealed class Table1
 		{
 			[PrimaryKey(1)]
-			[Identity] public long  Field1 { get; set; }
+			[Identity] public int  Field1 { get; set; }
 			[Nullable] public char? Foeld2 { get; set; }
 		}
 
-		sealed class Repository : DataConnection
-		{
-			public Repository(string configurationString) : base(configurationString)
-			{
-			}
-
-			public ITable<Table1> Table1 => this.GetTable<Table1>();
-		}
-
 		[Test]
-		public void Test([IncludeDataSources(TestProvName.AllAccess, TestProvName.AllClickHouse)] string context)
+		public void Test([DataSources] string context)
 		{
-			using (var db = new Repository(context))
-			{
-				var q =
-					from current  in db.Table1
-					from previous in db.Table1
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<Table1>();
+
+			var q =
+					from current  in db.GetTable<Table1>()
+					from previous in db.GetTable<Table1>()
 					where current.Foeld2 == previous.Foeld2
 					select new { current.Field1, Field2 = previous.Field1 };
 
-				var sql = q.ToSqlQuery().Sql;
-			}
+			_ = q.ToArray();
 		}
 	}
 }

--- a/Tests/Linq/UserTests/GroupBySubqueryTests.cs
+++ b/Tests/Linq/UserTests/GroupBySubqueryTests.cs
@@ -84,7 +84,7 @@ namespace Tests.UserTests
 				).Distinct();
 
 				var sql1 = q1.GetSelectQuery();
-				TestContext.Out.WriteLine(q1.ToString());
+				TestContext.Out.WriteLine(q1.ToSqlQuery().Sql);
 
 				Assert.That(sql1.Select.IsDistinct, "Distinct not present");
 
@@ -96,7 +96,7 @@ namespace Tests.UserTests
 					select new { g.Key.Field6, EngineeringCircuitNumber = g.Key.Field4, Count = g.Count() };
 
 				var sql2 = q2.GetSelectQuery();
-				TestContext.Out.WriteLine(q2.ToString());
+				TestContext.Out.WriteLine(q2.ToSqlQuery().Sql);
 
 				var distinct = q2.EnumQueries().FirstOrDefault(q => q.Select.IsDistinct)!;
 

--- a/Tests/Linq/UserTests/GroupBySubqueryTests.cs
+++ b/Tests/Linq/UserTests/GroupBySubqueryTests.cs
@@ -14,7 +14,7 @@ namespace Tests.UserTests
 	{
 		sealed class Table1
 		{
-			public long Field1 { get; set; }
+			public int Field1 { get; set; }
 			public int  Field2 { get; set; }
 
 			[Nullable]
@@ -39,7 +39,7 @@ namespace Tests.UserTests
 		sealed class Table3
 		{
 			public int  Field5 { get; set; }
-			public long Field1 { get; set; }
+			public int Field1 { get; set; }
 
 			[Association(ThisKey = "Field5", OtherKey = "Field5", CanBeNull = false)]
 			public Table4 Ref4 { get; set; } = null!;
@@ -68,41 +68,48 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void Test()
+		public void Test([DataSources] string context)
 		{
-			using (var db = new DataConnection())
-			{
-				var q1 = (
+			using var db = GetDataContext(context, o => o.OmitUnsupportedCompareNulls(context));
+			using var t8 = db.CreateLocalTable<Table1>();
+			using var t2 = db.CreateLocalTable<Table2>();
+			using var t7 = db.CreateLocalTable<Table3>();
+			using var t4 = db.CreateLocalTable<Table4>();
+			using var t5 = db.CreateLocalTable<Table5>();
+			using var t6 = db.CreateLocalTable<Table6>();
+
+			var q1 = (
 					from t1 in db.GetTable<Table1>()
 					where t1.Field3 != null
 					select new
 					{
-						t1.Ref1.Ref4.Field6, 
+						t1.Ref1.Ref4.Field6,
 						t1.Ref3!.Field4,
 						Field1 = t1.Ref2!.Ref5!.Field8 ?? string.Empty
 					}
 				).Distinct();
 
-				var sql1 = q1.GetSelectQuery();
-				TestContext.Out.WriteLine(q1.ToSqlQuery().Sql);
+			_ = q1.ToArray();
 
-				Assert.That(sql1.Select.IsDistinct, "Distinct not present");
+			var sql1 = q1.GetSelectQuery();
 
-				var q2 =
+			Assert.That(sql1.Select.IsDistinct, "Distinct not present");
+
+			var q2 =
 					from t3 in q1
 					group t3 by new { t3.Field6, t3.Field4 }
 					into g
 					where g.Count() > 1
 					select new { g.Key.Field6, EngineeringCircuitNumber = g.Key.Field4, Count = g.Count() };
 
-				var sql2 = q2.GetSelectQuery();
-				TestContext.Out.WriteLine(q2.ToSqlQuery().Sql);
+			_ = q2.ToArray();
 
-				var distinct = q2.EnumQueries().FirstOrDefault(q => q.Select.IsDistinct)!;
+			var sql2 = q2.GetSelectQuery();
 
-				Assert.That(distinct, Is.Not.Null);
-				Assert.That(distinct.Select.Columns, Has.Count.EqualTo(3));
-			}
+			var distinct = q2.EnumQueries().FirstOrDefault(q => q.Select.IsDistinct)!;
+
+			Assert.That(distinct, Is.Not.Null);
+			Assert.That(distinct.Select.Columns, Has.Count.EqualTo(3));
 		}
 	}
 }

--- a/Tests/Linq/UserTests/IndexOutOfRangeInUnions.cs
+++ b/Tests/Linq/UserTests/IndexOutOfRangeInUnions.cs
@@ -31,7 +31,7 @@ namespace Tests.UserTests
 					query = query?.Union(innerQuery) ?? innerQuery;
 				}
 
-				Assert.DoesNotThrow(() => TestContext.Out.WriteLine(query?.ToString()));
+				Assert.DoesNotThrow(() => TestContext.Out.WriteLine(query?.ToSqlQuery().Sql));
 
 				query!.ToList();
 			}

--- a/Tests/Linq/UserTests/IndexOutOfRangeInUnions.cs
+++ b/Tests/Linq/UserTests/IndexOutOfRangeInUnions.cs
@@ -31,8 +31,6 @@ namespace Tests.UserTests
 					query = query?.Union(innerQuery) ?? innerQuery;
 				}
 
-				Assert.DoesNotThrow(() => TestContext.Out.WriteLine(query?.ToSqlQuery().Sql));
-
 				query!.ToList();
 			}
 		}

--- a/Tests/Linq/UserTests/Issue1347Tests.cs
+++ b/Tests/Linq/UserTests/Issue1347Tests.cs
@@ -243,147 +243,164 @@ namespace Tests.UserTests
 		[TestFixture]
 		public class Issue1347Tests : TestBase
 		{
-			sealed class LimitedSources : IncludeDataSourcesAttribute
-			{
-				public LimitedSources() : base(TestProvName.AllSQLite, TestProvName.AllClickHouse)
-				{
-				}
-			}
-
 			[Test]
-			public void Test5([LimitedSources]string context)
+			public void Test5([DataSources] string context)
 			{
-				using (var s = GetDataContext(context))
-				{
-					var gts = s.GetTable<GlobalTaskDTO>().Union(
-						s.GetTable<GlobalTaskDTO>()
+				using var db = GetDataContext(context);
+				using var t1 = db.CreateLocalTable<GlobalTaskDTO>();
+				using var t11 = db.CreateLocalTable<GlobalTaskDTO>("WMS_GlobalTaskA");
+				using var t5 = db.CreateLocalTable<WmsLoadCarrierDTO>();
+				using var t51 = db.CreateLocalTable<WmsLoadCarrierDTO>("WMS_LoadCarrierA");
+
+				var gts = db.GetTable<GlobalTaskDTO>().Union(
+						db.GetTable<GlobalTaskDTO>()
 							.TableName(
 								"WMS_GlobalTaskA"));
 
-					var lcs = s.GetTable<WmsLoadCarrierDTO>().Union(
-						s.GetTable<WmsLoadCarrierDTO>()
+				var lcs = db.GetTable<WmsLoadCarrierDTO>().Union(
+						db.GetTable<WmsLoadCarrierDTO>()
 							.TableName(
 								"WMS_LoadCarrierA"));
 
-					var qry = from g in gts
-							  join res in lcs on g.ResourceID equals res.Id into reslist
-							  from res in reslist.DefaultIfEmpty()
-							  select new WmsGlobalTaskCombinedDTO()
-								  { GlobalTask = g, LoadCarrier = res };
+				var qry = from g in gts
+						  join res in lcs on g.ResourceID equals res.Id into reslist
+						  from res in reslist.DefaultIfEmpty()
+						  select new WmsGlobalTaskCombinedDTO()
+						  { GlobalTask = g, LoadCarrier = res };
 
-					TestContext.Out.WriteLine(qry.ToSqlQuery().Sql);
-				}
+				qry.ToArray();
 			}
 
 			[Test]
-			public void Test4([LimitedSources] string context)
+			public void Test4([DataSources] string context)
 			{
-				using (var s = GetDataContext(context))
-				{
-					var gts = s.GetTable<GlobalTaskDTO>().Union(
-						s.GetTable<GlobalTaskDTO>()
+				using var db = GetDataContext(context);
+				using var t1 = db.CreateLocalTable<GlobalTaskDTO>();
+				using var t11 = db.CreateLocalTable<GlobalTaskDTO>("WMS_GlobalTaskA");
+
+				var gts = db.GetTable<GlobalTaskDTO>().Union(
+						db.GetTable<GlobalTaskDTO>()
 							.TableName(
 								"WMS_GlobalTaskA"));
 
-					var qry = from g in gts
-						join source1 in s.GetTable<WmsResourcePointDTO>() on g.RPSourceID equals source1.Id into
+				var qry = from g in gts
+						  join source1 in db.GetTable<WmsResourcePointDTO>() on g.RPSourceID equals source1.Id into
 							source1List
-						select new WmsGlobalTaskCombinedDTO()
-						{
-							GlobalTask = g,
-						};
+						  select new WmsGlobalTaskCombinedDTO()
+						  {
+							  GlobalTask = g,
+						  };
 
-					TestContext.Out.WriteLine(qry.ToSqlQuery().Sql);
-				}
+				qry.ToArray();
 			}
 
 			[Test]
-			public void Test3([LimitedSources] string context)
+			public void Test3([DataSources] string context)
 			{
-				using (var s = GetDataContext(context))
-				{
-					var gts = s.GetTable<GlobalTaskDTO>().Union(
-						s.GetTable<GlobalTaskDTO>()
+				using var db = GetDataContext(context);
+				using var t1 = db.CreateLocalTable<GlobalTaskDTO>();
+				using var t11 = db.CreateLocalTable<GlobalTaskDTO>("WMS_GlobalTaskA");
+				using var t2 = db.CreateLocalTable<WmsResourcePointDTO>();
+				using var t3 = db.CreateLocalTable<StorageShelfDTO>();
+
+				var gts = db.GetTable<GlobalTaskDTO>().Union(
+						db.GetTable<GlobalTaskDTO>()
 							.TableName(
 								"WMS_GlobalTaskA"));
 
-						var qry = from g in gts
-						join source1 in s.GetTable<WmsResourcePointDTO>() on g.RPSourceID equals source1.Id into
+				var qry = from g in gts
+						  join source1 in db.GetTable<WmsResourcePointDTO>() on g.RPSourceID equals source1.Id into
 							source1List
-						from source in source1List.DefaultIfEmpty()
-						join sourceShelf1 in s.GetTable<StorageShelfDTO>() on g.StorageShelfSourceID equals sourceShelf1
+						  from source in source1List.DefaultIfEmpty()
+						  join sourceShelf1 in db.GetTable<StorageShelfDTO>() on g.StorageShelfSourceID equals sourceShelf1
 							.Id into sourceShelf1List
-						from sourceShelf in sourceShelf1List.DefaultIfEmpty()
-						join dest1 in s.GetTable<WmsResourcePointDTO>() on g.RPDestinationID equals dest1.Id into
+						  from sourceShelf in sourceShelf1List.DefaultIfEmpty()
+						  join dest1 in db.GetTable<WmsResourcePointDTO>() on g.RPDestinationID equals dest1.Id into
 							destList
-						from dest in destList.DefaultIfEmpty()
-						join destShelf1 in s.GetTable<StorageShelfDTO>() on g.StorageShelfDestinationID equals
+						  from dest in destList.DefaultIfEmpty()
+						  join destShelf1 in db.GetTable<StorageShelfDTO>() on g.StorageShelfDestinationID equals
 							destShelf1.Id into destShelf1List
-						from destShelf in destShelf1List.DefaultIfEmpty()
-						join origdest1 in s.GetTable<WmsResourcePointDTO>() on g.RPOrigDestinationID equals origdest1.Id
+						  from destShelf in destShelf1List.DefaultIfEmpty()
+						  join origdest1 in db.GetTable<WmsResourcePointDTO>() on g.RPOrigDestinationID equals origdest1.Id
 							into origdestList
-						from origdest in origdestList.DefaultIfEmpty()
-						select new WmsGlobalTaskCombinedDTO()
-						{
-							GlobalTask = g, Source = source, SourceShelf = sourceShelf,
-							Destination = dest, DestinationShelf = destShelf, OriginDestination = origdest
-						};
+						  from origdest in origdestList.DefaultIfEmpty()
+						  select new WmsGlobalTaskCombinedDTO()
+						  {
+							  GlobalTask = g,
+							  Source = source,
+							  SourceShelf = sourceShelf,
+							  Destination = dest,
+							  DestinationShelf = destShelf,
+							  OriginDestination = origdest
+						  };
 
-					TestContext.Out.WriteLine(qry.ToSqlQuery().Sql);
-				}
+				qry.ToArray();
 			}
 
 			[Test]
-			public void Test2([LimitedSources]string context)
+			public void Test2([DataSources] string context)
 			{
-				using (var s = GetDataContext(context))
-				{
-					var gts = s.GetTable<GlobalTaskDTO>().Union(
-						s.GetTable<GlobalTaskDTO>()
+				using var db = GetDataContext(context);
+				using var t1 = db.CreateLocalTable<GlobalTaskDTO>();
+				using var t11 = db.CreateLocalTable<GlobalTaskDTO>("WMS_GlobalTaskA");
+				using var t2 = db.CreateLocalTable<WmsResourcePointDTO>();
+				using var t3 = db.CreateLocalTable<StorageShelfDTO>();
+				using var t4 = db.CreateLocalTable<OutfeedTransportOrderDTO>();
+				using var t41 = db.CreateLocalTable<OutfeedTransportOrderDTO>("WMS_OutfeedTransportOrderA");
+				using var t5 = db.CreateLocalTable<WmsLoadCarrierDTO>();
+				using var t51 = db.CreateLocalTable<WmsLoadCarrierDTO>("WMS_LoadCarrierA");
+
+				var gts = db.GetTable<GlobalTaskDTO>().Union(
+						db.GetTable<GlobalTaskDTO>()
 							.TableName(
 								"WMS_GlobalTaskA"));
 
-					var lcs = s.GetTable<WmsLoadCarrierDTO>().Union(
-						s.GetTable<WmsLoadCarrierDTO>()
+				var lcs = db.GetTable<WmsLoadCarrierDTO>().Union(
+						db.GetTable<WmsLoadCarrierDTO>()
 							.TableName(
 								"WMS_LoadCarrierA"));
 
-					var ots = s.GetTable<OutfeedTransportOrderDTO>().Union(
-						s.GetTable<OutfeedTransportOrderDTO>()
+				var ots = db.GetTable<OutfeedTransportOrderDTO>().Union(
+						db.GetTable<OutfeedTransportOrderDTO>()
 							.TableName(
 								"WMS_OutfeedTransportOrderA"));
 
-					var qry = from g in gts
-						join source1 in s.GetTable<WmsResourcePointDTO>() on g.RPSourceID equals source1.Id into source1List
-						from source in source1List.DefaultIfEmpty()
-						join sourceShelf1 in s.GetTable<StorageShelfDTO>() on g.StorageShelfSourceID equals sourceShelf1.Id into sourceShelf1List
-						from sourceShelf in sourceShelf1List.DefaultIfEmpty()
-						join dest1 in s.GetTable<WmsResourcePointDTO>() on g.RPDestinationID equals dest1.Id into destList
-						from dest in destList.DefaultIfEmpty()
-						join destShelf1 in s.GetTable<StorageShelfDTO>() on g.StorageShelfDestinationID equals destShelf1.Id into destShelf1List
-						from destShelf in destShelf1List.DefaultIfEmpty()
-						join origdest1 in s.GetTable<WmsResourcePointDTO>() on g.RPOrigDestinationID equals origdest1.Id into origdestList
-						from origdest in origdestList.DefaultIfEmpty()
-						join res in lcs on g.ResourceID equals res.Id into reslist
-						from res in reslist.DefaultIfEmpty()
-						join outfeed1 in ots on g.OutfeedTransportOrderID equals outfeed1.Id into outfeed1List
-						from outfeed in outfeed1List.DefaultIfEmpty()
-						select new WmsGlobalTaskCombinedDTO() { GlobalTask = g, LoadCarrier = res, Source = source, SourceShelf = sourceShelf, Destination = dest, DestinationShelf = destShelf, OriginDestination = origdest, OutfeedTransportOrder = outfeed };
+				var qry = from g in gts
+						  join source1 in db.GetTable<WmsResourcePointDTO>() on g.RPSourceID equals source1.Id into source1List
+						  from source in source1List.DefaultIfEmpty()
+						  join sourceShelf1 in db.GetTable<StorageShelfDTO>() on g.StorageShelfSourceID equals sourceShelf1.Id into sourceShelf1List
+						  from sourceShelf in sourceShelf1List.DefaultIfEmpty()
+						  join dest1 in db.GetTable<WmsResourcePointDTO>() on g.RPDestinationID equals dest1.Id into destList
+						  from dest in destList.DefaultIfEmpty()
+						  join destShelf1 in db.GetTable<StorageShelfDTO>() on g.StorageShelfDestinationID equals destShelf1.Id into destShelf1List
+						  from destShelf in destShelf1List.DefaultIfEmpty()
+						  join origdest1 in db.GetTable<WmsResourcePointDTO>() on g.RPOrigDestinationID equals origdest1.Id into origdestList
+						  from origdest in origdestList.DefaultIfEmpty()
+						  join res in lcs on g.ResourceID equals res.Id into reslist
+						  from res in reslist.DefaultIfEmpty()
+						  join outfeed1 in ots on g.OutfeedTransportOrderID equals outfeed1.Id into outfeed1List
+						  from outfeed in outfeed1List.DefaultIfEmpty()
+						  select new WmsGlobalTaskCombinedDTO() { GlobalTask = g, LoadCarrier = res, Source = source, SourceShelf = sourceShelf, Destination = dest, DestinationShelf = destShelf, OriginDestination = origdest, OutfeedTransportOrder = outfeed };
 
-					TestContext.Out.WriteLine(qry.ToSqlQuery().Sql);
-				}
+				_ = qry.ToArray();
 			}
 
 			[Test]
-			public void Test([LimitedSources]string context)
+			public void Test([DataSources] string context)
 			{
-				using (var db = GetDataContext(context))
-				{
-					var query = db.GetTable<GlobalTaskDTO>()
+				using var db = GetDataContext(context);
+				using var t1 = db.CreateLocalTable<GlobalTaskDTO>();
+				using var t11 = db.CreateLocalTable<GlobalTaskDTO>("WMS_GlobalTaskA");
+				using var t2 = db.CreateLocalTable<WmsResourcePointDTO>();
+				using var t3 = db.CreateLocalTable<StorageShelfDTO>();
+				using var t4 = db.CreateLocalTable<OutfeedTransportOrderDTO>();
+				using var t41 = db.CreateLocalTable<OutfeedTransportOrderDTO>("WMS_OutfeedTransportOrderA");
+				using var t5 = db.CreateLocalTable<WmsLoadCarrierDTO>();
+				using var t51 = db.CreateLocalTable<WmsLoadCarrierDTO>("WMS_ResourceA");
+
+				var query = db.GetTable<GlobalTaskDTO>()
 						.Union(
 							db.GetTable<GlobalTaskDTO>()
-								.TableName(
-									"WMS_GlobalTaskA")
 								.TableName(
 									"WMS_GlobalTaskA"))
 						.GroupJoin(
@@ -476,8 +493,6 @@ namespace Tests.UserTests
 								.Union(
 									db.GetTable<WmsLoadCarrierDTO>()
 										.TableName(
-											"WMS_ResourceA")
-										.TableName(
 											"WMS_ResourceA")),
 							tp9 => tp9.tp8.tp7.tp6.tp5.tp4.tp3.tp2.tp1.tp0.g.ResourceID,
 							res => res.Id,
@@ -498,8 +513,6 @@ namespace Tests.UserTests
 							db.GetTable<OutfeedTransportOrderDTO>()
 								.Union(
 									db.GetTable<OutfeedTransportOrderDTO>()
-										.TableName(
-											"WMS_OutfeedTransportOrderA")
 										.TableName(
 											"WMS_OutfeedTransportOrderA")),
 							tp11 => tp11.tp10.tp9.tp8.tp7.tp6.tp5.tp4.tp3.tp2.tp1.tp0.g.OutfeedTransportOrderID,
@@ -524,9 +537,7 @@ namespace Tests.UserTests
 								OutfeedTransportOrder = outfeed
 							});
 
-					var str = query.ToSqlQuery().Sql;
-					TestContext.Out.WriteLine(str);
-				}
+				_ = query.ToArray();
 			}
 		}
 	}

--- a/Tests/Linq/UserTests/Issue1347Tests.cs
+++ b/Tests/Linq/UserTests/Issue1347Tests.cs
@@ -271,7 +271,7 @@ namespace Tests.UserTests
 							  select new WmsGlobalTaskCombinedDTO()
 								  { GlobalTask = g, LoadCarrier = res };
 
-					TestContext.Out.WriteLine(qry.ToString());
+					TestContext.Out.WriteLine(qry.ToSqlQuery().Sql);
 				}
 			}
 
@@ -293,7 +293,7 @@ namespace Tests.UserTests
 							GlobalTask = g,
 						};
 
-					TestContext.Out.WriteLine(qry.ToString());
+					TestContext.Out.WriteLine(qry.ToSqlQuery().Sql);
 				}
 			}
 
@@ -329,7 +329,7 @@ namespace Tests.UserTests
 							Destination = dest, DestinationShelf = destShelf, OriginDestination = origdest
 						};
 
-					TestContext.Out.WriteLine(qry.ToString());
+					TestContext.Out.WriteLine(qry.ToSqlQuery().Sql);
 				}
 			}
 
@@ -370,7 +370,7 @@ namespace Tests.UserTests
 						from outfeed in outfeed1List.DefaultIfEmpty()
 						select new WmsGlobalTaskCombinedDTO() { GlobalTask = g, LoadCarrier = res, Source = source, SourceShelf = sourceShelf, Destination = dest, DestinationShelf = destShelf, OriginDestination = origdest, OutfeedTransportOrder = outfeed };
 
-					TestContext.Out.WriteLine(qry.ToString());
+					TestContext.Out.WriteLine(qry.ToSqlQuery().Sql);
 				}
 			}
 
@@ -524,7 +524,7 @@ namespace Tests.UserTests
 								OutfeedTransportOrder = outfeed
 							});
 
-					var str = query.ToString();
+					var str = query.ToSqlQuery().Sql;
 					TestContext.Out.WriteLine(str);
 				}
 			}

--- a/Tests/Linq/UserTests/Issue1564Tests.cs
+++ b/Tests/Linq/UserTests/Issue1564Tests.cs
@@ -59,7 +59,7 @@ namespace Tests.UserTests
 				pathQuery.ToList();
 				adminCategoriesQuery.ToList();
 
-				Assert.That(adminCategoriesQuery.ToString()!, Does.Contain("ORDER BY"));
+				Assert.That(adminCategoriesQuery.ToSqlQuery().Sql, Does.Contain("ORDER BY"));
 			}
 
 			IQueryable<AdminCategoryPathItemCte> GetPathQuery(IDataContext db)

--- a/Tests/Linq/UserTests/Issue1979Tests.cs
+++ b/Tests/Linq/UserTests/Issue1979Tests.cs
@@ -80,7 +80,7 @@ namespace Tests.UserTests
 							where tagFilter.Where(t => t.TaggableId == i.Id).Any()
 							select i;
 
-				var sql = query.ToString();
+				var sql = query.ToSqlQuery().Sql;
 				query.ToList();
 
 				/*
@@ -116,7 +116,7 @@ WHERE
 							where i.Tagging.Any(x => x.Tag.Name == "Visu")
 							select i;
 
-				var sql = query.ToString();
+				var sql = query.ToSqlQuery().Sql;
 				query.ToList();
 
 				/*

--- a/Tests/Linq/UserTests/Issue1979Tests.cs
+++ b/Tests/Linq/UserTests/Issue1979Tests.cs
@@ -80,27 +80,7 @@ namespace Tests.UserTests
 							where tagFilter.Where(t => t.TaggableId == i.Id).Any()
 							select i;
 
-				var sql = query.ToSqlQuery().Sql;
 				query.ToList();
-
-				/*
-				 * SQL:
-SELECT
-	[i].[Id]
-FROM
-	[Issue] [i]
-WHERE
-	EXISTS(
-		SELECT
-			*
-		FROM
-			[Tagging] [t_1]
-				INNER JOIN [Tag] [t] ON [t_1].[TagId] = [t].[Id]
-		WHERE
-			[t].[Name] = N'Visu' AND [t_1].[TaggableId] = [i].[Id] AND
-			[t_1].[TaggableType] = N'Issue'
-	)
-	*/
 			}
 
 		}
@@ -116,42 +96,7 @@ WHERE
 							where i.Tagging.Any(x => x.Tag.Name == "Visu")
 							select i;
 
-				var sql = query.ToSqlQuery().Sql;
 				query.ToList();
-
-				/*
-
-SELECT
-	[i].[Id]
-FROM
-	[Issue] [i]
-WHERE
-	EXISTS(
-		SELECT
-			*
-		FROM
-			[Tagging] [_1]
-				OUTER APPLY (
-					SELECT
-						[t1].[Name]
-					FROM
-						(
-							SELECT
-								[_].[Name],
-								ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) as [RN]
-							FROM
-								[Tag] [_]
-							WHERE
-								Convert(BigInt, [_1].[TagId]) = [_].[Id]
-						) [t1]
-					WHERE
-						[t1].[RN] <= @take
-				) [a_Tag]
-		WHERE
-			[_1].[TaggableType] = N'Issue' AND [i].[Id] = [_1].[TaggableId] AND
-			[a_Tag].[Name] = N'Visu'
-	)
-				 */
 			}
 		}
 	}

--- a/Tests/Linq/UserTests/Issue2478Tests.cs
+++ b/Tests/Linq/UserTests/Issue2478Tests.cs
@@ -116,9 +116,9 @@ namespace Tests.UserTests
 			}
 		}
 
-		[ActiveIssue(Details = "Converted FuncLikePredicate expression is not a Predicate expression.")]
+		[ActiveIssue("Optimization issue: subquery always return 1 record")]
 		[Test]
-		public void ExistsRemoval([IncludeDataSources(TestProvName.AllSqlServer, TestProvName.AllClickHouse)] string context, [Values] bool shouldFilter, [Values] bool isPositive)
+		public void ExistsRemoval([IncludeDataSources(true, TestProvName.AllSqlServer)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -136,7 +136,7 @@ namespace Tests.UserTests
 
 				Assert.Multiple(() =>
 				{
-					Assert.That(query.ToSqlQuery().Sql, Does.Not.Contains("EXISTS"));
+					Assert.That(query.ToSqlQuery().Sql, Does.Not.Contain("EXISTS"));
 
 					Assert.That(cnt, Is.EqualTo(result.Length));
 				});

--- a/Tests/Linq/UserTests/Issue2478Tests.cs
+++ b/Tests/Linq/UserTests/Issue2478Tests.cs
@@ -136,7 +136,7 @@ namespace Tests.UserTests
 
 				Assert.Multiple(() =>
 				{
-					Assert.That(query.ToString(), Does.Not.Contains("EXISTS"));
+					Assert.That(query.ToSqlQuery().Sql, Does.Not.Contains("EXISTS"));
 
 					Assert.That(cnt, Is.EqualTo(result.Length));
 				});

--- a/Tests/Linq/UserTests/Issue2596Tests.cs
+++ b/Tests/Linq/UserTests/Issue2596Tests.cs
@@ -16,7 +16,7 @@ namespace Tests.UserTests
 			[Column, PrimaryKey, Identity] public int Id { get; set; } // integer
 		}
 
-		[Table(Schema = "public", Name = "custom_invoice")]
+		[Table]
 		public class CustomInvoice : BaseEntity
 		{
 			[Column, NotNull] public int ContractId { get; set; } // integer
@@ -39,78 +39,58 @@ namespace Tests.UserTests
 			[Association(ThisKey = "AccessTariffId", OtherKey = "Id", CanBeNull = false)]
 			public AccessTariff AccessTariff { get; set; }
 
-			/// <summary>
-			/// Línies d energia
-			/// </summary>
 			[Association(ThisKey = "Id", OtherKey = "CustomInvoiceId", CanBeNull = true)]
 			public ICollection<CustomInvoiceLine> InvoiceLines { get; set; }
 
-			/// <summary>
-			/// Lecturas de energía
-			/// </summary>
 			[Association(ThisKey = "Id", OtherKey = "CustomInvoiceId", CanBeNull = true)]
 			public ICollection<TypeAMeasures> TypeAMeasures { get; set; }
 
-			/// <summary>
-			/// Lecturas de energía
-			/// </summary>
 			[Association(ThisKey = "Id", OtherKey = "CustomInvoiceId", CanBeNull = true)]
 			public ICollection<TypeBMeasures> TypeBMeasures { get; set; }
 
 
 			[Column, NotNull] public int PriceListId { get; set; } // integer
 
-			/// <summary>
-			/// Price list used for this invoice
-			/// </summary>
 			[Association(ThisKey = "PriceListId", OtherKey = "Id", CanBeNull = true)]
 			public PriceList PriceList { get; set; }
 		}
 
-		[Table(Schema = "public", Name = "custom_invoice_linia")]
+		[Table]
 		public class CustomInvoiceLine : BaseEntity
 		{
 			[Column, NotNull] public int CustomInvoiceId { get; set; }
 		}
 
-		[Table(Schema = "public", Name = "polissa")]
+		[Table]
 		public class Contract : BaseEntity
 		{
 		}
 
-
-		[Table(Schema = "public", Name = "product_uom")]
+		[Table]
 		public class ProductUnit : BaseEntity
 		{
 		}
 
-
-		[Table(Schema = "public", Name = "cups_ps")]
+		[Table]
 		public class ServicePoint : BaseEntity
 		{
 			[Column, NotNull] public int TownId { get; set; }
 
 			[Column, NotNull] public int StreetTypeId { get; set; }
 
-			/// <summary>
-			///     Municipio
-			/// </summary>
 			[Association(ThisKey = "TownId", OtherKey = "Id", CanBeNull = true)]
 			public Town Town { get; set; }
 
-			/// <summary>
-			///     Tipo vía
-			/// </summary>
 			[Association(ThisKey = "StreetTypeId", OtherKey = "Id", CanBeNull = true)]
 			public StreetType StreetType { get; set; }
 		}
 
-		[Table(Schema = "public", Name = "street_type")]
+		[Table]
 		public class StreetType : BaseEntity
 		{
 		}
 
-		[Table(Schema = "public", Name = "type_a_measures")]
+		[Table]
 		public class TypeAMeasures : BaseEntity
 		{
 			/// <summary>
@@ -129,12 +109,12 @@ namespace Tests.UserTests
 			public MeasureSource PreviousSource { get; set; }
 		}
 
-		[Table(Schema = "public", Name = "lectures_origen")]
+		[Table]
 		public class MeasureSource : BaseEntity
 		{
 		}
 
-		[Table(Schema = "public", Name = "invoice")]
+		[Table]
 		public class Invoice : BaseEntity
 		{
 			/// <summary>
@@ -165,7 +145,7 @@ namespace Tests.UserTests
 			public Invoice RefundBy { get; set; }
 		}
 
-		[Table(Schema = "public", Name = "invoice_tax")]
+		[Table]
 		public class InvoiceTaxLine : BaseEntity
 		{
 			[Column, Nullable] public int InvoiceId { get; set; } // integer
@@ -176,13 +156,12 @@ namespace Tests.UserTests
 			public AccountTax Tax { get; set; }
 		}
 
-		[Table(Schema = "public", Name = "account_tax")]
+		[Table]
 		public class AccountTax : BaseEntity
 		{
 		}
 
-
-		[Table(Schema = "public", Name = "invoice_line")]
+		[Table]
 		public class InvoiceLine : BaseEntity
 		{
 			[Column, Nullable] public int? ProductUnitId { get; set; } // integer
@@ -196,7 +175,7 @@ namespace Tests.UserTests
 			public Product Product { get; set; }
 		}
 
-		[Table(Schema = "public", Name = "town")]
+		[Table]
 		public class Town : BaseEntity
 		{
 			[Column, Nullable] public int? StateId { get; set; } // integer
@@ -205,7 +184,7 @@ namespace Tests.UserTests
 			public CountryState State { get; set; }
 		}
 
-		[Table(Schema = "public", Name = "country_state")]
+		[Table]
 		public class CountryState : BaseEntity
 		{
 			[Column, NotNull] public int CountryId { get; set; } // integer
@@ -218,49 +197,69 @@ namespace Tests.UserTests
 			public Country Country { get; set; }
 		}
 
-		[Table(Schema = "public", Name = "autonomous_community")]
+		[Table]
 		public class AutonomousCommunity : BaseEntity
 		{
 		}
 
-		[Table(Schema = "public", Name = "country")]
+		[Table]
 		public class Country : BaseEntity
 		{
 		}
 
-		[Table(Schema = "public", Name = "invoice_pending_state")]
+		[Table]
 		public class InvoicePendingState : BaseEntity
 		{
 		}
 
-		[Table(Schema = "public", Name = "type_b_measures")]
+		[Table]
 		public class TypeBMeasures : BaseEntity
 		{
 			[Column, NotNull] public int CustomInvoiceId { get; set; }
 		}
 
-		[Table(Schema = "public", Name = "access_tariff")]
+		[Table]
 		public class AccessTariff : BaseEntity
 		{
 		}
 
-		[Table(Schema = "public", Name = "product_product")]
+		[Table]
 		public class Product : BaseEntity
 		{
 		}
 
-
-		[Table(Schema = "public", Name = "product_pricelist")]
+		[Table]
 		public class PriceList : BaseEntity
 		{
 		}
 
 		[Test]
-		public void TestLoadWithInfiniteLoop([IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
+		public void TestLoadWithInfiniteLoop([DataSources] string context)
 		{
-			using (var db = GetDataContext(context))
-			{
-				var query = db
+			using var db = GetDataContext(context);
+			using var t01 = db.CreateLocalTable<PriceList>();
+			using var t02 = db.CreateLocalTable<Product>();
+			using var t03 = db.CreateLocalTable<AccessTariff>();
+			using var t04 = db.CreateLocalTable<CountryState>();
+			using var t05 = db.CreateLocalTable<AutonomousCommunity>();
+			using var t06 = db.CreateLocalTable<Country>();
+			using var t07 = db.CreateLocalTable<InvoicePendingState>();
+			using var t08 = db.CreateLocalTable<TypeBMeasures>();
+			using var t09 = db.CreateLocalTable<Town>();
+			using var t10 = db.CreateLocalTable<InvoiceLine>();
+			using var t11 = db.CreateLocalTable<AccountTax>();
+			using var t12 = db.CreateLocalTable<InvoiceTaxLine>();
+			using var t13 = db.CreateLocalTable<Invoice>();
+			using var t14 = db.CreateLocalTable<MeasureSource>();
+			using var t15 = db.CreateLocalTable<TypeAMeasures>();
+			using var t16 = db.CreateLocalTable<StreetType>();
+			using var t17 = db.CreateLocalTable<ServicePoint>();
+			using var t18 = db.CreateLocalTable<ProductUnit>();
+			using var t19 = db.CreateLocalTable<Contract>();
+			using var t20 = db.CreateLocalTable<CustomInvoice>();
+			using var t21 = db.CreateLocalTable<CustomInvoiceLine>();
+
+			var query = db
 					.GetTable<CustomInvoice>()
 					.LoadWith(i => i.Invoice)
 					.LoadWith(i => i.Invoice.Rectifying)
@@ -285,8 +284,7 @@ namespace Tests.UserTests
 					.LoadWith(i => i.PriceList)
 					.Where(f => f.Id == 1);
 
-				Assert.DoesNotThrow(() => TestContext.Out.WriteLine(query.ToSqlQuery().Sql));
-			}
+			query.ToArray();
 		}
 	}
 }

--- a/Tests/Linq/UserTests/Issue2596Tests.cs
+++ b/Tests/Linq/UserTests/Issue2596Tests.cs
@@ -285,7 +285,7 @@ namespace Tests.UserTests
 					.LoadWith(i => i.PriceList)
 					.Where(f => f.Id == 1);
 
-				Assert.DoesNotThrow(() => TestContext.Out.WriteLine(query.ToString()));
+				Assert.DoesNotThrow(() => TestContext.Out.WriteLine(query.ToSqlQuery().Sql));
 			}
 		}
 	}

--- a/Tests/Linq/UserTests/Issue2619Tests.cs
+++ b/Tests/Linq/UserTests/Issue2619Tests.cs
@@ -20,7 +20,7 @@ namespace Tests.UserTests
 				var union = persons
 						.Union (persons);
 
-				var sql = union.ToString();
+				var sql = union.ToSqlQuery().Sql;
 
 				sql.Should().NotContain("ORDER");
 
@@ -39,7 +39,7 @@ namespace Tests.UserTests
 				var union = persons
 					.Union (persons);
 
-				var sql = union.ToString();
+				var sql = union.ToSqlQuery().Sql;
 
 				sql.Should().Contain("ORDER", Exactly.Twice());
 
@@ -58,7 +58,7 @@ namespace Tests.UserTests
 				var concat = persons
 					.Concat(persons);
 
-				var sql = concat.ToString();
+				var sql = concat.ToSqlQuery().Sql;
 
 				sql.Should().Contain("ORDER", Exactly.Twice());
 
@@ -77,7 +77,7 @@ namespace Tests.UserTests
 				var concat = persons
 					.Concat(persons);
 
-				var sql = concat.ToString();
+				var sql = concat.ToSqlQuery().Sql;
 
 				sql.Should().Contain("ORDER", Exactly.Twice());
 
@@ -97,7 +97,7 @@ namespace Tests.UserTests
 				var concat = persons
 					.Except(persons);
 
-				var sql = concat.ToString()!;
+				var sql = concat.ToSqlQuery().Sql;
 
 				if (!sql.Contains("EXISTS"))
 					sql.Should().NotContain("ORDER");
@@ -118,7 +118,7 @@ namespace Tests.UserTests
 				var except = persons
 					.Except(persons);
 
-				var sql = except.ToString();
+				var sql = except.ToSqlQuery().Sql;
 
 				sql.Should().Contain("ORDER", AtLeast.Once());
 

--- a/Tests/Linq/UserTests/Issue2647Tests.cs
+++ b/Tests/Linq/UserTests/Issue2647Tests.cs
@@ -32,8 +32,6 @@ namespace Tests.UserTests
 				                                     db.GetTable<IssueClass>().Count(ss3 => ss3.Id == ss.Id));
 
 				query.ToList();
-				var sql = query.ToSqlQuery().Sql;
-				TestContext.Out.WriteLine(sql);
 
 				var selectQuery = query.GetSelectQuery();
 				Assert.That(selectQuery.OrderBy.Items, Has.Count.EqualTo(2));

--- a/Tests/Linq/UserTests/Issue2647Tests.cs
+++ b/Tests/Linq/UserTests/Issue2647Tests.cs
@@ -32,7 +32,7 @@ namespace Tests.UserTests
 				                                     db.GetTable<IssueClass>().Count(ss3 => ss3.Id == ss.Id));
 
 				query.ToList();
-				var sql = query.ToString();
+				var sql = query.ToSqlQuery().Sql;
 				TestContext.Out.WriteLine(sql);
 
 				var selectQuery = query.GetSelectQuery();

--- a/Tests/Linq/UserTests/Issue271Tests.cs
+++ b/Tests/Linq/UserTests/Issue271Tests.cs
@@ -22,9 +22,10 @@ namespace Tests.UserTests
 		[Test]
 		public void Test1([IncludeDataSources(TestProvName.AllSqlServer)] string context)
 		{
-			using (var db = GetDataContext(context))
-			{
-				var q =
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<Entity>();
+
+			var q =
 					from e in db.GetTable<Entity>()
 					where
 						e.CharValue     == "CharValue"     &&
@@ -33,30 +34,29 @@ namespace Tests.UserTests
 						e.NVarCharValue == "NVarCharValue"
 					select e;
 
-				var str = q.ToSqlQuery().Sql;
+			var sql = q.ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(str);
+			Assert.That(sql, Does.Not.Contain("N'CharValue'"));
+			Assert.That(sql, Does.Not.Contain("N'VarCharValue'"));
 
-				Assert.That(str, Does.Not.Contain("N'CharValue'"));
-				Assert.That(str, Does.Not.Contain("N'VarCharValue'"));
+			Assert.That(sql, Does.Contain("N'NCharValue'"));
+			Assert.That(sql, Does.Contain("N'NVarCharValue'"));
 
-				Assert.That(str, Does.Contain("N'NCharValue'"));
-				Assert.That(str, Does.Contain("N'NVarCharValue'"));
-			}
-
+			q.ToArray();
 		}
 
 		[Test]
 		public void Test2([IncludeDataSources(TestProvName.AllSqlServer)] string context)
 		{
-			using (var db = GetDataContext(context))
-			{
-				var @char     = new[] { "CharValue"     };
-				var @varChar  = new[] { "VarCharValue"  };
-				var @nChar    = new[] { "NCharValue"    };
-				var @nVarChar = new[] { "NVarCharValue" };
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<Entity>();
 
-				var q =
+			var @char     = new[] { "CharValue"     };
+			var @varChar  = new[] { "VarCharValue"  };
+			var @nChar    = new[] { "NCharValue"    };
+			var @nVarChar = new[] { "NVarCharValue" };
+
+			var q =
 					from e in db.GetTable<Entity>()
 					where
 						@char    .Contains(e.CharValue    ) &&
@@ -65,16 +65,15 @@ namespace Tests.UserTests
 						@nVarChar.Contains(e.NVarCharValue)
 					select e;
 
-				var str = q.ToSqlQuery().Sql;
+			var sql = q.ToSqlQuery().Sql;
 
-				TestContext.Out.WriteLine(str);
+			Assert.That(sql, Does.Not.Contain("N'CharValue'"));
+			Assert.That(sql, Does.Not.Contain("N'VarCharValue'"));
 
-				Assert.That(str, Does.Not.Contain("N'CharValue'"));
-				Assert.That(str, Does.Not.Contain("N'VarCharValue'"));
+			Assert.That(sql, Does.Contain("N'NCharValue'"));
+			Assert.That(sql, Does.Contain("N'NVarCharValue'"));
 
-				Assert.That(str, Does.Contain("N'NCharValue'"));
-				Assert.That(str, Does.Contain("N'NVarCharValue'"));
-			}
+			q.ToArray();
 		}
 	}
 }

--- a/Tests/Linq/UserTests/Issue271Tests.cs
+++ b/Tests/Linq/UserTests/Issue271Tests.cs
@@ -33,7 +33,7 @@ namespace Tests.UserTests
 						e.NVarCharValue == "NVarCharValue"
 					select e;
 
-				var str = q.ToString()!;
+				var str = q.ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(str);
 
@@ -65,7 +65,7 @@ namespace Tests.UserTests
 						@nVarChar.Contains(e.NVarCharValue)
 					select e;
 
-				var str = q.ToString()!;
+				var str = q.ToSqlQuery().Sql;
 
 				TestContext.Out.WriteLine(str);
 

--- a/Tests/Linq/UserTests/Issue2832Tests.cs
+++ b/Tests/Linq/UserTests/Issue2832Tests.cs
@@ -98,7 +98,7 @@ namespace Tests.UserTests
 					).LeftJoin(x => x.SetpointtypeId == spt.Id).DefaultIfEmpty()
 					select new {spt.Id};
 
-				var sql = query.ToString();
+				var sql = query.ToSqlQuery().Sql;
 				TestContext.Out.WriteLine(sql);
 
 				var sourcesCount = QueryHelper.EnumerateAccessibleSources(query.GetSelectQuery()).Count(s => s.ElementType == QueryElementType.SqlQuery);

--- a/Tests/Linq/UserTests/Issue2832Tests.cs
+++ b/Tests/Linq/UserTests/Issue2832Tests.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Linq;
+
 using LinqToDB;
 using LinqToDB.Mapping;
 using LinqToDB.SqlQuery;
+
 using NUnit.Framework;
 
 namespace Tests.UserTests
@@ -65,11 +67,11 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void TestIssue2832([IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
+		public void TestIssue2832([DataSources] string context)
 		{
-			using (var db = GetDataContext(context))
-			{
-				var query =
+			using var db = GetDataContext(context);
+
+			var query =
 					from spt in db.GetTable<DctSetpointtype>()
 					from t2 in (
 						from w in db.GetTable<VWellTree>()
@@ -80,7 +82,7 @@ namespace Tests.UserTests
 									.DefaultIfEmpty()
 								from oudg in db.GetTable<UacUsersDatagroup>()
 									.Where(oudg =>
-										c.ParentId                 == oudg.DatagroupId && oudg.UserId == 150 &&
+										c.ParentId == oudg.DatagroupId && oudg.UserId == 150 &&
 										oudg.Inheritablepermission > 0)
 									.DefaultIfEmpty()
 								let p = UtilsGreatestnotnull3(
@@ -89,7 +91,8 @@ namespace Tests.UserTests
 								where p.HasValue
 								select new DataGroupPermission
 								{
-									DatagroupId = c.Id, Permission = Sql.Convert<int, decimal>(Sql.ToNotNull(p))
+									DatagroupId = c.Id,
+									Permission = Sql.Convert<int, decimal>(Sql.ToNotNull(p))
 								}
 							)
 							on w.ShopId equals tp2.DatagroupId
@@ -98,13 +101,11 @@ namespace Tests.UserTests
 					).LeftJoin(x => x.SetpointtypeId == spt.Id).DefaultIfEmpty()
 					select new {spt.Id};
 
-				var sql = query.ToSqlQuery().Sql;
-				TestContext.Out.WriteLine(sql);
+			BaselinesManager.LogQuery(query.GetSelectQuery().SqlText);
 
-				var sourcesCount = QueryHelper.EnumerateAccessibleSources(query.GetSelectQuery()).Count(s => s.ElementType == QueryElementType.SqlQuery);
+			var sourcesCount = QueryHelper.EnumerateAccessibleSources(query.GetSelectQuery()).Count(s => s.ElementType == QueryElementType.SqlQuery);
 
-				Assert.That(sourcesCount, Is.LessThanOrEqualTo(2));
-			}
+			Assert.That(sourcesCount, Is.LessThanOrEqualTo(2));
 		}
 	}
 }

--- a/Tests/Linq/UserTests/Issue2961Tests.cs
+++ b/Tests/Linq/UserTests/Issue2961Tests.cs
@@ -98,7 +98,7 @@ namespace Tests.UserTests
 
 				sqlCondos.Invoking(q => q.ToList()).Should().NotThrow();
 
-				var str = sqlCondos.ToString();
+				var str = sqlCondos.ToSqlQuery().Sql;
 
 				str.Should().Contain("COUNT(*)", AtLeast.Twice());
 			}

--- a/Tests/Linq/UserTests/Issue2961Tests.cs
+++ b/Tests/Linq/UserTests/Issue2961Tests.cs
@@ -98,9 +98,7 @@ namespace Tests.UserTests
 
 				sqlCondos.Invoking(q => q.ToList()).Should().NotThrow();
 
-				var str = sqlCondos.ToSqlQuery().Sql;
-
-				str.Should().Contain("COUNT(*)", AtLeast.Twice());
+				sqlCondos.ToSqlQuery().Sql.Should().Contain("COUNT(*)", AtLeast.Twice());
 			}
 		}
 	}

--- a/Tests/Linq/UserTests/Issue3061Tests.cs
+++ b/Tests/Linq/UserTests/Issue3061Tests.cs
@@ -76,7 +76,7 @@ namespace Tests.UserTests
 						IncidentNumber = x.IncidentProperties.FirstOrDefault()!.Incident.EventNumber
 					});
 
-				TestContext.Out.WriteLine(query.ToString());
+				TestContext.Out.WriteLine(query.ToSqlQuery().Sql);
 
 				query.GetSelectQuery().Select.Columns.Should().HaveCount(2);
 			}
@@ -134,7 +134,7 @@ namespace Tests.UserTests
 							.FirstOrDefault()
 					});
 
-				TestContext.Out.WriteLine(query.ToString());
+				TestContext.Out.WriteLine(query.ToSqlQuery().Sql);
 
 				query.GetSelectQuery().Select.Columns.Should().HaveCount(6);
 			}

--- a/Tests/Linq/UserTests/Issue3061Tests.cs
+++ b/Tests/Linq/UserTests/Issue3061Tests.cs
@@ -66,9 +66,14 @@ namespace Tests.UserTests
 		[Test]
 		public void TestColumnsOptimization([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
 		{
-			using (var db = GetDataContext(context))
-			{
-				var query = db.GetTable<Properties>()
+			using var db = GetDataContext(context);
+			using var t1 = db.CreateLocalTable<Properties>();
+			using var t2 = db.CreateLocalTable<CaseLog>();
+			using var t3 = db.CreateLocalTable<CaseLogProperty>();
+			using var t4 = db.CreateLocalTable<Incident>();
+			using var t5 = db.CreateLocalTable<IncidentProperty>();
+
+			var query = db.GetTable<Properties>()
 					.Where(x => x.Id.In(1, 2))
 					.Select(x => new
 					{
@@ -76,10 +81,9 @@ namespace Tests.UserTests
 						IncidentNumber = x.IncidentProperties.FirstOrDefault()!.Incident.EventNumber
 					});
 
-				TestContext.Out.WriteLine(query.ToSqlQuery().Sql);
+			query.GetSelectQuery().Select.Columns.Should().HaveCount(2);
 
-				query.GetSelectQuery().Select.Columns.Should().HaveCount(2);
-			}
+			query.ToArray();
 		}
 
 		[Table]
@@ -113,9 +117,12 @@ namespace Tests.UserTests
 		[Test]
 		public void TestColumnsOptimization3487([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
 		{
-			using (var db = GetDataContext(context))
-			{
-				var query = db.GetTable<Root>()
+			using var db = GetDataContext(context);
+			using var t1 = db.CreateLocalTable<Root>();
+			using var t2 = db.CreateLocalTable<Draft1>();
+			using var t3 = db.CreateLocalTable<Draft2>();
+
+			var query = db.GetTable<Root>()
 					.Select(x => new
 					{
 						NarrativeDraft = x.SomeDrafts
@@ -134,10 +141,8 @@ namespace Tests.UserTests
 							.FirstOrDefault()
 					});
 
-				TestContext.Out.WriteLine(query.ToSqlQuery().Sql);
-
-				query.GetSelectQuery().Select.Columns.Should().HaveCount(6);
-			}
+			query.GetSelectQuery().Select.Columns.Should().HaveCount(6);
+			query.ToArray();
 		}
 	}
 }

--- a/Tests/Linq/UserTests/Issue358Tests.cs
+++ b/Tests/Linq/UserTests/Issue358Tests.cs
@@ -36,7 +36,7 @@ namespace Tests.UserTests
 					where p.MyEnum != TestIssue358Enum.Value1
 					select p;
 
-				var sql = qry.ToString()!;
+				var sql = qry.ToSqlQuery().Sql;
 				TestContext.Out.WriteLine(sql);
 
 				Assert.That(sql, Does.Contain("NULL"));
@@ -55,7 +55,7 @@ namespace Tests.UserTests
 					where !!filter.Contains(p.MyEnum!.Value)
 					select p;
 
-				var sql = qry.ToString()!;
+				var sql = qry.ToSqlQuery().Sql;
 				TestContext.Out.WriteLine(sql);
 
 				Assert.That(sql, Does.Not.Contain("NULL"));
@@ -72,7 +72,7 @@ namespace Tests.UserTests
 					where p.MyEnum2 != TestIssue358Enum.Value1
 					select p;
 
-				var sql = qry.ToString()!;
+				var sql = qry.ToSqlQuery().Sql;
 				TestContext.Out.WriteLine(sql);
 
 				Assert.That(sql, Does.Not.Contain("NULL"));
@@ -91,7 +91,7 @@ namespace Tests.UserTests
 					where !filter.Contains(p.MyEnum2)
 					select p;
 
-				var sql = qry.ToString()!;
+				var sql = qry.ToSqlQuery().Sql;
 				TestContext.Out.WriteLine(sql);
 
 				Assert.That(sql, Does.Not.Contain("NULL"));

--- a/Tests/Linq/UserTests/Issue358Tests.cs
+++ b/Tests/Linq/UserTests/Issue358Tests.cs
@@ -27,75 +27,71 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void HasIsNull()
+		public void HasIsNull([DataSources] string context)
 		{
-			using (var db = new DataConnection())
-			{
-				var qry =
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<TestIssue358Class>();
+
+			var qry =
 					from p in db.GetTable<TestIssue358Class>()
 					where p.MyEnum != TestIssue358Enum.Value1
 					select p;
 
-				var sql = qry.ToSqlQuery().Sql;
-				TestContext.Out.WriteLine(sql);
+			Assert.That(qry.ToSqlQuery().Sql, Does.Contain("NULL"));
 
-				Assert.That(sql, Does.Contain("NULL"));
-			}
+			qry.ToArray();
 		}
 
 		[Test]
-		public void ContainsDoesNotHaveIsNull()
+		public void ContainsDoesNotHaveIsNull([DataSources] string context)
 		{
-			using (var db = new DataConnection())
-			{
-				var filter = new[] {TestIssue358Enum.Value2};
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<TestIssue358Class>();
 
-				var qry =
+			var filter = new[] {TestIssue358Enum.Value2};
+
+			var qry =
 					from p in db.GetTable<TestIssue358Class>()
 					where !!filter.Contains(p.MyEnum!.Value)
 					select p;
 
-				var sql = qry.ToSqlQuery().Sql;
-				TestContext.Out.WriteLine(sql);
+			Assert.That(qry.ToSqlQuery().Sql, Does.Not.Contain("NULL"));
 
-				Assert.That(sql, Does.Not.Contain("NULL"));
-			}
+			qry.ToArray();
 		}
 
 		[Test]
-		public void NoIsNull()
+		public void NoIsNull([DataSources] string context)
 		{
-			using (var db = new DataConnection())
-			{
-				var qry =
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<TestIssue358Class>();
+
+			var qry =
 					from p in db.GetTable<TestIssue358Class>()
 					where p.MyEnum2 != TestIssue358Enum.Value1
 					select p;
 
-				var sql = qry.ToSqlQuery().Sql;
-				TestContext.Out.WriteLine(sql);
+			Assert.That(qry.ToSqlQuery().Sql, Does.Not.Contain("NULL"));
 
-				Assert.That(sql, Does.Not.Contain("NULL"));
-			}
+			qry.ToArray();
 		}
 
 		[Test]
-		public void ContainsNoIsNull()
+		public void ContainsNoIsNull([DataSources] string context)
 		{
-			using (var db = new DataConnection())
-			{
-				var filter = new[] {TestIssue358Enum.Value2};
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<TestIssue358Class>();
 
-				var qry =
+			var filter = new[] {TestIssue358Enum.Value2};
+
+			var qry =
 					from p in db.GetTable<TestIssue358Class>()
 					where !filter.Contains(p.MyEnum2)
 					select p;
 
-				var sql = qry.ToSqlQuery().Sql;
-				TestContext.Out.WriteLine(sql);
+			Assert.That(qry.ToSqlQuery().Sql, Does.Not.Contain("NULL"));
 
-				Assert.That(sql, Does.Not.Contain("NULL"));
-			}
+			qry.ToArray();
 		}
 
 		static LinqDataTypes2 FixData(LinqDataTypes2 data)

--- a/Tests/Linq/UserTests/Issue4389Tests.cs
+++ b/Tests/Linq/UserTests/Issue4389Tests.cs
@@ -22,9 +22,7 @@ namespace Tests.UserTests
 
 			await tmp.BulkCopyAsync(new[] { new { ID = 2 } });
 
-			var count = await tmp.CountAsync();
-
-			TestContext.Out.WriteLine(count);
+			await tmp.CountAsync();
 		}
 	}
 }

--- a/Tests/Linq/UserTests/Issue447Tests.cs
+++ b/Tests/Linq/UserTests/Issue447Tests.cs
@@ -83,7 +83,7 @@ namespace Tests.UserTests
 				var cacheMiss = result1.GetCacheMissCount();
 
 				// from cache
-				var sql = result2.ToSqlQuery().Sql;
+				_ = result2.ToSqlQuery().Sql;
 
 				result1.GetCacheMissCount().Should().Be(cacheMiss);
 			}
@@ -138,7 +138,7 @@ namespace Tests.UserTests
 				var cacheMiss = combined1.GetCacheMissCount();
 
 				// from cache
-				var sql = combined2.ToSqlQuery().Sql;
+				_ = combined2.ToSqlQuery().Sql;
 
 				combined2.GetCacheMissCount().Should().Be(cacheMiss);
 			}

--- a/Tests/Linq/UserTests/Issue447Tests.cs
+++ b/Tests/Linq/UserTests/Issue447Tests.cs
@@ -4,6 +4,8 @@ using System.Linq.Expressions;
 
 using FluentAssertions;
 
+using LinqToDB;
+
 using NUnit.Framework;
 
 namespace Tests.UserTests
@@ -40,7 +42,7 @@ namespace Tests.UserTests
 				result = result.Where(predicate!);
 
 				// StackOverflowException cannot be handled and will terminate process
-				result.ToString();
+				_ = result.ToSqlQuery().Sql;
 			}
 		}
 
@@ -76,12 +78,12 @@ namespace Tests.UserTests
 				var result2 = result.Where(predicate2!);
 
 				// StackOverflowException cannot be handled and will terminate process
-				result1.ToString();
+				_ = result1.ToSqlQuery().Sql;
 
 				var cacheMiss = result1.GetCacheMissCount();
 
 				// from cache
-				var sql = result2.ToString();
+				var sql = result2.ToSqlQuery().Sql;
 
 				result1.GetCacheMissCount().Should().Be(cacheMiss);
 			}
@@ -131,12 +133,12 @@ namespace Tests.UserTests
 					select r1;
 
 				// StackOverflowException cannot be handled and will terminate process
-				combined1.ToString();
+				_ = combined1.ToSqlQuery().Sql;
 
 				var cacheMiss = combined1.GetCacheMissCount();
 
 				// from cache
-				var sql = combined2.ToString();
+				var sql = combined2.ToSqlQuery().Sql;
 
 				combined2.GetCacheMissCount().Should().Be(cacheMiss);
 			}

--- a/Tests/Linq/UserTests/Issue461Tests.cs
+++ b/Tests/Linq/UserTests/Issue461Tests.cs
@@ -85,9 +85,6 @@ namespace Tests.UserTests
 								   }).FirstOrDefault()
 							  }).ToList();
 
-				if (db is DataConnection connection)
-					TestContext.Out.WriteLine(connection.LastQuery);
-
 				var expected = from sep in Parent
 							   select new
 							   {
@@ -120,9 +117,6 @@ namespace Tests.UserTests
 									   ParentId = l.ParentID
 								   }).FirstOrDefault()
 							  }).ToList();
-
-				if (db is DataConnection connection)
-					TestContext.Out.WriteLine(connection.LastQuery);
 
 				var expected = from sep in Parent
 							   select new
@@ -157,9 +151,6 @@ namespace Tests.UserTests
 								   }).FirstOrDefault()
 							  }).ToList();
 
-				if (db is DataConnection connection)
-					TestContext.Out.WriteLine(connection.LastQuery);
-
 				var expected = from sep in Parent
 							   select new ValueValueHolder
 							   {
@@ -192,9 +183,6 @@ namespace Tests.UserTests
 									   ParentId = l.ParentID
 								   }).FirstOrDefault()
 							  }).ToList();
-
-				if (db is DataConnection connection)
-					TestContext.Out.WriteLine(connection.LastQuery);
 
 				var expected = from sep in Parent
 							   select new ValueValueHolder

--- a/Tests/Linq/UserTests/Issue773Tests.cs
+++ b/Tests/Linq/UserTests/Issue773Tests.cs
@@ -65,7 +65,7 @@ CREATE VIRTUAL TABLE dataFTS USING fts4(`ID` INTEGER, `FirstName` TEXT, `LastNam
 						});
 
 					var query = data.Where(arg => SqlLite.MatchFts<DtaFts>("John*"));
-					TestContext.Out.WriteLine(query.ToString());
+					TestContext.Out.WriteLine(query.ToSqlQuery().Sql);
 					var _ = query.ToList();
 				}
 				finally

--- a/Tests/Linq/UserTests/Issue773Tests.cs
+++ b/Tests/Linq/UserTests/Issue773Tests.cs
@@ -65,8 +65,7 @@ CREATE VIRTUAL TABLE dataFTS USING fts4(`ID` INTEGER, `FirstName` TEXT, `LastNam
 						});
 
 					var query = data.Where(arg => SqlLite.MatchFts<DtaFts>("John*"));
-					TestContext.Out.WriteLine(query.ToSqlQuery().Sql);
-					var _ = query.ToList();
+					_ = query.ToList();
 				}
 				finally
 				{

--- a/Tests/Linq/UserTests/Issue982Tests.cs
+++ b/Tests/Linq/UserTests/Issue982Tests.cs
@@ -73,7 +73,7 @@ namespace Tests.UserTests
 									c
 								};
 
-					var str = query.ToString()!;
+					var str = query.ToSqlQuery().Sql;
 					Assert.That(str, Does.Contain("'one' != 'two'"));
 					var _ = query.ToArray();
 				}

--- a/Tests/Linq/UserTests/Issue982Tests.cs
+++ b/Tests/Linq/UserTests/Issue982Tests.cs
@@ -73,8 +73,8 @@ namespace Tests.UserTests
 									c
 								};
 
-					var str = query.ToSqlQuery().Sql;
-					Assert.That(str, Does.Contain("'one' != 'two'"));
+					Assert.That(query.ToSqlQuery().Sql, Does.Contain("'one' != 'two'"));
+
 					var _ = query.ToArray();
 				}
 			}

--- a/Tests/Linq/UserTests/LetTests.cs
+++ b/Tests/Linq/UserTests/LetTests.cs
@@ -56,13 +56,17 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void LetTest1()
+		public void LetTest1([DataSources(TestProvName.AllAccess)] string context)
 		{
-			using (var repository = new DataConnection())
-			{
-				var q =
-					from t1 in repository.GetTable<Table2>()
-					from t2 in 
+			using var db = GetDataContext(context, o => o.OmitUnsupportedCompareNulls(context));
+			using var tb1 = db.CreateLocalTable<Table1>();
+			using var tb2 = db.CreateLocalTable<Table2>();
+			using var tb3 = db.CreateLocalTable<Table3>();
+			using var tb7 = db.CreateLocalTable<Table7>();
+
+			var q =
+					from t1 in db.GetTable<Table2>()
+					from t2 in
 						from t5 in t1.Ref3!.Ref4!.Ref1!.Ref2
 						let  t3 = t1.Ref3
 						where t3.Ref5!.Field8 == t5.Ref5!.Field8
@@ -70,18 +74,21 @@ namespace Tests.UserTests
 						select t4
 					select t1;
 
-				var linqResult = q.ToSqlQuery().Sql;
-			}
+			q.ToArray();
 		}
 
 		[Test]
-		public void LetTest2()
+		public void LetTest2([DataSources(TestProvName.AllAccess)] string context)
 		{
-			using (var repository = new DataConnection())
-			{
-				var q =
-					from t1 in repository.GetTable<Table2>()
-					from t2 in 
+			using var db = GetDataContext(context, o => o.OmitUnsupportedCompareNulls(context));
+			using var tb1 = db.CreateLocalTable<Table1>();
+			using var tb2 = db.CreateLocalTable<Table2>();
+			using var tb3 = db.CreateLocalTable<Table3>();
+			using var tb7 = db.CreateLocalTable<Table7>();
+
+			var q =
+					from t1 in db.GetTable<Table2>()
+					from t2 in
 						from t5 in t1.Ref3!.Ref4!.Ref1!.Ref2
 						let  t3 = t1.Ref3
 						where t3.Ref5 == t5.Ref5
@@ -89,8 +96,7 @@ namespace Tests.UserTests
 						select t4
 					select t1;
 
-				var linqResult = q.ToSqlQuery().Sql;
-			}
+			q.ToArray();
 		}
 	}
 }

--- a/Tests/Linq/UserTests/LetTests.cs
+++ b/Tests/Linq/UserTests/LetTests.cs
@@ -70,7 +70,7 @@ namespace Tests.UserTests
 						select t4
 					select t1;
 
-				var linqResult = q.ToString();
+				var linqResult = q.ToSqlQuery().Sql;
 			}
 		}
 
@@ -89,7 +89,7 @@ namespace Tests.UserTests
 						select t4
 					select t1;
 
-				var linqResult = q.ToString();
+				var linqResult = q.ToSqlQuery().Sql;
 			}
 		}
 	}

--- a/Tests/Linq/UserTests/SQLiteDateTime.cs
+++ b/Tests/Linq/UserTests/SQLiteDateTime.cs
@@ -50,7 +50,7 @@ namespace Tests.UserTests
 				var matchSymbolIds = new List<int>();
 
 				var queryable = GenerateQuery(db, new DateTime(2010, 3, 5)).Where(x => matchSymbolIds.Contains(x.ID));
-				return queryable.ToString()!;
+				return queryable.ToSqlQuery().Sql;
 			}
 		}
 

--- a/Tests/Linq/UserTests/SQLiteDateTime.cs
+++ b/Tests/Linq/UserTests/SQLiteDateTime.cs
@@ -45,13 +45,13 @@ namespace Tests.UserTests
 
 		string GetSql(string context)
 		{
-			using (var db = GetDataContext(context))
-			{
-				var matchSymbolIds = new List<int>();
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<A>();
 
-				var queryable = GenerateQuery(db, new DateTime(2010, 3, 5)).Where(x => matchSymbolIds.Contains(x.ID));
-				return queryable.ToSqlQuery().Sql;
-			}
+			var matchSymbolIds = new List<int>();
+
+			var queryable = GenerateQuery(db, new DateTime(2010, 3, 5)).Where(x => matchSymbolIds.Contains(x.ID));
+			return queryable.ToSqlQuery().Sql;
 		}
 
 		[Test]
@@ -60,10 +60,6 @@ namespace Tests.UserTests
 			var query1 = GetSql(context);
 			var query2 = GetSql(context);
 			var query3 = GetSql(context);
-
-			TestContext.Out.WriteLine(query1);
-			TestContext.Out.WriteLine(query2);
-			TestContext.Out.WriteLine(query3);
 
 			Assert.That(query2, Is.EqualTo(query1));
 		}

--- a/Tests/Linq/UserTests/UnknownSqlTests.cs
+++ b/Tests/Linq/UserTests/UnknownSqlTests.cs
@@ -33,7 +33,7 @@ namespace Tests.UserTests
 							DataType = Sql.AsSql(ColumnDataType.Unknown),
 						});
 
-				var sql = q.ToString();
+				var sql = q.ToSqlQuery().Sql;
 
 				Assert.That(sql, Is.Not.Contains("Unknown"));
 			}

--- a/Tests/Linq/UserTests/UnknownSqlTests.cs
+++ b/Tests/Linq/UserTests/UnknownSqlTests.cs
@@ -5,7 +5,6 @@ using NUnit.Framework;
 namespace Tests.UserTests
 {
 	using LinqToDB;
-	using LinqToDB.Data;
 
 	[TestFixture]
 	public class UnknownSqlTests : TestBase
@@ -22,21 +21,23 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void Test()
+		public void Test([DataSources] string context)
 		{
-			using (var db = new DataConnection())
-			{
-				var q = db.GetTable<CustomTableColumn>()
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<CustomTableColumn>();
+
+			var q = db.GetTable<CustomTableColumn>()
 					.Select(
 						x => new
 						{
 							DataType = Sql.AsSql(ColumnDataType.Unknown),
 						});
 
-				var sql = q.ToSqlQuery().Sql;
+			var sql = q.ToSqlQuery().Sql;
 
-				Assert.That(sql, Is.Not.Contains("Unknown"));
-			}
+			Assert.That(sql, Is.Not.Contains("Unknown"));
+
+			q.ToArray();
 		}
 	}
 }

--- a/Tests/Linq/UserTests/UnnecessaryInnerJoinTests.cs
+++ b/Tests/Linq/UserTests/UnnecessaryInnerJoinTests.cs
@@ -16,26 +16,29 @@ namespace Tests.UserTests
 		{
 			[PrimaryKey(1)]
 			[Identity]
-			public long Field1 { get; set; }
-			public long Field2 { get; set; }
+			public int Field1 { get; set; }
+			public int Field2 { get; set; }
 		}
 
 		sealed class Table2
 		{
 			[PrimaryKey(1)]
 			[Identity]
-			public long Field2 { get; set; }
+			public int Field2 { get; set; }
 
 			[Association(ThisKey = "Field2", OtherKey = "Field2", CanBeNull = false)]
 			public List<Table1> Field3 { get; set; } = null!;
 		}
 
 		[Test]
-		public void Test([DataSources] string context)
+		public void Test([DataSources(TestProvName.AllClickHouse)] string context)
 		{
+			using var db = GetDataContext(context);
+			using var tb1 = db.CreateLocalTable<Table1>();
+			using var tb2 = db.CreateLocalTable<Table2>();
+
 			var ids = new long[] { 1, 2, 3 };
 
-			using var db = GetDataContext(context);
 			var q =
 				from t1 in db.GetTable<Table2>()
 				where t1.Field3.Any(x => ids.Contains(x.Field1))
@@ -43,9 +46,9 @@ namespace Tests.UserTests
 
 			var sql = q.ToSqlQuery().Sql;
 
-			BaselinesManager.LogQuery(sql);
-
 			Assert.That(sql, Does.Not.Contain("INNER JOIN"));
+
+			q.ToArray();
 		}
 	}
 }

--- a/Tests/Linq/UserTests/UnnecessaryInnerJoinTests.cs
+++ b/Tests/Linq/UserTests/UnnecessaryInnerJoinTests.cs
@@ -42,7 +42,7 @@ namespace Tests.UserTests
 					where t1.Field3.Any(x => ids.Contains(x.Field1))
 					select new { t1.Field2 };
 
-				var sql = q.ToString()!;
+				var sql = q.ToSqlQuery().Sql;
 
 				Assert.That(sql.IndexOf("INNER JOIN"), Is.LessThan(0));
 			}

--- a/Tests/Linq/UserTests/UnnecessaryInnerJoinTests.cs
+++ b/Tests/Linq/UserTests/UnnecessaryInnerJoinTests.cs
@@ -31,21 +31,21 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void Test()
+		public void Test([DataSources] string context)
 		{
 			var ids = new long[] { 1, 2, 3 };
 
-			using (var db = new DataConnection())
-			{
-				var q =
-					from t1 in db.GetTable<Table2>()
-					where t1.Field3.Any(x => ids.Contains(x.Field1))
-					select new { t1.Field2 };
+			using var db = GetDataContext(context);
+			var q =
+				from t1 in db.GetTable<Table2>()
+				where t1.Field3.Any(x => ids.Contains(x.Field1))
+				select new { t1.Field2 };
 
-				var sql = q.ToSqlQuery().Sql;
+			var sql = q.ToSqlQuery().Sql;
 
-				Assert.That(sql.IndexOf("INNER JOIN"), Is.LessThan(0));
-			}
+			BaselinesManager.LogQuery(sql);
+
+			Assert.That(sql, Does.Not.Contain("INNER JOIN"));
 		}
 	}
 }


### PR DESCRIPTION
Move SQL generation from `ToString` overload on query to separate API as:
- use of `ToString` makes this heavy operation being called a lot by IDE debugger visualizer
- `ToString` generates single SQL string with all commands and parameters in `SQLServer`-like syntax making it problematic to use for SQL generation

New implementation:
- returns SQL command and command parameters
- don't generate unnecessary SQL comments (comments not supported by Acccess)
- adds missing support for `Merge` and `MultiInsert` queries

Known issues:
- secondary queries for eager load still not provided (only main query)
- some providers (e.g. SQL CE) could generate aliases on columns, making by-name mapping a bit complicated

TODO:
- [ ] `MultiInsert.When` generates incorrect SQL (`ToSqlQuery_IMultiInsertElse`)
- [ ] `ToSqlQuery_WithParametersDeduplication` test duplicates parameters for Access OleDb
- [ ] AS for some types of INSERT and UPDATE queries contain unnecessary SELECT query leading to incorrect parameters optimization for Informix and SQL CE (`ToSqlQuery_IValueInsertable_ClientIdentity`, `ToSqlQuery_IValueInsertable`, `ToSqlQuery_IUpdatable`, `ToSqlQuery_ISelectInsertable_ClientIdentity`, `ToSqlQuery_ISelectInsertable`)