### PR TITLE
Add DataContextModifier option to ScaffoldCommand

### DIFF
--- a/NuGet/TestToolLocal.cmd
+++ b/NuGet/TestToolLocal.cmd
@@ -15,7 +15,7 @@ dotnet script BuildNuspecs.csx /path:linq2db.cli.nuspec /buildPath:%NUSPECS% /ve
 
 RMDIR %NUGETS% /S /Q
 MD %NUGETS%
-dotnet pack empty\empty.csproj --no-build -p:NuspecFile=..\%NUSPECS%\linq2db.cli.nuspec -o %NUGETS%
+dotnet pack empty\empty.csproj -p:NuspecFile=..\%NUSPECS%\linq2db.cli.nuspec -o %NUGETS%
 
 dotnet tool uninstall linq2db.cli -g
 dotnet tool install -g --add-source %NUGETS% linq2db.cli --version %VERSION%

--- a/Source/LinqToDB.CLI/CommandLine/Commands/ScaffoldCommand.Configuration.cs
+++ b/Source/LinqToDB.CLI/CommandLine/Commands/ScaffoldCommand.Configuration.cs
@@ -98,10 +98,11 @@ namespace LinqToDB.CommandLine
 			if (options.Remove(DataModel.EntityClassIsPartial          , out value)) settings.EntityClassIsPartial               = (bool)value!;
 
 			// strings
-			if (options.Remove(DataModel.BaseEntity          , out value)) settings.BaseEntityClass  = (string)value!;
-			if (options.Remove(DataModel.BaseEntity          , out value)) settings.BaseEntityClass  = (string)value!;
-			if (options.Remove(DataModel.DataContextName     , out value)) settings.ContextClassName = (string)value!;
-			if (options.Remove(DataModel.DataContextBaseClass, out value)) settings.BaseContextClass = (string)value!;
+			if (options.Remove(DataModel.BaseEntity          , out value)) settings.BaseEntityClass      = (string)value!;
+			if (options.Remove(DataModel.BaseEntity          , out value)) settings.BaseEntityClass      = (string)value!;
+			if (options.Remove(DataModel.DataContextName     , out value)) settings.ContextClassName     = (string)value!;
+			if (options.Remove(DataModel.DataContextBaseClass, out value)) settings.BaseContextClass     = (string)value!;
+			if (options.Remove(DataModel.DataContextModifier , out value)) settings.ContextClassModifier = (string)value!;
 
 			// stored procedure signatures
 			if (options.Remove(DataModel.StoredProcedureTypes, out value))

--- a/Source/LinqToDB.CLI/CommandLine/Commands/ScaffoldCommand.Configuration.cs
+++ b/Source/LinqToDB.CLI/CommandLine/Commands/ScaffoldCommand.Configuration.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+
+using LinqToDB.CodeModel;
 using LinqToDB.DataModel;
 using LinqToDB.Metadata;
 using LinqToDB.Naming;
@@ -98,11 +100,23 @@ namespace LinqToDB.CommandLine
 			if (options.Remove(DataModel.EntityClassIsPartial          , out value)) settings.EntityClassIsPartial               = (bool)value!;
 
 			// strings
-			if (options.Remove(DataModel.BaseEntity          , out value)) settings.BaseEntityClass      = (string)value!;
-			if (options.Remove(DataModel.BaseEntity          , out value)) settings.BaseEntityClass      = (string)value!;
-			if (options.Remove(DataModel.DataContextName     , out value)) settings.ContextClassName     = (string)value!;
-			if (options.Remove(DataModel.DataContextBaseClass, out value)) settings.BaseContextClass     = (string)value!;
-			if (options.Remove(DataModel.DataContextModifier , out value)) settings.ContextClassModifier = (string)value!;
+			if (options.Remove(DataModel.BaseEntity          , out value)) settings.BaseEntityClass  = (string)value!;
+			if (options.Remove(DataModel.BaseEntity          , out value)) settings.BaseEntityClass  = (string)value!;
+			if (options.Remove(DataModel.DataContextName     , out value)) settings.ContextClassName = (string)value!;
+			if (options.Remove(DataModel.DataContextBaseClass, out value)) settings.BaseContextClass = (string)value!;
+
+			// data context access modifiers
+			if (options.Remove(DataModel.DataContextModifier, out value))
+			{
+				var str = (string)value!;
+				settings.ContextClassModifier = str switch
+				{
+					"public"   => Modifiers.Public,
+					"internal" => Modifiers.Internal,
+					"private"  => Modifiers.Private,
+					_ => throw new InvalidOperationException($"Unsuppored value for option {DataModel.DataContextModifier.Name}: {str}")
+				};
+			}
 
 			// stored procedure signatures
 			if (options.Remove(DataModel.StoredProcedureTypes, out value))

--- a/Source/LinqToDB.CLI/CommandLine/Commands/ScaffoldCommand.Options.cs
+++ b/Source/LinqToDB.CLI/CommandLine/Commands/ScaffoldCommand.Options.cs
@@ -723,6 +723,30 @@ If you don't specify some property, CLI will use default value for current optio
 					new[] { "LinqToDB.Data.DataConnection" });
 
 			/// <summary>
+			/// Base data context class modifier.
+			/// </summary>
+			public static readonly CliOption DataContextModifier = new StringEnumCliOption(
+					"context-modifier",
+					null,
+					false,
+					false,
+					"modifier for generated data context",
+					null,
+					new[]
+					{
+						"--context-modifier Internal",
+					},
+					new[]
+					{
+						/*lang=json,strict*/
+						"{ \"dataModel\": { \"context-modifier\": \"Internal\" } }"
+					},
+					false,
+					new (false, false, "Private", ""),
+					new (false, false, "Internal", ""),
+					new (false, false, "Public", ""));
+
+			/// <summary>
 			/// Generation of association properties on entity option.
 			/// </summary>
 			public static readonly CliOption EmitAssociations = new BooleanCliOption(

--- a/Source/LinqToDB.CLI/CommandLine/Commands/ScaffoldCommand.Options.cs
+++ b/Source/LinqToDB.CLI/CommandLine/Commands/ScaffoldCommand.Options.cs
@@ -723,28 +723,28 @@ If you don't specify some property, CLI will use default value for current optio
 					new[] { "LinqToDB.Data.DataConnection" });
 
 			/// <summary>
-			/// Base data context class modifier.
+			/// Data context class access modifier.
 			/// </summary>
 			public static readonly CliOption DataContextModifier = new StringEnumCliOption(
 					"context-modifier",
 					null,
 					false,
 					false,
-					"modifier for generated data context",
+					"access modifier for generated data context",
 					null,
 					new[]
 					{
-						"--context-modifier Internal",
+						"--context-modifier internal",
 					},
 					new[]
 					{
 						/*lang=json,strict*/
-						"{ \"dataModel\": { \"context-modifier\": \"Internal\" } }"
+						"{ \"dataModel\": { \"context-modifier\": \"internal\" } }"
 					},
 					false,
-					new (false, false, "Private", ""),
-					new (false, false, "Internal", ""),
-					new (false, false, "Public", ""));
+					new (false, false, "private", "applies 'public' to data context class"),
+					new (false, false, "internal", "applies 'internal' to data context class"),
+					new (true, true, "public", "applies 'private' to data context class"));
 
 			/// <summary>
 			/// Generation of association properties on entity option.

--- a/Source/LinqToDB.CLI/CommandLine/Commands/ScaffoldCommand.cs
+++ b/Source/LinqToDB.CLI/CommandLine/Commands/ScaffoldCommand.cs
@@ -68,6 +68,7 @@ namespace LinqToDB.CommandLine
 			AddOption(_dataModelOptions, DataModel.EmitTypedOptionsConstructor);
 			AddOption(_dataModelOptions, DataModel.DataContextName);
 			AddOption(_dataModelOptions, DataModel.DataContextBaseClass);
+			AddOption(_dataModelOptions, DataModel.DataContextModifier);
 			AddOption(_dataModelOptions, DataModel.EmitInitDataContextMethod);
 			AddOption(_dataModelOptions, DataModel.EmitAssociations);
 			AddOption(_dataModelOptions, DataModel.EmitAssociationExtensions);

--- a/Source/LinqToDB.Scaffold/Scaffold/DataModel/DataModelLoader.DataContext.cs
+++ b/Source/LinqToDB.Scaffold/Scaffold/DataModel/DataModelLoader.DataContext.cs
@@ -32,7 +32,7 @@ namespace LinqToDB.Scaffold
 
 			var dataContextClass = new ClassModel(className, className)
 			{
-				Modifiers = Modifiers.Public | Modifiers.Partial,
+				Modifiers = (System.Enum.TryParse<Modifiers>(_options.DataModel.ContextClassModifier, true, out var dataContextModifier) ? dataContextModifier : Modifiers.Public) | Modifiers.Partial,
 				Namespace = _options.CodeGeneration.Namespace
 			};
 

--- a/Source/LinqToDB.Scaffold/Scaffold/DataModel/DataModelLoader.DataContext.cs
+++ b/Source/LinqToDB.Scaffold/Scaffold/DataModel/DataModelLoader.DataContext.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
 using System.Globalization;
 
 using LinqToDB.CodeModel;
@@ -32,7 +33,7 @@ namespace LinqToDB.Scaffold
 
 			var dataContextClass = new ClassModel(className, className)
 			{
-				Modifiers = (System.Enum.TryParse<Modifiers>(_options.DataModel.ContextClassModifier, true, out var dataContextModifier) ? dataContextModifier : Modifiers.Public) | Modifiers.Partial,
+				Modifiers = (_options.DataModel.ContextClassModifier ?? Modifiers.Public) | Modifiers.Partial,
 				Namespace = _options.CodeGeneration.Namespace
 			};
 

--- a/Source/LinqToDB.Scaffold/Scaffold/Options/DataModelOptions.cs
+++ b/Source/LinqToDB.Scaffold/Scaffold/Options/DataModelOptions.cs
@@ -217,6 +217,15 @@ namespace LinqToDB.Scaffold
 		public string? ContextClassName { get; set; }
 
 		/// <summary>
+		/// Gets or sets the modifier of data context class. When not set, public will be used. Context class is always partial.
+		/// <list type="bullet">
+		/// <item>Default: not set</item>
+		/// <item>In T4 compability mode: not set</item>
+		/// </list>
+		/// </summary>
+		public string? ContextClassModifier { get; set; }
+
+		/// <summary>
 		/// Gets or sets type name (full name with namespace) of base class for generated data context. When not specified, <see cref="DataConnection"/> type used.
 		/// Provided type should implement <see cref="IDataContext"/> interface and it is recommented to use wether <see cref="DataConnection"/>
 		/// or <see cref="DataContext"/> classes or classes, derived from them.

--- a/Source/LinqToDB.Scaffold/Scaffold/Options/DataModelOptions.cs
+++ b/Source/LinqToDB.Scaffold/Scaffold/Options/DataModelOptions.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+
+using LinqToDB.CodeModel;
 using LinqToDB.Data;
 using LinqToDB.DataModel;
 using LinqToDB.Metadata;
@@ -223,7 +225,7 @@ namespace LinqToDB.Scaffold
 		/// <item>In T4 compability mode: not set</item>
 		/// </list>
 		/// </summary>
-		public string? ContextClassModifier { get; set; }
+		public Modifiers? ContextClassModifier { get; set; }
 
 		/// <summary>
 		/// Gets or sets type name (full name with namespace) of base class for generated data context. When not specified, <see cref="DataConnection"/> type used.

--- a/Source/LinqToDB.Scaffold/Scaffold/Options/ScaffoldOptions.cs
+++ b/Source/LinqToDB.Scaffold/Scaffold/Options/ScaffoldOptions.cs
@@ -75,6 +75,7 @@ namespace LinqToDB.Scaffold
 			options.DataModel.HasUntypedOptionsConstructor                   = true;
 			options.DataModel.HasTypedOptionsConstructor                     = true;
 			options.DataModel.ContextClassName                               = null;
+			options.DataModel.ContextClassModifier                           = null;
 			options.DataModel.BaseContextClass                               = null;
 			options.DataModel.GenerateInitDataContextMethod                  = true;
 			options.DataModel.GenerateAssociations                           = true;

--- a/Tests/Tests.T4/Cli/Interceptors.tt
+++ b/Tests/Tests.T4/Cli/Interceptors.tt
@@ -10,6 +10,7 @@
 
 	var options = new string[]
 	{
+		"--context-modifier internal",
 		$"--customize {interceptorsPath}"
 	};
 

--- a/Tests/Tests.T4/Cli/Interceptors/SQLite/TestDataDB.cs
+++ b/Tests/Tests.T4/Cli/Interceptors/SQLite/TestDataDB.cs
@@ -16,7 +16,7 @@ using System.Threading.Tasks;
 
 namespace Cli.Interceptors.SQLite
 {
-	public partial class TestDataDB : DataConnection
+	internal partial class TestDataDB : DataConnection
 	{
 		public TestDataDB()
 		{


### PR DESCRIPTION
Hey

In my ongoing quest to get my scaffolding exactly like I want it, I now have the need for changing the access modifier of the generated Context class.

I've added a property to the scaffolding dataModel that enables this.
When not specified it does as before.

I'm not entirely sure where or if it would be appropriate to add this new option to tests. 