### PR TITLE
Add removed issue-4090 tests

### DIFF
--- a/Tests/Linq/UserTests/Issue4090Tests.cs
+++ b/Tests/Linq/UserTests/Issue4090Tests.cs
@@ -254,7 +254,7 @@ namespace Tests.UserTests
 				new Table3 { Id3 = 26, ParentId3 = 16, Name3 = "Child26" },
 				new Table3 { Id3 = 27, ParentId3 = null, Name3 = "Child27" },
 			});
-			var ret = db.GetTable<Table3>()
+			var query = db.GetTable<Table3>()
 				.OrderBy(x => x.Id3)
 				.Select(t3 => new
 				{

--- a/Tests/Linq/UserTests/Issue4090Tests.cs
+++ b/Tests/Linq/UserTests/Issue4090Tests.cs
@@ -402,7 +402,11 @@ namespace Tests.UserTests
 						})
 						.FirstOrDefault()
 				});
+
+			// assert the generated SQL
 			var ret = AssertQuery(query);
+
+			// assert the result (more important than the SQL for these tests)
 			Assert.That(ret, Has.Count.EqualTo(7));
 
 			Assert.Multiple(() =>

--- a/Tests/Linq/UserTests/Issue4090Tests.cs
+++ b/Tests/Linq/UserTests/Issue4090Tests.cs
@@ -277,8 +277,79 @@ namespace Tests.UserTests
 							Id2 = t2.Id2,
 						})
 						.FirstOrDefault()
-			});
+				})
+				.ToList();
+			Assert.That(ret, Has.Count.EqualTo(7));
 
+			Assert.Multiple(() =>
+			{
+				Assert.That(ret[0].Name3!, Is.EqualTo("Child21"));
+				Assert.That(ret[0].Value2, Is.Not.Null);
+			});
+			Assert.Multiple(() =>
+			{
+				Assert.That(ret[0].Value2!.Name2!, Is.EqualTo("Child11"));
+				Assert.That(ret[0].Value2!.Value1, Is.Not.Null);
+			});
+			Assert.Multiple(() =>
+			{
+				Assert.That(ret[0].Value2!.Value1!.Name1!, Is.EqualTo("Some1"));
+
+				Assert.That(ret[1].Name3!, Is.EqualTo("Child22"));
+				Assert.That(ret[1].Value2, Is.Not.Null);
+			});
+			Assert.Multiple(() =>
+			{
+				Assert.That(ret[1].Value2!.Name2!, Is.EqualTo("Child12"));
+				Assert.That(ret[1].Value2!.Value1, Is.Not.Null);
+			});
+			Assert.Multiple(() =>
+			{
+				Assert.That(ret[1].Value2!.Value1!.Name1, Is.Null);
+
+				Assert.That(ret[2].Name3!, Is.EqualTo("Child23"));
+				Assert.That(ret[2].Value2, Is.Not.Null);
+			});
+			Assert.Multiple(() =>
+			{
+				Assert.That(ret[2].Value2!.Name2!, Is.EqualTo("Child13"));
+				Assert.That(ret[2].Value2!.Value1, Is.Null);
+
+				Assert.That(ret[3].Name3!, Is.EqualTo("Child24"));
+				Assert.That(ret[3].Value2, Is.Not.Null);
+			});
+			Assert.Multiple(() =>
+			{
+				Assert.That(ret[3].Value2!.Name2!, Is.Null);
+				Assert.That(ret[3].Value2!.Value1, Is.Not.Null);
+			});
+			Assert.Multiple(() =>
+			{
+				Assert.That(ret[3].Value2!.Value1!.Name1!, Is.EqualTo("Some1"));
+
+				Assert.That(ret[4].Name3!, Is.EqualTo("Child25"));
+				Assert.That(ret[4].Value2, Is.Not.Null);
+			});
+			Assert.Multiple(() =>
+			{
+				Assert.That(ret[4].Value2!.Name2!, Is.Null);
+				Assert.That(ret[4].Value2!.Value1, Is.Not.Null);
+			});
+			Assert.Multiple(() =>
+			{
+				Assert.That(ret[4].Value2!.Value1!.Name1, Is.Null);
+
+				Assert.That(ret[5].Name3!, Is.EqualTo("Child26"));
+				Assert.That(ret[5].Value2, Is.Not.Null);
+			});
+			Assert.Multiple(() =>
+			{
+				Assert.That(ret[5].Value2!.Name2!, Is.Null);
+				Assert.That(ret[5].Value2!.Value1, Is.Null);
+
+				Assert.That(ret[6].Name3!, Is.EqualTo("Child27"));
+				Assert.That(ret[6].Value2, Is.Null);
+			});
 			AssertQuery(query);
 		}
 

--- a/Tests/Linq/UserTests/Issue4090Tests.cs
+++ b/Tests/Linq/UserTests/Issue4090Tests.cs
@@ -254,7 +254,7 @@ namespace Tests.UserTests
 				new Table3 { Id3 = 26, ParentId3 = 16, Name3 = "Child26" },
 				new Table3 { Id3 = 27, ParentId3 = null, Name3 = "Child27" },
 			});
-			var query = db.GetTable<Table3>()
+			var ret = db.GetTable<Table3>()
 				.OrderBy(x => x.Id3)
 				.Select(t3 => new
 				{
@@ -350,7 +350,7 @@ namespace Tests.UserTests
 				Assert.That(ret[6].Name3!, Is.EqualTo("Child27"));
 				Assert.That(ret[6].Value2, Is.Null);
 			});
-			AssertQuery(query);
+			AssertQuery(ret);
 		}
 
 		[Test]

--- a/Tests/Linq/UserTests/Issue4090Tests.cs
+++ b/Tests/Linq/UserTests/Issue4090Tests.cs
@@ -283,7 +283,7 @@ namespace Tests.UserTests
 			var ret = AssertQuery(query);
 
 			// assert the result (more important than the SQL for these tests)
-			Assert.That(ret, Has.Count.EqualTo(7));
+			Assert.That(ret, Has.Length.EqualTo(7));
 
 			Assert.Multiple(() =>
 			{

--- a/Tests/Linq/UserTests/Issue4090Tests.cs
+++ b/Tests/Linq/UserTests/Issue4090Tests.cs
@@ -407,7 +407,7 @@ namespace Tests.UserTests
 						.FirstOrDefault()
 				})
 				.ToList();
-			Assert.That(ret, Has.Length.EqualTo(7));
+			Assert.That(ret, Has.Count.EqualTo(7));
 
 			Assert.Multiple(() =>
 			{

--- a/Tests/Linq/UserTests/Issue4090Tests.cs
+++ b/Tests/Linq/UserTests/Issue4090Tests.cs
@@ -37,7 +37,7 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void WithIdFirst_NoData([IncludeDataSources(TestProvName.AllSqlServer2008Plus, TestProvName.AllSQLite)] string context)
+		public void WithIdFirst_NoData([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tbl1 = db.CreateLocalTable(new[]
@@ -82,7 +82,7 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void WithIdFirst_WithData([IncludeDataSources(TestProvName.AllSqlServer2008Plus, TestProvName.AllSQLite)] string context)
+		public void WithIdFirst_WithData([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tbl1 = db.CreateLocalTable(new[]
@@ -132,7 +132,7 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void WithIdAfter_NoData([IncludeDataSources(TestProvName.AllSqlServer2008Plus, TestProvName.AllSQLite)] string context)
+		public void WithIdAfter_NoData([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tbl1 = db.CreateLocalTable(new[]
@@ -177,7 +177,7 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void WithIdAfter_WithData([IncludeDataSources(TestProvName.AllSqlServer2008Plus, TestProvName.AllSQLite)] string context)
+		public void WithIdAfter_WithData([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tbl1 = db.CreateLocalTable(new[]
@@ -227,7 +227,7 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void CrossApply_NullableFields_WithIds([IncludeDataSources(TestProvName.AllSqlServer2008Plus, TestProvName.AllSQLite)] string context)
+		public void CrossApply_NullableFields_WithIds([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tbl1 = db.CreateLocalTable(new[]
@@ -277,8 +277,12 @@ namespace Tests.UserTests
 							Id2 = t2.Id2,
 						})
 						.FirstOrDefault()
-				})
-				.ToList();
+				});
+
+			// assert the generated SQL
+			var ret = AssertQuery(query);
+
+			// assert the result (more important than the SQL for these tests)
 			Assert.That(ret, Has.Count.EqualTo(7));
 
 			Assert.Multiple(() =>
@@ -353,7 +357,7 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void CrossApply_NullableFields_WithoutIds([IncludeDataSources(TestProvName.AllSqlServer2008Plus, TestProvName.AllSQLite)] string context)
+		public void CrossApply_NullableFields_WithoutIds([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tbl1 = db.CreateLocalTable(new[]
@@ -380,7 +384,7 @@ namespace Tests.UserTests
 				new Table3 { Id3 = 26, ParentId3 = 16, Name3 = "Child26" },
 				new Table3 { Id3 = 27, ParentId3 = null, Name3 = "Child27" },
 			});
-			var query = db.GetTable<Table3>()
+			var ret = db.GetTable<Table3>()
 				.OrderBy(x => x.Id3)
 				.Select(t3 => new
 				{
@@ -401,12 +405,8 @@ namespace Tests.UserTests
 							Name2 = t2.Name2,
 						})
 						.FirstOrDefault()
-				});
-
-			// assert the generated SQL
-			var ret = AssertQuery(query);
-
-			// assert the result (more important than the SQL for these tests)
+				})
+				.ToList();
 			Assert.That(ret, Has.Length.EqualTo(7));
 
 			Assert.Multiple(() =>

--- a/Tests/Linq/UserTests/Issue4090Tests.cs
+++ b/Tests/Linq/UserTests/Issue4090Tests.cs
@@ -407,7 +407,7 @@ namespace Tests.UserTests
 			var ret = AssertQuery(query);
 
 			// assert the result (more important than the SQL for these tests)
-			Assert.That(ret, Has.Count.EqualTo(7));
+			Assert.That(ret, Has.Length.EqualTo(7));
 
 			Assert.Multiple(() =>
 			{

--- a/Tests/Linq/UserTests/Issue4090Tests.cs
+++ b/Tests/Linq/UserTests/Issue4090Tests.cs
@@ -37,7 +37,7 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void WithIdFirst_NoData([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
+		public void WithIdFirst_NoData([IncludeDataSources(TestProvName.AllSqlServer2008Plus, TestProvName.AllSQLite)] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tbl1 = db.CreateLocalTable(new[]
@@ -82,7 +82,7 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void WithIdFirst_WithData([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
+		public void WithIdFirst_WithData([IncludeDataSources(TestProvName.AllSqlServer2008Plus, TestProvName.AllSQLite)] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tbl1 = db.CreateLocalTable(new[]
@@ -132,7 +132,7 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void WithIdAfter_NoData([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
+		public void WithIdAfter_NoData([IncludeDataSources(TestProvName.AllSqlServer2008Plus, TestProvName.AllSQLite)] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tbl1 = db.CreateLocalTable(new[]
@@ -177,7 +177,7 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void WithIdAfter_WithData([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
+		public void WithIdAfter_WithData([IncludeDataSources(TestProvName.AllSqlServer2008Plus, TestProvName.AllSQLite)] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tbl1 = db.CreateLocalTable(new[]
@@ -227,7 +227,7 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void CrossApply_NullableFields_WithIds([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
+		public void CrossApply_NullableFields_WithIds([IncludeDataSources(TestProvName.AllSqlServer2008Plus, TestProvName.AllSQLite)] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tbl1 = db.CreateLocalTable(new[]
@@ -353,7 +353,7 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void CrossApply_NullableFields_WithoutIds([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
+		public void CrossApply_NullableFields_WithoutIds([IncludeDataSources(TestProvName.AllSqlServer2008Plus, TestProvName.AllSQLite)] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tbl1 = db.CreateLocalTable(new[]
@@ -380,7 +380,7 @@ namespace Tests.UserTests
 				new Table3 { Id3 = 26, ParentId3 = 16, Name3 = "Child26" },
 				new Table3 { Id3 = 27, ParentId3 = null, Name3 = "Child27" },
 			});
-			var ret = db.GetTable<Table3>()
+			var query = db.GetTable<Table3>()
 				.OrderBy(x => x.Id3)
 				.Select(t3 => new
 				{
@@ -401,8 +401,8 @@ namespace Tests.UserTests
 							Name2 = t2.Name2,
 						})
 						.FirstOrDefault()
-				})
-				.ToList();
+				});
+			var ret = AssertQuery(query);
 			Assert.That(ret, Has.Count.EqualTo(7));
 
 			Assert.Multiple(() =>

--- a/Tests/Linq/UserTests/Issue4090Tests.cs
+++ b/Tests/Linq/UserTests/Issue4090Tests.cs
@@ -350,7 +350,6 @@ namespace Tests.UserTests
 				Assert.That(ret[6].Name3!, Is.EqualTo("Child27"));
 				Assert.That(ret[6].Value2, Is.Null);
 			});
-			AssertQuery(ret);
 		}
 
 		[Test]


### PR DESCRIPTION
I was having an issue in my application that was indicating a regression in 6.0.0-preview-3 for the issue that #4092 tests for.  But for some reason the assertions in test #4092 were removed, asserting only the SQL generation rather than the results.  This PR adds the assertions back.

Note that the tests still pass; I'm still trying to diagnose the issue in my application and determine if it's a linq2db regression or an issue in my application.

Related:
- #4090 
- #4092
- https://github.com/linq2db/linq2db/pull/3401/files#diff-42e95e54c93767c3ca28c12414658435a61f694b4fc6a08624b82ec2c6d335ce