### PR TITLE
Fix EF.Core model `PropertySaveBehavior` attributes mapping

### DIFF
--- a/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.cs
@@ -363,12 +363,9 @@ namespace LinqToDB.EntityFrameworkCore
 					var beforeSaveBehavior = prop.GetBeforeSaveBehavior();
 					var afterSaveBehavior = prop.GetAfterSaveBehavior();
 
-					var skipOnInsert = prop.ValueGenerated.HasFlag(ValueGenerated.OnAdd)
-						|| isIdentity
-						|| beforeSaveBehavior != PropertySaveBehavior.Save;
+					var skipOnInsert = isIdentity || beforeSaveBehavior != PropertySaveBehavior.Save;
 
-					var skipOnUpdate = afterSaveBehavior != PropertySaveBehavior.Save ||
-						prop.ValueGenerated.HasFlag(ValueGenerated.OnUpdate);
+					var skipOnUpdate = afterSaveBehavior != PropertySaveBehavior.Save;
 
 					var ca = new ColumnAttribute()
 					{

--- a/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.cs
@@ -360,15 +360,14 @@ namespace LinqToDB.EntityFrameworkCore
 						}
 					}
 
-					var behavior = prop.GetBeforeSaveBehavior();
-					var skipOnInsert = prop.ValueGenerated.HasFlag(ValueGenerated.OnAdd);
+					var beforeSaveBehavior = prop.GetBeforeSaveBehavior();
+					var afterSaveBehavior = prop.GetAfterSaveBehavior();
 
-					if (skipOnInsert)
-					{
-						skipOnInsert = isIdentity || behavior != PropertySaveBehavior.Save;
-					}
+					var skipOnInsert = prop.ValueGenerated.HasFlag(ValueGenerated.OnAdd)
+						|| isIdentity
+						|| beforeSaveBehavior != PropertySaveBehavior.Save;
 
-					var skipOnUpdate = behavior != PropertySaveBehavior.Save ||
+					var skipOnUpdate = afterSaveBehavior != PropertySaveBehavior.Save ||
 						prop.ValueGenerated.HasFlag(ValueGenerated.OnUpdate);
 
 					var ca = new ColumnAttribute()

--- a/Tests/EntityFrameworkCore/Models/ForMapping/ForMappingContextBase.cs
+++ b/Tests/EntityFrameworkCore/Models/ForMapping/ForMappingContextBase.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace LinqToDB.EntityFrameworkCore.Tests.Models.ForMapping
 {
@@ -20,5 +21,25 @@ namespace LinqToDB.EntityFrameworkCore.Tests.Models.ForMapping
 		public DbSet<WithInheritanceA> WithInheritanceA { get; set; } = null!;
 		public DbSet<WithInheritanceA1> WithInheritanceA1 { get; set; } = null!;
 		public DbSet<WithInheritanceA2> WithInheritanceA2 { get; set; } = null!;
+
+		public DbSet<SkipModesTable> SkipModes { get; set; } = null!;
+
+
+		protected override void OnModelCreating(ModelBuilder modelBuilder)
+		{
+			base.OnModelCreating(modelBuilder);
+
+			modelBuilder.Entity<SkipModesTable>(b =>
+			{
+				b.Property(e => e.Id).ValueGeneratedNever();
+
+				b.Property(e => e.UpdateOnly).Metadata.SetBeforeSaveBehavior(PropertySaveBehavior.Ignore);
+				b.Property(e => e.InsertOnly).Metadata.SetAfterSaveBehavior(PropertySaveBehavior.Ignore);
+
+				var m = b.Property(e => e.ReadOnly).Metadata;
+				m.SetBeforeSaveBehavior(PropertySaveBehavior.Ignore);
+				m.SetAfterSaveBehavior(PropertySaveBehavior.Ignore);
+			});
+		}
 	}
 }

--- a/Tests/EntityFrameworkCore/Models/ForMapping/Npgsql/ForMappingContext.cs
+++ b/Tests/EntityFrameworkCore/Models/ForMapping/Npgsql/ForMappingContext.cs
@@ -12,6 +12,8 @@ namespace LinqToDB.EntityFrameworkCore.Tests.PostgreSQL.Models.ForMapping
 
 		protected override void OnModelCreating(ModelBuilder modelBuilder)
 		{
+			base.OnModelCreating(modelBuilder);
+
 			modelBuilder.Entity<WithIdentity>(b =>
 			{
 				b.HasKey(e => e.Id);

--- a/Tests/EntityFrameworkCore/Models/ForMapping/Pomelo/ForMappingContext.cs
+++ b/Tests/EntityFrameworkCore/Models/ForMapping/Pomelo/ForMappingContext.cs
@@ -12,6 +12,8 @@ namespace LinqToDB.EntityFrameworkCore.Tests.Pomelo.Models.ForMapping
 
 		protected override void OnModelCreating(ModelBuilder modelBuilder)
 		{
+			base.OnModelCreating(modelBuilder);
+
 			modelBuilder.Entity<WithIdentity>(b =>
 			{
 				b.HasKey(e => e.Id);

--- a/Tests/EntityFrameworkCore/Models/ForMapping/SQLServer/ForMappingContext.cs
+++ b/Tests/EntityFrameworkCore/Models/ForMapping/SQLServer/ForMappingContext.cs
@@ -12,6 +12,8 @@ namespace LinqToDB.EntityFrameworkCore.Tests.SqlServer.Models.ForMapping
 
 		protected override void OnModelCreating(ModelBuilder modelBuilder)
 		{
+			base.OnModelCreating(modelBuilder);
+
 			modelBuilder.Entity<WithIdentity>(b =>
 			{
 				b.HasKey(e => e.Id);

--- a/Tests/EntityFrameworkCore/Models/ForMapping/SQLite/ForMappingContext.cs
+++ b/Tests/EntityFrameworkCore/Models/ForMapping/SQLite/ForMappingContext.cs
@@ -12,6 +12,8 @@ namespace LinqToDB.EntityFrameworkCore.Tests.SQLite.Models.ForMapping
 
 		protected override void OnModelCreating(ModelBuilder modelBuilder)
 		{
+			base.OnModelCreating(modelBuilder);
+
 			modelBuilder.Entity<WithIdentity>(b =>
 			{
 				b.HasKey(e => e.Id);

--- a/Tests/EntityFrameworkCore/Models/ForMapping/SkipModesTable.cs
+++ b/Tests/EntityFrameworkCore/Models/ForMapping/SkipModesTable.cs
@@ -1,0 +1,10 @@
+﻿namespace LinqToDB.EntityFrameworkCore.Tests.Models.ForMapping
+{
+	public class SkipModesTable
+	{
+		public int Id { get; set; }
+		public int? InsertOnly { get; set; }
+		public int? UpdateOnly { get; set; }
+		public int? ReadOnly { get; set; }
+	}
+}


### PR DESCRIPTION
Migration of https://github.com/linq2db/linq2db.EntityFrameworkCore/pull/274 to this repo