### PR TITLE
Fix record exists check for multiple left joins

### DIFF
--- a/Source/LinqToDB/Expressions/SqlDefaultIfEmptyExpression.cs
+++ b/Source/LinqToDB/Expressions/SqlDefaultIfEmptyExpression.cs
@@ -24,7 +24,7 @@ namespace LinqToDB.Expressions
 
 		public SqlDefaultIfEmptyExpression Update(Expression innerExpression, ReadOnlyCollection<Expression> notNullExpressions)
 		{
-			if (ReferenceEquals(InnerExpression, innerExpression) && 
+			if (ReferenceEquals(InnerExpression, innerExpression) &&
 			    (ReferenceEquals(NotNullExpressions, notNullExpressions) || NotNullExpressions.SequenceEqual(notNullExpressions, ExpressionEqualityComparer.Instance)))
 			{
 				return this;

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuildVisitor.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuildVisitor.cs
@@ -1742,11 +1742,7 @@ namespace LinqToDB.Linq.Builder
 
 			if (innerExpression is SqlDefaultIfEmptyExpression defaultIfEmptyExpression)
 			{
-				var notNullConditions = node.NotNullExpressions
-					.Concat(defaultIfEmptyExpression.NotNullExpressions)
-					.Distinct(ExpressionEqualityComparer.Instance)
-					.ToList();
-				var newNode = node.Update(defaultIfEmptyExpression.InnerExpression, notNullConditions.AsReadOnly());
+				var newNode = node.Update(defaultIfEmptyExpression.InnerExpression, defaultIfEmptyExpression.NotNullExpressions);
 				return Visit(newNode);
 			}
 

--- a/Tests/Linq/Linq/DistinctTests.cs
+++ b/Tests/Linq/Linq/DistinctTests.cs
@@ -431,5 +431,59 @@ namespace Tests.Linq
 				Assert.That(res[4].F2, Is.EqualTo("2"));
 			});
 		}
+
+
+		sealed class Level1
+		{
+			[PrimaryKey] public int Id { get; set; }
+
+			[Association(ThisKey = nameof(Id), OtherKey = nameof(Level2.FK2))]
+			public Level2 Lvl2 { get; set; } = null!;
+
+			public static readonly Level1[] Data =
+			[
+				new Level1() { Id = 1 }
+			];
+		}
+
+		sealed class Level2
+		{
+			[PrimaryKey] public int Id { get; set; }
+			public int FK2 { get; set; }
+			public int FK3 { get; set; }
+
+			[Association(ThisKey = nameof(FK3), OtherKey = nameof(Level3.Id))]
+			public Level3 Lvl3 { get; set; } = null!;
+
+			public static readonly Level2[] Data =
+			[
+				new Level2() { Id = 11, FK2 = 1, FK3 = 21 },
+				new Level2() { Id = 12, FK2 = 1, FK3 = 21 }
+			];
+		}
+
+		sealed class Level3
+		{
+			[PrimaryKey] public int Id { get; set; }
+			public int Value { get; set; }
+
+			public static readonly Level3[] Data =
+			[
+				new Level3() { Id = 21 },
+				new Level3() { Id = 22 }
+			];
+		}
+
+		[Test]
+		public void DistinctSelectsUnusedColumn([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataContext(context);
+			using var t1 = db.CreateLocalTable(Level1.Data);
+			using var t2 = db.CreateLocalTable(Level2.Data);
+			using var t3 = db.CreateLocalTable(Level3.Data);
+
+
+			t1.Select(c => c.Lvl2.Lvl3).Where(p => p.Id == 21).Distinct().Select(p => p.Value).Single();
+		}
 	}
 }

--- a/Tests/Linq/Linq/DistinctTests.cs
+++ b/Tests/Linq/Linq/DistinctTests.cs
@@ -454,6 +454,9 @@ namespace Tests.Linq
 			[Association(ThisKey = nameof(FK3), OtherKey = nameof(Level3.Id))]
 			public Level3 Lvl3 { get; set; } = null!;
 
+			[Association(ThisKey = nameof(FK3), OtherKey = nameof(Level3AllNull.Id))]
+			public Level3AllNull Lvl3AllNull { get; set; } = null!;
+
 			public static readonly Level2[] Data =
 			[
 				new Level2() { Id = 11, FK2 = 1, FK3 = 21 },
@@ -473,6 +476,18 @@ namespace Tests.Linq
 			];
 		}
 
+		sealed class Level3AllNull
+		{
+			public int? Id { get; set; }
+			public int? Value { get; set; }
+
+			public static readonly Level3AllNull[] Data =
+			[
+				new Level3AllNull() { Id = 21 },
+				new Level3AllNull() { Id = 22 }
+			];
+		}
+
 		[Test]
 		public void DistinctSelectsUnusedColumn([IncludeDataSources(TestProvName.AllSQLite)] string context)
 		{
@@ -482,6 +497,17 @@ namespace Tests.Linq
 			using var t3 = db.CreateLocalTable(Level3.Data);
 
 			t1.Select(c => c.Lvl2.Lvl3).Where(p => p.Id == 21).Distinct().Select(p => p.Value).Single();
+		}
+
+		[Test]
+		public void DistinctSelectsUnusedColumn_Nullable([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataContext(context);
+			using var t1 = db.CreateLocalTable(Level1.Data);
+			using var t2 = db.CreateLocalTable(Level2.Data);
+			using var t3 = db.CreateLocalTable(Level3AllNull.Data);
+
+			t1.Select(c => c.Lvl2.Lvl3AllNull).Where(p => p.Id == 21).Distinct().Select(p => p.Value).Single();
 		}
 	}
 }

--- a/Tests/Linq/Linq/DistinctTests.cs
+++ b/Tests/Linq/Linq/DistinctTests.cs
@@ -432,7 +432,6 @@ namespace Tests.Linq
 			});
 		}
 
-
 		sealed class Level1
 		{
 			[PrimaryKey] public int Id { get; set; }

--- a/Tests/Linq/Linq/DistinctTests.cs
+++ b/Tests/Linq/Linq/DistinctTests.cs
@@ -482,7 +482,6 @@ namespace Tests.Linq
 			using var t2 = db.CreateLocalTable(Level2.Data);
 			using var t3 = db.CreateLocalTable(Level3.Data);
 
-
 			t1.Select(c => c.Lvl2.Lvl3).Where(p => p.Id == 21).Distinct().Select(p => p.Value).Single();
 		}
 	}


### PR DESCRIPTION
Issue exists at least since v5: distinct over record from association generate extra unused columns that could lead to de-duplication failure

```sql
SELECT
	[t1].[Value_1]
FROM
	(
		SELECT DISTINCT
			[a_Lvl3].[Id],
			[a_Lvl3].[Value] as [Value_1],
                        -- shouldn't be here
			[a_Lvl2].[Id] as [Id_1]
		FROM
			[Level1] [p]
				LEFT JOIN [Level2] [a_Lvl2] ON [p].[Id] = [a_Lvl2].[FK2]
				LEFT JOIN [Level3] [a_Lvl3] ON [a_Lvl2].[FK3] = [a_Lvl3].[Id]
		WHERE
			[a_Lvl3].[Id] = 21
	) [t1]
LIMIT 2
```