### PR TITLE
ORDER BY is removed from subquery even when TOP or LIMIT/OFFSET are used

### DIFF
--- a/Source/LinqToDB/DataProvider/DataProviderBase.cs
+++ b/Source/LinqToDB/DataProvider/DataProviderBase.cs
@@ -70,6 +70,7 @@ namespace LinqToDB.DataProvider
 				RowConstructorSupport                = RowFeature.None,
 				IsWindowFunctionsSupported           = true,
 				IsDerivedTableOrderBySupported       = true,
+				IsOrderByAggregateFunctionSupported  = true,
 			};
 
 			SetField<DbDataReader, bool>    ((r,i) => r.GetBoolean (i));

--- a/Source/LinqToDB/DataProvider/SqlCe/SqlCeDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlCe/SqlCeDataProvider.cs
@@ -28,16 +28,17 @@ namespace LinqToDB.DataProvider.SqlCe
 		protected SqlCeDataProvider(string name, MappingSchema mappingSchema)
 			: base(name, mappingSchema, SqlCeProviderAdapter.GetInstance())
 		{
-			SqlProviderFlags.IsSubQueryColumnSupported            = false;
-			SqlProviderFlags.IsCountSubQuerySupported             = false;
-			SqlProviderFlags.IsApplyJoinSupported                 = true;
-			SqlProviderFlags.IsInsertOrUpdateSupported            = false;
-			SqlProviderFlags.IsDistinctSetOperationsSupported     = false;
-			SqlProviderFlags.IsUpdateFromSupported                = false;
-			SqlProviderFlags.IsCountDistinctSupported             = false;
-			SqlProviderFlags.IsAggregationDistinctSupported       = false;
-			SqlProviderFlags.SupportsBooleanType                  = false;
-			SqlProviderFlags.IsWindowFunctionsSupported           = false;
+			SqlProviderFlags.IsSubQueryColumnSupported           = false;
+			SqlProviderFlags.IsCountSubQuerySupported            = false;
+			SqlProviderFlags.IsApplyJoinSupported                = true;
+			SqlProviderFlags.IsInsertOrUpdateSupported           = false;
+			SqlProviderFlags.IsDistinctSetOperationsSupported    = false;
+			SqlProviderFlags.IsUpdateFromSupported               = false;
+			SqlProviderFlags.IsCountDistinctSupported            = false;
+			SqlProviderFlags.IsAggregationDistinctSupported      = false;
+			SqlProviderFlags.SupportsBooleanType                 = false;
+			SqlProviderFlags.IsWindowFunctionsSupported          = false;
+			SqlProviderFlags.IsOrderByAggregateFunctionSupported = false;
 
 			SetCharFieldToType<char>("NChar", DataTools.GetCharExpression);
 

--- a/Source/LinqToDB/SqlProvider/SqlProviderFlags.cs
+++ b/Source/LinqToDB/SqlProvider/SqlProviderFlags.cs
@@ -517,6 +517,16 @@ namespace LinqToDB.SqlProvider
 		[DataMember(Order = 60)]
 		public bool IsDistinctFromSupported { get; set; }
 
+		/// <summary>
+		/// Provider supports Aggregate function in ORDER BY.
+		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
+		/// </summary>
+		/// <remarks>
+		/// Applied only to SqlCe provider.
+		/// </remarks>
+		[DataMember(Order = 61), DefaultValue(true)]
+		public bool IsOrderByAggregateFunctionSupported { get; set; }
+
 		public bool GetAcceptsTakeAsParameterFlag(SelectQuery selectQuery)
 		{
 			return AcceptsTakeAsParameter || AcceptsTakeAsParameterIfSkip && selectQuery.Select.SkipValue != null;
@@ -600,6 +610,7 @@ namespace LinqToDB.SqlProvider
 				^ SupportedCorrelatedSubqueriesLevel                   .GetHashCode()
 				^ IsDistinctFromSupported                              .GetHashCode()
 				^ DoesProviderTreatsEmptyStringAsNull                  .GetHashCode()
+				^ IsOrderByAggregateFunctionSupported                  .GetHashCode()
 				^ CustomFlags.Aggregate(0, (hash, flag) => flag.GetHashCode() ^ hash);
 	}
 
@@ -665,6 +676,7 @@ namespace LinqToDB.SqlProvider
 				&& SupportedCorrelatedSubqueriesLevel                    == other.SupportedCorrelatedSubqueriesLevel
 				&& IsDistinctFromSupported                               == other.IsDistinctFromSupported
 				&& DoesProviderTreatsEmptyStringAsNull                   == other.DoesProviderTreatsEmptyStringAsNull
+				&& IsOrderByAggregateFunctionSupported                   == other.IsOrderByAggregateFunctionSupported
 				// CustomFlags as List wasn't best idea
 				&& CustomFlags.Count                                     == other.CustomFlags.Count
 				&& (CustomFlags.Count                                    == 0

--- a/Source/LinqToDB/SqlProvider/SqlProviderFlags.cs
+++ b/Source/LinqToDB/SqlProvider/SqlProviderFlags.cs
@@ -524,7 +524,7 @@ namespace LinqToDB.SqlProvider
 		/// <remarks>
 		/// Applied only to SqlCe provider.
 		/// </remarks>
-		[DataMember(Order = 61), DefaultValue(true)]
+		[DataMember(Order = 61)]
 		public bool IsOrderByAggregateFunctionSupported { get; set; }
 
 		public bool GetAcceptsTakeAsParameterFlag(SelectQuery selectQuery)

--- a/Source/LinqToDB/SqlQuery/SelectQueryOptimizerVisitor.cs
+++ b/Source/LinqToDB/SqlQuery/SelectQueryOptimizerVisitor.cs
@@ -1388,11 +1388,9 @@ namespace LinqToDB.SqlQuery
 				}
 			}
 
-			if (parentQuery.Select.HasModifier)
+			if (parentQuery is { IsLimited: true, OrderBy.IsEmpty: false })
 			{
-				if (!subQuery.GroupBy.IsEmpty)
-					return false;
-				if (subQuery.HasSetOperators)
+				if (!subQuery.IsSimple)
 					return false;
 			}
 

--- a/Source/LinqToDB/SqlQuery/SelectQueryOptimizerVisitor.cs
+++ b/Source/LinqToDB/SqlQuery/SelectQueryOptimizerVisitor.cs
@@ -1388,6 +1388,14 @@ namespace LinqToDB.SqlQuery
 				}
 			}
 
+			if (parentQuery.Select.HasModifier)
+			{
+				if (!subQuery.GroupBy.IsEmpty)
+					return false;
+				if (subQuery.HasSetOperators)
+					return false;
+			}
+
 			if (subQuery.From.Tables.Count > 1)
 			{
 				if (!_providerFlags.IsMultiTablesSupportsJoins)

--- a/Source/LinqToDB/SqlQuery/SelectQueryOptimizerVisitor.cs
+++ b/Source/LinqToDB/SqlQuery/SelectQueryOptimizerVisitor.cs
@@ -861,7 +861,7 @@ namespace LinqToDB.SqlQuery
 		{
 			if (subQuery.OrderBy.Items.Count > 0)
 			{
-				var filterItems = mainQuery.Select.IsDistinct || !mainQuery.GroupBy.IsEmpty;
+				var filterItems = (mainQuery.Select.IsDistinct || !mainQuery.GroupBy.IsEmpty) && !mainQuery.IsLimited;
 
 				foreach (var item in subQuery.OrderBy.Items)
 				{
@@ -1386,12 +1386,6 @@ namespace LinqToDB.SqlQuery
 					// shortcut
 					return true;
 				}
-			}
-
-			if (parentQuery is { IsLimited: true, OrderBy.IsEmpty: false })
-			{
-				if (!subQuery.IsSimple)
-					return false;
 			}
 
 			if (subQuery.From.Tables.Count > 1)

--- a/Source/LinqToDB/SqlQuery/SelectQueryOptimizerVisitor.cs
+++ b/Source/LinqToDB/SqlQuery/SelectQueryOptimizerVisitor.cs
@@ -1407,6 +1407,22 @@ namespace LinqToDB.SqlQuery
 					return false;
 			}
 
+			if (!parentQuery.OrderBy.IsEmpty && !_providerFlags.IsOrderByAggregateFunctionSupported)
+			{
+				if (parentQuery.OrderBy.Items.Select(o => o.Expression).Any(e =>
+				    {
+					    var test = e;
+					    if (e is SqlColumn column)
+						    test = column.Expression;
+
+					    return QueryHelper.ContainsAggregationFunction(test);
+				    }))
+				{
+					// not allowed to move to parent if it has aggregates
+					return false;
+				}
+			}
+
 			if (!parentQuery.GroupBy.IsEmpty)
 			{
 				if (!subQuery.GroupBy.IsEmpty)

--- a/Source/LinqToDB/SqlQuery/SelectQueryOptimizerVisitor.cs
+++ b/Source/LinqToDB/SqlQuery/SelectQueryOptimizerVisitor.cs
@@ -861,7 +861,7 @@ namespace LinqToDB.SqlQuery
 		{
 			if (subQuery.OrderBy.Items.Count > 0)
 			{
-				var filterItems = (mainQuery.Select.IsDistinct || !mainQuery.GroupBy.IsEmpty) && !mainQuery.IsLimited;
+				var filterItems = !mainQuery.IsLimited && (mainQuery.Select.IsDistinct || !mainQuery.GroupBy.IsEmpty);
 
 				foreach (var item in subQuery.OrderBy.Items)
 				{

--- a/Source/LinqToDB/SqlQuery/SelectQueryOptimizerVisitor.cs
+++ b/Source/LinqToDB/SqlQuery/SelectQueryOptimizerVisitor.cs
@@ -1411,11 +1411,13 @@ namespace LinqToDB.SqlQuery
 			{
 				if (parentQuery.OrderBy.Items.Select(o => o.Expression).Any(e =>
 				    {
-					    var test = e;
-					    if (e is SqlColumn column)
-						    test = column.Expression;
+					    if (QueryHelper.UnwrapNullablity(e) is SqlColumn column)
+					    {
+							if (column.Parent == subQuery)
+								return QueryHelper.ContainsAggregationFunction(column.Expression);
+					    }
 
-					    return QueryHelper.ContainsAggregationFunction(test);
+					    return false;
 				    }))
 				{
 					// not allowed to move to parent if it has aggregates

--- a/Tests/Linq/Linq/GroupByTests.cs
+++ b/Tests/Linq/Linq/GroupByTests.cs
@@ -3783,26 +3783,14 @@ namespace Tests.Linq
 				orderby g.Max descending
 				select g
 			)
-			.TagQuery("GroupBy")
 			.Take(2);
 
-			var list = grp.ToList();
+			var query = 
+				from t in db.Child
+				where t.ParentID.In(grp.Select(x => x.ParentID))
+				select t;
 
-			AreEqual(
-				(
-					from t in db.Child
-					where t.ParentID.In(list.Select(x => x.ParentID))
-					select t
-				)
-				.TagQuery("List")
-				,
-				(
-					from t in db.Child
-					where t.ParentID.In(grp.Select(x => x.ParentID))
-					select t
-				)
-				.TagQuery("Query")
-			);
+			AssertQuery(query);
 		}
 	}
 }

--- a/Tests/Linq/Linq/GroupByTests.cs
+++ b/Tests/Linq/Linq/GroupByTests.cs
@@ -3765,6 +3765,7 @@ namespace Tests.Linq
 				.LongCount();
 		}
 
+		[ThrowsForProvider(typeof(LinqToDBException), providers: [TestProvName.AllSybase], ErrorMessage = ErrorHelper.Error_OrderBy_in_Derived)]
 		[Test]
 		public void Issue_FilterByOrderedGroupBy([DataSources] string context)
 		{

--- a/Tests/Linq/Linq/GroupByTests.cs
+++ b/Tests/Linq/Linq/GroupByTests.cs
@@ -4,9 +4,11 @@ using System.Linq;
 using FluentAssertions;
 
 using LinqToDB;
+using LinqToDB.Data;
 using LinqToDB.Linq;
 using LinqToDB.Mapping;
 using LinqToDB.SqlQuery;
+using LinqToDB.Tools;
 
 using NUnit.Framework;
 
@@ -876,7 +878,7 @@ namespace Tests.Linq
 					DistinctWithFilter       = g.Select(x => x.DataValue).Distinct().Count(x => x % 2 == 0),
 					FilterDistinct           = g.Select(x => x.DataValue).Where(x => x      % 2 == 0).Distinct().Count(),
 					FilterDistinctWithFilter = g.Select(x => x.DataValue).Where(x => x      % 2 == 0).Distinct().Count(x => x % 2 == 0),
-					
+
 					SubFilter           = filtered.Count(),
 					SubFilterDistinct   = filteredDistinct.Count(),
 					SubNoFilterDistinct = nonfilteredDistinct.Count(),
@@ -894,7 +896,7 @@ namespace Tests.Linq
 			using var db = GetDataContext(context);
 			using var table = db.CreateLocalTable(data);
 
-			var query = 
+			var query =
 				from t in table
 				group t by new { t.GroupId }  into g
 				select new
@@ -975,7 +977,7 @@ namespace Tests.Linq
 			using var db = GetDataContext(context);
 			using var table = db.CreateLocalTable(data);
 
-			var query = 
+			var query =
 				from t in table
 				where t.DataValue != null
 				group t by t.GroupId into g
@@ -1396,7 +1398,7 @@ namespace Tests.Linq
 		{
 			using var db = GetDataContext(context);
 
-			var query = 
+			var query =
 				from p in db.Parent
 				group p by p.Children.Average(c => c.ParentID) > 3
 				into g
@@ -3051,7 +3053,7 @@ namespace Tests.Linq
 				let cItems = p.Children.GroupBy(c => c.ParentID, (key, grouped) => new { Id = key, Count = grouped.Count() })
 				select new
 				{
-					p.ParentID, 
+					p.ParentID,
 					First = cItems.OrderBy(x => x.Count).ThenBy(x => x.Id).FirstOrDefault()
 				};
 
@@ -3761,6 +3763,46 @@ namespace Tests.Linq
 					label = "label"
 				})
 				.LongCount();
+		}
+
+		[Test]
+		public void Issue_FilterByOrderedGroupBy([DataSources] string context)
+		{
+			using var db  = GetDataContext(context);
+
+			var grp =
+			(
+				from c in db.Child
+				group c by c.ParentID into g
+				select new
+				{
+					ParentID = g.Key,
+					Max      = g.Max(x => x.ChildID)
+				}
+				into g
+				orderby g.Max descending
+				select g
+			)
+			.TagQuery("GroupBy")
+			.Take(2);
+
+			var list = grp.ToList();
+
+			AreEqual(
+				(
+					from t in db.Child
+					where t.ParentID.In(list.Select(x => x.ParentID))
+					select t
+				)
+				.TagQuery("List")
+				,
+				(
+					from t in db.Child
+					where t.ParentID.In(grp.Select(x => x.ParentID))
+					select t
+				)
+				.TagQuery("Query")
+			);
 		}
 	}
 }


### PR DESCRIPTION
See test.

`group by` itself has `order by`.

```sql
DECLARE @take Int -- Int32
SET     @take = 2

/* GroupBy */
SELECT TOP (@take)
	[t1].[Key_1],
	[t1].[Max_1]
FROM
	(
		SELECT
			MAX([g_1].[ChildID]) as [Max_1],
			[g_1].[ParentID] as [Key_1]
		FROM
			[Child] [g_1]
		GROUP BY
			[g_1].[ParentID]
	) [t1]
ORDER BY
	[t1].[Max_1] DESC
```

If it is used as subquery `order by` is lost.

```sql
/* GroupBy
Query */
SELECT
	[t].[ParentID],
	[t].[ChildID]
FROM
	[Child] [t]
WHERE
	[t].[ParentID] IN (
		SELECT
			[t1].[ParentID]
		FROM
			(
				SELECT TOP (2)
					[x].[ParentID]
				FROM
					[Child] [x]
				GROUP BY
					[x].[ParentID]
			) [t1]
	)
```
