### PR TITLE
Fix UseFSharp() extension method not found in F#.

### DIFF
--- a/Source/LinqToDB.FSharp/DataOptionsExtensions.fs
+++ b/Source/LinqToDB.FSharp/DataOptionsExtensions.fs
@@ -4,9 +4,9 @@ open LinqToDB
 open System.Runtime.CompilerServices
 
 [<Extension>]
-module Methods =
+type Methods() =
     /// <summary>Enables support for F#-specific features.</summary>
     /// <remarks>Currently it is limited to record types support, but we plan to add more support in future releases.</remarks>
     [<Extension>]
-    let UseFSharp(options : DataOptions) =
+    static member UseFSharp(options : DataOptions) =
         options.UseInterceptor FSharpEntityBindingInterceptor.Instance

--- a/Tests/FSharp/Issue4851.fs
+++ b/Tests/FSharp/Issue4851.fs
@@ -1,0 +1,10 @@
+module Tests.FSharp.Issue4851
+
+open LinqToDB
+open LinqToDB.FSharp
+
+let Issue4851Test1() =
+    let _ =
+        (new DataOptions())
+            .UseFSharp()
+    ()

--- a/Tests/FSharp/Tests.FSharp.fsproj
+++ b/Tests/FSharp/Tests.FSharp.fsproj
@@ -9,6 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<Compile Include="Issue4851.fs" />
 		<Compile Include="Issue2678.fs" />
 		<Compile Include="Models.fs" />
 		<Compile Include="Issue3357.fs" />


### PR DESCRIPTION
Closes #4851 