### PR TITLE
TempTable.Insert method is broken.

### DIFF
--- a/Source/LinqToDB/TempTable.cs
+++ b/Source/LinqToDB/TempTable.cs
@@ -576,9 +576,7 @@ namespace LinqToDB
 		/// <returns>Number of records, inserted into table.</returns>
 		public long Insert(IQueryable<T> items)
 		{
-			var l = GenerateInsertSetter(items ?? throw new ArgumentNullException(nameof(items)));
-
-			var count = items.Insert(_table, l);
+			var count = items.Insert(_table, e => e);
 
 			TotalCopied += count;
 
@@ -593,57 +591,11 @@ namespace LinqToDB
 		/// <returns>Number of records, inserted into table.</returns>
 		public async Task<long> InsertAsync(IQueryable<T> items, CancellationToken cancellationToken = default)
 		{
-			var l = GenerateInsertSetter(items ?? throw new ArgumentNullException(nameof(items)));
-
-			var count = await items.InsertAsync(_table, l, cancellationToken).ConfigureAwait(false);
+			var count = await items.InsertAsync(_table, e => e, cancellationToken).ConfigureAwait(false);
 
 			TotalCopied += count;
 
 			return count;
-		}
-
-		private Expression<Func<T,T>> GenerateInsertSetter(IQueryable<T> items)
-		{
-			var type = typeof(T);
-			var ed   = _tableDescriptor ?? _table.DataContext.MappingSchema.GetEntityDescriptor(type, _table.DataContext.Options.ConnectionOptions.OnEntityDescriptorCreated);
-			var p    = Expression.Parameter(type, "t");
-
-			return _setterDic.GetOrAdd(type, t =>
-			{
-				if (t.IsAnonymous())
-				{
-					var nctor = (NewExpression?)items.Expression.Find(t, static (t, e) => e.NodeType == ExpressionType.New && e.Type == t);
-
-					MemberInfo[]    members;
-					ConstructorInfo ctor;
-
-					if (nctor == null)
-					{
-						ctor    = t.GetConstructors().Single();
-						members = t.GetPublicInstanceValueMembers();
-					}
-					else
-					{
-						ctor    = nctor.Constructor!;
-						members = nctor.Members!
-							.Select(m => m is MethodInfo info ? info.GetPropertyInfo()! : m)
-							.ToArray();
-					}
-
-					return Expression.Lambda<Func<T,T>>(
-						Expression.New(
-							ctor,
-							members.Select(m => ExpressionHelper.PropertyOrField(p, m.Name)),
-							members),
-						p);
-				}
-
-				return Expression.Lambda<Func<T,T>>(
-					Expression.MemberInit(
-						Expression.New(t),
-						ed.Columns.Select(c => Expression.Bind(c.MemberInfo, Expression.MakeMemberAccess(p, c.MemberInfo)))),
-					p);
-			});
 		}
 
 		#region ITable<T> implementation

--- a/Source/LinqToDB/TempTable.cs
+++ b/Source/LinqToDB/TempTable.cs
@@ -567,8 +567,6 @@ namespace LinqToDB
 			return count.RowsCopied;
 		}
 
-		static readonly ConcurrentDictionary<Type,Expression<Func<T,T>>> _setterDic = new ();
-
 		/// <summary>
 		/// Insert data into table using records, returned by provided query.
 		/// </summary>

--- a/Tests/Linq/Update/TempTableTests.cs
+++ b/Tests/Linq/Update/TempTableTests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Linq;
+
+using NUnit.Framework;
+
+namespace Tests.xUpdate
+{
+	[TestFixture]
+	public class TempTableTests : TestBase
+	{
+		class Table1
+		{
+			public int ID;
+		}
+
+		class Table2
+		{
+			public int       ID;
+			public DateTime? Date;
+		}
+
+		[Test]
+		public void InsertTest([DataSources(false, TestProvName.AllClickHouse)] string context)
+		{
+			using var db = GetDataContext(context);
+			using var t1 = db.CreateLocalTable<Table1>([new Table1 { ID = 10 }]);
+			using var t2 = db.CreateLocalTable<Table2>();
+
+			t2.Insert(from t in t1 select new Table2 { ID = t.ID });
+
+			var result = t2.ToList();
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(result,         Has.Count.EqualTo(1));
+				Assert.That(result[0].ID,   Is.EqualTo(10));
+				Assert.That(result[0].Date, Is.Null);
+			});
+		}
+	}
+}


### PR DESCRIPTION
The following code stopped working:

```c#
class Table1
{
	public int ID;
}

class Table2
{
	public int       ID;
	public DateTime? Date;
}

[Test]
public void InsertTest([DataSources(false, TestProvName.AllClickHouse)] string context)
{
	using var db = GetDataContext(context);
	using var t1 = db.CreateLocalTable<Table1>([new Table1 { ID = 10 }]);
	using var t2 = db.CreateLocalTable<Table2>();

	t2.Insert(from t in t1 select new Table2 { ID = t.ID });

	var result = t2.ToList();

	Assert.Multiple(() =>
	{
		Assert.That(result,         Has.Count.EqualTo(1));
		Assert.That(result[0].ID,   Is.EqualTo(10));
		Assert.That(result[0].Date, Is.Null);
	});
}
```

Works in 5.4.1.