### PR TITLE
Add missing `AllowMultiple = true` to MappingAttribute-based attributed

### DIFF
--- a/Source/LinqToDB/Concurrency/OptimisticLockPropertyAttribute.cs
+++ b/Source/LinqToDB/Concurrency/OptimisticLockPropertyAttribute.cs
@@ -12,7 +12,7 @@ namespace LinqToDB.Concurrency
 	/// See <see cref="VersionBehavior"/> for supported strategies.
 	/// Used with <see cref="ConcurrencyExtensions" /> extensions.
 	/// </summary>
-	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = true)]
 	public class OptimisticLockPropertyAttribute : OptimisticLockPropertyBaseAttribute
 	{
 		private static readonly Expression _newGuidCall       = Expression.Call(null, Methods.System.Guid_NewGuid);

--- a/Source/LinqToDB/Concurrency/OptimisticLockPropertyBaseAttribute.cs
+++ b/Source/LinqToDB/Concurrency/OptimisticLockPropertyBaseAttribute.cs
@@ -9,7 +9,7 @@ namespace LinqToDB.Concurrency
 	/// Defines optimistic lock column value generation strategy for update.
 	/// Used with <see cref="ConcurrencyExtensions" /> extensions.
 	/// </summary>
-	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = true)]
 	public abstract class OptimisticLockPropertyBaseAttribute : MappingAttribute
 	{
 		protected OptimisticLockPropertyBaseAttribute()

--- a/Source/LinqToDB/Expressions/SkipIfConstantAttribute.cs
+++ b/Source/LinqToDB/Expressions/SkipIfConstantAttribute.cs
@@ -6,7 +6,7 @@ namespace LinqToDB.Expressions
 	/// Used to tell query expression comparer to skip method call argument comparison if it is constant.
 	/// Method parameter parameterization should be also implemented in method builder.
 	/// </summary>
-	[AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+	[AttributeUsage(AttributeTargets.Parameter)]
 	internal sealed class SkipIfConstantAttribute : Attribute
 	{
 	}

--- a/Source/LinqToDB/Linq/Builder/Attributes.cs
+++ b/Source/LinqToDB/Linq/Builder/Attributes.cs
@@ -14,7 +14,7 @@ namespace LinqToDB.Linq.Builder
 	// but it's a "Won't fix" C# bug: https://github.com/dotnet/roslyn/issues/4293
 	// Feel free to add more overloads as needed.
 
-	[AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+	[AttributeUsage(AttributeTargets.Class, Inherited = false)]
 	sealed class BuildsAnyAttribute : Attribute
 	{ }
 

--- a/Source/LinqToDB/Linq/Internal/ColumnReaderAttribute.cs
+++ b/Source/LinqToDB/Linq/Internal/ColumnReaderAttribute.cs
@@ -5,7 +5,7 @@ namespace LinqToDB.Linq.Internal
 	/// <summary>
 	/// Internal API.
 	/// </summary>
-	[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+	[AttributeUsage(AttributeTargets.Method)]
 	public class ColumnReaderAttribute : Attribute
 	{
 		public ColumnReaderAttribute(int indexParameterIndex)

--- a/Source/LinqToDB/Mapping/AssociationAttribute.cs
+++ b/Source/LinqToDB/Mapping/AssociationAttribute.cs
@@ -23,7 +23,7 @@ namespace LinqToDB.Mapping
 	/// records. To load data into association, you should explicitly specify it in your query using <see cref="LinqExtensions.LoadWith{TEntity,TProperty}(System.Linq.IQueryable{TEntity},Expression{Func{TEntity,TProperty}})"/> method.
 	/// </summary>
 	[PublicAPI]
-	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple=false)]
+	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = true)]
 	public class AssociationAttribute : MappingAttribute
 	{
 		/// <summary>

--- a/Source/LinqToDB/Mapping/DynamicColumnsStoreAttribute.cs
+++ b/Source/LinqToDB/Mapping/DynamicColumnsStoreAttribute.cs
@@ -6,7 +6,7 @@ namespace LinqToDB.Mapping
 	/// Marks target member as dynamic columns store.
 	/// </summary>
 	/// <seealso cref="Attribute" />
-	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = true)]
 	public class DynamicColumnsStoreAttribute : MappingAttribute
 	{
 		public override string GetObjectID() => Configuration ?? string.Empty;

--- a/Source/LinqToDB/Mapping/NotNullAttribute.cs
+++ b/Source/LinqToDB/Mapping/NotNullAttribute.cs
@@ -6,7 +6,7 @@ namespace LinqToDB.Mapping
 	/// Sets nullability flag for current column to <c>false</c>.
 	/// See <see cref="NullableAttribute"/> for more details.
 	/// </summary>
-	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = true)]
 	public class NotNullAttribute : NullableAttribute
 	{
 		/// <summary>

--- a/Source/LinqToDB/Mapping/QueryFilterAttribute.cs
+++ b/Source/LinqToDB/Mapping/QueryFilterAttribute.cs
@@ -9,7 +9,7 @@ namespace LinqToDB.Mapping
 	/// <summary>
 	/// Contains reference to filter function defined by <see cref="EntityMappingBuilder{T}.HasQueryFilter(Expression{Func{T, IDataContext, bool}})"/>
 	/// </summary>
-	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface)]
+	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = true)]
 	public class QueryFilterAttribute : MappingAttribute
 	{
 		/// <summary>

--- a/Source/LinqToDB/Mapping/ResultSetIndexAttribute.cs
+++ b/Source/LinqToDB/Mapping/ResultSetIndexAttribute.cs
@@ -5,7 +5,7 @@ namespace LinqToDB.Mapping
 	/// <summary>
 	/// Used to mark the index of a result set when multiple result sets need to be processed for a command.
 	/// </summary>
-	[AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+	[AttributeUsage(AttributeTargets.Property, Inherited = false)]
 	public class ResultSetIndexAttribute : Attribute
 	{
 		public int Index { get; }

--- a/Source/LinqToDB/Mapping/ValueConverterAttribute.cs
+++ b/Source/LinqToDB/Mapping/ValueConverterAttribute.cs
@@ -6,7 +6,7 @@ using LinqToDB.Reflection;
 
 namespace LinqToDB.Mapping
 {
-	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, Inherited = true)]
+	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, Inherited = true, AllowMultiple = true)]
 	public class ValueConverterAttribute : MappingAttribute
 	{
 		/// <summary>

--- a/Source/LinqToDB/Sql/Sql.EnumAttribute.cs
+++ b/Source/LinqToDB/Sql/Sql.EnumAttribute.cs
@@ -8,7 +8,7 @@ namespace LinqToDB
 {
 	partial class Sql
 	{
-		[AttributeUsage(AttributeTargets.Enum, AllowMultiple = false, Inherited = false)]
+		[AttributeUsage(AttributeTargets.Enum, AllowMultiple = true, Inherited = false)]
 		public class EnumAttribute : MappingAttribute
 		{
 			public override string GetObjectID() => "..";

--- a/Source/LinqToDB/Sql/Sql.ExtensionAttribute.cs
+++ b/Source/LinqToDB/Sql/Sql.ExtensionAttribute.cs
@@ -29,7 +29,7 @@ namespace LinqToDB
 		Values
 	}
 
-	[AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+	[AttributeUsage(AttributeTargets.Parameter)]
 	[MeansImplicitUse]
 	public class ExprParameterAttribute : Attribute
 	{


### PR DESCRIPTION
All attributes that inherit MappingAttribute must have `AllowMultiple=true` set as this is the only feature of this base class: allow configuration-based dispatch. Also remoted `AllowMultiple=false` from some non-maping attributes, as this is default value for this option.

Following mappin attributes fixed:
- `OptimisticLockPropertyBaseAttribute`-based attributes
- `AssociationAttribute`
- `DynamicColumnsStoreAttribute`
- `NotNullAttribute`
- `QueryFilterAttribute`
- `ValueConverterAttribute`
- `EnumAttribute`