### PR TITLE
Tests cleanup and remote context init fixes

### DIFF
--- a/Source/LinqToDB/Remote/RemoteDataContextBase.cs
+++ b/Source/LinqToDB/Remote/RemoteDataContextBase.cs
@@ -216,18 +216,27 @@ namespace LinqToDB.Remote
 			}
 		}
 
+		private MappingSchema? _providedMappingSchema;
 		private MappingSchema? _mappingSchema;
-		public  MappingSchema   MappingSchema
+		private MappingSchema? _serializationMappingSchema;
+
+		public MappingSchema   MappingSchema
 		{
-			get => _mappingSchema ??= GetConfigurationInfo().MappingSchema;
+			get => _mappingSchema ??= _providedMappingSchema == null ? GetConfigurationInfo().MappingSchema : MappingSchema.CombineSchemas(_providedMappingSchema, GetConfigurationInfo().MappingSchema);
 			set
 			{
-				_mappingSchema = value;
-				_serializationMappingSchema = MappingSchema.CombineSchemas(Remote.SerializationMappingSchema.Instance, MappingSchema);
+				// Because setter could be called from constructor, we cannot build composite schemas here to avoid server calls on half-initialized context
+				// Instead we reset schemas status and finish initialization in getters for MappingSchema and SerializationMappingSchema, when they are called
+				if (_providedMappingSchema != value)
+				{
+					_providedMappingSchema = value;
+					// reset schemas
+					_mappingSchema              = null;
+					_serializationMappingSchema = null;
+				}
 			}
 		}
 
-		private  MappingSchema? _serializationMappingSchema;
 		internal MappingSchema   SerializationMappingSchema => _serializationMappingSchema ??= MappingSchema.CombineSchemas(Remote.SerializationMappingSchema.Instance, MappingSchema);
 
 		public  bool InlineParameters { get; set; }
@@ -528,6 +537,11 @@ namespace LinqToDB.Remote
 		{
 			public static void Apply(RemoteDataContextBase dataContext, ConnectionOptions options)
 			{
+				if (options.ConfigurationString != null)
+				{
+					dataContext.ConfigurationString = options.ConfigurationString;
+				}
+
 				if (options.MappingSchema != null)
 				{
 					dataContext.MappingSchema = options.MappingSchema;

--- a/Tests/Base/Remote/ITestLinqService.cs
+++ b/Tests/Base/Remote/ITestLinqService.cs
@@ -1,0 +1,9 @@
+﻿using LinqToDB.Mapping;
+
+namespace Tests.Remote
+{
+	public interface ITestLinqService
+	{
+		MappingSchema? MappingSchema { get; set; }
+	}
+}

--- a/Tests/Base/Remote/ServerContainer/IServerContainer.cs
+++ b/Tests/Base/Remote/ServerContainer/IServerContainer.cs
@@ -12,6 +12,6 @@ namespace Tests.Remote.ServerContainer
 	{
 		bool KeepSamePortBetweenThreads { get; set; }
 
-		ITestDataContext CreateContext(MappingSchema? ms, string configuration, Func<DataOptions,DataOptions>? optionBuilder, Func<string, MappingSchema?, DataConnection> connectionFactory);
+		ITestDataContext CreateContext(Func<ITestLinqService,DataOptions, DataOptions> optionBuilder, Func<string, MappingSchema?, DataConnection> connectionFactory);
 	}
 }

--- a/Tests/Base/Remote/ServerContainer/WcfServerContainer.cs
+++ b/Tests/Base/Remote/ServerContainer/WcfServerContainer.cs
@@ -30,48 +30,30 @@ namespace Tests.Remote.ServerContainer
 
 		private Func<string, MappingSchema?, DataConnection> _connectionFactory = null!;
 
-		ITestDataContext IServerContainer.CreateContext(
-			MappingSchema? ms,
-			string configuration,
-			Func<DataOptions, DataOptions>? optionBuilder,
-			Func<string, MappingSchema?, DataConnection> connectionFactory)
+		ITestDataContext IServerContainer.CreateContext(Func<ITestLinqService,DataOptions, DataOptions> optionBuilder, Func<string, MappingSchema?, DataConnection> connectionFactory)
 		{
 			_connectionFactory = connectionFactory;
 
-			var service = OpenHost(ms);
+			var service = OpenHost();
 
-			var dx = new TestWcfDataContext(
-				GetPort(),
-				o => optionBuilder == null
-					? o.UseConfiguration(configuration)
-					: optionBuilder(o.UseConfiguration(configuration)))
-			{ ConfigurationString = configuration };
+			var dx = new TestWcfDataContext(GetPort(), o => optionBuilder(service, o));
 
 			Debug.WriteLine(((IDataContext)dx).ConfigurationID, "Provider ");
-
-			if (ms != null)
-				dx.MappingSchema = dx.MappingSchema == null ? ms : MappingSchema.CombineSchemas(ms, dx.MappingSchema);
 
 			return dx;
 		}
 
-		private TestWcfLinqService OpenHost(MappingSchema? ms)
+		private TestWcfLinqService OpenHost()
 		{
 			var port = GetPort();
 
 			if (_openHosts.TryGetValue(port, out var service))
-			{
-				service.MappingSchema = ms;
 				return service;
-			}
 
 			lock (_syncRoot)
 			{
 				if (_openHosts.TryGetValue(port, out service))
-				{
-					service.MappingSchema = ms;
 					return service;
-				}
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
 				var host = new ServiceHost(
@@ -82,9 +64,6 @@ namespace Tests.Remote.ServerContainer
 						},
 					new Uri($"net.tcp://localhost:{GetPort()}"));
 #pragma warning restore CA2000 // Dispose objects before losing scope
-
-				if (ms != null)
-					service.MappingSchema = ms;
 
 				host.Description.Behaviors.Add(new ServiceMetadataBehavior());
 				host.Description.Behaviors.Find<ServiceDebugBehavior>().IncludeExceptionDetailInFaults = true;

--- a/Tests/Base/Remote/TestGrpcLinqService.cs
+++ b/Tests/Base/Remote/TestGrpcLinqService.cs
@@ -11,7 +11,7 @@ using LinqToDB.Remote.Grpc;
 
 namespace Tests.Remote
 {
-	internal sealed class TestGrpcLinqService : GrpcLinqService
+	internal sealed class TestGrpcLinqService : GrpcLinqService, ITestLinqService
 	{
 		private readonly LinqService    _linqService;
 
@@ -21,7 +21,7 @@ namespace Tests.Remote
 			set => _linqService.AllowUpdates = value;
 		}
 
-		public MappingSchema? MappingSchema
+		MappingSchema? ITestLinqService.MappingSchema
 		{
 			get => _linqService.MappingSchema;
 			set => _linqService.MappingSchema = value;

--- a/Tests/Base/Remote/TestWcfLinqService.cs
+++ b/Tests/Base/Remote/TestWcfLinqService.cs
@@ -11,7 +11,7 @@ using LinqToDB.Remote.Wcf;
 namespace Tests.Remote
 {
 
-	internal sealed class TestWcfLinqService : WcfLinqService
+	internal sealed class TestWcfLinqService : WcfLinqService, ITestLinqService
 	{
 		private readonly LinqService    _linqService;
 
@@ -21,7 +21,7 @@ namespace Tests.Remote
 			set => _linqService.AllowUpdates = value;
 		}
 
-		public MappingSchema? MappingSchema
+		MappingSchema? ITestLinqService.MappingSchema
 		{
 			get => _linqService.MappingSchema;
 			set => _linqService.MappingSchema = value;

--- a/Tests/Linq/DataProvider/FirebirdTests.cs
+++ b/Tests/Linq/DataProvider/FirebirdTests.cs
@@ -19,7 +19,6 @@ using LinqToDB;
 using LinqToDB.Common;
 using LinqToDB.Data;
 using LinqToDB.DataProvider.Firebird;
-using LinqToDB.Linq;
 using LinqToDB.Mapping;
 using LinqToDB.SchemaProvider;
 
@@ -638,8 +637,7 @@ namespace Tests.DataProvider
 			[IncludeDataSources(TestProvName.AllFirebird)] string context,
 			[Values(FirebirdIdentifierQuoteMode.Auto, FirebirdIdentifierQuoteMode.Quote)] FirebirdIdentifierQuoteMode quoteMode)
 		{
-			Query.ClearCaches();
-			using (var db = GetDataContext(context, o => o.UseFirebird(o => o with { IdentifierQuoteMode = quoteMode })))
+			using (var db = GetDataContext(context, o => o.UseFirebird(o => o with { IdentifierQuoteMode = quoteMode }).UseDisableQueryCache(true)))
 			{
 				try
 				{
@@ -669,7 +667,6 @@ namespace Tests.DataProvider
 				finally
 				{
 					db.GetTable<CamelCaseName>().Delete();
-					Query.ClearCaches();
 				}
 			}
 		}
@@ -780,8 +777,7 @@ namespace Tests.DataProvider
 			[IncludeDataSources(false, TestProvName.AllFirebird)] string context,
 			[Values] FirebirdIdentifierQuoteMode quoteMode)
 		{
-			Query.ClearCaches();
-			using (var db      = GetDataConnection(context, o => o.UseFirebird(o => o with { IdentifierQuoteMode = quoteMode })))
+			using (var db      = GetDataConnection(context, o => o.UseFirebird(o => o with { IdentifierQuoteMode = quoteMode }).UseDisableQueryCache(true)))
 			using (var cards   = db.CreateLocalTable<Card>())
 			using (var clients = db.CreateLocalTable<Client>())
 			{
@@ -798,8 +794,6 @@ namespace Tests.DataProvider
 					sql.Should().Contain("\"Client\" \"a_Owner\"");
 				}
 			}
-
-			Query.ClearCaches();
 		}
 		#endregion
 

--- a/Tests/Linq/DataProvider/OracleTests.cs
+++ b/Tests/Linq/DataProvider/OracleTests.cs
@@ -2926,8 +2926,9 @@ namespace Tests.DataProvider
 		[Test]
 		public void TestLowercaseIdentifiersQuotation([IncludeDataSources(TestProvName.AllOracle)] string context)
 		{
-			using (var db = GetDataContext(context))
+			using (var db = GetDataContext(context, o => o.UseDisableQueryCache(true)))
 			{
+				// TODO: don't modify default options from tests + investigate wether it is expected behavior to react to options change after context created
 				var initial = OracleOptions.Default;
 
 				try
@@ -2936,8 +2937,6 @@ namespace Tests.DataProvider
 
 					_ = db.GetTable<TestIdentifiersTable1>().ToList();
 					_ = db.GetTable<TestIdentifiersTable2>().ToList();
-
-					Query.ClearCaches();
 
 					OracleOptions.Default = OracleOptions.Default with { DontEscapeLowercaseIdentifiers = false };
 
@@ -2949,7 +2948,6 @@ namespace Tests.DataProvider
 				finally
 				{
 					OracleOptions.Default = initial;
-					Query.ClearCaches();
 				}
 			}
 		}

--- a/Tests/Linq/DataProvider/SqlCeTests.cs
+++ b/Tests/Linq/DataProvider/SqlCeTests.cs
@@ -12,7 +12,6 @@ using LinqToDB;
 using LinqToDB.Common;
 using LinqToDB.Data;
 using LinqToDB.DataProvider.SqlCe;
-using LinqToDB.Linq;
 using LinqToDB.Mapping;
 
 using NUnit.Framework;
@@ -586,27 +585,15 @@ namespace Tests.DataProvider
 		[Test]
 		public void ParametersInlining([IncludeDataSources(ProviderName.SqlCe)] string context, [Values] bool inline)
 		{
-			Query.ClearCaches();
-			var defaultValue = SqlCeOptions.Default.InlineFunctionParameters;
-			try
-			{
-				SqlCeOptions.Default = SqlCeOptions.Default with { InlineFunctionParameters = inline };
+			using var db = GetDataConnection(context, o => o.UseDisableQueryCache(true).UseSqlCe(o => o with { InlineFunctionParameters = inline }));
 
-				using (var db = GetDataConnection(context))
-				{
-					var minValue = SqlDateTime.MinValue.Value;
+			var minValue = SqlDateTime.MinValue.Value;
 
-					var values = db.GetTable<TestInline>()
-						.Where(_ => (_.DateTimeValue ?? minValue) <= TestData.DateTime)
-						.ToList();
+			var values = db.GetTable<TestInline>()
+				.Where(_ => (_.DateTimeValue ?? minValue) <= TestData.DateTime)
+				.ToList();
 
-					Assert.That(db.LastQuery!.Contains(", @"), Is.Not.EqualTo(inline));
-				}
-			}
-			finally
-			{
-				SqlCeOptions.Default = SqlCeOptions.Default with { InlineFunctionParameters = defaultValue };
-			}
+			Assert.That(db.LastQuery!.Contains(", @"), Is.Not.EqualTo(inline));
 		}
 
 		[Table(Name = "AllTypes")]

--- a/Tests/Linq/DataProvider/SqlServerFunctionsTests.cs
+++ b/Tests/Linq/DataProvider/SqlServerFunctionsTests.cs
@@ -1157,7 +1157,7 @@ namespace Tests.DataProvider
 		public void OpenJson1([IncludeDataSources(TestProvName.AllSqlServer2016Plus)] string context)
 		{
 			using var db = new SystemDB(context);
-			var result = db.GetTable<SqlFn.JsonData>(null, LinqToDB.Linq.MethodHelper.GetMethodInfo(SqlFn.OpenJson, string.Empty), /*lang=json,strict*/ "{ \"test\" : 1 }").ToArray();
+			var result = db.QueryFromExpression(() => SqlFn.OpenJson(/*lang=json,strict*/ "{ \"test\" : 1 }")).ToArray();
 			Console.WriteLine(result);
 
 			var expected = new[]
@@ -1172,7 +1172,7 @@ namespace Tests.DataProvider
 		public void OpenJson2([IncludeDataSources(TestProvName.AllSqlServer2016Plus)] string context)
 		{
 			using var db = new SystemDB(context);
-			var result = db.GetTable<SqlFn.JsonData>(null, LinqToDB.Linq.MethodHelper.GetMethodInfo(SqlFn.OpenJson, string.Empty, string.Empty), /*lang=json,strict*/ "{ \"test\" : [ 10, 20 ] }", "$.test").ToArray();
+			var result = db.QueryFromExpression(() => SqlFn.OpenJson(/*lang=json,strict*/ "{ \"test\" : [ 10, 20 ] }", "$.test")).ToArray();
 			Console.WriteLine(result);
 
 			var expected = new[]
@@ -1188,7 +1188,7 @@ namespace Tests.DataProvider
 		public void OpenJson3([IncludeDataSources(TestProvName.AllSqlServer2016Plus)] string context)
 		{
 			using var db = new SystemDB(context);
-			var result = db.GetTable<SqlFn.JsonData>(null, LinqToDB.Linq.MethodHelper.GetMethodInfo(SqlFn.OpenJson, string.Empty), "[ 10, 20, 30, 40, 50, 60, 70 ]")
+			var result = db.QueryFromExpression(() => SqlFn.OpenJson(/*lang=json,strict*/ "[ 10, 20, 30, 40, 50, 60, 70 ]"))
 				.Where(jd => jd.Key != "2")
 				.Where(jd => jd.Value != "60")
 				.Select(jd => jd.Value)

--- a/Tests/Linq/DataProvider/SqlServerTypesTests.TVP.cs
+++ b/Tests/Linq/DataProvider/SqlServerTypesTests.TVP.cs
@@ -2,11 +2,9 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
-using System.Reflection;
 
 using LinqToDB;
 using LinqToDB.Data;
-using LinqToDB.Expressions;
 using LinqToDB.Linq;
 using LinqToDB.Mapping;
 
@@ -121,11 +119,9 @@ namespace Tests.DataProvider
 			throw new InvalidOperationException();
 		}
 
-		static readonly MethodInfo _methodInfo = MemberHelper.MethodOf(() => TableValue(null!));
-
 		private static ITable<SqlServerTestUtils.TVPRecord> TableValue(IDataContext ctx, DataParameter p)
 		{
-			return ctx.GetTable<SqlServerTestUtils.TVPRecord>(null, _methodInfo, p);
+			return ctx.TableFromExpression<SqlServerTestUtils.TVPRecord>(() => TableValue(p));
 		}
 
 		[Test]

--- a/Tests/Linq/Linq/CachingTests.cs
+++ b/Tests/Linq/Linq/CachingTests.cs
@@ -8,7 +8,6 @@ using LinqToDB;
 using LinqToDB.Common;
 using LinqToDB.Data;
 using LinqToDB.Expressions;
-using LinqToDB.Linq;
 using LinqToDB.Mapping;
 using LinqToDB.SqlQuery;
 
@@ -258,7 +257,6 @@ namespace Tests.Linq
 			db.Execute("IF EXISTS (SELECT * FROM sys.types WHERE name = 'IntTableType') DROP TYPE IntTableType");
 			db.Execute("CREATE TYPE IntTableType AS TABLE(Id INT)");
 
-			var currentMiss = Query<int>.CacheMissCount;
 			try
 			{
 				var persons = new List<int>() { 1, 2 };
@@ -267,9 +265,11 @@ namespace Tests.Linq
 							orderby p.ID
 							select p.ID;
 
+				var currentMiss = query.GetCacheMissCount();
+
 				var result =  query.ToList();
 				AreEqual(persons, result);
-				Assert.That(Query<int>.CacheMissCount, Is.EqualTo(currentMiss + 1));
+				Assert.That(query.GetCacheMissCount(), Is.EqualTo(currentMiss + 1));
 
 				persons.AddRange(new int[] { 3, 4 });
 
@@ -277,7 +277,7 @@ namespace Tests.Linq
 
 				AreEqual(persons, result);
 				// cache miss
-				Assert.That(Query<int>.CacheMissCount, Is.EqualTo(currentMiss + 2));
+				Assert.That(query.GetCacheMissCount(), Is.EqualTo(currentMiss + 2));
 			}
 			finally
 			{
@@ -294,8 +294,6 @@ namespace Tests.Linq
 			db.Execute("IF EXISTS (SELECT * FROM sys.types WHERE name = 'IntTableType') DROP TYPE IntTableType");
 			db.Execute("CREATE TYPE IntTableType AS TABLE(Id INT)");
 
-			var currentMiss = Query<int>.CacheMissCount;
-
 			try
 			{
 				var persons = new List<int>() { 1, 2 };
@@ -304,10 +302,12 @@ namespace Tests.Linq
 							orderby p.ID
 							select p.ID;
 
+				var currentMiss = query.GetCacheMissCount();
+
 				var result =  query.ToList();
 
 				AreEqual(persons, result);
-				Assert.That(Query<int>.CacheMissCount, Is.EqualTo(currentMiss + 1));
+				Assert.That(query.GetCacheMissCount(), Is.EqualTo(currentMiss + 1));
 
 				persons.AddRange(new int[] { 3, 4 });
 
@@ -320,7 +320,7 @@ namespace Tests.Linq
 
 				AreEqual(persons, result);
 				// cache miss
-				Assert.That(Query<int>.CacheMissCount, Is.EqualTo(currentMiss + 2));
+				Assert.That(query.GetCacheMissCount(), Is.EqualTo(currentMiss + 2));
 			}
 			finally
 			{
@@ -360,7 +360,7 @@ namespace Tests.Linq
 
 				dataTable.AcceptChanges();
 
-				var param = new LinqToDB.SqlQuery.SqlParameter(new LinqToDB.Common.DbDataType(dataTable.GetType() ?? typeof(object), "IntTableType"), parameterName, dataTable);
+				var param = new SqlParameter(new LinqToDB.Common.DbDataType(dataTable.GetType() ?? typeof(object), "IntTableType"), parameterName, dataTable);
 
 				builder.AddParameter("values", param);
 			}
@@ -384,7 +384,6 @@ namespace Tests.Linq
 			db.Execute("IF EXISTS (SELECT * FROM sys.types WHERE name = 'IntTableType') DROP TYPE IntTableType");
 			db.Execute("CREATE TYPE IntTableType AS TABLE(Id INT)");
 
-			var currentMiss = Query<int>.CacheMissCount;
 			try
 			{
 				var persons = new List<int>() { 1, 2 };
@@ -393,16 +392,18 @@ namespace Tests.Linq
 							orderby p.ID
 							select p.ID;
 
+				var currentMiss = query.GetCacheMissCount();
+
 				var result =  query.ToList();
 				AreEqual(persons, result);
-				Assert.That(Query<int>.CacheMissCount, Is.EqualTo(currentMiss + 1));
+				Assert.That(query.GetCacheMissCount(), Is.EqualTo(currentMiss + 1));
 
 				persons.AddRange(new int[] { 3, 4 });
 
 				result = query.ToList();
 
 				AreEqual(persons, result);
-				Assert.That(Query<int>.CacheMissCount, Is.EqualTo(currentMiss + 1));
+				Assert.That(query.GetCacheMissCount(), Is.EqualTo(currentMiss + 1));
 			}
 			finally
 			{
@@ -422,7 +423,6 @@ namespace Tests.Linq
 			db.Execute("IF EXISTS (SELECT * FROM sys.types WHERE name = 'IntTableType') DROP TYPE IntTableType");
 			db.Execute("CREATE TYPE IntTableType AS TABLE(Id INT)");
 
-			var currentMiss = Query<int>.CacheMissCount;
 			try
 			{
 				var persons = new List<int>() { 1, 2 };
@@ -431,16 +431,18 @@ namespace Tests.Linq
 							orderby p.ID
 							select p.ID;
 
+				var currentMiss = query.GetCacheMissCount();
+
 				var result =  query.ToList();
 				AreEqual(persons, result);
-				Assert.That(Query<int>.CacheMissCount, Is.EqualTo(currentMiss + 1));
+				Assert.That(query.GetCacheMissCount(), Is.EqualTo(currentMiss + 1));
 
 				persons.AddRange(new int[] { 3, 4 });
 
 				result = query.ToList();
 
 				AreEqual(persons, result);
-				Assert.That(Query<int>.CacheMissCount, Is.EqualTo(currentMiss + 1));
+				Assert.That(query.GetCacheMissCount(), Is.EqualTo(currentMiss + 1));
 			}
 			finally
 			{

--- a/Tests/Linq/Linq/CteTests.cs
+++ b/Tests/Linq/Linq/CteTests.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 
 using FluentAssertions;
 
 using LinqToDB;
 using LinqToDB.Data;
-using LinqToDB.Expressions;
 using LinqToDB.Mapping;
 using LinqToDB.Tools;
 
@@ -164,18 +162,6 @@ namespace Tests.Linq
 
 				AreSame(expected, result);
 			}
-		}
-
-		static IQueryable<TSource> RemoveCte<TSource>(IQueryable<TSource> source)
-		{
-			var newExpr = source.Expression.Transform<object?>(null, static (_, e) =>
-			{
-				if (e is MethodCallExpression methodCall && methodCall.Method.Name == "AsCte")
-					return methodCall.Arguments[0];
-				return e;
-			});
-
-			return source.Provider.CreateQuery<TSource>(newExpr);
 		}
 
 		[Test]

--- a/Tests/Linq/Linq/EnumerableSourceTests.cs
+++ b/Tests/Linq/Linq/EnumerableSourceTests.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using FluentAssertions;
 
 using LinqToDB;
-using LinqToDB.Linq;
 using LinqToDB.Mapping;
 
 using NUnit.Framework;
@@ -34,7 +33,7 @@ namespace Tests.Linq
 					if (i > 0)
 						doe += i;
 
-					var cacheMiss = Query<Person>.CacheMissCount;
+					var cacheMiss = db.Person.GetCacheMissCount();
 
 					var q =
 						from p in db.Person
@@ -44,7 +43,7 @@ namespace Tests.Linq
 					var result = q.ToList();
 
 					if (iteration > 1)
-						Query<Person>.CacheMissCount.Should().Be(cacheMiss);
+						db.Person.GetCacheMissCount().Should().Be(cacheMiss);
 
 					var expected =
 						from p in Person
@@ -63,7 +62,7 @@ namespace Tests.Linq
 			var doe = "Doe";
 			using (var db = GetDataContext(context))
 			{
-				var cacheMiss = Query<Person>.CacheMissCount;
+				var cacheMiss = db.Person.GetCacheMissCount();
 
 				var q =
 					from p in db.Person
@@ -73,7 +72,7 @@ namespace Tests.Linq
 				var result = q.ToList();
 
 				if (iteration > 1)
-					Query<Person>.CacheMissCount.Should().Be(cacheMiss);
+					db.Person.GetCacheMissCount().Should().Be(cacheMiss);
 
 				var expected =
 					from p in Person
@@ -91,7 +90,7 @@ namespace Tests.Linq
 			var doe = "Doe";
 			using (var db = GetDataContext(context))
 			{
-				var cacheMiss = Query<Person>.CacheMissCount;
+				var cacheMiss = db.Person.GetCacheMissCount();
 
 				var q =
 					from p in db.Person
@@ -101,7 +100,7 @@ namespace Tests.Linq
 				var result = q.ToList();
 
 				if (iteration > 1)
-					Query<Person>.CacheMissCount.Should().Be(cacheMiss);
+					db.Person.GetCacheMissCount().Should().Be(cacheMiss);
 
 				var expected =
 					from p in Person
@@ -125,7 +124,7 @@ namespace Tests.Linq
 					if (i > 0)
 						doe += i;
 
-					var cacheMiss = Query<Person>.CacheMissCount;
+					var cacheMiss = db.Person.GetCacheMissCount();
 
 					var q =
 						from p in db.Person
@@ -135,7 +134,7 @@ namespace Tests.Linq
 					var result = q.ToList();
 
 					if (iteration > 1)
-						Query<Person>.CacheMissCount.Should().Be(cacheMiss);
+						db.Person.GetCacheMissCount().Should().Be(cacheMiss);
 
 					var expected =
 						from p in Person
@@ -161,7 +160,7 @@ namespace Tests.Linq
 					if (i > 0)
 						arr[1] += i;
 
-					var cacheMiss = Query<Person>.CacheMissCount;
+					var cacheMiss = db.Person.GetCacheMissCount();
 
 					var q =
 						from p in db.Person
@@ -171,7 +170,7 @@ namespace Tests.Linq
 					var result = q.ToList();
 
 					if (iteration > 1)
-						Query<Person>.CacheMissCount.Should().Be(cacheMiss);
+						db.Person.GetCacheMissCount().Should().Be(cacheMiss);
 
 					var expected =
 						from p in Person
@@ -191,7 +190,7 @@ namespace Tests.Linq
 
 			using (var db = GetDataContext(context))
 			{
-				var cacheMiss = Query<Person>.CacheMissCount;
+				var cacheMiss = db.Person.GetCacheMissCount();
 
 				var q =
 					from n in new[] { "Janet", "Doe", "John", doe }.AsQueryable(db)
@@ -202,7 +201,7 @@ namespace Tests.Linq
 				var sql    = q.ToSqlQuery().Sql;
 
 				if (iteration > 1)
-					Query<Person>.CacheMissCount.Should().Be(cacheMiss);
+					db.Person.GetCacheMissCount().Should().Be(cacheMiss);
 
 				Assert.That(sql, Contains.Substring("JOIN"));
 
@@ -221,7 +220,7 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 			{
-				var cacheMiss = Query<Person>.CacheMissCount;
+				var cacheMiss = db.Person.GetCacheMissCount();
 
 				var q =
 					from p in db.Person
@@ -231,7 +230,7 @@ namespace Tests.Linq
 				var result = q.ToList();
 
 				if (iteration > 1)
-					Query<Person>.CacheMissCount.Should().Be(cacheMiss);
+					db.Person.GetCacheMissCount().Should().Be(cacheMiss);
 
 				var expected =
 					from p in Person
@@ -247,7 +246,7 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 			{
-				var cacheMiss = Query<Person>.CacheMissCount;
+				var cacheMiss = db.Person.GetCacheMissCount();
 
 				var q =
 					from p in db.Person
@@ -257,7 +256,7 @@ namespace Tests.Linq
 				var result = q.ToList();
 
 				if (iteration > 1)
-					Query<Person>.CacheMissCount.Should().Be(cacheMiss);
+					db.Person.GetCacheMissCount().Should().Be(cacheMiss);
 
 				var expected =
 					from p in Person
@@ -278,7 +277,7 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 			{
-				var cacheMiss = Query<Person>.CacheMissCount;
+				var cacheMiss = db.Person.GetCacheMissCount();
 
 				var q =
 					from p in db.Person
@@ -292,7 +291,7 @@ namespace Tests.Linq
 				var result = q.ToList();
 
 				if (iteration > 1)
-					Query<Person>.CacheMissCount.Should().Be(cacheMiss);
+					db.Person.GetCacheMissCount().Should().Be(cacheMiss);
 
 				var expected =
 					from p in Person
@@ -317,7 +316,7 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 			{
-				var cacheMiss = Query<Person>.CacheMissCount;
+				var cacheMiss = db.Person.GetCacheMissCount();
 
 				var q =
 					from p in db.Person
@@ -331,7 +330,7 @@ namespace Tests.Linq
 				var result = q.ToList();
 
 				if (iteration > 1)
-					Query<Person>.CacheMissCount.Should().Be(cacheMiss);
+					db.Person.GetCacheMissCount().Should().Be(cacheMiss);
 
 				var expected =
 					from p in Person
@@ -356,7 +355,7 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 			{
-				var cacheMiss = Query<Person>.CacheMissCount;
+				var cacheMiss = db.Person.GetCacheMissCount();
 
 				var q =
 					from p in db.Person
@@ -370,7 +369,7 @@ namespace Tests.Linq
 				var result = q.ToList();
 
 				if (iteration > 1)
-					Query<Person>.CacheMissCount.Should().Be(cacheMiss);
+					db.Person.GetCacheMissCount().Should().Be(cacheMiss);
 
 				var expected =
 					from p in Person
@@ -395,7 +394,7 @@ namespace Tests.Linq
 		{
 			using var db = GetDataContext(context);
 
-			var cacheMiss = Query<Person>.CacheMissCount;
+			var cacheMiss = db.Person.GetCacheMissCount();
 
 			var q =
 				from p in db.Person
@@ -409,7 +408,7 @@ namespace Tests.Linq
 			var result = q.ToList();
 
 			if (iteration > 1)
-				Query<Person>.CacheMissCount.Should().Be(cacheMiss);
+				db.Person.GetCacheMissCount().Should().Be(cacheMiss);
 
 			var expected =
 				from p in Person
@@ -429,7 +428,7 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 			{
-				var cacheMiss = Query<Person>.CacheMissCount;
+				var cacheMiss = db.Person.GetCacheMissCount();
 
 				var q =
 					from p in db.Person
@@ -440,7 +439,7 @@ namespace Tests.Linq
 				var result = q.ToList();
 
 				if (iteration > 1)
-					Query<Person>.CacheMissCount.Should().Be(cacheMiss);
+					db.Person.GetCacheMissCount().Should().Be(cacheMiss);
 
 				var expected =
 					from p in Person
@@ -458,7 +457,7 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 			{
-				var cacheMiss = Query<Person>.CacheMissCount;
+				var cacheMiss = db.Person.GetCacheMissCount();
 
 				var records   = new[] { new { ID = 1, Name = "Janet" }, new { ID = 1, Name = "Doe" }, };
 
@@ -470,7 +469,7 @@ namespace Tests.Linq
 				var result = q.ToList();
 
 				if (iteration > 1)
-					Query<Person>.CacheMissCount.Should().Be(cacheMiss);
+					db.Person.GetCacheMissCount().Should().Be(cacheMiss);
 
 				var expected =
 					from p in Person
@@ -487,7 +486,7 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context))
 			{
-				var cacheMiss = Query<Person>.CacheMissCount;
+				var cacheMiss = db.Person.GetCacheMissCount();
 
 				var records = new Person[]
 				{
@@ -502,7 +501,7 @@ namespace Tests.Linq
 				var result = q.ToList();
 
 				if (iteration > 1)
-					Query<Person>.CacheMissCount.Should().Be(cacheMiss);
+					db.Person.GetCacheMissCount().Should().Be(cacheMiss);
 
 				var expected =
 					from p in Person
@@ -526,7 +525,7 @@ namespace Tests.Linq
 					new() { ID = 2 + iteration, FirstName = "Doe" },
 				};
 
-				var cacheMiss = Query<Person>.CacheMissCount;
+				var cacheMiss = db.Person.GetCacheMissCount();
 
 				var q1 =
 					from p in db.Person
@@ -536,9 +535,9 @@ namespace Tests.Linq
 				var result1 = q1.ToList();
 
 				if (iteration > 1)
-					Query<Person>.CacheMissCount.Should().Be(cacheMiss);
+					db.Person.GetCacheMissCount().Should().Be(cacheMiss);
 
-				cacheMiss = Query<Person>.CacheMissCount;
+				cacheMiss = db.Person.GetCacheMissCount();
 
 				var records2 = new Person[]
 				{
@@ -553,7 +552,7 @@ namespace Tests.Linq
 
 				var result2 = q2.ToList();
 
-				Query<Person>.CacheMissCount.Should().Be(cacheMiss);
+				db.Person.GetCacheMissCount().Should().Be(cacheMiss);
 
 				result2.Count.Should().NotBe(result1.Count);
 			}
@@ -572,12 +571,12 @@ namespace Tests.Linq
 					new() { ID = 2 + iteration, FirstName = "Doe" },
 				};
 
-				var cacheMiss = Query<Person>.CacheMissCount;
+				var cacheMiss = db.Person.GetCacheMissCount();
 
 				var result = records.AsQueryable(db).ToArray();
 
 				if (iteration > 1)
-					Query<Person>.CacheMissCount.Should().Be(cacheMiss);
+					db.Person.GetCacheMissCount().Should().Be(cacheMiss);
 
 			}
 		}
@@ -636,7 +635,7 @@ namespace Tests.Linq
 					return true;
 				}
 
-				if (obj.GetType() != this.GetType())
+				if (obj.GetType() != GetType())
 				{
 					return false;
 				}
@@ -659,7 +658,7 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 			using (var table = db.CreateLocalTable<TableToInsert>())
 			{
-				var cacheMiss = Query<TableToInsert>.CacheMissCount;
+				var cacheMiss = table.GetCacheMissCount();
 
 				var records = new TableToInsert[]
 				{
@@ -681,7 +680,7 @@ namespace Tests.Linq
 					Assert.That(cnt, Is.EqualTo(0));
 
 				if (iteration > 1)
-					Query<TableToInsert>.CacheMissCount.Should().Be(cacheMiss);
+					table.GetCacheMissCount().Should().Be(cacheMiss);
 			}
 		}
 
@@ -705,7 +704,7 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 			using (var table = db.CreateLocalTable(records))
 			{
-				var cacheMiss = Query<TableToInsert>.CacheMissCount;
+				var cacheMiss = table.GetCacheMissCount();
 
 				var upadedValue = new TableToInsert[]
 				{
@@ -722,7 +721,7 @@ namespace Tests.Linq
 					.Update().Should().Be(2);
 
 				if (iteration > 1)
-					Query<TableToInsert>.CacheMissCount.Should().Be(cacheMiss);
+					table.GetCacheMissCount().Should().Be(cacheMiss);
 
 				AreEqual(table, upadedValue);
 			}
@@ -742,7 +741,7 @@ namespace Tests.Linq
 			using var db    = GetDataContext(context);
 			using var table = db.CreateLocalTable(records);
 
-			var cacheMiss   = Query<TableToInsert>.CacheMissCount;
+			var cacheMiss   = table.GetCacheMissCount();
 			var deleteValue = new TableToInsert[]
 			{
 				new () { Id = 1 + iteration },
@@ -757,7 +756,7 @@ namespace Tests.Linq
 			queryToDelete.Delete().Should().Be(2);
 
 			if (iteration > 1)
-				Query<TableToInsert>.CacheMissCount.Should().Be(cacheMiss);
+				table.GetCacheMissCount().Should().Be(cacheMiss);
 		}
 
 		[Test]
@@ -772,7 +771,7 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 			using (var table = db.CreateLocalTable(records))
 			{
-				var cacheMiss = Query<TableToInsert>.CacheMissCount;
+				var cacheMiss = table.GetCacheMissCount();
 
 				var queryToSelect =
 					from r in records.AsQueryable(db).AsCte()
@@ -784,7 +783,7 @@ namespace Tests.Linq
 				AreEqual(table, result);
 
 				if (iteration > 1)
-					Query<TableToInsert>.CacheMissCount.Should().Be(cacheMiss);
+					table.GetCacheMissCount().Should().Be(cacheMiss);
 			}
 		}
 
@@ -796,7 +795,7 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 			using (var table = db.CreateLocalTable<TableToInsert>())
 			{
-				var cacheMiss = Query<TableToInsert>.CacheMissCount;
+				var cacheMiss = table.GetCacheMissCount();
 
 				var queryToSelect =
 					from t in table
@@ -806,7 +805,7 @@ namespace Tests.Linq
 				queryToSelect.ToArray().Should().HaveCount(0);
 
 				if (iteration > 1)
-					Query<TableToInsert>.CacheMissCount.Should().Be(cacheMiss);
+					table.GetCacheMissCount().Should().Be(cacheMiss);
 			}
 		}
 
@@ -822,7 +821,7 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 			using (var table = db.CreateLocalTable(records))
 			{
-				var cacheMiss = Query<TableToInsert>.CacheMissCount;
+				var cacheMiss = table.GetCacheMissCount();
 
 				var queryToSelect =
 					from t in table
@@ -834,7 +833,7 @@ namespace Tests.Linq
 				AreEqual(table, result);
 
 				if (iteration > 1)
-					Query<TableToInsert>.CacheMissCount.Should().Be(cacheMiss);
+					table.GetCacheMissCount().Should().Be(cacheMiss);
 			}
 		}
 
@@ -846,7 +845,7 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 			using (var table = db.CreateLocalTable<TableToInsert>())
 			{
-				var cacheMiss = Query<TableToInsert>.CacheMissCount;
+				var cacheMiss = table.GetCacheMissCount();
 
 				var queryToSelect =
 					from t in table
@@ -856,7 +855,7 @@ namespace Tests.Linq
 				queryToSelect.ToArray().Should().HaveCount(0);
 
 				if (iteration > 1)
-					Query<TableToInsert>.CacheMissCount.Should().Be(cacheMiss);
+					table.GetCacheMissCount().Should().Be(cacheMiss);
 			}
 		}
 
@@ -876,7 +875,7 @@ namespace Tests.Linq
 
 			using (var db = GetDataContext(context))
 			{
-				var cacheMiss = Query<Person>.CacheMissCount;
+				var cacheMiss = db.Person.GetCacheMissCount();
 
 				var queryToSelect =
 					from t in db.Person
@@ -886,7 +885,7 @@ namespace Tests.Linq
 				 queryToSelect.ToArray().Should().HaveCountGreaterThan(0);
 
 				if (iteration > 1)
-					Query<Person>.CacheMissCount.Should().Be(cacheMiss);
+					db.Person.GetCacheMissCount().Should().Be(cacheMiss);
 			}
 		}
 

--- a/Tests/Linq/Linq/ExpressionsTests.cs
+++ b/Tests/Linq/Linq/ExpressionsTests.cs
@@ -1118,7 +1118,7 @@ namespace Tests.Linq
 				var left  = GetQuery(db, 0);
 				var right = GetQuery(db, 2);
 
-				var cacheMiss = Query<Patient>.CacheMissCount;
+				var cacheMiss = db.Patient.GetCacheMissCount();
 
 				Assert.That(
 					db.Person.Where(_ =>
@@ -1128,7 +1128,7 @@ namespace Tests.Linq
 					.Any(), Is.False);
 
 				if (iteration > 1)
-					Query<Patient>.CacheMissCount.Should().Be(cacheMiss);
+					db.Patient.GetCacheMissCount().Should().Be(cacheMiss);
 			}
 		}
 

--- a/Tests/Linq/Linq/FromSqlTests.cs
+++ b/Tests/Linq/Linq/FromSqlTests.cs
@@ -249,7 +249,7 @@ namespace Tests.Linq
 				var query = db.FromSql<SampleClass>("SELECT * FROM\n{0}\nwhere {3} >= {1} and {3} < {2}",
 					GetName(table), new DataParameter("startId", startId, DataType.Int64), endId, GetColumn("id"));
 
-				var save = Query<SampleClass>.CacheMissCount;
+				var save = query.GetCacheMissCount();
 
 				var projection = query
 					.Where(c => c.Id > 10)
@@ -259,7 +259,7 @@ namespace Tests.Linq
 
 				if (iteration > 1)
 				{
-					Query<SampleClass>.CacheMissCount.Should().Be(save);
+					query.GetCacheMissCount().Should().Be(save);
 				}
 
 				var expected = table

--- a/Tests/Linq/Linq/GenerateExpressionTests.cs
+++ b/Tests/Linq/Linq/GenerateExpressionTests.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Linq.Expressions;
 
 using LinqToDB;
-using LinqToDB.Linq;
 using LinqToDB.Mapping;
 
 using NUnit.Framework;
@@ -81,7 +80,7 @@ namespace Tests.Linq
 			Assert.That(testCase, Does.Not.Contain("Exception"));
 
 			TestUtils.DeleteTestCases();
-			Query<Entity>.ClearCache();
+			db.GetTable<Entity>().ClearCache();
 			Assert.That(() => query.ToArray(), Throws.Exception);
 
 			testCase = TestUtils.GetLastTestCase();

--- a/Tests/Linq/Linq/GroupByTests.cs
+++ b/Tests/Linq/Linq/GroupByTests.cs
@@ -4,8 +4,6 @@ using System.Linq;
 using FluentAssertions;
 
 using LinqToDB;
-using LinqToDB.Data;
-using LinqToDB.Linq;
 using LinqToDB.Mapping;
 using LinqToDB.SqlQuery;
 using LinqToDB.Tools;
@@ -878,7 +876,7 @@ namespace Tests.Linq
 					DistinctWithFilter       = g.Select(x => x.DataValue).Distinct().Count(x => x % 2 == 0),
 					FilterDistinct           = g.Select(x => x.DataValue).Where(x => x      % 2 == 0).Distinct().Count(),
 					FilterDistinctWithFilter = g.Select(x => x.DataValue).Where(x => x      % 2 == 0).Distinct().Count(x => x % 2 == 0),
-
+					
 					SubFilter           = filtered.Count(),
 					SubFilterDistinct   = filteredDistinct.Count(),
 					SubNoFilterDistinct = nonfilteredDistinct.Count(),
@@ -896,7 +894,7 @@ namespace Tests.Linq
 			using var db = GetDataContext(context);
 			using var table = db.CreateLocalTable(data);
 
-			var query =
+			var query = 
 				from t in table
 				group t by new { t.GroupId }  into g
 				select new
@@ -977,7 +975,7 @@ namespace Tests.Linq
 			using var db = GetDataContext(context);
 			using var table = db.CreateLocalTable(data);
 
-			var query =
+			var query = 
 				from t in table
 				where t.DataValue != null
 				group t by t.GroupId into g
@@ -1398,7 +1396,7 @@ namespace Tests.Linq
 		{
 			using var db = GetDataContext(context);
 
-			var query =
+			var query = 
 				from p in db.Parent
 				group p by p.Children.Average(c => c.ParentID) > 3
 				into g
@@ -2534,70 +2532,58 @@ namespace Tests.Linq
 		[Test]
 		public void Issue2306Test1([DataSources] string context)
 		{
-			Query.ClearCaches();
-			using (var db = GetDataContext(context, o => o.UseGuardGrouping(false)))
+			using (var db = GetDataContext(context, o => o.UseGuardGrouping(false).UseDisableQueryCache(true)))
 			{
 				db.Person.GroupBy(p => p.ID).ToDictionary(g => g.Key, g => g.Select(p => p.LastName).ToList());
 			}
 
-			Query.ClearCaches();
-			using (var db = GetDataContext(context, o => o.UseGuardGrouping(true)))
+			using (var db = GetDataContext(context, o => o.UseGuardGrouping(true).UseDisableQueryCache(true)))
 			{
 				Assert.Throws<LinqToDBException>(() => db.Person.GroupBy(p => p.ID).ToDictionary(g => g.Key, g => g.Select(p => p.LastName).ToList()));
 			}
 
-			Query.ClearCaches();
-			using (var db = GetDataContext(context, o => o.UseGuardGrouping(true)))
+			using (var db = GetDataContext(context, o => o.UseGuardGrouping(true).UseDisableQueryCache(true)))
 			{
 				db.Person.GroupBy(p => p.ID).DisableGuard().ToDictionary(g => g.Key, g => g.Select(p => p.LastName).ToList());
 			}
-
-			Query.ClearCaches();
 		}
 
 		[Test]
 		public void Issue2306Test2([DataSources] string context)
 		{
-			Query.ClearCaches();
-
-			using (var db = GetDataContext(context, o => o.UseGuardGrouping(false)))
+			using (var db = GetDataContext(context, o => o.UseGuardGrouping(false).UseDisableQueryCache(true)))
 			{
 				db.Person.GroupBy(p => p.ID).ToDictionary(g => g.Key, g => g.Select(p => p.LastName).ToList());
 			}
 
-			using (var db = GetDataContext(context, o => o.UseGuardGrouping(true)))
+			using (var db = GetDataContext(context, o => o.UseGuardGrouping(true).UseDisableQueryCache(true)))
 			{
 				Assert.Throws<LinqToDBException>(() => db.Person.GroupBy(p => p.ID).ToDictionary(g => g.Key, g => g.Select(p => p.LastName).ToList()));
 			}
 
-			using (var db = GetDataContext(context, o => o.UseGuardGrouping(true)))
+			using (var db = GetDataContext(context, o => o.UseGuardGrouping(true).UseDisableQueryCache(true)))
 			{
 				db.Person.GroupBy(p => p.ID).DisableGuard().ToDictionary(g => g.Key, g => g.Select(p => p.LastName).ToList());
 			}
-
-			Query.ClearCaches();
 		}
 
 		[Test]
 		public void Issue2306Test3([DataSources] string context)
 		{
-			Query.ClearCaches();
-			using (var db = GetDataContext(context, o => o.UseGuardGrouping(true)))
+			using (var db = GetDataContext(context, o => o.UseGuardGrouping(true).UseDisableQueryCache(true)))
 			{
 				Assert.Throws<LinqToDBException>(() => db.Person.GroupBy(p => p.ID).ToDictionary(g => g.Key, g => g.Select(p => p.LastName).ToList()));
 			}
 
-			using (var db = GetDataContext(context, o => o.UseGuardGrouping(false)))
+			using (var db = GetDataContext(context, o => o.UseGuardGrouping(false).UseDisableQueryCache(true)))
 			{
 				db.Person.GroupBy(p => p.ID).ToDictionary(g => g.Key, g => g.Select(p => p.LastName).ToList());
 			}
 
-			using (var db = GetDataContext(context, o => o.UseGuardGrouping(true)))
+			using (var db = GetDataContext(context, o => o.UseGuardGrouping(true).UseDisableQueryCache(true)))
 			{
 				db.Person.GroupBy(p => p.ID).DisableGuard().ToDictionary(g => g.Key, g => g.Select(p => p.LastName).ToList());
 			}
-
-			Query.ClearCaches();
 		}
 
 		[Test]
@@ -3053,7 +3039,7 @@ namespace Tests.Linq
 				let cItems = p.Children.GroupBy(c => c.ParentID, (key, grouped) => new { Id = key, Count = grouped.Count() })
 				select new
 				{
-					p.ParentID,
+					p.ParentID, 
 					First = cItems.OrderBy(x => x.Count).ThenBy(x => x.Id).FirstOrDefault()
 				};
 

--- a/Tests/Linq/Linq/ParameterTests.cs
+++ b/Tests/Linq/Linq/ParameterTests.cs
@@ -8,7 +8,6 @@ using FluentAssertions;
 
 using LinqToDB;
 using LinqToDB.Data;
-using LinqToDB.Linq;
 using LinqToDB.Mapping;
 using LinqToDB.SqlQuery;
 
@@ -328,9 +327,7 @@ namespace Tests.Linq
 		public void TestQueryableCallWithParameters([DataSources(TestProvName.AllClickHouse)] string context)
 		{
 			// baselines could be affected by cache
-			Query.ClearCaches();
-
-			using var db = GetDataContext(context);
+			using var db = GetDataContext(context, o => o.UseDisableQueryCache(true));
 			db.Parent.Where(p => GetChildrenFiltered(db, c => c.ChildID != 5).Select(c => c.ParentID).Contains(p.ParentID)).ToList();
 		}
 
@@ -338,9 +335,7 @@ namespace Tests.Linq
 		public void TestQueryableCallWithParametersWorkaround([DataSources(TestProvName.AllClickHouse)] string context)
 		{
 			// baselines could be affected by cache
-			Query.ClearCaches();
-
-			using var db = GetDataContext(context);
+			using var db = GetDataContext(context, o => o.UseDisableQueryCache(true));
 			db.Parent.Where(p => GetChildrenFiltered(db, ChildFilter).Select(c => c.ParentID).Contains(p.ParentID)).ToList();
 		}
 

--- a/Tests/Linq/Linq/ParameterTests.cs
+++ b/Tests/Linq/Linq/ParameterTests.cs
@@ -673,7 +673,7 @@ namespace Tests.Linq
 					String3 = str3,
 				});
 
-				var cacheMiss = Query<ParameterDeduplication>.CacheMissCount;
+				var cacheMiss = table.GetCacheMissCount();
 				var sql       = db.LastQuery!;
 
 				sql.Should().Contain("@id");
@@ -706,7 +706,7 @@ namespace Tests.Linq
 					String3 = str3,
 				});
 
-				Query<ParameterDeduplication>.CacheMissCount.Should().Be(cacheMiss);
+				table.GetCacheMissCount().Should().Be(cacheMiss);
 				sql = db.LastQuery!;
 
 				sql.Should().Contain("@id");
@@ -760,7 +760,7 @@ namespace Tests.Linq
 					String3 = "str",
 				});
 
-				var cacheMiss = Query<ParameterDeduplication>.CacheMissCount;
+				var cacheMiss = table.GetCacheMissCount();
 				var sql       = db.LastQuery!;
 
 				sql.Should().Contain("@Id");
@@ -784,7 +784,7 @@ namespace Tests.Linq
 					String3 = "str3",
 				});
 
-				Query<ParameterDeduplication>.CacheMissCount.Should().Be(cacheMiss);
+				table.GetCacheMissCount().Should().Be(cacheMiss);
 				sql = db.LastQuery!;
 
 				sql.Should().Contain("@Id");
@@ -837,7 +837,7 @@ namespace Tests.Linq
 					.Value(_ => _.String3, "str")
 					.Insert();
 
-				var cacheMiss = Query<ParameterDeduplication>.CacheMissCount;
+				var cacheMiss = table.GetCacheMissCount();
 				var sql       = db.LastQuery!;
 
 				sql.Should().Contain("@Id");
@@ -860,7 +860,7 @@ namespace Tests.Linq
 					.Value(_ => _.String3, "str3")
 					.Insert();
 
-				Query<ParameterDeduplication>.CacheMissCount.Should().Be(cacheMiss);
+				table.GetCacheMissCount().Should().Be(cacheMiss);
 				sql = db.LastQuery!;
 
 				sql.Should().Contain("@Id");
@@ -922,7 +922,7 @@ namespace Tests.Linq
 					.Value(_ => _.String3, () => str3)
 					.Insert();
 
-				var cacheMiss = Query<ParameterDeduplication>.CacheMissCount;
+				var cacheMiss = table.GetCacheMissCount();
 				var sql       = db.LastQuery!;
 
 				sql.Should().Contain("@id");
@@ -954,7 +954,7 @@ namespace Tests.Linq
 					.Value(_ => _.String3, () => str3)
 					.Insert();
 
-				Query<ParameterDeduplication>.CacheMissCount.Should().Be(cacheMiss);
+				table.GetCacheMissCount().Should().Be(cacheMiss);
 
 				sql = db.LastQuery!;
 
@@ -1018,7 +1018,7 @@ namespace Tests.Linq
 						String3 = str3,
 					});
 
-				var cacheMiss = Query<ParameterDeduplication>.CacheMissCount;
+				var cacheMiss = table.GetCacheMissCount();
 				var sql       = db.LastQuery!;
 
 				sql.Should().Contain("@id");
@@ -1051,7 +1051,7 @@ namespace Tests.Linq
 						String3 = str3,
 					});
 
-				Query<ParameterDeduplication>.CacheMissCount.Should().Be(cacheMiss);
+				table.GetCacheMissCount().Should().Be(cacheMiss);
 				sql = db.LastQuery!;
 
 				sql.Should().Contain("@id");
@@ -1105,7 +1105,7 @@ namespace Tests.Linq
 					String3 = "str",
 				});
 
-				var cacheMiss = Query<ParameterDeduplication>.CacheMissCount;
+				var cacheMiss = table.GetCacheMissCount();
 				var sql       = db.LastQuery!;
 
 				sql.Should().Contain("@Id");
@@ -1129,7 +1129,7 @@ namespace Tests.Linq
 					String3 = "str3",
 				});
 
-				Query<ParameterDeduplication>.CacheMissCount.Should().Be(cacheMiss);
+				table.GetCacheMissCount().Should().Be(cacheMiss);
 				sql = db.LastQuery!;
 
 				sql.Should().Contain("@Id");
@@ -1182,7 +1182,7 @@ namespace Tests.Linq
 					.Set(_ => _.String3, "str")
 					.Update();
 
-				var cacheMiss = Query<ParameterDeduplication>.CacheMissCount;
+				var cacheMiss = table.GetCacheMissCount();
 				var sql       = db.LastQuery!;
 
 				sql.Should().Contain("@id");
@@ -1205,7 +1205,7 @@ namespace Tests.Linq
 					.Set(_ => _.String3, "str3")
 					.Update();
 
-				Query<ParameterDeduplication>.CacheMissCount.Should().Be(cacheMiss);
+				table.GetCacheMissCount().Should().Be(cacheMiss);
 				sql = db.LastQuery!;
 
 				sql.Should().Contain("@id");
@@ -1266,7 +1266,7 @@ namespace Tests.Linq
 					.Set(_ => _.String3, () => str3)
 					.Update();
 
-				var cacheMiss = Query<ParameterDeduplication>.CacheMissCount;
+				var cacheMiss = table.GetCacheMissCount();
 				var sql       = db.LastQuery!;
 
 				sql.Should().Contain("@id");
@@ -1297,7 +1297,7 @@ namespace Tests.Linq
 					.Set(_ => _.String3, () => str3)
 					.Update();
 
-				Query<ParameterDeduplication>.CacheMissCount.Should().Be(cacheMiss);
+				table.GetCacheMissCount().Should().Be(cacheMiss);
 
 				sql = db.LastQuery!;
 

--- a/Tests/Linq/Linq/QueryFilterTests.cs
+++ b/Tests/Linq/Linq/QueryFilterTests.cs
@@ -162,7 +162,7 @@ namespace Tests.Linq
 
 			Assert.That(resultFiltered1, Has.Length.LessThan(resultNotFiltered1.Length));
 
-			var currentMissCount = Query<T>.CacheMissCount;
+			var currentMissCount = query.GetCacheMissCount();
 
 			db.IsSoftDeleteFilterEnabled = true;
 			query                        = Internals.CreateExpressionQueryInstance<T>(db, query.Expression);
@@ -177,7 +177,7 @@ namespace Tests.Linq
 			AreEqualWithComparer(resultFiltered1,    resultFiltered2);
 			AreEqualWithComparer(resultNotFiltered1, resultNotFiltered2);
 
-			Assert.That(currentMissCount, Is.EqualTo(Query<T>.CacheMissCount), () => "Caching is wrong.");
+			Assert.That(currentMissCount, Is.EqualTo(query.GetCacheMissCount()), () => "Caching is wrong.");
 		}
 
 		[Test]
@@ -186,9 +186,9 @@ namespace Tests.Linq
 			var testData = GenerateTestData();
 
 			using (var db = new MyDataContext(context, _filterMappingSchema))
-			using (db.CreateLocalTable(testData.Item1))
+			using (var tb = db.CreateLocalTable(testData.Item1))
 			{
-				var currentMissCount = Query<MasterClass>.CacheMissCount;
+				var currentMissCount = tb.GetCacheMissCount();
 
 				var query =
 					from m in db.GetTable<MasterClass>()
@@ -206,7 +206,7 @@ namespace Tests.Linq
 
 				if (iteration > 1)
 				{
-					Query<MasterClass>.CacheMissCount.Should().Be(currentMissCount);
+					tb.GetCacheMissCount().Should().Be(currentMissCount);
 				}
 			}
 		}

--- a/Tests/Linq/Linq/SelectTests.cs
+++ b/Tests/Linq/Linq/SelectTests.cs
@@ -1171,7 +1171,7 @@ namespace Tests.Linq
 				from c in db.Child
 				select new IntermediateChildResult { ParentId = c.ParentID, Child = includeChild ? c : null };
 
-			var cacheMissCount = Query<IntermediateChildResult>.CacheMissCount;
+			var cacheMissCount = query.GetCacheMissCount();
 
 			var result = query.ToArray().First();
 
@@ -1199,7 +1199,7 @@ namespace Tests.Linq
 
 			if (iteration > 1)
 			{
-				Query<IntermediateChildResult>.CacheMissCount.Should().Be(cacheMissCount);
+				query.GetCacheMissCount().Should().Be(cacheMissCount);
 			}
 		}
 
@@ -1956,13 +1956,13 @@ namespace Tests.Linq
 			p1.All(p => ReferenceEquals(p.Reference, reference)).Should().BeTrue();
 
 			reference = new Parent() { ParentID = 1002 };
-			var cacheMissCount = Query<Person>.CacheMissCount;
+			var cacheMissCount = db.Person.GetCacheMissCount();
 
 			var p2 = query.ToList();
 
 			p2.All(p => ReferenceEquals(p.Reference, reference)).Should().BeTrue();
 
-			Query<Person>.CacheMissCount.Should().Be(cacheMissCount);
+			db.Person.GetCacheMissCount().Should().Be(cacheMissCount);
 
 		}
 		

--- a/Tests/Linq/Linq/TakeSkipTests.cs
+++ b/Tests/Linq/Linq/TakeSkipTests.cs
@@ -8,7 +8,6 @@ using FluentAssertions;
 
 using LinqToDB;
 using LinqToDB.Data;
-using LinqToDB.Linq;
 using LinqToDB.Mapping;
 
 using NUnit.Framework;
@@ -55,7 +54,7 @@ namespace Tests.Linq
 					CheckTakeGlobalParams(db);
 				}
 
-				var currentCacheMissCount = Query<Child>.CacheMissCount;
+				var currentCacheMissCount = db.Child.GetCacheMissCount();
 
 				for (var i = 2; i <= 3; i++)
 				{
@@ -63,7 +62,7 @@ namespace Tests.Linq
 					CheckTakeGlobalParams(db);
 				}
 
-				Assert.That(Query<Child>.CacheMissCount, Is.EqualTo(currentCacheMissCount));
+				Assert.That(db.Child.GetCacheMissCount(), Is.EqualTo(currentCacheMissCount));
 			}
 		}
 
@@ -78,7 +77,7 @@ namespace Tests.Linq
 					CheckTakeGlobalParams(db);
 				}
 
-				var currentCacheMissCount = Query<Child>.CacheMissCount;
+				var currentCacheMissCount = db.Child.GetCacheMissCount();
 
 				for (var i = 2; i <= 3; i++)
 				{
@@ -86,7 +85,7 @@ namespace Tests.Linq
 					CheckTakeGlobalParams(db);
 				}
 
-				Assert.That(Query<Child>.CacheMissCount, Is.EqualTo(currentCacheMissCount));
+				Assert.That(db.Child.GetCacheMissCount(), Is.EqualTo(currentCacheMissCount));
 			}
 		}
 
@@ -251,11 +250,11 @@ namespace Tests.Linq
 			{
 				AreEqual(Child.OrderBy(_ => _.ChildID).Skip(3), db.Child.OrderBy(_ => _.ChildID).Skip(3));
 
-				var currentCacheMissCount = Query<Child>.CacheMissCount;
+				var currentCacheMissCount = db.Child.GetCacheMissCount();
 
 				AreEqual(Child.OrderBy(_ => _.ChildID).Skip(4), db.Child.OrderBy(_ => _.ChildID).Skip(4));
 
-				Assert.That(Query<Child>.CacheMissCount, Is.EqualTo(currentCacheMissCount));
+				Assert.That(db.Child.GetCacheMissCount(), Is.EqualTo(currentCacheMissCount));
 			}
 		}
 
@@ -730,13 +729,13 @@ namespace Tests.Linq
 		{
 			using (var db = GetDataContext(context, o => o.UseParameterizeTakeSkip(withParameters)))
 			{
-				var missCount = Query<Person>.CacheMissCount;
+				var missCount = db.Person.GetCacheMissCount();
 				Assert.That(
 					db.Person.OrderBy(p => p.LastName).ElementAtOrDefault(idx), Is.EqualTo(Person.   OrderBy(p => p.LastName).ElementAtOrDefault(idx)));
 				CheckTakeGlobalParams(db);
 
 				if (idx == 3)
-					Assert.That(missCount, Is.EqualTo(Query<Person>.CacheMissCount));
+					Assert.That(missCount, Is.EqualTo(db.Person.GetCacheMissCount()));
 			}
 		}
 
@@ -1299,7 +1298,7 @@ namespace Tests.Linq
 			{
 				for (int i = 1; i <= 2; i++)
 				{
-					var missCount = Query<TakeSkipClass>.CacheMissCount;
+					var missCount = tempTable.GetCacheMissCount();
 
 					var actual = tempTable
 						.OrderBy(t => t.Value)
@@ -1322,7 +1321,7 @@ namespace Tests.Linq
 					}
 
 					if (i == 2)
-						Assert.That(missCount, Is.EqualTo(Query<TakeSkipClass>.CacheMissCount));
+						Assert.That(missCount, Is.EqualTo(tempTable.GetCacheMissCount()));
 
 				}
 			}
@@ -1617,7 +1616,7 @@ namespace Tests.Linq
 		{
 			using var db = GetDataContext(context);
 
-			var cacheMissCount = Query<Parent>.CacheMissCount;
+			var cacheMissCount = db.Parent.GetCacheMissCount();
 
 			var result = db.Parent
 				.OrderBy(t => t.Value1)
@@ -1626,7 +1625,7 @@ namespace Tests.Linq
 				.ToArray();
 
 			if (skip > 1 || take > 1)
-				Query<Parent>.CacheMissCount.Should().Be(cacheMissCount);
+				db.Parent.GetCacheMissCount().Should().Be(cacheMissCount);
 		}
 	}
 }

--- a/Tests/Linq/Linq/TestQueryCache.cs
+++ b/Tests/Linq/Linq/TestQueryCache.cs
@@ -6,13 +6,10 @@ using System.Threading.Tasks;
 using LinqToDB;
 using LinqToDB.Data;
 using LinqToDB.Expressions;
-using LinqToDB.Linq;
 using LinqToDB.Mapping;
 using LinqToDB.SqlQuery;
 
 using NUnit.Framework;
-
-using Tests.Model;
 
 namespace Tests.Linq
 {
@@ -173,11 +170,11 @@ namespace Tests.Linq
 		public void TestSqlQueryDepended([IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
 		{
 			using (var db = GetDataContext(context))
-			using (db.CreateLocalTable<ManyFields>())
+			using (var tb = db.CreateLocalTable<ManyFields>())
 			{
-				Query<ManyFields>.ClearCache();
+				tb.ClearCache();
 
-				var currentMiss = Query<ManyFields>.CacheMissCount;
+				var currentMiss = tb.GetCacheMissCount();
 
 				int i;
 				for (i = 1; i <= 5; i++)
@@ -189,9 +186,9 @@ namespace Tests.Linq
 					_ = test.ToSqlQuery();
 				}
 
-				Assert.That(Query<ManyFields>.CacheMissCount - currentMiss, Is.EqualTo(5));
+				Assert.That(tb.GetCacheMissCount() - currentMiss, Is.EqualTo(5));
 
-				currentMiss = Query<ManyFields>.CacheMissCount;
+				currentMiss = tb.GetCacheMissCount();
 
 				for (i = 1; i <= 5; i++)
 				{
@@ -202,7 +199,7 @@ namespace Tests.Linq
 					_ = test.ToSqlQuery();
 				}
 
-				Assert.That(Query<ManyFields>.CacheMissCount, Is.EqualTo(currentMiss));
+				Assert.That(tb.GetCacheMissCount(), Is.EqualTo(currentMiss));
 			}
 		}
 
@@ -216,8 +213,8 @@ namespace Tests.Linq
 
 			WeakReference<IDataContext> ExecuteQuery(string ctx)
 			{
-				Query<Person>.ClearCache();
 				using var db = GetDataContext(ctx);
+				db.Person.ClearCache();
 
 				_ = db.Person.FirstOrDefault();
 

--- a/Tests/Linq/Mapping/FluentMappingTests.cs
+++ b/Tests/Linq/Mapping/FluentMappingTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Linq.Expressions;
 
 using LinqToDB;
-using LinqToDB.Linq;
 using LinqToDB.Mapping;
 using LinqToDB.Tools;
 
@@ -700,10 +699,8 @@ namespace Tests.Mapping
 		[Test]
 		public void ExpressionAlias([IncludeDataSources(TestProvName.AllSQLite)] string context, [Values] bool finalAliases)
 		{
-			using (var db = GetDataContext(context, o => o.UseGenerateFinalAliases(finalAliases)))
+			using (var db = GetDataContext(context, o => o.UseGenerateFinalAliases(finalAliases).UseDisableQueryCache(true)))
 			{
-				Query.ClearCaches();
-
 				var query = db.GetTable<PersonCustom>().Where(p => p.Name != "");
 				var sql1 = query.ToSqlQuery().Sql;
 				BaselinesManager.LogQuery(sql1);
@@ -733,10 +730,8 @@ namespace Tests.Mapping
 				.Property(p => p.Money).IsExpression(p => Sql.AsSql(p.Age * Sql.AsSql(1000) + p.Name.Length * 10), true, "MONEY")
 				.Build();
 
-			using (var db = GetDataContext(context, o => o.UseMappingSchema(ms).UseGenerateFinalAliases(finalAliases)))
+			using (var db = GetDataContext(context, o => o.UseMappingSchema(ms).UseGenerateFinalAliases(finalAliases).UseDisableQueryCache(true)))
 			{
-				Query.ClearCaches();
-
 				var query = db.GetTable<PersonCustom>().Where(p => p.Name != "");
 				var sql1 = query.ToSqlQuery().Sql;
 				BaselinesManager.LogQuery(sql1);

--- a/Tests/Linq/Update/CreateTableTypesTests.cs
+++ b/Tests/Linq/Update/CreateTableTypesTests.cs
@@ -7,7 +7,6 @@ using JetBrains.Annotations;
 
 using LinqToDB;
 using LinqToDB.Data;
-using LinqToDB.Linq;
 using LinqToDB.Mapping;
 using LinqToDB.Tools.Comparers;
 
@@ -167,8 +166,6 @@ namespace Tests.xUpdate
 				Assert.Ignore("test case is not valid");
 			}
 
-			Query.ClearCaches();
-
 			var ms = new MappingSchema();
 			var entity = new FluentMappingBuilder(ms)
 				.Entity<CreateTableTypes>()
@@ -189,7 +186,7 @@ namespace Tests.xUpdate
 				});
 			ms.SetConverter<string, List<(uint, string)>?>(_ => JsonSerializer.Deserialize<List<(uint, string)>>(_, options));
 
-			using (var db    = GetDataContext(context, ms))
+			using (var db    = GetDataContext(context, o => o.UseMappingSchema(ms).UseDisableQueryCache(true)))
 			using (var table = db.CreateLocalTable<CreateTableTypes>())
 			{
 				var defaultValue = new CreateTableTypes { Id = 1 };

--- a/Tests/Linq/Update/InsertTests.cs
+++ b/Tests/Linq/Update/InsertTests.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 
 using LinqToDB;
 using LinqToDB.Data;
-using LinqToDB.DataProvider.SqlServer;
 using LinqToDB.Mapping;
 using LinqToDB.Tools;
 
@@ -999,54 +998,36 @@ namespace Tests.xUpdate
 		[Test]
 		public void InsertWithGuidIdentityOutput([IncludeDataSources(TestProvName.AllSqlServer)] string context)
 		{
-			try
-			{
-				SqlServerOptions.Default = SqlServerOptions.Default with { GenerateScopeIdentity = false };
+			using var db = GetDataConnection(context, o => o.UseSqlServer(o => o with { GenerateScopeIdentity = false }));
 
-				using (var db = GetDataConnection(context))
-				{
-					var id = (Guid) db.InsertWithIdentity(new GuidID {Field1 = 1});
-					Assert.That(id, Is.Not.EqualTo(Guid.Empty));
-				}
-			}
-			finally
-			{
-				SqlServerOptions.Default = SqlServerOptions.Default with { GenerateScopeIdentity = true };
-			}
+			var id = (Guid) db.InsertWithIdentity(new GuidID {Field1 = 1});
+			Assert.That(id, Is.Not.EqualTo(Guid.Empty));
 		}
 
 		[Test]
 		public void InsertWithIdentityOutput([IncludeDataSources(TestProvName.AllSqlServer)] string context)
 		{
-			using (var db = GetDataContext(context))
+			using var db = GetDataConnection(context, o => o.UseSqlServer(o => o with { GenerateScopeIdentity = false }));
 			using (new DeletePerson(db))
 			{
-				try
-				{
-					SqlServerOptions.Default = SqlServerOptions.Default with { GenerateScopeIdentity = false };
 
-					for (var i = 0; i < 2; i++)
+				for (var i = 0; i < 2; i++)
+				{
+					var person = new Person
 					{
-						var person = new Person
-						{
-							FirstName = "John" + i,
-							LastName  = "Shepard",
-							Gender    = Gender.Male
-						};
+						FirstName = "John" + i,
+						LastName  = "Shepard",
+						Gender    = Gender.Male
+					};
 
-						var id = db.InsertWithIdentity(person);
+					var id = db.InsertWithIdentity(person);
 
-						Assert.That(id, Is.Not.Null);
+					Assert.That(id, Is.Not.Null);
 
-						var john = db.Person.Single(p => p.FirstName == "John" + i && p.LastName == "Shepard");
+					var john = db.Person.Single(p => p.FirstName == "John" + i && p.LastName == "Shepard");
 
-						Assert.That(john, Is.Not.Null);
-						Assert.That(john.ID, Is.EqualTo(id));
-					}
-				}
-				finally
-				{
-					SqlServerOptions.Default = SqlServerOptions.Default with { GenerateScopeIdentity = true };
+					Assert.That(john, Is.Not.Null);
+					Assert.That(john.ID, Is.EqualTo(id));
 				}
 			}
 		}

--- a/Tests/Linq/UserTests/Issue278Tests.cs
+++ b/Tests/Linq/UserTests/Issue278Tests.cs
@@ -168,7 +168,7 @@ namespace Tests.UserTests
 						for (var i = 0; i < TOTAL_QUERIES_PER_RUN / threadCount; i++)
 						{
 							if (mode == CacheMode.ClearCache)
-								Query<LinqDataTypes2>.ClearCache();
+								db.GetTable<LinqDataTypes2>().ClearCache();
 
 							if (mode == CacheMode.NoCacheScope && (rnd.Next() % 2 == 0))
 								using (NoLinqCache.Scope())

--- a/Tests/Linq/UserTests/Issue3148Tests.cs
+++ b/Tests/Linq/UserTests/Issue3148Tests.cs
@@ -4,7 +4,6 @@ using System.Linq.Expressions;
 
 using LinqToDB;
 using LinqToDB.Expressions;
-using LinqToDB.Linq;
 using LinqToDB.Mapping;
 
 using NUnit.Framework;
@@ -42,9 +41,9 @@ namespace Tests.UserTests
 				}
 
 				query1.ToArray();
-				var cacheMiss = Query<Person>.CacheMissCount;
+				var cacheMiss = db.Person.GetCacheMissCount();
 				query2.ToArray();
-				Assert.That(Query<Person>.CacheMissCount, Is.EqualTo(cacheMiss));
+				Assert.That(db.Person.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 			}
 		}
 
@@ -65,9 +64,9 @@ namespace Tests.UserTests
 				}
 
 				query1.ToArray();
-				var cacheMiss = Query<Person>.CacheMissCount;
+				var cacheMiss = db.Person.GetCacheMissCount();
 				query2.ToArray();
-				Assert.That(Query<Person>.CacheMissCount, Is.EqualTo(cacheMiss));
+				Assert.That(db.Person.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 			}
 		}
 
@@ -88,9 +87,9 @@ namespace Tests.UserTests
 				}
 
 				query1.ToArray();
-				var cacheMiss = Query<Person>.CacheMissCount;
+				var cacheMiss = db.Person.GetCacheMissCount();
 				query2.ToArray();
-				Assert.That(Query<Person>.CacheMissCount, Is.EqualTo(cacheMiss));
+				Assert.That(db.Person.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 			}
 		}
 
@@ -121,9 +120,9 @@ namespace Tests.UserTests
 				}
 
 				query1.ToArray();
-				var cacheMiss = Query<Parent>.CacheMissCount;
+				var cacheMiss = db.Parent.GetCacheMissCount();
 				query2.ToArray();
-				Assert.That(Query<Parent>.CacheMissCount, Is.EqualTo(cacheMiss));
+				Assert.That(db.Parent.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 			}
 		}
 
@@ -154,9 +153,9 @@ namespace Tests.UserTests
 				}
 
 				query1.ToArray();
-				var cacheMiss = Query<Parent>.CacheMissCount;
+				var cacheMiss = db.Parent.GetCacheMissCount();
 				query2.ToArray();
-				Assert.That(Query<Parent>.CacheMissCount, Is.EqualTo(cacheMiss));
+				Assert.That(db.Parent.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 			}
 		}
 
@@ -187,9 +186,9 @@ namespace Tests.UserTests
 				}
 
 				query1.ToArray();
-				var cacheMiss = Query<Parent>.CacheMissCount;
+				var cacheMiss = db.Parent.GetCacheMissCount();
 				query2.ToArray();
-				Assert.That(Query<Parent>.CacheMissCount, Is.EqualTo(cacheMiss));
+				Assert.That(db.Parent.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 			}
 		}
 
@@ -231,9 +230,9 @@ namespace Tests.UserTests
 				}
 
 				query1.ToArray();
-				var cacheMiss = Query<Child>.CacheMissCount;
+				var cacheMiss = db.Child.GetCacheMissCount();
 				query2.ToArray();
-				Assert.That(Query<Child>.CacheMissCount, Is.EqualTo(cacheMiss));
+				Assert.That(db.Child.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 			}
 		}
 
@@ -273,9 +272,9 @@ namespace Tests.UserTests
 				}
 
 				query1.ToArray();
-				var cacheMiss = Query<Child>.CacheMissCount;
+				var cacheMiss = db.Child.GetCacheMissCount();
 				query2.ToArray();
-				Assert.That(Query<Child>.CacheMissCount, Is.EqualTo(cacheMiss));
+				Assert.That(db.Child.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 			}
 		}
 
@@ -305,9 +304,9 @@ namespace Tests.UserTests
 						            .FirstOrDefault());
 
 				query1.ToArray();
-				var cacheMiss = Query<Child>.CacheMissCount;
+				var cacheMiss = db.Child.GetCacheMissCount();
 				query2.ToArray();
-				Assert.That(Query<Child>.CacheMissCount, Is.EqualTo(cacheMiss));
+				Assert.That(db.Child.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 			}
 		}
 
@@ -382,9 +381,9 @@ namespace Tests.UserTests
 				var query2 = provider.CreateQuery<TestTable>(body2);
 
 				query1.ToArray();
-				var cacheMiss = Query<TestTable>.CacheMissCount;
+				var cacheMiss = db.GetTable<TestTable>().GetCacheMissCount();
 				query2.ToArray();
-				Assert.That(Query<TestTable>.CacheMissCount, Is.EqualTo(cacheMiss));
+				Assert.That(db.GetTable<TestTable>().GetCacheMissCount(), Is.EqualTo(cacheMiss));
 			}
 		}
 
@@ -405,9 +404,9 @@ namespace Tests.UserTests
 				}
 
 				query1.ToArray();
-				var cacheMiss = Query<Person>.CacheMissCount;
+				var cacheMiss = db.Person.GetCacheMissCount();
 				query2.ToArray();
-				Assert.That(Query<Person>.CacheMissCount, Is.EqualTo(cacheMiss));
+				Assert.That(db.Person.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 			}
 		}
 
@@ -428,9 +427,9 @@ namespace Tests.UserTests
 				}
 
 				query1.ToArray();
-				var cacheMiss = Query<Person>.CacheMissCount;
+				var cacheMiss = db.Person.GetCacheMissCount();
 				query2.ToArray();
-				Assert.That(Query<Person>.CacheMissCount, Is.EqualTo(cacheMiss));
+				Assert.That(db.Person.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 			}
 		}
 
@@ -451,9 +450,9 @@ namespace Tests.UserTests
 				}
 
 				query1.ToArray();
-				var cacheMiss = Query<Person>.CacheMissCount;
+				var cacheMiss = db.Person.GetCacheMissCount();
 				query2.ToArray();
-				Assert.That(Query<Person>.CacheMissCount, Is.EqualTo(cacheMiss));
+				Assert.That(db.Person.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 			}
 		}
 
@@ -488,9 +487,9 @@ namespace Tests.UserTests
 				}
 
 				query1.ToArray();
-				var cacheMiss = Query<Person>.CacheMissCount;
+				var cacheMiss = db.Person.GetCacheMissCount();
 				query2.ToArray();
-				Assert.That(Query<Person>.CacheMissCount, Is.EqualTo(cacheMiss));
+				Assert.That(db.Person.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 			}
 		}
 
@@ -509,9 +508,9 @@ namespace Tests.UserTests
 				}
 
 				query1.ToArray();
-				var cacheMiss = Query<int>.CacheMissCount;
+				var cacheMiss = query2.GetCacheMissCount();
 				query2.ToArray();
-				Assert.That(Query<int>.CacheMissCount, Is.EqualTo(cacheMiss));
+				Assert.That(query2.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 			}
 		}
 
@@ -530,9 +529,9 @@ namespace Tests.UserTests
 				}
 
 				query1.ToArray();
-				var cacheMiss = Query<int?>.CacheMissCount;
+				var cacheMiss = query2.GetCacheMissCount();
 				query2.ToArray();
-				Assert.That(Query<int?>.CacheMissCount, Is.EqualTo(cacheMiss));
+				Assert.That(query2.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 			}
 		}
 
@@ -552,9 +551,9 @@ namespace Tests.UserTests
 				}
 
 				query1.ToArray();
-				var cacheMiss = Query<string>.CacheMissCount;
+				var cacheMiss = query2.GetCacheMissCount();
 				query2.ToArray();
-				Assert.That(Query<string>.CacheMissCount, Is.EqualTo(cacheMiss));
+				Assert.That(query2.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 			}
 		}
 
@@ -575,9 +574,9 @@ namespace Tests.UserTests
 				}
 
 				query1.ToArray();
-				var cacheMiss = Query<Person>.CacheMissCount;
+				var cacheMiss = db.Person.GetCacheMissCount();
 				query2.ToArray();
-				Assert.That(Query<Person>.CacheMissCount, Is.EqualTo(cacheMiss));
+				Assert.That(db.Person.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 			}
 		}
 
@@ -604,9 +603,9 @@ namespace Tests.UserTests
 				var query2 = provider.CreateQuery<TestTable>(body2);
 
 				query1.ToArray();
-				var cacheMiss = Query<TestTable>.CacheMissCount;
+				var cacheMiss = db.GetTable<TestTable>().GetCacheMissCount();
 				query2.ToArray();
-				Assert.That(Query<TestTable>.CacheMissCount, Is.EqualTo(cacheMiss));
+				Assert.That(db.GetTable<TestTable>().GetCacheMissCount(), Is.EqualTo(cacheMiss));
 			}
 		}
 
@@ -637,9 +636,9 @@ namespace Tests.UserTests
 				}
 
 				query1.ToArray();
-				var cacheMiss = Query<Doctor>.CacheMissCount;
+				var cacheMiss = db.Doctor.GetCacheMissCount();
 				query2.ToArray();
-				Assert.That(Query<Doctor>.CacheMissCount, Is.EqualTo(cacheMiss));
+				Assert.That(db.Doctor.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 			}
 		}
 

--- a/Tests/Model/ParentChild.cs
+++ b/Tests/Model/ParentChild.cs
@@ -3,10 +3,8 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 
 using LinqToDB;
-using LinqToDB.Expressions;
 using LinqToDB.Mapping;
 
 namespace Tests.Model
@@ -646,13 +644,11 @@ namespace Tests.Model
 			throw new InvalidOperationException();
 		}
 
-		static readonly MethodInfo _methodInfo = MemberHelper.MethodOf(() => WithTabLockOld<int>()).GetGenericMethodDefinition();
-
 		[Sql.TableExpression("{0} {1} WITH (TABLOCK)")]
 		public static ITable<T> WithTabLockOld<T>(this IDataContext ctx)
 			where T : class
 		{
-			return ctx.GetTable<T>(null, _methodInfo.MakeGenericMethod(typeof(T)));
+			return ctx.TableFromExpression<T>(() => ctx.WithTabLockOld<T>());
 		}
 	}
 
@@ -689,13 +685,11 @@ namespace Tests.Model
 			throw new InvalidOperationException();
 		}
 
-		static readonly MethodInfo _methodInfo = MemberHelper.MethodOf(() => WithTabLock1<int>()).GetGenericMethodDefinition();
-
 		[Sql.TableExpression("{0} {1} WITH (TABLOCK)")]
 		public static ITable<T> WithTabLock1<T>(IDataContext ctx)
 			where T : class
 		{
-			return ctx.GetTable<T>(null, _methodInfo.MakeGenericMethod(typeof(T)));
+			return ctx.TableFromExpression<T>(() => WithTabLock1<T>(ctx));
 		}
 	}
 


### PR DESCRIPTION
- use existing `[Query|Table]FromExpression` API instead on reflection
- use `GetCacheMissCount` and `ClearCache` test helpers instead of access to internal `Query` class
- use context-level options instead of editing default provider options
- disable query cache on context istead of global cache cleanup
- fix remote context initialization flow to avoid server calls from uninitialized client