### PR TITLE
UseOptions

### DIFF
--- a/Source/LinqToDB/Common/IApplicable.cs
+++ b/Source/LinqToDB/Common/IApplicable.cs
@@ -1,4 +1,6 @@
-﻿namespace LinqToDB.Common
+﻿using System;
+
+namespace LinqToDB.Common
 {
 	interface IApplicable<in T>
 	{

--- a/Source/LinqToDB/Common/IOptionSet.cs
+++ b/Source/LinqToDB/Common/IOptionSet.cs
@@ -1,4 +1,6 @@
-﻿using LinqToDB.Common.Internal;
+﻿using System;
+
+using LinqToDB.Common.Internal;
 
 namespace LinqToDB.Common
 {
@@ -13,5 +15,9 @@ namespace LinqToDB.Common
 	/// </summary>
 	public interface IOptionSet : IConfigurationID
 	{
+		/// <summary>
+		/// Gets the default options.
+		/// </summary>
+		IOptionSet Default { get; }
 	}
 }

--- a/Source/LinqToDB/Common/IReapplicable.cs
+++ b/Source/LinqToDB/Common/IReapplicable.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace LinqToDB.Common
+{
+	interface IReapplicable<T>
+	{
+		Action? Apply(T obj, object? previousObject);
+	}
+}

--- a/Source/LinqToDB/Common/Internal/DisposableAction.cs
+++ b/Source/LinqToDB/Common/Internal/DisposableAction.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace LinqToDB.Common.Internal
+{
+	class DisposableAction(Action action) : IDisposable
+	{
+		public void Dispose() => action();
+	}
+}

--- a/Source/LinqToDB/Data/BulkCopyOptions.cs
+++ b/Source/LinqToDB/Data/BulkCopyOptions.cs
@@ -172,6 +172,8 @@ namespace LinqToDB.Data
 
 		public static readonly BulkCopyOptions Empty = new();
 
+		IOptionSet IOptionSet.Default => Empty;
+
 		int? _configurationID;
 		int IConfigurationID.ConfigurationID
 		{

--- a/Source/LinqToDB/Data/QueryTraceOptions.cs
+++ b/Source/LinqToDB/Data/QueryTraceOptions.cs
@@ -23,7 +23,7 @@ namespace LinqToDB.Data
 		// If you add another parameter here, don't forget to update
 		// QueryTraceOptions copy constructor and IConfigurationID.ConfigurationID.
 	)
-		: IOptionSet, IApplicable<DataConnection>
+		: IOptionSet, IApplicable<DataConnection>, IReapplicable<DataConnection>
 	{
 		public QueryTraceOptions() : this((TraceLevel?)null)
 		{
@@ -57,9 +57,18 @@ namespace LinqToDB.Data
 
 		public static readonly QueryTraceOptions Empty = new();
 
+		IOptionSet IOptionSet.Default => Empty;
+
 		void IApplicable<DataConnection>.Apply(DataConnection obj)
 		{
 			DataConnection.ConfigurationApplier.Apply(obj, this);
+		}
+
+		Action? IReapplicable<DataConnection>.Apply(DataConnection obj, object? previousObject)
+		{
+			return ((IConfigurationID)this).ConfigurationID == ((IConfigurationID?)previousObject)?.ConfigurationID
+				? null
+				: DataConnection.ConfigurationApplier.Reapply(obj, this, (QueryTraceOptions?)previousObject);
 		}
 
 		#region IEquatable implementation
@@ -69,12 +78,12 @@ namespace LinqToDB.Data
 			if (ReferenceEquals(null, other)) return false;
 			if (ReferenceEquals(this, other)) return true;
 
-			return ((IOptionSet)this).ConfigurationID == ((IOptionSet)other).ConfigurationID;
+			return ((IConfigurationID)this).ConfigurationID == ((IConfigurationID)other).ConfigurationID;
 		}
 
 		public override int GetHashCode()
 		{
-			return ((IOptionSet)this).ConfigurationID;
+			return ((IConfigurationID)this).ConfigurationID;
 		}
 
 		#endregion

--- a/Source/LinqToDB/Data/RetryPolicy/RetryPolicyOptions.cs
+++ b/Source/LinqToDB/Data/RetryPolicy/RetryPolicyOptions.cs
@@ -39,7 +39,7 @@ namespace LinqToDB.Data.RetryPolicy
 		// If you add another parameter here, don't forget to update
 		// RetryPolicyOptions copy constructor and IConfigurationID.ConfigurationID.
 	)
-		: IOptionSet, IApplicable<DataConnection>
+		: IOptionSet, IApplicable<DataConnection>, IReapplicable<DataConnection>
 	{
 		public RetryPolicyOptions() : this((IRetryPolicy?)null)
 		{
@@ -79,9 +79,18 @@ namespace LinqToDB.Data.RetryPolicy
 			}
 		}
 
+		IOptionSet IOptionSet.Default => Common.Configuration.RetryPolicy.Options;
+
 		void IApplicable<DataConnection>.Apply(DataConnection obj)
 		{
 			DataConnection.ConfigurationApplier.Apply(obj, this);
+		}
+
+		Action? IReapplicable<DataConnection>.Apply(DataConnection obj, object? previousObject)
+		{
+			return ((IConfigurationID)this).ConfigurationID == ((IConfigurationID?)previousObject)?.ConfigurationID
+				? null
+				: DataConnection.ConfigurationApplier.Reapply(obj, this, (RetryPolicyOptions?)previousObject);
 		}
 
 		#region IEquatable implementation

--- a/Source/LinqToDB/DataExtensions.cs
+++ b/Source/LinqToDB/DataExtensions.cs
@@ -9,6 +9,8 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 
 using LinqToDB.Common;
+using LinqToDB.Data;
+using LinqToDB.Data.RetryPolicy;
 using LinqToDB.Expressions;
 using LinqToDB.Expressions.Internal;
 using LinqToDB.Extensions;
@@ -1727,6 +1729,42 @@ namespace LinqToDB
 
 		/// <inheritdoc cref="IDataContext.UseOptions"/>
 		public static IDisposable? UseLinqOptions(this IDataContext dataContext, Func<LinqOptions,LinqOptions> optionSetter)
+		{
+			return dataContext.UseOptions(o => o.WithOptions(optionSetter));
+		}
+
+		/// <inheritdoc cref="IDataContext.UseOptions"/>
+		public static IDisposable? UseSqlOptions(this IDataContext dataContext, Func<SqlOptions,SqlOptions> optionSetter)
+		{
+			return dataContext.UseOptions(o => o.WithOptions(optionSetter));
+		}
+
+		/// <inheritdoc cref="IDataContext.UseOptions"/>
+		public static IDisposable? UseDataContextOptions(this IDataContext dataContext, Func<DataContextOptions,DataContextOptions> optionSetter)
+		{
+			return dataContext.UseOptions(o => o.WithOptions(optionSetter));
+		}
+
+		/// <inheritdoc cref="IDataContext.UseOptions"/>
+		public static IDisposable? UseRetryPolicyOptions(this IDataContext dataContext, Func<RetryPolicyOptions,RetryPolicyOptions> optionSetter)
+		{
+			return dataContext.UseOptions(o => o.WithOptions(optionSetter));
+		}
+
+		/// <inheritdoc cref="IDataContext.UseOptions"/>
+		public static IDisposable? UseBulkCopyOptions(this IDataContext dataContext, Func<BulkCopyOptions,BulkCopyOptions> optionSetter)
+		{
+			return dataContext.UseOptions(o => o.WithOptions(optionSetter));
+		}
+
+		/// <inheritdoc cref="IDataContext.UseOptions"/>
+		public static IDisposable? UseConnectionOptions(this IDataContext dataContext, Func<ConnectionOptions,ConnectionOptions> optionSetter)
+		{
+			return dataContext.UseOptions(o => o.WithOptions(optionSetter));
+		}
+
+		/// <inheritdoc cref="IDataContext.UseOptions"/>
+		public static IDisposable? UseQueryTraceOptions(this IDataContext dataContext, Func<QueryTraceOptions,QueryTraceOptions> optionSetter)
 		{
 			return dataContext.UseOptions(o => o.WithOptions(optionSetter));
 		}

--- a/Source/LinqToDB/DataExtensions.cs
+++ b/Source/LinqToDB/DataExtensions.cs
@@ -1720,6 +1720,8 @@ namespace LinqToDB
 			return new ExpressionQueryImpl<TResult>(dataContext, expression.Body);
 		}
 
+		#region UseOptions
+
 		/// <inheritdoc cref="IDataContext.UseOptions"/>
 		public static IDisposable? UseOptions<TSet>(this IDataContext dataContext, Func<TSet,TSet> optionSetter)
 			where TSet : class, IOptionSet, new()
@@ -1768,5 +1770,7 @@ namespace LinqToDB
 		{
 			return dataContext.UseOptions(o => o.WithOptions(optionSetter));
 		}
+
+		#endregion
 	}
 }

--- a/Source/LinqToDB/DataExtensions.cs
+++ b/Source/LinqToDB/DataExtensions.cs
@@ -1718,5 +1718,17 @@ namespace LinqToDB
 			return new ExpressionQueryImpl<TResult>(dataContext, expression.Body);
 		}
 
+		/// <inheritdoc cref="IDataContext.UseOptions"/>
+		public static IDisposable? UseOptions<TSet>(this IDataContext dataContext, Func<TSet,TSet> optionSetter)
+			where TSet : class, IOptionSet, new()
+		{
+			return dataContext.UseOptions(o => o.WithOptions(optionSetter));
+		}
+
+		/// <inheritdoc cref="IDataContext.UseOptions"/>
+		public static IDisposable? UseLinqOptions(this IDataContext dataContext, Func<LinqOptions,LinqOptions> optionSetter)
+		{
+			return dataContext.UseOptions(o => o.WithOptions(optionSetter));
+		}
 	}
 }

--- a/Source/LinqToDB/DataOptions.cs
+++ b/Source/LinqToDB/DataOptions.cs
@@ -112,13 +112,40 @@ namespace LinqToDB
 
 		public void Apply(DataConnection dataConnection)
 		{
-			((IApplicable<DataConnection>)ConnectionOptions).Apply(dataConnection);
+			((IApplicable<DataConnection>)ConnectionOptions). Apply(dataConnection);
 			((IApplicable<DataConnection>)RetryPolicyOptions).Apply(dataConnection);
 
 			if (_dataContextOptions is IApplicable<DataConnection> a)
 				a.Apply(dataConnection);
 
 			base.Apply(dataConnection);
+		}
+
+		public Action? Reapply(DataConnection dataConnection, DataOptions previousOptions)
+		{
+			Action? actions = null;
+
+			Add(((IReapplicable<DataConnection>)ConnectionOptions). Apply(dataConnection, previousOptions.ConnectionOptions));
+			Add(((IReapplicable<DataConnection>)RetryPolicyOptions).Apply(dataConnection, previousOptions.RetryPolicyOptions));
+
+			if (_dataContextOptions is IReapplicable<DataConnection> a)
+			{
+				Add(a.Apply(dataConnection, previousOptions._dataContextOptions));
+			}
+			else if (previousOptions._dataContextOptions is not null)
+			{
+				Add(((IReapplicable<DataConnection>)DataContextOptions.Empty).Apply(dataConnection, previousOptions._dataContextOptions));
+			}
+
+			Add(base.Reapply(dataConnection, previousOptions));
+
+			return actions;
+
+			void Add(Action? action)
+			{
+				if (action is not null)
+					actions += action;
+			}
 		}
 
 		public void Apply(DataContext dataContext)
@@ -131,6 +158,32 @@ namespace LinqToDB
 			base.Apply(dataContext);
 		}
 
+		public Action? Reapply(DataContext dataContext, DataOptions previousOptions)
+		{
+			Action? actions = null;
+
+			Add(((IReapplicable<DataContext>)ConnectionOptions). Apply(dataContext, previousOptions.ConnectionOptions));
+
+			if (_dataContextOptions is IReapplicable<DataContext> a)
+			{
+				Add(a.Apply(dataContext, previousOptions._dataContextOptions));
+			}
+			else if (previousOptions._dataContextOptions is not null)
+			{
+				Add(((IReapplicable<DataContext>)DataContextOptions.Empty).Apply(dataContext, previousOptions._dataContextOptions));
+			}
+
+			Add(base.Reapply(dataContext, previousOptions));
+
+			return actions;
+
+			void Add(Action? action)
+			{
+				if (action is not null)
+					actions += action;
+			}
+		}
+
 		public void Apply(RemoteDataContextBase dataContext)
 		{
 			((IApplicable<RemoteDataContextBase>)ConnectionOptions).Apply(dataContext);
@@ -139,6 +192,32 @@ namespace LinqToDB
 				a.Apply(dataContext);
 
 			base.Apply(dataContext);
+		}
+
+		public Action? Reapply(RemoteDataContextBase dataContext, DataOptions previousOptions)
+		{
+			Action? actions = null;
+
+			Add(((IReapplicable<RemoteDataContextBase>)ConnectionOptions). Apply(dataContext, previousOptions.ConnectionOptions));
+
+			if (_dataContextOptions is IReapplicable<RemoteDataContextBase> a)
+			{
+				Add(a.Apply(dataContext, previousOptions._dataContextOptions));
+			}
+			else if (previousOptions._dataContextOptions is not null)
+			{
+				Add(((IReapplicable<RemoteDataContextBase>)DataContextOptions.Empty).Apply(dataContext, previousOptions._dataContextOptions));
+			}
+
+			Add(base.Reapply(dataContext, previousOptions));
+
+			return actions;
+
+			void Add(Action? action)
+			{
+				if (action is not null)
+					actions += action;
+			}
 		}
 
 		int? _configurationID;

--- a/Source/LinqToDB/DataProvider/DataProviderOptions.cs
+++ b/Source/LinqToDB/DataProvider/DataProviderOptions.cs
@@ -47,5 +47,7 @@ namespace LinqToDB.DataProvider
 		/// Default options.
 		/// </summary>
 		public static T Default { get; set; } = new();
+
+		IOptionSet IOptionSet.Default => Default;
 	}
 }

--- a/Source/LinqToDB/IDataContext.cs
+++ b/Source/LinqToDB/IDataContext.cs
@@ -126,5 +126,17 @@ namespace LinqToDB
 		/// Gets initial value for database connection configuration name.
 		/// </summary>
 		string?                       ConfigurationString         { get; }
+
+		/// <summary>
+		/// Sets new options for current data context.
+		/// </summary>
+		/// <param name="optionsSetter">
+		/// Options setter function.
+		/// </param>
+		/// <returns>
+		/// Returns disposable object, which could be used to restore previous options.
+		/// </returns>
+		/// <exception cref="ArgumentNullException"></exception>
+		public IDisposable? UseOptions(Func<DataOptions,DataOptions> optionsSetter);
 	}
 }

--- a/Source/LinqToDB/Interceptors/InterceptorExtensions.cs
+++ b/Source/LinqToDB/Interceptors/InterceptorExtensions.cs
@@ -119,7 +119,7 @@ namespace LinqToDB.Interceptors
 				case AggregatedInterceptor<T> ae:
 					ae.Remove(interceptor);
 					break;
-				case T e when ReferenceEquals(e, interceptor):
+				case { } e when ReferenceEquals(e, interceptor):
 					typedInterceptable.Interceptor = default;
 					break;
 				default:

--- a/Source/LinqToDB/LinqOptions.cs
+++ b/Source/LinqToDB/LinqOptions.cs
@@ -51,9 +51,9 @@ namespace LinqToDB
 	/// <param name="CompareNulls">
 	/// <summary>
 	/// If set to <see cref="CompareNulls.LikeClr" /> nullable fields would be checked for <c>IS NULL</c> in Equal/NotEqual comparisons.
-	/// If set to <see cref="CompareNulls.LikeSql" /> comparisons are compiled straight to equivalent SQL operators, 
+	/// If set to <see cref="CompareNulls.LikeSql" /> comparisons are compiled straight to equivalent SQL operators,
 	/// which consider nulls values as not equal.
-	/// <see cref="CompareNulls.LikeSqlExceptParameters" /> is a backward compatible option that works mostly as <see cref="CompareNulls.LikeSql" />, 
+	/// <see cref="CompareNulls.LikeSqlExceptParameters" /> is a backward compatible option that works mostly as <see cref="CompareNulls.LikeSql" />,
 	/// but sniffs parameters value and changes = into <c>IS NULL</c> when parameters are null.
 	/// Comparisons to literal null are always compiled into <c>IS NULL</c>.
 	/// This affects: Equal, NotEqual, Not Contains
@@ -227,6 +227,8 @@ namespace LinqToDB
 				return _configurationID.Value;
 			}
 		}
+
+		IOptionSet IOptionSet.Default => Common.Configuration.Linq.Options;
 
 		public TimeSpan CacheSlidingExpirationOrDefault => CacheSlidingExpiration ?? TimeSpan.FromHours(1);
 

--- a/Source/LinqToDB/SqlOptions.cs
+++ b/Source/LinqToDB/SqlOptions.cs
@@ -73,6 +73,8 @@ namespace LinqToDB
 			}
 		}
 
+		IOptionSet IOptionSet.Default => (SqlOptions)Common.Configuration.Sql.Options;
+
 		#region IEquatable implementation
 
 		public bool Equals(SqlOptions? other)

--- a/Tests/Model/TestDataCustomConnection.cs
+++ b/Tests/Model/TestDataCustomConnection.cs
@@ -109,6 +109,11 @@ namespace Tests.Model
 
 		public string? ConfigurationString => ((IDataContext)Connection).ConfigurationString;
 
+		public IDisposable? UseOptions(Func<DataOptions, DataOptions> optionsSetter)
+		{
+			return null;
+		}
+
 		public int ConfigurationID => ((IConfigurationID)Connection).ConfigurationID;
 
 		public void AddInterceptor(IInterceptor interceptor)

--- a/linq2db.sln.DotSettings
+++ b/linq2db.sln.DotSettings
@@ -52,5 +52,6 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Parameterize/@EntryIndexedValue">True</s:Boolean>
 	
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Postgre/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Reapplicable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=subquery/@EntryIndexedValue">True</s:Boolean>
 </wpf:ResourceDictionary>


### PR DESCRIPTION
A new method, `UseOptions`, has been introduced to allow temporary changes to `IDataContext` options, with automatic restoration afterward.

`IDataContext` options are immutable, meaning they cannot be changed once set. With this feature, it is now possible to override options within a specific execution context while ensuring they revert to their original state when no longer needed.

Several overloads are available to fit different use cases:

```c#
using (db.UseOptions(o => o
	.WithOptions<LinqOptions>    (co => co with { OptimizeJoins = false })
	.WithOptions<BulkCopyOptions>(bo => bo with { BulkCopyType = BulkCopyType.RowByRow })))
{
	// ...
}
```

```c#
using (db.UseOptions<DataContextOptions>(o => o with { CommandTimeout = 45 }))
{
	// ...
}
```

```c#
using (db.UseLinqOptions(o => o with { CompareNulls = param }))
{
	// ...
}
```