### PR TITLE
JOIN with nullable expression is not working

### DIFF
--- a/Tests/Base/TestBase.Asserts.cs
+++ b/Tests/Base/TestBase.Asserts.cs
@@ -21,9 +21,9 @@ namespace Tests
 {
 	partial class TestBase
 	{
-		protected void AreEqual<T>(IEnumerable<T> expected, IEnumerable<T> result, bool allowEmpty = false)
+		protected void AreEqual<T>(IEnumerable<T> expected, IEnumerable<T> result, bool allowEmpty = false, bool printData = false)
 		{
-			AreEqual(t => t, expected, result, EqualityComparer<T>.Default, allowEmpty);
+			AreEqual(t => t, expected, result, EqualityComparer<T>.Default, allowEmpty, printData : printData);
 		}
 
 		protected void AreEqual<T>(IEnumerable<T> expected, IEnumerable<T> result, Func<IEnumerable<T>, IEnumerable<T>> sort)
@@ -41,9 +41,9 @@ namespace Tests
 			AreEqual(t => t, expected, result, ComparerBuilder.GetEqualityComparer<T>(memberPredicate));
 		}
 
-		protected void AreEqual<T>(IEnumerable<T> expected, IEnumerable<T> result, IEqualityComparer<T> comparer, bool allowEmpty = false)
+		protected void AreEqual<T>(IEnumerable<T> expected, IEnumerable<T> result, IEqualityComparer<T> comparer, bool allowEmpty = false, bool printData = false)
 		{
-			AreEqual(t => t, expected, result, comparer, allowEmpty);
+			AreEqual(t => t, expected, result, comparer, allowEmpty, printData : printData);
 		}
 
 		protected void AreEqual<T>(IEnumerable<T> expected, IEnumerable<T> result, IEqualityComparer<T> comparer, Func<IEnumerable<T>, IEnumerable<T>> sort)
@@ -56,9 +56,9 @@ namespace Tests
 			AreEqual(fixSelector, expected, result, EqualityComparer<T>.Default);
 		}
 
-		protected void AreEqual<T>(Func<T, T> fixSelector, IEnumerable<T> expected, IEnumerable<T> result, IEqualityComparer<T> comparer, bool allowEmpty = false)
+		protected void AreEqual<T>(Func<T, T> fixSelector, IEnumerable<T> expected, IEnumerable<T> result, IEqualityComparer<T> comparer, bool allowEmpty = false, bool printData = false)
 		{
-			AreEqual(fixSelector, expected, result, comparer, null, allowEmpty);
+			AreEqual(fixSelector, expected, result, comparer, null, allowEmpty, printData : printData);
 		}
 
 		protected void AreEqual<T>(
@@ -67,7 +67,8 @@ namespace Tests
 			IEnumerable<T> result,
 			IEqualityComparer<T> comparer,
 			Func<IEnumerable<T>, IEnumerable<T>>? sort,
-			bool allowEmpty = false)
+			bool allowEmpty = false,
+			bool printData  = false)
 		{
 			var resultList   = result.  Select(fixSelector).ToList();
 			var lastQuery    = LastQuery;
@@ -77,6 +78,12 @@ namespace Tests
 			{
 				resultList = sort(resultList).ToList();
 				expectedList = sort(expectedList).ToList();
+			}
+
+			if (printData)
+			{
+				Console.WriteLine(expectedList.ToDiagnosticString("Expected"));
+				Console.WriteLine(resultList.  ToDiagnosticString("Result"));
 			}
 
 			if (!allowEmpty)


### PR DESCRIPTION
The following code is not working 

```c#
from t2 in temp1
join t3 in temp2 on t2.ID equals t3.ID into gt3
from t3 in gt3.DefaultIfEmpty()
let Value = t3.Value ?? t2.Value
//let Value = Sql.AsNullable(t3.Value) ?? t2.Value
join t4 in temp3 on new { Value } equals new { t4.Value } into gt5
from t4 in gt5.DefaultIfEmpty()
select t4
```

If you uncomment the commented line, the code works.

Worked in 2.xxx