### PR TITLE
obsolete DataContext/DataConnection constructors

### DIFF
--- a/Source/LinqToDB.CLI/CommandLine/Commands/ScaffoldCommand.Execute.cs
+++ b/Source/LinqToDB.CLI/CommandLine/Commands/ScaffoldCommand.Execute.cs
@@ -314,7 +314,7 @@ Provider could be downloaded from:
 							return null;
 						}
 
-						secondaryConnection = new DataConnection(secondaryDataProvider, additionalConnectionString);
+						secondaryConnection = new DataConnection(new DataOptions().UseConnectionString(secondaryDataProvider, additionalConnectionString));
 						// to simplify things for caller (no need to detect connection type)
 						// returned connection should be OLE DB and additional - ODBC
 						returnSecondary     = isSecondaryOleDb;
@@ -335,7 +335,7 @@ Provider could be downloaded from:
 				return null;
 			}
 
-			var dc = new DataConnection(dataProvider, connectionString);
+			var dc = new DataConnection(new DataOptions().UseConnectionString(dataProvider, connectionString));
 
 			if (secondaryConnection != null && returnSecondary)
 			{

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFToolsDataContext.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFToolsDataContext.cs
@@ -31,7 +31,7 @@ namespace LinqToDB.EntityFrameworkCore
 			IDataProvider                                                         dataProvider,
 			string                                                                connectionString,
 			IModel                                                                model,
-			Func<Expression, IDataContext, DbContext?, IModel, bool, Expression>? transformFunc) : base(dataProvider, connectionString)
+			Func<Expression, IDataContext, DbContext?, IModel, bool, Expression>? transformFunc) : base(new DataOptions().UseConnectionString(dataProvider, connectionString))
 		{
 			_context       = context;
 			_model         = model;

--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
@@ -43,6 +44,8 @@ namespace LinqToDB.Data
 		/// <summary>
 		/// Creates database connection object that uses default connection configuration from <see cref="DefaultConfiguration"/> property.
 		/// </summary>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions()...)"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(Func<DataOptions,DataOptions> optionsSetter) : this(optionsSetter(DefaultDataOptions))
 		{
 		}
@@ -64,6 +67,8 @@ namespace LinqToDB.Data
 		/// </summary>
 		/// <param name="configurationString">Name of database connection configuration to use with this connection.
 		/// In case of <c>null</c>, configuration from <see cref="DefaultConfiguration"/> property will be used.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseConfiguration(configurationString)...)"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(string? configurationString, Func<DataOptions,DataOptions> optionsSetter)
 			: this(optionsSetter(configurationString == null
 				? DefaultDataOptions
@@ -75,6 +80,8 @@ namespace LinqToDB.Data
 		/// Creates database connection object that uses default connection configuration from <see cref="DefaultConfiguration"/> property and provided mapping schema.
 		/// </summary>
 		/// <param name="mappingSchema">Mapping schema to use with this connection.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseMappingSchema(mappingSchema))"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(MappingSchema mappingSchema) : this(DefaultDataOptions.UseMappingSchema(mappingSchema))
 		{
 		}
@@ -83,6 +90,8 @@ namespace LinqToDB.Data
 		/// Creates database connection object that uses default connection configuration from <see cref="DefaultConfiguration"/> property and provided mapping schema.
 		/// </summary>
 		/// <param name="mappingSchema">Mapping schema to use with this connection.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseMappingSchema(mappingSchema)...)"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(MappingSchema mappingSchema, Func<DataOptions,DataOptions> optionsSetter)
 			: this(optionsSetter(DefaultDataOptions.UseMappingSchema(mappingSchema)))
 		{
@@ -94,8 +103,10 @@ namespace LinqToDB.Data
 		/// <param name="configurationString">Name of database connection configuration to use with this connection.
 		/// In case of null, configuration from <see cref="DefaultConfiguration"/> property will be used.</param>
 		/// <param name="mappingSchema">Mapping schema to use with this connection.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseConfiguration(configurationString, mappingSchema))"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(string? configurationString, MappingSchema mappingSchema)
-			: this(DefaultDataOptions.UseConfigurationString(configurationString).UseMappingSchema(mappingSchema))
+			: this(DefaultDataOptions.UseConfiguration(configurationString, mappingSchema))
 		{
 		}
 
@@ -105,8 +116,10 @@ namespace LinqToDB.Data
 		/// <param name="configurationString">Name of database connection configuration to use with this connection.
 		/// In case of null, configuration from <see cref="DefaultConfiguration"/> property will be used.</param>
 		/// <param name="mappingSchema">Mapping schema to use with this connection.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseConfiguration(configurationString, mappingSchema)...)"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(string? configurationString, MappingSchema mappingSchema, Func<DataOptions,DataOptions> optionsSetter)
-			: this(optionsSetter(DefaultDataOptions.UseConfigurationString(configurationString).UseMappingSchema(mappingSchema)))
+			: this(optionsSetter(DefaultDataOptions.UseConfiguration(configurationString, mappingSchema)))
 		{
 		}
 
@@ -116,6 +129,8 @@ namespace LinqToDB.Data
 		/// <param name="providerName">Name of database provider to use with this connection. <see cref="ProviderName"/> class for list of providers.</param>
 		/// <param name="connectionString">Database connection string to use for connection with database.</param>
 		/// <param name="mappingSchema">Mapping schema to use with this connection.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseConnectionString(providerName, connectionString).UseMappingSchema(mappingSchema))"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(
 			string        providerName,
 			string        connectionString,
@@ -130,6 +145,8 @@ namespace LinqToDB.Data
 		/// <param name="providerName">Name of database provider to use with this connection. <see cref="ProviderName"/> class for list of providers.</param>
 		/// <param name="connectionString">Database connection string to use for connection with database.</param>
 		/// <param name="mappingSchema">Mapping schema to use with this connection.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseConnectionString(providerName, connectionString).UseMappingSchema(mappingSchema)...)"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(
 			string                        providerName,
 			string                        connectionString,
@@ -144,6 +161,8 @@ namespace LinqToDB.Data
 		/// </summary>
 		/// <param name="providerName">Name of database provider to use with this connection. <see cref="ProviderName"/> class for list of providers.</param>
 		/// <param name="connectionString">Database connection string to use for connection with database.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseConnectionString(dataProvider, connectionString))"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(
 			string providerName,
 			string connectionString)
@@ -156,6 +175,8 @@ namespace LinqToDB.Data
 		/// </summary>
 		/// <param name="providerName">Name of database provider to use with this connection. <see cref="ProviderName"/> class for list of providers.</param>
 		/// <param name="connectionString">Database connection string to use for connection with database.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseConnectionString(dataProvider, connectionString)...)"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(
 			string                        providerName,
 			string                        connectionString,
@@ -170,6 +191,8 @@ namespace LinqToDB.Data
 		/// <param name="dataProvider">Database provider implementation to use with this connection.</param>
 		/// <param name="connectionString">Database connection string to use for connection with database.</param>
 		/// <param name="mappingSchema">Mapping schema to use with this connection.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseConnectionString(dataProvider, connectionString).UseMappingSchema(mappingSchema))"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(
 			IDataProvider dataProvider,
 			string        connectionString,
@@ -184,6 +207,8 @@ namespace LinqToDB.Data
 		/// <param name="dataProvider">Database provider implementation to use with this connection.</param>
 		/// <param name="connectionString">Database connection string to use for connection with database.</param>
 		/// <param name="mappingSchema">Mapping schema to use with this connection.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseConnectionString(dataProvider, connectionString).UseMappingSchema(mappingSchema)...)"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(
 			IDataProvider                 dataProvider,
 			string                        connectionString,
@@ -198,6 +223,8 @@ namespace LinqToDB.Data
 		/// </summary>
 		/// <param name="dataProvider">Database provider implementation to use with this connection.</param>
 		/// <param name="connectionString">Database connection string to use for connection with database.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseConnectionString(dataProvider, connectionString))"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(
 			IDataProvider dataProvider,
 			string        connectionString)
@@ -210,6 +237,8 @@ namespace LinqToDB.Data
 		/// </summary>
 		/// <param name="dataProvider">Database provider implementation to use with this connection.</param>
 		/// <param name="connectionString">Database connection string to use for connection with database.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseConnectionString(dataProvider, connectionString)...)"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(
 			IDataProvider                 dataProvider,
 			string                        connectionString,
@@ -224,6 +253,8 @@ namespace LinqToDB.Data
 		/// <param name="dataProvider">Database provider implementation to use with this connection.</param>
 		/// <param name="connectionFactory">Database connection factory method.</param>
 		/// <param name="mappingSchema">Mapping schema to use with this connection.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseConnectionFactory(dataProvider, connectionFactory).UseMappingSchema(mappingSchema))"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(
 			IDataProvider                   dataProvider,
 			Func<DataOptions, DbConnection> connectionFactory,
@@ -238,6 +269,8 @@ namespace LinqToDB.Data
 		/// <param name="dataProvider">Database provider implementation to use with this connection.</param>
 		/// <param name="connectionFactory">Database connection factory method.</param>
 		/// <param name="mappingSchema">Mapping schema to use with this connection.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseConnectionFactory(dataProvider, connectionFactory).UseMappingSchema(mappingSchema)...)"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(
 			IDataProvider                   dataProvider,
 			Func<DataOptions, DbConnection> connectionFactory,
@@ -252,6 +285,8 @@ namespace LinqToDB.Data
 		/// </summary>
 		/// <param name="dataProvider">Database provider implementation to use with this connection.</param>
 		/// <param name="connectionFactory">Database connection factory method.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseConnectionFactory(dataProvider, connectionFactory))"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(
 			IDataProvider                   dataProvider,
 			Func<DataOptions, DbConnection> connectionFactory)
@@ -264,6 +299,8 @@ namespace LinqToDB.Data
 		/// </summary>
 		/// <param name="dataProvider">Database provider implementation to use with this connection.</param>
 		/// <param name="connectionFactory">Database connection factory method.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseConnectionFactory(dataProvider, connectionFactory)...)"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(
 			IDataProvider                   dataProvider,
 			Func<DataOptions, DbConnection> connectionFactory,
@@ -278,6 +315,8 @@ namespace LinqToDB.Data
 		/// <param name="dataProvider">Database provider implementation to use with this connection.</param>
 		/// <param name="connection">Existing database connection to use.</param>
 		/// <param name="mappingSchema">Mapping schema to use with this connection.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseConnection(dataProvider, connection).UseMappingSchema(mappingSchema))"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(
 			IDataProvider dataProvider,
 			DbConnection  connection,
@@ -292,6 +331,8 @@ namespace LinqToDB.Data
 		/// <param name="dataProvider">Database provider implementation to use with this connection.</param>
 		/// <param name="connection">Existing database connection to use.</param>
 		/// <param name="mappingSchema">Mapping schema to use with this connection.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseConnection(dataProvider, connection).UseMappingSchema(mappingSchema)...)"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(
 			IDataProvider                 dataProvider,
 			DbConnection                  connection,
@@ -309,6 +350,8 @@ namespace LinqToDB.Data
 		/// <remarks>
 		/// <paramref name="connection"/> would not be disposed.
 		/// </remarks>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseConnection(dataProvider, connection))"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(
 			IDataProvider dataProvider,
 			DbConnection  connection)
@@ -324,9 +367,11 @@ namespace LinqToDB.Data
 		/// <remarks>
 		/// <paramref name="connection"/> would not be disposed.
 		/// </remarks>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseConnection(dataProvider, connection)...)"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(
-			IDataProvider dataProvider,
-			DbConnection  connection,
+			IDataProvider                 dataProvider,
+			DbConnection                  connection,
 			Func<DataOptions,DataOptions> optionsSetter)
 			: this(dataProvider, connection, false, optionsSetter)
 		{
@@ -338,6 +383,8 @@ namespace LinqToDB.Data
 		/// <param name="dataProvider">Database provider implementation to use with this connection.</param>
 		/// <param name="connection">Existing database connection to use.</param>
 		/// <param name="disposeConnection">If true <paramref name="connection"/> would be disposed on DataConnection disposing.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseConnection(dataProvider, connection, disposeConnection))"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(
 			IDataProvider dataProvider,
 			DbConnection  connection,
@@ -352,6 +399,8 @@ namespace LinqToDB.Data
 		/// <param name="dataProvider">Database provider implementation to use with this connection.</param>
 		/// <param name="connection">Existing database connection to use.</param>
 		/// <param name="disposeConnection">If true <paramref name="connection"/> would be disposed on DataConnection disposing.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseConnection(dataProvider, connection, disposeConnection)...)"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(
 			IDataProvider                 dataProvider,
 			DbConnection                  connection,
@@ -367,6 +416,8 @@ namespace LinqToDB.Data
 		/// <param name="dataProvider">Database provider implementation to use with this connection.</param>
 		/// <param name="transaction">Existing database transaction to use.</param>
 		/// <param name="mappingSchema">Mapping schema to use with this connection.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseTransaction(dataProvider, transaction).UseMappingSchema(mappingSchema))"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(
 			IDataProvider dataProvider,
 			DbTransaction transaction,
@@ -381,6 +432,8 @@ namespace LinqToDB.Data
 		/// <param name="dataProvider">Database provider implementation to use with this connection.</param>
 		/// <param name="transaction">Existing database transaction to use.</param>
 		/// <param name="mappingSchema">Mapping schema to use with this connection.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseTransaction(dataProvider, transaction).UseMappingSchema(mappingSchema)...)"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(
 			IDataProvider                 dataProvider,
 			DbTransaction                 transaction,
@@ -395,6 +448,8 @@ namespace LinqToDB.Data
 		/// </summary>
 		/// <param name="dataProvider">Database provider implementation to use with this connection.</param>
 		/// <param name="transaction">Existing database transaction to use.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseTransaction(dataProvider, transaction))"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(
 			IDataProvider dataProvider,
 			DbTransaction transaction)
@@ -407,6 +462,8 @@ namespace LinqToDB.Data
 		/// </summary>
 		/// <param name="dataProvider">Database provider implementation to use with this connection.</param>
 		/// <param name="transaction">Existing database transaction to use.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataConnection(new DataOptions().UseTransaction(dataProvider, transaction)...)"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataConnection(
 			IDataProvider                 dataProvider,
 			DbTransaction                 transaction,
@@ -428,7 +485,6 @@ namespace LinqToDB.Data
 
 			DataProvider!.InitContext(this);
 		}
-
 #pragma warning restore CS8618
 
 		#endregion

--- a/Source/LinqToDB/DataContext.cs
+++ b/Source/LinqToDB/DataContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Data;
 using System.Data.Common;
 using System.Linq.Expressions;
@@ -26,6 +27,8 @@ namespace LinqToDB
 	public partial class DataContext : IDataContext, IInfrastructure<IServiceProvider>
 	{
 		bool _disposed;
+
+		#region .ctors
 
 		/// <summary>
 		/// Creates data context using default database configuration.
@@ -54,6 +57,8 @@ namespace LinqToDB
 		/// </summary>
 		/// <param name="dataProvider">Database provider implementation.</param>
 		/// <param name="connectionString">Database connection string.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataContext(new DataOptions().UseConnectionString(dataProvider, connectionString))"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataContext(IDataProvider dataProvider, string connectionString)
 			: this(new DataOptions()
 				.UseConnectionString(
@@ -67,6 +72,8 @@ namespace LinqToDB
 		/// </summary>
 		/// <param name="providerName">Name of database provider to use with this connection. <see cref="ProviderName"/> class for list of providers.</param>
 		/// <param name="connectionString">Database connection string to use for connection with database.</param>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Instead use: new DataContext(new DataOptions().UseConnectionString(providerName, connectionString))"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DataContext( string providerName, string connectionString)
 			: this(new DataOptions()
 				.UseConnectionString(
@@ -86,6 +93,8 @@ namespace LinqToDB
 			DataProvider  = default!;
 			Options.Apply(this);
 		}
+
+		#endregion
 
 		/// <summary>
 		/// Current DataContext options

--- a/Source/LinqToDB/DataProvider/Access/AccessTools.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessTools.cs
@@ -34,17 +34,20 @@ namespace LinqToDB.DataProvider.Access
 
 		public static DataConnection CreateDataConnection(string connectionString, AccessVersion version = AccessVersion.AutoDetect, AccessProvider provider = AccessProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString), provider, version), connectionString);
+			return new DataConnection(new DataOptions()
+				.UseConnectionString(ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString), provider, version), connectionString));
 		}
 
 		public static DataConnection CreateDataConnection(DbConnection connection, AccessVersion version = AccessVersion.AutoDetect, AccessProvider provider = AccessProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbConnection: connection), provider, version), connection);
+			return new DataConnection(new DataOptions()
+				.UseConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbConnection: connection), provider, version), connection));
 		}
 
 		public static DataConnection CreateDataConnection(DbTransaction transaction, AccessVersion version = AccessVersion.AutoDetect, AccessProvider provider = AccessProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbTransaction: transaction), provider, version), transaction);
+			return new DataConnection(new DataOptions()
+				.UseTransaction(ProviderDetector.GetDataProvider(new ConnectionOptions(DbTransaction: transaction), provider, version), transaction));
 		}
 
 		#endregion

--- a/Source/LinqToDB/DataProvider/ClickHouse/ClickHouseTools.cs
+++ b/Source/LinqToDB/DataProvider/ClickHouse/ClickHouseTools.cs
@@ -21,17 +21,20 @@ namespace LinqToDB.DataProvider.ClickHouse
 
 		public static DataConnection CreateDataConnection(string connectionString, ClickHouseProvider provider = ClickHouseProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString), provider, default), connectionString);
+			return new DataConnection(new DataOptions()
+				.UseConnectionString(ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString), provider, default), connectionString));
 		}
 
 		public static DataConnection CreateDataConnection(DbConnection connection, ClickHouseProvider provider = ClickHouseProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbConnection: connection), provider, default), connection);
+			return new DataConnection(new DataOptions()
+				.UseConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbConnection: connection), provider, default), connection));
 		}
 
 		public static DataConnection CreateDataConnection(DbTransaction transaction, ClickHouseProvider provider = ClickHouseProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbTransaction: transaction), provider, default), transaction);
+			return new DataConnection(new DataOptions()
+				.UseTransaction(ProviderDetector.GetDataProvider(new ConnectionOptions(DbTransaction: transaction), provider, default), transaction));
 		}
 	}
 }

--- a/Source/LinqToDB/DataProvider/DB2/DB2Tools.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2Tools.cs
@@ -46,7 +46,8 @@ namespace LinqToDB.DataProvider.DB2
 		/// <returns><see cref="DataConnection"/> instance.</returns>
 		public static DataConnection CreateDataConnection(string connectionString, DB2Version version = DB2Version.LUW)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString), default, version), connectionString);
+			return new DataConnection(new DataOptions()
+				.UseConnectionString(ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString), default, version), connectionString));
 		}
 
 		/// <summary>
@@ -57,7 +58,8 @@ namespace LinqToDB.DataProvider.DB2
 		/// <returns><see cref="DataConnection"/> instance.</returns>
 		public static DataConnection CreateDataConnection(DbConnection connection, DB2Version version = DB2Version.LUW)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbConnection: connection), default, version), connection);
+			return new DataConnection(new DataOptions()
+				.UseConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbConnection: connection), default, version), connection));
 		}
 
 		/// <summary>
@@ -68,7 +70,8 @@ namespace LinqToDB.DataProvider.DB2
 		/// <returns><see cref="DataConnection"/> instance.</returns>
 		public static DataConnection CreateDataConnection(DbTransaction transaction, DB2Version version = DB2Version.LUW)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbTransaction: transaction), default, version), transaction);
+			return new DataConnection(new DataOptions()
+				.UseTransaction(ProviderDetector.GetDataProvider(new ConnectionOptions(DbTransaction: transaction), default, version), transaction));
 		}
 
 		#endregion

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdTools.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdTools.cs
@@ -40,17 +40,20 @@ namespace LinqToDB.DataProvider.Firebird
 
 		public static DataConnection CreateDataConnection(string connectionString, FirebirdVersion version = FirebirdVersion.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString), default, version), connectionString);
+			return new DataConnection(new DataOptions()
+				.UseConnectionString(ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString), default, version), connectionString));
 		}
 
 		public static DataConnection CreateDataConnection(DbConnection connection, FirebirdVersion version = FirebirdVersion.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbConnection: connection), default, version), connection);
+			return new DataConnection(new DataOptions()
+				.UseConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbConnection: connection), default, version), connection));
 		}
 
 		public static DataConnection CreateDataConnection(DbTransaction transaction, FirebirdVersion version = FirebirdVersion.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbTransaction: transaction), default, version), transaction);
+			return new DataConnection(new DataOptions()
+				.UseTransaction(ProviderDetector.GetDataProvider(new ConnectionOptions(DbTransaction: transaction), default, version), transaction));
 		}
 
 		#endregion

--- a/Source/LinqToDB/DataProvider/Informix/InformixTools.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixTools.cs
@@ -23,17 +23,20 @@ namespace LinqToDB.DataProvider.Informix
 
 		public static DataConnection CreateDataConnection(string connectionString, InformixProvider provider = InformixProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString), provider, default), connectionString);
+			return new DataConnection(new DataOptions()
+				.UseConnectionString(ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString), provider, default), connectionString));
 		}
 
 		public static DataConnection CreateDataConnection(DbConnection connection, InformixProvider provider = InformixProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbConnection: connection), provider, default), connection);
+			return new DataConnection(new DataOptions()
+				.UseConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbConnection: connection), provider, default), connection));
 		}
 
 		public static DataConnection CreateDataConnection(DbTransaction transaction, InformixProvider provider = InformixProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbTransaction: transaction), provider, default), transaction);
+			return new DataConnection(new DataOptions()
+				.UseTransaction(ProviderDetector.GetDataProvider(new ConnectionOptions(DbTransaction: transaction), provider, default), transaction));
 		}
 
 		#endregion

--- a/Source/LinqToDB/DataProvider/MySql/MySqlTools.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlTools.cs
@@ -40,7 +40,8 @@ namespace LinqToDB.DataProvider.MySql
 			MySqlVersion  version  = MySqlVersion.AutoDetect,
 			MySqlProvider provider = MySqlProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString), provider, version), connectionString);
+			return new DataConnection(new DataOptions()
+				.UseConnectionString(ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString), provider, version), connectionString));
 		}
 
 		public static DataConnection CreateDataConnection(
@@ -48,7 +49,8 @@ namespace LinqToDB.DataProvider.MySql
 			MySqlVersion  version  = MySqlVersion.AutoDetect,
 			MySqlProvider provider = MySqlProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbConnection: connection), provider, version), connection);
+			return new DataConnection(new DataOptions()
+				.UseConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbConnection: connection), provider, version), connection));
 		}
 
 		public static DataConnection CreateDataConnection(
@@ -56,7 +58,8 @@ namespace LinqToDB.DataProvider.MySql
 			MySqlVersion  version  = MySqlVersion.AutoDetect,
 			MySqlProvider provider = MySqlProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbTransaction: transaction), provider, version), transaction);
+			return new DataConnection(new DataOptions()
+				.UseTransaction(ProviderDetector.GetDataProvider(new ConnectionOptions(DbTransaction: transaction), provider, version), transaction));
 		}
 
 		#endregion

--- a/Source/LinqToDB/DataProvider/Oracle/OracleTools.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleTools.cs
@@ -35,7 +35,8 @@ namespace LinqToDB.DataProvider.Oracle
 			OracleVersion version   = OracleVersion.AutoDetect,
 			OracleProvider provider = OracleProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString), provider, version), connectionString);
+			return new DataConnection(new DataOptions()
+				.UseConnectionString(ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString), provider, version), connectionString));
 		}
 
 		public static DataConnection CreateDataConnection(
@@ -43,7 +44,8 @@ namespace LinqToDB.DataProvider.Oracle
 			OracleVersion version   = OracleVersion.AutoDetect,
 			OracleProvider provider = OracleProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbConnection: connection), provider, version), connection);
+			return new DataConnection(new DataOptions()
+				.UseConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbConnection: connection), provider, version), connection));
 		}
 
 		public static DataConnection CreateDataConnection(
@@ -51,7 +53,8 @@ namespace LinqToDB.DataProvider.Oracle
 			OracleVersion version   = OracleVersion.AutoDetect,
 			OracleProvider provider = OracleProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbTransaction: transaction), provider, version), transaction);
+			return new DataConnection(new DataOptions()
+				.UseTransaction(ProviderDetector.GetDataProvider(new ConnectionOptions(DbTransaction: transaction), provider, version), transaction));
 		}
 
 		#endregion

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLTools.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLTools.cs
@@ -42,17 +42,20 @@ namespace LinqToDB.DataProvider.PostgreSQL
 
 		public static DataConnection CreateDataConnection(string connectionString, PostgreSQLVersion version = PostgreSQLVersion.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString), default, version), connectionString);
+			return new DataConnection(new DataOptions()
+				.UseConnectionString(ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString), default, version), connectionString));
 		}
 
 		public static DataConnection CreateDataConnection(DbConnection connection, PostgreSQLVersion version = PostgreSQLVersion.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbConnection: connection), default, version), connection);
+			return new DataConnection(new DataOptions()
+				.UseConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbConnection: connection), default, version), connection));
 		}
 
 		public static DataConnection CreateDataConnection(DbTransaction transaction, PostgreSQLVersion version = PostgreSQLVersion.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbTransaction: transaction), default, version), transaction);
+			return new DataConnection(new DataOptions()
+				.UseTransaction(ProviderDetector.GetDataProvider(new ConnectionOptions(DbTransaction: transaction), default, version), transaction));
 		}
 
 		#endregion

--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteTools.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteTools.cs
@@ -36,17 +36,20 @@ namespace LinqToDB.DataProvider.SQLite
 
 		public static DataConnection CreateDataConnection(string connectionString, SQLiteProvider provider = SQLiteProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString), provider, default), connectionString);
+			return new DataConnection(new DataOptions()
+				.UseConnectionString(ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString), provider, default), connectionString));
 		}
 
 		public static DataConnection CreateDataConnection(DbConnection connection, SQLiteProvider provider = SQLiteProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbConnection: connection), provider, default), connection);
+			return new DataConnection(new DataOptions()
+				.UseConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbConnection: connection), provider, default), connection));
 		}
 
 		public static DataConnection CreateDataConnection(DbTransaction transaction, SQLiteProvider provider = SQLiteProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbTransaction: transaction), provider, default), transaction);
+			return new DataConnection(new DataOptions()
+				.UseTransaction(ProviderDetector.GetDataProvider(new ConnectionOptions(DbTransaction: transaction), provider, default), transaction));
 		}
 
 		#endregion

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaTools.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaTools.cs
@@ -37,17 +37,20 @@ namespace LinqToDB.DataProvider.SapHana
 
 		public static DataConnection CreateDataConnection(string connectionString, SapHanaProvider provider = SapHanaProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString), provider, default), connectionString);
+			return new DataConnection(new DataOptions()
+				.UseConnectionString(ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString), provider, default), connectionString));
 		}
 
 		public static DataConnection CreateDataConnection(DbConnection connection, SapHanaProvider provider = SapHanaProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbConnection: connection), provider, default), connection);
+			return new DataConnection(new DataOptions()
+				.UseConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbConnection: connection), provider, default), connection));
 		}
 
 		public static DataConnection CreateDataConnection(DbTransaction transaction, SapHanaProvider provider = SapHanaProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbTransaction: transaction), provider, default), transaction);
+			return new DataConnection(new DataOptions()
+				.UseTransaction(ProviderDetector.GetDataProvider(new ConnectionOptions(DbTransaction: transaction), provider, default), transaction));
 		}
 
 		#endregion

--- a/Source/LinqToDB/DataProvider/SqlCe/SqlCeTools.cs
+++ b/Source/LinqToDB/DataProvider/SqlCe/SqlCeTools.cs
@@ -39,17 +39,20 @@ namespace LinqToDB.DataProvider.SqlCe
 
 		public static DataConnection CreateDataConnection(string connectionString)
 		{
-			return new DataConnection(_sqlCeDataProvider.Value, connectionString);
+			return new DataConnection(new DataOptions()
+				.UseConnectionString(_sqlCeDataProvider.Value, connectionString));
 		}
 
 		public static DataConnection CreateDataConnection(DbConnection connection)
 		{
-			return new DataConnection(_sqlCeDataProvider.Value, connection);
+			return new DataConnection(new DataOptions()
+				.UseConnection(_sqlCeDataProvider.Value, connection));
 		}
 
 		public static DataConnection CreateDataConnection(DbTransaction transaction)
 		{
-			return new DataConnection(_sqlCeDataProvider.Value, transaction);
+			return new DataConnection(new DataOptions()
+				.UseTransaction(_sqlCeDataProvider.Value, transaction));
 		}
 
 		#endregion

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerTools.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerTools.cs
@@ -84,7 +84,8 @@ namespace LinqToDB.DataProvider.SqlServer
 			SqlServerVersion  version  = SqlServerVersion.AutoDetect,
 			SqlServerProvider provider = SqlServerProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString), provider, version), connectionString);
+			return new DataConnection(new DataOptions()
+				.UseConnectionString(ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString), provider, version), connectionString));
 		}
 
 		public static DataConnection CreateDataConnection(
@@ -92,7 +93,8 @@ namespace LinqToDB.DataProvider.SqlServer
 			SqlServerVersion  version  = SqlServerVersion.AutoDetect,
 			SqlServerProvider provider = SqlServerProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbConnection: connection), provider, version), connection);
+			return new DataConnection(new DataOptions()
+				.UseConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbConnection: connection), provider, version), connection));
 		}
 
 		public static DataConnection CreateDataConnection(
@@ -100,7 +102,8 @@ namespace LinqToDB.DataProvider.SqlServer
 			SqlServerVersion  version  = SqlServerVersion.AutoDetect,
 			SqlServerProvider provider = SqlServerProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbTransaction: transaction), provider, version), transaction);
+			return new DataConnection(new DataOptions()
+				.UseTransaction(ProviderDetector.GetDataProvider(new ConnectionOptions(DbTransaction: transaction), provider, version), transaction));
 		}
 
 		#endregion

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseTools.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseTools.cs
@@ -34,17 +34,20 @@ namespace LinqToDB.DataProvider.Sybase
 
 		public static DataConnection CreateDataConnection(string connectionString, SybaseProvider provider = SybaseProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString), provider, default), connectionString);
+			return new DataConnection(new DataOptions()
+				.UseConnectionString(ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString), provider, default), connectionString));
 		}
 
 		public static DataConnection CreateDataConnection(DbConnection connection, SybaseProvider provider = SybaseProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbConnection: connection), provider, default), connection);
+			return new DataConnection(new DataOptions()
+				.UseConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbConnection: connection), provider, default), connection));
 		}
 
 		public static DataConnection CreateDataConnection(DbTransaction transaction, SybaseProvider provider = SybaseProvider.AutoDetect)
 		{
-			return new DataConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbTransaction: transaction), provider, default), transaction);
+			return new DataConnection(new DataOptions()
+				.UseTransaction(ProviderDetector.GetDataProvider(new ConnectionOptions(DbTransaction: transaction), provider, default), transaction));
 		}
 
 		#endregion

--- a/Source/LinqToDB/Extensions/DataOptionsExtensions.cs
+++ b/Source/LinqToDB/Extensions/DataOptionsExtensions.cs
@@ -688,6 +688,8 @@ namespace LinqToDB
 		/// <summary>
 		/// Defines configuration sting to use with DataOptions.
 		/// </summary>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Use UseConfiguration method instead"), EditorBrowsable(EditorBrowsableState.Never)]
 		[Pure]
 		public static DataOptions UseConfigurationString(this DataOptions options, string? configurationString)
 		{
@@ -697,6 +699,8 @@ namespace LinqToDB
 		/// <summary>
 		/// Defines configuration sting and MappingSchema to use with DataOptions.
 		/// </summary>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7. Use UseConfiguration method instead"), EditorBrowsable(EditorBrowsableState.Never)]
 		[Pure]
 		public static DataOptions UseConfigurationString(this DataOptions options, string configurationString, MappingSchema mappingSchema)
 		{
@@ -717,7 +721,7 @@ namespace LinqToDB
 		/// Defines configuration sting and MappingSchema to use with DataOptions.
 		/// </summary>
 		[Pure]
-		public static DataOptions UseConfiguration(this DataOptions options, string configurationString, MappingSchema mappingSchema)
+		public static DataOptions UseConfiguration(this DataOptions options, string? configurationString, MappingSchema mappingSchema)
 		{
 			return options
 				.WithOptions<ConnectionOptions> (o => o with { ConfigurationString = configurationString, MappingSchema = mappingSchema });

--- a/Tests/Base/TestBase.Context.cs
+++ b/Tests/Base/TestBase.Context.cs
@@ -120,7 +120,7 @@ namespace Tests
 
 			Debug.WriteLine(configuration, "Provider ");
 
-			var options = new DataOptions().UseConfigurationString(configuration);
+			var options = new DataOptions().UseConfiguration(configuration);
 
 			if (configuration.IsAnyOf(TestProvName.AllSqlServerSequentialAccess))
 			{

--- a/Tests/Linq/Data/DataConnectionTests.cs
+++ b/Tests/Linq/Data/DataConnectionTests.cs
@@ -34,7 +34,7 @@ namespace Tests.Data
 			var connectionString = DataConnection.GetConnectionString(context);
 			var dataProvider     = DataConnection.GetDataProvider(context);
 
-			using (var conn = new DataConnection(dataProvider, connectionString))
+			using (var conn = new DataConnection(new DataOptions().UseConnectionString(dataProvider, connectionString)))
 			{
 				Assert.Multiple(() =>
 				{
@@ -337,7 +337,7 @@ namespace Tests.Data
 		public void TestServiceCollection1([IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
 		{
 			var collection = new ServiceCollection();
-			collection.AddLinqToDB((serviceProvider, options) => options.UseConfigurationString(context));
+			collection.AddLinqToDB((serviceProvider, options) => options.UseConfiguration(context));
 			var provider = collection.BuildServiceProvider();
 			var con = provider.GetService<IDataContext>()!;
 			Assert.Multiple(() =>
@@ -351,7 +351,7 @@ namespace Tests.Data
 		public void TestServiceCollection2([IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
 		{
 			var collection = new ServiceCollection();
-			collection.AddLinqToDBContext<DataConnection>((serviceProvider, options) => options.UseConfigurationString(context));
+			collection.AddLinqToDBContext<DataConnection>((serviceProvider, options) => options.UseConfiguration(context));
 			var provider = collection.BuildServiceProvider();
 			var con = provider.GetService<DataConnection>()!;
 			Assert.That(con.ConfigurationString, Is.EqualTo(context));
@@ -362,7 +362,7 @@ namespace Tests.Data
 		{
 			var collection = new ServiceCollection();
 			collection.AddTransient<DummyService>();
-			collection.AddLinqToDBContext<DbConnection3>((serviceProvider, options) => options.UseConfigurationString(context));
+			collection.AddLinqToDBContext<DbConnection3>((serviceProvider, options) => options.UseConfiguration(context));
 			var provider = collection.BuildServiceProvider();
 			var con = provider.GetService<DbConnection3>()!;
 			Assert.That(con.ConfigurationString, Is.EqualTo(context));
@@ -372,7 +372,7 @@ namespace Tests.Data
 		public void TestServiceCollection_Issue4326_Positive([IncludeDataSources(TestProvName.AllSQLite)] string context)
 		{
 			var collection = new ServiceCollection();
-			collection.AddLinqToDBContext<IDataContext, DbConnection1>((serviceProvider, options) => options.UseConfigurationString(context));
+			collection.AddLinqToDBContext<IDataContext, DbConnection1>((serviceProvider, options) => options.UseConfiguration(context));
 			var provider = collection.BuildServiceProvider();
 			var con = provider.GetService<IDataContext>()!;
 			Assert.That(con, Is.TypeOf<DbConnection1>());
@@ -383,7 +383,7 @@ namespace Tests.Data
 		public void TestServiceCollection_Issue4326_Compat([IncludeDataSources(TestProvName.AllSQLite)] string context)
 		{
 			var collection = new ServiceCollection();
-			collection.AddLinqToDBContext<IDataContext, DbConnection4>((serviceProvider, options) => options.UseConfigurationString(context));
+			collection.AddLinqToDBContext<IDataContext, DbConnection4>((serviceProvider, options) => options.UseConfiguration(context));
 			var provider = collection.BuildServiceProvider();
 			var con = provider.GetService<IDataContext>()!;
 			Assert.That(con, Is.TypeOf<DbConnection4>());
@@ -437,7 +437,7 @@ namespace Tests.Data
 		{
 			var collection = new ServiceCollection();
 
-			collection.AddLinqToDBContext<DbConnection5>((_, options) => options.UseConfigurationString(context).UseCommandTimeout(91));
+			collection.AddLinqToDBContext<DbConnection5>((_, options) => options.UseConfiguration(context).UseCommandTimeout(91));
 
 			var provider = collection.BuildServiceProvider();
 			var con      = provider.GetService<DbConnection5>()!;
@@ -449,7 +449,7 @@ namespace Tests.Data
 		public void TestSettingsPerDb([IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
 		{
 			var collection = new ServiceCollection();
-			collection.AddLinqToDBContext<DbConnection1>((provider, options) => options.UseConfigurationString(context));
+			collection.AddLinqToDBContext<DbConnection1>((provider, options) => options.UseConfiguration(context));
 			collection.AddLinqToDBContext<DbConnection2>((provider, options) => options);
 
 			var serviceProvider = collection.BuildServiceProvider();

--- a/Tests/Linq/Data/InterceptorsTests.cs
+++ b/Tests/Linq/Data/InterceptorsTests.cs
@@ -92,7 +92,7 @@ namespace Tests.Data
 			var interceptor2 = new TestCommandInterceptor();
 
 			var builder = new DataOptions()
-				.UseConfigurationString(context)
+				.UseConfiguration(context)
 				.UseInterceptor(interceptor1)
 				.UseInterceptor(interceptor2);
 
@@ -153,7 +153,7 @@ namespace Tests.Data
 			var interceptor2 = new TestCommandInterceptor();
 
 			var builder = new DataOptions()
-				.UseConfigurationString(context)
+				.UseConfiguration(context)
 				.UseInterceptor(interceptor1)
 				.UseInterceptor(interceptor2);
 

--- a/Tests/Linq/Data/MiniProfilerTests.cs
+++ b/Tests/Linq/Data/MiniProfilerTests.cs
@@ -74,7 +74,7 @@ namespace Tests.Data
 		{
 			public MiniProfilerDataContext(string configurationString)
 #pragma warning disable CA2000 // Dispose objects before losing scope
-				: base(GetDataProvider(), GetConnection(configurationString)) { }
+				: base(new DataOptions().UseConnection(GetDataProvider(), GetConnection(configurationString))) { }
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
 			private static IDataProvider GetDataProvider()

--- a/Tests/Linq/Data/TraceTests.cs
+++ b/Tests/Linq/Data/TraceTests.cs
@@ -57,7 +57,7 @@ namespace Tests.Data
 			var counters = GetEnumValues((TraceInfoStep s) => 0);
 
 			using (var db0 = (TestDataConnection)GetDataContext(context))
-			using (var db  = new DataContext(db0.DataProvider.Name, "BAD"))
+			using (var db  = new DataContext(new DataOptions().UseConnectionString(db0.DataProvider.Name, "BAD")))
 			{
 				db.OnTraceConnection = e =>
 				{
@@ -91,7 +91,7 @@ namespace Tests.Data
 			var counters = GetEnumValues((TraceInfoStep s) => 0);
 
 			using (var db0 = (TestDataConnection)GetDataContext(context))
-			using (var db  = new DataContext(db0.DataProvider.Name, "BAD"))
+			using (var db  = new DataContext(new DataOptions().UseConnectionString(db0.DataProvider.Name, "BAD")))
 			{
 				db.OnTraceConnection = e =>
 				{

--- a/Tests/Linq/DataProvider/AccessTests.cs
+++ b/Tests/Linq/DataProvider/AccessTests.cs
@@ -455,7 +455,7 @@ namespace Tests.DataProvider
 			Assert.That(File.Exists(expectedName), Is.True);
 
 			var connectionString = $"Provider={providerName};Data Source={expectedName};Locale Identifier=1033;Persist Security Info=True";
-			using (var db = new DataConnection(AccessTools.GetDataProvider(version, AccessProvider.AutoDetect, connectionString), connectionString))
+			using (var db = new DataConnection(new DataOptions().UseConnectionString(AccessTools.GetDataProvider(version, AccessProvider.AutoDetect, connectionString), connectionString)))
 			{
 				db.CreateTable<SqlCeTests.CreateTableTest>();
 				db.DropTable<SqlCeTests.CreateTableTest>();

--- a/Tests/Linq/DataProvider/ExpressionTests.cs
+++ b/Tests/Linq/DataProvider/ExpressionTests.cs
@@ -2,6 +2,7 @@
 using System.Data.Common;
 using System.Linq.Expressions;
 
+using LinqToDB;
 using LinqToDB.Common;
 using LinqToDB.Data;
 
@@ -18,7 +19,7 @@ namespace Tests.DataProvider
 			var connectionString = DataConnection.GetConnectionString(context);
 			var dataProvider     = DataConnection.GetDataProvider(context);
 
-			using (var conn = new DataConnection(dataProvider, connectionString))
+			using (var conn = new DataConnection(new DataOptions().UseConnectionString(dataProvider, connectionString)))
 			using (var rd = conn.ExecuteReader("SELECT 1"))
 			{
 				if (rd.Reader!.Read())

--- a/Tests/Linq/DataProvider/OracleTests.cs
+++ b/Tests/Linq/DataProvider/OracleTests.cs
@@ -2117,7 +2117,7 @@ namespace Tests.DataProvider
 
 			provider.ReaderExpressions[new ReaderInfo { FieldType = typeof(decimal) }] = (Expression<Func<DbDataReader, int, decimal>>)((r,i) => GetDecimal(r, i));
 
-			using (var db = new DataConnection(provider, DataConnection.GetConnectionString(context)))
+			using (var db = new DataConnection(new DataOptions().UseConnectionString(provider, DataConnection.GetConnectionString(context))))
 			{
 				var list = db.GetTable<DecimalOverflow>().ToList();
 			}
@@ -4032,7 +4032,7 @@ CREATE TABLE ""TABLE_A""(
 			if ((copyType == BulkCopyType.ProviderSpecific || copyType == BulkCopyType.Default) && !keepIdentity)
 				Assert.Inconclusive($"{nameof(BulkCopyType.ProviderSpecific)} doesn't support {nameof(BulkCopyOptions.KeepIdentity)} = false mode");
 
-			using (var db    = new DataConnection(context, o => o.UseOracle(o => o with { AlternativeBulkCopy = multipeRowsMode })))
+			using (var db    = new DataConnection(new DataOptions().UseConfiguration(context).UseOracle(o => o with { AlternativeBulkCopy = multipeRowsMode })))
 			using (var table = db.CreateLocalTable<NativeIdentity>())
 			{
 				var ms = new MappingSchema();

--- a/Tests/Linq/DataProvider/SQLiteTests.cs
+++ b/Tests/Linq/DataProvider/SQLiteTests.cs
@@ -539,7 +539,7 @@ namespace Tests.DataProvider
 			Assert.That(File.Exists ("TestDatabase.sqlite"), Is.True);
 
 			var provider = context.IsAnyOf(TestProvName.AllSQLiteClassic) ? SQLiteProvider.System : SQLiteProvider.Microsoft;
-			using (var db = new DataConnection(SQLiteTools.GetDataProvider(provider), "Data Source=TestDatabase.sqlite"))
+			using (var db = new DataConnection(new DataOptions().UseConnectionString(SQLiteTools.GetDataProvider(provider), "Data Source=TestDatabase.sqlite")))
 			{
 				db.CreateTable<CreateTableTest>();
 				db.DropTable  <CreateTableTest>();
@@ -672,7 +672,7 @@ namespace Tests.DataProvider
 			if (context.Contains("Classic") && columnType != "TEXT")
 				Assert.Inconclusive("System.Data.SQLite doesn't supports only ISO8601 dates as of v1.0.108");
 
-			using var db    = new DataConnection(context, ConfigureMapping(columnType));
+			using var db    = new DataConnection(new DataOptions().UseConfiguration(context, ConfigureMapping(columnType)));
 			using var table = db.CreateLocalTable<DateTimeTable>();
 
 			db.InlineParameters = inline;
@@ -721,7 +721,7 @@ namespace Tests.DataProvider
 			if (context.Contains("Classic") && columnType != "TEXT")
 				Assert.Inconclusive("System.Data.SQLite doesn't supports only ISO8601 dates as of v1.0.108");
 
-			using var db    = new DataConnection(context, ConfigureMapping(columnType));
+			using var db    = new DataConnection(new DataOptions().UseConfiguration(context, ConfigureMapping(columnType)));
 			using var table = db.CreateLocalTable<DateTimeTable>();
 
 			db.InlineParameters = inline;

--- a/Tests/Linq/DataProvider/SqlCeTests.cs
+++ b/Tests/Linq/DataProvider/SqlCeTests.cs
@@ -462,7 +462,7 @@ namespace Tests.DataProvider
 			SqlCeTools.CreateDatabase ("TestDatabase");
 			Assert.That(File.Exists ("TestDatabase.sdf"), Is.True);
 
-			using (var db = new DataConnection(SqlCeTools.GetDataProvider(), "Data Source=TestDatabase.sdf"))
+			using (var db = new DataConnection(new DataOptions().UseConnectionString(SqlCeTools.GetDataProvider(), "Data Source=TestDatabase.sdf")))
 			{
 				db.CreateTable<CreateTableTest>();
 				db.DropTable  <CreateTableTest>();

--- a/Tests/Linq/DataProvider/SqlServerTests.cs
+++ b/Tests/Linq/DataProvider/SqlServerTests.cs
@@ -1471,7 +1471,7 @@ namespace Tests.DataProvider
 
 			provider.ReaderExpressions[new ReaderInfo { FieldType = typeof(decimal) }] = (Expression<Func<DbDataReader, int, decimal>>)((r, i) => GetDecimal(r, i));
 
-			using (var db = new DataConnection(provider, DataConnection.GetConnectionString(context)))
+			using (var db = new DataConnection(new DataOptions().UseConnectionString(provider, DataConnection.GetConnectionString(context))))
 			{
 				var list = db.GetTable<DecimalOverflow>().ToList();
 			}

--- a/Tests/Linq/Linq/DataContextTests.cs
+++ b/Tests/Linq/Linq/DataContextTests.cs
@@ -75,7 +75,7 @@ namespace Tests.Linq
 		{
 			using (var db = (TestDataConnection)GetDataContext(context))
 			{
-				Assert.Throws<LinqToDBException>(() => new DataContext("BAD", db.ConnectionString!));
+				Assert.Throws<LinqToDBException>(() => new DataContext(new DataOptions().UseConnectionString("BAD", db.ConnectionString!)));
 			}
 
 		}
@@ -83,7 +83,7 @@ namespace Tests.Linq
 		public void ProviderConnectionStringConstructorTest2([DataSources(false)] string context)
 		{
 			using (var db = (TestDataConnection)GetDataContext(context))
-			using (var db1 = new DataContext(db.DataProvider.Name, "BAD"))
+			using (var db1 = new DataContext(new DataOptions().UseConnectionString(db.DataProvider.Name, "BAD")))
 			{
 				Assert.That(
 					() => db1.GetTable<Child>().ToList(),
@@ -96,7 +96,7 @@ namespace Tests.Linq
 		public void ProviderConnectionStringConstructorTest3([DataSources(false)] string context)
 		{
 			using (var db = (TestDataConnection)GetDataContext(context))
-			using (var db1 = new DataContext(db.DataProvider.Name, db.ConnectionString!))
+			using (var db1 = new DataContext(new DataOptions().UseConnectionString(db.DataProvider.Name, db.ConnectionString!)))
 			{
 				Assert.Multiple(() =>
 				{

--- a/Tests/Linq/Linq/QueryFilterTests.cs
+++ b/Tests/Linq/Linq/QueryFilterTests.cs
@@ -111,7 +111,7 @@ namespace Tests.Linq
 
 		sealed class MyDataContext : DataConnection
 		{
-			public MyDataContext(string configuration, MappingSchema mappingSchema) : base(configuration, mappingSchema)
+			public MyDataContext(string configuration, MappingSchema mappingSchema) : base(new DataOptions().UseConfiguration(configuration, mappingSchema))
 			{
 
 			}

--- a/Tests/Linq/Samples/ConcurrencyCheckTests.cs
+++ b/Tests/Linq/Samples/ConcurrencyCheckTests.cs
@@ -17,7 +17,7 @@ namespace Tests.Samples
 	{
 		sealed class InterceptDataConnection : DataConnection
 		{
-			public InterceptDataConnection(string providerName, string connectionString) : base(providerName, connectionString)
+			public InterceptDataConnection(string providerName, string connectionString) : base(new DataOptions().UseConnectionString(providerName, connectionString))
 			{
 			}
 

--- a/Tests/Linq/Samples/JsonConvertTests.cs
+++ b/Tests/Linq/Samples/JsonConvertTests.cs
@@ -84,7 +84,7 @@ namespace Tests.Samples
 			MappingHelper.GenerateConvertorsForTables(typeof(MyDataConnection), _convertorSchema);
 		}
 
-		public MyDataConnection(string providerName, string connectionString, MappingSchema mappingSchema) : base(providerName, connectionString, mappingSchema)
+		public MyDataConnection(string providerName, string connectionString, MappingSchema mappingSchema) : base(new DataOptions().UseConnectionString(providerName, connectionString).UseMappingSchema(mappingSchema))
 		{
 			AddMappingSchema(_convertorSchema);
 		}

--- a/Tests/Linq/SchemaProvider/SchemaProviderTests.cs
+++ b/Tests/Linq/SchemaProvider/SchemaProviderTests.cs
@@ -312,7 +312,7 @@ namespace Tests.SchemaProvider
 		public void SchemaProviderNormalizeName([IncludeDataSources(TestProvName.AllSQLiteClassic)]
 			string context)
 		{
-			using (var db = new DataConnection(context, "Data Source=:memory:;"))
+			using (var db = new DataConnection(new DataOptions().UseConnectionString(context, "Data Source=:memory:;")))
 			{
 				db.Execute(
 					@"create table Customer

--- a/Tests/Linq/Update/BulkCopyTests.cs
+++ b/Tests/Linq/Update/BulkCopyTests.cs
@@ -436,7 +436,7 @@ namespace Tests.xUpdate
 		)
 		{
 			// This makes use of array-bound parameters, which is a unique code-path in OracleBulkCopy (issue #4385)
-			using var db    = new DataConnection(context, o => o.UseOracle(o => o with { AlternativeBulkCopy = AlternativeBulkCopy.InsertInto }));
+			using var db    = new DataConnection(new DataOptions().UseConfiguration(context).UseOracle(o => o with { AlternativeBulkCopy = AlternativeBulkCopy.InsertInto }));
 			var options     = GetDefaultBulkCopyOptions(context) with { BulkCopyType = BulkCopyType.MultipleRows };
 			using var table = db.CreateLocalTable<DateOnlyTable>();
 			
@@ -940,7 +940,7 @@ namespace Tests.xUpdate
 			[Values(AlternativeBulkCopy.InsertDual, AlternativeBulkCopy.InsertInto)] AlternativeBulkCopy alternateCopyType)
 		{
 			var interceptor = new TestDataContextInterceptor();
-			using var db    = new DataConnection(context, o => o.UseOracle(o => o with { AlternativeBulkCopy = alternateCopyType }));
+			using var db    = new DataConnection(new DataOptions().UseConfiguration(context).UseOracle(o => o with { AlternativeBulkCopy = alternateCopyType }));
 			using var table = db.CreateLocalTable<SimpleBulkCopyTable>();
 			var options     = GetDefaultBulkCopyOptions(context) with { BulkCopyType = BulkCopyType.MultipleRows };
 
@@ -963,7 +963,7 @@ namespace Tests.xUpdate
 			[Values(AlternativeBulkCopy.InsertDual, AlternativeBulkCopy.InsertInto)] AlternativeBulkCopy alternateCopyType)
 		{
 			var interceptor = new TestDataContextInterceptor();
-			using var db    = new DataConnection(context, o => o.UseOracle(o => o with { AlternativeBulkCopy = alternateCopyType }));
+			using var db    = new DataConnection(new DataOptions().UseConfiguration(context).UseOracle(o => o with { AlternativeBulkCopy = alternateCopyType }));
 			using var table = db.CreateLocalTable<SimpleBulkCopyTable>();
 			var options     = GetDefaultBulkCopyOptions(context) with { BulkCopyType = BulkCopyType.MultipleRows };
 
@@ -1065,7 +1065,7 @@ namespace Tests.xUpdate
 				new Inherited3 { Id = 3, Value3 = "Str3", NullableBool = true },
 			};
 
-			using (var db = new DataConnection(context, ms))
+			using (var db = new DataConnection(new DataOptions().UseConfiguration(context, ms)))
 			using (var table = db.CreateLocalTable<BaseClass>())
 			{
 				var options = GetDefaultBulkCopyOptions(context) with { BulkCopyType = copyType };

--- a/Tests/Linq/UserTests/GenericsFilterTests.cs
+++ b/Tests/Linq/UserTests/GenericsFilterTests.cs
@@ -39,8 +39,7 @@ namespace Tests.UserTests
 
 		void CheckPredicate(Expression<Func<Firm, bool>> predicate, string context)
 		{
-			using (var db = new DataConnection(context,
-				context == ProviderName.SQLiteMS ? "Data Source=:memory:;" : "Data Source=:memory:;Version=3;New=True;"))
+			using (var db = new DataConnection(new DataOptions().UseConnectionString(context, context == ProviderName.SQLiteMS ? "Data Source=:memory:;" : "Data Source=:memory:;Version=3;New=True;")))
 			{
 				db.CreateTable<TypeA>();
 				db.CreateTable<TypeB>();

--- a/Tests/Linq/UserTests/Issue0010Tests.cs
+++ b/Tests/Linq/UserTests/Issue0010Tests.cs
@@ -15,7 +15,7 @@ namespace Tests.UserTests
 		public void TestOleDb([IncludeDataSources(ProviderName.AccessAceOleDb)] string context)
 		{
 			var cs = DataConnection.GetConnectionString(context);
-			using (var db = new DataConnection(AccessTools.GetDataProvider(provider: AccessProvider.OleDb, connectionString: cs), "Provider=Microsoft.ACE.OLEDB.12.0;Data Source=Database\\issue_10_linqpad.accdb;"))
+			using (var db = new DataConnection(new DataOptions().UseConnectionString(AccessTools.GetDataProvider(provider: AccessProvider.OleDb, connectionString: cs), "Provider=Microsoft.ACE.OLEDB.12.0;Data Source=Database\\issue_10_linqpad.accdb;")))
 			{
 				var schemaProvider = db.DataProvider.GetSchemaProvider();
 
@@ -35,7 +35,7 @@ namespace Tests.UserTests
 		public void TestOdbc([IncludeDataSources(ProviderName.AccessAceOdbc)] string context)
 		{
 			var cs = DataConnection.GetConnectionString(context);
-			using (var db = new DataConnection(AccessTools.GetDataProvider(provider: AccessProvider.ODBC, connectionString: cs), "Driver={Microsoft Access Driver (*.mdb, *.accdb)};Dbq=Database\\issue_10_linqpad.accdb;"))
+			using (var db = new DataConnection(new DataOptions().UseConnectionString(AccessTools.GetDataProvider(provider: AccessProvider.ODBC, connectionString: cs), "Driver={Microsoft Access Driver (*.mdb, *.accdb)};Dbq=Database\\issue_10_linqpad.accdb;")))
 			{
 				var schemaProvider = db.DataProvider.GetSchemaProvider();
 

--- a/Tests/Linq/UserTests/Issue1164Tests.cs
+++ b/Tests/Linq/UserTests/Issue1164Tests.cs
@@ -1,4 +1,5 @@
-﻿using LinqToDB.Data;
+﻿using LinqToDB;
+using LinqToDB.Data;
 using LinqToDB.DataProvider.Access;
 
 using NUnit.Framework;
@@ -13,7 +14,7 @@ namespace Tests.UserTests
 		{
 			var cs = DataConnection.GetConnectionString(context).Replace("TestData", "issue_1164");
 
-			using (var db = new DataConnection(AccessTools.GetDataProvider(provider: AccessProvider.OleDb, connectionString: cs), cs))
+			using (var db = new DataConnection(new DataOptions().UseConnectionString(AccessTools.GetDataProvider(provider: AccessProvider.OleDb, connectionString: cs), cs)))
 			{
 				var schemaProvider = db.DataProvider.GetSchemaProvider();
 
@@ -27,7 +28,7 @@ namespace Tests.UserTests
 		public void TestOdbc([IncludeDataSources(TestProvName.AllAccessOdbc)] string context)
 		{
 			var cs = DataConnection.GetConnectionString(context).Replace("TestData.ODBC", "issue_1164");
-			using (var db = new DataConnection(AccessTools.GetDataProvider(provider: AccessProvider.ODBC, connectionString: cs), cs))
+			using (var db = new DataConnection(new DataOptions().UseConnectionString(AccessTools.GetDataProvider(provider: AccessProvider.ODBC, connectionString: cs), cs)))
 			{
 				var schemaProvider = db.DataProvider.GetSchemaProvider();
 

--- a/Tests/Linq/UserTests/Issue1174Tests.cs
+++ b/Tests/Linq/UserTests/Issue1174Tests.cs
@@ -38,7 +38,7 @@ namespace Tests.UserTests
 				: base(configuration)
 			{
 			}
-			public MyDB(IDataProvider dataProvider, string connectionString) : base(dataProvider, connectionString)
+			public MyDB(IDataProvider dataProvider, string connectionString) : base(new DataOptions().UseConnectionString(dataProvider, connectionString))
 			{
 			}
 		}

--- a/Tests/Linq/UserTests/Issue1438Tests.cs
+++ b/Tests/Linq/UserTests/Issue1438Tests.cs
@@ -70,7 +70,7 @@ namespace Tests.UserTests
 				.Build();
 
 			using (var cn = new NpgsqlConnection(cs))
-			using (var db = new DataConnection(provider, cn))
+			using (var db = new DataConnection(new DataOptions().UseConnection(provider, cn)))
 			{
 				db.AddMappingSchema(ms);
 				using (var tbl = db.CreateLocalTable<Client>())

--- a/Tests/Linq/UserTests/Issue1486Tests.cs
+++ b/Tests/Linq/UserTests/Issue1486Tests.cs
@@ -18,7 +18,7 @@ namespace Tests.UserTests
 		public class IssueDataConnection : DataConnection
 		{
 			public IssueDataConnection(string configuration)
-				: base(GetDataProvider(configuration), GetConnection(configuration), true)
+				: base(new DataOptions().UseConnection(GetDataProvider(configuration), GetConnection(configuration), true))
 			{
 				// to avoid mapper conflict with SequentialAccess test provider
 				AddMappingSchema(new MappingSchema());
@@ -40,7 +40,7 @@ namespace Tests.UserTests
 		public class FactoryDataConnection : DataConnection
 		{
 			public FactoryDataConnection(string configuration)
-				: base(GetDataProvider(configuration), _ => GetConnection(configuration))
+				: base(new DataOptions().UseConnectionFactory(GetDataProvider(configuration), _ => GetConnection(configuration)))
 			{
 				// to avoid mapper conflict with SequentialAccess test provider
 				AddMappingSchema(new MappingSchema());

--- a/Tests/Linq/UserTests/Issue3251Tests.cs
+++ b/Tests/Linq/UserTests/Issue3251Tests.cs
@@ -29,7 +29,7 @@ namespace Tests.UserTests
 			var mb = new FluentMappingBuilder(ms);
 			mb.Entity<Class1>().HasTableName("Class1Table").Build();
 
-			using (var db = new DataConnection("SQLite.MS", ms))
+			using (var db = new DataConnection(new DataOptions().UseConfiguration(ProviderName.SQLiteMS, ms)))
 			{
 				using (var u = db.CreateLocalTable<Class1>())
 				{
@@ -40,7 +40,7 @@ namespace Tests.UserTests
 			var newMs = new MappingSchema(ms);
 			var mb2 = new FluentMappingBuilder(newMs);
 			mb2.Entity<Class2>().HasTableName("Class2Table").Build();
-			using (var db = new DataConnection("SQLite.MS", newMs))
+			using (var db = new DataConnection(new DataOptions().UseConfiguration(ProviderName.SQLiteMS, newMs)))
 			{
 				var ed1 = newMs.GetEntityDescriptor(typeof(Class2));
 				var ed2 = db.MappingSchema.GetEntityDescriptor(typeof(Class2));

--- a/Tests/Linq/UserTests/Issue464Tests.cs
+++ b/Tests/Linq/UserTests/Issue464Tests.cs
@@ -34,7 +34,7 @@ namespace Tests.UserTests
 				  .HasColumn(x => x.Value)
 				  .Build();
 
-			using (var db = new DataConnection(context, o => o.UseFirebird(o => o with { IdentifierQuoteMode = FirebirdIdentifierQuoteMode.Auto })))
+			using (var db = new DataConnection(new DataOptions().UseConfiguration(context).UseFirebird(o => o with { IdentifierQuoteMode = FirebirdIdentifierQuoteMode.Auto })))
 			{
 				db.AddMappingSchema(schema);
 				try

--- a/Tests/Linq/UserTests/Issue927Tests.cs
+++ b/Tests/Linq/UserTests/Issue927Tests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Data;
 
+using LinqToDB;
 using LinqToDB.Data;
 
 using NUnit.Framework;
@@ -9,15 +10,15 @@ namespace Tests.UserTests
 	[TestFixture]
 	public class Issue927Tests
 	{
-		[Test, Theory]
-		public void ExternalConnectionDisposing(bool dispose)
+		[Test]
+		public void ExternalConnectionDisposing([Values] bool dispose)
 		{
 #pragma warning disable CA2000 // Dispose objects before losing scope
 			var connection = new TestNoopConnection("");
 #pragma warning restore CA2000 // Dispose objects before losing scope
 			Assert.That(connection.State, Is.EqualTo(ConnectionState.Closed));
 
-			using (var db = new DataConnection(new TestNoopProvider(), connection, dispose))
+			using (var db = new DataConnection(new DataOptions().UseConnection(new TestNoopProvider(), connection, dispose)))
 			{
 				var c = db.Connection;
 				Assert.That(c.State, Is.EqualTo(ConnectionState.Open));
@@ -35,7 +36,7 @@ namespace Tests.UserTests
 		{
 			TestNoopConnection? connection;
 
-			using (var db = new DataConnection(new TestNoopProvider(), ""))
+			using (var db = new DataConnection(new DataOptions().UseConnectionString(new TestNoopProvider(), "")))
 			{
 				connection = db.Connection as TestNoopConnection;
 				Assert.That(connection, Is.Not.Null);
@@ -59,7 +60,7 @@ namespace Tests.UserTests
 
 			Assert.That(connection.State, Is.EqualTo(ConnectionState.Open));
 
-			using (var db = new DataConnection(new TestNoopProvider(), connection, false))
+			using (var db = new DataConnection(new DataOptions().UseConnection(new TestNoopProvider(), connection, false)))
 			{
 				var c = db.Connection;
 				Assert.That(c.State, Is.EqualTo(ConnectionState.Open));

--- a/Tests/Model/TestDataConnection.cs
+++ b/Tests/Model/TestDataConnection.cs
@@ -15,7 +15,7 @@ namespace Tests.Model
 		{
 		}
 
-		public TestDataConnection(Func<DataOptions,DataOptions> optionsSetter) : base(optionsSetter)
+		public TestDataConnection(Func<DataOptions,DataOptions> optionsSetter) : base(optionsSetter(new DataOptions()))
 		{
 		}
 

--- a/Tests/Tests.Benchmarks/Benchmarks/Queries/ConcurrentBenchmark.cs
+++ b/Tests/Tests.Benchmarks/Benchmarks/Queries/ConcurrentBenchmark.cs
@@ -60,7 +60,7 @@ namespace LinqToDB.Benchmarks.Queries
 
 			for (var i = 0; i < _threads.Length; i++)
 			{
-				_db[i]                   = new DataConnection(PostgreSQLTools.GetDataProvider(PostgreSQLVersion.v95), _cn);
+				_db[i]                   = new DataConnection(new DataOptions().UseConnection(PostgreSQLTools.GetDataProvider(PostgreSQLVersion.v95), _cn));
 				_threads[i]              = new Thread(ThreadWorker);
 				_threads[i].IsBackground = true; // we don't stop threads explicitly
 				_threads[i].Start(i);

--- a/Tests/Tests.Benchmarks/Benchmarks/Queries/Issue3253Benchmark.cs
+++ b/Tests/Tests.Benchmarks/Benchmarks/Queries/Issue3253Benchmark.cs
@@ -25,7 +25,7 @@ namespace LinqToDB.Benchmarks.Queries
 		public void Setup()
 		{
 			_cn = new MockDbConnection(new QueryResult() { Return = 1 }, ConnectionState.Open);
-			_db = new DataConnection(SQLiteTools.GetDataProvider(SQLiteProvider.Microsoft), _cn);
+			_db = new DataConnection(new DataOptions().UseConnection(SQLiteTools.GetDataProvider(SQLiteProvider.Microsoft), _cn));
 
 			_compiledInsert = CompiledQuery.Compile<DataConnection, string, string, string, decimal, decimal, int>((ctx, key, value1, value2, value3, value4) =>
 				ctx.GetTable<TESTTABLE>()

--- a/Tests/Tests.Benchmarks/Benchmarks/Queries/Issue3268Benchmark.cs
+++ b/Tests/Tests.Benchmarks/Benchmarks/Queries/Issue3268Benchmark.cs
@@ -24,7 +24,7 @@ namespace LinqToDB.Benchmarks.Queries
 		public void Setup()
 		{
 			_cn = new MockDbConnection(new QueryResult() { Return = 1 }, ConnectionState.Open);
-			_db = new DataConnection(SqlServerTools.GetDataProvider(SqlServerVersion.v2008, SqlServerProvider.MicrosoftDataSqlClient), _cn);
+			_db = new DataConnection(new DataOptions().UseConnection(SqlServerTools.GetDataProvider(SqlServerVersion.v2008, SqlServerProvider.MicrosoftDataSqlClient), _cn));
 
 			_compiled = CompiledQuery.Compile<DataConnection, int, int>((ctx, i) =>
 				ctx.GetTable<MyPOCO>()
@@ -62,7 +62,7 @@ namespace LinqToDB.Benchmarks.Queries
 		{
 			for (var i = 0; i < _iterations; i++)
 			{
-				using (var db = new DataConnection(SqlServerTools.GetDataProvider(SqlServerVersion.v2008, SqlServerProvider.MicrosoftDataSqlClient), _cn))
+				using (var db = new DataConnection(new DataOptions().UseConnection(SqlServerTools.GetDataProvider(SqlServerVersion.v2008, SqlServerProvider.MicrosoftDataSqlClient), _cn)))
 				{
 					db.GetTable<MyPOCON>()
 						.Where(p => p.Code == "A" + i && p.Currency == "SUR")
@@ -88,7 +88,7 @@ namespace LinqToDB.Benchmarks.Queries
 		{
 			for (var i = 0; i < _iterations; i++)
 			{
-				using (var db = new DataConnection(SqlServerTools.GetDataProvider(SqlServerVersion.v2008, SqlServerProvider.MicrosoftDataSqlClient), _cn))
+				using (var db = new DataConnection(new DataOptions().UseConnection(SqlServerTools.GetDataProvider(SqlServerVersion.v2008, SqlServerProvider.MicrosoftDataSqlClient), _cn)))
 				{
 					_compiledNullable(db, i);
 				}
@@ -114,7 +114,7 @@ namespace LinqToDB.Benchmarks.Queries
 		{
 			for (var i = 0; i < _iterations; i++)
 			{
-				using (var db = new DataConnection(SqlServerTools.GetDataProvider(SqlServerVersion.v2008, SqlServerProvider.MicrosoftDataSqlClient), _cn))
+				using (var db = new DataConnection(new DataOptions().UseConnection(SqlServerTools.GetDataProvider(SqlServerVersion.v2008, SqlServerProvider.MicrosoftDataSqlClient), _cn)))
 				{
 					db.GetTable<MyPOCO>()
 						.Where(p => p.Code == "A" + i && p.Currency == "SUR")
@@ -140,7 +140,7 @@ namespace LinqToDB.Benchmarks.Queries
 		{
 			for (var i = 0; i < _iterations; i++)
 			{
-				using (var db = new DataConnection(SqlServerTools.GetDataProvider(SqlServerVersion.v2008, SqlServerProvider.MicrosoftDataSqlClient), _cn))
+				using (var db = new DataConnection(new DataOptions().UseConnection(SqlServerTools.GetDataProvider(SqlServerVersion.v2008, SqlServerProvider.MicrosoftDataSqlClient), _cn)))
 				{
 					_compiled(db, i);
 				}

--- a/Tests/Tests.Benchmarks/Benchmarks/Queries/SelectBenchmark.cs
+++ b/Tests/Tests.Benchmarks/Benchmarks/Queries/SelectBenchmark.cs
@@ -41,7 +41,7 @@ namespace LinqToDB.Benchmarks.Queries
 			};
 
 			_cn = new MockDbConnection(result, ConnectionState.Open);
-			_db = new DataConnection(PostgreSQLTools.GetDataProvider(PostgreSQLVersion.v95), _cn);
+			_db = new DataConnection(new DataOptions().UseConnection(PostgreSQLTools.GetDataProvider(PostgreSQLVersion.v95), _cn));
 
 			_compiled = CompiledQuery.Compile<DataConnection, long, IQueryable<User>>(
 				(db, userId) => from c in db.GetTable<User>()

--- a/Tests/Tests.Benchmarks/Benchmarks/Queries/UpdateBenchmark.cs
+++ b/Tests/Tests.Benchmarks/Benchmarks/Queries/UpdateBenchmark.cs
@@ -38,7 +38,7 @@ namespace LinqToDB.Benchmarks.Queries
 		public void Setup()
 		{
 			_cn = new MockDbConnection(new QueryResult() { Return = 1 }, ConnectionState.Open);
-			_db = new DataConnection(PostgreSQLTools.GetDataProvider(PostgreSQLVersion.v95), _cn);
+			_db = new DataConnection(new DataOptions().UseConnection(PostgreSQLTools.GetDataProvider(PostgreSQLVersion.v95), _cn));
 
 			_compiledLinqSet = CompiledQuery.Compile<DataConnection, Workflow, int>(
 				(db, record) => db.GetTable<Workflow>()

--- a/Tests/Tests.Benchmarks/Models/Northwind/NorthwindDB.cs
+++ b/Tests/Tests.Benchmarks/Models/Northwind/NorthwindDB.cs
@@ -17,7 +17,7 @@ namespace LinqToDB.Benchmarks.Models
 		}
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
-		public NorthwindDB(IDataProvider provider) : base(provider, new MockDbConnection(Array.Empty<QueryResult>(), ConnectionState.Open))
+		public NorthwindDB(IDataProvider provider) : base(new DataOptions().UseConnection(provider, new MockDbConnection(Array.Empty<QueryResult>(), ConnectionState.Open)))
 #pragma warning restore CA2000 // Dispose objects before losing scope
 		{
 		}

--- a/Tests/Tests.Benchmarks/TestClasses/RawDataAccessBencherMappings.cs
+++ b/Tests/Tests.Benchmarks/TestClasses/RawDataAccessBencherMappings.cs
@@ -10,18 +10,18 @@ namespace LinqToDB.Benchmarks.Mappings
 {
 	public class Db : Data.DataConnection
 	{
-		public Db(string connectionString) : base(ProviderName.SqlServer2008, connectionString)
+		public Db(string connectionString) : base(new DataOptions().UseConnectionString(ProviderName.SqlServer2008, connectionString))
 		{
 		}
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
-		public Db(IDataProvider provider, QueryResult result) : base(provider, new MockDbConnection(result, ConnectionState.Open))
+		public Db(IDataProvider provider, QueryResult result) : base(new DataOptions().UseConnection(provider, new MockDbConnection(result, ConnectionState.Open)))
 #pragma warning restore CA2000 // Dispose objects before losing scope
 		{
 		}
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
-		public Db(IDataProvider provider, QueryResult[] results) : base(provider, new MockDbConnection(results, ConnectionState.Open))
+		public Db(IDataProvider provider, QueryResult[] results) : base(new DataOptions().UseConnection(provider, new MockDbConnection(results, ConnectionState.Open)))
 #pragma warning restore CA2000 // Dispose objects before losing scope
 		{
 		}

--- a/Tests/Tests.T4/Default/TestTemplate.cs
+++ b/Tests/Tests.T4/Default/TestTemplate.cs
@@ -15,7 +15,7 @@ namespace Default.SqlServer
 		static DataOptions GetSqlServerDataOptions(string? configuration = null)
 		{
 			return _sqlServerDataOptions ??= new DataOptions()
-				.UseConfigurationString(configuration ?? "SqlServerConfig")
+				.UseConfiguration(configuration ?? "SqlServerConfig")
 				.WithOptions<BulkCopyOptions>  (o => o with { BulkCopyTimeout = 60 * 100 })
 				;
 		}


### PR DESCRIPTION
Fix #3940

Obsolete constructors on `DataContext` and `DataConnection` classes except:
- `.ctor()`
- `.ctor(string configuration)`
- `.ctor(DataOptions)`
 
Also obsolete `UseConfigurationString` configuration API, which duplicates `UseConfiguration` API