### PR TITLE
Use EnsureConnection() in ConfigurationID property of DataConnection and DataContext

### DIFF
--- a/Source/LinqToDB/Data/DataConnection.Configuration.cs
+++ b/Source/LinqToDB/Data/DataConnection.Configuration.cs
@@ -488,7 +488,7 @@ namespace LinqToDB.Data
 					using var idBuilder = new IdentifierBuilder();
 					_configurationID = idBuilder
 						.Add(_msID = ((IConfigurationID)MappingSchema).ConfigurationID)
-						.Add(ConfigurationString ?? ConnectionString ?? Connection.ConnectionString)
+						.Add(ConfigurationString ?? ConnectionString ?? EnsureConnection(connect: false).ConnectionString)
 						.Add(Options)
 						.Add(GetType())
 						.CreateID();

--- a/Source/LinqToDB/DataContext.cs
+++ b/Source/LinqToDB/DataContext.cs
@@ -125,7 +125,7 @@ namespace LinqToDB
 					_configurationID = idBuilder
 						.Add(_msID = ((IConfigurationID)MappingSchema).ConfigurationID)
 						// GetDataConnection :-/
-						.Add(ConfigurationString ?? ConnectionString ?? GetDataConnection().Connection.ConnectionString)
+						.Add(ConfigurationString ?? ConnectionString ?? GetDataConnection().EnsureConnection(connect: false).ConnectionString)
 						.Add(Options)
 						.Add(GetType())
 						.CreateID();

--- a/Tests/Linq/UserTests/Issue4883Tests.cs
+++ b/Tests/Linq/UserTests/Issue4883Tests.cs
@@ -2,19 +2,20 @@
 using System.Threading.Tasks;
 
 using LinqToDB;
+using LinqToDB.Data;
 
 using NUnit.Framework;
 
 namespace Tests.UserTests;
 
 [TestFixture]
-public class Issue4883Tests : TestBase
+public class Issue4883Tests
 {
 	[Test]
 	public async Task TestDataConnection()
 	{
 		var dbConn = new TestDbConnection();
-		var db     = GetDataConnection(new DataOptions().UseConnection(
+		var db     = new DataConnection(new DataOptions().UseConnection(
 			new TestNoopProvider(), dbConn));
 
 		_ = await db.GetTable<TestEntity>().SingleOrDefaultAsync();
@@ -26,7 +27,7 @@ public class Issue4883Tests : TestBase
 	public async Task TestDataContext()
 	{
 		var dbConn = new TestDbConnection();
-		var db     = GetDataContext("", dbOptions => dbOptions.UseConnection(
+		var db     = new DataContext(new DataOptions().UseConnection(
 			new TestNoopProvider(), dbConn));
 
 		_ = await db.GetTable<TestEntity>().SingleOrDefaultAsync();

--- a/Tests/Linq/UserTests/Issue4883Tests.cs
+++ b/Tests/Linq/UserTests/Issue4883Tests.cs
@@ -6,52 +6,53 @@ using LinqToDB.Data;
 
 using NUnit.Framework;
 
-namespace Tests.UserTests;
-
-[TestFixture]
-public class Issue4883Tests
+namespace Tests.UserTests
 {
-	[Test]
-	public async Task TestDataConnection()
+	[TestFixture]
+	public class Issue4883Tests
 	{
-		var dbConn = new TestDbConnection();
-		var db     = new DataConnection(new DataOptions().UseConnection(
-			new TestNoopProvider(), dbConn));
-
-		_ = await db.GetTable<TestEntity>().SingleOrDefaultAsync();
-		
-		Assert.That(dbConn.OpenedAsync, Is.True);
-	}
-	
-	[Test]
-	public async Task TestDataContext()
-	{
-		var dbConn = new TestDbConnection();
-		var db     = new DataContext(new DataOptions().UseConnection(
-			new TestNoopProvider(), dbConn));
-
-		_ = await db.GetTable<TestEntity>().SingleOrDefaultAsync();
-		
-		Assert.That(dbConn.OpenedAsync, Is.True);
-	}
-
-	class TestEntity;
-
-	class TestDbConnection() : TestNoopConnection(string.Empty)
-	{
-		public bool OpenedAsync { get; private set; }
-
-		public override void Open()
+		[Test]
+		public async Task TestDataConnection()
 		{
-			OpenedAsync = false;
-			base.Open();
+			var dbConn = new TestDbConnection();
+			var db     = new DataConnection(new DataOptions().UseConnection(
+				new TestNoopProvider(), dbConn));
+
+			_ = await db.GetTable<TestEntity>().SingleOrDefaultAsync();
+		
+			Assert.That(dbConn.OpenedAsync, Is.True);
+		}
+	
+		[Test]
+		public async Task TestDataContext()
+		{
+			var dbConn = new TestDbConnection();
+			var db     = new DataContext(new DataOptions().UseConnection(
+				new TestNoopProvider(), dbConn));
+
+			_ = await db.GetTable<TestEntity>().SingleOrDefaultAsync();
+		
+			Assert.That(dbConn.OpenedAsync, Is.True);
 		}
 
-		public override Task OpenAsync(CancellationToken cancellationToken)
+		class TestEntity;
+
+		class TestDbConnection() : TestNoopConnection(string.Empty)
 		{
-			OpenedAsync = true;
-			base.Open();
-			return Task.CompletedTask;
+			public bool OpenedAsync { get; private set; }
+
+			public override void Open()
+			{
+				OpenedAsync = false;
+				base.Open();
+			}
+
+			public override Task OpenAsync(CancellationToken cancellationToken)
+			{
+				OpenedAsync = true;
+				base.Open();
+				return Task.CompletedTask;
+			}
 		}
 	}
 }

--- a/Tests/Linq/UserTests/Issue4883Tests.cs
+++ b/Tests/Linq/UserTests/Issue4883Tests.cs
@@ -1,0 +1,59 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+using LinqToDB;
+
+using NUnit.Framework;
+
+namespace Tests.UserTests;
+
+[TestFixture]
+public class Issue4883Tests : TestBase
+{
+	[Test]
+	public async Task TestDataConnection()
+	{
+		var dbConn = new MockDbConnection();
+		var db     = GetDataConnection(new DataOptions().UseConnection(
+			new TestNoopProvider(), dbConn));
+
+		var _ = await db.GetTable<TestEntity>().SingleOrDefaultAsync();
+		
+		Assert.That(dbConn.OpenedAsync, Is.True);
+	}
+	
+	[Test]
+	public async Task TestDataContext()
+	{
+		var dbConn = new MockDbConnection();
+		var db     = GetDataContext("", dbOptions => dbOptions.UseConnection(
+			new TestNoopProvider(), dbConn));
+
+		var _ = await db.GetTable<TestEntity>().SingleOrDefaultAsync();
+		
+		Assert.That(dbConn.OpenedAsync, Is.True);
+	}
+
+	private class TestEntity
+	{
+		
+	}
+
+	private class MockDbConnection() : TestNoopConnection(string.Empty)
+	{
+		public bool OpenedAsync { get; private set; }
+
+		public override    void          Open()
+		{
+			OpenedAsync = false;
+			base.Open();
+		}
+
+		public override Task OpenAsync(CancellationToken cancellationToken)
+		{
+			OpenedAsync = true;
+			base.Open();
+			return Task.CompletedTask;
+		}
+	}
+}

--- a/Tests/Linq/UserTests/Issue4883Tests.cs
+++ b/Tests/Linq/UserTests/Issue4883Tests.cs
@@ -13,11 +13,11 @@ public class Issue4883Tests : TestBase
 	[Test]
 	public async Task TestDataConnection()
 	{
-		var dbConn = new MockDbConnection();
+		var dbConn = new TestDbConnection();
 		var db     = GetDataConnection(new DataOptions().UseConnection(
 			new TestNoopProvider(), dbConn));
 
-		var _ = await db.GetTable<TestEntity>().SingleOrDefaultAsync();
+		_ = await db.GetTable<TestEntity>().SingleOrDefaultAsync();
 		
 		Assert.That(dbConn.OpenedAsync, Is.True);
 	}
@@ -25,25 +25,22 @@ public class Issue4883Tests : TestBase
 	[Test]
 	public async Task TestDataContext()
 	{
-		var dbConn = new MockDbConnection();
+		var dbConn = new TestDbConnection();
 		var db     = GetDataContext("", dbOptions => dbOptions.UseConnection(
 			new TestNoopProvider(), dbConn));
 
-		var _ = await db.GetTable<TestEntity>().SingleOrDefaultAsync();
+		_ = await db.GetTable<TestEntity>().SingleOrDefaultAsync();
 		
 		Assert.That(dbConn.OpenedAsync, Is.True);
 	}
 
-	private class TestEntity
-	{
-		
-	}
+	class TestEntity;
 
-	private class MockDbConnection() : TestNoopConnection(string.Empty)
+	class TestDbConnection() : TestNoopConnection(string.Empty)
 	{
 		public bool OpenedAsync { get; private set; }
 
-		public override    void          Open()
+		public override void Open()
 		{
 			OpenedAsync = false;
 			base.Open();


### PR DESCRIPTION
Use EnsureConnection(connect: false) in ConfigurationID to obtain connection string. This way connection is not opened synchronously during query generation.

Fixes #4883 