### PR TITLE
Left Join issue

### DIFF
--- a/Source/LinqToDB/Linq/Query.cs
+++ b/Source/LinqToDB/Linq/Query.cs
@@ -590,19 +590,6 @@ namespace LinqToDB.Linq
 
 		internal static Query<T> CreateQuery(ExpressionTreeOptimizationContext optimizationContext, ParametersContext parametersContext, IDataContext dataContext, ref IQueryExpressions expressions)
 		{
-			var linqOptions = optimizationContext.DataContext.Options.LinqOptions;
-
-			if (linqOptions.GenerateExpressionTest)
-			{
-				var testFile = new ExpressionTestGenerator(dataContext).GenerateSource(expressions.MainExpression);
-
-				if (dataContext.GetTraceSwitch().TraceInfo)
-					dataContext.WriteTraceLine(
-						$"Expression test code generated: \'{testFile}\'.",
-						dataContext.GetTraceSwitch().DisplayName,
-						TraceLevel.Info);
-			}
-
 			var query = new Query<T>(dataContext);
 
 			try
@@ -623,7 +610,19 @@ namespace LinqToDB.Linq
 			}
 			catch (Exception)
 			{
-				if (!linqOptions.GenerateExpressionTest)
+				var linqOptions = optimizationContext.DataContext.Options.LinqOptions;
+
+				if (linqOptions.GenerateExpressionTest)
+				{
+					var testFile = new ExpressionTestGenerator(dataContext).GenerateSource(expressions.MainExpression);
+
+					if (dataContext.GetTraceSwitch().TraceInfo)
+						dataContext.WriteTraceLine(
+							$"Expression test code generated: \'{testFile}\'.",
+							dataContext.GetTraceSwitch().DisplayName,
+							TraceLevel.Info);
+				}
+				else
 				{
 					dataContext.WriteTraceLine(
 						"""

--- a/Tests/Linq/Linq/LeftJoinTests.cs
+++ b/Tests/Linq/Linq/LeftJoinTests.cs
@@ -53,5 +53,19 @@ namespace Tests.Linq
 				Assert.That(result, Has.Length.EqualTo(1));
 			}
 		}
+
+		[Test]
+		public void LeftJoinGroupTest([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var q =
+				from p in db.Parent
+				join c in db.Child on p.Value1 equals c.ParentID into g
+				where g == null
+				select p.ParentID;
+
+			_ = q.ToSqlQuery().Sql;
+		}
 	}
 }


### PR DESCRIPTION
The following code is not working:

```c#
from p in db.Parent
join c in db.Child on p.Value1 equals c.ParentID into g
from c in g.DefaultIfEmpty()
where g == null
select p.ParentID;
```

```
LinqToDB.LinqToDBException : The LINQ expression 'g' could not be converted to SQL.
```


Worked in 5.4.1.