### PR TITLE
GroupBy issue

### DIFF
--- a/Source/LinqToDB/Linq/Builder/DeleteBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/DeleteBuilder.cs
@@ -83,11 +83,12 @@ namespace LinqToDB.Linq.Builder
 						throw new InvalidOperationException();
 
 					var destinationRef = new ContextRefExpression(destinationContext.ObjectType, destinationContext);
+					var sourceRef      = SequenceHelper.CreateRef(sequence);
 
 					var outputBody = SequenceHelper.PrepareBody(outputExpression, deletedContext);
 
 					var outputExpressions = new List<UpdateBuilder.SetExpressionEnvelope>();
-					UpdateBuilder.ParseSetter(builder, destinationRef, outputBody, outputExpressions);
+					UpdateBuilder.ParseSetter(builder, destinationRef, sourceRef, outputBody, outputExpressions);
 
 					UpdateBuilder.InitializeSetExpressions(builder, destinationContext, sequence, outputExpressions, deleteStatement.Output.OutputItems, createColumns : false);
 
@@ -177,6 +178,7 @@ namespace LinqToDB.Linq.Builder
 
 						var selectContext     = new SelectContext(Parent, outputBody, QuerySequence, false);
 						var outputRef         = new ContextRefExpression(path.Type, selectContext);
+						var sourceRef         = SequenceHelper.CreateRef(QuerySequence);
 						var outputExpressions = new List<UpdateBuilder.SetExpressionEnvelope>();
 
 						var sqlExpr = Builder.BuildSqlExpression(selectContext, outputRef);
@@ -185,7 +187,7 @@ namespace LinqToDB.Linq.Builder
 						if (sqlExpr is SqlPlaceholderExpression)
 							outputExpressions.Add(new UpdateBuilder.SetExpressionEnvelope(sqlExpr, sqlExpr, false));
 						else
-							UpdateBuilder.ParseSetter(Builder, outputRef, sqlExpr, outputExpressions);
+							UpdateBuilder.ParseSetter(Builder, outputRef, sourceRef, sqlExpr, outputExpressions);
 
 						var setItems = new List<SqlSetExpression>();
 						UpdateBuilder.InitializeSetExpressions(Builder, selectContext, selectContext, outputExpressions, setItems, createColumns : false);

--- a/Source/LinqToDB/Linq/Builder/InsertBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/InsertBuilder.cs
@@ -92,7 +92,7 @@ namespace LinqToDB.Linq.Builder
 
 						var sqlExpr = builder.BuildSqlExpression(sequence, sourceRef);
 
-						UpdateBuilder.ParseSetter(builder, targetRef, sqlExpr, insertContext.SetExpressions);
+						UpdateBuilder.ParseSetter(builder, targetRef, sourceRef, sqlExpr, insertContext.SetExpressions);
 					}
 				}
 				else if (methodCall.Arguments.Count > 1                  &&
@@ -118,8 +118,9 @@ namespace LinqToDB.Linq.Builder
 
 					var targetType = genericArguments[1];
 					var contextRef = new ContextRefExpression(targetType, into);
+					var sourceRef  = SequenceHelper.CreateRef(sequence);
 
-					UpdateBuilder.ParseSetter(builder, contextRef, setterExpr, insertContext.SetExpressions);
+					UpdateBuilder.ParseSetter(builder, contextRef, sourceRef, setterExpr, insertContext.SetExpressions);
 				}
 				else if (typeof(ITable<>).IsSameOrParentOf(argument.Type))
 				{
@@ -181,6 +182,7 @@ namespace LinqToDB.Linq.Builder
 
 					UpdateBuilder.ParseSetter(builder,
 						intoContextRef,
+						sourceRef,
 						redirectedExpression,
 						insertContext.SetExpressions);
 				}
@@ -214,13 +216,14 @@ namespace LinqToDB.Linq.Builder
 						var destination = builder.BuildSequence(new BuildInfo(buildInfo, outputTable, new SelectQuery()));
 
 						var destinationRef = new ContextRefExpression(outputExpression.Body.Type, destination);
+						var sourceRef      = SequenceHelper.CreateRef(sequence);
 
 						var outputExpr   = SequenceHelper.PrepareBody(outputExpression, outputAnchor);
 
 						insertStatement.Output.OutputTable = ((TableBuilder.TableContext)destination).SqlTable;
 
 						var outputSetters = new List<UpdateBuilder.SetExpressionEnvelope>();
-						UpdateBuilder.ParseSetter(builder, destinationRef, outputExpr, outputSetters);
+						UpdateBuilder.ParseSetter(builder, destinationRef, sourceRef, outputExpr, outputSetters);
 
 						UpdateBuilder.InitializeSetExpressions(builder, outputAnchor, outputAnchor,
 							outputSetters, insertStatement.Output.OutputItems, false);
@@ -294,7 +297,8 @@ namespace LinqToDB.Linq.Builder
 							? new SelectContext(Parent, OutputExpression, false, OutputContext)
 							: new AnchorContext(Parent, new SelectContext(Parent, OutputExpression, false, OutputContext), SqlAnchor.AnchorKindEnum.Inserted);
 
-						var outputRef     = new ContextRefExpression(path.Type, selectContext);
+						var outputRef = new ContextRefExpression(path.Type, selectContext);
+						var sourceRef = SequenceHelper.CreateRef(QuerySequence);
 
 						var outputExpressions = new List<UpdateBuilder.SetExpressionEnvelope>();
 
@@ -304,7 +308,7 @@ namespace LinqToDB.Linq.Builder
 						if (sqlExpr is SqlPlaceholderExpression)
 							outputExpressions.Add(new UpdateBuilder.SetExpressionEnvelope(sqlExpr, sqlExpr, false));
 						else
-							UpdateBuilder.ParseSetter(Builder, outputRef, sqlExpr, outputExpressions);
+							UpdateBuilder.ParseSetter(Builder, outputRef, sourceRef, sqlExpr, outputExpressions);
 
 						var setItems = new List<SqlSetExpression>();
 						UpdateBuilder.InitializeSetExpressions(Builder, selectContext, selectContext, outputExpressions, setItems, false);
@@ -479,6 +483,7 @@ namespace LinqToDB.Linq.Builder
 
 				var tableType  = methodCall.Method.GetGenericArguments()[1];
 				var contextRef = new ContextRefExpression(tableType, insertContext.Into);
+				var sourceRef  = SequenceHelper.CreateRef(sequence);
 
 				var extractExp = SequenceHelper.PrepareBody(extract, insertContext.Into);
 				var updateExpr = update;
@@ -490,7 +495,7 @@ namespace LinqToDB.Linq.Builder
 					forceParameters = false;
 				}
 
-				UpdateBuilder.ParseSet(contextRef, extractExp, updateExpr, insertContext.SetExpressions, forceParameters);
+				UpdateBuilder.ParseSet(contextRef, sourceRef, extractExp, updateExpr, insertContext.SetExpressions, forceParameters);
 				insertContext.LastBuildInfo = buildInfo;
 
 				return BuildSequenceResult.FromContext(insertContext);

--- a/Source/LinqToDB/Linq/Builder/InsertOrUpdateBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/InsertOrUpdateBuilder.cs
@@ -30,7 +30,7 @@ namespace LinqToDB.Linq.Builder
 			var contextRef       = new ContextRefExpression(methodCall.Method.GetGenericArguments()[0], sequence);
 			var insertSetterExpr = SequenceHelper.PrepareBody(methodCall.Arguments[1].UnwrapLambda(), sequence);
 
-			UpdateBuilder.ParseSetter(builder, contextRef, insertSetterExpr, insertExpressions);
+			UpdateBuilder.ParseSetter(builder, contextRef, contextRef, insertSetterExpr, insertExpressions);
 
 			var updateExpr = methodCall.Arguments[2].Unwrap();
 			if (!updateExpr.IsNullValue())
@@ -38,7 +38,7 @@ namespace LinqToDB.Linq.Builder
 				updateExpressions = new List<UpdateBuilder.SetExpressionEnvelope>();
 				var updateSetterExpr = SequenceHelper.PrepareBody(updateExpr.UnwrapLambda(), sequence);
 
-				UpdateBuilder.ParseSetter(builder, contextRef, updateSetterExpr, updateExpressions);
+				UpdateBuilder.ParseSetter(builder, contextRef, contextRef, updateSetterExpr, updateExpressions);
 			}
 
 			var tableContext = SequenceHelper.GetTableContext(sequence);
@@ -89,7 +89,7 @@ namespace LinqToDB.Linq.Builder
 
 				var keysExpr = SequenceHelper.PrepareBody(methodCall.Arguments[3].UnwrapLambda(), sequence);
 
-				UpdateBuilder.ParseSetter(builder, contextRef, keysExpr, keysExpressions);
+				UpdateBuilder.ParseSetter(builder, contextRef, contextRef, keysExpr, keysExpressions);
 
 				UpdateBuilder.InitializeSetExpressions(builder, tableContext, sequence,
 					keysExpressions, insertOrUpdateStatement.Update.Keys, false);

--- a/Source/LinqToDB/Linq/Builder/MergeBuilder.InsertWhenNotMatched.cs
+++ b/Source/LinqToDB/Linq/Builder/MergeBuilder.InsertWhenNotMatched.cs
@@ -47,9 +47,10 @@ namespace LinqToDB.Linq.Builder
 						EntityConstructorBase.FullEntityPurpose.Insert);
 				}
 
-				var setterExpressions = new List<UpdateBuilder.SetExpressionEnvelope>();
+				var setterExpressions    = new List<UpdateBuilder.SetExpressionEnvelope>();
+				var targetRef = mergeContext.SourceContext.TargetContextRef.WithType(setterExpression.Type);
 				UpdateBuilder.ParseSetter(builder,
-					mergeContext.SourceContext.TargetContextRef.WithType(setterExpression.Type), setterExpression,
+					targetRef, targetRef, setterExpression,
 					setterExpressions);
 				UpdateBuilder.InitializeSetExpressions(builder, mergeContext.TargetContext, mergeContext.SourceContext, setterExpressions, operation.Items, createColumns : false);
 

--- a/Source/LinqToDB/Linq/Builder/MergeBuilder.MergeContext.cs
+++ b/Source/LinqToDB/Linq/Builder/MergeBuilder.MergeContext.cs
@@ -81,7 +81,7 @@ namespace LinqToDB.Linq.Builder
 					if (sqlExpr is SqlPlaceholderExpression)
 						outputExpressions.Add(new UpdateBuilder.SetExpressionEnvelope(sqlExpr, sqlExpr, false));
 					else
-						UpdateBuilder.ParseSetter(Builder, outputRef, sqlExpr, outputExpressions);
+						UpdateBuilder.ParseSetter(Builder, outputRef, outputRef, sqlExpr, outputExpressions);
 
 					var setItems = new List<SqlSetExpression>();
 					UpdateBuilder.InitializeSetExpressions(Builder, selectContext, selectContext, outputExpressions, setItems, false);

--- a/Source/LinqToDB/Linq/Builder/MergeBuilder.UpdateWhenMatched.cs
+++ b/Source/LinqToDB/Linq/Builder/MergeBuilder.UpdateWhenMatched.cs
@@ -36,9 +36,10 @@ namespace LinqToDB.Linq.Builder
 
 					var setterExpression = mergeContext.SourceContext.PrepareTargetSource(setterLambda);
 
-					var setterExpressions = new List<UpdateBuilder.SetExpressionEnvelope>();
+					var setterExpressions    = new List<UpdateBuilder.SetExpressionEnvelope>();
+					var targetRef = mergeContext.SourceContext.TargetContextRef.WithType(setterExpression.Type);
 					UpdateBuilder.ParseSetter(builder,
-						mergeContext.SourceContext.TargetContextRef.WithType(setterExpression.Type),
+						targetRef, targetRef,
 						setterExpression, setterExpressions);
 
 					UpdateBuilder.InitializeSetExpressions(builder, mergeContext.TargetContext, mergeContext.SourceContext, setterExpressions, operation.Items, createColumns : false);

--- a/Source/LinqToDB/Linq/Builder/MergeBuilder.UpdateWhenMatchedThenDelete.cs
+++ b/Source/LinqToDB/Linq/Builder/MergeBuilder.UpdateWhenMatchedThenDelete.cs
@@ -39,8 +39,10 @@ namespace LinqToDB.Linq.Builder
 					mergeContext.SourceContext.SourceContextRef.Alias = setterLambda.Parameters[1].Name;
 
 					var setterExpressions = new List<UpdateBuilder.SetExpressionEnvelope>();
+					var targetRef         = mergeContext.SourceContext.TargetContextRef.WithType(setterExpression.Type);
 					UpdateBuilder.ParseSetter(builder,
-						mergeContext.SourceContext.TargetContextRef.WithType(setterExpression.Type), setterExpression,
+						targetRef, targetRef, 
+						setterExpression,
 						setterExpressions);
 					UpdateBuilder.InitializeSetExpressions(builder, mergeContext.TargetContext, mergeContext.SourceContext, setterExpressions, operation.Items, createColumns : false);
 				}

--- a/Source/LinqToDB/Linq/Builder/MergeBuilder.UpdateWhenNotMatchedBySource.cs
+++ b/Source/LinqToDB/Linq/Builder/MergeBuilder.UpdateWhenNotMatchedBySource.cs
@@ -30,9 +30,10 @@ namespace LinqToDB.Linq.Builder
 
 				var setterExpression = mergeContext.SourceContext.PrepareSelfTargetLambda(setterLambda);
 
-				var setterExpressions = new List<UpdateBuilder.SetExpressionEnvelope>();
+				var setterExpressions    = new List<UpdateBuilder.SetExpressionEnvelope>();
+				var targetRef = mergeContext.SourceContext.TargetContextRef.WithType(setterExpression.Type);
 				UpdateBuilder.ParseSetter(builder,
-					mergeContext.SourceContext.TargetContextRef.WithType(setterExpression.Type), setterExpression,
+					targetRef, targetRef, setterExpression,
 					setterExpressions);
 
 				UpdateBuilder.InitializeSetExpressions(builder, mergeContext.TargetContext, mergeContext.SourceContext, setterExpressions, operation.Items, false);

--- a/Source/LinqToDB/Linq/Builder/MergeBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/MergeBuilder.cs
@@ -99,7 +99,7 @@ namespace LinqToDB.Linq.Builder
 					var destinationRef = new ContextRefExpression(methodCall.Method.GetGenericArguments()[2], destination);
 
 					var outputSetters = new List<UpdateBuilder.SetExpressionEnvelope>();
-					UpdateBuilder.ParseSetter(builder, destinationRef, outputExpression, outputSetters);
+					UpdateBuilder.ParseSetter(builder, destinationRef, destinationRef, outputExpression, outputSetters);
 					UpdateBuilder.InitializeSetExpressions(builder, mergeContext.SourceContext,
 						mergeContext.TargetContext, outputSetters, mergeContext.Merge.Output.OutputItems, createColumns : false);
 

--- a/Source/LinqToDB/Linq/Builder/MultiInsertBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/MultiInsertBuilder.cs
@@ -105,10 +105,11 @@ namespace LinqToDB.Linq.Builder
 
 			var setterExpression = source.PrepareSourceBody(setterLambda);
 
-			var targetRef        = new ContextRefExpression(setterExpression.Type, into);
+			var targetRef = new ContextRefExpression(setterExpression.Type, into);
+			var sourceRef = SequenceHelper.CreateRef(source);
 
 			var setterExpressions = new List<UpdateBuilder.SetExpressionEnvelope>();
-			UpdateBuilder.ParseSetter(builder, targetRef, setterExpression, setterExpressions);
+			UpdateBuilder.ParseSetter(builder, targetRef, sourceRef, setterExpression, setterExpressions);
 			UpdateBuilder.InitializeSetExpressions(builder, into, source, setterExpressions, insert.Items, false);
 
 			return multiInsertContext;

--- a/Source/LinqToDB/Linq/Builder/UpdateBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/UpdateBuilder.cs
@@ -141,8 +141,9 @@ namespace LinqToDB.Linq.Builder
 					objectType                  = genericArguments[0];
 
 					var targetRef = new ContextRefExpression(objectType, updateContext.TargetTable);
+					var sourceRef = SequenceHelper.CreateRef(sequence);
 
-					ParseSetter(builder, targetRef, setterExpr, updateContext.SetExpressions);
+					ParseSetter(builder, targetRef, sourceRef, setterExpr, updateContext.SetExpressions);
 
 					outputExpression = RewriteOutputExpression(outputExpression);
 
@@ -233,8 +234,9 @@ namespace LinqToDB.Linq.Builder
 					}
 
 					var targetRef = new ContextRefExpression(objectType, updateContext.TargetTable);
+					var sourceRef = SequenceHelper.CreateRef(sequence);
 
-					ParseSetter(builder, targetRef, setterExpr, updateContext.SetExpressions);
+					ParseSetter(builder, targetRef, sourceRef, setterExpr, updateContext.SetExpressions);
 
 					break;
 				}
@@ -289,8 +291,9 @@ namespace LinqToDB.Linq.Builder
 
 				var outputBody = SequenceHelper.PrepareBody(outputExpression, sequence, deletedContext, insertedContext);
 
+				var sourceRef         = SequenceHelper.CreateRef(sequence);
 				var outputExpressions = new List<SetExpressionEnvelope>();
-				ParseSetter(builder, destinationRef, outputBody, outputExpressions);
+				ParseSetter(builder, destinationRef, sourceRef, outputBody, outputExpressions);
 
 				InitializeSetExpressions(builder, destinationContext, sequence, outputExpressions, updateStatement.Output.OutputItems, false);
 
@@ -539,6 +542,7 @@ namespace LinqToDB.Linq.Builder
 
 		internal static void ParseSet(
 			ContextRefExpression        targetRef,
+			ContextRefExpression        sourceRef,
 			Expression                  fieldExpression,
 			Expression                  valueExpression,
 			List<SetExpressionEnvelope> envelopes,
@@ -550,6 +554,7 @@ namespace LinqToDB.Linq.Builder
 		internal static void ParseSetter(
 			ExpressionBuilder           builder,
 			ContextRefExpression        targetRef,
+			ContextRefExpression        sourceRef,
 			Expression                  setterExpression,
 			List<SetExpressionEnvelope> envelopes)
 		{
@@ -557,7 +562,7 @@ namespace LinqToDB.Linq.Builder
 
 			if (correctedSetter is not SqlGenericConstructorExpression)
 			{
-				correctedSetter = builder.BuildSqlExpression(targetRef.BuildContext, correctedSetter);
+				correctedSetter = builder.BuildSqlExpression(sourceRef.BuildContext, correctedSetter);
 			}
 
 			if (correctedSetter is SqlGenericConstructorExpression generic)
@@ -566,7 +571,7 @@ namespace LinqToDB.Linq.Builder
 				{
 					var memberAccess = Expression.MakeMemberAccess(targetRef, assignment.MemberInfo);
 
-					ParseSet(builder, targetRef.BuildContext, memberAccess, memberAccess, assignment.Expression, envelopes, false);
+					ParseSet(builder, sourceRef.BuildContext, memberAccess, memberAccess, assignment.Expression, envelopes, false);
 				}
 			}
 			else
@@ -765,7 +770,7 @@ namespace LinqToDB.Linq.Builder
 						if (sqlExpr is SqlPlaceholderExpression)
 							outputExpressions.Add(new SetExpressionEnvelope(sqlExpr, sqlExpr, false));
 						else
-							ParseSetter(Builder, outputRef, sqlExpr, outputExpressions);
+							ParseSetter(Builder, outputRef, outputRef, sqlExpr, outputExpressions);
 
 						var setItems = new List<SqlSetExpression>();
 						InitializeSetExpressions(Builder, selectContext, selectContext, outputExpressions, setItems, false);

--- a/Tests/Linq/Linq/GroupByTests.cs
+++ b/Tests/Linq/Linq/GroupByTests.cs
@@ -876,7 +876,7 @@ namespace Tests.Linq
 					DistinctWithFilter       = g.Select(x => x.DataValue).Distinct().Count(x => x % 2 == 0),
 					FilterDistinct           = g.Select(x => x.DataValue).Where(x => x      % 2 == 0).Distinct().Count(),
 					FilterDistinctWithFilter = g.Select(x => x.DataValue).Where(x => x      % 2 == 0).Distinct().Count(x => x % 2 == 0),
-					
+
 					SubFilter           = filtered.Count(),
 					SubFilterDistinct   = filteredDistinct.Count(),
 					SubNoFilterDistinct = nonfilteredDistinct.Count(),
@@ -894,7 +894,7 @@ namespace Tests.Linq
 			using var db = GetDataContext(context);
 			using var table = db.CreateLocalTable(data);
 
-			var query = 
+			var query =
 				from t in table
 				group t by new { t.GroupId }  into g
 				select new
@@ -975,7 +975,7 @@ namespace Tests.Linq
 			using var db = GetDataContext(context);
 			using var table = db.CreateLocalTable(data);
 
-			var query = 
+			var query =
 				from t in table
 				where t.DataValue != null
 				group t by t.GroupId into g
@@ -1396,7 +1396,7 @@ namespace Tests.Linq
 		{
 			using var db = GetDataContext(context);
 
-			var query = 
+			var query =
 				from p in db.Parent
 				group p by p.Children.Average(c => c.ParentID) > 3
 				into g
@@ -3039,7 +3039,7 @@ namespace Tests.Linq
 				let cItems = p.Children.GroupBy(c => c.ParentID, (key, grouped) => new { Id = key, Count = grouped.Count() })
 				select new
 				{
-					p.ParentID, 
+					p.ParentID,
 					First = cItems.OrderBy(x => x.Count).ThenBy(x => x.Id).FirstOrDefault()
 				};
 
@@ -3772,12 +3772,27 @@ namespace Tests.Linq
 			)
 			.Take(2);
 
-			var query = 
+			var query =
 				from t in db.Child
 				where t.ParentID.In(grp.Select(x => x.ParentID))
 				select t;
 
 			AssertQuery(query);
+		}
+
+		[Test]
+		public void Test([DataSources(false, TestProvName.AllFirebird)] string context)
+		{
+			using var db = GetDataContext(context);
+
+			using var t1 = db.CreateLocalTable("temp_table_1", [new { ID = 1, Value = ""}]);
+			using var t2 = db.CreateTempTable("temp_table_2",
+				from c in t1
+				group c by c.ID into gr
+				select new
+				{
+					gr.First().Value,
+				});
 		}
 	}
 }

--- a/Tests/Linq/Linq/GroupByTests.cs
+++ b/Tests/Linq/Linq/GroupByTests.cs
@@ -3781,7 +3781,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void Test([DataSources(false, TestProvName.AllFirebird)] string context)
+		public void InsertFirstFromGroup([DataSources(false, TestProvName.AllFirebird)] string context)
 		{
 			using var db = GetDataContext(context);
 

--- a/Tests/Linq/Linq/GroupByTests.cs
+++ b/Tests/Linq/Linq/GroupByTests.cs
@@ -3781,7 +3781,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void InsertFirstFromGroup([DataSources(false, TestProvName.AllFirebird)] string context)
+		public void InsertFirstFromGroup([DataSources(false, TestProvName.AllFirebird, TestProvName.AllMySql57, TestProvName.AllAccess, TestProvName.AllSybase)] string context)
 		{
 			using var db = GetDataContext(context);
 

--- a/Tests/Linq/Linq/LeftJoinTests.cs
+++ b/Tests/Linq/Linq/LeftJoinTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 
 using LinqToDB;
+using LinqToDB.Tools;
 
 using NUnit.Framework;
 


### PR DESCRIPTION
The following code is not working

```c#
using var t1 = db.CreateLocalTable("temp_table_1", [new { ID = 1, Value = ""}]);
using var t2 = db.CreateTempTable("temp_table_2",
	from c in t1
	group c by c.ID into gr
	select new
	{
		gr.First().Value,
	});
```

Worked in v5.4.1.