### PR TITLE
Lambda as a parameter issue

### DIFF
--- a/Source/LinqToDB/Linq/Builder/ExpressionBuildVisitor.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuildVisitor.cs
@@ -1077,6 +1077,14 @@ namespace LinqToDB.Linq.Builder
 			return base.VisitChangeTypeExpression(node);
 		}
 
+		protected override Expression VisitInvocation(InvocationExpression node)
+		{
+			if (IsSqlOrExpression() && HandleValue(node, out var translated))
+				return Visit(translated);
+
+			return base.VisitInvocation(node);
+		}
+
 		public bool HandleExtension(IBuildContext context, Expression expr, [NotNullWhen(true)] out Sql.ExpressionAttribute? attribute, [NotNullWhen(true)] out Expression? translated)
 		{
 			// Handling ExpressionAttribute

--- a/Tests/Linq/Linq/ParameterTests.cs
+++ b/Tests/Linq/Linq/ParameterTests.cs
@@ -1443,7 +1443,7 @@ namespace Tests.Linq
 			List<Person> Query(ITestDataContext db)
 			{
 				return db.Person
-					.Where(_ => 
+					.Where(_ =>
 					 GetQuery1(db).Select(p => p.ID).Contains(_.ID) &&
 					(GetQuery2(db).Select(p => p.ID).Contains(_.ID) ||
 					 GetQuery3(db).Select(p => p.ID).Contains(_.ID)))
@@ -1983,5 +1983,14 @@ namespace Tests.Linq
 			public TValue? Value { get; }
 		}
 
+		[Test]
+		public void LambdaParameterTest([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var valueGetter = () => 1;
+
+			AssertQuery(db.Parent.Where(r => r.ParentID == valueGetter()));
+		}
 	}
 }


### PR DESCRIPTION
The following code in not working:

```c#
var valueGetter = () => 1;

_ = db.Parent.Where(r => r.ParentID == valueGetter());
```

Worked in v5.4.1.