### PR TITLE
Address several API issues around IDataContext implementations

### DIFF
--- a/Source/LinqToDB.EntityFrameworkCore/Internal/LinqToDBForEFQueryProvider.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/Internal/LinqToDBForEFQueryProvider.cs
@@ -195,6 +195,9 @@ namespace LinqToDB.EntityFrameworkCore.Internal
 		IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options) =>
 			((IExpressionQuery)QueryProvider).GetSqlQueries(options);
 
+		Task<IReadOnlyList<QuerySql>> IExpressionQuery.GetSqlQueriesAsync(SqlGenerationOptions? options, CancellationToken cancellationToken) =>
+			((IExpressionQuery)QueryProvider).GetSqlQueriesAsync(options, cancellationToken);
+
 		#endregion
 	}
 }

--- a/Source/LinqToDB.EntityFrameworkCore/Internal/LinqToDBForEFQueryProvider.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/Internal/LinqToDBForEFQueryProvider.cs
@@ -195,9 +195,6 @@ namespace LinqToDB.EntityFrameworkCore.Internal
 		IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options) =>
 			((IExpressionQuery)QueryProvider).GetSqlQueries(options);
 
-		Task<IReadOnlyList<QuerySql>> IExpressionQuery.GetSqlQueriesAsync(SqlGenerationOptions? options, CancellationToken cancellationToken) =>
-			((IExpressionQuery)QueryProvider).GetSqlQueriesAsync(options, cancellationToken);
-
 		#endregion
 	}
 }

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.cs
@@ -49,7 +49,7 @@ namespace LinqToDB.EntityFrameworkCore
 
 			InitializeMapping();
 
-			var instantiator = MemberHelper.MethodOf(() => Linq.Internals.CreateExpressionQueryInstance<int>(null!, null!))
+			var instantiator = MemberHelper.MethodOf(() => Internals.CreateExpressionQueryInstance<int>(null!, null!))
 				.GetGenericMethodDefinition();
 
 			LinqExtensions.ProcessSourceQueryable = queryable =>
@@ -256,6 +256,7 @@ namespace LinqToDB.EntityFrameworkCore
 			var info    = GetEFProviderInfo(context);
 			var options = context.GetLinqToDBOptions() ?? new DataOptions();
 			options     = AddMappingSchema(options, GetMappingSchema(context.Model, context, options));
+			options     = EnableTracing(options, CreateLogger(info.Options));
 
 			DataConnection? dc = null;
 
@@ -286,20 +287,19 @@ namespace LinqToDB.EntityFrameworkCore
 				}
 			}
 
-			var logger = CreateLogger(info.Options);
-			if (logger != null)
-				EnableTracing(dc, logger);
-
 			return dc;
 		}
 
 		private static readonly TraceSwitch _defaultTraceSwitch =
 			new("DataConnection", "DataConnection trace switch", TraceLevel.Info.ToString());
 
-		static void EnableTracing(DataConnection dc, ILogger logger)
+		static DataOptions EnableTracing(DataOptions options, ILogger? logger)
 		{
-			dc.OnTraceConnection = t => Implementation.LogConnectionTrace(t, logger);
-			dc.TraceSwitchConnection = _defaultTraceSwitch;
+			return logger == null
+				? options
+				: options
+					.UseTracing(t => Implementation.LogConnectionTrace(t, logger))
+					.UseTraceSwitch(_defaultTraceSwitch);
 		}
 
 		/// <summary>
@@ -334,6 +334,7 @@ namespace LinqToDB.EntityFrameworkCore
 			var connectionInfo = GetConnectionInfo(info);
 			var provider       = GetDataProvider(options, info, connectionInfo);
 			var logger         = CreateLogger(info.Options);
+			options            = EnableTracing(options, logger);
 
 			if (transaction != null)
 			{
@@ -369,9 +370,6 @@ namespace LinqToDB.EntityFrameworkCore
 				}
 			}
 
-			if (logger != null)
-				EnableTracing(dc, logger);
-
 			return dc;
 		}
 
@@ -394,11 +392,9 @@ namespace LinqToDB.EntityFrameworkCore
 				.UseDataProvider(dataProvider)
 				.UseConnectionString(connectionInfo.ConnectionString!);
 
-			var dc = new LinqToDBForEFToolsDataConnection(context, options, context.Model, TransformExpression);
-			var logger = CreateLogger(info.Options);
+			options = EnableTracing(options, CreateLogger(info.Options));
 
-			if (logger != null)
-				EnableTracing(dc, logger);
+			var dc = new LinqToDBForEFToolsDataConnection(context, options, context.Model, TransformExpression);
 
 			return dc;
 		}
@@ -456,6 +452,7 @@ namespace LinqToDB.EntityFrameworkCore
 				dataOptions = AddMappingSchema(dataOptions, GetMappingSchema(model, null, dataOptions));
 
 			dataOptions = dataOptions.UseDataProvider(dataProvider);
+			dataOptions = EnableTracing(dataOptions, CreateLogger(info.Options));
 
 			if (connectionInfo.Connection != null)
 			{
@@ -470,10 +467,6 @@ namespace LinqToDB.EntityFrameworkCore
 
 			if (dc == null)
 				throw new LinqToDBForEFToolsException($"Can not extract connection information from {nameof(DbContextOptions)}");
-
-			var logger = CreateLogger(info.Options);
-			if (logger != null)
-				EnableTracing(dc, logger);
 
 			return dc;
 		}

--- a/Source/LinqToDB/Common/Configuration.cs
+++ b/Source/LinqToDB/Common/Configuration.cs
@@ -157,6 +157,8 @@ namespace LinqToDB.Common
 			/// Enables throwing of <see cref="ObjectDisposedException"/> when access disposed <see cref="DataConnection"/> instance.
 			/// Default value: <c>true</c>.
 			/// </summary>
+			// TODO: Remove in v7
+			[Obsolete("This API scheduled for removal in v7"), EditorBrowsable(EditorBrowsableState.Never)]
 			public static bool ThrowOnDisposed = true;
 
 			/// <summary>

--- a/Source/LinqToDB/Common/Tools.cs
+++ b/Source/LinqToDB/Common/Tools.cs
@@ -123,7 +123,7 @@ namespace LinqToDB.Common
 		{
 			Query.ClearCaches();
 			MappingSchema.ClearCache();
-			DataConnection.ClearObjectReaderCache();
+			CommandInfo.ClearObjectReaderCache();
 		}
 	}
 }

--- a/Source/LinqToDB/Data/CommandInfo.cs
+++ b/Source/LinqToDB/Data/CommandInfo.cs
@@ -377,7 +377,7 @@ namespace LinqToDB.Data
 
 							try
 							{
-								result = objectReader(reader);
+								result = objectReader(DataConnection, reader);
 							}
 							catch (InvalidCastException)
 							{
@@ -386,7 +386,7 @@ namespace LinqToDB.Data
 
 								isFaulted    = true;
 								objectReader = GetObjectReader2<T>(DataConnection, reader, CommandText, additionalKey);
-								result       = objectReader(reader);
+								result       = objectReader(DataConnection, reader);
 							}
 
 							rowCount++;
@@ -491,7 +491,7 @@ namespace LinqToDB.Data
 
 							try
 							{
-								result = objectReader(reader);
+								result = objectReader(DataConnection, reader);
 							}
 							catch (InvalidCastException)
 							{
@@ -500,7 +500,7 @@ namespace LinqToDB.Data
 
 								isFaulted    = true;
 								objectReader = GetObjectReader2<T>(DataConnection, reader, CommandText, additionalKey);
-								result       = objectReader(reader);
+								result       = objectReader(DataConnection, reader);
 							}
 
 							action(result);
@@ -558,7 +558,7 @@ namespace LinqToDB.Data
 
 								try
 								{
-									result = objectReader(reader);
+									result = objectReader(DataConnection, reader);
 								}
 								catch (InvalidCastException)
 								{
@@ -567,7 +567,7 @@ namespace LinqToDB.Data
 
 									isFaulted = true;
 									objectReader = GetObjectReader2<T>(DataConnection, reader, CommandText, additionalKey);
-									result = objectReader(reader);
+									result = objectReader(DataConnection, reader);
 								}
 
 								yield return result;
@@ -834,13 +834,13 @@ namespace LinqToDB.Data
 
 		sealed class ReaderAsyncEnumerator<T> : IAsyncEnumerator<T>
 		{
-			readonly CommandInfo      _commandInfo;
-			readonly DbDataReader     _rd;
-			readonly string?          _additionalKey;
-			Func<DbDataReader, T>     _objectReader;
-			bool                      _isFaulted;
-			bool                      _isFinished;
-			CancellationToken         _cancellationToken;
+			readonly CommandInfo               _commandInfo;
+			readonly DbDataReader              _rd;
+			readonly string?                   _additionalKey;
+			Func<IDataContext,DbDataReader, T> _objectReader;
+			bool                               _isFaulted;
+			bool                               _isFinished;
+			CancellationToken                  _cancellationToken;
 
 			public ReaderAsyncEnumerator(CommandInfo commandInfo, DbDataReader rd, CancellationToken cancellationToken)
 			{
@@ -872,7 +872,7 @@ namespace LinqToDB.Data
 
 				try
 				{
-					Current = _objectReader(_rd);
+					Current = _objectReader(_commandInfo.DataConnection, _rd);
 				}
 				catch (InvalidCastException)
 				{
@@ -883,7 +883,7 @@ namespace LinqToDB.Data
 					_objectReader = GetObjectReader2<T>(_commandInfo.DataConnection, _rd,
 						_commandInfo.CommandText,
 						_additionalKey);
-					Current = _objectReader(_rd);
+					Current = _objectReader(_commandInfo.DataConnection, _rd);
 				}
 
 				return true;
@@ -1143,15 +1143,15 @@ namespace LinqToDB.Data
 
 					try
 					{
-						result = objectReader(reader);
+						result = objectReader(DataConnection, reader);
 					}
 					catch (InvalidCastException)
 					{
-						result = GetObjectReader2<T>(DataConnection, reader, CommandText, additionalKey)(reader);
+						result = GetObjectReader2<T>(DataConnection, reader, CommandText, additionalKey)(DataConnection, reader);
 					}
 					catch (FormatException)
 					{
-						result = GetObjectReader2<T>(DataConnection, reader, CommandText, additionalKey)(reader);
+						result = GetObjectReader2<T>(DataConnection, reader, CommandText, additionalKey)(DataConnection, reader);
 					}
 				}
 
@@ -1218,11 +1218,11 @@ namespace LinqToDB.Data
 							var additionalKey = GetCommandAdditionalKey(rd.DataReader!, typeof(T));
 							try
 							{
-								result = GetObjectReader<T>(DataConnection, rd.DataReader!, CommandText, additionalKey)(rd.DataReader!);
+								result = GetObjectReader<T>(DataConnection, rd.DataReader!, CommandText, additionalKey)(DataConnection, rd.DataReader!);
 							}
 							catch (InvalidCastException)
 							{
-								result = GetObjectReader2<T>(DataConnection, rd.DataReader!, CommandText, additionalKey)(rd.DataReader!);
+								result = GetObjectReader2<T>(DataConnection, rd.DataReader!, CommandText, additionalKey)(DataConnection, rd.DataReader!);
 							}
 						}
 
@@ -1303,7 +1303,7 @@ namespace LinqToDB.Data
 
 					try
 					{
-						result = objectReader(rd);
+						result = objectReader(DataConnection, rd);
 					}
 					catch (InvalidCastException)
 					{
@@ -1312,7 +1312,7 @@ namespace LinqToDB.Data
 
 						isFaulted    = true;
 						objectReader = GetObjectReader2<T>(DataConnection, rd, sql, additionalKey);
-						result       = objectReader(rd);
+						result       = objectReader(DataConnection, rd);
 					}
 
 					yield return result;
@@ -1329,11 +1329,11 @@ namespace LinqToDB.Data
 				var additionalKey = GetCommandAdditionalKey(rd, typeof(T));
 				try
 				{
-					return GetObjectReader<T>(DataConnection, rd, sql, additionalKey)(rd);
+					return GetObjectReader<T>(DataConnection, rd, sql, additionalKey)(DataConnection, rd);
 				}
 				catch (InvalidCastException)
 				{
-					return GetObjectReader2<T>(DataConnection, rd, sql, additionalKey)(rd);
+					return GetObjectReader2<T>(DataConnection, rd, sql, additionalKey)(DataConnection, rd);
 				}
 			}
 
@@ -1408,7 +1408,7 @@ namespace LinqToDB.Data
 
 					try
 					{
-						result = objectReader(rd);
+						result = objectReader(DataConnection, rd);
 					}
 					catch (InvalidCastException)
 					{
@@ -1417,7 +1417,7 @@ namespace LinqToDB.Data
 
 						isFaulted    = true;
 						objectReader = GetObjectReader2<T>(DataConnection, rd, sql, additionalKey);
-						result       = objectReader(rd);
+						result       = objectReader(DataConnection, rd);
 					}
 
 					action(result);
@@ -1444,7 +1444,7 @@ namespace LinqToDB.Data
 
 						try
 						{
-							result = objectReader(rd);
+							result = objectReader(DataConnection, rd);
 						}
 						catch (InvalidCastException)
 						{
@@ -1453,7 +1453,7 @@ namespace LinqToDB.Data
 
 							isFaulted = true;
 							objectReader = GetObjectReader2<T>(DataConnection, rd, sql, additionalKey);
-							result = objectReader(rd);
+							result = objectReader(DataConnection, rd);
 						}
 
 						yield return result;
@@ -1470,11 +1470,11 @@ namespace LinqToDB.Data
 				var additionalKey = GetCommandAdditionalKey(rd, typeof(T));
 				try
 				{
-					return GetObjectReader<T>(DataConnection, rd, sql, additionalKey)(rd);
+					return GetObjectReader<T>(DataConnection, rd, sql, additionalKey)(DataConnection, rd);
 				}
 				catch (InvalidCastException)
 				{
-					return GetObjectReader2<T>(DataConnection, rd, sql, additionalKey)(rd);
+					return GetObjectReader2<T>(DataConnection, rd, sql, additionalKey)(DataConnection, rd);
 				}
 			}
 
@@ -1718,7 +1718,7 @@ namespace LinqToDB.Data
 			return sb.Value.ToString();
 		}
 
-		static Func<DbDataReader,T> GetObjectReader<T>(DataConnection dataConnection, DbDataReader dataReader, string sql, string? additionalKey)
+		static Func<IDataContext,DbDataReader,T> GetObjectReader<T>(DataConnection dataConnection, DbDataReader dataReader, string sql, string? additionalKey)
 		{
 			var func = _objectReaders.GetOrCreate(
 				new QueryKey(typeof(T), dataReader.GetType(), ((IConfigurationID)dataConnection).ConfigurationID, sql, additionalKey, dataReader.FieldCount <= 1, dataReader.FieldCount == 1 ? dataReader.GetFieldType(0) : null),
@@ -1732,18 +1732,18 @@ namespace LinqToDB.Data
 					// dynamic case
 					//
 					return CreateDynamicObjectReader<T>(context.dataConnection, context.dataReader,
-						(dc, dr, type, idx, dataReaderExpr) =>
-							new ConvertFromDataReaderExpression(type, idx, null, dataReaderExpr, canBeNull: (bool?)null).Reduce(dc, dr));
+						(dc, dr, type, idx, dataContextExpr, dataReaderExpr) =>
+							new ConvertFromDataReaderExpression(type, idx, null, dataContextExpr, dataReaderExpr, canBeNull: (bool?)null).Reduce(dc, dr));
 				}
 
-				return CreateObjectReader<T>(context.dataConnection, context.dataReader, (dc, dr, type, idx, dataReaderExpr, conv) =>
-					new ConvertFromDataReaderExpression(type, idx, conv, dataReaderExpr, canBeNull: (bool?)null).Reduce(dc, dr));
+				return CreateObjectReader<T>(context.dataConnection, context.dataReader, (dc, dr, type, idx, dataContextExpr, dataReaderExpr, conv) =>
+					new ConvertFromDataReaderExpression(type, idx, conv, dataContextExpr, dataReaderExpr, canBeNull: (bool?)null).Reduce(dc, dr));
 			});
 
-			return (Func<DbDataReader,T>)func;
+			return (Func<IDataContext, DbDataReader,T>)func;
 		}
 
-		static Func<DbDataReader,T> GetObjectReader2<T>(
+		static Func<IDataContext,DbDataReader, T> GetObjectReader2<T>(
 			DataConnection dataConnection,
 			DbDataReader   dataReader,
 			string         sql,
@@ -1757,26 +1757,27 @@ namespace LinqToDB.Data
 			{
 				// dynamic case
 				//
-				func = CreateDynamicObjectReader<T>(dataConnection, dataReader, (dc, dr, type, idx, dataReaderExpr) =>
-				new ConvertFromDataReaderExpression(type, idx, null, dataReaderExpr, canBeNull: true).Reduce(dc, slowMode: true));
+				func = CreateDynamicObjectReader<T>(dataConnection, dataReader, (dc, dr, type, idx, dataContextExpr, dataReaderExpr) =>
+				new ConvertFromDataReaderExpression(type, idx, null, dataContextExpr, dataReaderExpr, canBeNull: true).Reduce(dc, slowMode: true));
 			}
 			else
 			{
-				func = CreateObjectReader<T>(dataConnection, dataReader, (dc, dr, type, idx, dataReaderExpr, conv) =>
-				new ConvertFromDataReaderExpression(type, idx, conv, dataReaderExpr, canBeNull: true).Reduce(dc, slowMode: true));
+				func = CreateObjectReader<T>(dataConnection, dataReader, (dc, dr, type, idx, dataContextExpr, dataReaderExpr, conv) =>
+				new ConvertFromDataReaderExpression(type, idx, conv, dataContextExpr, dataReaderExpr, canBeNull: true).Reduce(dc, slowMode: true));
 			}
 
 			_objectReaders.Set(key, func,
 				new MemoryCacheEntryOptions<QueryKey> { SlidingExpiration = dataConnection.Options.LinqOptions.CacheSlidingExpirationOrDefault });
 
-			return (Func<DbDataReader,T>)func;
+			return (Func<IDataContext, DbDataReader, T>)func;
 		}
 
-		static Func<DbDataReader, T> CreateObjectReader<T>(
+		static Func<IDataContext,DbDataReader, T> CreateObjectReader<T>(
 			DataConnection dataConnection,
 			DbDataReader   dataReader,
-			Func<DataConnection, DbDataReader, Type, int,Expression,IValueConverter?,Expression> getMemberExpression)
+			Func<DataConnection, DbDataReader, Type, int, Expression,Expression, IValueConverter?,Expression> getMemberExpression)
 		{
+			var ctxParameter   = Expression.Parameter(typeof(IDataContext));
 			var parameter      = Expression.Parameter(typeof(DbDataReader));
 			var dataReaderExpr = (Expression)Expression.Convert(parameter, dataReader.GetType());
 			var readerType     = dataReader.GetType();
@@ -1809,7 +1810,7 @@ namespace LinqToDB.Data
 
 			if (dataConnection.MappingSchema.IsScalarType(typeof(T)))
 			{
-				expr = getMemberExpression(dataConnection, dataReader, typeof(T), 0, dataReaderExpr, null);
+				expr = getMemberExpression(dataConnection, dataReader, typeof(T), 0, ctxParameter, dataReaderExpr, null);
 			}
 			else
 			{
@@ -1852,6 +1853,7 @@ namespace LinqToDB.Data
 									(names
 										.Select((n,i) => new { n, i })
 										.FirstOrDefault(n => dataConnection.MappingSchema.ColumnNameComparer.Compare(n.n, p.Name) == 0) ?? new { n="", i=-1 }).i,
+									ctxParameter,
 									dataReaderExpr,
 									null) :
 								Expression.Constant(dataConnection.MappingSchema.GetDefaultValue(p.ParameterType), p.ParameterType)));
@@ -1869,7 +1871,7 @@ namespace LinqToDB.Data
 						select new
 						{
 							Member = member,
-							Expr   = getMemberExpression(dataConnection, dataReader, member.MemberType, n.idx, dataReaderExpr, member.ValueConverter),
+							Expr   = getMemberExpression(dataConnection, dataReader, member.MemberType, n.idx, ctxParameter, dataReaderExpr, member.ValueConverter),
 						}
 					).ToList();
 
@@ -1891,7 +1893,7 @@ namespace LinqToDB.Data
 					expr = SequentialAccessHelper.OptimizeMappingExpressionForSequentialAccess(expr, dataReader.FieldCount, reduce: false);
 			}
 
-			var lex = Expression.Lambda<Func<DbDataReader,T>>(expr, parameter);
+			var lex = Expression.Lambda<Func<IDataContext, DbDataReader,T>>(expr, ctxParameter, parameter);
 
 			return lex.CompileExpression();
 		}
@@ -1899,11 +1901,12 @@ namespace LinqToDB.Data
 		static readonly ConstructorInfo _expandoObjectConstructor = MemberHelper.ConstructorOf(() => new ExpandoObject());
 		static readonly MethodInfo      _expandoAddMethodInfo     = MemberHelper.MethodOf(() => ((IDictionary<string, object>)null!).Add("", ""));
 
-		static Func<DbDataReader, T> CreateDynamicObjectReader<T>(
+		static Func<IDataContext, DbDataReader, T> CreateDynamicObjectReader<T>(
 			DataConnection dataConnection,
 			DbDataReader dataReader,
-			Func<DataConnection, DbDataReader, Type, int, Expression, Expression> getMemberExpression)
+			Func<DataConnection, DbDataReader, Type, int, Expression, Expression, Expression> getMemberExpression)
 		{
+			var ctxParameter   = Expression.Parameter(typeof(IDataContext));
 			var parameter      = Expression.Parameter(typeof(DbDataReader));
 			var dataReaderExpr = (Expression)Expression.Convert(parameter, dataReader.GetType());
 			var readerType     = dataReader.GetType();
@@ -1937,6 +1940,7 @@ namespace LinqToDB.Data
 				Enumerable.Range(0, dataReader.FieldCount).Select(idx =>
 				{
 					var readerExpr = getMemberExpression(dataConnection, dataReader, typeof(object), idx,
+						ctxParameter,
 						dataReaderExpr);
 					return Expression.ElementInit(_expandoAddMethodInfo, Expression.Constant(dataReader.GetName(idx)), readerExpr);
 				}));
@@ -1950,7 +1954,7 @@ namespace LinqToDB.Data
 				expr = Expression.Block(new[] { dataReaderVar }, assignment, expr);
 			}
 
-			var lex = Expression.Lambda<Func<DbDataReader,T>>(expr, parameter);
+			var lex = Expression.Lambda<Func<IDataContext,DbDataReader,T>>(expr, ctxParameter, parameter);
 
 			return lex.CompileExpression();
 		}

--- a/Source/LinqToDB/Data/CommandInfo.cs
+++ b/Source/LinqToDB/Data/CommandInfo.cs
@@ -1367,7 +1367,16 @@ namespace LinqToDB.Data
 			// make sure command creation will not lead to sync connection.Open call
 			await DataConnection.EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false);
 
-			return InitCommand();
+			var hasParameters = Parameters?.Length > 0;
+
+			await DataConnection.InitCommandAsync(CommandType, CommandText, Parameters, null, hasParameters, cancellationToken).ConfigureAwait(false);
+
+			if (hasParameters)
+				SetParameters(DataConnection, Parameters!);
+
+			DataConnection.CommitCommandInit();
+
+			return hasParameters;
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Source/LinqToDB/Data/DataConnection.Async.cs
+++ b/Source/LinqToDB/Data/DataConnection.Async.cs
@@ -43,8 +43,6 @@ namespace LinqToDB.Data
 			if (!DataProvider.TransactionsSupported)
 				return new(this);
 
-			await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-
 			// If transaction is open, we dispose it, it will rollback all changes.
 			//
 			if (TransactionAsync != null) await TransactionAsync.DisposeAsync().ConfigureAwait(false);
@@ -56,9 +54,11 @@ namespace LinqToDB.Data
 				default(object?),
 				static async (dataConnection, _, cancellationToken) =>
 				{
+					var connection = await dataConnection.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+
 					// Create new transaction object.
 					//
-					dataConnection.TransactionAsync = await dataConnection._connection!.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+					dataConnection.TransactionAsync = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
 
 					dataConnection._closeTransaction = true;
 
@@ -87,8 +87,6 @@ namespace LinqToDB.Data
 			if (!DataProvider.TransactionsSupported)
 				return new(this);
 
-			await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-
 			// If transaction is open, we dispose it, it will rollback all changes.
 			//
 			if (TransactionAsync != null) await TransactionAsync.DisposeAsync().ConfigureAwait(false);
@@ -100,9 +98,11 @@ namespace LinqToDB.Data
 				isolationLevel,
 				static async (dataConnection, isolationLevel, cancellationToken) =>
 				{
+					var connection = await dataConnection.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+
 					// Create new transaction object.
 					//
-					dataConnection.TransactionAsync = await dataConnection._connection!.BeginTransactionAsync(isolationLevel, cancellationToken).ConfigureAwait(false);
+					dataConnection.TransactionAsync = await connection.BeginTransactionAsync(isolationLevel, cancellationToken).ConfigureAwait(false);
 
 					dataConnection._closeTransaction = true;
 
@@ -447,10 +447,10 @@ namespace LinqToDB.Data
 		{
 			CheckAndThrowOnDisposed();
 
-			await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-
 			try
 			{
+				await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+
 				if (((IInterceptable<ICommandInterceptor>)this).Interceptor is { } cInterceptor)
 				{
 					Option<int> result;
@@ -546,10 +546,10 @@ namespace LinqToDB.Data
 		{
 			CheckAndThrowOnDisposed();
 
-			await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-
 			try
 			{
+				await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+
 				if (((IInterceptable<ICommandInterceptor>)this).Interceptor is { } cInterceptor)
 				{
 					Option<object?> result;
@@ -651,10 +651,10 @@ namespace LinqToDB.Data
 		{
 			CheckAndThrowOnDisposed();
 
-			await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-
 			try
 			{
+				await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+
 				DbDataReader reader;
 
 				if (((IInterceptable<ICommandInterceptor>)this).Interceptor is { } cInterceptor)

--- a/Source/LinqToDB/Data/DataConnection.Async.cs
+++ b/Source/LinqToDB/Data/DataConnection.Async.cs
@@ -19,7 +19,9 @@ namespace LinqToDB.Data
 	public partial class DataConnection
 	{
 #if NET6_0_OR_GREATER
-		private async ValueTask DisposeCommandAsync()
+		// TODO: Mark private in v7 and remove warning suppressions from callers
+		[Obsolete("This API scheduled for removal in v7"), EditorBrowsable(EditorBrowsableState.Never)]
+		public async ValueTask DisposeCommandAsync()
 		{
 			if (_command != null)
 			{
@@ -370,7 +372,9 @@ namespace LinqToDB.Data
 			}
 
 #if NET6_0_OR_GREATER
+#pragma warning disable CS0618 // Type or member is obsolete
 			await DisposeCommandAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 #else
 			DisposeCommand();
 #endif

--- a/Source/LinqToDB/Data/DataConnection.Async.cs
+++ b/Source/LinqToDB/Data/DataConnection.Async.cs
@@ -119,6 +119,14 @@ namespace LinqToDB.Data
 		}
 
 		/// <summary>
+		/// Returns underlying <see cref="DbConnection"/> instance. If connection is not open yet - it will be opened.
+		/// </summary>
+		public async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken)
+		{
+			return (await EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false)).Connection;
+		}
+
+		/// <summary>
 		/// Ensure that database connection opened. If opened connection missing, it will be opened asynchronously.
 		/// </summary>
 		/// <param name="cancellationToken">Asynchronous operation cancellation token.</param>

--- a/Source/LinqToDB/Data/DataConnection.Async.cs
+++ b/Source/LinqToDB/Data/DataConnection.Async.cs
@@ -371,13 +371,13 @@ namespace LinqToDB.Data
 					await interceptor.OnClosingAsync(new (this)).ConfigureAwait(false);
 			}
 
-#if NET6_0_OR_GREATER
 #pragma warning disable CS0618 // Type or member is obsolete
+#if NET6_0_OR_GREATER
 			await DisposeCommandAsync().ConfigureAwait(false);
-#pragma warning restore CS0618 // Type or member is obsolete
 #else
 			DisposeCommand();
 #endif
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (TransactionAsync != null && _closeTransaction)
 			{

--- a/Source/LinqToDB/Data/DataConnection.Async.cs
+++ b/Source/LinqToDB/Data/DataConnection.Async.cs
@@ -29,6 +29,18 @@ namespace LinqToDB.Data
 				_command = null;
 			}
 		}
+
+		/// <summary>
+		/// Sets command timeout to default connection value.
+		/// </summary>
+		public ValueTask ResetCommandTimeoutAsync()
+		{
+			_commandTimeout = null;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+			return DisposeCommandAsync();
+#pragma warning restore CS0618 // Type or member is obsolete
+		}
 #endif
 
 		/// <summary>

--- a/Source/LinqToDB/Data/DataConnection.Async.cs
+++ b/Source/LinqToDB/Data/DataConnection.Async.cs
@@ -37,6 +37,8 @@ namespace LinqToDB.Data
 		/// <returns>Database transaction object.</returns>
 		public virtual async Task<DataConnectionTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
 		{
+			CheckAndThrowOnDisposed();
+
 			if (!DataProvider.TransactionsSupported)
 				return new(this);
 
@@ -79,6 +81,8 @@ namespace LinqToDB.Data
 		/// <returns>Database transaction object.</returns>
 		public virtual async Task<DataConnectionTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
 		{
+			CheckAndThrowOnDisposed();
+
 			if (!DataProvider.TransactionsSupported)
 				return new(this);
 
@@ -199,6 +203,8 @@ namespace LinqToDB.Data
 		/// <returns>Asynchronous operation completion task.</returns>
 		public virtual async Task CommitTransactionAsync(CancellationToken cancellationToken = default)
 		{
+			CheckAndThrowOnDisposed();
+
 			if (TransactionAsync != null)
 			{
 				await TraceActionAsync(
@@ -233,6 +239,8 @@ namespace LinqToDB.Data
 		/// <returns>Asynchronous operation completion task.</returns>
 		public virtual async Task RollbackTransactionAsync(CancellationToken cancellationToken = default)
 		{
+			CheckAndThrowOnDisposed();
+
 			if (TransactionAsync != null)
 			{
 				await TraceActionAsync(
@@ -268,6 +276,8 @@ namespace LinqToDB.Data
 		/// <returns>Asynchronous operation completion task.</returns>
 		public virtual async Task DisposeTransactionAsync()
 		{
+			CheckAndThrowOnDisposed();
+
 			if (TransactionAsync != null)
 			{
 				await TraceActionAsync(
@@ -422,6 +432,8 @@ namespace LinqToDB.Data
 
 		protected virtual async Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
 		{
+			CheckAndThrowOnDisposed();
+
 			try
 			{
 				if (((IInterceptable<ICommandInterceptor>)this).Interceptor is { } cInterceptor)
@@ -454,6 +466,8 @@ namespace LinqToDB.Data
 
 		internal async Task<int> ExecuteNonQueryDataAsync(CancellationToken cancellationToken)
 		{
+			CheckAndThrowOnDisposed();
+
 			if (TraceSwitchConnection.Level == TraceLevel.Off)
 				await using ((DataProvider.ExecuteScope(this) ?? EmptyIAsyncDisposable.Instance).ConfigureAwait(false))
 					return await ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
@@ -515,6 +529,8 @@ namespace LinqToDB.Data
 
 		protected virtual async Task<object?> ExecuteScalarAsync(CancellationToken cancellationToken)
 		{
+			CheckAndThrowOnDisposed();
+
 			try
 			{
 				if (((IInterceptable<ICommandInterceptor>)this).Interceptor is { } cInterceptor)
@@ -547,6 +563,8 @@ namespace LinqToDB.Data
 
 		internal async Task<object?> ExecuteScalarDataAsync(CancellationToken cancellationToken)
 		{
+			CheckAndThrowOnDisposed();
+
 			if (TraceSwitchConnection.Level == TraceLevel.Off)
 				await using ((DataProvider.ExecuteScope(this) ?? EmptyIAsyncDisposable.Instance).ConfigureAwait(false))
 					return await ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
@@ -609,6 +627,8 @@ namespace LinqToDB.Data
 			CommandBehavior   commandBehavior,
 			CancellationToken cancellationToken)
 		{
+			CheckAndThrowOnDisposed();
+
 			try
 			{
 				DbDataReader reader;
@@ -665,6 +685,8 @@ namespace LinqToDB.Data
 			CommandBehavior commandBehavior,
 			CancellationToken cancellationToken)
 		{
+			CheckAndThrowOnDisposed();
+
 			if (TraceSwitchConnection.Level == TraceLevel.Off)
 				await using ((DataProvider.ExecuteScope(this) ?? EmptyIAsyncDisposable.Instance).ConfigureAwait(false))
 					return await ExecuteReaderAsync(commandBehavior, cancellationToken)

--- a/Source/LinqToDB/Data/DataConnection.Async.cs
+++ b/Source/LinqToDB/Data/DataConnection.Async.cs
@@ -32,6 +32,7 @@ namespace LinqToDB.Data
 
 		/// <summary>
 		/// Sets command timeout to default connection value.
+		/// Note that default provider/connection timeout is not the same value as timeout value you can specify upon context configuration.
 		/// </summary>
 		public ValueTask ResetCommandTimeoutAsync()
 		{
@@ -459,8 +460,6 @@ namespace LinqToDB.Data
 
 			try
 			{
-				await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-
 				if (((IInterceptable<ICommandInterceptor>)this).Interceptor is { } cInterceptor)
 				{
 					Option<int> result;
@@ -492,6 +491,8 @@ namespace LinqToDB.Data
 		internal async Task<int> ExecuteNonQueryDataAsync(CancellationToken cancellationToken)
 		{
 			CheckAndThrowOnDisposed();
+
+			await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
 
 			if (TraceSwitchConnection.Level == TraceLevel.Off)
 				await using ((DataProvider.ExecuteScope(this) ?? EmptyIAsyncDisposable.Instance).ConfigureAwait(false))
@@ -558,8 +559,6 @@ namespace LinqToDB.Data
 
 			try
 			{
-				await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-
 				if (((IInterceptable<ICommandInterceptor>)this).Interceptor is { } cInterceptor)
 				{
 					Option<object?> result;
@@ -591,6 +590,8 @@ namespace LinqToDB.Data
 		internal async Task<object?> ExecuteScalarDataAsync(CancellationToken cancellationToken)
 		{
 			CheckAndThrowOnDisposed();
+
+			await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
 
 			if (TraceSwitchConnection.Level == TraceLevel.Off)
 				await using ((DataProvider.ExecuteScope(this) ?? EmptyIAsyncDisposable.Instance).ConfigureAwait(false))
@@ -658,8 +659,6 @@ namespace LinqToDB.Data
 
 			try
 			{
-				await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-
 				DbDataReader reader;
 
 				if (((IInterceptable<ICommandInterceptor>)this).Interceptor is { } cInterceptor)
@@ -715,6 +714,8 @@ namespace LinqToDB.Data
 			CancellationToken cancellationToken)
 		{
 			CheckAndThrowOnDisposed();
+
+			await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
 
 			if (TraceSwitchConnection.Level == TraceLevel.Off)
 				await using ((DataProvider.ExecuteScope(this) ?? EmptyIAsyncDisposable.Instance).ConfigureAwait(false))

--- a/Source/LinqToDB/Data/DataConnection.Async.cs
+++ b/Source/LinqToDB/Data/DataConnection.Async.cs
@@ -94,7 +94,7 @@ namespace LinqToDB.Data
 			var dataConnectionTransaction = await TraceActionAsync(
 				this,
 				TraceOperation.BeginTransaction,
-				static il => $"BeginTransactionAsync({il})",
+				static ctx => $"BeginTransactionAsync({ctx.isolationLevel})",
 				(isolationLevel, connection),
 				static async (dataConnection, ctx, cancellationToken) =>
 				{

--- a/Source/LinqToDB/Data/DataConnection.Async.cs
+++ b/Source/LinqToDB/Data/DataConnection.Async.cs
@@ -366,8 +366,9 @@ namespace LinqToDB.Data
 		/// <returns>Asynchronous operation completion task.</returns>
 		public async ValueTask DisposeAsync()
 		{
-			Disposed = true;
 			await CloseAsync().ConfigureAwait(false);
+
+			Disposed = true;
 		}
 
 		protected static async Task<TResult> TraceActionAsync<TContext, TResult>(

--- a/Source/LinqToDB/Data/DataConnection.Configuration.cs
+++ b/Source/LinqToDB/Data/DataConnection.Configuration.cs
@@ -483,12 +483,14 @@ namespace LinqToDB.Data
 		{
 			get
 			{
+				ThrowOnDisposed();
+
 				if (_configurationID == null || _msID != ((IConfigurationID)MappingSchema).ConfigurationID)
 				{
 					using var idBuilder = new IdentifierBuilder();
 					_configurationID = idBuilder
 						.Add(_msID = ((IConfigurationID)MappingSchema).ConfigurationID)
-						.Add(ConfigurationString ?? ConnectionString ?? EnsureConnection(connect: false).ConnectionString)
+						.Add(ConfigurationString)
 						.Add(Options)
 						.Add(GetType())
 						.CreateID();

--- a/Source/LinqToDB/Data/DataConnection.Configuration.cs
+++ b/Source/LinqToDB/Data/DataConnection.Configuration.cs
@@ -644,7 +644,6 @@ namespace LinqToDB.Data
 
 				IAsyncDbConnection WrapConnection(DbConnection connection)
 				{
-					// TODO: IT Look into.
 					return connection is IAsyncDbConnection asyncDbConnection
 						? asyncDbConnection
 						: AsyncFactory.CreateAndSetDataContext(dataConnection, connection);

--- a/Source/LinqToDB/Data/DataConnection.Configuration.cs
+++ b/Source/LinqToDB/Data/DataConnection.Configuration.cs
@@ -669,7 +669,7 @@ namespace LinqToDB.Data
 			public static void Apply(DataConnection dataConnection, QueryTraceOptions options)
 			{
 #pragma warning disable CS0618 // Type or member is obsolete
-				if (options.OnTrace     != null) dataConnection.OnTraceConnection     = options.OnTrace;
+				if (options.OnTrace    != null) dataConnection.OnTraceConnection     = options.OnTrace;
 				if (options.WriteTrace != null) dataConnection.WriteTraceLineConnection = options.WriteTrace;
 
 				if      (options.TraceSwitch != null) dataConnection.TraceSwitchConnection = options.TraceSwitch;

--- a/Source/LinqToDB/Data/DataConnection.Configuration.cs
+++ b/Source/LinqToDB/Data/DataConnection.Configuration.cs
@@ -652,7 +652,9 @@ namespace LinqToDB.Data
 
 			public static void Apply(DataConnection dataConnection, RetryPolicyOptions options)
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
 				dataConnection.RetryPolicy = options.RetryPolicy ?? options.Factory?.Invoke(dataConnection);
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			public static void Apply(DataConnection dataConnection, DataContextOptions options)
@@ -666,9 +668,13 @@ namespace LinqToDB.Data
 
 			public static void Apply(DataConnection dataConnection, QueryTraceOptions options)
 			{
-				if (options.OnTrace    != null) dataConnection.OnTraceConnection        = options.OnTrace;
-				if (options.TraceLevel != null) dataConnection.TraceSwitchConnection    = new("DataConnection", "DataConnection trace switch") {Level = options.TraceLevel.Value};
+#pragma warning disable CS0618 // Type or member is obsolete
+				if (options.OnTrace     != null) dataConnection.OnTraceConnection     = options.OnTrace;
 				if (options.WriteTrace != null) dataConnection.WriteTraceLineConnection = options.WriteTrace;
+
+				if      (options.TraceSwitch != null) dataConnection.TraceSwitchConnection = options.TraceSwitch;
+				else if (options.TraceLevel  != null) dataConnection.TraceSwitchConnection = new("DataConnection", "DataConnection trace switch") {Level = options.TraceLevel.Value};
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 		}
 	}

--- a/Source/LinqToDB/Data/DataConnection.Configuration.cs
+++ b/Source/LinqToDB/Data/DataConnection.Configuration.cs
@@ -483,7 +483,7 @@ namespace LinqToDB.Data
 		{
 			get
 			{
-				ThrowOnDisposed();
+				CheckAndThrowOnDisposed();
 
 				if (_configurationID == null || _msID != ((IConfigurationID)MappingSchema).ConfigurationID)
 				{

--- a/Source/LinqToDB/Data/DataConnection.Interceptors.cs
+++ b/Source/LinqToDB/Data/DataConnection.Interceptors.cs
@@ -27,6 +27,8 @@ namespace LinqToDB.Data
 		/// <inheritdoc cref="IDataContext.AddInterceptor(IInterceptor)"/>
 		public void AddInterceptor(IInterceptor interceptor)
 		{
+			CheckAndThrowOnDisposed();
+
 			this.AddInterceptorImpl(interceptor);
 		}
 
@@ -35,6 +37,8 @@ namespace LinqToDB.Data
 		/// <inheritdoc cref="IDataContext.RemoveInterceptor(IInterceptor)"/>
 		public void RemoveInterceptor(IInterceptor interceptor)
 		{
+			CheckAndThrowOnDisposed();
+
 			this.RemoveInterceptorImpl(interceptor);
 			OnRemoveInterceptor?.Invoke(interceptor);
 		}

--- a/Source/LinqToDB/Data/DataConnection.Linq.cs
+++ b/Source/LinqToDB/Data/DataConnection.Linq.cs
@@ -12,6 +12,8 @@ namespace LinqToDB.Data
 	{
 		protected virtual SqlStatement ProcessQuery(SqlStatement statement, EvaluationContext context)
 		{
+			CheckAndThrowOnDisposed();
+
 			return statement;
 		}
 
@@ -25,6 +27,8 @@ namespace LinqToDB.Data
 
 		Expression IDataContext.GetReaderExpression(DbDataReader reader, int idx, Expression readerExpression, Type toType)
 		{
+			CheckAndThrowOnDisposed();
+
 			return DataProvider.GetReaderExpression(reader, idx, readerExpression, toType);
 		}
 

--- a/Source/LinqToDB/Data/DataConnection.Linq.cs
+++ b/Source/LinqToDB/Data/DataConnection.Linq.cs
@@ -41,12 +41,7 @@ namespace LinqToDB.Data
 
 		Func<ISqlBuilder> IDataContext.CreateSqlProvider => () => DataProvider.CreateSqlBuilder(MappingSchema, Options);
 
-		static Func<DataOptions,ISqlOptimizer> GetGetSqlOptimizer(IDataProvider dp)
-		{
-			return dp.GetSqlOptimizer;
-		}
-
-		Func<DataOptions,ISqlOptimizer> IDataContext.GetSqlOptimizer => GetGetSqlOptimizer(DataProvider);
+		Func<DataOptions,ISqlOptimizer> IDataContext.GetSqlOptimizer => DataProvider.GetSqlOptimizer;
 
 		#endregion
 	}

--- a/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
+++ b/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
@@ -30,6 +30,7 @@ namespace LinqToDB.Data
 			object?[]? preambles)
 		{
 			CheckAndThrowOnDisposed();
+
 			return new QueryRunner(query, queryNumber, this, parametersContext, expressions, parameters, preambles);
 		}
 

--- a/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
+++ b/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
@@ -384,7 +384,13 @@ namespace LinqToDB.Data
 				finally
 				{
 					if (forGetSqlText && dbCommand != null)
+					{
+#if NET6_0_OR_GREATER
 						await dbCommand.DisposeAsync().ConfigureAwait(false);
+#else
+						dbCommand.Dispose();
+#endif
+					}
 				}
 
 				return result;

--- a/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
+++ b/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
@@ -640,7 +640,7 @@ namespace LinqToDB.Data
 
 				InitFirstCommand(dataConnection, executionQuery);
 
-				return dataConnection.ExecuteReader(CommandBehavior.Default);
+				return dataConnection.ExecuteDataReader(CommandBehavior.Default);
 			}
 
 			public override DataReaderWrapper ExecuteReader()
@@ -649,7 +649,7 @@ namespace LinqToDB.Data
 
 				InitFirstCommand(_dataConnection, _executionQuery!);
 
-				return _dataConnection.ExecuteReader(CommandBehavior.Default);
+				return _dataConnection.ExecuteDataReader(CommandBehavior.Default);
 			}
 
 			#endregion

--- a/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
+++ b/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
@@ -375,7 +375,7 @@ namespace LinqToDB.Data
 
 				for (var i = 0; i < executionQuery.PreparedQuery.Commands.Length; i++)
 				{
-					InitCommand(dataConnection, executionQuery, 1);
+					InitCommand(dataConnection, executionQuery, i);
 
 					if (i < executionQuery.PreparedQuery.Commands.Length - 1 && executionQuery.PreparedQuery.Commands[i].Command.StartsWith("DROP"))
 					{
@@ -709,7 +709,7 @@ namespace LinqToDB.Data
 
 				for (var i = 0; i < _executionQuery.PreparedQuery.Commands.Length; i++)
 				{
-					InitCommand(_dataConnection, _executionQuery, 1);
+					InitCommand(_dataConnection, _executionQuery, i);
 
 					if (i < _executionQuery.PreparedQuery.Commands.Length - 1 && _executionQuery.PreparedQuery.Commands[i].Command.StartsWith("DROP"))
 					{

--- a/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
+++ b/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
@@ -308,7 +308,7 @@ namespace LinqToDB.Data
 							var sqlp = command.SqlParameters[i];
 
 							dbCommand ??= forGetSqlText
-								? dataConnection.EnsureConnection(false).CreateCommand()
+								? dataConnection.EnsureConnection(connect: false).CreateCommand()
 								: dataConnection.GetOrCreateCommand();
 
 							parms[i] = CreateParameter(dataConnection, dbCommand, sqlp, sqlp.GetParameterValue(parameterValues), forGetSqlText);
@@ -690,7 +690,7 @@ namespace LinqToDB.Data
 			{
 				_isAsync = true;
 
-				await _dataConnection.EnsureConnectionAsync(cancellationToken).ConfigureAwait(false);
+				await _dataConnection.EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false);
 
 				SetCommand(false);
 
@@ -705,7 +705,7 @@ namespace LinqToDB.Data
 			{
 				_isAsync = true;
 
-				await _dataConnection.EnsureConnectionAsync(cancellationToken).ConfigureAwait(false);
+				await _dataConnection.EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false);
 
 				SetCommand(false);
 
@@ -743,7 +743,7 @@ namespace LinqToDB.Data
 			{
 				_isAsync = true;
 
-				await _dataConnection.EnsureConnectionAsync(cancellationToken)
+				await _dataConnection.EnsureConnectionAsync(connect: true, cancellationToken)
 					.ConfigureAwait(false);
 
 				SetCommand();

--- a/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
+++ b/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
@@ -367,7 +367,7 @@ namespace LinqToDB.Data
 				{
 					InitFirstCommand(dataConnection, executionQuery);
 
-					return await dataConnection.ExecuteNonQueryAsync(cancellationToken)
+					return await dataConnection.ExecuteNonQueryDataAsync(cancellationToken)
 						.ConfigureAwait(false);
 				}
 
@@ -381,7 +381,7 @@ namespace LinqToDB.Data
 					{
 						try
 						{
-							await dataConnection.ExecuteNonQueryAsync(cancellationToken)
+							await dataConnection.ExecuteNonQueryDataAsync(cancellationToken)
 								.ConfigureAwait(false);
 						}
 						catch (Exception)
@@ -390,7 +390,7 @@ namespace LinqToDB.Data
 					}
 					else
 					{
-						var n = await dataConnection.ExecuteNonQueryAsync(cancellationToken)
+						var n = await dataConnection.ExecuteNonQueryDataAsync(cancellationToken)
 							.ConfigureAwait(false);
 
 						if (i == 0)
@@ -630,7 +630,7 @@ namespace LinqToDB.Data
 
 				InitFirstCommand(dataConnection, executionQuery);
 
-				return dataConnection.ExecuteReaderAsync(cancellationToken);
+				return dataConnection.ExecuteDataReaderAsync(CommandBehavior.Default, cancellationToken);
 			}
 
 			// In case of change the logic of this method, DO NOT FORGET to change the sibling method.
@@ -640,7 +640,7 @@ namespace LinqToDB.Data
 
 				InitFirstCommand(dataConnection, executionQuery);
 
-				return dataConnection.ExecuteReader();
+				return dataConnection.ExecuteReader(CommandBehavior.Default);
 			}
 
 			public override DataReaderWrapper ExecuteReader()
@@ -649,7 +649,7 @@ namespace LinqToDB.Data
 
 				InitFirstCommand(_dataConnection, _executionQuery!);
 
-				return _dataConnection.ExecuteReader();
+				return _dataConnection.ExecuteReader(CommandBehavior.Default);
 			}
 
 			#endregion
@@ -689,7 +689,7 @@ namespace LinqToDB.Data
 
 				InitFirstCommand(_dataConnection, _executionQuery!);
 
-				var dataReader = await _dataConnection.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+				var dataReader = await _dataConnection.ExecuteDataReaderAsync(CommandBehavior.Default, cancellationToken).ConfigureAwait(false);
 
 				return new DataReaderAsync(dataReader);
 			}

--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -1643,9 +1643,9 @@ namespace LinqToDB.Data
 		/// </summary>
 		public void Dispose()
 		{
-			Disposed = true;
-
 			Close();
+
+			Disposed = true;
 		}
 
 		#endregion

--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -1002,6 +1002,7 @@ namespace LinqToDB.Data
 
 		/// <summary>
 		/// Resets command timeout to provider or connection defaults.
+		/// Note that default provider/connection timeout is not the same value as timeout value you can specify upon context configuration.
 		/// </summary>
 		public void ResetCommandTimeout()
 		{
@@ -1056,8 +1057,6 @@ namespace LinqToDB.Data
 
 			try
 			{
-				OpenConnection();
-
 				if (((IInterceptable<ICommandInterceptor>)this).Interceptor is { } cInterceptor)
 				{
 					Option<int> result;
@@ -1083,6 +1082,8 @@ namespace LinqToDB.Data
 		internal int ExecuteNonQuery()
 		{
 			CheckAndThrowOnDisposed();
+
+			OpenConnection();
 
 			if (TraceSwitchConnection.Level == TraceLevel.Off)
 				using (DataProvider.ExecuteScope(this))
@@ -1145,8 +1146,6 @@ namespace LinqToDB.Data
 
 			try
 			{
-				OpenConnection();
-
 				if (((IInterceptable<ICommandInterceptor>)this).Interceptor is { } cInterceptor)
 				{
 					Option<int> result;
@@ -1172,6 +1171,8 @@ namespace LinqToDB.Data
 		internal int ExecuteNonQueryCustom(Func<DbCommand, int> customExecute)
 		{
 			CheckAndThrowOnDisposed();
+
+			OpenConnection();
 
 			if (TraceSwitchConnection.Level == TraceLevel.Off)
 				using (DataProvider.ExecuteScope(this))
@@ -1238,8 +1239,6 @@ namespace LinqToDB.Data
 
 			try
 			{
-				OpenConnection();
-
 				if (((IInterceptable<ICommandInterceptor>)this).Interceptor is { } cInterceptor)
 				{
 					Option<object?> result;
@@ -1264,6 +1263,8 @@ namespace LinqToDB.Data
 
 		object? ExecuteScalar()
 		{
+			OpenConnection();
+
 			if (TraceSwitchConnection.Level == TraceLevel.Off)
 				using (DataProvider.ExecuteScope(this))
 					return ExecuteScalar(CurrentCommand!);
@@ -1328,8 +1329,6 @@ namespace LinqToDB.Data
 
 			try
 			{
-				OpenConnection();
-
 				DbDataReader reader;
 
 				if (((IInterceptable<ICommandInterceptor>)this).Interceptor is { } cInterceptor)
@@ -1374,6 +1373,8 @@ namespace LinqToDB.Data
 		internal DataReaderWrapper ExecuteDataReader(CommandBehavior commandBehavior)
 		{
 			CheckAndThrowOnDisposed();
+
+			OpenConnection();
 
 			if (TraceSwitchConnection.Level == TraceLevel.Off)
 				using (DataProvider.ExecuteScope(this))

--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -514,11 +514,15 @@ namespace LinqToDB.Data
 		/// </summary>
 		public IRetryPolicy? RetryPolicy         { get; set; }
 
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7"), EditorBrowsable(EditorBrowsableState.Never)]
 		private bool? _isMarsEnabled;
 		/// <summary>
 		/// Gets or sets status of Multiple Active Result Sets (MARS) feature. This feature available only for
 		/// SQL Azure and SQL Server 2005+.
 		/// </summary>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7"), EditorBrowsable(EditorBrowsableState.Never)]
 		public  bool   IsMarsEnabled
 		{
 			get

--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -1648,11 +1648,15 @@ namespace LinqToDB.Data
 		#region System.IDisposable Members
 
 		protected bool  Disposed        { get; private set; }
-		public    bool? ThrowOnDisposed { get; set; }
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7"), EditorBrowsable(EditorBrowsableState.Never)]
+		public bool? ThrowOnDisposed { get; set; }
 
 		protected void CheckAndThrowOnDisposed()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (Disposed && (ThrowOnDisposed ?? Common.Configuration.Data.ThrowOnDisposed))
+#pragma warning restore CS0618 // Type or member is obsolete
 				throw new ObjectDisposedException("DataConnection", "IDataContext is disposed, see https://github.com/linq2db/linq2db/wiki/Managing-data-connection");
 		}
 

--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -504,7 +504,7 @@ namespace LinqToDB.Data
 		/// <summary>
 		/// Database provider implementation for specific database engine.
 		/// </summary>
-		public IDataProvider DataProvider        { get; internal set; }
+		public IDataProvider DataProvider        { get; private set; }
 		/// <summary>
 		/// Database connection string.
 		/// </summary>
@@ -512,7 +512,13 @@ namespace LinqToDB.Data
 		/// <summary>
 		/// Retry policy for current connection.
 		/// </summary>
-		public IRetryPolicy? RetryPolicy         { get; set; }
+		public IRetryPolicy? RetryPolicy
+		{
+			get;
+			// TODO: Make private in v7 and remove obsoletion warning ignores from callers
+			[Obsolete("This API scheduled for removal in v7. Use DataOptions's UseRetryPolicy API"), EditorBrowsable(EditorBrowsableState.Never)]
+			set;
+		}
 
 		// TODO: Remove in v7
 		[Obsolete("This API scheduled for removal in v7"), EditorBrowsable(EditorBrowsableState.Never)]
@@ -546,7 +552,13 @@ namespace LinqToDB.Data
 		/// Configured on the connection builder using <see cref="DataOptionsExtensions.UseTracing(DataOptions,Action{TraceInfo})"/>.
 		/// defaults to <see cref="WriteTraceLineConnection"/> calls.
 		/// </summary>
-		public Action<TraceInfo> OnTraceConnection { get; set; } = DefaultOnTraceConnection;
+		public Action<TraceInfo> OnTraceConnection
+		{
+			get;
+			// TODO: Make private in v7 and remove obsoletion warning ignores from callers
+			[Obsolete("This API scheduled for removal in v7. Use DataOptions's UseTracing API"), EditorBrowsable(EditorBrowsableState.Never)]
+			set;
+		} = DefaultOnTraceConnection;
 
 		/// <summary>
 		/// Writes the trace out using <see cref="WriteTraceLineConnection"/>.
@@ -685,6 +697,8 @@ namespace LinqToDB.Data
 		public TraceSwitch TraceSwitchConnection
 		{
 			get => _traceSwitchConnection ?? _traceSwitch;
+			// TODO: Make private in v7 and remove obsoletion warning ignores from callers
+			[Obsolete("This API scheduled for removal in v7. Use DataOptions's UseTraceSwitch API"), EditorBrowsable(EditorBrowsableState.Never)]
 			set => _traceSwitchConnection = value;
 		}
 
@@ -704,7 +718,13 @@ namespace LinqToDB.Data
 		/// Defaults to <see cref="WriteTraceLine"/>.
 		/// Used for the current instance.
 		/// </summary>
-		public Action<string,string,TraceLevel> WriteTraceLineConnection { get; protected set; } = WriteTraceLine;
+		public Action<string,string,TraceLevel> WriteTraceLineConnection
+		{
+			get;
+			// TODO: Make private in v7 and remove obsoletion warning ignores from callers
+			[Obsolete("This API scheduled for removal in v7. Use DataOptions's UseTraceWith API"), EditorBrowsable(EditorBrowsableState.Never)]
+			protected set;
+		} = WriteTraceLine;
 
 		#endregion
 
@@ -815,7 +835,9 @@ namespace LinqToDB.Data
 					interceptor.OnClosing(new(this));
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			DisposeCommand();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (TransactionAsync != null && _closeTransaction)
 			{
@@ -857,7 +879,9 @@ namespace LinqToDB.Data
 		/// <summary>
 		/// Creates if needed and returns current command instance.
 		/// </summary>
+#pragma warning disable CS0618 // Type or member is obsolete
 		internal DbCommand GetOrCreateCommand() => _command ??= CreateCommand();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		/// <summary>
 		/// Contains text of last command, sent to database using current connection.
@@ -911,7 +935,9 @@ namespace LinqToDB.Data
 					_commandTimeout = null;
 					// TODO: that's not good - user is not aware that he can trigger blocking operation
 					// we should postpone disposal till command used (or redesign CommandTimeout to methods)
+#pragma warning disable CS0618 // Type or member is obsolete
 					DisposeCommand();
+#pragma warning restore CS0618 // Type or member is obsolete
 				}
 				else
 				{
@@ -922,9 +948,8 @@ namespace LinqToDB.Data
 			}
 		}
 
-		/// <summary>
-		/// This is internal API and is not intended for use by Linq To DB applications.
-		/// </summary>
+		// TODO: Mark private in v7
+		[Obsolete("This API scheduled for removal in v7. Use TryGetConnection/OpenConnection or OpenConnectionASync chained with CreateCommand call. Note that it is your responsibility to dispose such command after use."), EditorBrowsable(EditorBrowsableState.Never)]
 		public DbCommand CreateCommand()
 		{
 			CheckAndThrowOnDisposed();
@@ -943,6 +968,8 @@ namespace LinqToDB.Data
 		/// <summary>
 		/// This is internal API and is not intended for use by Linq To DB applications.
 		/// </summary>
+		// TODO: Mark private in v7 and remove warning supporessions from callers
+		[Obsolete("This API scheduled for removal in v7"), EditorBrowsable(EditorBrowsableState.Never)]
 		public void DisposeCommand()
 		{
 			CheckAndThrowOnDisposed();
@@ -1338,6 +1365,8 @@ namespace LinqToDB.Data
 		/// <summary>
 		/// Removes cached data mappers.
 		/// </summary>
+		// TODO: remove in v7
+		[Obsolete("This API scheduled for removal in v7. Use CommandInfo.ClearObjectReaderCache instead"), EditorBrowsable(EditorBrowsableState.Never)]
 		public static void ClearObjectReaderCache()
 		{
 			CommandInfo.ClearObjectReaderCache();
@@ -1662,7 +1691,7 @@ namespace LinqToDB.Data
 #pragma warning disable CS0618 // Type or member is obsolete
 			if (Disposed && (ThrowOnDisposed ?? Common.Configuration.Data.ThrowOnDisposed))
 #pragma warning restore CS0618 // Type or member is obsolete
-				throw new ObjectDisposedException("DataConnection", "IDataContext is disposed, see https://github.com/linq2db/linq2db/wiki/Managing-data-connection");
+				throw new ObjectDisposedException(GetType().FullName, "IDataContext is disposed, see https://github.com/linq2db/linq2db/wiki/Managing-data-connection");
 		}
 
 		/// <summary>

--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -720,7 +720,7 @@ namespace LinqToDB.Data
 		/// Gets underlying database connection, used by current connection object, or opens new.
 		/// </summary>
 		// TODO: Remove in v7
-		[Obsolete("This API scheduled for removal in v7. Use TryGetDbConnection instead"), EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("This API scheduled for removal in v7. Use TryGetDbConnection, OpenConnection or OpenConnectionAsync instead based on your use-case"), EditorBrowsable(EditorBrowsableState.Never)]
 		public DbConnection Connection
 		{
 			get
@@ -735,6 +735,11 @@ namespace LinqToDB.Data
 		/// Returns underlying <see cref="DbConnection"/> instance or <c>null</c> if connection is not open.
 		/// </summary>
 		public DbConnection? TryGetDbConnection() => _connection?.Connection;
+
+		/// <summary>
+		/// Returns underlying <see cref="DbConnection"/> instance. If connection is not open yet - it will be opened.
+		/// </summary>
+		public DbConnection OpenConnection() => EnsureConnection(connect: true).Connection;
 
 		internal DbConnection? CurrentConnection => _connection?.Connection;
 

--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -6,6 +6,9 @@ using System.Data.Common;
 using System.Diagnostics;
 using System.Globalization;
 using System.Threading;
+#if NETFRAMEWORK || NETSTANDARD2_0
+using System.Text;
+#endif
 
 using JetBrains.Annotations;
 

--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -1004,10 +1004,10 @@ namespace LinqToDB.Data
 		{
 			CheckAndThrowOnDisposed();
 
-			OpenConnection();
-
 			try
 			{
+				OpenConnection();
+
 				if (((IInterceptable<ICommandInterceptor>)this).Interceptor is { } cInterceptor)
 				{
 					Option<int> result;
@@ -1093,10 +1093,10 @@ namespace LinqToDB.Data
 		{
 			CheckAndThrowOnDisposed();
 
-			OpenConnection();
-
 			try
 			{
+				OpenConnection();
+
 				if (((IInterceptable<ICommandInterceptor>)this).Interceptor is { } cInterceptor)
 				{
 					Option<int> result;
@@ -1186,10 +1186,10 @@ namespace LinqToDB.Data
 		{
 			CheckAndThrowOnDisposed();
 
-			OpenConnection();
-
 			try
 			{
+				OpenConnection();
+
 				if (((IInterceptable<ICommandInterceptor>)this).Interceptor is { } cInterceptor)
 				{
 					Option<object?> result;
@@ -1276,10 +1276,10 @@ namespace LinqToDB.Data
 		{
 			CheckAndThrowOnDisposed();
 
-			OpenConnection();
-
 			try
 			{
+				OpenConnection();
+
 				DbDataReader reader;
 
 				if (((IInterceptable<ICommandInterceptor>)this).Interceptor is { } cInterceptor)
@@ -1433,8 +1433,6 @@ namespace LinqToDB.Data
 			//
 			TransactionAsync?.Dispose();
 
-			OpenConnection();
-
 			var dataConnectionTransaction = TraceAction(
 				this,
 				TraceOperation.BeginTransaction,
@@ -1444,7 +1442,7 @@ namespace LinqToDB.Data
 				{
 					// Create new transaction object.
 					//
-					dataContext.TransactionAsync = dataContext._connection!.BeginTransaction();
+					dataContext.TransactionAsync = dataContext.OpenConnection().BeginTransaction();
 
 					dataContext._closeTransaction = true;
 
@@ -1474,8 +1472,6 @@ namespace LinqToDB.Data
 			//
 			TransactionAsync?.Dispose();
 
-			OpenConnection();
-
 			var dataConnectionTransaction = TraceAction(
 				this,
 				TraceOperation.BeginTransaction,
@@ -1485,7 +1481,7 @@ namespace LinqToDB.Data
 				{
 					// Create new transaction object.
 					//
-					dataConnection.TransactionAsync = dataConnection._connection!.BeginTransaction(isolationLevel);
+					dataConnection.TransactionAsync = dataConnection.OpenConnection().BeginTransaction(isolationLevel);
 
 					dataConnection._closeTransaction = true;
 

--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -834,8 +834,8 @@ namespace LinqToDB.Data
 					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.Open, false)
 					{
 						TraceLevel = TraceLevel.Error,
-						StartTime = DateTime.UtcNow,
-						Exception = ex,
+						StartTime  = DateTime.UtcNow,
+						Exception  = ex,
 					});
 				}
 
@@ -1062,9 +1062,9 @@ namespace LinqToDB.Data
 			{
 				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute, TraceOperation.ExecuteNonQuery, false)
 				{
-					TraceLevel     = TraceLevel.Info,
-					Command        = CurrentCommand,
-					StartTime      = now,
+					TraceLevel = TraceLevel.Info,
+					Command    = CurrentCommand,
+					StartTime  = now,
 				});
 			}
 
@@ -1094,11 +1094,11 @@ namespace LinqToDB.Data
 				{
 					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.ExecuteNonQuery, false)
 					{
-						TraceLevel     = TraceLevel.Error,
-						Command        = CurrentCommand,
-						StartTime      = now,
-						ExecutionTime  = sw.Elapsed,
-						Exception      = ex,
+						TraceLevel    = TraceLevel.Error,
+						Command       = CurrentCommand,
+						StartTime     = now,
+						ExecutionTime = sw.Elapsed,
+						Exception     = ex,
 					});
 				}
 
@@ -1152,8 +1152,8 @@ namespace LinqToDB.Data
 				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute, TraceOperation.ExecuteNonQuery, false)
 				{
 					TraceLevel = TraceLevel.Info,
-					Command = CurrentCommand,
-					StartTime = now,
+					Command    = CurrentCommand,
+					StartTime  = now,
 				});
 			}
 
@@ -1167,10 +1167,10 @@ namespace LinqToDB.Data
 				{
 					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute, TraceOperation.ExecuteNonQuery, false)
 					{
-						TraceLevel = TraceLevel.Info,
-						Command = CurrentCommand,
-						StartTime = now,
-						ExecutionTime = sw.Elapsed,
+						TraceLevel      = TraceLevel.Info,
+						Command         = CurrentCommand,
+						StartTime       = now,
+						ExecutionTime   = sw.Elapsed,
 						RecordsAffected = ret,
 					});
 				}
@@ -1183,11 +1183,11 @@ namespace LinqToDB.Data
 				{
 					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.ExecuteNonQuery, false)
 					{
-						TraceLevel = TraceLevel.Error,
-						Command = CurrentCommand,
-						StartTime = now,
+						TraceLevel    = TraceLevel.Error,
+						Command       = CurrentCommand,
+						StartTime     = now,
 						ExecutionTime = sw.Elapsed,
-						Exception = ex,
+						Exception     = ex,
 					});
 				}
 
@@ -1242,9 +1242,9 @@ namespace LinqToDB.Data
 			{
 				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute, TraceOperation.ExecuteScalar, false)
 				{
-					TraceLevel     = TraceLevel.Info,
-					Command        = CurrentCommand,
-					StartTime      = now,
+					TraceLevel = TraceLevel.Info,
+					Command    = CurrentCommand,
+					StartTime  = now,
 				});
 			}
 
@@ -1258,10 +1258,10 @@ namespace LinqToDB.Data
 				{
 					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute, TraceOperation.ExecuteScalar, false)
 					{
-						TraceLevel     = TraceLevel.Info,
-						Command        = CurrentCommand,
-						StartTime      = now,
-						ExecutionTime  = sw.Elapsed,
+						TraceLevel    = TraceLevel.Info,
+						Command       = CurrentCommand,
+						StartTime     = now,
+						ExecutionTime = sw.Elapsed,
 					});
 				}
 
@@ -1273,11 +1273,11 @@ namespace LinqToDB.Data
 				{
 					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.ExecuteScalar, false)
 					{
-						TraceLevel     = TraceLevel.Error,
-						Command        = CurrentCommand,
-						StartTime      = now,
-						ExecutionTime  = sw.Elapsed,
-						Exception      = ex,
+						TraceLevel    = TraceLevel.Error,
+						Command       = CurrentCommand,
+						StartTime     = now,
+						ExecutionTime = sw.Elapsed,
+						Exception     = ex,
 					});
 				}
 
@@ -1353,9 +1353,9 @@ namespace LinqToDB.Data
 			{
 				OnTraceConnection(new TraceInfo(this, TraceInfoStep.BeforeExecute, TraceOperation.ExecuteReader, false)
 				{
-					TraceLevel     = TraceLevel.Info,
-					Command        = CurrentCommand,
-					StartTime      = now,
+					TraceLevel = TraceLevel.Info,
+					Command    = CurrentCommand,
+					StartTime  = now,
 				});
 			}
 
@@ -1370,10 +1370,10 @@ namespace LinqToDB.Data
 				{
 					OnTraceConnection(new TraceInfo(this, TraceInfoStep.AfterExecute, TraceOperation.ExecuteReader, false)
 					{
-						TraceLevel     = TraceLevel.Info,
-						Command        = ret.Command,
-						StartTime      = now,
-						ExecutionTime  = sw.Elapsed,
+						TraceLevel    = TraceLevel.Info,
+						Command       = ret.Command,
+						StartTime     = now,
+						ExecutionTime = sw.Elapsed,
 					});
 				}
 
@@ -1385,11 +1385,11 @@ namespace LinqToDB.Data
 				{
 					OnTraceConnection(new TraceInfo(this, TraceInfoStep.Error, TraceOperation.ExecuteReader, false)
 					{
-						TraceLevel     = TraceLevel.Error,
-						Command        = CurrentCommand,
-						StartTime      = now,
-						ExecutionTime  = sw.Elapsed,
-						Exception      = ex,
+						TraceLevel    = TraceLevel.Error,
+						Command       = CurrentCommand,
+						StartTime     = now,
+						ExecutionTime = sw.Elapsed,
+						Exception     = ex,
 					});
 				}
 
@@ -1489,7 +1489,7 @@ namespace LinqToDB.Data
 			var dataConnectionTransaction = TraceAction(
 				this,
 				TraceOperation.BeginTransaction,
-				static il => $"BeginTransaction({il})",
+				static ctx => $"BeginTransaction({ctx.isolationLevel})",
 				(isolationLevel, connection),
 				static (dataConnection, ctx) =>
 				{

--- a/Source/LinqToDB/Data/DataConnection.cs
+++ b/Source/LinqToDB/Data/DataConnection.cs
@@ -968,7 +968,7 @@ namespace LinqToDB.Data
 		/// <summary>
 		/// This is internal API and is not intended for use by Linq To DB applications.
 		/// </summary>
-		// TODO: Mark private in v7 and remove warning supporessions from callers
+		// TODO: Mark private in v7 and remove warning suppressions from callers
 		[Obsolete("This API scheduled for removal in v7"), EditorBrowsable(EditorBrowsableState.Never)]
 		public void DisposeCommand()
 		{

--- a/Source/LinqToDB/Data/QueryTraceOptions.cs
+++ b/Source/LinqToDB/Data/QueryTraceOptions.cs
@@ -55,8 +55,6 @@ namespace LinqToDB.Data
 						.Add(WriteTrace)
 						.Add(TraceSwitch?.DisplayName)
 						.Add(TraceSwitch?.Description)
-						.Add(TraceSwitch?.DefaultValue)
-						.Add(TraceSwitch?.Level)
 						.CreateID();
 				}
 

--- a/Source/LinqToDB/Data/QueryTraceOptions.cs
+++ b/Source/LinqToDB/Data/QueryTraceOptions.cs
@@ -7,7 +7,7 @@ using LinqToDB.Common.Internal;
 namespace LinqToDB.Data
 {
 	/// <param name="TraceLevel">
-	/// Gets custom trace level to use with <see cref="DataConnection"/> instance.
+	/// Gets custom trace level to use with <see cref="DataConnection"/> instance. Value is ignored when <paramref name="TraceSwitch"/> specified.
 	/// </param>
 	/// <param name="OnTrace">
 	/// Gets custom trace method to use with <see cref="DataConnection"/> instance.
@@ -15,11 +15,15 @@ namespace LinqToDB.Data
 	/// <param name="WriteTrace">
 	/// Gets custom trace writer to use with <see cref="DataConnection"/> instance.
 	/// </param>
+	/// <param name="TraceSwitch">
+	/// Gets custom trace switcher to use with <see cref="DataConnection"/> instance.
+	/// </param>
 	public sealed record QueryTraceOptions
 	(
-		TraceLevel?                       TraceLevel = default,
-		Action<TraceInfo>?                OnTrace    = default,
-		Action<string,string,TraceLevel>? WriteTrace = default
+		TraceLevel?                       TraceLevel  = default,
+		Action<TraceInfo>?                OnTrace     = default,
+		Action<string,string,TraceLevel>? WriteTrace  = default,
+		TraceSwitch?                      TraceSwitch = default
 		// If you add another parameter here, don't forget to update
 		// QueryTraceOptions copy constructor and IConfigurationID.ConfigurationID.
 	)
@@ -31,9 +35,10 @@ namespace LinqToDB.Data
 
 		QueryTraceOptions(QueryTraceOptions original)
 		{
-			TraceLevel = original.TraceLevel;
-			OnTrace    = original.OnTrace;
-			WriteTrace = original.WriteTrace;
+			TraceLevel  = original.TraceLevel;
+			OnTrace     = original.OnTrace;
+			WriteTrace  = original.WriteTrace;
+			TraceSwitch = original.TraceSwitch;
 		}
 
 		int? _configurationID;
@@ -48,6 +53,10 @@ namespace LinqToDB.Data
 						.Add(TraceLevel)
 						.Add(OnTrace)
 						.Add(WriteTrace)
+						.Add(TraceSwitch?.DisplayName)
+						.Add(TraceSwitch?.Description)
+						.Add(TraceSwitch?.DefaultValue)
+						.Add(TraceSwitch?.Level)
 						.CreateID();
 				}
 

--- a/Source/LinqToDB/DataContext.Interceptors.cs
+++ b/Source/LinqToDB/DataContext.Interceptors.cs
@@ -74,6 +74,8 @@ namespace LinqToDB
 		/// <inheritdoc cref="IDataContext.AddInterceptor(IInterceptor)"/>
 		public void AddInterceptor(IInterceptor interceptor)
 		{
+			AssertDisposed();
+
 			AddInterceptor(interceptor, true);
 		}
 
@@ -122,6 +124,8 @@ namespace LinqToDB
 
 		public void RemoveInterceptor(IInterceptor interceptor)
 		{
+			AssertDisposed();
+
 			Options = Options.RemoveInterceptor(interceptor);
 
 			this.RemoveInterceptorImpl(interceptor);

--- a/Source/LinqToDB/DataContext.cs
+++ b/Source/LinqToDB/DataContext.cs
@@ -418,8 +418,9 @@ namespace LinqToDB
 		/// </summary>
 		protected virtual void Dispose(bool disposing)
 		{
-			_disposed = true;
 			((IDataContext)this).Close();
+
+			_disposed = true;
 		}
 
 		public async ValueTask DisposeAsync()
@@ -430,10 +431,11 @@ namespace LinqToDB
 		/// <summary>
 		/// Closes underlying connection.
 		/// </summary>
-		protected virtual ValueTask DisposeAsync(bool disposing)
+		protected virtual async ValueTask DisposeAsync(bool disposing)
 		{
+			await ((IDataContext)this).CloseAsync().ConfigureAwait(false);
+
 			_disposed = true;
-			return new ValueTask(((IDataContext)this).CloseAsync());
 		}
 
 		void IDataContext.Close()

--- a/Source/LinqToDB/DataContext.cs
+++ b/Source/LinqToDB/DataContext.cs
@@ -135,8 +135,7 @@ namespace LinqToDB
 					using var idBuilder = new IdentifierBuilder();
 					_configurationID = idBuilder
 						.Add(_msID = ((IConfigurationID)MappingSchema).ConfigurationID)
-						// GetDataConnection :-/
-						.Add(ConfigurationString ?? ConnectionString ?? GetDataConnection().EnsureConnection(connect: false).ConnectionString)
+						.Add(ConfigurationString)
 						.Add(Options)
 						.Add(GetType())
 						.CreateID();

--- a/Source/LinqToDB/DataContext.cs
+++ b/Source/LinqToDB/DataContext.cs
@@ -157,7 +157,13 @@ namespace LinqToDB
 		/// <summary>
 		/// Contains text of last command, sent to database using current context.
 		/// </summary>
-		public string?       LastQuery           { get; private set; }
+		public string?       LastQuery
+		{
+			get;
+			// TODO: Mark private in v7 and remove warning suppressions from callers
+			[Obsolete("This API scheduled for removal in v7"), EditorBrowsable(EditorBrowsableState.Never)]
+			set;
+		}
 
 		/// <summary>
 		/// Gets or sets trace handler, used for data connection instance.
@@ -360,7 +366,9 @@ namespace LinqToDB
 
 			if (_dataConnection != null)
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
 				LastQuery = _dataConnection.LastQuery;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				if (LockDbManagerCounter == 0 && KeepConnectionAlive == false)
 				{
@@ -385,7 +393,9 @@ namespace LinqToDB
 
 			if (_dataConnection != null)
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
 				LastQuery = _dataConnection.LastQuery;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				if (LockDbManagerCounter == 0 && KeepConnectionAlive == false)
 				{

--- a/Source/LinqToDB/DataContext.cs
+++ b/Source/LinqToDB/DataContext.cs
@@ -128,6 +128,8 @@ namespace LinqToDB
 			// can we just delegate it to underlying DataConnection?
 			get
 			{
+				AssertDisposed();
+
 				if (_configurationID == null || _msID != ((IConfigurationID)MappingSchema).ConfigurationID)
 				{
 					using var idBuilder = new IdentifierBuilder();
@@ -173,6 +175,8 @@ namespace LinqToDB
 			get => _keepConnectionAlive;
 			set
 			{
+				AssertDisposed();
+
 				_keepConnectionAlive = value;
 
 				if (value == false)
@@ -189,6 +193,8 @@ namespace LinqToDB
 		{
 			get
 			{
+				AssertDisposed();
+
 				if (_isMarsEnabled == null)
 				{
 					if (_dataConnection == null)
@@ -209,6 +215,8 @@ namespace LinqToDB
 		{
 			get
 			{
+				AssertDisposed();
+
 				if (_dataConnection != null)
 					return _dataConnection.QueryHints;
 
@@ -224,6 +232,8 @@ namespace LinqToDB
 		{
 			get
 			{
+				AssertDisposed();
+
 				if (_dataConnection != null)
 					return _dataConnection.NextQueryHints;
 
@@ -254,6 +264,8 @@ namespace LinqToDB
 			get => _commandTimeout ?? -1;
 			set
 			{
+				AssertDisposed();
+
 				if (value < 0)
 				{
 					_commandTimeout = null;
@@ -280,7 +292,12 @@ namespace LinqToDB
 		/// Creates instance of <see cref="DataConnection"/> class, used by context internally.
 		/// </summary>
 		/// <returns>New <see cref="DataConnection"/> instance.</returns>
-		protected virtual DataConnection CreateDataConnection(DataOptions options) => new(options);
+		protected virtual DataConnection CreateDataConnection(DataOptions options)
+		{
+			AssertDisposed();
+
+			return new(options);
+		}
 
 		/// <summary>
 		/// Returns associated database connection <see cref="DataConnection"/> or create new connection, if connection
@@ -333,6 +350,8 @@ namespace LinqToDB
 		/// </summary>
 		internal void ReleaseQuery()
 		{
+			AssertDisposed();
+
 			if (_dataConnection != null)
 			{
 				LastQuery = _dataConnection.LastQuery;
@@ -356,6 +375,8 @@ namespace LinqToDB
 		/// </summary>
 		internal async Task ReleaseQueryAsync()
 		{
+			AssertDisposed();
+
 			if (_dataConnection != null)
 			{
 				LastQuery = _dataConnection.LastQuery;
@@ -380,6 +401,8 @@ namespace LinqToDB
 
 		Expression IDataContext.GetReaderExpression(DbDataReader reader, int idx, Expression readerExpression, Type toType)
 		{
+			AssertDisposed();
+
 			return DataProvider.GetReaderExpression(reader, idx, readerExpression, toType);
 		}
 
@@ -465,6 +488,8 @@ namespace LinqToDB
 		/// <returns>Database transaction object.</returns>
 		public virtual DataContextTransaction BeginTransaction(IsolationLevel level)
 		{
+			AssertDisposed();
+
 			var dct = new DataContextTransaction(this);
 
 			dct.BeginTransaction(level);
@@ -479,6 +504,8 @@ namespace LinqToDB
 		/// <returns>Database transaction object.</returns>
 		public virtual DataContextTransaction BeginTransaction()
 		{
+			AssertDisposed();
+
 			var dct = new DataContextTransaction(this);
 
 			dct.BeginTransaction();
@@ -495,6 +522,8 @@ namespace LinqToDB
 		/// <returns>Database transaction object.</returns>
 		public virtual async Task<DataContextTransaction> BeginTransactionAsync(IsolationLevel level, CancellationToken cancellationToken = default)
 		{
+			AssertDisposed();
+
 			var dct = new DataContextTransaction(this);
 
 			await dct.BeginTransactionAsync(level, cancellationToken).ConfigureAwait(false);
@@ -510,6 +539,8 @@ namespace LinqToDB
 		/// <returns>Database transaction object.</returns>
 		public virtual async Task<DataContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
 		{
+			AssertDisposed();
+
 			var dct = new DataContextTransaction(this);
 
 			await dct.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
@@ -519,6 +550,8 @@ namespace LinqToDB
 
 		IQueryRunner IDataContext.GetQueryRunner(Query query, IDataContext parametersContext, int queryNumber, IQueryExpressions expressions, object?[]? parameters, object?[]? preambles)
 		{
+			AssertDisposed();
+
 			return new QueryRunner(this, ((IDataContext)GetDataConnection()).GetQueryRunner(query, parametersContext, queryNumber, expressions, parameters, preambles));
 		}
 

--- a/Source/LinqToDB/DataContext.cs
+++ b/Source/LinqToDB/DataContext.cs
@@ -636,11 +636,6 @@ namespace LinqToDB
 				return _queryRunner!.GetSqlText();
 			}
 
-			public Task<IReadOnlyList<QuerySql>> GetSqlTextAsync(CancellationToken cancellationToken)
-			{
-				return _queryRunner!.GetSqlTextAsync(cancellationToken);
-			}
-
 			public IDataContext      DataContext      => _dataContext!;
 			public IQueryExpressions Expressions      => _queryRunner!.Expressions;
 			public object?[]?        Parameters       => _queryRunner!.Parameters;

--- a/Source/LinqToDB/DataContext.cs
+++ b/Source/LinqToDB/DataContext.cs
@@ -172,22 +172,43 @@ namespace LinqToDB
 
 		private bool _keepConnectionAlive;
 		/// <summary>
-		/// Gets or sets option to dispose underlying connection after use.
+		/// Gets flag indicating wether context should dispose underlying connection after use or not.
 		/// Default value: <c>false</c>.
 		/// </summary>
 		public  bool  KeepConnectionAlive
 		{
 			get => _keepConnectionAlive;
-			set
-			{
-				AssertDisposed();
+			// TODO: Remove in v7
+			[Obsolete("This API scheduled for removal in v7. To set KeepAlive value use SetKeepAlive or SetKeepAliveAsync methods"), EditorBrowsable(EditorBrowsableState.Never)]
+			set => SetKeepConnectionAlive(value);
+		}
 
-				_keepConnectionAlive = value;
+		/// <summary>
+		/// Sets connection management behavior to specify if context should dispose underlying connection after use or not.
+		/// </summary>
+		public void SetKeepConnectionAlive(bool keepAlive)
+		{
+			AssertDisposed();
 
-				// TODO: call to blocking operation without async API
-				if (value == false)
-					ReleaseQuery();
-			}
+			_keepConnectionAlive = keepAlive;
+
+			if (keepAlive == false)
+				ReleaseQuery();
+		}
+
+		/// <summary>
+		/// Sets connection management behavior to specify if context should dispose underlying connection after use or not.
+		/// </summary>
+		public Task SetKeepConnectionAliveAsync(bool keepAlive)
+		{
+			AssertDisposed();
+
+			_keepConnectionAlive = keepAlive;
+
+			if (keepAlive == false)
+				return ReleaseQueryAsync();
+
+			return Task.CompletedTask;
 		}
 
 		// TODO: Remove in v7

--- a/Source/LinqToDB/DataContext.cs
+++ b/Source/LinqToDB/DataContext.cs
@@ -183,11 +183,15 @@ namespace LinqToDB
 			}
 		}
 
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7"), EditorBrowsable(EditorBrowsableState.Never)]
 		private bool? _isMarsEnabled;
 		/// <summary>
 		/// Gets or sets status of Multiple Active Result Sets (MARS) feature. This feature available only for
 		/// SQL Azure and SQL Server 2005+.
 		/// </summary>
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7"), EditorBrowsable(EditorBrowsableState.Never)]
 		public bool   IsMarsEnabled
 		{
 			get

--- a/Source/LinqToDB/DataContext.cs
+++ b/Source/LinqToDB/DataContext.cs
@@ -121,9 +121,9 @@ namespace LinqToDB
 		int  _msID;
 		int? _configurationID;
 		/// <summary>
-		/// Gets or sets ContextID.
+		/// Gets context configuration ID.
 		/// </summary>
-		public int           ConfigurationID
+		int IConfigurationID.ConfigurationID
 		{
 			// can we just delegate it to underlying DataConnection?
 			get
@@ -157,7 +157,7 @@ namespace LinqToDB
 		/// <summary>
 		/// Contains text of last command, sent to database using current context.
 		/// </summary>
-		public string?       LastQuery           { get; set; }
+		public string?       LastQuery           { get; private set; }
 
 		/// <summary>
 		/// Gets or sets trace handler, used for data connection instance.
@@ -178,6 +178,7 @@ namespace LinqToDB
 
 				_keepConnectionAlive = value;
 
+				// TODO: call to blocking operation without async API
 				if (value == false)
 					ReleaseQuery();
 			}
@@ -331,7 +332,9 @@ namespace LinqToDB
 				}
 
 				if (OnTraceConnection != null)
+#pragma warning disable CS0618 // Type or member is obsolete
 					_dataConnection.OnTraceConnection = OnTraceConnection;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				_dataConnection.OnRemoveInterceptor += RemoveInterceptor;
 			}
@@ -343,7 +346,7 @@ namespace LinqToDB
 		{
 			if (_disposed)
 				// GetType().FullName to support inherited types
-				throw new ObjectDisposedException(GetType().FullName);
+				throw new ObjectDisposedException(GetType().FullName, "IDataContext is disposed, see https://github.com/linq2db/linq2db/wiki/Managing-data-connection");
 		}
 
 		/// <summary>
@@ -621,6 +624,11 @@ namespace LinqToDB
 			public IReadOnlyList<QuerySql> GetSqlText()
 			{
 				return _queryRunner!.GetSqlText();
+			}
+
+			public Task<IReadOnlyList<QuerySql>> GetSqlTextAsync(CancellationToken cancellationToken)
+			{
+				return _queryRunner!.GetSqlTextAsync(cancellationToken);
 			}
 
 			public IDataContext      DataContext      => _dataContext!;

--- a/Source/LinqToDB/DataProvider/Access/AccessODBCSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessODBCSchemaProvider.cs
@@ -31,9 +31,10 @@ namespace LinqToDB.DataProvider.Access
 		{
 			// tables and views has same schema, only difference in TABLE_TYPE
 			// views also include SELECT procedures, including procedures with parameters(!)
-			var tables = dataConnection.Connection.GetSchema("Tables");
-			var views  = dataConnection.Connection.GetSchema("Views");
-			var procs  = dataConnection.Connection.GetSchema("Procedures");
+			var dbConnection = dataConnection.EnsureConnection(connect: true).Connection;
+			var tables       = dbConnection.GetSchema("Tables");
+			var views        = dbConnection.GetSchema("Views");
+			var procs        = dbConnection.GetSchema("Procedures");
 
 			var procIds = new HashSet<string>(
 				procs.AsEnumerable().Select(p => $"{p.Field<string>("PROCEDURE_CAT")}.{p.Field<string>("PROCEDURE_SCHEM")}.{p.Field<string>("PROCEDURE_NAME")}"));
@@ -73,7 +74,7 @@ namespace LinqToDB.DataProvider.Access
 
 		protected override List<ColumnInfo> GetColumns(DataConnection dataConnection, GetSchemaOptions options)
 		{
-			var cs = dataConnection.Connection.GetSchema("Columns");
+			var cs = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("Columns");
 
 			return
 			(
@@ -100,7 +101,7 @@ namespace LinqToDB.DataProvider.Access
 
 		protected override List<ProcedureInfo>? GetProcedures(DataConnection dataConnection, GetSchemaOptions options)
 		{
-			var ps = dataConnection.Connection.GetSchema("Procedures");
+			var ps = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("Procedures");
 
 			return
 			(
@@ -121,7 +122,7 @@ namespace LinqToDB.DataProvider.Access
 
 		protected override List<ProcedureParameterInfo> GetProcedureParameters(DataConnection dataConnection, IEnumerable<ProcedureInfo> procedures, GetSchemaOptions options)
 		{
-			var ps = dataConnection.Connection.GetSchema("ProcedureParameters");
+			var ps = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("ProcedureParameters");
 			return
 			(
 				from p in ps.AsEnumerable()
@@ -150,7 +151,7 @@ namespace LinqToDB.DataProvider.Access
 
 		protected override DataTable? GetProcedureSchema(DataConnection dataConnection, string commandText, CommandType commandType, DataParameter[] parameters, GetSchemaOptions options)
 		{
-			return dataConnection.Connection.GetSchema("ProcedureColumns", new[] { null, null, commandText.TrimStart('[').TrimEnd(']') });
+			return dataConnection.EnsureConnection(connect: true).Connection.GetSchema("ProcedureColumns", new[] { null, null, commandText.TrimStart('[').TrimEnd(']') });
 		}
 
 		protected override string? GetDbType(GetSchemaOptions options, string? columnType, DataTypeInfo? dataType, int? length, int? precision, int? scale, string? udtCatalog, string? udtSchema, string? udtName)

--- a/Source/LinqToDB/DataProvider/Access/AccessODBCSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessODBCSchemaProvider.cs
@@ -31,7 +31,7 @@ namespace LinqToDB.DataProvider.Access
 		{
 			// tables and views has same schema, only difference in TABLE_TYPE
 			// views also include SELECT procedures, including procedures with parameters(!)
-			var dbConnection = dataConnection.EnsureConnection(connect: true).Connection;
+			var dbConnection = dataConnection.OpenDbConnection();
 			var tables       = dbConnection.GetSchema("Tables");
 			var views        = dbConnection.GetSchema("Views");
 			var procs        = dbConnection.GetSchema("Procedures");
@@ -74,7 +74,7 @@ namespace LinqToDB.DataProvider.Access
 
 		protected override List<ColumnInfo> GetColumns(DataConnection dataConnection, GetSchemaOptions options)
 		{
-			var cs = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("Columns");
+			var cs = dataConnection.OpenDbConnection().GetSchema("Columns");
 
 			return
 			(
@@ -101,7 +101,7 @@ namespace LinqToDB.DataProvider.Access
 
 		protected override List<ProcedureInfo>? GetProcedures(DataConnection dataConnection, GetSchemaOptions options)
 		{
-			var ps = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("Procedures");
+			var ps = dataConnection.OpenDbConnection().GetSchema("Procedures");
 
 			return
 			(
@@ -122,7 +122,7 @@ namespace LinqToDB.DataProvider.Access
 
 		protected override List<ProcedureParameterInfo> GetProcedureParameters(DataConnection dataConnection, IEnumerable<ProcedureInfo> procedures, GetSchemaOptions options)
 		{
-			var ps = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("ProcedureParameters");
+			var ps = dataConnection.OpenDbConnection().GetSchema("ProcedureParameters");
 			return
 			(
 				from p in ps.AsEnumerable()
@@ -151,7 +151,7 @@ namespace LinqToDB.DataProvider.Access
 
 		protected override DataTable? GetProcedureSchema(DataConnection dataConnection, string commandText, CommandType commandType, DataParameter[] parameters, GetSchemaOptions options)
 		{
-			return dataConnection.EnsureConnection(connect: true).Connection.GetSchema("ProcedureColumns", new[] { null, null, commandText.TrimStart('[').TrimEnd(']') });
+			return dataConnection.OpenDbConnection().GetSchema("ProcedureColumns", new[] { null, null, commandText.TrimStart('[').TrimEnd(']') });
 		}
 
 		protected override string? GetDbType(GetSchemaOptions options, string? columnType, DataTypeInfo? dataType, int? length, int? precision, int? scale, string? udtCatalog, string? udtSchema, string? udtName)

--- a/Source/LinqToDB/DataProvider/Access/AccessOleDbSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessOleDbSchemaProvider.cs
@@ -35,7 +35,7 @@ namespace LinqToDB.DataProvider.Access
 
 			// user configured external connection: use it
 			// there is no big value in support for such edge case
-			if (newConnection.EnsureConnection(connect: true).Connection == dataConnection.EnsureConnection(connect: true).Connection)
+			if (newConnection.OpenDbConnection() == dataConnection.OpenDbConnection())
 				return action(dataConnection);
 
 			return action(newConnection);
@@ -44,7 +44,7 @@ namespace LinqToDB.DataProvider.Access
 		protected override IReadOnlyCollection<ForeignKeyInfo> GetForeignKeys(DataConnection dataConnection,
 			IEnumerable<TableSchema> tables, GetSchemaOptions options)
 		{
-			var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.EnsureConnection(connect: true).Connection);
+			var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.OpenDbConnection());
 			if (connection == null)
 				return [];
 
@@ -69,7 +69,7 @@ namespace LinqToDB.DataProvider.Access
 
 		protected override List<TableInfo> GetTables(DataConnection dataConnection, GetSchemaOptions options)
 		{
-			var tables = ExecuteOnNewConnection(dataConnection, cn => cn.EnsureConnection(connect: true).Connection.GetSchema("Tables"));
+			var tables = ExecuteOnNewConnection(dataConnection, cn => cn.OpenDbConnection().GetSchema("Tables"));
 
 			return
 			(
@@ -96,7 +96,7 @@ namespace LinqToDB.DataProvider.Access
 		protected override IReadOnlyCollection<PrimaryKeyInfo> GetPrimaryKeys(DataConnection dataConnection,
 			IEnumerable<TableSchema> tables, GetSchemaOptions options)
 		{
-			var idxs = ExecuteOnNewConnection(dataConnection, cn => cn.EnsureConnection(connect: true).Connection.GetSchema("Indexes"));
+			var idxs = ExecuteOnNewConnection(dataConnection, cn => cn.OpenDbConnection().GetSchema("Indexes"));
 
 			return
 			(
@@ -114,7 +114,7 @@ namespace LinqToDB.DataProvider.Access
 
 		protected override List<ColumnInfo> GetColumns(DataConnection dataConnection, GetSchemaOptions options)
 		{
-			var cs = ExecuteOnNewConnection(dataConnection, cn => cn.EnsureConnection(connect: true).Connection.GetSchema("Columns"));
+			var cs = ExecuteOnNewConnection(dataConnection, cn => cn.OpenDbConnection().GetSchema("Columns"));
 
 			return
 			(
@@ -165,7 +165,7 @@ namespace LinqToDB.DataProvider.Access
 
 		protected override List<ProcedureInfo>? GetProcedures(DataConnection dataConnection, GetSchemaOptions options)
 		{
-			var ps = ExecuteOnNewConnection(dataConnection, cn => cn.EnsureConnection(connect: true).Connection.GetSchema("Procedures"));
+			var ps = ExecuteOnNewConnection(dataConnection, cn => cn.OpenDbConnection().GetSchema("Procedures"));
 
 			return
 			(

--- a/Source/LinqToDB/DataProvider/Access/AccessOleDbSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/Access/AccessOleDbSchemaProvider.cs
@@ -35,7 +35,7 @@ namespace LinqToDB.DataProvider.Access
 
 			// user configured external connection: use it
 			// there is no big value in support for such edge case
-			if (newConnection.Connection == dataConnection.Connection)
+			if (newConnection.EnsureConnection(connect: true).Connection == dataConnection.EnsureConnection(connect: true).Connection)
 				return action(dataConnection);
 
 			return action(newConnection);
@@ -44,7 +44,7 @@ namespace LinqToDB.DataProvider.Access
 		protected override IReadOnlyCollection<ForeignKeyInfo> GetForeignKeys(DataConnection dataConnection,
 			IEnumerable<TableSchema> tables, GetSchemaOptions options)
 		{
-			var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.Connection);
+			var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.EnsureConnection(connect: true).Connection);
 			if (connection == null)
 				return [];
 
@@ -69,7 +69,7 @@ namespace LinqToDB.DataProvider.Access
 
 		protected override List<TableInfo> GetTables(DataConnection dataConnection, GetSchemaOptions options)
 		{
-			var tables = ExecuteOnNewConnection(dataConnection, cn => cn.Connection.GetSchema("Tables"));
+			var tables = ExecuteOnNewConnection(dataConnection, cn => cn.EnsureConnection(connect: true).Connection.GetSchema("Tables"));
 
 			return
 			(
@@ -96,7 +96,7 @@ namespace LinqToDB.DataProvider.Access
 		protected override IReadOnlyCollection<PrimaryKeyInfo> GetPrimaryKeys(DataConnection dataConnection,
 			IEnumerable<TableSchema> tables, GetSchemaOptions options)
 		{
-			var idxs = ExecuteOnNewConnection(dataConnection, cn => cn.Connection.GetSchema("Indexes"));
+			var idxs = ExecuteOnNewConnection(dataConnection, cn => cn.EnsureConnection(connect: true).Connection.GetSchema("Indexes"));
 
 			return
 			(
@@ -114,7 +114,7 @@ namespace LinqToDB.DataProvider.Access
 
 		protected override List<ColumnInfo> GetColumns(DataConnection dataConnection, GetSchemaOptions options)
 		{
-			var cs = ExecuteOnNewConnection(dataConnection, cn => cn.Connection.GetSchema("Columns"));
+			var cs = ExecuteOnNewConnection(dataConnection, cn => cn.EnsureConnection(connect: true).Connection.GetSchema("Columns"));
 
 			return
 			(
@@ -165,7 +165,7 @@ namespace LinqToDB.DataProvider.Access
 
 		protected override List<ProcedureInfo>? GetProcedures(DataConnection dataConnection, GetSchemaOptions options)
 		{
-			var ps = ExecuteOnNewConnection(dataConnection, cn => cn.Connection.GetSchema("Procedures"));
+			var ps = ExecuteOnNewConnection(dataConnection, cn => cn.EnsureConnection(connect: true).Connection.GetSchema("Procedures"));
 
 			return
 			(

--- a/Source/LinqToDB/DataProvider/ClickHouse/ClickHouseBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/ClickHouse/ClickHouseBulkCopy.cs
@@ -103,7 +103,7 @@ namespace LinqToDB.DataProvider.ClickHouse
 		{
 			if (table.TryGetDataConnection(out var dataConnection) && _provider.Adapter.SupportsBulkCopy)
 			{
-				var connection  = _provider.TryGetProviderConnection(dataConnection, dataConnection.EnsureConnection(connect: true).Connection);
+				var connection  = _provider.TryGetProviderConnection(dataConnection, dataConnection.OpenDbConnection());
 
 				if (connection != null)
 				{
@@ -123,7 +123,7 @@ namespace LinqToDB.DataProvider.ClickHouse
 		{
 			if (table.TryGetDataConnection(out var dataConnection) && _provider.Adapter.SupportsBulkCopy)
 			{
-				var connection  = _provider.TryGetProviderConnection(dataConnection, (await dataConnection.EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false)).Connection);
+				var connection  = _provider.TryGetProviderConnection(dataConnection, await dataConnection.OpenDbConnectionAsync(cancellationToken).ConfigureAwait(false));
 
 				if (connection != null)
 				{

--- a/Source/LinqToDB/DataProvider/DB2/DB2BulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2BulkCopy.cs
@@ -31,7 +31,7 @@ namespace LinqToDB.DataProvider.DB2
 		{
 			if (table.TryGetDataConnection(out var dataConnection))
 			{
-				var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.EnsureConnection(connect: true).Connection);
+				var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.OpenDbConnection());
 
 				if (connection != null)
 					return DB2BulkCopyShared.ProviderSpecificCopyImpl(
@@ -51,7 +51,7 @@ namespace LinqToDB.DataProvider.DB2
 		{
 			if (table.TryGetDataConnection(out var dataConnection))
 			{
-				var connection = _provider.TryGetProviderConnection(dataConnection, (await dataConnection.EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false)).Connection);
+				var connection = _provider.TryGetProviderConnection(dataConnection, await dataConnection.OpenDbConnectionAsync(cancellationToken).ConfigureAwait(false));
 				if (connection != null)
 					// call the synchronous provider-specific implementation
 					return DB2BulkCopyShared.ProviderSpecificCopyImpl(
@@ -71,7 +71,7 @@ namespace LinqToDB.DataProvider.DB2
 		{
 			if (table.TryGetDataConnection(out var dataConnection))
 			{
-				var connection = _provider.TryGetProviderConnection(dataConnection, (await dataConnection.EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false)).Connection);
+				var connection = _provider.TryGetProviderConnection(dataConnection, await dataConnection.OpenDbConnectionAsync(cancellationToken).ConfigureAwait(false));
 
 				if (connection != null)
 				{

--- a/Source/LinqToDB/DataProvider/DB2/DB2BulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2BulkCopy.cs
@@ -31,7 +31,7 @@ namespace LinqToDB.DataProvider.DB2
 		{
 			if (table.TryGetDataConnection(out var dataConnection))
 			{
-				var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.Connection);
+				var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.EnsureConnection(connect: true).Connection);
 
 				if (connection != null)
 					return DB2BulkCopyShared.ProviderSpecificCopyImpl(
@@ -47,31 +47,31 @@ namespace LinqToDB.DataProvider.DB2
 			return MultipleRowsCopy(table, options, source);
 		}
 
-		protected override Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(ITable<T> table, DataOptions options, IEnumerable<T> source, CancellationToken cancellationToken)
+		protected override async Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(ITable<T> table, DataOptions options, IEnumerable<T> source, CancellationToken cancellationToken)
 		{
 			if (table.TryGetDataConnection(out var dataConnection))
 			{
-				var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.Connection);
+				var connection = _provider.TryGetProviderConnection(dataConnection, (await dataConnection.EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false)).Connection);
 				if (connection != null)
 					// call the synchronous provider-specific implementation
-					return Task.FromResult(DB2BulkCopyShared.ProviderSpecificCopyImpl(
+					return DB2BulkCopyShared.ProviderSpecificCopyImpl(
 						table,
 						options.BulkCopyOptions,
 						source,
 						dataConnection,
 						connection,
 						_provider.Adapter.BulkCopy,
-						TraceAction));
+						TraceAction);
 			}
 
-			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
+			return await MultipleRowsCopyAsync(table, options, source, cancellationToken).ConfigureAwait(false);
 		}
 
 		protected override async Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(ITable<T> table, DataOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
 			if (table.TryGetDataConnection(out var dataConnection))
 			{
-				var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.Connection);
+				var connection = _provider.TryGetProviderConnection(dataConnection, (await dataConnection.EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false)).Connection);
 
 				if (connection != null)
 				{

--- a/Source/LinqToDB/DataProvider/DB2/DB2LUWSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2LUWSchemaProvider.cs
@@ -37,7 +37,7 @@ namespace LinqToDB.DataProvider.DB2
 
 		protected override List<DataTypeInfo> GetDataTypes(DataConnection dataConnection)
 		{
-			DataTypesSchema = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("DataTypes");
+			DataTypesSchema = dataConnection.OpenDbConnection().GetSchema("DataTypes");
 
 			return DataTypesSchema.AsEnumerable()
 				.Select(t => new DataTypeInfo
@@ -59,7 +59,7 @@ namespace LinqToDB.DataProvider.DB2
 
 		protected override List<TableInfo> GetTables(DataConnection dataConnection, GetSchemaOptions options)
 		{
-			var connection = dataConnection.EnsureConnection(connect: true).Connection;
+			var connection = dataConnection.OpenDbConnection();
 			var database   = connection.Database;
 
 			var tables = connection.GetSchema("Tables");
@@ -90,7 +90,7 @@ namespace LinqToDB.DataProvider.DB2
 		protected override IReadOnlyCollection<PrimaryKeyInfo> GetPrimaryKeys(DataConnection dataConnection,
 			IEnumerable<TableSchema> tables, GetSchemaOptions options)
 		{
-			var database = dataConnection.EnsureConnection(connect: true).Connection.Database;
+			var database = dataConnection.OpenDbConnection().Database;
 
 			return
 			(
@@ -144,7 +144,7 @@ FROM
 WHERE
 	" + GetSchemaFilter("TABSCHEMA");
 
-			var database = dataConnection.EnsureConnection(connect: true).Connection.Database;
+			var database = dataConnection.OpenDbConnection().Database;
 
 			return _columns = dataConnection.Query(rd =>
 				{
@@ -214,7 +214,7 @@ WHERE
 		protected override IReadOnlyCollection<ForeignKeyInfo> GetForeignKeys(DataConnection dataConnection,
 			IEnumerable<TableSchema> tables, GetSchemaOptions options)
 		{
-			var database = dataConnection.EnsureConnection(connect: true).Connection.Database;
+			var database = dataConnection.OpenDbConnection().Database;
 
 			return dataConnection
 				.Query(rd => new
@@ -391,7 +391,7 @@ WHERE
 
 		protected override string GetDataSourceName(DataConnection dbConnection)
 		{
-			var str = dbConnection.EnsureConnection(connect: true).Connection.ConnectionString;
+			var str = dbConnection.OpenDbConnection().ConnectionString;
 
 			var host = str?.Split(';')
 				.Select(s =>

--- a/Source/LinqToDB/DataProvider/DB2/DB2LUWSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2LUWSchemaProvider.cs
@@ -37,7 +37,7 @@ namespace LinqToDB.DataProvider.DB2
 
 		protected override List<DataTypeInfo> GetDataTypes(DataConnection dataConnection)
 		{
-			DataTypesSchema = dataConnection.Connection.GetSchema("DataTypes");
+			DataTypesSchema = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("DataTypes");
 
 			return DataTypesSchema.AsEnumerable()
 				.Select(t => new DataTypeInfo
@@ -59,13 +59,16 @@ namespace LinqToDB.DataProvider.DB2
 
 		protected override List<TableInfo> GetTables(DataConnection dataConnection, GetSchemaOptions options)
 		{
-			var tables = dataConnection.Connection.GetSchema("Tables");
+			var connection = dataConnection.EnsureConnection(connect: true).Connection;
+			var database   = connection.Database;
+
+			var tables = connection.GetSchema("Tables");
 
 			return
 			(
 				from t in tables.AsEnumerable()
 				where _tableTypes.Contains(t.Field<string>("TABLE_TYPE"))
-				let catalog = dataConnection.Connection.Database
+				let catalog = database
 				let schema  = t.Field<string>("TABLE_SCHEMA")
 				let name    = t.Field<string>("TABLE_NAME")
 				let system  = t.Field<string>("TABLE_TYPE") == "SYSTEM TABLE"
@@ -87,13 +90,15 @@ namespace LinqToDB.DataProvider.DB2
 		protected override IReadOnlyCollection<PrimaryKeyInfo> GetPrimaryKeys(DataConnection dataConnection,
 			IEnumerable<TableSchema> tables, GetSchemaOptions options)
 		{
+			var database = dataConnection.EnsureConnection(connect: true).Connection.Database;
+
 			return
 			(
 				from pk in dataConnection.Query(
 					rd => new
 					{
 						// IMPORTANT: reader calls must be ordered to support SequentialAccess
-						id   = dataConnection.Connection.Database + "." + rd.ToString(0) + "." + rd.ToString(1),
+						id   = database + "." + rd.ToString(0) + "." + rd.ToString(1),
 						name = rd.ToString(2),
 						cols = rd.ToString(3)!.Split('+').Skip(1).ToArray(),
 					},@"
@@ -139,10 +144,12 @@ FROM
 WHERE
 	" + GetSchemaFilter("TABSCHEMA");
 
+			var database = dataConnection.EnsureConnection(connect: true).Connection.Database;
+
 			return _columns = dataConnection.Query(rd =>
 				{
 					// IMPORTANT: reader calls must be ordered to support SequentialAccess
-					var tableId     = dataConnection.Connection.Database + "." + rd.ToString(0) + "." + rd.ToString(1);
+					var tableId     = database + "." + rd.ToString(0) + "." + rd.ToString(1);
 					var name        = rd.ToString(2)!;
 					var size        = Converter.ChangeTypeTo<int?>(rd[3]);
 					var scale       = Converter.ChangeTypeTo<int?>(rd[4]);
@@ -207,14 +214,16 @@ WHERE
 		protected override IReadOnlyCollection<ForeignKeyInfo> GetForeignKeys(DataConnection dataConnection,
 			IEnumerable<TableSchema> tables, GetSchemaOptions options)
 		{
+			var database = dataConnection.EnsureConnection(connect: true).Connection.Database;
+
 			return dataConnection
 				.Query(rd => new
 				{
 					// IMPORTANT: reader calls must be ordered to support SequentialAccess
 					name         = rd.ToString(0)!,
-					thisTable    = dataConnection.Connection.Database + "." + rd.ToString(1)  + "." + rd.ToString(2),
+					thisTable    = database + "." + rd.ToString(1)  + "." + rd.ToString(2),
 					thisColumns  = rd.ToString(3)!,
-					otherTable   = dataConnection.Connection.Database + "." + rd.ToString(4)  + "." + rd.ToString(5),
+					otherTable   = database + "." + rd.ToString(4)  + "." + rd.ToString(5),
 					otherColumns = rd.ToString(6)!,
 				},@"
 SELECT
@@ -382,7 +391,7 @@ WHERE
 
 		protected override string GetDataSourceName(DataConnection dbConnection)
 		{
-			var str = dbConnection.Connection.ConnectionString;
+			var str = dbConnection.EnsureConnection(connect: true).Connection.ConnectionString;
 
 			var host = str?.Split(';')
 				.Select(s =>

--- a/Source/LinqToDB/DataProvider/DB2/DB2zOSSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2zOSSchemaProvider.cs
@@ -53,7 +53,7 @@ namespace LinqToDB.DataProvider.DB2
 		protected override IReadOnlyCollection<PrimaryKeyInfo> GetPrimaryKeys(DataConnection dataConnection,
 			IEnumerable<TableSchema> tables, GetSchemaOptions options)
 		{
-			var database = dataConnection.EnsureConnection(connect: true).Connection.Database;
+			var database = dataConnection.OpenDbConnection().Database;
 
 			return _primaryKeys = dataConnection.Query(
 				rd => new PrimaryKeyInfo
@@ -101,7 +101,7 @@ namespace LinqToDB.DataProvider.DB2
 				WHERE
 					" + GetSchemaFilter("TBCREATOR");
 
-			var database = dataConnection.EnsureConnection(connect: true).Connection.Database;
+			var database = dataConnection.OpenDbConnection().Database;
 
 			return dataConnection.Query(rd =>
 				{
@@ -162,7 +162,7 @@ namespace LinqToDB.DataProvider.DB2
 		protected override IReadOnlyCollection<ForeignKeyInfo> GetForeignKeys(DataConnection dataConnection,
 			IEnumerable<TableSchema> tables, GetSchemaOptions options)
 		{
-			var database = dataConnection.EnsureConnection(connect: true).Connection.Database;
+			var database = dataConnection.OpenDbConnection().Database;
 
 			return
 			(
@@ -211,7 +211,7 @@ namespace LinqToDB.DataProvider.DB2
 
 		protected override List<ProcedureInfo>? GetProcedures(DataConnection dataConnection, GetSchemaOptions options)
 		{
-			var database = dataConnection.EnsureConnection(connect: true).Connection.Database;
+			var database = dataConnection.OpenDbConnection().Database;
 
 			return dataConnection
 				.Query(rd =>
@@ -244,7 +244,7 @@ namespace LinqToDB.DataProvider.DB2
 
 		protected override List<ProcedureParameterInfo> GetProcedureParameters(DataConnection dataConnection, IEnumerable<ProcedureInfo> procedures, GetSchemaOptions options)
 		{
-			var database = dataConnection.EnsureConnection(connect: true).Connection.Database;
+			var database = dataConnection.OpenDbConnection().Database;
 			return dataConnection
 				.Query(rd =>
 				{

--- a/Source/LinqToDB/DataProvider/DB2/DB2zOSSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/DB2/DB2zOSSchemaProvider.cs
@@ -53,11 +53,13 @@ namespace LinqToDB.DataProvider.DB2
 		protected override IReadOnlyCollection<PrimaryKeyInfo> GetPrimaryKeys(DataConnection dataConnection,
 			IEnumerable<TableSchema> tables, GetSchemaOptions options)
 		{
+			var database = dataConnection.EnsureConnection(connect: true).Connection.Database;
+
 			return _primaryKeys = dataConnection.Query(
 				rd => new PrimaryKeyInfo
 				{
 					// IMPORTANT: reader calls must be ordered to support SequentialAccess
-					TableID        = dataConnection.Connection.Database + "." + rd.ToString(0) + "." + rd.ToString(1),
+					TableID        = database + "." + rd.ToString(0) + "." + rd.ToString(1),
 					PrimaryKeyName = rd.ToString(2)!,
 					ColumnName     = rd.ToString(3)!,
 					Ordinal        = Converter.ChangeTypeTo<int>(rd[4])
@@ -99,10 +101,12 @@ namespace LinqToDB.DataProvider.DB2
 				WHERE
 					" + GetSchemaFilter("TBCREATOR");
 
+			var database = dataConnection.EnsureConnection(connect: true).Connection.Database;
+
 			return dataConnection.Query(rd =>
 				{
 					// IMPORTANT: reader calls must be ordered to support SequentialAccess
-					var tableId = dataConnection.Connection.Database + "." + rd.ToString(0) + "." + rd.ToString(1);
+					var tableId = database + "." + rd.ToString(0) + "." + rd.ToString(1);
 					var name    = rd.ToString(2)!;
 					var size    = rd[3];
 					var scale   = rd[4];
@@ -158,16 +162,18 @@ namespace LinqToDB.DataProvider.DB2
 		protected override IReadOnlyCollection<ForeignKeyInfo> GetForeignKeys(DataConnection dataConnection,
 			IEnumerable<TableSchema> tables, GetSchemaOptions options)
 		{
+			var database = dataConnection.EnsureConnection(connect: true).Connection.Database;
+
 			return
 			(
 				from fk in dataConnection.Query(rd => new
 				{
 					// IMPORTANT: reader calls must be ordered to support SequentialAccess
 					name        = rd.ToString(0),
-					thisTable   = dataConnection.Connection.Database + "." + rd.ToString(1)  + "." + rd.ToString(2),
+					thisTable   = database + "." + rd.ToString(1)  + "." + rd.ToString(2),
 					thisColumn  = rd.ToString(3),
 					ordinal     = Converter.ChangeTypeTo<int>(rd[4]),
-					otherTable  = dataConnection.Connection.Database + "." + rd.ToString(5)  + "." + rd.ToString(6),
+					otherTable  = database + "." + rd.ToString(5)  + "." + rd.ToString(6),
 				},@"
 					SELECT
 						A.RELNAME,
@@ -205,6 +211,8 @@ namespace LinqToDB.DataProvider.DB2
 
 		protected override List<ProcedureInfo>? GetProcedures(DataConnection dataConnection, GetSchemaOptions options)
 		{
+			var database = dataConnection.EnsureConnection(connect: true).Connection.Database;
+
 			return dataConnection
 				.Query(rd =>
 				{
@@ -215,8 +223,8 @@ namespace LinqToDB.DataProvider.DB2
 
 					return new ProcedureInfo
 					{
-						ProcedureID   = dataConnection.Connection.Database + "." + schema + "." + name,
-						CatalogName   = dataConnection.Connection.Database,
+						ProcedureID   = database + "." + schema + "." + name,
+						CatalogName   = database,
 						SchemaName    = schema,
 						ProcedureName = name,
 						IsFunction    = isFunction,
@@ -236,6 +244,7 @@ namespace LinqToDB.DataProvider.DB2
 
 		protected override List<ProcedureParameterInfo> GetProcedureParameters(DataConnection dataConnection, IEnumerable<ProcedureInfo> procedures, GetSchemaOptions options)
 		{
+			var database = dataConnection.EnsureConnection(connect: true).Connection.Database;
 			return dataConnection
 				.Query(rd =>
 				{
@@ -251,7 +260,7 @@ namespace LinqToDB.DataProvider.DB2
 
 					var ppi = new ProcedureParameterInfo
 					{
-						ProcedureID   = dataConnection.Connection.Database + "." + schema + "." + procname,
+						ProcedureID   = database + "." + schema + "." + procname,
 						ParameterName = pName,
 						DataType      = dataType,
 						Ordinal       = ConvertTo<int>.From(ordinal),

--- a/Source/LinqToDB/DataProvider/DataProviderBase.cs
+++ b/Source/LinqToDB/DataProvider/DataProviderBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Data;
 using System.Data.Common;
 using System.Data.Linq;
@@ -166,6 +167,8 @@ namespace LinqToDB.DataProvider
 		}
 #endif
 
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7"), EditorBrowsable(EditorBrowsableState.Never)]
 		public virtual object? GetConnectionInfo(DataConnection dataConnection, string parameterName)
 		{
 			return null;

--- a/Source/LinqToDB/DataProvider/DatabaseSpecificTable.cs
+++ b/Source/LinqToDB/DataProvider/DatabaseSpecificTable.cs
@@ -32,8 +32,7 @@ namespace LinqToDB.DataProvider
 
 		public Expression Expression => _table.Expression;
 
-		IReadOnlyList<QuerySql>       IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options)                                           => _table.GetSqlQueries(options);
-		Task<IReadOnlyList<QuerySql>> IExpressionQuery.GetSqlQueriesAsync(SqlGenerationOptions? options, CancellationToken cancellationToken) => _table.GetSqlQueriesAsync(options, cancellationToken);
+		IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options) => _table.GetSqlQueries(options);
 
 		public IDataContext   DataContext => _table.DataContext;
 		public Type           ElementType => _table.ElementType;

--- a/Source/LinqToDB/DataProvider/DatabaseSpecificTable.cs
+++ b/Source/LinqToDB/DataProvider/DatabaseSpecificTable.cs
@@ -32,10 +32,12 @@ namespace LinqToDB.DataProvider
 
 		public Expression Expression => _table.Expression;
 
-		IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options) => _table.GetSqlQueries(options);
-		public IDataContext   DataContext                                                     => _table.DataContext;
-		public Type           ElementType                                                     => _table.ElementType;
-		public IQueryProvider Provider                                                        => _table.Provider;
+		IReadOnlyList<QuerySql>       IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options)                                           => _table.GetSqlQueries(options);
+		Task<IReadOnlyList<QuerySql>> IExpressionQuery.GetSqlQueriesAsync(SqlGenerationOptions? options, CancellationToken cancellationToken) => _table.GetSqlQueriesAsync(options, cancellationToken);
+
+		public IDataContext   DataContext => _table.DataContext;
+		public Type           ElementType => _table.ElementType;
+		public IQueryProvider Provider    => _table.Provider;
 
 		public IQueryable CreateQuery(Expression expression)
 		{

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdSchemaProvider.cs
@@ -27,7 +27,7 @@ namespace LinqToDB.DataProvider.Firebird
 
 		protected override List<TableInfo> GetTables(DataConnection dataConnection, GetSchemaOptions options)
 		{
-			var tables = dataConnection.Connection.GetSchema("Tables");
+			var tables = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("Tables");
 
 			return
 			(
@@ -52,7 +52,7 @@ namespace LinqToDB.DataProvider.Firebird
 		protected override IReadOnlyCollection<PrimaryKeyInfo> GetPrimaryKeys(DataConnection dataConnection,
 			IEnumerable<TableSchema> tables, GetSchemaOptions options)
 		{
-			var pks = dataConnection.Connection.GetSchema("PrimaryKeys");
+			var pks = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("PrimaryKeys");
 
 			return
 			(
@@ -69,7 +69,7 @@ namespace LinqToDB.DataProvider.Firebird
 
 		protected override List<ColumnInfo> GetColumns(DataConnection dataConnection, GetSchemaOptions options)
 		{
-			var tcs  = dataConnection.Connection.GetSchema("Columns");
+			var tcs  = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("Columns");
 
 			return
 			(
@@ -98,7 +98,7 @@ namespace LinqToDB.DataProvider.Firebird
 		protected override IReadOnlyCollection<ForeignKeyInfo> GetForeignKeys(DataConnection dataConnection,
 			IEnumerable<TableSchema> tables, GetSchemaOptions options)
 		{
-			var cols = dataConnection.Connection.GetSchema("ForeignKeyColumns");
+			var cols = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("ForeignKeyColumns");
 
 			return
 			(

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdSchemaProvider.cs
@@ -27,7 +27,7 @@ namespace LinqToDB.DataProvider.Firebird
 
 		protected override List<TableInfo> GetTables(DataConnection dataConnection, GetSchemaOptions options)
 		{
-			var tables = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("Tables");
+			var tables = dataConnection.OpenDbConnection().GetSchema("Tables");
 
 			return
 			(
@@ -52,7 +52,7 @@ namespace LinqToDB.DataProvider.Firebird
 		protected override IReadOnlyCollection<PrimaryKeyInfo> GetPrimaryKeys(DataConnection dataConnection,
 			IEnumerable<TableSchema> tables, GetSchemaOptions options)
 		{
-			var pks = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("PrimaryKeys");
+			var pks = dataConnection.OpenDbConnection().GetSchema("PrimaryKeys");
 
 			return
 			(
@@ -69,7 +69,7 @@ namespace LinqToDB.DataProvider.Firebird
 
 		protected override List<ColumnInfo> GetColumns(DataConnection dataConnection, GetSchemaOptions options)
 		{
-			var tcs  = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("Columns");
+			var tcs  = dataConnection.OpenDbConnection().GetSchema("Columns");
 
 			return
 			(
@@ -98,7 +98,7 @@ namespace LinqToDB.DataProvider.Firebird
 		protected override IReadOnlyCollection<ForeignKeyInfo> GetForeignKeys(DataConnection dataConnection,
 			IEnumerable<TableSchema> tables, GetSchemaOptions options)
 		{
-			var cols = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("ForeignKeyColumns");
+			var cols = dataConnection.OpenDbConnection().GetSchema("ForeignKeyColumns");
 
 			return
 			(

--- a/Source/LinqToDB/DataProvider/IDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/IDataProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Data;
 using System.Data.Common;
 using System.Linq.Expressions;
@@ -43,6 +44,8 @@ namespace LinqToDB.DataProvider
 #if NET6_0_OR_GREATER
 		ValueTask          DisposeCommandAsync   (DbCommand command);
 #endif
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7"), EditorBrowsable(EditorBrowsableState.Never)]
 		object?            GetConnectionInfo     (DataConnection dataConnection, string parameterName);
 		Expression         GetReaderExpression   (DbDataReader reader, int idx, Expression readerExpression, Type toType);
 		bool?              IsDBNullAllowed       (DataOptions options, DbDataReader reader, int idx);

--- a/Source/LinqToDB/DataProvider/Informix/InformixBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixBulkCopy.cs
@@ -27,7 +27,7 @@ namespace LinqToDB.DataProvider.Informix
 			if ((_provider.Adapter.InformixBulkCopy != null || _provider.Adapter.DB2BulkCopy != null)
 				&& table.TryGetDataConnection(out var dataConnection) && dataConnection.Transaction == null)
 			{
-				var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.EnsureConnection(connect: true).Connection);
+				var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.OpenDbConnection());
 
 				if (connection != null)
 				{
@@ -60,7 +60,7 @@ namespace LinqToDB.DataProvider.Informix
 			if ((_provider.Adapter.InformixBulkCopy != null || _provider.Adapter.DB2BulkCopy != null)
 				&& table.TryGetDataConnection(out var dataConnection) && dataConnection.Transaction == null)
 			{
-				var connection = _provider.TryGetProviderConnection(dataConnection, (await dataConnection.EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false)).Connection);
+				var connection = _provider.TryGetProviderConnection(dataConnection, await dataConnection.OpenDbConnectionAsync(cancellationToken).ConfigureAwait(false));
 
 				if (connection != null)
 				{
@@ -94,7 +94,7 @@ namespace LinqToDB.DataProvider.Informix
 			if ((_provider.Adapter.InformixBulkCopy != null || _provider.Adapter.DB2BulkCopy != null)
 				&& table.TryGetDataConnection(out var dataConnection) && dataConnection.Transaction == null)
 			{
-				var connection = _provider.TryGetProviderConnection(dataConnection, (await dataConnection.EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false)).Connection);
+				var connection = _provider.TryGetProviderConnection(dataConnection, await dataConnection.OpenDbConnectionAsync(cancellationToken).ConfigureAwait(false));
 
 				if (connection != null)
 				{

--- a/Source/LinqToDB/DataProvider/Informix/InformixBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/Informix/InformixBulkCopy.cs
@@ -27,7 +27,7 @@ namespace LinqToDB.DataProvider.Informix
 			if ((_provider.Adapter.InformixBulkCopy != null || _provider.Adapter.DB2BulkCopy != null)
 				&& table.TryGetDataConnection(out var dataConnection) && dataConnection.Transaction == null)
 			{
-				var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.Connection);
+				var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.EnsureConnection(connect: true).Connection);
 
 				if (connection != null)
 				{
@@ -54,38 +54,38 @@ namespace LinqToDB.DataProvider.Informix
 			return MultipleRowsCopy(table, options, source);
 		}
 
-		protected override Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
+		protected override async Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T> table, DataOptions options, IEnumerable<T> source, CancellationToken cancellationToken)
 		{
 			if ((_provider.Adapter.InformixBulkCopy != null || _provider.Adapter.DB2BulkCopy != null)
 				&& table.TryGetDataConnection(out var dataConnection) && dataConnection.Transaction == null)
 			{
-				var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.Connection);
+				var connection = _provider.TryGetProviderConnection(dataConnection, (await dataConnection.EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false)).Connection);
 
 				if (connection != null)
 				{
 					// call the synchronous provider-specific implementation
 					if (_provider.Adapter.InformixBulkCopy != null)
-						return Task.FromResult(IDSProviderSpecificCopy(
+						return IDSProviderSpecificCopy(
 							table,
 							options.BulkCopyOptions,
 							source,
 							dataConnection,
 							connection,
-							_provider.Adapter.InformixBulkCopy));
+							_provider.Adapter.InformixBulkCopy);
 					else
-						return Task.FromResult(DB2.DB2BulkCopyShared.ProviderSpecificCopyImpl(
+						return DB2.DB2BulkCopyShared.ProviderSpecificCopyImpl(
 							table,
 							options.BulkCopyOptions,
 							source,
 							dataConnection,
 							connection,
 							_provider.Adapter.DB2BulkCopy!,
-							TraceAction));
+							TraceAction);
 				}
 			}
 
-			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
+			return await MultipleRowsCopyAsync(table, options, source, cancellationToken).ConfigureAwait(false);
 		}
 
 		protected override async Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
@@ -94,7 +94,7 @@ namespace LinqToDB.DataProvider.Informix
 			if ((_provider.Adapter.InformixBulkCopy != null || _provider.Adapter.DB2BulkCopy != null)
 				&& table.TryGetDataConnection(out var dataConnection) && dataConnection.Transaction == null)
 			{
-				var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.Connection);
+				var connection = _provider.TryGetProviderConnection(dataConnection, (await dataConnection.EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false)).Connection);
 
 				if (connection != null)
 				{

--- a/Source/LinqToDB/DataProvider/MySql/MySqlBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlBulkCopy.cs
@@ -84,7 +84,7 @@ namespace LinqToDB.DataProvider.MySql
 		{
 			if (table.TryGetDataConnection(out var dataConnection) && _provider.Adapter.BulkCopy != null)
 			{
-				var connection  = _provider.TryGetProviderConnection(dataConnection, dataConnection.EnsureConnection(connect: true).Connection);
+				var connection  = _provider.TryGetProviderConnection(dataConnection, dataConnection.OpenDbConnection());
 				var transaction = dataConnection.Transaction;
 
 				if (connection != null && transaction != null)
@@ -109,7 +109,7 @@ namespace LinqToDB.DataProvider.MySql
 		{
 			if (table.TryGetDataConnection(out var dataConnection) && _provider.Adapter.BulkCopy != null)
 			{
-				var connection  = _provider.TryGetProviderConnection(dataConnection, (await dataConnection.EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false)).Connection);
+				var connection  = _provider.TryGetProviderConnection(dataConnection, await dataConnection.OpenDbConnectionAsync(cancellationToken).ConfigureAwait(false));
 				var transaction = dataConnection.Transaction;
 
 				if (connection != null && transaction != null)

--- a/Source/LinqToDB/DataProvider/MySql/MySqlBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/MySql/MySqlBulkCopy.cs
@@ -45,38 +45,38 @@ namespace LinqToDB.DataProvider.MySql
 			return MultipleRowsCopy(table, options, source);
 		}
 
-		protected override Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
+		protected override async Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T> table, DataOptions options, IEnumerable<T> source, CancellationToken cancellationToken)
 		{
-			var connections = TryGetProviderConnections(table);
+			var connections = await TryGetProviderConnectionsAsync(table, cancellationToken).ConfigureAwait(false);
 			if (connections.HasValue)
 			{
-				return ProviderSpecificCopyInternalAsync(
+				return await ProviderSpecificCopyInternalAsync(
 					connections.Value,
 					table,
 					options.BulkCopyOptions,
 					source,
-					cancellationToken);
+					cancellationToken).ConfigureAwait(false);
 			}
 
-			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
+			return await MultipleRowsCopyAsync(table, options, source, cancellationToken).ConfigureAwait(false);
 		}
 
-		protected override Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
+		protected override async Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T> table, DataOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
-			var connections = TryGetProviderConnections(table);
+			var connections = await TryGetProviderConnectionsAsync(table, cancellationToken).ConfigureAwait(false);
 			if (connections.HasValue)
 			{
-				return ProviderSpecificCopyInternalAsync(
+				return await ProviderSpecificCopyInternalAsync(
 					connections.Value,
 					table,
 					options.BulkCopyOptions,
 					source,
-					cancellationToken);
+					cancellationToken).ConfigureAwait(false);
 			}
 
-			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
+			return await MultipleRowsCopyAsync(table, options, source, cancellationToken).ConfigureAwait(false);
 		}
 
 		private ProviderConnections? TryGetProviderConnections<T>(ITable<T> table)
@@ -84,7 +84,7 @@ namespace LinqToDB.DataProvider.MySql
 		{
 			if (table.TryGetDataConnection(out var dataConnection) && _provider.Adapter.BulkCopy != null)
 			{
-				var connection  = _provider.TryGetProviderConnection(dataConnection, dataConnection.Connection);
+				var connection  = _provider.TryGetProviderConnection(dataConnection, dataConnection.EnsureConnection(connect: true).Connection);
 				var transaction = dataConnection.Transaction;
 
 				if (connection != null && transaction != null)
@@ -96,6 +96,31 @@ namespace LinqToDB.DataProvider.MySql
 					{
 						DataConnection      = dataConnection,
 						ProviderConnection  = connection,
+						ProviderTransaction = transaction
+					};
+				}
+			}
+
+			return null;
+		}
+
+		private async Task<ProviderConnections?> TryGetProviderConnectionsAsync<T>(ITable<T> table, CancellationToken cancellationToken)
+			where T : notnull
+		{
+			if (table.TryGetDataConnection(out var dataConnection) && _provider.Adapter.BulkCopy != null)
+			{
+				var connection  = _provider.TryGetProviderConnection(dataConnection, (await dataConnection.EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false)).Connection);
+				var transaction = dataConnection.Transaction;
+
+				if (connection != null && transaction != null)
+					transaction = _provider.TryGetProviderTransaction(dataConnection, transaction);
+
+				if (connection != null && (dataConnection.Transaction == null || transaction != null))
+				{
+					return new ProviderConnections
+					{
+						DataConnection = dataConnection,
+						ProviderConnection = connection,
 						ProviderTransaction = transaction
 					};
 				}

--- a/Source/LinqToDB/DataProvider/Oracle/OracleBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleBulkCopy.cs
@@ -50,7 +50,7 @@ namespace LinqToDB.DataProvider.Oracle
 
 			if (table.TryGetDataConnection(out var dataConnection) && _provider.Adapter.BulkCopy != null && serverName == null)
 			{
-				var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.Connection);
+				var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.EnsureConnection(connect: true).Connection);
 
 				if (connection != null)
 				{

--- a/Source/LinqToDB/DataProvider/Oracle/OracleBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleBulkCopy.cs
@@ -50,7 +50,7 @@ namespace LinqToDB.DataProvider.Oracle
 
 			if (table.TryGetDataConnection(out var dataConnection) && _provider.Adapter.BulkCopy != null && serverName == null)
 			{
-				var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.EnsureConnection(connect: true).Connection);
+				var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.OpenDbConnection());
 
 				if (connection != null)
 				{

--- a/Source/LinqToDB/DataProvider/Oracle/OracleSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleSchemaProvider.cs
@@ -38,7 +38,7 @@ namespace LinqToDB.DataProvider.Oracle
 
 		protected override string GetDataSourceName(DataConnection dbConnection)
 		{
-			var connection = _provider.TryGetProviderConnection(dbConnection, dbConnection.EnsureConnection(connect: true).Connection);
+			var connection = _provider.TryGetProviderConnection(dbConnection, dbConnection.OpenDbConnection());
 			if (connection == null)
 				return string.Empty;
 
@@ -47,7 +47,7 @@ namespace LinqToDB.DataProvider.Oracle
 
 		protected override string GetDatabaseName(DataConnection dbConnection)
 		{
-			var connection = _provider.TryGetProviderConnection(dbConnection, dbConnection.EnsureConnection(connect: true).Connection);
+			var connection = _provider.TryGetProviderConnection(dbConnection, dbConnection.OpenDbConnection());
 			if (connection == null)
 				return string.Empty;
 

--- a/Source/LinqToDB/DataProvider/Oracle/OracleSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleSchemaProvider.cs
@@ -38,7 +38,7 @@ namespace LinqToDB.DataProvider.Oracle
 
 		protected override string GetDataSourceName(DataConnection dbConnection)
 		{
-			var connection = _provider.TryGetProviderConnection(dbConnection, dbConnection.Connection);
+			var connection = _provider.TryGetProviderConnection(dbConnection, dbConnection.EnsureConnection(connect: true).Connection);
 			if (connection == null)
 				return string.Empty;
 
@@ -47,7 +47,7 @@ namespace LinqToDB.DataProvider.Oracle
 
 		protected override string GetDatabaseName(DataConnection dbConnection)
 		{
-			var connection = _provider.TryGetProviderConnection(dbConnection, dbConnection.Connection);
+			var connection = _provider.TryGetProviderConnection(dbConnection, dbConnection.EnsureConnection(connect: true).Connection);
 			if (connection == null)
 				return string.Empty;
 

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
@@ -80,7 +80,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			DataConnection dataConnection, ITable<T> table, DataOptions options, IEnumerable<T> source)
 			where T : notnull
 		{
-			var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.Connection);
+			var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.EnsureConnection(connect: true).Connection);
 
 			if (connection == null)
 				return MultipleRowsCopy(table, options, source);
@@ -246,7 +246,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			CancellationToken cancellationToken)
 			where T : notnull
 		{
-			var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.Connection);
+			var connection = _provider.TryGetProviderConnection(dataConnection, (await dataConnection.EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false)).Connection);
 
 			if (connection == null)
 				return await MultipleRowsCopyAsync(table, options, source, cancellationToken).ConfigureAwait(false);
@@ -367,7 +367,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			CancellationToken   cancellationToken)
 		where T: notnull
 		{
-			var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.Connection);
+			var connection = _provider.TryGetProviderConnection(dataConnection, (await dataConnection.EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false)).Connection);
 
 			if (connection == null)
 				return await MultipleRowsCopyAsync(table, options, source, cancellationToken).ConfigureAwait(false);

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
@@ -80,7 +80,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			DataConnection dataConnection, ITable<T> table, DataOptions options, IEnumerable<T> source)
 			where T : notnull
 		{
-			var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.EnsureConnection(connect: true).Connection);
+			var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.OpenDbConnection());
 
 			if (connection == null)
 				return MultipleRowsCopy(table, options, source);
@@ -246,7 +246,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			CancellationToken cancellationToken)
 			where T : notnull
 		{
-			var connection = _provider.TryGetProviderConnection(dataConnection, (await dataConnection.EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false)).Connection);
+			var connection = _provider.TryGetProviderConnection(dataConnection, await dataConnection.OpenDbConnectionAsync(cancellationToken).ConfigureAwait(false));
 
 			if (connection == null)
 				return await MultipleRowsCopyAsync(table, options, source, cancellationToken).ConfigureAwait(false);
@@ -367,7 +367,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			CancellationToken   cancellationToken)
 		where T: notnull
 		{
-			var connection = _provider.TryGetProviderConnection(dataConnection, (await dataConnection.EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false)).Connection);
+			var connection = _provider.TryGetProviderConnection(dataConnection, await dataConnection.OpenDbConnectionAsync(cancellationToken).ConfigureAwait(false));
 
 			if (connection == null)
 				return await MultipleRowsCopyAsync(table, options, source, cancellationToken).ConfigureAwait(false);

--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteSchemaProvider.cs
@@ -31,7 +31,7 @@ namespace LinqToDB.DataProvider.SQLite
 
 		protected override List<TableInfo> GetTables(DataConnection dataConnection, GetSchemaOptions options)
 		{
-			var dbConnection = dataConnection.EnsureConnection(connect: true).Connection;
+			var dbConnection = dataConnection.OpenDbConnection();
 
 			var tables = dbConnection.GetSchema("Tables");
 			var views =  dbConnection.GetSchema("Views");
@@ -74,7 +74,7 @@ namespace LinqToDB.DataProvider.SQLite
 		protected override IReadOnlyCollection<PrimaryKeyInfo> GetPrimaryKeys(DataConnection dataConnection,
 			IEnumerable<TableSchema> tables, GetSchemaOptions options)
 		{
-			var dbConnection = dataConnection.EnsureConnection(connect: true).Connection;
+			var dbConnection = dataConnection.OpenDbConnection();
 			var pks          = dbConnection.GetSchema("IndexColumns");
 			var idxs         = dbConnection.GetSchema("Indexes");
 
@@ -96,7 +96,7 @@ namespace LinqToDB.DataProvider.SQLite
 
 		protected override List<ColumnInfo> GetColumns(DataConnection dataConnection, GetSchemaOptions options)
 		{
-			var cs = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("Columns");
+			var cs = dataConnection.OpenDbConnection().GetSchema("Columns");
 
 			return
 			(
@@ -123,7 +123,7 @@ namespace LinqToDB.DataProvider.SQLite
 		protected override IReadOnlyCollection<ForeignKeyInfo> GetForeignKeys(DataConnection dataConnection,
 			IEnumerable<TableSchema> tables, GetSchemaOptions options)
 		{
-			var fks = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("ForeignKeys");
+			var fks = dataConnection.OpenDbConnection().GetSchema("ForeignKeys");
 
 			var result =
 			(
@@ -157,7 +157,7 @@ namespace LinqToDB.DataProvider.SQLite
 
 		protected override string GetDatabaseName(DataConnection dbConnection)
 		{
-			return dbConnection.EnsureConnection(connect: true).Connection.DataSource;
+			return dbConnection.OpenDbConnection().DataSource;
 		}
 
 		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? precision, int? scale)

--- a/Source/LinqToDB/DataProvider/SQLite/SQLiteSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/SQLite/SQLiteSchemaProvider.cs
@@ -31,8 +31,10 @@ namespace LinqToDB.DataProvider.SQLite
 
 		protected override List<TableInfo> GetTables(DataConnection dataConnection, GetSchemaOptions options)
 		{
-			var tables = dataConnection.Connection.GetSchema("Tables");
-			var views =  dataConnection.Connection.GetSchema("Views");
+			var dbConnection = dataConnection.EnsureConnection(connect: true).Connection;
+
+			var tables = dbConnection.GetSchema("Tables");
+			var views =  dbConnection.GetSchema("Views");
 
 			return Enumerable
 				.Empty<TableInfo>()
@@ -72,7 +74,7 @@ namespace LinqToDB.DataProvider.SQLite
 		protected override IReadOnlyCollection<PrimaryKeyInfo> GetPrimaryKeys(DataConnection dataConnection,
 			IEnumerable<TableSchema> tables, GetSchemaOptions options)
 		{
-			var dbConnection = dataConnection.Connection;
+			var dbConnection = dataConnection.EnsureConnection(connect: true).Connection;
 			var pks          = dbConnection.GetSchema("IndexColumns");
 			var idxs         = dbConnection.GetSchema("Indexes");
 
@@ -94,7 +96,7 @@ namespace LinqToDB.DataProvider.SQLite
 
 		protected override List<ColumnInfo> GetColumns(DataConnection dataConnection, GetSchemaOptions options)
 		{
-			var cs = dataConnection.Connection.GetSchema("Columns");
+			var cs = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("Columns");
 
 			return
 			(
@@ -121,7 +123,7 @@ namespace LinqToDB.DataProvider.SQLite
 		protected override IReadOnlyCollection<ForeignKeyInfo> GetForeignKeys(DataConnection dataConnection,
 			IEnumerable<TableSchema> tables, GetSchemaOptions options)
 		{
-			var fks = dataConnection.Connection.GetSchema("ForeignKeys");
+			var fks = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("ForeignKeys");
 
 			var result =
 			(
@@ -155,7 +157,7 @@ namespace LinqToDB.DataProvider.SQLite
 
 		protected override string GetDatabaseName(DataConnection dbConnection)
 		{
-			return dbConnection.Connection.DataSource;
+			return dbConnection.EnsureConnection(connect: true).Connection.DataSource;
 		}
 
 		protected override DataType GetDataType(string? dataType, string? columnType, int? length, int? precision, int? scale)

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaBulkCopy.cs
@@ -72,7 +72,7 @@ namespace LinqToDB.DataProvider.SapHana
 		{
 			if (table.TryGetDataConnection(out var dataConnection))
 			{
-				var connection  = _provider.TryGetProviderConnection(dataConnection, dataConnection.EnsureConnection(connect: true).Connection);
+				var connection  = _provider.TryGetProviderConnection(dataConnection, dataConnection.OpenDbConnection());
 				var transaction = dataConnection.Transaction;
 
 				if (connection != null && transaction != null)
@@ -97,7 +97,7 @@ namespace LinqToDB.DataProvider.SapHana
 		{
 			if (table.TryGetDataConnection(out var dataConnection))
 			{
-				var connection  = _provider.TryGetProviderConnection(dataConnection, (await dataConnection.EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false)).Connection);
+				var connection  = _provider.TryGetProviderConnection(dataConnection, await dataConnection.OpenDbConnectionAsync(cancellationToken).ConfigureAwait(false));
 				var transaction = dataConnection.Transaction;
 
 				if (connection != null && transaction != null)

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaBulkCopy.cs
@@ -33,38 +33,38 @@ namespace LinqToDB.DataProvider.SapHana
 			return MultipleRowsCopy(table, options, source);
 		}
 
-		protected override Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
+		protected override async Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T> table, DataOptions options, IEnumerable<T> source, CancellationToken cancellationToken)
 		{
-			var connections = TryGetProviderConnections(table);
+			var connections = await TryGetProviderConnectionsAsync(table,cancellationToken).ConfigureAwait(false);
 			if (connections.HasValue)
 			{
-				return ProviderSpecificCopyInternalAsync(
+				return await ProviderSpecificCopyInternalAsync(
 					connections.Value,
 					table,
 					options.BulkCopyOptions,
 					(columns) => new BulkCopyReader<T>(connections.Value.DataConnection, columns, source),
-					cancellationToken);
+					cancellationToken).ConfigureAwait(false);
 			}
 
-			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
+			return await MultipleRowsCopyAsync(table, options, source, cancellationToken).ConfigureAwait(false);
 		}
 
-		protected override Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
+		protected override async Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T> table, DataOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
-			var connections = TryGetProviderConnections(table);
+			var connections = await TryGetProviderConnectionsAsync(table,cancellationToken).ConfigureAwait(false);
 			if (connections.HasValue)
 			{
-				return ProviderSpecificCopyInternalAsync(
+				return await ProviderSpecificCopyInternalAsync(
 					connections.Value,
 					table,
 					options.BulkCopyOptions,
 					(columns) => new BulkCopyReader<T>(connections.Value.DataConnection, columns, source, cancellationToken),
-					cancellationToken);
+					cancellationToken).ConfigureAwait(false);
 			}
 
-			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
+			return await MultipleRowsCopyAsync(table, options, source, cancellationToken).ConfigureAwait(false);
 		}
 
 		private ProviderConnections? TryGetProviderConnections<T>(ITable<T> table)
@@ -72,7 +72,7 @@ namespace LinqToDB.DataProvider.SapHana
 		{
 			if (table.TryGetDataConnection(out var dataConnection))
 			{
-				var connection  = _provider.TryGetProviderConnection(dataConnection, dataConnection.Connection);
+				var connection  = _provider.TryGetProviderConnection(dataConnection, dataConnection.EnsureConnection(connect: true).Connection);
 				var transaction = dataConnection.Transaction;
 
 				if (connection != null && transaction != null)
@@ -84,6 +84,31 @@ namespace LinqToDB.DataProvider.SapHana
 					{
 						DataConnection      = dataConnection,
 						ProviderConnection  = connection,
+						ProviderTransaction = transaction
+					};
+				}
+			}
+
+			return default;
+		}
+
+		private async ValueTask<ProviderConnections?> TryGetProviderConnectionsAsync<T>(ITable<T> table, CancellationToken cancellationToken)
+			where T : notnull
+		{
+			if (table.TryGetDataConnection(out var dataConnection))
+			{
+				var connection  = _provider.TryGetProviderConnection(dataConnection, (await dataConnection.EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false)).Connection);
+				var transaction = dataConnection.Transaction;
+
+				if (connection != null && transaction != null)
+					transaction = _provider.TryGetProviderTransaction(dataConnection, transaction);
+
+				if (connection != null && (dataConnection.Transaction == null || transaction != null))
+				{
+					return new ProviderConnections()
+					{
+						DataConnection = dataConnection,
+						ProviderConnection = connection,
 						ProviderTransaction = transaction
 					};
 				}

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaOdbcSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaOdbcSchemaProvider.cs
@@ -13,7 +13,7 @@ namespace LinqToDB.DataProvider.SapHana
 	{
 		protected override List<DataTypeInfo> GetDataTypes(DataConnection dataConnection)
 		{
-			var dts = dataConnection.Connection.GetSchema("DataTypes");
+			var dts = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("DataTypes");
 
 			var dt = dts.AsEnumerable()
 				.Where(x=> x["ProviderDbType"] != DBNull.Value)

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaOdbcSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaOdbcSchemaProvider.cs
@@ -13,7 +13,7 @@ namespace LinqToDB.DataProvider.SapHana
 	{
 		protected override List<DataTypeInfo> GetDataTypes(DataConnection dataConnection)
 		{
-			var dts = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("DataTypes");
+			var dts = dataConnection.OpenDbConnection().GetSchema("DataTypes");
 
 			var dt = dts.AsEnumerable()
 				.Where(x=> x["ProviderDbType"] != DBNull.Value)

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaSchemaProvider.cs
@@ -48,7 +48,7 @@ namespace LinqToDB.DataProvider.SapHana
 
 		protected override List<DataTypeInfo> GetDataTypes(DataConnection dataConnection)
 		{
-			var dts = dataConnection.Connection.GetSchema("DataTypes");
+			var dts = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("DataTypes");
 
 			var dt = dts.AsEnumerable()
 				.Select(t => new DataTypeInfo
@@ -161,7 +161,7 @@ namespace LinqToDB.DataProvider.SapHana
 		protected override IReadOnlyCollection<PrimaryKeyInfo> GetPrimaryKeys(DataConnection dataConnection,
 			IEnumerable<TableSchema> tables, GetSchemaOptions options)
 		{
-			var pks = dataConnection.Connection.GetSchema("IndexColumns");
+			var pks = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("IndexColumns");
 
 			return
 			(

--- a/Source/LinqToDB/DataProvider/SapHana/SapHanaSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/SapHana/SapHanaSchemaProvider.cs
@@ -48,7 +48,7 @@ namespace LinqToDB.DataProvider.SapHana
 
 		protected override List<DataTypeInfo> GetDataTypes(DataConnection dataConnection)
 		{
-			var dts = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("DataTypes");
+			var dts = dataConnection.OpenDbConnection().GetSchema("DataTypes");
 
 			var dt = dts.AsEnumerable()
 				.Select(t => new DataTypeInfo
@@ -161,7 +161,7 @@ namespace LinqToDB.DataProvider.SapHana
 		protected override IReadOnlyCollection<PrimaryKeyInfo> GetPrimaryKeys(DataConnection dataConnection,
 			IEnumerable<TableSchema> tables, GetSchemaOptions options)
 		{
-			var pks = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("IndexColumns");
+			var pks = dataConnection.OpenDbConnection().GetSchema("IndexColumns");
 
 			return
 			(

--- a/Source/LinqToDB/DataProvider/SqlCe/SqlCeSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlCe/SqlCeSchemaProvider.cs
@@ -43,7 +43,7 @@ namespace LinqToDB.DataProvider.SqlCe
 
 		protected override List<TableInfo> GetTables(DataConnection dataConnection, GetSchemaOptions options)
 		{
-			var tables = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("Tables");
+			var tables = dataConnection.OpenDbConnection().GetSchema("Tables");
 
 			return
 			(
@@ -82,7 +82,7 @@ WHERE PRIMARY_KEY = 1");
 
 		protected override List<ColumnInfo> GetColumns(DataConnection dataConnection, GetSchemaOptions options)
 		{
-			var cs = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("Columns");
+			var cs = dataConnection.OpenDbConnection().GetSchema("Columns");
 
 			return
 			(
@@ -127,7 +127,7 @@ FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS rc
 
 		protected override string GetDatabaseName(DataConnection dbConnection)
 		{
-			return Path.GetFileNameWithoutExtension(dbConnection.EnsureConnection(connect: true).Connection.Database);
+			return Path.GetFileNameWithoutExtension(dbConnection.OpenDbConnection().Database);
 		}
 
 		protected override Type? GetSystemType(string? dataType, string? columnType, DataTypeInfo? dataTypeInfo, int? length, int? precision, int? scale, GetSchemaOptions options)

--- a/Source/LinqToDB/DataProvider/SqlCe/SqlCeSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlCe/SqlCeSchemaProvider.cs
@@ -43,7 +43,7 @@ namespace LinqToDB.DataProvider.SqlCe
 
 		protected override List<TableInfo> GetTables(DataConnection dataConnection, GetSchemaOptions options)
 		{
-			var tables = dataConnection.Connection.GetSchema("Tables");
+			var tables = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("Tables");
 
 			return
 			(
@@ -82,7 +82,7 @@ WHERE PRIMARY_KEY = 1");
 
 		protected override List<ColumnInfo> GetColumns(DataConnection dataConnection, GetSchemaOptions options)
 		{
-			var cs = dataConnection.Connection.GetSchema("Columns");
+			var cs = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("Columns");
 
 			return
 			(
@@ -127,7 +127,7 @@ FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS rc
 
 		protected override string GetDatabaseName(DataConnection dbConnection)
 		{
-			return Path.GetFileNameWithoutExtension(dbConnection.Connection.Database);
+			return Path.GetFileNameWithoutExtension(dbConnection.EnsureConnection(connect: true).Connection.Database);
 		}
 
 		protected override Type? GetSystemType(string? dataType, string? columnType, DataTypeInfo? dataTypeInfo, int? length, int? precision, int? scale, GetSchemaOptions options)

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerBulkCopy.cs
@@ -44,38 +44,38 @@ namespace LinqToDB.DataProvider.SqlServer
 			return MultipleRowsCopy(table, options, source);
 		}
 
-		protected override Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
+		protected override async Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T> table, DataOptions options, IEnumerable<T> source, CancellationToken cancellationToken)
 		{
-			var connections = TryGetProviderConnections(table);
+			var connections = await TryGetProviderConnectionsAsync(table, cancellationToken).ConfigureAwait(false);
 			if (connections.HasValue)
 			{
-				return ProviderSpecificCopyInternalAsync(
+				return await ProviderSpecificCopyInternalAsync(
 					connections.Value,
 					table,
 					options.BulkCopyOptions,
 					(columns) => new BulkCopyReader<T>(connections.Value.DataConnection, columns, source),
-					cancellationToken);
+					cancellationToken).ConfigureAwait(false);
 			}
 
-			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
+			return await MultipleRowsCopyAsync(table, options, source, cancellationToken).ConfigureAwait(false);
 		}
 
-		protected override Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
+		protected override async Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T> table, DataOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
-			var connections = TryGetProviderConnections(table);
+			var connections = await TryGetProviderConnectionsAsync(table, cancellationToken).ConfigureAwait(false);
 			if (connections.HasValue)
 			{
-				return ProviderSpecificCopyInternalAsync(
+				return await ProviderSpecificCopyInternalAsync(
 					connections.Value,
 					table,
 					options.BulkCopyOptions,
 					(columns) => new BulkCopyReader<T>(connections.Value.DataConnection, columns, source, cancellationToken),
-					cancellationToken);
+					cancellationToken).ConfigureAwait(false);
 			}
 
-			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
+			return await MultipleRowsCopyAsync(table, options, source, cancellationToken).ConfigureAwait(false);
 		}
 
 		private ProviderConnections? TryGetProviderConnections<T>(ITable<T> table)
@@ -83,7 +83,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		{
 			if (table.TryGetDataConnection(out var dataConnection))
 			{
-				var connection  = _provider.TryGetProviderConnection(dataConnection, dataConnection.Connection);
+				var connection  = _provider.TryGetProviderConnection(dataConnection, dataConnection.EnsureConnection(connect: true).Connection);
 				var transaction = dataConnection.Transaction;
 
 				if (connection != null && transaction != null)
@@ -95,6 +95,31 @@ namespace LinqToDB.DataProvider.SqlServer
 					{
 						DataConnection      = dataConnection,
 						ProviderConnection  = connection,
+						ProviderTransaction = transaction
+					};
+				}
+			}
+
+			return null;
+		}
+
+		private async Task<ProviderConnections?> TryGetProviderConnectionsAsync<T>(ITable<T> table, CancellationToken cancellationToken)
+			where T : notnull
+		{
+			if (table.TryGetDataConnection(out var dataConnection))
+			{
+				var connection  = _provider.TryGetProviderConnection(dataConnection, (await dataConnection.EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false)).Connection);
+				var transaction = dataConnection.Transaction;
+
+				if (connection != null && transaction != null)
+					transaction = _provider.TryGetProviderTransaction(dataConnection, transaction);
+
+				if (connection != null && (dataConnection.Transaction == null || transaction != null))
+				{
+					return new ProviderConnections()
+					{
+						DataConnection = dataConnection,
+						ProviderConnection = connection,
 						ProviderTransaction = transaction
 					};
 				}

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerBulkCopy.cs
@@ -83,7 +83,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		{
 			if (table.TryGetDataConnection(out var dataConnection))
 			{
-				var connection  = _provider.TryGetProviderConnection(dataConnection, dataConnection.EnsureConnection(connect: true).Connection);
+				var connection  = _provider.TryGetProviderConnection(dataConnection, dataConnection.OpenDbConnection());
 				var transaction = dataConnection.Transaction;
 
 				if (connection != null && transaction != null)
@@ -108,7 +108,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		{
 			if (table.TryGetDataConnection(out var dataConnection))
 			{
-				var connection  = _provider.TryGetProviderConnection(dataConnection, (await dataConnection.EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false)).Connection);
+				var connection  = _provider.TryGetProviderConnection(dataConnection, await dataConnection.OpenDbConnectionAsync(cancellationToken).ConfigureAwait(false));
 				var transaction = dataConnection.Transaction;
 
 				if (connection != null && transaction != null)

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
@@ -218,7 +218,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		{
 			// take it from real Connection object, as dataConnection.ConnectionString could be null
 			// also it will not cache original connection string with credentials in _marsFlags
-			var connectionString = dataConnection.Connection.ConnectionString;
+			var connectionString = dataConnection.EnsureConnection(connect: true).Connection.ConnectionString;
 			switch (parameterName)
 			{
 				case "IsMarsEnabled" :

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Data;
 using System.Data.Common;
 using System.Data.SqlTypes;
@@ -214,6 +215,8 @@ namespace LinqToDB.DataProvider.SqlServer
 
 		static readonly ConcurrentDictionary<string,bool> _marsFlags = new ();
 
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7"), EditorBrowsable(EditorBrowsableState.Never)]
 		public override object? GetConnectionInfo(DataConnection dataConnection, string parameterName)
 		{
 			// take it from real Connection object, as dataConnection.ConnectionString could be null

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerDataProvider.cs
@@ -221,7 +221,7 @@ namespace LinqToDB.DataProvider.SqlServer
 		{
 			// take it from real Connection object, as dataConnection.ConnectionString could be null
 			// also it will not cache original connection string with credentials in _marsFlags
-			var connectionString = dataConnection.EnsureConnection(connect: true).Connection.ConnectionString;
+			var connectionString = dataConnection.OpenDbConnection().ConnectionString;
 			switch (parameterName)
 			{
 				case "IsMarsEnabled" :

--- a/Source/LinqToDB/DataProvider/SqlServer/SqlServerProviderAdapter.cs
+++ b/Source/LinqToDB/DataProvider/SqlServer/SqlServerProviderAdapter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
@@ -58,7 +59,9 @@ namespace LinqToDB.DataProvider.SqlServer
 			Action<DbParameter, string> typeNameSetter,
 			Func  <DbParameter, string> typeNameGetter,
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			Func<string, SqlConnectionStringBuilder> createConnectionStringBuilder,
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			Func<DbConnection, SqlBulkCopyOptions, DbTransaction?, SqlBulkCopy> createBulkCopy,
 			Func<int, string, SqlBulkCopyColumnMapping>                         createBulkCopyColumnMapping,
@@ -85,9 +88,11 @@ namespace LinqToDB.DataProvider.SqlServer
 			SetTypeName    = typeNameSetter;
 			GetTypeName    = typeNameGetter;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			_createConnectionStringBuilder = createConnectionStringBuilder;
+#pragma warning restore CS0618 // Type or member is obsolete
 
-			_createBulkCopy              = createBulkCopy;
+			_createBulkCopy = createBulkCopy;
 			_createBulkCopyColumnMapping = createBulkCopyColumnMapping;
 
 			MappingSchema = mappingSchema;
@@ -122,7 +127,11 @@ namespace LinqToDB.DataProvider.SqlServer
 		public string? GetSqlJsonReaderMethod => SqlJsonType == null ? null : "GetSqlJson";
 		public SqlDbType JsonDbType => SqlJsonType == null ? SqlDbType.NVarChar : (SqlDbType)35;
 
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7"), EditorBrowsable(EditorBrowsableState.Never)]
 		private readonly Func<string, SqlConnectionStringBuilder> _createConnectionStringBuilder;
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7"), EditorBrowsable(EditorBrowsableState.Never)]
 		public SqlConnectionStringBuilder CreateConnectionStringBuilder(string connectionString) => _createConnectionStringBuilder(connectionString);
 
 		private readonly Func<DbConnection, SqlBulkCopyOptions, DbTransaction?, SqlBulkCopy> _createBulkCopy;
@@ -221,7 +230,9 @@ namespace LinqToDB.DataProvider.SqlServer
 			typeMapper.RegisterTypeWrapper<SqlErrorCollection>(sqlErrorCollectionType);
 			typeMapper.RegisterTypeWrapper<SqlException>(sqlExceptionType);
 			typeMapper.RegisterTypeWrapper<SqlError>(sqlErrorType);
+#pragma warning disable CS0618 // Type or member is obsolete
 			typeMapper.RegisterTypeWrapper<SqlConnectionStringBuilder>(sqlConnectionStringBuilderType);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			// bulk copy types
 			typeMapper.RegisterTypeWrapper<SqlBulkCopy>(bulkCopyType);
@@ -312,7 +323,9 @@ namespace LinqToDB.DataProvider.SqlServer
 				typeNameBuilder.BuildSetter<DbParameter>(),
 				typeNameBuilder.BuildGetter<DbParameter>(),
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				typeMapper.BuildWrappedFactory((string connectionString) => new SqlConnectionStringBuilder(connectionString)),
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				typeMapper.BuildWrappedFactory((DbConnection connection, SqlBulkCopyOptions options, DbTransaction? transaction) => new SqlBulkCopy((SqlConnection)(object)connection, options, (SqlTransaction?)(object?)transaction)),
 				typeMapper.BuildWrappedFactory((int source, string destination) => new SqlBulkCopyColumnMapping(source, destination)),
@@ -430,6 +443,8 @@ namespace LinqToDB.DataProvider.SqlServer
 			public SqlDbType SqlDbType   { get; set; }
 		}
 
+		// TODO: Remove in v7
+		[Obsolete("This API scheduled for removal in v7"), EditorBrowsable(EditorBrowsableState.Never)]
 		[Wrapper]
 		public class SqlConnectionStringBuilder : TypeWrapper
 		{

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseBulkCopy.cs
@@ -47,38 +47,38 @@ namespace LinqToDB.DataProvider.Sybase
 			return MultipleRowsCopy(table, options, source);
 		}
 
-		protected override Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
+		protected override async Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T> table, DataOptions options, IEnumerable<T> source, CancellationToken cancellationToken)
 		{
-			var connections = GetProviderConnection(table);
+			var connections = await GetProviderConnectionAsync(table, cancellationToken).ConfigureAwait(false);
 			if (connections.HasValue && !table.TableOptions.HasIsTemporary())
 			{
 				// call the synchronous provider-specific implementation
-				return Task.FromResult(ProviderSpecificCopyInternal(
+				return ProviderSpecificCopyInternal(
 					connections.Value,
 					table,
 					options.BulkCopyOptions,
-					(columns) => new BulkCopyReader<T>(connections.Value.DataConnection, columns, source)));
+					(columns) => new BulkCopyReader<T>(connections.Value.DataConnection, columns, source));
 			}
 
-			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
+			return await MultipleRowsCopyAsync(table, options, source, cancellationToken).ConfigureAwait(false);
 		}
 
-		protected override Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
+		protected override async Task<BulkCopyRowsCopied> ProviderSpecificCopyAsync<T>(
 			ITable<T> table, DataOptions options, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
 		{
-			var connections = GetProviderConnection(table);
+			var connections = await GetProviderConnectionAsync(table, cancellationToken).ConfigureAwait(false);
 			if (connections.HasValue && !table.TableOptions.HasIsTemporary())
 			{
 				// call the synchronous provider-specific implementation
-				return Task.FromResult(ProviderSpecificCopyInternal(
+				return ProviderSpecificCopyInternal(
 					connections.Value,
 					table,
 					options.BulkCopyOptions,
-					(columns) => new BulkCopyReader<T>(connections.Value.DataConnection, columns, source, cancellationToken)));
+					(columns) => new BulkCopyReader<T>(connections.Value.DataConnection, columns, source, cancellationToken));
 			}
 
-			return MultipleRowsCopyAsync(table, options, source, cancellationToken);
+			return await MultipleRowsCopyAsync(table, options, source, cancellationToken).ConfigureAwait(false);
 		}
 
 		private ProviderConnections? GetProviderConnection<T>(ITable<T> table)
@@ -86,7 +86,7 @@ namespace LinqToDB.DataProvider.Sybase
 		{
 			if (table.TryGetDataConnection(out var dataConnection) && _provider.Adapter.BulkCopy != null)
 			{
-				var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.Connection);
+				var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.EnsureConnection(connect: true).Connection);
 
 				// for run in transaction see
 				// https://stackoverflow.com/questions/57675379
@@ -102,6 +102,35 @@ namespace LinqToDB.DataProvider.Sybase
 					{
 						DataConnection      = dataConnection,
 						ProviderConnection  = connection,
+						ProviderTransaction = transaction
+					};
+				}
+			}
+
+			return default;
+		}
+
+		private async Task<ProviderConnections?> GetProviderConnectionAsync<T>(ITable<T> table, CancellationToken cancellationToken)
+			where T : notnull
+		{
+			if (table.TryGetDataConnection(out var dataConnection) && _provider.Adapter.BulkCopy != null)
+			{
+				var connection = _provider.TryGetProviderConnection(dataConnection, (await dataConnection.EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false)).Connection);
+
+				// for run in transaction see
+				// https://stackoverflow.com/questions/57675379
+				// provider will call sp_oledb_columns which creates temp table
+				var transaction = dataConnection.Transaction;
+
+				if (connection != null && transaction != null)
+					transaction = _provider.TryGetProviderTransaction(dataConnection, transaction);
+
+				if (connection != null && (dataConnection.Transaction == null || transaction != null))
+				{
+					return new ProviderConnections()
+					{
+						DataConnection = dataConnection,
+						ProviderConnection = connection,
 						ProviderTransaction = transaction
 					};
 				}

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseBulkCopy.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseBulkCopy.cs
@@ -86,7 +86,7 @@ namespace LinqToDB.DataProvider.Sybase
 		{
 			if (table.TryGetDataConnection(out var dataConnection) && _provider.Adapter.BulkCopy != null)
 			{
-				var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.EnsureConnection(connect: true).Connection);
+				var connection = _provider.TryGetProviderConnection(dataConnection, dataConnection.OpenDbConnection());
 
 				// for run in transaction see
 				// https://stackoverflow.com/questions/57675379
@@ -115,7 +115,7 @@ namespace LinqToDB.DataProvider.Sybase
 		{
 			if (table.TryGetDataConnection(out var dataConnection) && _provider.Adapter.BulkCopy != null)
 			{
-				var connection = _provider.TryGetProviderConnection(dataConnection, (await dataConnection.EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false)).Connection);
+				var connection = _provider.TryGetProviderConnection(dataConnection, await dataConnection.OpenDbConnectionAsync(cancellationToken).ConfigureAwait(false));
 
 				// for run in transaction see
 				// https://stackoverflow.com/questions/57675379

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseSchemaProvider.cs
@@ -91,7 +91,7 @@ FROM
 	sysobjects
 WHERE
 	type IN ('U','V')",
-				new { @db = dataConnection.EnsureConnection(connect: true).Connection.Database})
+				new { @db = dataConnection.OpenDbConnection().Database})
 				.ToList();
 		}
 

--- a/Source/LinqToDB/DataProvider/Sybase/SybaseSchemaProvider.cs
+++ b/Source/LinqToDB/DataProvider/Sybase/SybaseSchemaProvider.cs
@@ -91,7 +91,7 @@ FROM
 	sysobjects
 WHERE
 	type IN ('U','V')",
-				new { @db = dataConnection.Connection.Database})
+				new { @db = dataConnection.EnsureConnection(connect: true).Connection.Database})
 				.ToList();
 		}
 

--- a/Source/LinqToDB/Expressions/ConvertFromDataReaderExpression.cs
+++ b/Source/LinqToDB/Expressions/ConvertFromDataReaderExpression.cs
@@ -16,18 +16,19 @@ namespace LinqToDB.Expressions
 {
 	sealed class ConvertFromDataReaderExpression : Expression
 	{
-		public ConvertFromDataReaderExpression(Type type, int idx, IValueConverter? converter, Expression dataReaderParam, bool? canBeNull)
+		public ConvertFromDataReaderExpression(Type type, int idx, IValueConverter? converter, Expression dataContextParam, Expression dataReaderParam, bool? canBeNull)
 		{
 			_type            = type;
 			Converter        = converter;
 			CanBeNull        = canBeNull;
 			_idx             = idx;
+			DataContextParam = dataContextParam;
 			_dataReaderParam = dataReaderParam;
 		}
 
 		// slow mode constructor
-		public ConvertFromDataReaderExpression(Type type, int idx, IValueConverter? converter, Expression dataReaderParam, IDataContext dataContext)
-			: this(type, idx, converter, dataReaderParam, (bool?)null)
+		public ConvertFromDataReaderExpression(Type type, int idx, IValueConverter? converter, Expression dataContextParam, Expression dataReaderParam, IDataContext dataContext)
+			: this(type, idx, converter, dataContextParam, dataReaderParam, (bool?)null)
 		{
 			_slowModeDataContext = dataContext;
 		}
@@ -37,8 +38,9 @@ namespace LinqToDB.Expressions
 		readonly Type           _type;
 		readonly IDataContext?  _slowModeDataContext;
 
-		public IValueConverter? Converter { get; }
-		public bool?            CanBeNull { get; }
+		public Expression       DataContextParam { get; }
+		public IValueConverter? Converter        { get; }
+		public bool?            CanBeNull        { get; }
 
 		public override Type           Type      => _type;
 		public override ExpressionType NodeType  => ExpressionType.Extension;
@@ -55,12 +57,12 @@ namespace LinqToDB.Expressions
 			if (dataContext == null)
 				return _dataReaderParam;
 
-			var columnReader = new ColumnReader(dataContext, dataContext.MappingSchema, _type, _idx, Converter, slowMode);
+			var columnReader = new ColumnReader(dataContext.MappingSchema, _type, _idx, Converter, slowMode);
 
 			if (slowMode && Common.Configuration.OptimizeForSequentialAccess)
-				return Convert(Call(Constant(columnReader), Methods.LinqToDB.ColumnReader.GetValueSequential, _dataReaderParam, Call(_dataReaderParam, Methods.ADONet.IsDBNull, ExpressionInstances.Int32Array(_idx)), Call(Methods.LinqToDB.ColumnReader.RawValuePlaceholder)), _type);
+				return Convert(Call(Constant(columnReader), Methods.LinqToDB.ColumnReader.GetValueSequential, DataContextParam, _dataReaderParam, Call(_dataReaderParam, Methods.ADONet.IsDBNull, ExpressionInstances.Int32Array(_idx)), Call(Methods.LinqToDB.ColumnReader.RawValuePlaceholder)), _type);
 			else
-				return Convert(Call(Constant(columnReader), Methods.LinqToDB.ColumnReader.GetValue, _dataReaderParam), _type);
+				return Convert(Call(Constant(columnReader), Methods.LinqToDB.ColumnReader.GetValue, DataContextParam, _dataReaderParam), _type);
 		}
 
 		public Expression Reduce(IDataContext dataContext, DbDataReader dataReader)
@@ -183,9 +185,8 @@ namespace LinqToDB.Expressions
 
 		internal sealed class ColumnReader
 		{
-			public ColumnReader(IDataContext dataContext, MappingSchema mappingSchema, Type columnType, int columnIndex, IValueConverter? converter, bool slowMode)
+			public ColumnReader(MappingSchema mappingSchema, Type columnType, int columnIndex, IValueConverter? converter, bool slowMode)
 			{
-				_dataContext   = dataContext;
 				_mappingSchema = mappingSchema;
 				ColumnType     = columnType;
 				ColumnIndex    = columnIndex;
@@ -214,7 +215,7 @@ namespace LinqToDB.Expressions
 			 * column mapping expressions should use same reader method to get column value. This limitation enforced
 			 * in GetRawValueSequential method.
 			 */
-			public object? GetValueSequential(DbDataReader dataReader, bool isNull, object? rawValue)
+			public object? GetValueSequential(IDataContext dataContext, DbDataReader dataReader, bool isNull, object? rawValue)
 			{
 				var fromType = dataReader.GetFieldType(ColumnIndex);
 
@@ -225,7 +226,7 @@ namespace LinqToDB.Expressions
 					var rawValueParameter   = Parameter(typeof(object));
 					var dataReaderExpr      = Convert(dataReaderParameter, dataReader.GetType());
 
-					var expr = GetColumnReader(_dataContext, _mappingSchema, dataReader, ColumnType, _converter, ColumnIndex, dataReaderExpr, _slowMode);
+					var expr = GetColumnReader(dataContext, _mappingSchema, dataReader, ColumnType, _converter, ColumnIndex, dataReaderExpr, _slowMode);
 					expr     = SequentialAccessHelper.OptimizeColumnReaderForSequentialAccess(expr, isNullParameter, rawValueParameter, ColumnIndex);
 
 					var lex  = Lambda<Func<bool, object?, object?>>(
@@ -256,7 +257,7 @@ namespace LinqToDB.Expressions
 				}
 			}
 
-			public object GetRawValueSequential(DbDataReader dataReader, Type[] forTypes)
+			public object GetRawValueSequential(IDataContext dataContext, DbDataReader dataReader, Type[] forTypes)
 			{
 				var fromType = dataReader.GetFieldType(ColumnIndex);
 
@@ -268,7 +269,7 @@ namespace LinqToDB.Expressions
 					MethodCallExpression rawExpr = null!;
 					foreach (var type in forTypes)
 					{
-						var expr           = GetColumnReader(_dataContext, _mappingSchema, dataReader, type, _converter, ColumnIndex, dataReaderExpr, _slowMode);
+						var expr           = GetColumnReader(dataContext, _mappingSchema, dataReader, type, _converter, ColumnIndex, dataReaderExpr, _slowMode);
 						var currentRawExpr = SequentialAccessHelper.ExtractRawValueReader(expr, ColumnIndex);
 
 						if (rawExpr == null)
@@ -289,7 +290,7 @@ namespace LinqToDB.Expressions
 				return func(dataReader);
 			}
 
-			public object? GetValue(DbDataReader dataReader)
+			public object? GetValue(IDataContext dataContext, DbDataReader dataReader)
 			{
 				var fromType = dataReader.GetFieldType(ColumnIndex);
 
@@ -298,7 +299,7 @@ namespace LinqToDB.Expressions
 					var parameter      = Parameter(typeof(DbDataReader));
 					var dataReaderExpr = Convert(parameter, dataReader.GetType());
 
-					var expr = GetColumnReader(_dataContext, _mappingSchema, dataReader, ColumnType, _converter, ColumnIndex, dataReaderExpr, _slowMode);
+					var expr = GetColumnReader(dataContext, _mappingSchema, dataReader, ColumnType, _converter, ColumnIndex, dataReaderExpr, _slowMode);
 
 					var lex  = Lambda<Func<DbDataReader, object>>(
 						expr.Type == typeof(object) ? expr : Convert(expr, typeof(object)),
@@ -331,7 +332,6 @@ namespace LinqToDB.Expressions
 			readonly ConcurrentDictionary<Type, Func<bool, object?, object?>> _slowColumnConverters = new ();
 			readonly ConcurrentDictionary<Type, Func<DbDataReader, object>>   _slowRawReaders       = new ();
 
-			readonly IDataContext     _dataContext;
 			readonly MappingSchema    _mappingSchema;
 			readonly IValueConverter? _converter;
 			readonly bool             _slowMode;
@@ -353,7 +353,7 @@ namespace LinqToDB.Expressions
 			if (!Type.IsNullableType())
 			{
 				var type = Type.AsNullable();
-				return new ConvertFromDataReaderExpression(type, _idx, Converter, _dataReaderParam, true);
+				return new ConvertFromDataReaderExpression(type, _idx, Converter, DataContextParam, _dataReaderParam, true);
 			}
 
 			return this;
@@ -364,7 +364,7 @@ namespace LinqToDB.Expressions
 			if (Type.IsNullable())
 			{
 				var type = Type.GetGenericArguments()[0];
-				return new ConvertFromDataReaderExpression(type, _idx, Converter, _dataReaderParam, (bool?)null);
+				return new ConvertFromDataReaderExpression(type, _idx, Converter, DataContextParam, _dataReaderParam, (bool?)null);
 			}
 
 			return this;

--- a/Source/LinqToDB/Extensions/DataOptionsExtensions.cs
+++ b/Source/LinqToDB/Extensions/DataOptionsExtensions.cs
@@ -1161,6 +1161,17 @@ namespace LinqToDB
 		}
 
 		/// <summary>
+		/// Configure the database connection to use the specified <see cref="TraceSwitch"/> for tracing.
+		/// </summary>
+		/// <param name="traceSwitch"><see cref="TraceSwitch"/> instance to use with connection.</param>
+		/// <returns>The builder instance so calls can be chained.</returns>
+		[Pure]
+		public static DataOptions UseTraceSwitch(this DataOptions options, TraceSwitch traceSwitch)
+		{
+			return options.WithOptions<QueryTraceOptions>(o => o with { TraceSwitch = traceSwitch });
+		}
+
+		/// <summary>
 		/// Configure the database to use the specified trace level and callback for logging or tracing.
 		/// </summary>
 		/// <param name="traceLevel">Trace level to use.</param>

--- a/Source/LinqToDB/KeepConnectionAliveScope.cs
+++ b/Source/LinqToDB/KeepConnectionAliveScope.cs
@@ -23,7 +23,7 @@ namespace LinqToDB
 			_dataContext = dataContext;
 			_savedValue  = dataContext.KeepConnectionAlive;
 
-			dataContext.KeepConnectionAlive = true;
+			dataContext.SetKeepConnectionAlive(true);
 		}
 
 		/// <summary>
@@ -31,7 +31,7 @@ namespace LinqToDB
 		/// </summary>
 		public void Dispose()
 		{
-			_dataContext.KeepConnectionAlive = _savedValue;
+			_dataContext.SetKeepConnectionAlive(_savedValue);
 		}
 	}
 }

--- a/Source/LinqToDB/KeepConnectionAliveScope.cs
+++ b/Source/LinqToDB/KeepConnectionAliveScope.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 using JetBrains.Annotations;
 
@@ -9,7 +10,7 @@ namespace LinqToDB
 	/// See <see cref="DataContext.KeepConnectionAlive"/> for more details.
 	/// </summary>
 	[PublicAPI]
-	public class KeepConnectionAliveScope : IDisposable
+	public class KeepConnectionAliveScope : IDisposable, IAsyncDisposable
 	{
 		readonly DataContext _dataContext;
 		readonly bool        _savedValue;
@@ -23,6 +24,7 @@ namespace LinqToDB
 			_dataContext = dataContext;
 			_savedValue  = dataContext.KeepConnectionAlive;
 
+			// it is safe to call sync API as 'true' value doesn't trigger blocking operation
 			dataContext.SetKeepConnectionAlive(true);
 		}
 
@@ -32,6 +34,11 @@ namespace LinqToDB
 		public void Dispose()
 		{
 			_dataContext.SetKeepConnectionAlive(_savedValue);
+		}
+
+		public async ValueTask DisposeAsync()
+		{
+			await _dataContext.SetKeepConnectionAliveAsync(_savedValue).ConfigureAwait(false);
 		}
 	}
 }

--- a/Source/LinqToDB/Linq/Builder/ExpressionBuilder.QueryBuilder.cs
+++ b/Source/LinqToDB/Linq/Builder/ExpressionBuilder.QueryBuilder.cs
@@ -567,7 +567,7 @@ namespace LinqToDB.Linq.Builder
 					}
 
 					var readerExpression = (Expression)new ConvertFromDataReaderExpression(valueType, placeholder.Index.Value,
-						columnDescriptor?.ValueConverter, DataReaderParam, canBeNull);
+						columnDescriptor?.ValueConverter, Expression.Property(QueryRunnerParam, QueryRunner.DataContextInfo), DataReaderParam, canBeNull);
 
 					if (placeholder.Type != readerExpression.Type)
 					{

--- a/Source/LinqToDB/Linq/ExpressionQuery.cs
+++ b/Source/LinqToDB/Linq/ExpressionQuery.cs
@@ -140,7 +140,7 @@ namespace LinqToDB.Linq
 			if (TransactionScopeHelper.IsInsideTransactionScope)
 				return null;
 
-			dc.EnsureConnection();
+			dc.EnsureConnection(connect: true);
 
 			if (dc.TransactionAsync != null || dc.CurrentCommand?.Transaction != null)
 				return null;
@@ -173,7 +173,7 @@ namespace LinqToDB.Linq
 			if (TransactionScopeHelper.IsInsideTransactionScope)
 				return null;
 
-			await dc.EnsureConnectionAsync(cancellationToken).ConfigureAwait(false);
+			await dc.EnsureConnectionAsync(connect: true, cancellationToken).ConfigureAwait(false);
 
 			if (dc.TransactionAsync != null || dc.CurrentCommand?.Transaction != null)
 				return null;

--- a/Source/LinqToDB/Linq/IExpressionQuery.cs
+++ b/Source/LinqToDB/Linq/IExpressionQuery.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace LinqToDB.Linq
 {
@@ -8,6 +10,7 @@ namespace LinqToDB.Linq
 		Expression   Expression  { get; }
 		IDataContext DataContext { get; }
 
-		IReadOnlyList<QuerySql> GetSqlQueries(SqlGenerationOptions? options);
+		IReadOnlyList<QuerySql>       GetSqlQueries(SqlGenerationOptions? options);
+		Task<IReadOnlyList<QuerySql>> GetSqlQueriesAsync(SqlGenerationOptions? options, CancellationToken cancellationToken);
 	}
 }

--- a/Source/LinqToDB/Linq/IExpressionQuery.cs
+++ b/Source/LinqToDB/Linq/IExpressionQuery.cs
@@ -10,7 +10,6 @@ namespace LinqToDB.Linq
 		Expression   Expression  { get; }
 		IDataContext DataContext { get; }
 
-		IReadOnlyList<QuerySql>       GetSqlQueries(SqlGenerationOptions? options);
-		Task<IReadOnlyList<QuerySql>> GetSqlQueriesAsync(SqlGenerationOptions? options, CancellationToken cancellationToken);
+		IReadOnlyList<QuerySql> GetSqlQueries(SqlGenerationOptions? options);
 	}
 }

--- a/Source/LinqToDB/Linq/IQueryRunner.cs
+++ b/Source/LinqToDB/Linq/IQueryRunner.cs
@@ -50,7 +50,13 @@ namespace LinqToDB.Linq
 		/// </summary>
 		/// <returns>Query SQL text with parameters.</returns>
 		IReadOnlyList<QuerySql> GetSqlText();
-		
+
+		/// <summary>
+		/// Returns SQL text with parameters for query.
+		/// </summary>
+		/// <returns>Query SQL text with parameters.</returns>
+		Task<IReadOnlyList<QuerySql>> GetSqlTextAsync(CancellationToken cancellationToken);
+
 		IQueryExpressions Expressions      { get; }
 		IDataContext      DataContext      { get; }
 		object?[]?        Parameters       { get; }

--- a/Source/LinqToDB/Linq/IQueryRunner.cs
+++ b/Source/LinqToDB/Linq/IQueryRunner.cs
@@ -51,12 +51,6 @@ namespace LinqToDB.Linq
 		/// <returns>Query SQL text with parameters.</returns>
 		IReadOnlyList<QuerySql> GetSqlText();
 
-		/// <summary>
-		/// Returns SQL text with parameters for query.
-		/// </summary>
-		/// <returns>Query SQL text with parameters.</returns>
-		Task<IReadOnlyList<QuerySql>> GetSqlTextAsync(CancellationToken cancellationToken);
-
 		IQueryExpressions Expressions      { get; }
 		IDataContext      DataContext      { get; }
 		object?[]?        Parameters       { get; }

--- a/Source/LinqToDB/Linq/PersistentTableT.cs
+++ b/Source/LinqToDB/Linq/PersistentTableT.cs
@@ -30,7 +30,9 @@ namespace LinqToDB.Linq
 
 		public Expression Expression => _query.Expression;
 
-		IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options) => Array.Empty<QuerySql>();
+		IReadOnlyList<QuerySql>       IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options)                                           => Array.Empty<QuerySql>();
+		Task<IReadOnlyList<QuerySql>> IExpressionQuery.GetSqlQueriesAsync(SqlGenerationOptions? options, CancellationToken cancellationToken) => Task.FromResult((IReadOnlyList<QuerySql>)Array.Empty<QuerySql>());
+
 		public IDataContext   DataContext                                                     => null!;
 		public Type           ElementType                                                     => _query.ElementType;
 		public IQueryProvider Provider                                                        => _query.Provider;

--- a/Source/LinqToDB/Linq/PersistentTableT.cs
+++ b/Source/LinqToDB/Linq/PersistentTableT.cs
@@ -30,8 +30,7 @@ namespace LinqToDB.Linq
 
 		public Expression Expression => _query.Expression;
 
-		IReadOnlyList<QuerySql>       IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options)                                           => Array.Empty<QuerySql>();
-		Task<IReadOnlyList<QuerySql>> IExpressionQuery.GetSqlQueriesAsync(SqlGenerationOptions? options, CancellationToken cancellationToken) => Task.FromResult((IReadOnlyList<QuerySql>)Array.Empty<QuerySql>());
+		IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options) => Array.Empty<QuerySql>();
 
 		public IDataContext   DataContext                                                     => null!;
 		public Type           ElementType                                                     => _query.ElementType;

--- a/Source/LinqToDB/Linq/QueryRunner.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.cs
@@ -187,7 +187,7 @@ namespace LinqToDB.Linq
 						static (context, e) =>
 						{
 							if (e is ConvertFromDataReaderExpression ex)
-								return new ConvertFromDataReaderExpression(ex.Type, ex.Index, ex.Converter, context.NewVariable!, context.Context).Reduce();
+								return new ConvertFromDataReaderExpression(ex.Type, ex.Index, ex.Converter, ex.DataContextParam, context.NewVariable!, context.Context).Reduce();
 
 							return ReplaceVariable(context, e);
 						});
@@ -650,6 +650,7 @@ namespace LinqToDB.Linq
 		static readonly PropertyInfo _preamblesInfo   = MemberHelper.PropertyOf<IQueryRunner>(p => p.Preambles);
 
 		public static readonly PropertyInfo RowsCountInfo   = MemberHelper.PropertyOf<IQueryRunner>(p => p.RowsCount);
+		public static readonly PropertyInfo DataContextInfo = MemberHelper.PropertyOf<IQueryRunner>(p => p.DataContext);
 
 		static Expression<Func<IQueryRunner, DbDataReader, T>> WrapMapper<T>(
 			Expression<Func<IQueryRunner,IDataContext, DbDataReader, IQueryExpressions, object?[]?,object?[]?,T>> expression)

--- a/Source/LinqToDB/Linq/QueryRunner.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.cs
@@ -1003,14 +1003,6 @@ namespace LinqToDB.Linq
 			return runner.GetSqlText();
 		}
 
-		public static Task<IReadOnlyList<QuerySql>> GetSqlTextAsync(Query query, IDataContext dataContext, IQueryExpressions expressions, object?[]? parameters, object?[]? preambles, CancellationToken cancellationToken)
-		{
-			using var m      = ActivityService.Start(ActivityID.GetSqlText);
-
-			using var runner = dataContext.GetQueryRunner(query, dataContext, 0, expressions, parameters, preambles);
-			return runner.GetSqlTextAsync(cancellationToken);
-		}
-
 		#endregion
 	}
 }

--- a/Source/LinqToDB/Linq/QueryRunner.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.cs
@@ -1002,6 +1002,14 @@ namespace LinqToDB.Linq
 			return runner.GetSqlText();
 		}
 
+		public static Task<IReadOnlyList<QuerySql>> GetSqlTextAsync(Query query, IDataContext dataContext, IQueryExpressions expressions, object?[]? parameters, object?[]? preambles, CancellationToken cancellationToken)
+		{
+			using var m      = ActivityService.Start(ActivityID.GetSqlText);
+
+			using var runner = dataContext.GetQueryRunner(query, dataContext, 0, expressions, parameters, preambles);
+			return runner.GetSqlTextAsync(cancellationToken);
+		}
+
 		#endregion
 	}
 }

--- a/Source/LinqToDB/Linq/QueryRunnerBase.cs
+++ b/Source/LinqToDB/Linq/QueryRunnerBase.cs
@@ -63,19 +63,8 @@ namespace LinqToDB.Linq
 			SetQuery(parameterValues, forGetSqlText);
 		}
 
-		protected virtual Task SetCommandAsync(bool forGetSqlText, CancellationToken cancellationToken)
-		{
-			var parameterValues = new SqlParameterValues();
-
-			QueryRunner.SetParameters(Query, Expressions, ParametersContext, Parameters, QueryNumber, parameterValues);
-
-			return SetQueryAsync(parameterValues, forGetSqlText, cancellationToken);
-		}
-
 		protected abstract void SetQuery(IReadOnlyParameterValues parameterValues, bool forGetSqlText);
-		protected abstract Task SetQueryAsync(IReadOnlyParameterValues parameterValues, bool forGetSqlText, CancellationToken cancellationToken);
 
-		public    abstract IReadOnlyList<QuerySql>       GetSqlText();
-		public    abstract Task<IReadOnlyList<QuerySql>> GetSqlTextAsync(CancellationToken cancellationToken);
+		public abstract IReadOnlyList<QuerySql> GetSqlText();
 	}
 }

--- a/Source/LinqToDB/Linq/QueryRunnerBase.cs
+++ b/Source/LinqToDB/Linq/QueryRunnerBase.cs
@@ -63,8 +63,19 @@ namespace LinqToDB.Linq
 			SetQuery(parameterValues, forGetSqlText);
 		}
 
-		protected abstract void SetQuery(IReadOnlyParameterValues parameterValues, bool forGetSqlText);
+		protected virtual Task SetCommandAsync(bool forGetSqlText, CancellationToken cancellationToken)
+		{
+			var parameterValues = new SqlParameterValues();
 
-		public    abstract IReadOnlyList<QuerySql> GetSqlText();
+			QueryRunner.SetParameters(Query, Expressions, ParametersContext, Parameters, QueryNumber, parameterValues);
+
+			return SetQueryAsync(parameterValues, forGetSqlText, cancellationToken);
+		}
+
+		protected abstract void SetQuery(IReadOnlyParameterValues parameterValues, bool forGetSqlText);
+		protected abstract Task SetQueryAsync(IReadOnlyParameterValues parameterValues, bool forGetSqlText, CancellationToken cancellationToken);
+
+		public    abstract IReadOnlyList<QuerySql>       GetSqlText();
+		public    abstract Task<IReadOnlyList<QuerySql>> GetSqlTextAsync(CancellationToken cancellationToken);
 	}
 }

--- a/Source/LinqToDB/Linq/SequentialAccessHelper.cs
+++ b/Source/LinqToDB/Linq/SequentialAccessHelper.cs
@@ -40,6 +40,7 @@ namespace LinqToDB.Linq
 			// slow mode column types
 			public Dictionary<int, Tuple<ConvertFromDataReaderExpression.ColumnReader, ISet<Type>>>? SlowColumnTypes;
 
+			public Expression? DataContextExpr;
 			public Expression? DataReaderExpr;
 			public string?     FailMessage;
 			public bool        Updated;
@@ -146,7 +147,8 @@ namespace LinqToDB.Linq
 							if (context.SlowColumnTypes == null)
 							{
 								context.SlowColumnTypes = new Dictionary<int, Tuple<ConvertFromDataReaderExpression.ColumnReader, ISet<Type>>>();
-								context.DataReaderExpr  = call.Arguments[0];
+								context.DataContextExpr = call.Arguments[0];
+								context.DataReaderExpr  = call.Arguments[1];
 							}
 
 							context.SlowColumnTypes.Add(columnIndex.Value, new Tuple<ConvertFromDataReaderExpression.ColumnReader, ISet<Type>>(columnReader, new HashSet<Type>()));
@@ -157,7 +159,7 @@ namespace LinqToDB.Linq
 						// replacement expression build later when we know all types
 						return call.Update(
 							call.Object,
-							call.Arguments.Take(2).Select(a => a.Transform(context, TranformFunc)).Concat(new[] { context.NewVariables[index]! }));
+							new[] { call.Arguments[0] }.Concat(call.Arguments.Skip(1).Take(2).Select(a => a.Transform(context, TranformFunc)).Concat(new[] { context.NewVariables[index]! })));
 					}
 
 					foreach (var arg in call.Arguments)
@@ -219,6 +221,7 @@ namespace LinqToDB.Linq
 							Expression.Call(
 								Expression.Constant(kvp.Value.Item1),
 								Methods.LinqToDB.ColumnReader.GetRawValueSequential,
+								ctx.DataContextExpr!,
 								ctx.DataReaderExpr!,
 								Expression.Constant(kvp.Value.Item2.ToArray())),
 							valueVariable.Type));

--- a/Source/LinqToDB/LinqExtensions.LoadWith.cs
+++ b/Source/LinqToDB/LinqExtensions.LoadWith.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
 
 using JetBrains.Annotations;
 
@@ -76,9 +77,10 @@ namespace LinqToDB
 
 			public IQueryable<TEntity> Query { get; }
 
-			Expression              IExpressionQuery.Expression                                   => Query.Expression;
-			IDataContext            IExpressionQuery.DataContext                                  => ((IExpressionQuery)Query.GetLinqToDBSource()).DataContext;
-			IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options) => ((IExpressionQuery)Query.GetLinqToDBSource()).GetSqlQueries(options);
+			Expression                    IExpressionQuery.Expression                                                                             => Query.Expression;
+			IDataContext                  IExpressionQuery.DataContext                                                                            => ((IExpressionQuery)Query.GetLinqToDBSource()).DataContext;
+			IReadOnlyList<QuerySql>       IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options)                                           => ((IExpressionQuery)Query.GetLinqToDBSource()).GetSqlQueries(options);
+			Task<IReadOnlyList<QuerySql>> IExpressionQuery.GetSqlQueriesAsync(SqlGenerationOptions? options, CancellationToken cancellationToken) => ((IExpressionQuery)Query.GetLinqToDBSource()).GetSqlQueriesAsync(options, cancellationToken);
 		}
 
 		sealed class LoadWithQueryable<TEntity, TProperty> : LoadWithQueryableBase<TEntity>, ILoadWithQueryable<TEntity, TProperty>

--- a/Source/LinqToDB/LinqExtensions.LoadWith.cs
+++ b/Source/LinqToDB/LinqExtensions.LoadWith.cs
@@ -77,10 +77,9 @@ namespace LinqToDB
 
 			public IQueryable<TEntity> Query { get; }
 
-			Expression                    IExpressionQuery.Expression                                                                             => Query.Expression;
-			IDataContext                  IExpressionQuery.DataContext                                                                            => ((IExpressionQuery)Query.GetLinqToDBSource()).DataContext;
-			IReadOnlyList<QuerySql>       IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options)                                           => ((IExpressionQuery)Query.GetLinqToDBSource()).GetSqlQueries(options);
-			Task<IReadOnlyList<QuerySql>> IExpressionQuery.GetSqlQueriesAsync(SqlGenerationOptions? options, CancellationToken cancellationToken) => ((IExpressionQuery)Query.GetLinqToDBSource()).GetSqlQueriesAsync(options, cancellationToken);
+			Expression              IExpressionQuery.Expression                                   => Query.Expression;
+			IDataContext            IExpressionQuery.DataContext                                  => ((IExpressionQuery)Query.GetLinqToDBSource()).DataContext;
+			IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options) => ((IExpressionQuery)Query.GetLinqToDBSource()).GetSqlQueries(options);
 		}
 
 		sealed class LoadWithQueryable<TEntity, TProperty> : LoadWithQueryableBase<TEntity>, ILoadWithQueryable<TEntity, TProperty>

--- a/Source/LinqToDB/LinqExtensions.cs
+++ b/Source/LinqToDB/LinqExtensions.cs
@@ -4105,37 +4105,11 @@ namespace LinqToDB
 		/// <summary>
 		/// Convert Linq To DB query to SQL command with parameters.
 		/// </summary>
-		/// <remarks>Eager load queries currently return only SQL for main query.</remarks>
-		public static async Task<QuerySql> ToSqlQueryAsync<T>(this IQueryable<T> query, SqlGenerationOptions? options = null, CancellationToken cancellationToken = default)
-		{
-			if (query is LoadWithQueryableBase<T> loadWith)
-				query = loadWith.Query;
-
-			var expressionQuery = (IExpressionQuery)query.GetLinqToDBSource();
-
-			// currently we have only non-linq APIs that could generate multiple commands like
-			// InsertOrReplace, CreateTable, DropTable
-			return (await expressionQuery.GetSqlQueriesAsync(options, cancellationToken).ConfigureAwait(false))[0];
-		}
-
-		/// <summary>
-		/// Convert Linq To DB query to SQL command with parameters.
-		/// </summary>
 		public static QuerySql ToSqlQuery<T>(this IUpdatable<T> query, SqlGenerationOptions? options = null)
 		{
 			var expressionQuery = (IExpressionQuery)((Updatable<T>)query).Query.GetLinqToDBSource();
 
 			return expressionQuery.GetSqlQueries(options)[0];
-		}
-
-		/// <summary>
-		/// Convert Linq To DB query to SQL command with parameters.
-		/// </summary>
-		public static async Task<QuerySql> ToSqlQueryAsync<T>(this IUpdatable<T> query, SqlGenerationOptions? options = null, CancellationToken cancellationToken = default)
-		{
-			var expressionQuery = (IExpressionQuery)((Updatable<T>)query).Query.GetLinqToDBSource();
-
-			return (await expressionQuery.GetSqlQueriesAsync(options, cancellationToken).ConfigureAwait(false))[0];
 		}
 
 		/// <summary>
@@ -4151,31 +4125,11 @@ namespace LinqToDB
 		/// <summary>
 		/// Convert Linq To DB query to SQL command with parameters.
 		/// </summary>
-		public static async Task<QuerySql> ToSqlQueryAsync<T>(this IValueInsertable<T> query, SqlGenerationOptions? options = null, CancellationToken cancellationToken = default)
-		{
-			var expressionQuery = (IExpressionQuery)((ValueInsertable<T>)query).Query.GetLinqToDBSource();
-
-			return (await expressionQuery.GetSqlQueriesAsync(options, cancellationToken).ConfigureAwait(false))[0];
-		}
-
-		/// <summary>
-		/// Convert Linq To DB query to SQL command with parameters.
-		/// </summary>
 		public static QuerySql ToSqlQuery<TSource, TTarget>(this ISelectInsertable<TSource, TTarget> query, SqlGenerationOptions? options = null)
 		{
 			var expressionQuery = (IExpressionQuery)((SelectInsertable<TSource, TTarget>)query).Query.GetLinqToDBSource();
 
 			return expressionQuery.GetSqlQueries(options)[0];
-		}
-
-		/// <summary>
-		/// Convert Linq To DB query to SQL command with parameters.
-		/// </summary>
-		public static async Task<QuerySql> ToSqlQueryAsync<TSource, TTarget>(this ISelectInsertable<TSource, TTarget> query, SqlGenerationOptions? options = null, CancellationToken cancellationToken = default)
-		{
-			var expressionQuery = (IExpressionQuery)((SelectInsertable<TSource, TTarget>)query).Query.GetLinqToDBSource();
-
-			return (await expressionQuery.GetSqlQueriesAsync(options, cancellationToken).ConfigureAwait(false))[0];
 		}
 
 		/// <summary>
@@ -4193,33 +4147,11 @@ namespace LinqToDB
 		/// Convert Linq To DB query to SQL command with parameters.
 		/// </summary>
 		/// <remarks>Eager load queries currently return only SQL for main query.</remarks>
-		public static async Task<QuerySql> ToSqlQueryAsync<TSource>(this IMultiInsertInto<TSource> query, SqlGenerationOptions? options = null, CancellationToken cancellationToken = default)
-		{
-			var expressionQuery = (IExpressionQuery)((MultiInsertQuery<TSource>)query).Query.GetLinqToDBSource();
-
-			return (await expressionQuery.GetSqlQueriesAsync(options, cancellationToken).ConfigureAwait(false))[0];
-		}
-
-		/// <summary>
-		/// Convert Linq To DB query to SQL command with parameters.
-		/// </summary>
-		/// <remarks>Eager load queries currently return only SQL for main query.</remarks>
 		public static QuerySql ToSqlQuery<TSource>(this IMultiInsertElse<TSource> query, SqlGenerationOptions? options = null)
 		{
 			var expressionQuery = (IExpressionQuery)((MultiInsertQuery<TSource>)query).Query.GetLinqToDBSource();
 
 			return expressionQuery.GetSqlQueries(options)[0];
-		}
-
-		/// <summary>
-		/// Convert Linq To DB query to SQL command with parameters.
-		/// </summary>
-		/// <remarks>Eager load queries currently return only SQL for main query.</remarks>
-		public static async Task<QuerySql> ToSqlQueryAsync<TSource>(this IMultiInsertElse<TSource> query, SqlGenerationOptions? options = null, CancellationToken cancellationToken = default)
-		{
-			var expressionQuery = (IExpressionQuery)((MultiInsertQuery<TSource>)query).Query.GetLinqToDBSource();
-
-			return (await expressionQuery.GetSqlQueriesAsync(options, cancellationToken).ConfigureAwait(false))[0];
 		}
 
 		/// <summary>
@@ -4233,16 +4165,6 @@ namespace LinqToDB
 			return expressionQuery.GetSqlQueries(options)[0];
 		}
 
-		/// <summary>
-		/// Convert Linq To DB query to SQL command with parameters.
-		/// </summary>
-		/// <remarks>Eager load queries currently return only SQL for main query.</remarks>
-		public static async Task<QuerySql> ToSqlQueryAsync<TSource, TTarget>(this IMergeable<TSource, TTarget> query, SqlGenerationOptions? options = null, CancellationToken cancellationToken = default)
-		{
-			var expressionQuery = (IExpressionQuery)((MergeQuery<TSource, TTarget>)query).Query.GetLinqToDBSource();
-
-			return (await expressionQuery.GetSqlQueriesAsync(options, cancellationToken).ConfigureAwait(false))[0];
-		}
 		#endregion
 	}
 }

--- a/Source/LinqToDB/LinqExtensions.cs
+++ b/Source/LinqToDB/LinqExtensions.cs
@@ -4105,11 +4105,37 @@ namespace LinqToDB
 		/// <summary>
 		/// Convert Linq To DB query to SQL command with parameters.
 		/// </summary>
+		/// <remarks>Eager load queries currently return only SQL for main query.</remarks>
+		public static async Task<QuerySql> ToSqlQueryAsync<T>(this IQueryable<T> query, SqlGenerationOptions? options = null, CancellationToken cancellationToken = default)
+		{
+			if (query is LoadWithQueryableBase<T> loadWith)
+				query = loadWith.Query;
+
+			var expressionQuery = (IExpressionQuery)query.GetLinqToDBSource();
+
+			// currently we have only non-linq APIs that could generate multiple commands like
+			// InsertOrReplace, CreateTable, DropTable
+			return (await expressionQuery.GetSqlQueriesAsync(options, cancellationToken).ConfigureAwait(false))[0];
+		}
+
+		/// <summary>
+		/// Convert Linq To DB query to SQL command with parameters.
+		/// </summary>
 		public static QuerySql ToSqlQuery<T>(this IUpdatable<T> query, SqlGenerationOptions? options = null)
 		{
 			var expressionQuery = (IExpressionQuery)((Updatable<T>)query).Query.GetLinqToDBSource();
 
 			return expressionQuery.GetSqlQueries(options)[0];
+		}
+
+		/// <summary>
+		/// Convert Linq To DB query to SQL command with parameters.
+		/// </summary>
+		public static async Task<QuerySql> ToSqlQueryAsync<T>(this IUpdatable<T> query, SqlGenerationOptions? options = null, CancellationToken cancellationToken = default)
+		{
+			var expressionQuery = (IExpressionQuery)((Updatable<T>)query).Query.GetLinqToDBSource();
+
+			return (await expressionQuery.GetSqlQueriesAsync(options, cancellationToken).ConfigureAwait(false))[0];
 		}
 
 		/// <summary>
@@ -4125,11 +4151,31 @@ namespace LinqToDB
 		/// <summary>
 		/// Convert Linq To DB query to SQL command with parameters.
 		/// </summary>
+		public static async Task<QuerySql> ToSqlQueryAsync<T>(this IValueInsertable<T> query, SqlGenerationOptions? options = null, CancellationToken cancellationToken = default)
+		{
+			var expressionQuery = (IExpressionQuery)((ValueInsertable<T>)query).Query.GetLinqToDBSource();
+
+			return (await expressionQuery.GetSqlQueriesAsync(options, cancellationToken).ConfigureAwait(false))[0];
+		}
+
+		/// <summary>
+		/// Convert Linq To DB query to SQL command with parameters.
+		/// </summary>
 		public static QuerySql ToSqlQuery<TSource, TTarget>(this ISelectInsertable<TSource, TTarget> query, SqlGenerationOptions? options = null)
 		{
 			var expressionQuery = (IExpressionQuery)((SelectInsertable<TSource, TTarget>)query).Query.GetLinqToDBSource();
 
 			return expressionQuery.GetSqlQueries(options)[0];
+		}
+
+		/// <summary>
+		/// Convert Linq To DB query to SQL command with parameters.
+		/// </summary>
+		public static async Task<QuerySql> ToSqlQueryAsync<TSource, TTarget>(this ISelectInsertable<TSource, TTarget> query, SqlGenerationOptions? options = null, CancellationToken cancellationToken = default)
+		{
+			var expressionQuery = (IExpressionQuery)((SelectInsertable<TSource, TTarget>)query).Query.GetLinqToDBSource();
+
+			return (await expressionQuery.GetSqlQueriesAsync(options, cancellationToken).ConfigureAwait(false))[0];
 		}
 
 		/// <summary>
@@ -4147,6 +4193,17 @@ namespace LinqToDB
 		/// Convert Linq To DB query to SQL command with parameters.
 		/// </summary>
 		/// <remarks>Eager load queries currently return only SQL for main query.</remarks>
+		public static async Task<QuerySql> ToSqlQueryAsync<TSource>(this IMultiInsertInto<TSource> query, SqlGenerationOptions? options = null, CancellationToken cancellationToken = default)
+		{
+			var expressionQuery = (IExpressionQuery)((MultiInsertQuery<TSource>)query).Query.GetLinqToDBSource();
+
+			return (await expressionQuery.GetSqlQueriesAsync(options, cancellationToken).ConfigureAwait(false))[0];
+		}
+
+		/// <summary>
+		/// Convert Linq To DB query to SQL command with parameters.
+		/// </summary>
+		/// <remarks>Eager load queries currently return only SQL for main query.</remarks>
 		public static QuerySql ToSqlQuery<TSource>(this IMultiInsertElse<TSource> query, SqlGenerationOptions? options = null)
 		{
 			var expressionQuery = (IExpressionQuery)((MultiInsertQuery<TSource>)query).Query.GetLinqToDBSource();
@@ -4158,11 +4215,33 @@ namespace LinqToDB
 		/// Convert Linq To DB query to SQL command with parameters.
 		/// </summary>
 		/// <remarks>Eager load queries currently return only SQL for main query.</remarks>
+		public static async Task<QuerySql> ToSqlQueryAsync<TSource>(this IMultiInsertElse<TSource> query, SqlGenerationOptions? options = null, CancellationToken cancellationToken = default)
+		{
+			var expressionQuery = (IExpressionQuery)((MultiInsertQuery<TSource>)query).Query.GetLinqToDBSource();
+
+			return (await expressionQuery.GetSqlQueriesAsync(options, cancellationToken).ConfigureAwait(false))[0];
+		}
+
+		/// <summary>
+		/// Convert Linq To DB query to SQL command with parameters.
+		/// </summary>
+		/// <remarks>Eager load queries currently return only SQL for main query.</remarks>
 		public static QuerySql ToSqlQuery<TSource, TTarget>(this IMergeable<TSource, TTarget> query, SqlGenerationOptions? options = null)
 		{
 			var expressionQuery = (IExpressionQuery)((MergeQuery<TSource, TTarget>)query).Query.GetLinqToDBSource();
 
 			return expressionQuery.GetSqlQueries(options)[0];
+		}
+
+		/// <summary>
+		/// Convert Linq To DB query to SQL command with parameters.
+		/// </summary>
+		/// <remarks>Eager load queries currently return only SQL for main query.</remarks>
+		public static async Task<QuerySql> ToSqlQueryAsync<TSource, TTarget>(this IMergeable<TSource, TTarget> query, SqlGenerationOptions? options = null, CancellationToken cancellationToken = default)
+		{
+			var expressionQuery = (IExpressionQuery)((MergeQuery<TSource, TTarget>)query).Query.GetLinqToDBSource();
+
+			return (await expressionQuery.GetSqlQueriesAsync(options, cancellationToken).ConfigureAwait(false))[0];
 		}
 		#endregion
 	}

--- a/Source/LinqToDB/Reflection/Methods.cs
+++ b/Source/LinqToDB/Reflection/Methods.cs
@@ -361,9 +361,9 @@ namespace LinqToDB.Reflection
 
 			public static class ColumnReader
 			{
-				public static readonly MethodInfo GetValue              = MemberHelper.MethodOf<ConvertFromDataReaderExpression.ColumnReader>(cr => cr.GetValue(null!));
-				public static readonly MethodInfo GetValueSequential    = MemberHelper.MethodOf<ConvertFromDataReaderExpression.ColumnReader>(cr => cr.GetValueSequential(null!, false, null));
-				public static readonly MethodInfo GetRawValueSequential = MemberHelper.MethodOf<ConvertFromDataReaderExpression.ColumnReader>(cr => cr.GetRawValueSequential(null!, null!));
+				public static readonly MethodInfo GetValue              = MemberHelper.MethodOf<ConvertFromDataReaderExpression.ColumnReader>(cr => cr.GetValue(null!, null!));
+				public static readonly MethodInfo GetValueSequential    = MemberHelper.MethodOf<ConvertFromDataReaderExpression.ColumnReader>(cr => cr.GetValueSequential(null!, null!, false, null));
+				public static readonly MethodInfo GetRawValueSequential = MemberHelper.MethodOf<ConvertFromDataReaderExpression.ColumnReader>(cr => cr.GetRawValueSequential(null!, null!, null!));
 				public static readonly MethodInfo RawValuePlaceholder   = MemberHelper.MethodOf(() => ConvertFromDataReaderExpression.ColumnReader.RawValuePlaceholder());
 			}
 

--- a/Source/LinqToDB/Remote/LinqService.cs
+++ b/Source/LinqToDB/Remote/LinqService.cs
@@ -427,7 +427,7 @@ namespace LinqToDB.Remote
 			var columnReaders = new ConvertFromDataReaderExpression.ColumnReader[rd.DataReader!.FieldCount];
 
 			for (var i = 0; i < ret.FieldCount; i++)
-				columnReaders[i] = new ConvertFromDataReaderExpression.ColumnReader(db, db.MappingSchema,
+				columnReaders[i] = new ConvertFromDataReaderExpression.ColumnReader(db.MappingSchema,
 					// converter must be null, see notes above
 					ret.FieldTypes[i], i, converter: null, true);
 
@@ -441,7 +441,7 @@ namespace LinqToDB.Remote
 				{
 					if (!reader.IsDBNull(i))
 					{
-						var value = columnReaders[i].GetValue(reader);
+						var value = columnReaders[i].GetValue(db, reader);
 
 						if (value != null)
 							data[i] = SerializationConverter.Serialize(SerializationMappingSchema, value);

--- a/Source/LinqToDB/Remote/RemoteDataContextBase.Interceptors.cs
+++ b/Source/LinqToDB/Remote/RemoteDataContextBase.Interceptors.cs
@@ -24,12 +24,16 @@ namespace LinqToDB.Remote
 		/// <inheritdoc cref="IDataContext.AddInterceptor(IInterceptor)"/>
 		public void AddInterceptor(IInterceptor interceptor)
 		{
+			ThrowOnDisposed();
+
 			this.AddInterceptorImpl(interceptor);
 		}
 
 		/// <inheritdoc cref="IDataContext.RemoveInterceptor(IInterceptor)"/>
 		public void RemoveInterceptor(IInterceptor interceptor)
 		{
+			ThrowOnDisposed();
+
 			this.RemoveInterceptorImpl(interceptor);
 		}
 	}

--- a/Source/LinqToDB/Remote/RemoteDataContextBase.QueryRunner.cs
+++ b/Source/LinqToDB/Remote/RemoteDataContextBase.QueryRunner.cs
@@ -50,24 +50,11 @@ namespace LinqToDB.Remote
 				_evaluationContext = new EvaluationContext(parameterValues);
 			}
 
-			protected override Task SetQueryAsync(IReadOnlyParameterValues parameterValues, bool forGetSqlText, CancellationToken cancellationToken)
-			{
-				_evaluationContext = new EvaluationContext(parameterValues);
-				return Task.CompletedTask;
-			}
-
 			#region GetSqlText
 
 			public override IReadOnlyList<QuerySql> GetSqlText()
 			{
 				SetCommand(true);
-				return GetSqlTextImpl();
-			}
-
-			public override async Task<IReadOnlyList<QuerySql>> GetSqlTextAsync(CancellationToken cancellationToken)
-			{
-				await SetCommandAsync(true, cancellationToken).ConfigureAwait(false);
-
 				return GetSqlTextImpl();
 			}
 
@@ -287,7 +274,7 @@ namespace LinqToDB.Remote
 				// preload _configurationInfo asynchronously if needed
 				await _dataContext.GetConfigurationInfoAsync(cancellationToken).ConfigureAwait(false);
 
-				await SetCommandAsync(false, cancellationToken).ConfigureAwait(false);
+				SetCommand(false);
 
 				var queryContext = Query.Queries[QueryNumber];
 
@@ -318,7 +305,7 @@ namespace LinqToDB.Remote
 				// preload _configurationInfo asynchronously if needed
 				await _dataContext.GetConfigurationInfoAsync(cancellationToken).ConfigureAwait(false);
 
-				await SetCommandAsync(false, cancellationToken).ConfigureAwait(false);
+				SetCommand(false);
 
 				var queryContext = Query.Queries[QueryNumber];
 
@@ -352,7 +339,7 @@ namespace LinqToDB.Remote
 				// preload _configurationInfo asynchronously if needed
 				await _dataContext.GetConfigurationInfoAsync(cancellationToken).ConfigureAwait(false);
 
-				await SetCommandAsync(false, cancellationToken).ConfigureAwait(false);
+				SetCommand(false);
 
 				var queryContext = Query.Queries[QueryNumber];
 

--- a/Source/LinqToDB/Remote/RemoteDataContextBase.QueryRunner.cs
+++ b/Source/LinqToDB/Remote/RemoteDataContextBase.QueryRunner.cs
@@ -270,7 +270,12 @@ namespace LinqToDB.Remote
 
 				public ValueTask DisposeAsync()
 				{
+#if NET6_0_OR_GREATER
 					return DataReader.DisposeAsync();
+#else
+					DataReader.Dispose();
+					return default;
+#endif
 				}
 			}
 

--- a/Source/LinqToDB/Remote/RemoteDataContextBase.cs
+++ b/Source/LinqToDB/Remote/RemoteDataContextBase.cs
@@ -50,6 +50,8 @@ namespace LinqToDB.Remote
 		{
 			get
 			{
+				ThrowOnDisposed();
+
 				if (_serviceProvider == null)
 				{
 					lock (_guard)
@@ -222,9 +224,16 @@ namespace LinqToDB.Remote
 
 		public MappingSchema   MappingSchema
 		{
-			get => _mappingSchema ??= _providedMappingSchema == null ? GetConfigurationInfo().MappingSchema : MappingSchema.CombineSchemas(_providedMappingSchema, GetConfigurationInfo().MappingSchema);
+			get
+			{
+				ThrowOnDisposed();
+
+				return _mappingSchema ??= _providedMappingSchema == null ? GetConfigurationInfo().MappingSchema : MappingSchema.CombineSchemas(_providedMappingSchema, GetConfigurationInfo().MappingSchema);
+			}
 			set
 			{
+				ThrowOnDisposed();
+
 				// Because setter could be called from constructor, we cannot build composite schemas here to avoid server calls on half-initialized context
 				// Instead we reset schemas status and finish initialization in getters for MappingSchema and SerializationMappingSchema, when they are called
 				if (_providedMappingSchema != value)
@@ -253,6 +262,8 @@ namespace LinqToDB.Remote
 		{
 			get
 			{
+				ThrowOnDisposed();
+
 				if (_sqlProviderType == null)
 				{
 					var type = GetConfigurationInfo().LinqServiceInfo.SqlBuilderType;
@@ -262,7 +273,12 @@ namespace LinqToDB.Remote
 				return _sqlProviderType;
 			}
 
-			set => _sqlProviderType = value;
+			set
+			{
+				ThrowOnDisposed();
+
+				_sqlProviderType = value;
+			}
 		}
 
 		private        Type? _sqlOptimizerType;
@@ -279,7 +295,12 @@ namespace LinqToDB.Remote
 				return _sqlOptimizerType;
 			}
 
-			set => _sqlOptimizerType = value;
+			set
+			{
+				ThrowOnDisposed();
+
+				_sqlOptimizerType = value;
+			}
 		}
 
 		/// <summary>
@@ -294,6 +315,8 @@ namespace LinqToDB.Remote
 
 		Expression IDataContext.GetReaderExpression(DbDataReader reader, int idx, Expression readerExpression, Type toType)
 		{
+			ThrowOnDisposed();
+
 			var dataType   = reader.GetFieldType(idx);
 			var methodInfo = GetReaderMethodInfo(dataType);
 
@@ -341,6 +364,8 @@ namespace LinqToDB.Remote
 		{
 			get
 			{
+				ThrowOnDisposed();
+
 				if (_createSqlProvider == null)
 				{
 					var key = Tuple.Create(SqlProviderType, MappingSchema, SqlOptimizerType, ((IDataContext)this).SqlProviderFlags, Options);
@@ -398,6 +423,8 @@ namespace LinqToDB.Remote
 		{
 			get
 			{
+				ThrowOnDisposed();
+
 				if (_getSqlOptimizer == null)
 				{
 					var key = Tuple.Create(SqlOptimizerType, ((IDataContext)this).SqlProviderFlags);
@@ -432,6 +459,8 @@ namespace LinqToDB.Remote
 
 		public void BeginBatch()
 		{
+			ThrowOnDisposed();
+
 			_batchCounter++;
 
 			_queryBatch ??= new List<string>();
@@ -439,6 +468,8 @@ namespace LinqToDB.Remote
 
 		public void CommitBatch()
 		{
+			ThrowOnDisposed();
+
 			if (_batchCounter == 0)
 				throw new InvalidOperationException();
 
@@ -463,6 +494,8 @@ namespace LinqToDB.Remote
 
 		public async Task CommitBatchAsync()
 		{
+			ThrowOnDisposed();
+
 			if (_batchCounter == 0)
 				throw new InvalidOperationException();
 

--- a/Source/LinqToDB/Remote/RemoteDataContextBase.cs
+++ b/Source/LinqToDB/Remote/RemoteDataContextBase.cs
@@ -554,16 +554,16 @@ namespace LinqToDB.Remote
 
 		public virtual void Dispose()
 		{
-			Disposed = true;
-
 			((IDataContext)this).Close();
+
+			Disposed = true;
 		}
 
-		public virtual ValueTask DisposeAsync()
+		public virtual async ValueTask DisposeAsync()
 		{
-			Disposed = true;
+			await ((IDataContext)this).CloseAsync().ConfigureAwait(false);
 
-			return new ValueTask(((IDataContext)this).CloseAsync());
+			Disposed = true;
 		}
 
 		internal static class ConfigurationApplier

--- a/Source/LinqToDB/Remote/RemoteDataContextBase.cs
+++ b/Source/LinqToDB/Remote/RemoteDataContextBase.cs
@@ -37,7 +37,7 @@ namespace LinqToDB.Remote
 			options.Apply(this);
 		}
 
-		public string?          ConfigurationString { get; set; }
+		public string?          ConfigurationString { get; private set; }
 
 		protected void InitServiceProvider(SimpleServiceProvider serviceProvider)
 		{
@@ -231,7 +231,7 @@ namespace LinqToDB.Remote
 
 				return _mappingSchema ??= _providedMappingSchema == null ? GetConfigurationInfo().MappingSchema : MappingSchema.CombineSchemas(_providedMappingSchema, GetConfigurationInfo().MappingSchema);
 			}
-			set
+			private set
 			{
 				ThrowOnDisposed();
 
@@ -258,8 +258,8 @@ namespace LinqToDB.Remote
 		private List<string>? _nextQueryHints;
 		public  List<string>   NextQueryHints => _nextQueryHints ??= new();
 
-		private        Type? _sqlProviderType;
-		public virtual Type   SqlProviderType
+		private           Type? _sqlProviderType;
+		protected virtual Type   SqlProviderType
 		{
 			get
 			{
@@ -282,8 +282,8 @@ namespace LinqToDB.Remote
 			}
 		}
 
-		private        Type? _sqlOptimizerType;
-		public virtual Type   SqlOptimizerType
+		private           Type? _sqlOptimizerType;
+		protected virtual Type   SqlOptimizerType
 		{
 			get
 			{
@@ -493,7 +493,7 @@ namespace LinqToDB.Remote
 			}
 		}
 
-		public async Task CommitBatchAsync()
+		public async Task CommitBatchAsync(CancellationToken cancellationToken = default)
 		{
 			ThrowOnDisposed();
 
@@ -509,7 +509,7 @@ namespace LinqToDB.Remote
 				try
 				{
 					var data = LinqServiceSerializer.Serialize(SerializationMappingSchema, _queryBatch!.ToArray());
-					await client.ExecuteBatchAsync(ConfigurationString, data).ConfigureAwait(false);
+					await client.ExecuteBatchAsync(ConfigurationString, data, cancellationToken).ConfigureAwait(false);
 				}
 				finally
 				{

--- a/Source/LinqToDB/Remote/RemoteDataContextBase.cs
+++ b/Source/LinqToDB/Remote/RemoteDataContextBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Data.Common;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -37,7 +38,13 @@ namespace LinqToDB.Remote
 			options.Apply(this);
 		}
 
-		public string?          ConfigurationString { get; private set; }
+		public string?          ConfigurationString
+		{
+			get;
+			// TODO: Mark private in v7 and remove warning suppressions from callers
+			[Obsolete("This API scheduled for removal in v7"), EditorBrowsable(EditorBrowsableState.Never)]
+			set;
+		}
 
 		protected void InitServiceProvider(SimpleServiceProvider serviceProvider)
 		{
@@ -231,7 +238,9 @@ namespace LinqToDB.Remote
 
 				return _mappingSchema ??= _providedMappingSchema == null ? GetConfigurationInfo().MappingSchema : MappingSchema.CombineSchemas(_providedMappingSchema, GetConfigurationInfo().MappingSchema);
 			}
-			private set
+			// TODO: Mark private in v7 and remove warning suppressions from callers
+			[Obsolete("This API scheduled for removal in v7"), EditorBrowsable(EditorBrowsableState.Never)]
+			set
 			{
 				ThrowOnDisposed();
 
@@ -589,16 +598,22 @@ namespace LinqToDB.Remote
 			{
 				if (options.ConfigurationString != null)
 				{
+#pragma warning disable CS0618 // Type or member is obsolete
 					dataContext.ConfigurationString = options.ConfigurationString;
+#pragma warning restore CS0618 // Type or member is obsolete
 				}
 
 				if (options.MappingSchema != null)
 				{
+#pragma warning disable CS0618 // Type or member is obsolete
 					dataContext.MappingSchema = options.MappingSchema;
+#pragma warning restore CS0618 // Type or member is obsolete
 				}
 				else if (dataContext.Options.LinqOptions.EnableContextSchemaEdit)
 				{
+#pragma warning disable CS0618 // Type or member is obsolete
 					dataContext.MappingSchema = new(dataContext.MappingSchema);
+#pragma warning restore CS0618 // Type or member is obsolete
 				}
 			}
 

--- a/Source/LinqToDB/Remote/RemoteDataContextBase.cs
+++ b/Source/LinqToDB/Remote/RemoteDataContextBase.cs
@@ -540,7 +540,7 @@ namespace LinqToDB.Remote
 		protected void ThrowOnDisposed()
 		{
 			if (Disposed)
-				throw new ObjectDisposedException("RemoteDataContext", "IDataContext is disposed, see https://github.com/linq2db/linq2db/wiki/Managing-data-connection");
+				throw new ObjectDisposedException(GetType().FullName, "IDataContext is disposed, see https://github.com/linq2db/linq2db/wiki/Managing-data-connection");
 		}
 
 		void IDataContext.Close()

--- a/Source/LinqToDB/SchemaProvider/SchemaProviderBase.cs
+++ b/Source/LinqToDB/SchemaProvider/SchemaProviderBase.cs
@@ -96,7 +96,7 @@ namespace LinqToDB.SchemaProvider
 			ExcludedCatalogs      = GetHashSet(options.ExcludedCatalogs, options.StringComparer);
 			GenerateChar1AsString = options.GenerateChar1AsString;
 
-			var dbConnection = dataConnection.EnsureConnection(connect: true).Connection;
+			var dbConnection = dataConnection.OpenDbConnection();
 
 			InitProvider(dataConnection, options);
 
@@ -570,8 +570,8 @@ namespace LinqToDB.SchemaProvider
 			).ToList();
 		}
 
-		protected virtual string GetDataSourceName(DataConnection dbConnection) => dbConnection.EnsureConnection(connect: true).Connection.DataSource;
-		protected virtual string GetDatabaseName  (DataConnection dbConnection) => dbConnection.EnsureConnection(connect: true).Connection.Database;
+		protected virtual string GetDataSourceName(DataConnection dbConnection) => dbConnection.OpenDbConnection().DataSource;
+		protected virtual string GetDatabaseName  (DataConnection dbConnection) => dbConnection.OpenDbConnection().Database;
 
 		protected virtual void InitProvider(DataConnection dataConnection, GetSchemaOptions options)
 		{
@@ -584,7 +584,7 @@ namespace LinqToDB.SchemaProvider
 		/// <returns>List of database data types.</returns>
 		protected virtual List<DataTypeInfo> GetDataTypes(DataConnection dataConnection)
 		{
-			DataTypesSchema = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("DataTypes");
+			DataTypesSchema = dataConnection.OpenDbConnection().GetSchema("DataTypes");
 
 			return DataTypesSchema.AsEnumerable()
 				.Select(t => new DataTypeInfo

--- a/Source/LinqToDB/SchemaProvider/SchemaProviderBase.cs
+++ b/Source/LinqToDB/SchemaProvider/SchemaProviderBase.cs
@@ -96,7 +96,7 @@ namespace LinqToDB.SchemaProvider
 			ExcludedCatalogs      = GetHashSet(options.ExcludedCatalogs, options.StringComparer);
 			GenerateChar1AsString = options.GenerateChar1AsString;
 
-			var dbConnection = dataConnection.Connection;
+			var dbConnection = dataConnection.EnsureConnection(connect: true).Connection;
 
 			InitProvider(dataConnection, options);
 
@@ -570,8 +570,8 @@ namespace LinqToDB.SchemaProvider
 			).ToList();
 		}
 
-		protected virtual string GetDataSourceName(DataConnection dbConnection) => dbConnection.Connection.DataSource;
-		protected virtual string GetDatabaseName  (DataConnection dbConnection) => dbConnection.Connection.Database;
+		protected virtual string GetDataSourceName(DataConnection dbConnection) => dbConnection.EnsureConnection(connect: true).Connection.DataSource;
+		protected virtual string GetDatabaseName  (DataConnection dbConnection) => dbConnection.EnsureConnection(connect: true).Connection.Database;
 
 		protected virtual void InitProvider(DataConnection dataConnection, GetSchemaOptions options)
 		{
@@ -584,7 +584,7 @@ namespace LinqToDB.SchemaProvider
 		/// <returns>List of database data types.</returns>
 		protected virtual List<DataTypeInfo> GetDataTypes(DataConnection dataConnection)
 		{
-			DataTypesSchema = dataConnection.Connection.GetSchema("DataTypes");
+			DataTypesSchema = dataConnection.EnsureConnection(connect: true).Connection.GetSchema("DataTypes");
 
 			return DataTypesSchema.AsEnumerable()
 				.Select(t => new DataTypeInfo

--- a/Source/LinqToDB/TempTable.cs
+++ b/Source/LinqToDB/TempTable.cs
@@ -674,7 +674,6 @@ namespace LinqToDB
 		public IDataContext DataContext => _table.DataContext;
 
 		IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options) => _table.GetSqlQueries(options);
-		Task<IReadOnlyList<QuerySql>> IExpressionQuery.GetSqlQueriesAsync(SqlGenerationOptions? options, CancellationToken cancellationToken) => _table.GetSqlQueriesAsync(options, cancellationToken);
 
 		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 		Expression IExpressionQuery.Expression => ((IExpressionQuery)_table).Expression;

--- a/Source/LinqToDB/TempTable.cs
+++ b/Source/LinqToDB/TempTable.cs
@@ -674,6 +674,7 @@ namespace LinqToDB
 		public IDataContext DataContext => _table.DataContext;
 
 		IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options) => _table.GetSqlQueries(options);
+		Task<IReadOnlyList<QuerySql>> IExpressionQuery.GetSqlQueriesAsync(SqlGenerationOptions? options, CancellationToken cancellationToken) => _table.GetSqlQueriesAsync(options, cancellationToken);
 
 		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 		Expression IExpressionQuery.Expression => ((IExpressionQuery)_table).Expression;

--- a/Source/LinqToDB/Tools/ActivityBase.cs
+++ b/Source/LinqToDB/Tools/ActivityBase.cs
@@ -40,8 +40,10 @@ namespace LinqToDB.Tools
 
 			if (connection != null)
 			{
-				AddTag(ActivityTagID.DataSourceName, connection.DataSource);
-				AddTag(ActivityTagID.DatabaseName,   connection.Database);
+				// those properties could throw for some providers when connection failed to initialize, e.g. due to bad connection string
+				// Observed for MySqlConnector and Sap.Data.*
+				try { AddTag(ActivityTagID.DataSourceName, connection.DataSource); } catch { }
+				try { AddTag(ActivityTagID.DatabaseName,   connection.Database);   } catch { }
 			}
 
 			if (command != null)

--- a/Source/LinqToDB/Tools/ActivityBase.cs
+++ b/Source/LinqToDB/Tools/ActivityBase.cs
@@ -42,8 +42,21 @@ namespace LinqToDB.Tools
 			{
 				// those properties could throw for some providers when connection failed to initialize, e.g. due to bad connection string
 				// Observed for MySqlConnector and Sap.Data.*
-				try { AddTag(ActivityTagID.DataSourceName, connection.DataSource); } catch { }
-				try { AddTag(ActivityTagID.DatabaseName,   connection.Database);   } catch { }
+				try
+				{
+					AddTag(ActivityTagID.DataSourceName, connection.DataSource);
+				}
+				catch
+				{
+				}
+
+				try
+				{
+					AddTag(ActivityTagID.DatabaseName,   connection.Database);
+				}
+				catch
+				{
+				}
 			}
 
 			if (command != null)

--- a/Tests/Base/TestBase.Utils.cs
+++ b/Tests/Base/TestBase.Utils.cs
@@ -5,6 +5,7 @@ using System.Text;
 using LinqToDB;
 using LinqToDB.Data;
 using LinqToDB.DataProvider.Informix;
+using LinqToDB.DataProvider.SqlServer;
 
 using Tests.Model;
 using Tests.Tools;
@@ -14,6 +15,14 @@ namespace Tests
 	public partial class TestBase
 	{
 		protected internal const string LinqServiceSuffix = ".LinqService";
+
+		protected static bool IsSqlServerMarsEnabled(DataConnection dc)
+		{
+			// good-enough check for tests
+			return dc.DataProvider is SqlServerDataProvider
+				&& dc.ConnectionString is string cs
+				&& cs.Contains("MultipleActiveResultSets=True", StringComparison.OrdinalIgnoreCase);
+		}
 
 		protected static char GetParameterToken(string context)
 		{

--- a/Tests/Base/TestUtils.cs
+++ b/Tests/Base/TestUtils.cs
@@ -227,13 +227,8 @@ namespace Tests
 
 		public static Version GetSqliteVersion(DataConnection db)
 		{
-			using (var cmd = db.CreateCommand())
-			{
-				cmd.CommandText = "select sqlite_version();";
-				var version     = (string)cmd.ExecuteScalar()!;
-
-				return new Version(version);
-			}
+			var version = db.Execute<string>("select sqlite_version();");
+			return new Version(version);
 		}
 
 		public static TempTable<T> CreateLocalTable<T>(this IDataContext db, string? tableName = null, TableOptions tableOptions = TableOptions.CheckExistence)

--- a/Tests/Base/TestUtils.cs
+++ b/Tests/Base/TestUtils.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 
 using LinqToDB;
 using LinqToDB.Data;
@@ -194,6 +195,19 @@ namespace Tests
 				FirebirdTools.ClearAllPools();
 				base.Dispose();
 			}
+
+			public override ValueTask DisposeAsync()
+			{
+				if (DataContext is DataConnection dc && dc.DataProvider.Name.Contains(ProviderName.Firebird))
+				{
+					FirebirdTools.ClearAllPools();
+				}
+
+				DataContext.CloseAsync();
+				FirebirdTools.ClearAllPools();
+
+				return base.DisposeAsync();
+			}
 		}
 		class TestTempTable<T> : TempTable<T>
 			where T : notnull
@@ -207,6 +221,12 @@ namespace Tests
 			{
 				using var _ = new DisableBaseline("Test setup");
 				base.Dispose();
+			}
+
+			public override ValueTask DisposeAsync()
+			{
+				using var _ = new DisableBaseline("Test setup");
+				return base.DisposeAsync();
 			}
 		}
 

--- a/Tests/Linq/Create/CreateData.cs
+++ b/Tests/Linq/Create/CreateData.cs
@@ -67,7 +67,7 @@ public class a_CreateData : TestBase
 			}
 			//db.CommandTimeout = 20;
 
-			var database = databaseName ?? db.TryGetDbConnection()!.Database;
+			var database = databaseName ?? db.OpenConnection().Database;
 
 			var cmds = text
 				.Replace("{DBNAME}", database)

--- a/Tests/Linq/Create/CreateData.cs
+++ b/Tests/Linq/Create/CreateData.cs
@@ -67,7 +67,7 @@ public class a_CreateData : TestBase
 			}
 			//db.CommandTimeout = 20;
 
-			var database = databaseName ?? db.Connection.Database;
+			var database = databaseName ?? db.TryGetDbConnection()!.Database;
 
 			var cmds = text
 				.Replace("{DBNAME}", database)
@@ -238,7 +238,7 @@ public class a_CreateData : TestBase
 					new InheritanceChild2() {InheritanceChildId = 3, TypeDiscriminator = 2,    InheritanceParentId = 3, Name = "InheritanceParent2" }
 				});
 
-			action?.Invoke(db.Connection);
+			action?.Invoke(db.TryGetDbConnection()!);
 
 			if (exception != null)
 				throw exception;

--- a/Tests/Linq/Create/CreateData.cs
+++ b/Tests/Linq/Create/CreateData.cs
@@ -238,7 +238,7 @@ public class a_CreateData : TestBase
 					new InheritanceChild2() {InheritanceChildId = 3, TypeDiscriminator = 2,    InheritanceParentId = 3, Name = "InheritanceParent2" }
 				});
 
-			action?.Invoke(db.TryGetDbConnection()!);
+			action?.Invoke(db.OpenConnection());
 
 			if (exception != null)
 				throw exception;

--- a/Tests/Linq/Create/CreateData.cs
+++ b/Tests/Linq/Create/CreateData.cs
@@ -67,7 +67,7 @@ public class a_CreateData : TestBase
 			}
 			//db.CommandTimeout = 20;
 
-			var database = databaseName ?? db.OpenConnection().Database;
+			var database = databaseName ?? db.OpenDbConnection().Database;
 
 			var cmds = text
 				.Replace("{DBNAME}", database)
@@ -238,7 +238,7 @@ public class a_CreateData : TestBase
 					new InheritanceChild2() {InheritanceChildId = 3, TypeDiscriminator = 2,    InheritanceParentId = 3, Name = "InheritanceParent2" }
 				});
 
-			action?.Invoke(db.OpenConnection());
+			action?.Invoke(db.OpenDbConnection());
 
 			if (exception != null)
 				throw exception;

--- a/Tests/Linq/Data/DataConnectionTests.cs
+++ b/Tests/Linq/Data/DataConnectionTests.cs
@@ -967,7 +967,7 @@ namespace Tests.Data
 				var sql = db.LastQuery!;
 
 				// we need to use raw ADO.NET for this test, as we ADO.NET test provider behavior without linq2db
-				using (var cmd = db.CreateCommand())
+				using (var cmd = db.OpenConnection().CreateCommand())
 				{
 					cmd.CommandText = sql;
 					using (var reader1 = cmd.ExecuteReader())
@@ -1018,7 +1018,7 @@ namespace Tests.Data
 				var sql = db.LastQuery!;
 
 				// we need to use raw ADO.NET for this test, as we ADO.NET test provider behavior without linq2db
-				using (var cmd = db.CreateCommand())
+				using (var cmd = db.OpenConnection().CreateCommand())
 				{
 					cmd.CommandText = sql;
 					try
@@ -1095,7 +1095,7 @@ namespace Tests.Data
 				var sql = db.LastQuery!;
 
 				// we need to use raw ADO.NET for this test, as we ADO.NET test provider behavior without linq2db
-				using (var cmd = db.CreateCommand())
+				using (var cmd = db.OpenConnection().CreateCommand())
 				{
 					cmd.CommandText = sql;
 					using (var reader1 = cmd.ExecuteReader())
@@ -1105,7 +1105,7 @@ namespace Tests.Data
 							cnt2++;
 
 							// open another reader on new command
-							using (var cmd2 = db.CreateCommand())
+							using (var cmd2 = db.OpenConnection().CreateCommand())
 							{
 								var cnt3 = 0;
 								cmd2.CommandText = sql;
@@ -1157,7 +1157,7 @@ namespace Tests.Data
 				var sql = db.LastQuery!;
 
 				// we need to use raw ADO.NET for this test, as we ADO.NET test provider behavior without linq2db
-				using (var cmd = db.CreateCommand())
+				using (var cmd = db.OpenConnection().CreateCommand())
 				{
 					cmd.CommandText = sql;
 					try
@@ -1167,7 +1167,7 @@ namespace Tests.Data
 							while (reader1.Read())
 							{
 								// open another reader on new command
-								using (var cmd2 = db.CreateCommand())
+								using (var cmd2 = db.OpenConnection().CreateCommand())
 								{
 									cmd2.CommandText = sql;
 
@@ -1236,7 +1236,7 @@ namespace Tests.Data
 				var sql = db.LastQuery!;
 
 				// we need to use raw ADO.NET for this test, as we ADO.NET test provider behavior without linq2db
-				var cmd = db.CreateCommand();
+				var cmd = db.OpenConnection().CreateCommand();
 				cmd.CommandText = sql;
 				using (var reader1 = cmd.ExecuteReader())
 				{
@@ -1246,7 +1246,7 @@ namespace Tests.Data
 						cnt2++;
 
 						// open another reader on new command
-						using (var cmd2 = db.CreateCommand())
+						using (var cmd2 = db.OpenConnection().CreateCommand())
 						{
 							var cnt3 = 0;
 							cmd2.CommandText = sql;
@@ -1296,7 +1296,7 @@ namespace Tests.Data
 				var sql = db.LastQuery!;
 
 				// we need to use raw ADO.NET for this test, as we ADO.NET test provider behavior without linq2db
-				var cmd = db.CreateCommand();
+				var cmd = db.OpenConnection().CreateCommand();
 				cmd.CommandText = sql;
 				using (var reader1 = cmd.ExecuteReader())
 				{
@@ -1306,7 +1306,7 @@ namespace Tests.Data
 						while (reader1.Read())
 						{
 							// open another reader on new command
-							using (var cmd2 = db.CreateCommand())
+							using (var cmd2 = db.OpenConnection().CreateCommand())
 							{
 								cmd2.CommandText = sql;
 

--- a/Tests/Linq/Data/DataConnectionTests.cs
+++ b/Tests/Linq/Data/DataConnectionTests.cs
@@ -36,8 +36,7 @@ namespace Tests.Data
 
 			using (var conn = new DataConnection(new DataOptions().UseConnectionString(dataProvider, connectionString)))
 			{
-				var connection = conn.TryGetDbConnection();
-				Assert.That(connection, Is.Not.Null);
+				var connection = conn.OpenConnection();
 
 				Assert.Multiple(() =>
 				{
@@ -52,8 +51,7 @@ namespace Tests.Data
 		{
 			using (var conn = new DataConnection())
 			{
-				var connection = conn.TryGetDbConnection();
-				Assert.That(connection, Is.Not.Null);
+				var connection = conn.OpenConnection();
 
 				Assert.Multiple(() =>
 				{
@@ -288,8 +286,7 @@ namespace Tests.Data
 					Assert.That(opened, Is.False);
 					Assert.That(openedAsync, Is.False);
 
-					var connection = conn.TryGetDbConnection();
-					Assert.That(connection, Is.Not.Null);
+					var connection = conn.OpenConnection();
 					Assert.That(connection!.State, Is.EqualTo(ConnectionState.Open));
 				});
 				Assert.Multiple(() =>
@@ -332,8 +329,7 @@ namespace Tests.Data
 		{
 			using (var conn = new DataConnection())
 			{
-				var connection = conn.TryGetDbConnection();
-				Assert.That(connection, Is.Not.Null);
+				var connection = conn.OpenConnection();
 				Assert.That(connection.State, Is.EqualTo(ConnectionState.Open));
 			}
 		}
@@ -635,8 +631,7 @@ namespace Tests.Data
 				{
 					Assert.That(open, Is.False);
 					Assert.That(openAsync, Is.False);
-					var connection = conn.TryGetDbConnection();
-					Assert.That(connection, Is.Not.Null);
+					var connection = conn.OpenConnection();
 					Assert.That(connection!.State, Is.EqualTo(ConnectionState.Open));
 				});
 				Assert.Multiple(() =>

--- a/Tests/Linq/Data/DataConnectionTests.cs
+++ b/Tests/Linq/Data/DataConnectionTests.cs
@@ -36,9 +36,12 @@ namespace Tests.Data
 
 			using (var conn = new DataConnection(new DataOptions().UseConnectionString(dataProvider, connectionString)))
 			{
+				var connection = conn.TryGetDbConnection();
+				Assert.That(connection, Is.Not.Null);
+
 				Assert.Multiple(() =>
 				{
-					Assert.That(conn.Connection.State, Is.EqualTo(ConnectionState.Open));
+					Assert.That(connection.State, Is.EqualTo(ConnectionState.Open));
 					Assert.That(conn.ConfigurationString, Is.Null);
 				});
 			}
@@ -49,9 +52,12 @@ namespace Tests.Data
 		{
 			using (var conn = new DataConnection())
 			{
+				var connection = conn.TryGetDbConnection();
+				Assert.That(connection, Is.Not.Null);
+
 				Assert.Multiple(() =>
 				{
-					Assert.That(conn.Connection.State, Is.EqualTo(ConnectionState.Open));
+					Assert.That(connection.State, Is.EqualTo(ConnectionState.Open));
 					Assert.That(conn.ConfigurationString, Is.EqualTo(DataConnection.DefaultConfiguration));
 				});
 			}
@@ -67,9 +73,12 @@ namespace Tests.Data
 		{
 			using (var conn = GetDataConnection(context))
 			{
+				var connection = conn.TryGetDbConnection();
+				Assert.That(connection, Is.Not.Null);
+
 				Assert.Multiple(() =>
 				{
-					Assert.That(conn.Connection.State, Is.EqualTo(ConnectionState.Open));
+					Assert.That(connection.State, Is.EqualTo(ConnectionState.Open));
 					Assert.That(conn.ConfigurationString, Is.EqualTo(context));
 				});
 
@@ -278,7 +287,10 @@ namespace Tests.Data
 				{
 					Assert.That(opened, Is.False);
 					Assert.That(openedAsync, Is.False);
-					Assert.That(conn.Connection.State, Is.EqualTo(ConnectionState.Open));
+
+					var connection = conn.TryGetDbConnection();
+					Assert.That(connection, Is.Not.Null);
+					Assert.That(connection!.State, Is.EqualTo(ConnectionState.Open));
 				});
 				Assert.Multiple(() =>
 				{
@@ -320,7 +332,9 @@ namespace Tests.Data
 		{
 			using (var conn = new DataConnection())
 			{
-				Assert.That(conn.Connection.State, Is.EqualTo(ConnectionState.Open));
+				var connection = conn.TryGetDbConnection();
+				Assert.That(connection, Is.Not.Null);
+				Assert.That(connection.State, Is.EqualTo(ConnectionState.Open));
 			}
 		}
 
@@ -621,7 +635,9 @@ namespace Tests.Data
 				{
 					Assert.That(open, Is.False);
 					Assert.That(openAsync, Is.False);
-					Assert.That(conn.Connection.State, Is.EqualTo(ConnectionState.Open));
+					var connection = conn.TryGetDbConnection();
+					Assert.That(connection, Is.Not.Null);
+					Assert.That(connection!.State, Is.EqualTo(ConnectionState.Open));
 				});
 				Assert.Multiple(() =>
 				{
@@ -894,7 +910,7 @@ namespace Tests.Data
 					db.GetTable<TransactionScopeTable>().Insert(() => new TransactionScopeTable() { Id = 1 });
 					using (var transaction = new TransactionScope(TransactionScopeOption.Required, TransactionScopeAsyncFlowOption.Enabled))
 					{
-						db.Connection.EnlistTransaction(Transaction.Current);
+						db.TryGetDbConnection()!.EnlistTransaction(Transaction.Current);
 						db.GetTable<TransactionScopeTable>().Insert(() => new TransactionScopeTable() { Id = 2 });
 
 						Transaction.Current!.Rollback();

--- a/Tests/Linq/Data/DataConnectionTests.cs
+++ b/Tests/Linq/Data/DataConnectionTests.cs
@@ -958,7 +958,7 @@ namespace Tests.Data
 		{
 			using (var db = GetDataConnection(context))
 			{
-				if (db.DataProvider is SqlServerDataProvider && !db.IsMarsEnabled)
+				if (db.DataProvider is SqlServerDataProvider && !IsSqlServerMarsEnabled(db))
 					Assert.Ignore("MARS not enabled");
 
 				var cnt1 = db.Person.Count();
@@ -1011,7 +1011,7 @@ namespace Tests.Data
 		{
 			using (var db = GetDataConnection(context))
 			{
-				if (db.DataProvider is SqlServerDataProvider && !db.IsMarsEnabled)
+				if (db.DataProvider is SqlServerDataProvider && !IsSqlServerMarsEnabled(db))
 					Assert.Ignore("MARS not enabled");
 
 				db.Person.ToList();
@@ -1086,7 +1086,7 @@ namespace Tests.Data
 		{
 			using (var db = GetDataConnection(context))
 			{
-				if (db.DataProvider is SqlServerDataProvider && !db.IsMarsEnabled)
+				if (db.DataProvider is SqlServerDataProvider && !IsSqlServerMarsEnabled(db))
 					Assert.Ignore("MARS not enabled");
 
 				var cnt1 = db.Person.Count();
@@ -1150,7 +1150,7 @@ namespace Tests.Data
 		{
 			using (var db = GetDataConnection(context))
 			{
-				if (db.DataProvider is SqlServerDataProvider && !db.IsMarsEnabled)
+				if (db.DataProvider is SqlServerDataProvider && !IsSqlServerMarsEnabled(db))
 					Assert.Ignore("MARS not enabled");
 
 				db.Person.ToList();
@@ -1227,7 +1227,7 @@ namespace Tests.Data
 		{
 			using (var db = GetDataConnection(context))
 			{
-				if (db.DataProvider is SqlServerDataProvider && !db.IsMarsEnabled)
+				if (db.DataProvider is SqlServerDataProvider && !IsSqlServerMarsEnabled(db))
 					Assert.Ignore("MARS not enabled");
 
 				var cnt1 = db.Person.Count();
@@ -1289,7 +1289,7 @@ namespace Tests.Data
 		{
 			using (var db = GetDataConnection(context))
 			{
-				if (db.DataProvider is SqlServerDataProvider && !db.IsMarsEnabled)
+				if (db.DataProvider is SqlServerDataProvider && !IsSqlServerMarsEnabled(db))
 					Assert.Ignore("MARS not enabled");
 
 				db.Person.ToList();
@@ -1341,7 +1341,7 @@ namespace Tests.Data
 		{
 			using (var db = GetDataConnection(context))
 			{
-				if (db.DataProvider is SqlServerDataProvider && !db.IsMarsEnabled)
+				if (db.DataProvider is SqlServerDataProvider && !IsSqlServerMarsEnabled(db))
 					Assert.Ignore("MARS not enabled");
 
 				var cnt1 = db.Person.Count();
@@ -1371,7 +1371,7 @@ namespace Tests.Data
 		{
 			using (var db = GetDataConnection(context))
 			{
-				if (db.DataProvider is SqlServerDataProvider && db.IsMarsEnabled)
+				if (db.DataProvider is SqlServerDataProvider && IsSqlServerMarsEnabled(db))
 					Assert.Ignore("MARS enabled");
 
 				var failed = false;
@@ -1432,7 +1432,7 @@ namespace Tests.Data
 		{
 			using (var db = GetDataConnection(context))
 			{
-				if (db.DataProvider is SqlServerDataProvider && !db.IsMarsEnabled)
+				if (db.DataProvider is SqlServerDataProvider && !IsSqlServerMarsEnabled(db))
 					Assert.Ignore("MARS not enabled");
 
 				var cnt1 = await db.Person.CountAsync();
@@ -1462,7 +1462,7 @@ namespace Tests.Data
 		{
 			using (var db = GetDataConnection(context))
 			{
-				if (db.DataProvider is SqlServerDataProvider && db.IsMarsEnabled)
+				if (db.DataProvider is SqlServerDataProvider && IsSqlServerMarsEnabled(db))
 					Assert.Ignore("MARS enabled");
 
 				var failed = false;

--- a/Tests/Linq/Data/DataConnectionTests.cs
+++ b/Tests/Linq/Data/DataConnectionTests.cs
@@ -36,7 +36,7 @@ namespace Tests.Data
 
 			using (var conn = new DataConnection(new DataOptions().UseConnectionString(dataProvider, connectionString)))
 			{
-				var connection = conn.OpenConnection();
+				var connection = conn.OpenDbConnection();
 
 				Assert.Multiple(() =>
 				{
@@ -51,7 +51,7 @@ namespace Tests.Data
 		{
 			using (var conn = new DataConnection())
 			{
-				var connection = conn.OpenConnection();
+				var connection = conn.OpenDbConnection();
 
 				Assert.Multiple(() =>
 				{
@@ -71,7 +71,7 @@ namespace Tests.Data
 		{
 			using (var conn = GetDataConnection(context))
 			{
-				var connection = conn.OpenConnection();
+				var connection = conn.OpenDbConnection();
 
 				Assert.Multiple(() =>
 				{
@@ -285,7 +285,7 @@ namespace Tests.Data
 					Assert.That(opened, Is.False);
 					Assert.That(openedAsync, Is.False);
 
-					var connection = conn.OpenConnection();
+					var connection = conn.OpenDbConnection();
 					Assert.That(connection!.State, Is.EqualTo(ConnectionState.Open));
 				});
 				Assert.Multiple(() =>
@@ -328,7 +328,7 @@ namespace Tests.Data
 		{
 			using (var conn = new DataConnection())
 			{
-				var connection = conn.OpenConnection();
+				var connection = conn.OpenDbConnection();
 				Assert.That(connection.State, Is.EqualTo(ConnectionState.Open));
 			}
 		}
@@ -630,7 +630,7 @@ namespace Tests.Data
 				{
 					Assert.That(open, Is.False);
 					Assert.That(openAsync, Is.False);
-					var connection = conn.OpenConnection();
+					var connection = conn.OpenDbConnection();
 					Assert.That(connection!.State, Is.EqualTo(ConnectionState.Open));
 				});
 				Assert.Multiple(() =>
@@ -904,7 +904,7 @@ namespace Tests.Data
 					db.GetTable<TransactionScopeTable>().Insert(() => new TransactionScopeTable() { Id = 1 });
 					using (var transaction = new TransactionScope(TransactionScopeOption.Required, TransactionScopeAsyncFlowOption.Enabled))
 					{
-						db.OpenConnection().EnlistTransaction(Transaction.Current);
+						db.OpenDbConnection().EnlistTransaction(Transaction.Current);
 						db.GetTable<TransactionScopeTable>().Insert(() => new TransactionScopeTable() { Id = 2 });
 
 						Transaction.Current!.Rollback();
@@ -961,7 +961,7 @@ namespace Tests.Data
 				var sql = db.LastQuery!;
 
 				// we need to use raw ADO.NET for this test, as we ADO.NET test provider behavior without linq2db
-				using (var cmd = db.OpenConnection().CreateCommand())
+				using (var cmd = db.OpenDbConnection().CreateCommand())
 				{
 					cmd.CommandText = sql;
 					using (var reader1 = cmd.ExecuteReader())
@@ -1012,7 +1012,7 @@ namespace Tests.Data
 				var sql = db.LastQuery!;
 
 				// we need to use raw ADO.NET for this test, as we ADO.NET test provider behavior without linq2db
-				using (var cmd = db.OpenConnection().CreateCommand())
+				using (var cmd = db.OpenDbConnection().CreateCommand())
 				{
 					cmd.CommandText = sql;
 					try
@@ -1089,7 +1089,7 @@ namespace Tests.Data
 				var sql = db.LastQuery!;
 
 				// we need to use raw ADO.NET for this test, as we ADO.NET test provider behavior without linq2db
-				using (var cmd = db.OpenConnection().CreateCommand())
+				using (var cmd = db.OpenDbConnection().CreateCommand())
 				{
 					cmd.CommandText = sql;
 					using (var reader1 = cmd.ExecuteReader())
@@ -1099,7 +1099,7 @@ namespace Tests.Data
 							cnt2++;
 
 							// open another reader on new command
-							using (var cmd2 = db.OpenConnection().CreateCommand())
+							using (var cmd2 = db.OpenDbConnection().CreateCommand())
 							{
 								var cnt3 = 0;
 								cmd2.CommandText = sql;
@@ -1151,7 +1151,7 @@ namespace Tests.Data
 				var sql = db.LastQuery!;
 
 				// we need to use raw ADO.NET for this test, as we ADO.NET test provider behavior without linq2db
-				using (var cmd = db.OpenConnection().CreateCommand())
+				using (var cmd = db.OpenDbConnection().CreateCommand())
 				{
 					cmd.CommandText = sql;
 					try
@@ -1161,7 +1161,7 @@ namespace Tests.Data
 							while (reader1.Read())
 							{
 								// open another reader on new command
-								using (var cmd2 = db.OpenConnection().CreateCommand())
+								using (var cmd2 = db.OpenDbConnection().CreateCommand())
 								{
 									cmd2.CommandText = sql;
 
@@ -1230,7 +1230,7 @@ namespace Tests.Data
 				var sql = db.LastQuery!;
 
 				// we need to use raw ADO.NET for this test, as we ADO.NET test provider behavior without linq2db
-				var cmd = db.OpenConnection().CreateCommand();
+				var cmd = db.OpenDbConnection().CreateCommand();
 				cmd.CommandText = sql;
 				using (var reader1 = cmd.ExecuteReader())
 				{
@@ -1240,7 +1240,7 @@ namespace Tests.Data
 						cnt2++;
 
 						// open another reader on new command
-						using (var cmd2 = db.OpenConnection().CreateCommand())
+						using (var cmd2 = db.OpenDbConnection().CreateCommand())
 						{
 							var cnt3 = 0;
 							cmd2.CommandText = sql;
@@ -1290,7 +1290,7 @@ namespace Tests.Data
 				var sql = db.LastQuery!;
 
 				// we need to use raw ADO.NET for this test, as we ADO.NET test provider behavior without linq2db
-				var cmd = db.OpenConnection().CreateCommand();
+				var cmd = db.OpenDbConnection().CreateCommand();
 				cmd.CommandText = sql;
 				using (var reader1 = cmd.ExecuteReader())
 				{
@@ -1300,7 +1300,7 @@ namespace Tests.Data
 						while (reader1.Read())
 						{
 							// open another reader on new command
-							using (var cmd2 = db.OpenConnection().CreateCommand())
+							using (var cmd2 = db.OpenDbConnection().CreateCommand())
 							{
 								cmd2.CommandText = sql;
 

--- a/Tests/Linq/Data/DataConnectionTests.cs
+++ b/Tests/Linq/Data/DataConnectionTests.cs
@@ -71,8 +71,7 @@ namespace Tests.Data
 		{
 			using (var conn = GetDataConnection(context))
 			{
-				var connection = conn.TryGetDbConnection();
-				Assert.That(connection, Is.Not.Null);
+				var connection = conn.OpenConnection();
 
 				Assert.Multiple(() =>
 				{
@@ -905,7 +904,7 @@ namespace Tests.Data
 					db.GetTable<TransactionScopeTable>().Insert(() => new TransactionScopeTable() { Id = 1 });
 					using (var transaction = new TransactionScope(TransactionScopeOption.Required, TransactionScopeAsyncFlowOption.Enabled))
 					{
-						db.TryGetDbConnection()!.EnlistTransaction(Transaction.Current);
+						db.OpenConnection().EnlistTransaction(Transaction.Current);
 						db.GetTable<TransactionScopeTable>().Insert(() => new TransactionScopeTable() { Id = 2 });
 
 						Transaction.Current!.Rollback();

--- a/Tests/Linq/Data/DataExtensionsTests.cs
+++ b/Tests/Linq/Data/DataExtensionsTests.cs
@@ -330,7 +330,7 @@ namespace Tests.Data
 				var v1 = dc.Query<object>("SELECT v1 FROM #t1").ToList();
 				dc.Execute("ALTER TABLE #t1 ALTER COLUMN v1 INT NULL");
 
-				DataConnection.ClearObjectReaderCache();
+				CommandInfo.ClearObjectReaderCache();
 
 				dc.Execute("INSERT INTO #t1(v1) VALUES (null)");
 				var v2 = dc.Query<object>("SELECT v1 FROM #t1").ToList();

--- a/Tests/Linq/Data/InterceptorsTests.cs
+++ b/Tests/Linq/Data/InterceptorsTests.cs
@@ -1465,7 +1465,7 @@ namespace Tests.Data
 			IDataContext main;
 			using (var db = main = new DataContext(context))
 			{
-				((DataContext)db).KeepConnectionAlive = false;
+				((DataContext)db).SetKeepConnectionAlive(false);
 				db.CloseAfterUse = closeAfterUse;
 				db.AddInterceptor(closeInterceptor);
 				db.AddInterceptor(openInterceptor);
@@ -1523,7 +1523,7 @@ namespace Tests.Data
 			IDataContext main;
 			using (var db = main = new DataContext(context))
 			{
-				((DataContext)db).KeepConnectionAlive = true;
+				((DataContext)db).SetKeepConnectionAlive(true);
 				db.CloseAfterUse = closeAfterUse;
 				db.AddInterceptor(closeInterceptor);
 				db.AddInterceptor(openInterceptor);

--- a/Tests/Linq/Data/MiniProfilerTests.cs
+++ b/Tests/Linq/Data/MiniProfilerTests.cs
@@ -108,21 +108,25 @@ namespace Tests.Data
 		[Test]
 		public void TestAccessOleDb([IncludeDataSources(TestProvName.AllAccessOleDb)] string context, [Values] ConnectionType type)
 		{
+			var trace = string.Empty;
+
 			var unmapped = type == ConnectionType.MiniProfilerNoMappings;
 			var connectionString = DataConnection.GetConnectionString(context);
+
 #if NETFRAMEWORK
-			using (var db = CreateDataConnection(AccessTools.GetDataProvider(provider: AccessProvider.OleDb, connectionString: connectionString), context, type, cs => new System.Data.OleDb.OleDbConnection(cs)))
-#else
-			using (var db = CreateDataConnection(AccessTools.GetDataProvider(provider: AccessProvider.OleDb, connectionString: connectionString), context, type, "System.Data.OleDb.OleDbConnection, System.Data.OleDb"))
-#endif
-			{
-				var trace = string.Empty;
-				db.OnTraceConnection += (TraceInfo ti) =>
+			using (var db = CreateDataConnection(AccessTools.GetDataProvider(provider: AccessProvider.OleDb, connectionString: connectionString), context, type, cs => new System.Data.OleDb.OleDbConnection(cs), onTrace: ti =>
 				{
 					if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
 						trace = ti.SqlText;
-				};
-
+				}))
+#else
+			using (var db = CreateDataConnection(AccessTools.GetDataProvider(provider: AccessProvider.OleDb, connectionString: connectionString), context, type, "System.Data.OleDb.OleDbConnection, System.Data.OleDb", onTrace: ti =>
+			{
+				if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
+					trace = ti.SqlText;
+			}))
+#endif
+			{
 				Assert.Multiple(() =>
 				{
 					// assert provider-specific parameter type name
@@ -166,21 +170,24 @@ namespace Tests.Data
 		[Test]
 		public void TestAccessODBC([IncludeDataSources(TestProvName.AllAccessOdbc)] string context, [Values] ConnectionType type)
 		{
+			var trace = string.Empty;
+
 			var unmapped = type == ConnectionType.MiniProfilerNoMappings;
 			var connectionString = DataConnection.GetConnectionString(context);
 #if NETFRAMEWORK
-			using (var db = CreateDataConnection(AccessTools.GetDataProvider(provider: AccessProvider.ODBC, connectionString: connectionString), context, type, cs => new System.Data.Odbc.OdbcConnection(cs)))
-#else
-			using (var db = CreateDataConnection(AccessTools.GetDataProvider(provider: AccessProvider.ODBC, connectionString: connectionString), context, type, "System.Data.Odbc.OdbcConnection, System.Data.Odbc"))
-#endif
-			{
-				var trace = string.Empty;
-				db.OnTraceConnection += (TraceInfo ti) =>
+			using (var db = CreateDataConnection(AccessTools.GetDataProvider(provider: AccessProvider.ODBC, connectionString: connectionString), context, type, cs => new System.Data.Odbc.OdbcConnection(cs), onTrace: ti =>
 				{
 					if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
 						trace = ti.SqlText;
-				};
-
+				}))
+#else
+			using (var db = CreateDataConnection(AccessTools.GetDataProvider(provider: AccessProvider.ODBC, connectionString: connectionString), context, type, "System.Data.Odbc.OdbcConnection, System.Data.Odbc", onTrace: ti =>
+			{
+				if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
+					trace = ti.SqlText;
+			}))
+#endif
+			{
 				Assert.Multiple(() =>
 				{
 					// assert provider-specific parameter type name
@@ -218,16 +225,14 @@ namespace Tests.Data
 			}
 
 			var provider = (FirebirdDataProvider)Activator.CreateInstance(providerType)!;
+			var trace = string.Empty;
 
-			using (var db = CreateDataConnection(provider, context, type, "FirebirdSql.Data.FirebirdClient.FbConnection, FirebirdSql.Data.FirebirdClient"))
+			using (var db = CreateDataConnection(provider, context, type, "FirebirdSql.Data.FirebirdClient.FbConnection, FirebirdSql.Data.FirebirdClient", onTrace: ti =>
 			{
-				var trace = string.Empty;
-				db.OnTraceConnection += (TraceInfo ti) =>
-				{
-					if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
-						trace = ti.SqlText;
-				};
-
+				if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
+					trace = ti.SqlText;
+			}))
+			{
 				Assert.Multiple(() =>
 				{
 					// assert provider-specific parameter type name
@@ -262,16 +267,15 @@ namespace Tests.Data
 		[Test]
 		public void TestSqlCe([IncludeDataSources(ProviderName.SqlCe)] string context, [Values] ConnectionType type)
 		{
-			var unmapped = type == ConnectionType.MiniProfilerNoMappings;
-			using (var db = CreateDataConnection(new SqlCeDataProvider(), context, type, DbProviderFactories.GetFactory("System.Data.SqlServerCe.4.0").GetType().Assembly.GetType("System.Data.SqlServerCe.SqlCeConnection")!))
-			{
-				var trace = string.Empty;
-				db.OnTraceConnection += (TraceInfo ti) =>
-				{
-					if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
-						trace = ti.SqlText;
-				};
+			var trace = string.Empty;
 
+			var unmapped = type == ConnectionType.MiniProfilerNoMappings;
+			using (var db = CreateDataConnection(new SqlCeDataProvider(), context, type, DbProviderFactories.GetFactory("System.Data.SqlServerCe.4.0").GetType().Assembly.GetType("System.Data.SqlServerCe.SqlCeConnection")!, onTrace: ti =>
+			{
+				if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
+					trace = ti.SqlText;
+			}))
+			{
 				Assert.Multiple(() =>
 				{
 					// assert provider-specific parameter type name
@@ -456,17 +460,15 @@ namespace Tests.Data
 
 			var provider = (MySqlDataProvider)Activator.CreateInstance(providerType)!;
 
+			var trace = string.Empty;
 			var unmapped = type == ConnectionType.MiniProfilerNoMappings;
 			// AllowZeroDateTime is to enable MySqlDateTime type
-			using (var db = CreateDataConnection(provider, context, type, "MySql.Data.MySqlClient.MySqlConnection, MySql.Data", ";AllowZeroDateTime=true"))
+			using (var db = CreateDataConnection(provider, context, type, "MySql.Data.MySqlClient.MySqlConnection, MySql.Data", ";AllowZeroDateTime=true", onTrace: ti =>
 			{
-				var trace = string.Empty;
-				db.OnTraceConnection += (TraceInfo ti) =>
-				{
-					if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
-						trace = ti.SqlText;
-				};
-
+				if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
+					trace = ti.SqlText;
+			}))
+			{
 				// test provider-specific type readers
 				// (using both SetProviderField and SetToTypeField registrations)
 				var decValue = 123.456m;
@@ -541,15 +543,13 @@ namespace Tests.Data
 
 			var unmapped = type == ConnectionType.MiniProfilerNoMappings;
 			var connectionTypeName = "MySqlConnector.MySqlConnection, MySqlConnector";
-			using (var db = CreateDataConnection(provider, context, type, connectionTypeName, ";AllowZeroDateTime=true"))
+			var trace = string.Empty;
+			using (var db = CreateDataConnection(provider, context, type, connectionTypeName, ";AllowZeroDateTime=true", onTrace: ti =>
 			{
-				var trace = string.Empty;
-				db.OnTraceConnection += (TraceInfo ti) =>
-				{
-					if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
-						trace = ti.SqlText;
-				};
-
+				if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
+					trace = ti.SqlText;
+			}))
+			{
 				// test provider-specific type readers
 				var dtValue = new DateTime(2012, 12, 12, 12, 12, 12, 0);
 				Assert.That(db.Execute<MySqlConnectorDateTime>("SELECT Cast(@p as datetime)", new DataParameter("@p", dtValue, DataType.DateTime)).GetDateTime(), Is.EqualTo(dtValue));
@@ -645,15 +645,13 @@ namespace Tests.Data
 		public void TestDB2([IncludeDataSources(ProviderName.DB2)] string context, [Values] ConnectionType type)
 		{
 			var unmapped = type == ConnectionType.MiniProfilerNoMappings;
-			using (var db = CreateDataConnection(new TestDB2LUWDataProvider(), context, type, $"{DB2ProviderAdapter.ClientNamespace}.DB2Connection, {DB2ProviderAdapter.AssemblyName}"))
+			var trace = string.Empty;
+			using (var db = CreateDataConnection(new TestDB2LUWDataProvider(), context, type, $"{DB2ProviderAdapter.ClientNamespace}.DB2Connection, {DB2ProviderAdapter.AssemblyName}", onTrace: ti =>
 			{
-				var trace = string.Empty;
-				db.OnTraceConnection += (TraceInfo ti) =>
-				{
-					if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
-						trace = ti.SqlText;
-				};
-
+				if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
+					trace = ti.SqlText;
+			}))
+			{
 				// we have DB2 tests for all types, so here we will test only one type (they all look the same)
 				// test provider-specific type readers
 				var longValue = -12335L;
@@ -726,21 +724,23 @@ namespace Tests.Data
 			var tvpSupported = version >= SqlServerVersion.v2008;
 			var hierarchyidSupported = version >= SqlServerVersion.v2008;
 
+			var trace = string.Empty;
 			var unmapped = type == ConnectionType.MiniProfilerNoMappings;
 			using (new DisableBaseline("TODO: debug reason for inconsistent bulk copy sql"))
 #if NETFRAMEWORK
-			using (var db = CreateDataConnection(new SqlServerTests.TestSqlServerDataProvider(providerName, version, SqlServerProvider.SystemDataSqlClient), context, type, typeof(SqlConnection)))
-#else
-			using (var db = CreateDataConnection(new SqlServerTests.TestSqlServerDataProvider(providerName, version, SqlServerProvider.SystemDataSqlClient), context, type, "System.Data.SqlClient.SqlConnection, System.Data.SqlClient"))
-#endif
-			{
-				var trace = string.Empty;
-				db.OnTraceConnection += (TraceInfo ti) =>
+			using (var db = CreateDataConnection(new SqlServerTests.TestSqlServerDataProvider(providerName, version, SqlServerProvider.SystemDataSqlClient), context, type, typeof(SqlConnection), onTrace: ti =>
 				{
 					if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
 						trace = ti.SqlText;
-				};
-
+				}))
+#else
+			using (var db = CreateDataConnection(new SqlServerTests.TestSqlServerDataProvider(providerName, version, SqlServerProvider.SystemDataSqlClient), context, type, "System.Data.SqlClient.SqlConnection, System.Data.SqlClient", onTrace: ti =>
+			{
+				if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
+					trace = ti.SqlText;
+			}))
+#endif
+			{
 				var testValue = -1.2335m;
 				Assert.That(db.Execute<SqlMoney>("SELECT Cast(@p as money)", new DataParameter("@p", testValue, DataType.Money)).Value, Is.EqualTo(testValue));
 				var rawValue = db.Execute<object>("SELECT Cast(@p as money)", new DataParameter("@p", testValue, DataType.Money));
@@ -916,16 +916,14 @@ namespace Tests.Data
 			var tvpSupported = version >= SqlServerVersion.v2008;
 
 			var unmapped = type == ConnectionType.MiniProfilerNoMappings;
+			var trace = string.Empty;
 			using (new DisableBaseline("TODO: debug reason for inconsistent bulk copy sql"))
-			using (var db = CreateDataConnection(new SqlServerTests.TestSqlServerDataProvider(providerName, version, SqlServerProvider.MicrosoftDataSqlClient), context, type, "Microsoft.Data.SqlClient.SqlConnection, Microsoft.Data.SqlClient"))
+			using (var db = CreateDataConnection(new SqlServerTests.TestSqlServerDataProvider(providerName, version, SqlServerProvider.MicrosoftDataSqlClient), context, type, "Microsoft.Data.SqlClient.SqlConnection, Microsoft.Data.SqlClient", onTrace: ti =>
 			{
-				var trace = string.Empty;
-				db.OnTraceConnection += (TraceInfo ti) =>
-				{
-					if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
-						trace = ti.SqlText;
-				};
-
+				if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
+					trace = ti.SqlText;
+			}))
+			{
 				var testValue = -1.2335m;
 				Assert.That(db.Execute<SqlMoney>("SELECT Cast(@p as money)", new DataParameter("@p", testValue, DataType.Money)).Value, Is.EqualTo(testValue));
 				var rawValue = db.Execute<object>("SELECT Cast(@p as money)", new DataParameter("@p", testValue, DataType.Money));
@@ -1087,17 +1085,15 @@ namespace Tests.Data
 		public async Task TestSapHanaNative([IncludeDataSources(ProviderName.SapHanaNative)] string context, [Values] ConnectionType type)
 		{
 			var unmapped = type == ConnectionType.MiniProfilerNoMappings;
+			var trace = string.Empty;
 
 			var connectionType = ((SapHanaDataProvider)SapHanaTools.GetDataProvider(SapHanaProvider.Unmanaged)).Adapter.ConnectionType;
-			using (var db = CreateDataConnection(new SapHanaNativeDataProvider(), context, type, connectionType))
+			using (var db = CreateDataConnection(new SapHanaNativeDataProvider(), context, type, connectionType, onTrace: ti =>
 			{
-				var trace = string.Empty;
-				db.OnTraceConnection += (TraceInfo ti) =>
-				{
-					if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
-						trace = ti.SqlText;
-				};
-
+				if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
+					trace = ti.SqlText;
+			}))
+			{
 				var binaryValue = new byte[] { 1, 2, 3 };
 				Assert.Multiple(() =>
 				{
@@ -1198,16 +1194,14 @@ namespace Tests.Data
 		[Test]
 		public void TestSybaseNative([IncludeDataSources(ProviderName.Sybase)] string context, [Values] ConnectionType type)
 		{
+			var trace = string.Empty;
 			var unmapped = type == ConnectionType.MiniProfilerNoMappings;
-			using (var db = CreateDataConnection(SybaseTools.GetDataProvider(SybaseProvider.Unmanaged), context, type, DbProviderFactories.GetFactory("Sybase.Data.AseClient").GetType().Assembly.GetType("Sybase.Data.AseClient.AseConnection")!))
+			using (var db = CreateDataConnection(SybaseTools.GetDataProvider(SybaseProvider.Unmanaged), context, type, DbProviderFactories.GetFactory("Sybase.Data.AseClient").GetType().Assembly.GetType("Sybase.Data.AseClient.AseConnection")!, onTrace: ti =>
 			{
-				var trace = string.Empty;
-				db.OnTraceConnection += (TraceInfo ti) =>
-				{
-					if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
-						trace = ti.SqlText;
-				};
-
+				if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
+					trace = ti.SqlText;
+			}))
+			{
 				var ntextValue = "тест";
 				Assert.Multiple(() =>
 				{
@@ -1256,16 +1250,14 @@ namespace Tests.Data
 		[Test]
 		public void TestSybaseManaged([IncludeDataSources(ProviderName.SybaseManaged)] string context, [Values] ConnectionType type)
 		{
+			var trace = string.Empty;
 			var unmapped = type == ConnectionType.MiniProfilerNoMappings;
-			using (var db = CreateDataConnection(SybaseTools.GetDataProvider(SybaseProvider.DataAction), context, type, "AdoNetCore.AseClient.AseConnection, AdoNetCore.AseClient"))
+			using (var db = CreateDataConnection(SybaseTools.GetDataProvider(SybaseProvider.DataAction), context, type, "AdoNetCore.AseClient.AseConnection, AdoNetCore.AseClient", onTrace: ti =>
 			{
-				var trace = string.Empty;
-				db.OnTraceConnection += (TraceInfo ti) =>
-				{
-					if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
-						trace = ti.SqlText;
-				};
-
+				if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
+					trace = ti.SqlText;
+			}))
+			{
 				var ntextValue = "тест";
 				Assert.Multiple(() =>
 				{
@@ -1377,17 +1369,15 @@ namespace Tests.Data
 		[Test]
 		public void TestInformixDB2([IncludeDataSources(ProviderName.InformixDB2)] string context, [Values] ConnectionType type)
 		{
+			var trace = string.Empty;
 			var unmapped = type == ConnectionType.MiniProfilerNoMappings;
 			var provider = new TestInformixDataProvider(ProviderName.InformixDB2, InformixProvider.DB2);
-			using (var db = CreateDataConnection(provider, context, type, $"{DB2ProviderAdapter.ClientNamespace}.DB2Connection, {DB2ProviderAdapter.AssemblyName}"))
+			using (var db = CreateDataConnection(provider, context, type, $"{DB2ProviderAdapter.ClientNamespace}.DB2Connection, {DB2ProviderAdapter.AssemblyName}", onTrace: ti =>
 			{
-				var trace = string.Empty;
-				db.OnTraceConnection += (TraceInfo ti) =>
-				{
-					if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
-						trace = ti.SqlText;
-				};
-
+				if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
+					trace = ti.SqlText;
+			}))
+			{
 				// DB2Type type name test
 				try
 				{
@@ -1565,15 +1555,13 @@ namespace Tests.Data
 			using (var db = GetDataConnection(context))
 				provider = new OracleTests.TestOracleDataProvider(db.DataProvider.Name, ((OracleDataProvider)db.DataProvider).Provider, ((OracleDataProvider)db.DataProvider).Version);
 
-			using (var db = CreateDataConnection(provider, context, type, "Oracle.ManagedDataAccess.Client.OracleConnection, Oracle.ManagedDataAccess"))
+			var trace = string.Empty;
+			using (var db = CreateDataConnection(provider, context, type, "Oracle.ManagedDataAccess.Client.OracleConnection, Oracle.ManagedDataAccess", onTrace: ti =>
 			{
-				var trace = string.Empty;
-				db.OnTraceConnection += (TraceInfo ti) =>
-				{
-					if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
-						trace = ti.SqlText;
-				};
-
+				if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
+					trace = ti.SqlText;
+			}))
+			{
 				var commandInterceptor = new SaveWrappedCommandInterceptor(wrapped);
 				db.AddInterceptor(commandInterceptor);
 
@@ -1620,7 +1608,7 @@ namespace Tests.Data
 				//schema.DataSource not asserted, as it returns db hostname
 
 				// dbcommand properties
-				db.DisposeCommand();
+				//db.DisposeCommand();
 
 				// starting from v23 those properties available only on non-disposed command
 				void assertCommand(DbCommand command)
@@ -1685,15 +1673,13 @@ namespace Tests.Data
 			using (var db = GetDataConnection(context))
 				provider = new OracleTests.TestOracleDataProvider(db.DataProvider.Name, ((OracleDataProvider)db.DataProvider).Provider, ((OracleDataProvider)db.DataProvider).Version);
 
-			using (var db = CreateDataConnection(provider, context, type, "Devart.Data.Oracle.OracleConnection, Devart.Data.Oracle"))
+			var trace = string.Empty;
+			using (var db = CreateDataConnection(provider, context, type, "Devart.Data.Oracle.OracleConnection, Devart.Data.Oracle", onTrace: ti =>
 			{
-				var trace = string.Empty;
-				db.OnTraceConnection += (TraceInfo ti) =>
-				{
-					if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
-						trace = ti.SqlText;
-				};
-
+				if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
+					trace = ti.SqlText;
+			}))
+			{
 				var commandInterceptor = new SaveWrappedCommandInterceptor(wrapped);
 				db.AddInterceptor(commandInterceptor);
 
@@ -1737,7 +1723,7 @@ namespace Tests.Data
 					TestBulkCopy();
 
 				// dbcommand properties
-				db.DisposeCommand();
+				//db.DisposeCommand();
 
 				db.Execute<DateTimeOffset>("SELECT :p FROM SYS.DUAL", new DataParameter("p", dtoVal, DataType.DateTimeOffset));
 
@@ -1792,18 +1778,16 @@ namespace Tests.Data
 			}
 
 			var provider = (PostgreSQLDataProvider)Activator.CreateInstance(providerType)!;
+			var trace = string.Empty;
 
-			using (var db = CreateDataConnection(provider, context, type, "Npgsql.NpgsqlConnection, Npgsql"))
+			using (var db = CreateDataConnection(provider, context, type, "Npgsql.NpgsqlConnection, Npgsql", onTrace: ti =>
+			{
+				if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
+					trace = ti.SqlText;
+			}))
 			{
 				// needed for proper AllTypes columns mapping
 				db.AddMappingSchema(new MappingSchema(context));
-
-				var trace = string.Empty;
-				db.OnTraceConnection += (TraceInfo ti) =>
-				{
-					if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
-						trace = ti.SqlText;
-				};
 
 				var jsonValue = /*lang=json,strict*/ "{ \"x\": 1 }";
 				Assert.Multiple(() =>
@@ -1961,15 +1945,13 @@ namespace Tests.Data
 			using (var db = GetDataConnection(context))
 				provider = new TestClickHouseDataProvider(db.DataProvider.Name, ((ClickHouseDataProvider)db.DataProvider).Provider);
 
-			using (var db = CreateDataConnection(provider, context, type, provider.Adapter.ConnectionType))
+			var trace = string.Empty;
+			using (var db = CreateDataConnection(provider, context, type, provider.Adapter.ConnectionType, onTrace: ti =>
 			{
-				var trace = string.Empty;
-				db.OnTraceConnection += (TraceInfo ti) =>
-				{
-					if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
-						trace = ti.SqlText;
-				};
-
+				if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
+					trace = ti.SqlText;
+			}))
+			{
 				// native bulk copy not supported for mysql interface
 				if (!context.IsAnyOf(ProviderName.ClickHouseMySql))
 				{
@@ -2035,19 +2017,30 @@ namespace Tests.Data
 			MiniProfilerNoMappings
 		}
 
-		private DataConnection CreateDataConnection(IDataProvider provider, string context, ConnectionType type, Type connectionType, string? csExtra = null)
+		private DataConnection CreateDataConnection(IDataProvider provider, string context, ConnectionType type, Type connectionType, string? csExtra = null, Action<TraceInfo>? onTrace = null)
 		{
-			return CreateDataConnection(provider, context, type, cs => (DbConnection)Activator.CreateInstance(connectionType, cs)!, csExtra);
+			return CreateDataConnection(provider, context, type, cs => (DbConnection)Activator.CreateInstance(connectionType, cs)!, csExtra, onTrace: onTrace);
 		}
 
-		private DataConnection CreateDataConnection(IDataProvider provider, string context, ConnectionType type, string connectionTypeName, string? csExtra = null)
+		private DataConnection CreateDataConnection(IDataProvider provider, string context, ConnectionType type, string connectionTypeName, string? csExtra = null, Action<TraceInfo>? onTrace = null)
 		{
-			return CreateDataConnection(provider, context, type, cs => (DbConnection)Activator.CreateInstance(Type.GetType(connectionTypeName, true)!, cs)!, csExtra);
+			return CreateDataConnection(provider, context, type, cs => (DbConnection)Activator.CreateInstance(Type.GetType(connectionTypeName, true)!, cs)!, csExtra, onTrace: onTrace);
 		}
 
-		private DataConnection CreateDataConnection(IDataProvider provider, string context, ConnectionType type, Func<string, DbConnection> connectionFactory, string? csExtra = null, Func<DataConnection, IRetryPolicy?>? retryPolicyFactory = null)
+		private DataConnection CreateDataConnection(
+			IDataProvider provider,
+			string context,
+			ConnectionType type,
+			Func<string, DbConnection> connectionFactory,
+			string? csExtra = null,
+			Func<DataConnection, IRetryPolicy?>? retryPolicyFactory = null,
+			Action<TraceInfo>? onTrace = null)
 		{
-			var db = new DataConnection(new DataOptions().UseConnectionFactory(provider, options =>
+			var options = new DataOptions();
+			if (onTrace != null)
+				options = options.UseTracing(onTrace);
+
+			var db = new DataConnection(options.UseConnectionFactory(provider, options =>
 			{
 				// don't create connection using provider, or it will initialize types
 				var cn = connectionFactory(DataConnection.GetConnectionString(context) + csExtra);

--- a/Tests/Linq/Data/MiniProfilerTests.cs
+++ b/Tests/Linq/Data/MiniProfilerTests.cs
@@ -1275,15 +1275,13 @@ namespace Tests.Data
 		{
 			var unmapped  = type == ConnectionType.MiniProfilerNoMappings;
 			var provider  = new TestInformixDataProvider(ProviderName.Informix, InformixProvider.Informix);
-			using (var db = CreateDataConnection(provider, context, type, "IBM.Data.Informix.IfxConnection, IBM.Data.Informix"))
+			var trace = string.Empty;
+			using (var db = CreateDataConnection(provider, context, type, "IBM.Data.Informix.IfxConnection, IBM.Data.Informix", onTrace: ti =>
 			{
-				var trace = string.Empty;
-				db.OnTraceConnection += (TraceInfo ti) =>
-				{
-					if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
-						trace = ti.SqlText;
-				};
-
+				if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
+					trace = ti.SqlText;
+			}))
+			{
 				// IfxType type name test
 				try
 				{
@@ -1450,15 +1448,13 @@ namespace Tests.Data
 				connectionType = ((OracleDataProvider)db.DataProvider).Adapter.ConnectionType;
 			}
 
-			using (var db = CreateDataConnection(provider, context, type, connectionType))
+			var trace = string.Empty;
+			using (var db = CreateDataConnection(provider, context, type, connectionType, onTrace: ti =>
 			{
-				var trace = string.Empty;
-				db.OnTraceConnection += (TraceInfo ti) =>
-				{
-					if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
-						trace = ti.SqlText;
-				};
-
+				if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
+					trace = ti.SqlText;
+			}))
+			{
 				var commandInterceptor = new SaveWrappedCommandInterceptor(wrapped);
 				db.AddInterceptor(commandInterceptor);
 
@@ -1499,7 +1495,7 @@ namespace Tests.Data
 				//schema.DataSource not asserted, as it returns db hostname
 
 				// dbcommand properties
-				db.DisposeCommand();
+				//db.DisposeCommand();
 
 				db.Execute<DateTimeOffset>("SELECT :p FROM SYS.DUAL", new DataParameter("p", dtoVal, DataType.DateTimeOffset));
 

--- a/Tests/Linq/Data/MiniProfilerTests.cs
+++ b/Tests/Linq/Data/MiniProfilerTests.cs
@@ -826,7 +826,9 @@ namespace Tests.Data
 				var cs = DataConnection.GetConnectionString(GetProviderName(context, out var _));
 
 				// test MARS not set
+#pragma warning disable CS0618 // Type or member is obsolete
 				Assert.That(db.IsMarsEnabled, Is.EqualTo(cs.ToLowerInvariant().Contains("multipleactiveresultsets=true")));
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				// test server version
 				using (var cn = ((SqlServerDataProvider)db.DataProvider).Adapter.CreateConnection(cs))
@@ -1005,7 +1007,9 @@ namespace Tests.Data
 				var cs = DataConnection.GetConnectionString(GetProviderName(context, out var _));
 
 				// test MARS not set
+#pragma warning disable CS0618 // Type or member is obsolete
 				Assert.That(db.IsMarsEnabled, Is.EqualTo(cs.ToLowerInvariant().Contains("multipleactiveresultsets=true")));
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				// test server version
 				using (var cn = ((SqlServerDataProvider)db.DataProvider).Adapter.CreateConnection(cs))

--- a/Tests/Linq/Data/RetryPolicyTest.cs
+++ b/Tests/Linq/Data/RetryPolicyTest.cs
@@ -215,7 +215,7 @@ namespace Tests.Data
 		{
 			using var db1 = GetDataConnection(context);
 
-			var connection = db1.OpenConnection();
+			var connection = db1.OpenDbConnection();
 
 			try
 			{
@@ -236,7 +236,7 @@ namespace Tests.Data
 		{
 			using (var db1 = GetDataConnection(context))
 			{
-				var connection = db1.OpenConnection();
+				var connection = db1.OpenDbConnection();
 				try
 				{
 					using (var db = GetDataConnection(context,

--- a/Tests/Linq/Data/RetryPolicyTest.cs
+++ b/Tests/Linq/Data/RetryPolicyTest.cs
@@ -215,8 +215,7 @@ namespace Tests.Data
 		{
 			using var db1 = GetDataConnection(context);
 
-			var connection = db1.TryGetDbConnection();
-			Assert.That(connection, Is.Not.Null);
+			var connection = db1.OpenConnection();
 
 			try
 			{
@@ -237,8 +236,7 @@ namespace Tests.Data
 		{
 			using (var db1 = GetDataConnection(context))
 			{
-				var connection = db1.TryGetDbConnection();
-				Assert.That(connection, Is.Not.Null);
+				var connection = db1.OpenConnection();
 				try
 				{
 					using (var db = GetDataConnection(context,

--- a/Tests/Linq/Data/RetryPolicyTest.cs
+++ b/Tests/Linq/Data/RetryPolicyTest.cs
@@ -214,9 +214,13 @@ namespace Tests.Data
 		public void ExternalConnection([DataSources(false)] string context)
 		{
 			using var db1 = GetDataConnection(context);
+
+			var connection = db1.TryGetDbConnection();
+			Assert.That(connection, Is.Not.Null);
+
 			try
 			{
-				using (var db = new DataConnection(new DataOptions().UseConnection(db1.DataProvider, db1.Connection).UseFactory(connection => new DummyRetryPolicy())))
+				using (var db = new DataConnection(new DataOptions().UseConnection(db1.DataProvider, connection).UseFactory(connection => new DummyRetryPolicy())))
 				using (db.CreateLocalTable<MyEntity>())
 				{
 					Assert.Fail("Exception expected");
@@ -233,11 +237,13 @@ namespace Tests.Data
 		{
 			using (var db1 = GetDataConnection(context))
 			{
+				var connection = db1.TryGetDbConnection();
+				Assert.That(connection, Is.Not.Null);
 				try
 				{
 					using (var db = GetDataConnection(context,
 						o => o
-							.UseConnection(db1.DataProvider, db1.Connection)
+							.UseConnection(db1.DataProvider, connection)
 							.UseRetryPolicy(new DummyRetryPolicy())))
 
 					using (db.CreateLocalTable<MyEntity>())

--- a/Tests/Linq/Data/TraceTests.cs
+++ b/Tests/Linq/Data/TraceTests.cs
@@ -123,14 +123,12 @@ namespace Tests.Data
 			var events   = GetEnumValues((TraceInfoStep s) => default(TraceInfo));
 			var counters = GetEnumValues((TraceInfoStep s) => 0);
 
-			using (var db = GetDataConnection(context))
+			using (var db = GetDataConnection(context, o => o.UseTracing(e =>
 			{
-				db.OnTraceConnection = e =>
-				{
-					events[e.TraceInfoStep] = e;
-					counters[e.TraceInfoStep]++;
-				};
-
+				events[e.TraceInfoStep] = e;
+				counters[e.TraceInfoStep]++;
+			})))
+			{
 				var _ = db.GetTable<Northwind.Category>().ToList();
 
 				// the same command is reported on each step
@@ -159,14 +157,13 @@ namespace Tests.Data
 			var events   = GetEnumValues((TraceInfoStep s) => default(TraceInfo));
 			var counters = GetEnumValues((TraceInfoStep s) => 0);
 
-			using (var db = GetDataConnection(context))
+			using (var db = GetDataConnection(context, o => o.UseTracing(e =>
+			{
+				events[e.TraceInfoStep] = e;
+				counters[e.TraceInfoStep]++;
+			})))
 			{
 				var sql = db.GetTable<Northwind.Category>().ToSqlQuery().Sql;
-				db.OnTraceConnection = e =>
-				{
-					events[e.TraceInfoStep] = e;
-					counters[e.TraceInfoStep]++;
-				};
 
 				using (var reader = db.ExecuteReader(sql))
 				{
@@ -199,14 +196,13 @@ namespace Tests.Data
 			var events   = GetEnumValues((TraceInfoStep s) => default(TraceInfo));
 			var counters = GetEnumValues((TraceInfoStep s) => 0);
 
-			using (var db = GetDataConnection(context))
+			using (var db = GetDataConnection(context, o => o.UseTracing(e =>
+			{
+				events[e.TraceInfoStep] = e;
+				counters[e.TraceInfoStep]++;
+			})))
 			{
 				var sql = db.GetTable<Northwind.Category>().ToSqlQuery().Sql;
-				db.OnTraceConnection = e =>
-				{
-					events[e.TraceInfoStep] = e;
-					counters[e.TraceInfoStep]++;
-				};
 
 				await using (var reader = await new CommandInfo(db, sql).ExecuteReaderAsync())
 				{
@@ -239,14 +235,13 @@ namespace Tests.Data
 			var events = GetEnumValues((TraceInfoStep s) => default(TraceInfo));
 			var counters = GetEnumValues((TraceInfoStep s) => 0);
 
-			using (var db = new DataConnection(context))
+			using (var db = new DataConnection(new DataOptions().UseConfiguration(context).UseTracing(e =>
+			{
+				events[e.TraceInfoStep] = e;
+				counters[e.TraceInfoStep]++;
+			})))
 			{
 				var sql = db.GetTable<Northwind.Category>().ToSqlQuery().Sql;
-				db.OnTraceConnection = e =>
-				{
-					events[e.TraceInfoStep] = e;
-					counters[e.TraceInfoStep]++;
-				};
 
 				db.SetCommand(sql).Query<Northwind.Category>().ToArray();
 
@@ -276,14 +271,13 @@ namespace Tests.Data
 			var events = GetEnumValues((TraceInfoStep s) => default(TraceInfo));
 			var counters = GetEnumValues((TraceInfoStep s) => 0);
 
-			using (var db = new DataConnection(context))
+			using (var db = new DataConnection(new DataOptions().UseConfiguration(context).UseTracing(e =>
+			{
+				events[e.TraceInfoStep] = e;
+				counters[e.TraceInfoStep]++;
+			})))
 			{
 				var sql = db.GetTable<Northwind.Category>().ToSqlQuery().Sql;
-				db.OnTraceConnection = e =>
-				{
-					events[e.TraceInfoStep] = e;
-					counters[e.TraceInfoStep]++;
-				};
 
 				using (var reader = db.SetCommand(sql).ExecuteReader())
 				{
@@ -316,15 +310,13 @@ namespace Tests.Data
 			var events = GetEnumValues((TraceInfoStep s) => default(TraceInfo));
 			var counters = GetEnumValues((TraceInfoStep s) => 0);
 
-			using (var db = new DataConnection(context))
+			using (var db = new DataConnection(new DataOptions().UseConfiguration(context).UseTracing(e =>
+			{
+				events[e.TraceInfoStep] = e;
+				counters[e.TraceInfoStep]++;
+			})))
 			using (db.BeginTransaction())
 			{
-				db.OnTraceConnection = e =>
-				{
-					events[e.TraceInfoStep] = e;
-					counters[e.TraceInfoStep]++;
-				};
-
 				db.GetTable<Northwind.Category>()
 					.Set(c => c.CategoryName, c => c.CategoryName)
 					.Update();
@@ -357,15 +349,13 @@ namespace Tests.Data
 			var events = GetEnumValues((TraceInfoStep s) => default(TraceInfo));
 			var counters = GetEnumValues((TraceInfoStep s) => 0);
 
-			using (var db = new DataConnection(context))
+			using (var db = new DataConnection(new DataOptions().UseConfiguration(context).UseTracing(e =>
+			{
+				events[e.TraceInfoStep] = e;
+				counters[e.TraceInfoStep]++;
+			})))
 			using (db.BeginTransaction())
 			{
-				db.OnTraceConnection = e =>
-				{
-					events[e.TraceInfoStep] = e;
-					counters[e.TraceInfoStep]++;
-				};
-
 				db.SetCommand(@"UPDATE Categories SET CategoryName = CategoryName WHERE 1=2").Execute();
 
 				// the same command is reported on each step
@@ -396,15 +386,13 @@ namespace Tests.Data
 			var events = GetEnumValues((TraceInfoStep s) => default(TraceInfo));
 			var counters = GetEnumValues((TraceInfoStep s) => 0);
 
-			using (var db = new DataConnection(context))
+			using (var db = new DataConnection(new DataOptions().UseConfiguration(context).UseTracing(e =>
+			{
+				events[e.TraceInfoStep] = e;
+				counters[e.TraceInfoStep]++;
+			})))
 			using (db.BeginTransaction())
 			{
-				db.OnTraceConnection = e =>
-				{
-					events[e.TraceInfoStep] = e;
-					counters[e.TraceInfoStep]++;
-				};
-
 				db.SetCommand(@"INSERT INTO Categories(CategoryID, CategoryName) VALUES(1024, '1024')").Execute();
 
 				// the same command is reported on each step
@@ -435,15 +423,13 @@ namespace Tests.Data
 			var events = GetEnumValues((TraceInfoStep s) => default(TraceInfo));
 			var counters = GetEnumValues((TraceInfoStep s) => 0);
 
-			using (var db = new DataConnection(context))
+			using (var db = new DataConnection(new DataOptions().UseConfiguration(context).UseTracing(e =>
+			{
+				events[e.TraceInfoStep] = e;
+				counters[e.TraceInfoStep]++;
+			})))
 			using (db.BeginTransaction())
 			{
-				db.OnTraceConnection = e =>
-				{
-					events[e.TraceInfoStep] = e;
-					counters[e.TraceInfoStep]++;
-				};
-
 				db.SetCommand(@"DELETE FROM Categories WHERE CategoryID = 1024").Execute();
 
 				// the same command is reported on each step
@@ -474,14 +460,13 @@ namespace Tests.Data
 			var events = GetEnumValues((TraceInfoStep s) => default(TraceInfo));
 			var counters = GetEnumValues((TraceInfoStep s) => 0);
 
-			using (var db = new DataConnection(context))
+			using (var db = new DataConnection(new DataOptions().UseConfiguration(context).UseTracing(e =>
+			{
+				events[e.TraceInfoStep] = e;
+				counters[e.TraceInfoStep]++;
+			})))
 			{
 				var sql = db.GetTable<Northwind.Category>().ToSqlQuery().Sql;
-				db.OnTraceConnection = e =>
-				{
-					events[e.TraceInfoStep] = e;
-					counters[e.TraceInfoStep]++;
-				};
 
 				db.SetCommand(sql).Execute<Northwind.Category>();
 
@@ -511,13 +496,12 @@ namespace Tests.Data
 			var events = GetEnumValues((TraceInfoStep s) => default(TraceInfo));
 			var counters = GetEnumValues((TraceInfoStep s) => 0);
 
-			using (var db = new DataConnection(context))
+			using (var db = new DataConnection(new DataOptions().UseConfiguration(context).UseTracing(e =>
 			{
-				db.OnTraceConnection = e =>
-				{
-					events[e.TraceInfoStep] = e;
-					counters[e.TraceInfoStep]++;
-				};
+				events[e.TraceInfoStep] = e;
+				counters[e.TraceInfoStep]++;
+			})))
+			{
 				using (db.BeginTransaction())
 				{
 					Assert.Multiple(() =>
@@ -558,13 +542,12 @@ namespace Tests.Data
 			var events = GetEnumValues((TraceInfoStep s) => default(TraceInfo));
 			var counters = GetEnumValues((TraceInfoStep s) => 0);
 
-			using (var db = new DataConnection(context))
+			using (var db = new DataConnection(new DataOptions().UseConfiguration(context).UseTracing(e =>
 			{
-				db.OnTraceConnection = e =>
-				{
-					events[e.TraceInfoStep] = e;
-					counters[e.TraceInfoStep]++;
-				};
+				events[e.TraceInfoStep] = e;
+				counters[e.TraceInfoStep]++;
+			})))
+			{
 				using (await db.BeginTransactionAsync())
 				{
 					Assert.Multiple(() =>
@@ -604,13 +587,12 @@ namespace Tests.Data
 			var events = GetEnumValues((TraceInfoStep s) => default(TraceInfo));
 			var counters = GetEnumValues((TraceInfoStep s) => 0);
 
-			using (var db = new DataConnection(context))
+			using (var db = new DataConnection(new DataOptions().UseConfiguration(context).UseTracing(e =>
 			{
-				db.OnTraceConnection = e =>
-				{
-					events[e.TraceInfoStep] = e;
-					counters[e.TraceInfoStep]++;
-				};
+				events[e.TraceInfoStep] = e;
+				counters[e.TraceInfoStep]++;
+			})))
+			{
 				using (db.BeginTransaction())
 				{
 					Assert.Multiple(() =>
@@ -650,13 +632,12 @@ namespace Tests.Data
 			var events = GetEnumValues((TraceInfoStep s) => default(TraceInfo));
 			var counters = GetEnumValues((TraceInfoStep s) => 0);
 
-			using (var db = new DataConnection(context))
+			using (var db = new DataConnection(new DataOptions().UseConfiguration(context).UseTracing(e =>
 			{
-				db.OnTraceConnection = e =>
-				{
-					events[e.TraceInfoStep] = e;
-					counters[e.TraceInfoStep]++;
-				};
+				events[e.TraceInfoStep] = e;
+				counters[e.TraceInfoStep]++;
+			})))
+			{
 				using (await db.BeginTransactionAsync())
 				{
 					Assert.Multiple(() =>
@@ -700,13 +681,12 @@ namespace Tests.Data
 			var events = GetEnumValues((TraceInfoStep s) => default(TraceInfo));
 			var counters = GetEnumValues((TraceInfoStep s) => 0);
 
-			using (var db = new DataConnection(context))
+			using (var db = new DataConnection(new DataOptions().UseConfiguration(context).UseTracing(e =>
 			{
-				db.OnTraceConnection = e =>
-				{
-					events[e.TraceInfoStep] = e;
-					counters[e.TraceInfoStep]++;
-				};
+				events[e.TraceInfoStep] = e;
+				counters[e.TraceInfoStep]++;
+			})))
+			{
 				using (db.BeginTransaction(IsolationLevel.ReadCommitted))
 				{
 					Assert.Multiple(() =>
@@ -751,13 +731,12 @@ namespace Tests.Data
 			var events = GetEnumValues((TraceInfoStep s) => default(TraceInfo));
 			var counters = GetEnumValues((TraceInfoStep s) => 0);
 
-			using (var db = new DataConnection(context))
+			using (var db = new DataConnection(new DataOptions().UseConfiguration(context).UseTracing(e =>
 			{
-				db.OnTraceConnection = e =>
-				{
-					events[e.TraceInfoStep] = e;
-					counters[e.TraceInfoStep]++;
-				};
+				events[e.TraceInfoStep] = e;
+				counters[e.TraceInfoStep]++;
+			})))
+			{
 				using (await db.BeginTransactionAsync(IsolationLevel.ReadCommitted))
 				{
 					Assert.Multiple(() =>

--- a/Tests/Linq/Data/TraceTests.cs
+++ b/Tests/Linq/Data/TraceTests.cs
@@ -164,6 +164,9 @@ namespace Tests.Data
 			})))
 			{
 				var sql = db.GetTable<Northwind.Category>().ToSqlQuery().Sql;
+				// reset
+				events = GetEnumValues((TraceInfoStep s) => default(TraceInfo));
+				counters = GetEnumValues((TraceInfoStep s) => 0);
 
 				using (var reader = db.ExecuteReader(sql))
 				{
@@ -203,6 +206,9 @@ namespace Tests.Data
 			})))
 			{
 				var sql = db.GetTable<Northwind.Category>().ToSqlQuery().Sql;
+				// reset
+				events = GetEnumValues((TraceInfoStep s) => default(TraceInfo));
+				counters = GetEnumValues((TraceInfoStep s) => 0);
 
 				await using (var reader = await new CommandInfo(db, sql).ExecuteReaderAsync())
 				{
@@ -242,6 +248,9 @@ namespace Tests.Data
 			})))
 			{
 				var sql = db.GetTable<Northwind.Category>().ToSqlQuery().Sql;
+				// reset
+				events = GetEnumValues((TraceInfoStep s) => default(TraceInfo));
+				counters = GetEnumValues((TraceInfoStep s) => 0);
 
 				db.SetCommand(sql).Query<Northwind.Category>().ToArray();
 
@@ -278,6 +287,9 @@ namespace Tests.Data
 			})))
 			{
 				var sql = db.GetTable<Northwind.Category>().ToSqlQuery().Sql;
+				// reset
+				events = GetEnumValues((TraceInfoStep s) => default(TraceInfo));
+				counters = GetEnumValues((TraceInfoStep s) => 0);
 
 				using (var reader = db.SetCommand(sql).ExecuteReader())
 				{
@@ -317,6 +329,10 @@ namespace Tests.Data
 			})))
 			using (db.BeginTransaction())
 			{
+				// reset
+				events = GetEnumValues((TraceInfoStep s) => default(TraceInfo));
+				counters = GetEnumValues((TraceInfoStep s) => 0);
+
 				db.GetTable<Northwind.Category>()
 					.Set(c => c.CategoryName, c => c.CategoryName)
 					.Update();
@@ -356,6 +372,10 @@ namespace Tests.Data
 			})))
 			using (db.BeginTransaction())
 			{
+				// reset
+				events = GetEnumValues((TraceInfoStep s) => default(TraceInfo));
+				counters = GetEnumValues((TraceInfoStep s) => 0);
+
 				db.SetCommand(@"UPDATE Categories SET CategoryName = CategoryName WHERE 1=2").Execute();
 
 				// the same command is reported on each step
@@ -393,6 +413,10 @@ namespace Tests.Data
 			})))
 			using (db.BeginTransaction())
 			{
+				// reset
+				events = GetEnumValues((TraceInfoStep s) => default(TraceInfo));
+				counters = GetEnumValues((TraceInfoStep s) => 0);
+
 				db.SetCommand(@"INSERT INTO Categories(CategoryID, CategoryName) VALUES(1024, '1024')").Execute();
 
 				// the same command is reported on each step
@@ -430,6 +454,10 @@ namespace Tests.Data
 			})))
 			using (db.BeginTransaction())
 			{
+				// reset
+				events = GetEnumValues((TraceInfoStep s) => default(TraceInfo));
+				counters = GetEnumValues((TraceInfoStep s) => 0);
+
 				db.SetCommand(@"DELETE FROM Categories WHERE CategoryID = 1024").Execute();
 
 				// the same command is reported on each step
@@ -467,6 +495,10 @@ namespace Tests.Data
 			})))
 			{
 				var sql = db.GetTable<Northwind.Category>().ToSqlQuery().Sql;
+
+				// reset
+				events = GetEnumValues((TraceInfoStep s) => default(TraceInfo));
+				counters = GetEnumValues((TraceInfoStep s) => 0);
 
 				db.SetCommand(sql).Execute<Northwind.Category>();
 

--- a/Tests/Linq/Data/TransactionTests.cs
+++ b/Tests/Linq/Data/TransactionTests.cs
@@ -17,23 +17,23 @@ namespace Tests.Data
 		[Test]
 		public async Task DataContextBeginTransactionAsync([DataSources(false, TestProvName.AllClickHouse)] string context)
 		{
-			using (var db = new DataContext(context))
-			using (new RestoreBaseTables(db))
+			using var db = new DataContext(context);
+			using var ts = new RestoreBaseTables(db);
+
+			// ensure connection opened and test results not affected by OpenAsync
+			using var ks = new KeepConnectionAliveScope(db);
+
+			await db.GetTable<Parent>().ToListAsync();
+
+			var tid = Environment.CurrentManagedThreadId;
+
+			using (await db.BeginTransactionAsync())
 			{
-				// ensure connection opened and test results not affected by OpenAsync
-				db.KeepConnectionAlive = true;
-				await db.GetTable<Parent>().ToListAsync();
+				// perform synchonously to not mess with BeginTransactionAsync testing
+				db.Insert(new Parent { ParentID = 1010, Value1 = 1010 });
 
-				var tid = Environment.CurrentManagedThreadId;
-
-				using (await db.BeginTransactionAsync())
-				{
-					// perform synchonously to not mess with BeginTransactionAsync testing
-					db.Insert(new Parent { ParentID = 1010, Value1 = 1010 });
-
-					if (tid == Environment.CurrentManagedThreadId)
-						Assert.Inconclusive("Executed synchronously due to lack of async support or there were no underlying async operations");
-				}
+				if (tid == Environment.CurrentManagedThreadId)
+					Assert.Inconclusive("Executed synchronously due to lack of async support or there were no underlying async operations");
 			}
 		}
 

--- a/Tests/Linq/DataProvider/DB2Tests.cs
+++ b/Tests/Linq/DataProvider/DB2Tests.cs
@@ -691,8 +691,9 @@ namespace Tests.DataProvider
 
 				Assert.Multiple(() =>
 				{
-					Assert.That(new DB2Clob((DB2Connection)conn.TryGetDbConnection()!).IsNull, Is.True);
-					Assert.That(new DB2Blob((DB2Connection)conn.TryGetDbConnection()!).IsNull, Is.True);
+					var connection = (DB2Connection)conn.OpenConnection();
+					Assert.That(new DB2Clob(connection).IsNull, Is.True);
+					Assert.That(new DB2Blob(connection).IsNull, Is.True);
 				});
 			}
 

--- a/Tests/Linq/DataProvider/DB2Tests.cs
+++ b/Tests/Linq/DataProvider/DB2Tests.cs
@@ -691,7 +691,7 @@ namespace Tests.DataProvider
 
 				Assert.Multiple(() =>
 				{
-					var connection = (DB2Connection)conn.OpenConnection();
+					var connection = (DB2Connection)conn.OpenDbConnection();
 					Assert.That(new DB2Clob(connection).IsNull, Is.True);
 					Assert.That(new DB2Blob(connection).IsNull, Is.True);
 				});

--- a/Tests/Linq/DataProvider/DB2Tests.cs
+++ b/Tests/Linq/DataProvider/DB2Tests.cs
@@ -691,8 +691,8 @@ namespace Tests.DataProvider
 
 				Assert.Multiple(() =>
 				{
-					Assert.That(new DB2Clob((DB2Connection)conn.Connection).IsNull, Is.True);
-					Assert.That(new DB2Blob((DB2Connection)conn.Connection).IsNull, Is.True);
+					Assert.That(new DB2Clob((DB2Connection)conn.TryGetDbConnection()!).IsNull, Is.True);
+					Assert.That(new DB2Blob((DB2Connection)conn.TryGetDbConnection()!).IsNull, Is.True);
 				});
 			}
 

--- a/Tests/Linq/DataProvider/OracleTests.cs
+++ b/Tests/Linq/DataProvider/OracleTests.cs
@@ -3917,7 +3917,7 @@ CREATE TABLE ""TABLE_A""(
 
 			using var tx = dc.BeginTransaction();
 
-			using var blob = new OracleBlob((OracleConnection)dc.Connection);
+			using var blob = new OracleBlob((OracleConnection)dc.TryGetDbConnection()!);
 			blob.WriteByte(1);
 
 			db.GetTable<LinqDataTypesBlobs>().Insert(() => new LinqDataTypesBlobs { ID = -10, BinaryValue = blob });
@@ -3953,7 +3953,7 @@ CREATE TABLE ""TABLE_A""(
 
 			using var tx = dc.BeginTransaction();
 
-			using var blob = new DA.OracleLob((DA.OracleConnection)dc.Connection, DA.OracleDbType.Blob);
+			using var blob = new DA.OracleLob((DA.OracleConnection)dc.TryGetDbConnection()!, DA.OracleDbType.Blob);
 			blob.WriteByte(1);
 
 			db.GetTable<LinqDataTypesBlobsDevart>().Insert(() => new LinqDataTypesBlobsDevart { ID = -10, BinaryValue = blob });

--- a/Tests/Linq/DataProvider/OracleTests.cs
+++ b/Tests/Linq/DataProvider/OracleTests.cs
@@ -3913,7 +3913,7 @@ CREATE TABLE ""TABLE_A""(
 
 			using var tx = dc.BeginTransaction();
 
-			using var blob = new OracleBlob((OracleConnection)dc.OpenConnection());
+			using var blob = new OracleBlob((OracleConnection)dc.OpenDbConnection());
 			blob.WriteByte(1);
 
 			db.GetTable<LinqDataTypesBlobs>().Insert(() => new LinqDataTypesBlobs { ID = -10, BinaryValue = blob });
@@ -3949,7 +3949,7 @@ CREATE TABLE ""TABLE_A""(
 
 			using var tx = dc.BeginTransaction();
 
-			using var blob = new DA.OracleLob((DA.OracleConnection)dc.OpenConnection(), DA.OracleDbType.Blob);
+			using var blob = new DA.OracleLob((DA.OracleConnection)dc.OpenDbConnection(), DA.OracleDbType.Blob);
 			blob.WriteByte(1);
 
 			db.GetTable<LinqDataTypesBlobsDevart>().Insert(() => new LinqDataTypesBlobsDevart { ID = -10, BinaryValue = blob });
@@ -3986,7 +3986,7 @@ CREATE TABLE ""TABLE_A""(
 
 			using var tx = dc.BeginTransaction();
 
-			using var blob = new Oracle.DataAccess.Types.OracleBlob((Oracle.DataAccess.Client.OracleConnection)dc.OpenConnection());
+			using var blob = new Oracle.DataAccess.Types.OracleBlob((Oracle.DataAccess.Client.OracleConnection)dc.OpenDbConnection());
 			blob.WriteByte(1);
 
 			db.GetTable<LinqDataTypesBlobsNative>().Insert(() => new LinqDataTypesBlobsNative { ID = -10, BinaryValue = blob });

--- a/Tests/Linq/DataProvider/OracleTests.cs
+++ b/Tests/Linq/DataProvider/OracleTests.cs
@@ -3913,7 +3913,7 @@ CREATE TABLE ""TABLE_A""(
 
 			using var tx = dc.BeginTransaction();
 
-			using var blob = new OracleBlob((OracleConnection)dc.TryGetDbConnection()!);
+			using var blob = new OracleBlob((OracleConnection)dc.OpenConnection());
 			blob.WriteByte(1);
 
 			db.GetTable<LinqDataTypesBlobs>().Insert(() => new LinqDataTypesBlobs { ID = -10, BinaryValue = blob });
@@ -3949,7 +3949,7 @@ CREATE TABLE ""TABLE_A""(
 
 			using var tx = dc.BeginTransaction();
 
-			using var blob = new DA.OracleLob((DA.OracleConnection)dc.TryGetDbConnection()!, DA.OracleDbType.Blob);
+			using var blob = new DA.OracleLob((DA.OracleConnection)dc.OpenConnection(), DA.OracleDbType.Blob);
 			blob.WriteByte(1);
 
 			db.GetTable<LinqDataTypesBlobsDevart>().Insert(() => new LinqDataTypesBlobsDevart { ID = -10, BinaryValue = blob });
@@ -3986,7 +3986,7 @@ CREATE TABLE ""TABLE_A""(
 
 			using var tx = dc.BeginTransaction();
 
-			using var blob = new Oracle.DataAccess.Types.OracleBlob((Oracle.DataAccess.Client.OracleConnection)dc.Connection);
+			using var blob = new Oracle.DataAccess.Types.OracleBlob((Oracle.DataAccess.Client.OracleConnection)dc.OpenConnection());
 			blob.WriteByte(1);
 
 			db.GetTable<LinqDataTypesBlobsNative>().Insert(() => new LinqDataTypesBlobsNative { ID = -10, BinaryValue = blob });

--- a/Tests/Linq/DataProvider/OracleTests.cs
+++ b/Tests/Linq/DataProvider/OracleTests.cs
@@ -3597,17 +3597,16 @@ namespace Tests.DataProvider
 		public void BulkCopyWithSchemaName(
 			[IncludeDataSources(false, TestProvName.AllOracle)] string context, [Values] bool withSchema)
 		{
-			using var db    = GetDataConnection(context);
+			var trace = string.Empty;
+
+			using var db    = GetDataConnection(context, o => o.UseTracing(ti =>
+			{
+				if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
+					trace = ti.SqlText;
+			}));
 			using var table = db.CreateLocalTable<BulkCopyTable>();
 			{
 				var schemaName = TestUtils.GetSchemaName(db, context);
-
-				var trace = string.Empty;
-				db.OnTraceConnection += ti =>
-				{
-					if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
-						trace = ti.SqlText;
-				};
 
 				table.BulkCopy(
 						new BulkCopyOptions() { BulkCopyType = BulkCopyType.ProviderSpecific, SchemaName = withSchema ? schemaName : null },
@@ -3624,17 +3623,16 @@ namespace Tests.DataProvider
 		public void BulkCopyWithServerName(
 			[IncludeDataSources(false, TestProvName.AllOracle)] string context, [Values] bool withServer)
 		{
-			using var db    = GetDataConnection(context);
+			var trace = string.Empty;
+
+			using var db    = GetDataConnection(context, o => o.UseTracing(ti =>
+			{
+				if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
+					trace = ti.SqlText;
+			}));
 			using var table = db.CreateLocalTable<BulkCopyTable>();
 			{
 				var serverName = TestUtils.GetServerName(db, context);
-
-				var trace = string.Empty;
-				db.OnTraceConnection += ti =>
-				{
-					if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
-						trace = ti.SqlText;
-				};
 
 				table.BulkCopy(
 						new BulkCopyOptions() { BulkCopyType = BulkCopyType.ProviderSpecific, ServerName = withServer ? serverName : null },
@@ -3651,17 +3649,16 @@ namespace Tests.DataProvider
 		public void BulkCopyWithEscapedColumn(
 			[IncludeDataSources(false, TestProvName.AllOracle)] string context)
 		{
-			using var db    = GetDataConnection(context);
+			var trace = string.Empty;
+
+			using var db    = GetDataConnection(context, o => o.UseTracing(ti =>
+			{
+				if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
+					trace = ti.SqlText;
+			}));
 			using var table = db.CreateLocalTable<BulkCopyTable2>();
 			{
 				var serverName = TestUtils.GetServerName(db, context);
-
-				var trace = string.Empty;
-				db.OnTraceConnection += ti =>
-				{
-					if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
-						trace = ti.SqlText;
-				};
 
 				table.BulkCopy(
 						new BulkCopyOptions() { BulkCopyType = BulkCopyType.ProviderSpecific },
@@ -3675,7 +3672,13 @@ namespace Tests.DataProvider
 		public void BulkCopyTransactionTest(
 			[IncludeDataSources(false, TestProvName.AllOracle)] string context, [Values] bool withTransaction, [Values] bool withInternalTransaction)
 		{
-			using var db    = GetDataConnection(context);
+			var trace = string.Empty;
+
+			using var db    = GetDataConnection(context, o => o.UseTracing(ti =>
+			{
+				if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
+					trace = ti.SqlText;
+			}));
 			using var table = db.CreateLocalTable<BulkCopyTable>();
 			{
 				IDisposable? tr = null;
@@ -3684,13 +3687,6 @@ namespace Tests.DataProvider
 
 				try
 				{
-					var trace = string.Empty;
-					db.OnTraceConnection += ti =>
-					{
-						if (ti.TraceInfoStep == TraceInfoStep.BeforeExecute)
-							trace = ti.SqlText;
-					};
-
 					// Another devart bug: explicit + internal transaction doesn't produce error...
 					if (withTransaction && withInternalTransaction && !context.IsAnyOf(TestProvName.AllOracleDevart))
 						Assert.Throws<InvalidOperationException>(() =>

--- a/Tests/Linq/DataProvider/PostgreSQLTests.cs
+++ b/Tests/Linq/DataProvider/PostgreSQLTests.cs
@@ -1014,7 +1014,7 @@ namespace Tests.DataProvider
 				// color enum type will not work without this call if _create test was run in the same session
 				// More details here: https://github.com/npgsql/npgsql/issues/1357
 				// must be called before transaction opened due to: https://github.com/npgsql/npgsql/issues/2244
-				((dynamic)db.TryGetDbConnection()!).ReloadTypes();
+				((dynamic)db.OpenConnection()).ReloadTypes();
 
 				DataConnectionTransaction? ts = null;
 
@@ -1158,7 +1158,7 @@ namespace Tests.DataProvider
 				// color enum type will not work without this call if _create test was run in the same session
 				// More details here: https://github.com/npgsql/npgsql/issues/1357
 				// must be called before transaction opened due to: https://github.com/npgsql/npgsql/issues/2244
-				((dynamic)db.TryGetDbConnection()!).ReloadTypes();
+				((dynamic)db.OpenConnection()).ReloadTypes();
 
 				DataConnectionTransaction? ts = null;
 

--- a/Tests/Linq/DataProvider/PostgreSQLTests.cs
+++ b/Tests/Linq/DataProvider/PostgreSQLTests.cs
@@ -1014,7 +1014,7 @@ namespace Tests.DataProvider
 				// color enum type will not work without this call if _create test was run in the same session
 				// More details here: https://github.com/npgsql/npgsql/issues/1357
 				// must be called before transaction opened due to: https://github.com/npgsql/npgsql/issues/2244
-				((dynamic)db.OpenConnection()).ReloadTypes();
+				((dynamic)db.OpenDbConnection()).ReloadTypes();
 
 				DataConnectionTransaction? ts = null;
 
@@ -1158,7 +1158,7 @@ namespace Tests.DataProvider
 				// color enum type will not work without this call if _create test was run in the same session
 				// More details here: https://github.com/npgsql/npgsql/issues/1357
 				// must be called before transaction opened due to: https://github.com/npgsql/npgsql/issues/2244
-				((dynamic)db.OpenConnection()).ReloadTypes();
+				((dynamic)db.OpenDbConnection()).ReloadTypes();
 
 				DataConnectionTransaction? ts = null;
 

--- a/Tests/Linq/DataProvider/PostgreSQLTests.cs
+++ b/Tests/Linq/DataProvider/PostgreSQLTests.cs
@@ -1014,7 +1014,7 @@ namespace Tests.DataProvider
 				// color enum type will not work without this call if _create test was run in the same session
 				// More details here: https://github.com/npgsql/npgsql/issues/1357
 				// must be called before transaction opened due to: https://github.com/npgsql/npgsql/issues/2244
-				((dynamic)db.Connection).ReloadTypes();
+				((dynamic)db.TryGetDbConnection()!).ReloadTypes();
 
 				DataConnectionTransaction? ts = null;
 
@@ -1158,7 +1158,7 @@ namespace Tests.DataProvider
 				// color enum type will not work without this call if _create test was run in the same session
 				// More details here: https://github.com/npgsql/npgsql/issues/1357
 				// must be called before transaction opened due to: https://github.com/npgsql/npgsql/issues/2244
-				((dynamic)db.Connection).ReloadTypes();
+				((dynamic)db.TryGetDbConnection()!).ReloadTypes();
 
 				DataConnectionTransaction? ts = null;
 

--- a/Tests/Linq/DataProvider/SqlServerTypesTests.TVP.cs
+++ b/Tests/Linq/DataProvider/SqlServerTypesTests.TVP.cs
@@ -53,7 +53,11 @@ namespace Tests.DataProvider
 				yield return new ParameterFactory("DataTable", _ => GetDataTable());
 
 				// as IEnumerable<SqlDataRecord>
-				yield return new ParameterFactory("SqlDataRecords", _ => _.Connection is Microsoft.Data.SqlClient.SqlConnection ? (object)SqlServerTestUtils.GetSqlDataRecordsMS() : SqlServerTestUtils.GetSqlDataRecords());
+				yield return new ParameterFactory("SqlDataRecords", db =>
+				{
+					var connection = db.TryGetDbConnection() ?? throw new InvalidOperationException("Open connection before call");
+					return connection is Microsoft.Data.SqlClient.SqlConnection ? (object)SqlServerTestUtils.GetSqlDataRecordsMS() : SqlServerTestUtils.GetSqlDataRecords();
+				});
 
 				// TODO: doesn't work now as DbDataReader converted to Lst<object> of DbDataRecordInternal somewhere in linq2db
 				// before we can pass it to provider

--- a/Tests/Linq/DataProvider/SqlServerTypesTests.TVP.cs
+++ b/Tests/Linq/DataProvider/SqlServerTypesTests.TVP.cs
@@ -55,7 +55,7 @@ namespace Tests.DataProvider
 				// as IEnumerable<SqlDataRecord>
 				yield return new ParameterFactory("SqlDataRecords", db =>
 				{
-					var connection = db.TryGetDbConnection() ?? throw new InvalidOperationException("Open connection before call");
+					var connection = db.OpenConnection();
 					return connection is Microsoft.Data.SqlClient.SqlConnection ? (object)SqlServerTestUtils.GetSqlDataRecordsMS() : SqlServerTestUtils.GetSqlDataRecords();
 				});
 

--- a/Tests/Linq/DataProvider/SqlServerTypesTests.TVP.cs
+++ b/Tests/Linq/DataProvider/SqlServerTypesTests.TVP.cs
@@ -55,7 +55,7 @@ namespace Tests.DataProvider
 				// as IEnumerable<SqlDataRecord>
 				yield return new ParameterFactory("SqlDataRecords", db =>
 				{
-					var connection = db.OpenConnection();
+					var connection = db.OpenDbConnection();
 					return connection is Microsoft.Data.SqlClient.SqlConnection ? (object)SqlServerTestUtils.GetSqlDataRecordsMS() : SqlServerTestUtils.GetSqlDataRecords();
 				});
 

--- a/Tests/Linq/DataProvider/UniqueParametersNormalizerTests.cs
+++ b/Tests/Linq/DataProvider/UniqueParametersNormalizerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
@@ -368,6 +369,8 @@ namespace Tests.DataProvider
 #endif
 			public IExecutionScope? ExecuteScope(DataConnection dataConnection) => _baseProvider.ExecuteScope(dataConnection);
 			public CommandBehavior GetCommandBehavior(CommandBehavior commandBehavior) => _baseProvider.GetCommandBehavior(commandBehavior);
+			// TODO: Remove in v7
+			[Obsolete("This API scheduled for removal in v7"), EditorBrowsable(EditorBrowsableState.Never)]
 			public object? GetConnectionInfo(DataConnection dataConnection, string parameterName) => _baseProvider.GetConnectionInfo(dataConnection, parameterName);
 			public IQueryParametersNormalizer GetQueryParameterNormalizer() => _normalizerFactory(_baseProvider.GetQueryParameterNormalizer());
 			public Expression GetReaderExpression(DbDataReader reader, int idx, Expression readerExpression, Type toType) => _baseProvider.GetReaderExpression(reader, idx, readerExpression, toType);

--- a/Tests/Linq/Infrastructure/DataOptionsTests.cs
+++ b/Tests/Linq/Infrastructure/DataOptionsTests.cs
@@ -63,8 +63,11 @@ namespace Tests.Infrastructure
 
 			Assert.That(s1, Is.Null);
 
+			var connection = db.TryGetDbConnection();
+			Assert.That(connection, Is.Not.Null);
+
 			using var db1 = new TestDataConnection(db.Options
-				.UseConnection   (db.DataProvider, db.Connection, false)
+				.UseConnection   (db.DataProvider, connection, false)
 				.UseMappingSchema(db.MappingSchema)
 				.UseTracing(ti => s1 = ti.SqlText));
 

--- a/Tests/Linq/Linq/DataContextTests.cs
+++ b/Tests/Linq/Linq/DataContextTests.cs
@@ -23,12 +23,11 @@ namespace Tests.Linq
 			{
 				ctx.GetTable<Person>().ToList();
 
-				ctx.KeepConnectionAlive = true;
-
-				ctx.GetTable<Person>().ToList();
-				ctx.GetTable<Person>().ToList();
-
-				ctx.KeepConnectionAlive = false;
+				using (var _ = new KeepConnectionAliveScope(ctx))
+				{
+					ctx.GetTable<Person>().ToList();
+					ctx.GetTable<Person>().ToList();
+				}
 
 				using (var tran = new DataContextTransaction(ctx))
 				{
@@ -64,8 +63,8 @@ namespace Tests.Linq
 		{
 			using (var ctx = new DataContext(context))
 			{
-				ctx.KeepConnectionAlive = true;
-				ctx.KeepConnectionAlive = false;
+				ctx.SetKeepConnectionAlive(true);
+				ctx.SetKeepConnectionAlive(false);
 			}
 		}
 
@@ -176,25 +175,24 @@ namespace Tests.Linq
 		[Test]
 		public void CommandTimeoutTests([IncludeDataSources(false, TestProvName.AllSqlServer, TestProvName.AllClickHouse)] string context)
 		{
-			using (var db = new TestDataContext(context))
-			{
-				db.KeepConnectionAlive = true;
-				db.CommandTimeout = 10;
-				Assert.That(db.DataConnection, Is.Null);
-				db.GetTable<Person>().ToList();
-				Assert.That(db.DataConnection, Is.Not.Null);
-				Assert.That(db.DataConnection!.CommandTimeout, Is.EqualTo(10));
+			using var db = new TestDataContext(context);
+			using var _ = new KeepConnectionAliveScope(db);
 
-				Assert.That(() => db.CommandTimeout = -10, Throws.InstanceOf<ArgumentOutOfRangeException>());
+			db.CommandTimeout = 10;
+			Assert.That(db.DataConnection, Is.Null);
+			db.GetTable<Person>().ToList();
+			Assert.That(db.DataConnection, Is.Not.Null);
+			Assert.That(db.DataConnection!.CommandTimeout, Is.EqualTo(10));
 
-				db.ResetCommandTimeout();
-				Assert.That(db.DataConnection.CommandTimeout, Is.EqualTo(-1));
+			Assert.That(() => db.CommandTimeout = -10, Throws.InstanceOf<ArgumentOutOfRangeException>());
 
-				db.CommandTimeout = 11;
-				var record = db.GetTable<Child>().First();
+			db.ResetCommandTimeout();
+			Assert.That(db.DataConnection.CommandTimeout, Is.EqualTo(-1));
 
-				Assert.That(db.DataConnection!.CommandTimeout, Is.EqualTo(11));
-			}
+			db.CommandTimeout = 11;
+			var record = db.GetTable<Child>().First();
+
+			Assert.That(db.DataConnection!.CommandTimeout, Is.EqualTo(11));
 		}
 
 		[Test]
@@ -204,12 +202,14 @@ namespace Tests.Linq
 			{
 				Assert.That(db.CreateCalled, Is.EqualTo(0));
 
-				db.KeepConnectionAlive = true;
-				db.GetTable<Person>().ToList();
-				Assert.That(db.CreateCalled, Is.EqualTo(1));
-				db.GetTable<Person>().ToList();
-				Assert.That(db.CreateCalled, Is.EqualTo(1));
-				db.KeepConnectionAlive = false;
+				using (var _ = new KeepConnectionAliveScope(db))
+				{
+					db.GetTable<Person>().ToList();
+					Assert.That(db.CreateCalled, Is.EqualTo(1));
+					db.GetTable<Person>().ToList();
+					Assert.That(db.CreateCalled, Is.EqualTo(1));
+				}
+
 				db.GetTable<Person>().ToList();
 				Assert.That(db.CreateCalled, Is.EqualTo(2));
 			}

--- a/Tests/Linq/Linq/DataContextTests.cs
+++ b/Tests/Linq/Linq/DataContextTests.cs
@@ -185,7 +185,9 @@ namespace Tests.Linq
 				Assert.That(db.DataConnection, Is.Not.Null);
 				Assert.That(db.DataConnection!.CommandTimeout, Is.EqualTo(10));
 
-				db.CommandTimeout = -10;
+				Assert.That(() => db.CommandTimeout = -10, Throws.InstanceOf<ArgumentOutOfRangeException>());
+
+				db.ResetCommandTimeout();
 				Assert.That(db.DataConnection.CommandTimeout, Is.EqualTo(-1));
 
 				db.CommandTimeout = 11;

--- a/Tests/Linq/Linq/EagerLoadingTests.cs
+++ b/Tests/Linq/Linq/EagerLoadingTests.cs
@@ -1791,7 +1791,7 @@ FROM
 
 			await using (var db = new DataContext(options))
 			{
-				db.KeepConnectionAlive = true;
+				await db.SetKeepConnectionAliveAsync(true);
 
 				await db.GetTable<Parent>()
 					.LoadWith(x => x.Children)
@@ -1800,7 +1800,7 @@ FROM
 
 			await using (var db = new DataContext(options))
 			{
-				db.KeepConnectionAlive = false;
+				await db.SetKeepConnectionAliveAsync(false);
 
 				await db.GetTable<Parent>()
 					.LoadWith(x => x.Children)
@@ -1823,7 +1823,7 @@ FROM
 
 			using (var db = new DataContext(options))
 			{
-				db.KeepConnectionAlive = true;
+				db.SetKeepConnectionAlive(true);
 
 				db.GetTable<Parent>()
 					.LoadWith(x => x.Children)
@@ -1832,7 +1832,7 @@ FROM
 
 			using (var db = new DataContext(options))
 			{
-				db.KeepConnectionAlive = false;
+				db.SetKeepConnectionAlive(false);
 
 				db.GetTable<Parent>()
 					.LoadWith(x => x.Children)
@@ -1856,7 +1856,7 @@ FROM
 
 			await using (var db = new DataContext(options))
 			{
-				db.KeepConnectionAlive = true;
+				db.SetKeepConnectionAlive(true);
 
 				using var _ = db.BeginTransaction();
 				await db.GetTable<Parent>()
@@ -1866,7 +1866,7 @@ FROM
 
 			await using (var db = new DataContext(options))
 			{
-				db.KeepConnectionAlive = false;
+				db.SetKeepConnectionAlive(false);
 
 				using var _ = db.BeginTransaction();
 				await db.GetTable<Parent>()
@@ -1891,7 +1891,7 @@ FROM
 
 			using (var db = new DataContext(options))
 			{
-				db.KeepConnectionAlive = true;
+				db.SetKeepConnectionAlive(true);
 
 				using var _ = db.BeginTransaction();
 				db.GetTable<Parent>()
@@ -1901,7 +1901,7 @@ FROM
 
 			using (var db = new DataContext(options))
 			{
-				db.KeepConnectionAlive = false;
+				db.SetKeepConnectionAlive(false);
 
 				using var _ = db.BeginTransaction();
 				db.GetTable<Parent>()

--- a/Tests/Linq/Linq/TemporalTableTests.cs
+++ b/Tests/Linq/Linq/TemporalTableTests.cs
@@ -11,8 +11,6 @@ using LinqToDB.Mapping;
 using LinqToDB.SqlQuery;
 using LinqToDB.Tools.DataProvider.SqlServer.Schemas;
 
-using Microsoft.AspNetCore.Razor.Runtime.TagHelpers;
-
 using NUnit.Framework;
 
 using Tests.Model;

--- a/Tests/Linq/Linq/TemporalTableTests.cs
+++ b/Tests/Linq/Linq/TemporalTableTests.cs
@@ -34,7 +34,7 @@ namespace Tests.Linq
 		TemporalTest[] CreateTestTable(ITestDataContext db)
 		{
 			using var dc = db is TestDataConnection dcx ?
-				new DataConnection(db.Options.UseConnection(dcx.DataProvider, dcx.TryGetDbConnection() ?? throw new InvalidOperationException($"Open connection first"))) :
+				new DataConnection(db.Options.UseConnection(dcx.DataProvider, dcx.OpenConnection())) :
 				new DataConnection(db.ConfigurationString);
 
 			using var sy = new SystemDB(db.ConfigurationString!);

--- a/Tests/Linq/Linq/TemporalTableTests.cs
+++ b/Tests/Linq/Linq/TemporalTableTests.cs
@@ -34,7 +34,7 @@ namespace Tests.Linq
 		TemporalTest[] CreateTestTable(ITestDataContext db)
 		{
 			using var dc = db is TestDataConnection dcx ?
-				new DataConnection(db.Options.UseConnection(dcx.DataProvider, dcx.OpenConnection())) :
+				new DataConnection(db.Options.UseConnection(dcx.DataProvider, dcx.OpenDbConnection())) :
 				new DataConnection(db.ConfigurationString);
 
 			using var sy = new SystemDB(db.ConfigurationString!);

--- a/Tests/Linq/Linq/TemporalTableTests.cs
+++ b/Tests/Linq/Linq/TemporalTableTests.cs
@@ -11,6 +11,8 @@ using LinqToDB.Mapping;
 using LinqToDB.SqlQuery;
 using LinqToDB.Tools.DataProvider.SqlServer.Schemas;
 
+using Microsoft.AspNetCore.Razor.Runtime.TagHelpers;
+
 using NUnit.Framework;
 
 using Tests.Model;
@@ -34,7 +36,7 @@ namespace Tests.Linq
 		TemporalTest[] CreateTestTable(ITestDataContext db)
 		{
 			using var dc = db is TestDataConnection dcx ?
-				new DataConnection(db.Options.UseConnection(dcx.DataProvider, dcx.Connection)) :
+				new DataConnection(db.Options.UseConnection(dcx.DataProvider, dcx.TryGetDbConnection() ?? throw new InvalidOperationException($"Open connection first"))) :
 				new DataConnection(db.ConfigurationString);
 
 			using var sy = new SystemDB(db.ConfigurationString!);

--- a/Tests/Linq/Samples/ExceptionInterceptTests.cs
+++ b/Tests/Linq/Samples/ExceptionInterceptTests.cs
@@ -112,9 +112,8 @@ namespace Tests.Samples
 
 			Assert.Throws<DivideByZeroException>(() =>
 			{
-				using (var db = GetDataConnection(context))
+				using (var db = GetDataConnection(context, o => o.UseRetryPolicy(ret)))
 				{
-					db.RetryPolicy = ret;
 					db.GetTable<TestTable>().ToList();
 				}
 			});

--- a/Tests/Linq/Update/MergeTests.ApiParametersValidation.cs
+++ b/Tests/Linq/Update/MergeTests.ApiParametersValidation.cs
@@ -189,15 +189,14 @@ namespace Tests.xUpdate
 		sealed class FakeTable<TEntity> : ITable<TEntity>
 			where TEntity : notnull
 		{
-			IDataContext                  IExpressionQuery.DataContext                                                                            => throw new NotImplementedException();
-			Expression                    IExpressionQuery.Expression                                                                             => throw new NotImplementedException();
-			IReadOnlyList<QuerySql>       IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options)                                           => throw new NotImplementedException();
-			Task<IReadOnlyList<QuerySql>> IExpressionQuery.GetSqlQueriesAsync(SqlGenerationOptions? options, CancellationToken cancellationToken) => throw new NotImplementedException();
+			IDataContext            IExpressionQuery.DataContext                                  => throw new NotImplementedException();
+			Expression              IExpressionQuery.Expression                                   => throw new NotImplementedException();
+			IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options) => throw new NotImplementedException();
 
-			Type                    IQueryable.         ElementType                                  => throw new NotImplementedException();
-			Expression              IQueryable.         Expression                                   => throw new NotImplementedException();
-			IQueryProvider          IQueryable.         Provider                                     => new FakeQueryProvider();
-			Expression              IQueryProviderAsync.Expression                                   => throw new NotImplementedException();
+			Type                    IQueryable.         ElementType                               => throw new NotImplementedException();
+			Expression              IQueryable.         Expression                                => throw new NotImplementedException();
+			IQueryProvider          IQueryable.         Provider                                  => new FakeQueryProvider();
+			Expression              IQueryProviderAsync.Expression                                => throw new NotImplementedException();
 
 			Expression IExpressionQuery<TEntity>.Expression => Expression.Constant((ITable<TEntity>)this);
 

--- a/Tests/Linq/Update/MergeTests.ApiParametersValidation.cs
+++ b/Tests/Linq/Update/MergeTests.ApiParametersValidation.cs
@@ -189,9 +189,11 @@ namespace Tests.xUpdate
 		sealed class FakeTable<TEntity> : ITable<TEntity>
 			where TEntity : notnull
 		{
-			IDataContext            IExpressionQuery.   DataContext                                  => throw new NotImplementedException();
-			Expression              IExpressionQuery.   Expression                                   => throw new NotImplementedException();
-			IReadOnlyList<QuerySql> IExpressionQuery.   GetSqlQueries(SqlGenerationOptions? options) => throw new NotImplementedException();
+			IDataContext                  IExpressionQuery.DataContext                                                                            => throw new NotImplementedException();
+			Expression                    IExpressionQuery.Expression                                                                             => throw new NotImplementedException();
+			IReadOnlyList<QuerySql>       IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options)                                           => throw new NotImplementedException();
+			Task<IReadOnlyList<QuerySql>> IExpressionQuery.GetSqlQueriesAsync(SqlGenerationOptions? options, CancellationToken cancellationToken) => throw new NotImplementedException();
+
 			Type                    IQueryable.         ElementType                                  => throw new NotImplementedException();
 			Expression              IQueryable.         Expression                                   => throw new NotImplementedException();
 			IQueryProvider          IQueryable.         Provider                                     => new FakeQueryProvider();

--- a/Tests/Linq/Update/UpdateTests.cs
+++ b/Tests/Linq/Update/UpdateTests.cs
@@ -1450,7 +1450,7 @@ namespace Tests.xUpdate
 				var updatedPerson = table.Single();
 				Assert.That(updatedPerson.MiddleName, Is.EqualTo("None"));
 
-				if (db is DataConnection dc && dc.OpenConnection() is FirebirdSql.Data.FirebirdClient.FbConnection)
+				if (db is DataConnection dc && dc.OpenDbConnection() is FirebirdSql.Data.FirebirdClient.FbConnection)
 					db.Close();
 
 				table.Drop();

--- a/Tests/Linq/Update/UpdateTests.cs
+++ b/Tests/Linq/Update/UpdateTests.cs
@@ -1450,7 +1450,7 @@ namespace Tests.xUpdate
 				var updatedPerson = table.Single();
 				Assert.That(updatedPerson.MiddleName, Is.EqualTo("None"));
 
-				if (db is DataConnection { Connection: FirebirdSql.Data.FirebirdClient.FbConnection })
+				if (db is DataConnection dc && dc.TryGetDbConnection() is FirebirdSql.Data.FirebirdClient.FbConnection)
 					db.Close();
 
 				table.Drop();

--- a/Tests/Linq/Update/UpdateTests.cs
+++ b/Tests/Linq/Update/UpdateTests.cs
@@ -1450,7 +1450,7 @@ namespace Tests.xUpdate
 				var updatedPerson = table.Single();
 				Assert.That(updatedPerson.MiddleName, Is.EqualTo("None"));
 
-				if (db is DataConnection dc && dc.TryGetDbConnection() is FirebirdSql.Data.FirebirdClient.FbConnection)
+				if (db is DataConnection dc && dc.OpenConnection() is FirebirdSql.Data.FirebirdClient.FbConnection)
 					db.Close();
 
 				table.Drop();

--- a/Tests/Linq/UserTests/Issue1174Tests.cs
+++ b/Tests/Linq/UserTests/Issue1174Tests.cs
@@ -20,11 +20,7 @@ namespace Tests.UserTests
 			{
 				return () =>
 				{
-					var db = new MyDB(configuration)
-					{
-						// No exception if policy removed
-						RetryPolicy = new SqlServerRetryPolicy(retryCount, delay, randomFactor, exponentialBase, coefficient, null)
-					};
+					var db = new MyDB(new DataOptions().UseConfiguration(configuration).UseRetryPolicy(new SqlServerRetryPolicy(retryCount, delay, randomFactor, exponentialBase, coefficient, null)));
 					return db;
 				};
 			}
@@ -34,10 +30,11 @@ namespace Tests.UserTests
 			{
 			}
 
-			public MyDB(string configuration)
-				: base(configuration)
+			public MyDB(DataOptions options)
+				: base(options)
 			{
 			}
+
 			public MyDB(IDataProvider dataProvider, string connectionString) : base(new DataOptions().UseConnectionString(dataProvider, connectionString))
 			{
 			}

--- a/Tests/Linq/UserTests/Issue3548Tests.cs
+++ b/Tests/Linq/UserTests/Issue3548Tests.cs
@@ -84,7 +84,7 @@ namespace Tests.UserTests
 				using var db = GetDataConnection(options);
 				using var _  = db.CreateLocalTable(User.Data);
 
-				((NpgsqlConnection)db.Connection).ReloadTypes();
+				((NpgsqlConnection)db.TryGetDbConnection()!).ReloadTypes();
 
 				var user  = new User() { Id = 1, Type = UserTypeEnum.Organization };
 				var users = db.GetTable<User>().Where(x => x.InYourOrganization(user)).OrderBy(x => x.Id).Select(x => x.Id.ToString()).ToList();

--- a/Tests/Linq/UserTests/Issue3548Tests.cs
+++ b/Tests/Linq/UserTests/Issue3548Tests.cs
@@ -84,7 +84,7 @@ namespace Tests.UserTests
 				using var db = GetDataConnection(options);
 				using var _  = db.CreateLocalTable(User.Data);
 
-				((NpgsqlConnection)db.TryGetDbConnection()!).ReloadTypes();
+				((NpgsqlConnection)db.OpenConnection()).ReloadTypes();
 
 				var user  = new User() { Id = 1, Type = UserTypeEnum.Organization };
 				var users = db.GetTable<User>().Where(x => x.InYourOrganization(user)).OrderBy(x => x.Id).Select(x => x.Id.ToString()).ToList();

--- a/Tests/Linq/UserTests/Issue3548Tests.cs
+++ b/Tests/Linq/UserTests/Issue3548Tests.cs
@@ -84,7 +84,7 @@ namespace Tests.UserTests
 				using var db = GetDataConnection(options);
 				using var _  = db.CreateLocalTable(User.Data);
 
-				((NpgsqlConnection)db.OpenConnection()).ReloadTypes();
+				((NpgsqlConnection)db.OpenDbConnection()).ReloadTypes();
 
 				var user  = new User() { Id = 1, Type = UserTypeEnum.Organization };
 				var users = db.GetTable<User>().Where(x => x.InYourOrganization(user)).OrderBy(x => x.Id).Select(x => x.Id.ToString()).ToList();

--- a/Tests/Linq/UserTests/Issue4883Tests.cs
+++ b/Tests/Linq/UserTests/Issue4883Tests.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 namespace Tests.UserTests
 {
 	[TestFixture]
-	public class Issue4883Tests
+	public class Issue4883Tests : TestBase
 	{
 		[Test]
 		public async Task TestDataConnection()

--- a/Tests/Linq/UserTests/Issue927Tests.cs
+++ b/Tests/Linq/UserTests/Issue927Tests.cs
@@ -20,7 +20,7 @@ namespace Tests.UserTests
 
 			using (var db = new DataConnection(new DataOptions().UseConnection(new TestNoopProvider(), connection, dispose)))
 			{
-				var c = db.OpenConnection();
+				var c = db.OpenDbConnection();
 				Assert.That(c.State, Is.EqualTo(ConnectionState.Open));
 			}
 
@@ -38,7 +38,7 @@ namespace Tests.UserTests
 
 			using (var db = new DataConnection(new DataOptions().UseConnectionString(new TestNoopProvider(), "")))
 			{
-				connection = db.OpenConnection() as TestNoopConnection;
+				connection = db.OpenDbConnection() as TestNoopConnection;
 				Assert.That(connection!.State, Is.EqualTo(ConnectionState.Open));
 			}
 

--- a/Tests/Linq/UserTests/Issue927Tests.cs
+++ b/Tests/Linq/UserTests/Issue927Tests.cs
@@ -20,7 +20,8 @@ namespace Tests.UserTests
 
 			using (var db = new DataConnection(new DataOptions().UseConnection(new TestNoopProvider(), connection, dispose)))
 			{
-				var c = db.Connection;
+				var c = db.TryGetDbConnection();
+				Assert.That(c, Is.Not.Null);
 				Assert.That(c.State, Is.EqualTo(ConnectionState.Open));
 			}
 
@@ -38,7 +39,7 @@ namespace Tests.UserTests
 
 			using (var db = new DataConnection(new DataOptions().UseConnectionString(new TestNoopProvider(), "")))
 			{
-				connection = db.Connection as TestNoopConnection;
+				connection = db.TryGetDbConnection() as TestNoopConnection;
 				Assert.That(connection, Is.Not.Null);
 				Assert.That(connection!.State, Is.EqualTo(ConnectionState.Open));
 			}
@@ -62,7 +63,8 @@ namespace Tests.UserTests
 
 			using (var db = new DataConnection(new DataOptions().UseConnection(new TestNoopProvider(), connection, false)))
 			{
-				var c = db.Connection;
+				var c = db.TryGetDbConnection();
+				Assert.That(c, Is.Not.Null);
 				Assert.That(c.State, Is.EqualTo(ConnectionState.Open));
 			}
 

--- a/Tests/Linq/UserTests/Issue927Tests.cs
+++ b/Tests/Linq/UserTests/Issue927Tests.cs
@@ -20,8 +20,7 @@ namespace Tests.UserTests
 
 			using (var db = new DataConnection(new DataOptions().UseConnection(new TestNoopProvider(), connection, dispose)))
 			{
-				var c = db.TryGetDbConnection();
-				Assert.That(c, Is.Not.Null);
+				var c = db.OpenConnection();
 				Assert.That(c.State, Is.EqualTo(ConnectionState.Open));
 			}
 
@@ -39,8 +38,7 @@ namespace Tests.UserTests
 
 			using (var db = new DataConnection(new DataOptions().UseConnectionString(new TestNoopProvider(), "")))
 			{
-				connection = db.TryGetDbConnection() as TestNoopConnection;
-				Assert.That(connection, Is.Not.Null);
+				connection = db.OpenConnection() as TestNoopConnection;
 				Assert.That(connection!.State, Is.EqualTo(ConnectionState.Open));
 			}
 


### PR DESCRIPTION
- [x] Fix #4320 : add missing disposed checks
- [x] Fix #4894
- [x] Obsolete/fix dangerous dbconnection access APIs on `DataConnection`
- [x] fix discovered multiple sync-over-async calls
- [x] obsolete `IsMarsEnabled` and  `GetConnectionInfo` APIs
- [x] obsolete (but still use for now)  `Configuration.Data.ThrowOnDisposed` option
- [x] review existing APIs on contexts for more obsoletion/removal candidates
- [x] add explicit connect APIs to data connection to replace Connection property obsoletion
- [x] add `UseTraceSwitch` `DataOptions` configuration API
- [x] add  `DataContext.SetKeepConnectionAlive[Async]` method instead of blocking property setter
- [x] Fix context instance stuck in mapper discovered by new use-after-dispose exceptions
- [x] **BREAKIN' CHANGE** `DataConnection.BeginTransaction*` will throw exception if transaction already exists instead of silently rolling it back
- [x] **BREAKIN' CHANGE** disallow setting negative command timeout to `DataConnection.CommadTimeout` to reset it. Instead introduce `ResetCommandTimeout[Async]()` APIs

Obsolete several APIs for various reasons, mostly because:
- they are not expected to be available to user
- they implement sync-over-async pattern
- perform changes (e.g. to context configuration) that should be done through `DataOptions`

Some of obsoletions are temporary as we don't plan to remove API itself, but only change it's visibility with v7 release.