### PR TITLE
Update TempTable comment

### DIFF
--- a/Source/LinqToDB/TempTable.cs
+++ b/Source/LinqToDB/TempTable.cs
@@ -23,8 +23,8 @@ namespace LinqToDB
 	// TODO: v6: obsolete methods with setTable parameter
 	// IT: ??? how to use anonymous types then?
 	/// <summary>
-	/// Temporary table. Temporary table is a table, created when you create instance of this class and deleted when
-	/// you dispose it. It uses regular tables even if underlying database supports temporary tables concept.
+	/// Temporary table. Temporary table is a table, created when you create instance of this class and deleted when you dispose it.
+	/// It uses regular tables, unless option <see cref="TableOptions.IsTemporary"/> is specified and underlying database supports temporary tables.
 	/// </summary>
 	/// <typeparam name="T">Table record mapping class.</typeparam>
 	[PublicAPI]


### PR DESCRIPTION
Clarifying comment that says `TmpTable` uses real tables.
It actually depends on option `TableOptions.IsTemporary`, which is the default when using `db.CreateTempTable<T>`.

Side note (breaking change, for v6?): 
It would be nice if internally we had a flag on the table that indicates whether the table is normal or temporary.
We don't need to send DROP TABLE statements in `Dispose()` for real temporary table,

The only use case would be if someone wants to re-create the same temporary table in the same transaction, in which case it seems appropriate to have users call `DropTable()` themselves.