### PR TITLE
Remove IsTakeSupported from SqlProviderFlags

### DIFF
--- a/Source/LinqToDB/DataProvider/DataProviderBase.cs
+++ b/Source/LinqToDB/DataProvider/DataProviderBase.cs
@@ -39,7 +39,6 @@ namespace LinqToDB.DataProvider
 				IsParameterOrderDependent            = false,
 				AcceptsTakeAsParameter               = true,
 				AcceptsTakeAsParameterIfSkip         = false,
-				IsTakeSupported                      = true,
 				IsSkipSupported                      = true,
 				IsSkipSupportedIfTake                = false,
 				TakeHintsSupported                   = null,

--- a/Source/LinqToDB/Linq/QueryRunner.cs
+++ b/Source/LinqToDB/Linq/QueryRunner.cs
@@ -445,17 +445,6 @@ namespace LinqToDB.Linq
 						EvaluateTakeSkipValue(qq, expr, db, ps, qn, skipValue), null);
 			}
 
-			if (select.TakeValue != null && !query.SqlProviderFlags.IsTakeSupported)
-			{
-				var takeValue = select.TakeValue;
-
-				var q = queryFunc;
-
-				queryFunc = (qq, db, mapper, expr, ps, preambles, qn) =>
-					new LimitResultEnumerable<T>(q(qq, db, mapper, expr, ps, preambles, qn),
-						null, EvaluateTakeSkipValue(qq, expr, db, ps, qn, takeValue));
-			}
-
 			return queryFunc;
 		}
 

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -260,9 +260,6 @@ namespace LinqToDB.SqlProvider
 				&& skipExpr != null)
 				throw new LinqToDBException(ErrorHelper.Error_Skip_in_Subquery);
 
-			if (!SqlProviderFlags.IsTakeSupported && takeExpr != null)
-				throw new LinqToDBException($"Take for subqueries is not supported by the '{Name}' provider.");
-
 			var sqlBuilder = (BasicSqlBuilder)CreateSqlBuilder();
 			sqlBuilder.BuildSql(0,
 				new SqlSelectStatement(selectQuery) { ParentStatement = Statement }, StringBuilder, OptimizationContext, indent, skipAlias);
@@ -2318,7 +2315,7 @@ namespace LinqToDB.SqlProvider
 			=> skipExpression != null && SqlProviderFlags.GetIsSkipSupportedFlag(takeExpression, skipExpression);
 
 		protected bool NeedTake(ISqlExpression? takeExpression)
-			=> takeExpression != null && SqlProviderFlags.IsTakeSupported;
+			=> takeExpression != null;
 
 		protected virtual void BuildSkipFirst(SelectQuery selectQuery)
 		{

--- a/Source/LinqToDB/SqlProvider/SqlProviderFlags.cs
+++ b/Source/LinqToDB/SqlProvider/SqlProviderFlags.cs
@@ -39,43 +39,37 @@ namespace LinqToDB.SqlProvider
 		[DataMember(Order =  4)]
 		public bool        AcceptsTakeAsParameterIfSkip   { get; set; }
 		/// <summary>
-		/// Indicates support for TOP/TAKE/LIMIT paging clause.
-		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
-		/// </summary>
-		[DataMember(Order =  5)]
-		public bool        IsTakeSupported                { get; set; }
-		/// <summary>
 		/// Indicates support for SKIP/OFFSET paging clause (parameter) without TAKE clause.
 		/// Provider could set this flag even if database not support it if emulates missing functionality.
 		/// E.g. : <c>TAKE [MAX_ALLOWED_VALUE] SKIP skip_value </c>
 		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
 		/// </summary>
-		[DataMember(Order =  6)]
+		[DataMember(Order =  5)]
 		public bool        IsSkipSupported                { get; set; }
 		/// <summary>
 		/// Indicates support for SKIP/OFFSET paging clause (parameter) only if also TAKE/LIMIT specified.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
 		/// </summary>
-		[DataMember(Order =  7)]
+		[DataMember(Order =  6)]
 		public bool        IsSkipSupportedIfTake          { get; set; }
 		/// <summary>
 		/// Indicates supported TAKE/LIMIT hints.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>null</c> (none).
 		/// </summary>
-		[DataMember(Order =  8)]
+		[DataMember(Order =  7)]
 		public TakeHints?  TakeHintsSupported              { get; set; }
 		/// <summary>
 		/// Indicates support for paging clause in subquery.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
 		/// </summary>
-		[DataMember(Order =  9)]
+		[DataMember(Order =  8)]
 		public bool        IsSubQueryTakeSupported        { get; set; }
 
 		/// <summary>
 		/// Indicates support for paging clause in derived table.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
 		/// </summary>
-		[DataMember(Order = 10)]
+		[DataMember(Order =  9)]
 		public bool IsDerivedTableTakeSupported { get; set; }
 
 		/// <summary>
@@ -83,28 +77,28 @@ namespace LinqToDB.SqlProvider
 		/// Default <c>false</c>.
 		/// </summary>
 		/// <remarks>Currently use as workaround over Sybase bug.</remarks>
-		[DataMember(Order = 11)]
+		[DataMember(Order = 10)]
 		public bool IsJoinDerivedTableWithTakeInvalid { get; set; }
 
 		/// <summary>
 		/// Indicates support for paging clause in correlated subquery.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
 		/// </summary>
-		[DataMember(Order = 12)]
+		[DataMember(Order = 11)]
 		public bool IsCorrelatedSubQueryTakeSupported { get; set; }
 
 		/// <summary>
 		/// Indicates that provider supports JOIN without condition ON 1=1.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
 		/// </summary>
-		[DataMember(Order = 13)]
+		[DataMember(Order = 12)]
 		public bool IsSupportsJoinWithoutCondition { get; set; }
 		
 		/// <summary>
 		/// Indicates support for skip clause in column expression subquery.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
 		/// </summary>
-		[DataMember(Order = 14)]
+		[DataMember(Order = 13)]
 		public bool        IsSubQuerySkipSupported        { get; set; }
 
 		/// <summary>
@@ -112,64 +106,64 @@ namespace LinqToDB.SqlProvider
 		/// E.g. <c>SELECT (SELECT TOP 1 value FROM some_table) AS MyColumn, ...</c>
 		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
 		/// </summary>
-		[DataMember(Order = 15)]
+		[DataMember(Order = 14)]
 		public bool        IsSubQueryColumnSupported      { get; set; }
 		/// <summary>
 		/// Indicates support of <c>ORDER BY</c> clause in sub-queries.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
 		/// </summary>
-		[DataMember(Order = 16)]
+		[DataMember(Order = 15)]
 		public bool        IsSubQueryOrderBySupported     { get; set; }
 		/// <summary>
 		/// Indicates that database supports count subquery as scalar in column.
 		/// <code>SELECT (SELECT COUNT(*) FROM some_table) FROM ...</code>
 		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
 		/// </summary>
-		[DataMember(Order = 17)]
+		[DataMember(Order = 16)]
 		public bool        IsCountSubQuerySupported       { get; set; }
 
 		/// <summary>
 		/// Indicates that provider requires explicit output parameter for insert with identity queries to get identity from database.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
 		/// </summary>
-		[DataMember(Order = 18)]
+		[DataMember(Order = 17)]
 		public bool        IsIdentityParameterRequired    { get; set; }
 		/// <summary>
 		/// Indicates support for OUTER/CROSS APPLY.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
 		/// </summary>
-		[DataMember(Order = 19)]
+		[DataMember(Order = 18)]
 		public bool        IsApplyJoinSupported           { get; set; }
 		/// <summary>
 		/// Indicates support for CROSS APPLY supports condition LATERAL JOIN for example.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
 		/// </summary>
-		[DataMember(Order = 20)]
+		[DataMember(Order = 19)]
 		public bool IsCrossApplyJoinSupportsCondition { get; set; }
 		/// <summary>
 		/// Indicates support for OUTER APPLY supports condition LATERAL JOIN for example.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
 		/// </summary>
-		[DataMember(Order = 21)]
+		[DataMember(Order = 20)]
 		public bool IsOuterApplyJoinSupportsCondition { get; set; }
 		/// <summary>
 		/// Indicates support for single-query insert-or-update operation support.
 		/// Otherwise two separate queries used to emulate operation (update, then insert if nothing found to update).
 		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
 		/// </summary>
-		[DataMember(Order = 22)]
+		[DataMember(Order = 21)]
 		public bool        IsInsertOrUpdateSupported      { get; set; }
 		/// <summary>
 		/// Indicates that provider could share parameter between statements in multi-statement batch.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
 		/// </summary>
-		[DataMember(Order = 23)]
+		[DataMember(Order = 22)]
 		public bool        CanCombineParameters           { get; set; }
 		/// <summary>
 		/// Specifies limit of number of values in single <c>IN</c> predicate without splitting it into several IN's.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>int.MaxValue</c> (basically means there is no limit).
 		/// </summary>
-		[DataMember(Order = 24)]
+		[DataMember(Order = 23)]
 		public int         MaxInListValuesCount           { get; set; }
 
 		/// <summary>
@@ -177,35 +171,35 @@ namespace LinqToDB.SqlProvider
 		/// table with special name (e.g. DELETED or OLD). Otherwise fields should be referenced using target table.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
 		/// </summary>
-		[DataMember(Order = 25)]
+		[DataMember(Order = 24)]
 		public bool        OutputDeleteUseSpecialTable    { get; set; }
 		/// <summary>
 		/// If <c>true</c>, added record fields in OUTPUT clause of INSERT statement should be referenced using
 		/// table with special name (e.g. INSERTED or NEW). Otherwise fields should be referenced using target table.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
 		/// </summary>
-		[DataMember(Order = 26)]
+		[DataMember(Order = 25)]
 		public bool        OutputInsertUseSpecialTable    { get; set; }
 		/// <summary>
 		/// If <c>true</c>, OUTPUT clause supports both OLD and NEW data in UPDATE statement using tables with special names.
 		/// Otherwise only current record fields (after update) available using target table.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
 		/// </summary>
-		[DataMember(Order = 27)]
+		[DataMember(Order = 26)]
 		public bool        OutputUpdateUseSpecialTables   { get; set; }
 		/// <summary>
 		/// If <c>true</c>, OUTPUT clause supports both OLD and NEW data in MERGE statement using tables with special names.
 		/// Otherwise only current record fields (after all changes) available using target table.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
 		/// </summary>
-		[DataMember(Order = 28)]
+		[DataMember(Order = 27)]
 		public bool        OutputMergeUseSpecialTables    { get; set; }
 
 		/// <summary>
 		/// Indicates support for CROSS JOIN.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
 		/// </summary>
-		[DataMember(Order = 29)]
+		[DataMember(Order = 28)]
 		public bool        IsCrossJoinSupported              { get; set; }
 
 		/// <summary>
@@ -213,7 +207,7 @@ namespace LinqToDB.SqlProvider
 		/// If provider does not support CTE, unsuported exception will be thrown when using CTE.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
 		/// </summary>
-		[DataMember(Order = 30)]
+		[DataMember(Order = 29)]
 		public bool IsCommonTableExpressionsSupported     { get; set; }
 
 		/// <summary>
@@ -221,21 +215,21 @@ namespace LinqToDB.SqlProvider
 		/// It is specific behaviour only for Oracle.
 		/// Default <c>false</c>
 		/// </summary>
-		[DataMember(Order = 31)]
+		[DataMember(Order = 30)]
 		public bool DoesProviderTreatsEmptyStringAsNull { get; set; }
 
 		/// <summary>
 		/// Provider supports EXCEPT ALL, INTERSECT ALL set operators. Otherwise they will be emulated.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
 		/// </summary>
-		[DataMember(Order = 32)]
+		[DataMember(Order = 31)]
 		public bool IsAllSetOperationsSupported           { get; set; }
 
 		/// <summary>
 		/// Provider supports EXCEPT, INTERSECT set operators. Otherwise it will be emulated.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
 		/// </summary>
-		[DataMember(Order = 33)]
+		[DataMember(Order = 32)]
 		public bool IsDistinctSetOperationsSupported      { get; set; }
 
 		/// <summary>
@@ -264,7 +258,7 @@ namespace LinqToDB.SqlProvider
 		///</code>
 		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
 		/// </summary>
-		[DataMember(Order = 34)]
+		[DataMember(Order = 33)]
 		public bool AcceptsOuterExpressionInAggregate { get; set; }
 
 		/// <summary>
@@ -276,7 +270,7 @@ namespace LinqToDB.SqlProvider
 		/// </code>
 		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
 		/// </summary>
-		[DataMember(Order = 35)]
+		[DataMember(Order = 34)]
 		public bool IsUpdateFromSupported             { get; set; }
 
 		/// <summary>
@@ -286,48 +280,48 @@ namespace LinqToDB.SqlProvider
 		/// </code>
 		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
 		/// </summary>
-		[DataMember(Order = 36)]
+		[DataMember(Order = 35)]
 		public bool IsNamingQueryBlockSupported       { get; set; }
 
 		/// <summary>
 		/// Indicates that provider supports window functions.
 		/// Default value: <c>true</c>.
 		/// </summary>
-		[DataMember(Order = 37)]
+		[DataMember(Order = 36)]
 		public bool IsWindowFunctionsSupported { get; set; }
 
 		/// <summary>
 		/// Used when there is query which needs several additional database requests for completing query (e.g. eager load or client-side GroupBy).
 		/// Default (set by <see cref="DataProviderBase"/>): <see cref="IsolationLevel.RepeatableRead"/>.
 		/// </summary>
-		[DataMember(Order = 38)]
+		[DataMember(Order = 37)]
 		public IsolationLevel DefaultMultiQueryIsolationLevel { get; set; }
 
 		/// <summary>
 		/// Provider support Row Constructor `(1, 2, 3)` in various positions (flags)
 		/// Default (set by <see cref="DataProviderBase"/>): <see cref="RowFeature.None"/>.
 		/// </summary>
-		[DataMember(Order = 39), DefaultValue(RowFeature.None)]
+		[DataMember(Order = 38), DefaultValue(RowFeature.None)]
 		public RowFeature RowConstructorSupport { get; set; }
 
 		/// <summary>
 		/// Default value: <c>false</c>.
 		/// </summary>
-		[DataMember(Order = 40)]
+		[DataMember(Order = 39)]
 		public bool IsExistsPreferableForContains   { get; set; }
 
 		/// <summary>
 		/// Provider supports ROW_NUMBER OVER () without ORDER BY
 		/// Default value: <c>true</c>.
 		/// </summary>
-		[DataMember(Order = 41), DefaultValue(true)]
+		[DataMember(Order = 40), DefaultValue(true)]
 		public bool IsRowNumberWithoutOrderBySupported { get; set; } = true;
 
 		/// <summary>
 		/// Provider supports condition in subquery which references parent table
 		/// Default value: <c>true</c>.
 		/// </summary>
-		[DataMember(Order = 42), DefaultValue(true)]
+		[DataMember(Order = 41), DefaultValue(true)]
 		public bool IsSubqueryWithParentReferenceInJoinConditionSupported { get; set; } = true;
 
 		/// <summary>
@@ -337,7 +331,7 @@ namespace LinqToDB.SqlProvider
 		/// Used only for Oracle 11. linq2db emulates Take(n) via 'ROWNUM' and it causes additional nesting.
 		/// Default value: <c>true</c>.
 		/// </remarks>
-		[DataMember(Order = 43), DefaultValue(true)]
+		[DataMember(Order = 42), DefaultValue(true)]
 		public bool IsColumnSubqueryWithParentReferenceAndTakeSupported { get; set; } = true;
 
 		/// <summary>
@@ -347,14 +341,14 @@ namespace LinqToDB.SqlProvider
 		/// <remarks>
 		/// See Issue3557Case1 test.
 		/// </remarks>
-		[DataMember(Order = 44), DefaultValue(false)]
+		[DataMember(Order = 43), DefaultValue(false)]
 		public bool IsColumnSubqueryShouldNotContainParentIsNotNull { get; set; } = false;
 
 		/// <summary>
 		/// Provider supports INNER JOIN with condition inside Recursive CTE, currently not supported only by DB2
 		/// Default value: <c>true</c>.
 		/// </summary>
-		[DataMember(Order = 45), DefaultValue(true)]
+		[DataMember(Order = 44), DefaultValue(true)]
 		public bool IsRecursiveCTEJoinWithConditionSupported { get; set; } = true;
 
 		/// <summary>
@@ -377,7 +371,7 @@ namespace LinqToDB.SqlProvider
 		/// Currently not supported only by Access.
 		/// </remarks>
 		/// </summary>
-		[DataMember(Order = 46), DefaultValue(true)]
+		[DataMember(Order = 45), DefaultValue(true)]
 		public bool IsOuterJoinSupportsInnerJoin { get; set; } = true;
 
 		/// <summary>
@@ -403,14 +397,14 @@ namespace LinqToDB.SqlProvider
 		/// Currently not supported only by Access.
 		/// </remarks>
 		/// </summary>
-		[DataMember(Order = 47), DefaultValue(true)]
+		[DataMember(Order = 46), DefaultValue(true)]
 		public bool IsMultiTablesSupportsJoins { get; set; } = true;
 
 		/// <summary>
 		/// Indicates that top level CTE query supports ORDER BY.
 		/// Default value: <c>true</c>.
 		/// </summary>
-		[DataMember(Order = 48), DefaultValue(true)]
+		[DataMember(Order = 47), DefaultValue(true)]
 		public bool IsCTESupportsOrdering { get; set; } = true;
 
 		/// <summary>
@@ -426,21 +420,21 @@ namespace LinqToDB.SqlProvider
 		/// As workaround translator is trying to check for nullability all projected fields.
 		/// Default value: <c>false</c>.
 		/// </summary>
-		[DataMember(Order =  49)]
+		[DataMember(Order =  48)]
 		public bool IsAccessBuggyLeftJoinConstantNullability { get; set; }
 
 		/// <summary>
 		/// Indicates that provider supports direct comparison of predicates.
 		/// Default value: <c>false</c>.
 		/// </summary>
-		[DataMember(Order = 50)]
+		[DataMember(Order = 49)]
 		public bool SupportsPredicatesComparison { get; set; }
 
 		/// <summary>
 		/// Indicates that boolean type could be used as predicate without additional conversions.
 		/// Default value: <c>true</c>.
 		/// </summary>
-		[DataMember(Order = 51), DefaultValue(true)]
+		[DataMember(Order = 50), DefaultValue(true)]
 		public bool SupportsBooleanType { get; set; } = true;
 
 		/// <summary>
@@ -454,42 +448,42 @@ namespace LinqToDB.SqlProvider
 		/// </code>.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
 		/// </summary>
-		[DataMember(Order = 52), DefaultValue(true)]
+		[DataMember(Order = 51), DefaultValue(true)]
 		public bool IsNestedJoinsSupported { get; set; } = true;
 
 		/// <summary>
 		/// Provider supports COUNT(DISTINCT column) function. Otherwise, it will be emulated.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
 		/// </summary>
-		[DataMember(Order = 53)]
+		[DataMember(Order = 52)]
 		public bool IsCountDistinctSupported { get; set; }
 
 		/// <summary>
 		/// Provider supports SUM/AVG/MIN/MAX(DISTINCT column) function. Otherwise, it will be emulated.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
 		/// </summary>
-		[DataMember(Order = 54)]
+		[DataMember(Order = 53)]
 		public bool IsAggregationDistinctSupported { get; set; }
 
 		/// <summary>
 		/// Provider supports SUM/AVG/MIN/MAX(DISTINCT column) function. Otherwise, it will be emulated.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>true</c>.
 		/// </summary>
-		[DataMember(Order = 55)]
+		[DataMember(Order = 54)]
 		public bool IsDerivedTableOrderBySupported { get; set; }
 
 		/// <summary>
 		/// Provider supports TAKE limit for UPDATE query.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
 		/// </summary>
-		[DataMember(Order = 56)]
+		[DataMember(Order = 55)]
 		public bool IsUpdateTakeSupported { get; set; }
 
 		/// <summary>
 		/// Provider supports SKIP+TAKE limit for UPDATE query.
 		/// Default (set by <see cref="DataProviderBase"/>): <c>false</c>.
 		/// </summary>
-		[DataMember(Order = 57)]
+		[DataMember(Order = 56)]
 		public bool IsUpdateSkipTakeSupported { get; set; }
 
 		/// <summary>
@@ -499,14 +493,14 @@ namespace LinqToDB.SqlProvider
 		/// <remarks>
 		/// Applied only to ClickHouse provider.
 		/// </remarks>
-		[DataMember(Order = 58)]
+		[DataMember(Order = 57)]
 		public bool IsSupportedSimpleCorrelatedSubqueries { get; set; }
 
 		/// <summary>
 		/// Provider supports correlated subqueris, but limited how deep in subquery outer reference
 		/// Default <c>null</c>. If this value is <c>0</c>c>, provider do not support correlated subqueries
 		/// </summary>
-		[DataMember(Order = 59)]
+		[DataMember(Order = 58)]
 		public int? SupportedCorrelatedSubqueriesLevel { get; set; }
 
 		/// <summary>
@@ -514,7 +508,7 @@ namespace LinqToDB.SqlProvider
 		/// This doesn't include emulation using INTERSECT.
 		/// Default <c>false</c>
 		/// </summary>
-		[DataMember(Order = 60)]
+		[DataMember(Order = 59)]
 		public bool IsDistinctFromSupported { get; set; }
 
 		/// <summary>
@@ -524,7 +518,7 @@ namespace LinqToDB.SqlProvider
 		/// <remarks>
 		/// Applied only to SqlCe provider.
 		/// </remarks>
-		[DataMember(Order = 61)]
+		[DataMember(Order = 60)]
 		public bool IsOrderByAggregateFunctionSupported { get; set; }
 
 		public bool GetAcceptsTakeAsParameterFlag(SelectQuery selectQuery)
@@ -554,7 +548,6 @@ namespace LinqToDB.SqlProvider
 			return IsParameterOrderDependent                           .GetHashCode()
 				^ AcceptsTakeAsParameter                               .GetHashCode()
 				^ AcceptsTakeAsParameterIfSkip                         .GetHashCode()
-				^ IsTakeSupported                                      .GetHashCode()
 				^ IsSkipSupported                                      .GetHashCode()
 				^ IsSkipSupportedIfTake                                .GetHashCode()
 				^ IsSubQueryTakeSupported                              .GetHashCode()
@@ -620,7 +613,6 @@ namespace LinqToDB.SqlProvider
 				&& IsParameterOrderDependent                             == other.IsParameterOrderDependent
 				&& AcceptsTakeAsParameter                                == other.AcceptsTakeAsParameter
 				&& AcceptsTakeAsParameterIfSkip                          == other.AcceptsTakeAsParameterIfSkip
-				&& IsTakeSupported                                       == other.IsTakeSupported
 				&& IsSkipSupported                                       == other.IsSkipSupported
 				&& IsSkipSupportedIfTake                                 == other.IsSkipSupportedIfTake
 				&& IsSubQueryTakeSupported                               == other.IsSubQueryTakeSupported


### PR DESCRIPTION
`IsTakeSupported` was probably a legacy provider flags that was used before.
Currently all providers have `IsTakeSupported = true`, even the few that don't support TOP/TAKE/FETCH such as Oracle 11.

I'm noting that we have 60 flags remaining, that's a lot of bool / bytes. It would fit into just 8 bytes (a `long`) if we stored them as a bitfield. That would also simplify serialization (numbering 60 `Datamember` is no fun) as well as `Equals` and `GetHashCode` implementations.

In fact `GetHashCode()` impl. is currently horrible: `bool.GetHashCode()` simply returns 1 or 0. So all those chained `^` xor just compute whether there's an odd or even number of true flags ☹️ 