### PR TITLE
Allow subclasses of QueryCompiler

### DIFF
--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFToolsImplDefault.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFToolsImplDefault.cs
@@ -607,7 +607,12 @@ namespace LinqToDB.EntityFrameworkCore
 			var compilerField = typeof (EntityQueryProvider).GetField("_queryCompiler", BindingFlags.NonPublic | BindingFlags.Instance)!;
 			var compiler = (QueryCompiler)compilerField.GetValue(query.Provider)!;
 
-			var queryContextFactoryField = compiler.GetType().GetField("_queryContextFactory", BindingFlags.NonPublic | BindingFlags.Instance)
+			// Allow subclasses of QueryCompiler. E.g. used by https://github.com/koenbeuk/EntityFrameworkCore.Projectables.
+			// In case we never find it in the class hierarchy, the GetField below will throw an exception.
+			var compilerType = compiler.GetType();
+			while (compilerType != typeof(QueryCompiler) && compilerType.BaseType is {} baseType) compilerType = baseType;
+
+			var queryContextFactoryField = compilerType.GetField("_queryContextFactory", BindingFlags.NonPublic | BindingFlags.Instance)
 				?? throw new LinqToDBForEFToolsException($"Can not find private field '{compiler.GetType()}._queryContextFactory' in current EFCore Version.");
 			if (queryContextFactoryField.GetValue(compiler) is not RelationalQueryContextFactory queryContextFactory)
 				throw new LinqToDBForEFToolsException("LinqToDB Tools for EFCore support only Relational Databases.");


### PR DESCRIPTION
Currently, the reflection code in `LinqToDBForEFToolsImplDefault. GetCurrentContext` fails if the compiler returned from `IQueryable. _queryCompiler` is a subclass of `QueryCompiler`.

This is e.g. the case when using [EntityFrameworkCore.Projectables](https://github.com/koenbeuk/EntityFrameworkCore.Projectables).

I'm too inexperienced with EF Core's internals to tell whether this is actually a valid use case or not, but it was a simple fix in the implementation, so I thought I'd propose this here.

Feel free to simply close this PR if this is not something that you'd like to support.