### PR TITLE
Fixed IsNotNull method misleading summary (Issue #4941)

### DIFF
--- a/Source/LinqToDB/Mapping/PropertyMappingBuilder.cs
+++ b/Source/LinqToDB/Mapping/PropertyMappingBuilder.cs
@@ -366,7 +366,7 @@ namespace LinqToDB.Mapping
 		}
 
 		/// <summary>
-		/// Sets whether a column can contain <c>NULL</c> values.
+		/// Sets the column as <c>NOT NULL</c>, disallowing any <c>NULL</c> values.
 		/// </summary>
 		/// <returns>Returns current column mapping builder.</returns>
 		public PropertyMappingBuilder<TEntity, TProperty> IsNotNull()


### PR DESCRIPTION
The summary tag for the IsNotNull() method was previously duplicating the description
used by IsNullable(), which was misleading. This change updates the documentation
to clearly state that IsNotNull() marks the column as NOT NULL, disallowing any NULL values.

See the [issue](https://github.com/linq2db/linq2db/issues/4941) for details