### PR TITLE
Fix configuration string tracing

### DIFF
--- a/Source/LinqToDB/Data/TraceInfo.cs
+++ b/Source/LinqToDB/Data/TraceInfo.cs
@@ -111,7 +111,10 @@ namespace LinqToDB.Data
 					using var sbv    = Pools.StringBuilder.Allocate();
 					var sb           = sbv.Value;
 
-					sb.Append("-- ").Append(DataConnection.ConfigurationString);
+					sb.Append("--");
+
+					if (DataConnection.ConfigurationString != null)
+						sb.Append(' ').Append(DataConnection.ConfigurationString);
 
 					if (DataConnection.ConfigurationString != DataConnection.DataProvider.Name)
 						sb.Append(' ').Append(DataConnection.DataProvider.Name);


### PR DESCRIPTION
Don't add space to trace when not necesary.
This space keeps reappearing in baselines making review a nightmare (e.g. here https://github.com/linq2db/linq2db.baselines/pull/1445 )