### PR TITLE
Fix mapping typing by constant

### DIFF
--- a/Build/Azure/scripts/pgsql18.sh
+++ b/Build/Azure/scripts/pgsql18.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker run -d --name pgsql -e POSTGRES_PASSWORD=Password12! -p 5432:5432 -v /var/run/postgresql:/var/run/postgresql postgres:18beta1
+docker run -d --name pgsql -e POSTGRES_PASSWORD=Password12! -p 5432:5432 -v /var/run/postgresql:/var/run/postgresql postgres:18beta2
 
 retries=0
 until docker exec pgsql psql -U postgres -c '\l' | grep -q 'testdata'; do

--- a/Data/Setup Scripts/pgsql18.cmd
+++ b/Data/Setup Scripts/pgsql18.cmd
@@ -5,8 +5,8 @@ docker stop pgsql18
 docker rm -f pgsql18
 
 REM use pull to get latest layers (run will use cached layers)
-docker pull postgres:18beta1
-docker run -d --name pgsql18 -e POSTGRES_PASSWORD=Password12! -p 5418:5432 -v /var/run/postgresql:/var/run/postgresql postgres:18beta1
+docker pull postgres:18beta2
+docker run -d --name pgsql18 -e POSTGRES_PASSWORD=Password12! -p 5418:5432 -v /var/run/postgresql:/var/run/postgresql postgres:18beta2
 
 call wait pgsql18 "server started"
 

--- a/Source/LinqToDB/Internal/DataProvider/Access/AccessSqlBuilderBase.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Access/AccessSqlBuilderBase.cs
@@ -252,10 +252,18 @@ namespace LinqToDB.Internal.DataProvider.Access
 		{
 			if (parameter.NeedsCast && BuildStep != Step.TypedExpression)
 			{
+				var paramValue = parameter.GetParameterValue(OptimizationContext.EvaluationContext.ParameterValues);
+
 				var saveStep = BuildStep;
 				BuildStep = Step.TypedExpression;
 
-				StringBuilder.Append("CVar(");
+				// 1. Single parameter loose precision when used with CVar
+				// 2. Only CVar accepts NULL
+				if (paramValue.ProviderValue != null && parameter.Type.DataType is DataType.Single)
+					StringBuilder.Append("CSng(");
+				else
+					StringBuilder.Append("CVar(");
+
 				base.BuildParameter(parameter);
 				StringBuilder.Append(')');
 				BuildStep = saveStep;

--- a/Source/LinqToDB/Internal/DataProvider/DB2/DB2MappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/DB2/DB2MappingSchema.cs
@@ -63,6 +63,7 @@ namespace LinqToDB.Internal.DataProvider.DB2
 			SetDataType(typeof(byte), new SqlDataType(DataType.Int16, typeof(byte)));
 			// in DB2 DECIMAL has 0 scale by default
 			SetDataType(typeof(decimal), new SqlDataType(DataType.Decimal, typeof(decimal), 18, 10));
+			SetDataType(typeof(ulong), new SqlDataType(DataType.Decimal, typeof(decimal), precision: 20, scale: 0));
 
 			SetValueToSqlConverter(typeof(Guid),     (sb, _,_,v) => ConvertBinaryToSql  (sb, ((Guid)v).ToByteArray()));
 			SetValueToSqlConverter(typeof(string),   (sb, _,_,v) => ConvertStringToSql  (sb, (string)v));

--- a/Source/LinqToDB/Internal/DataProvider/DB2/DB2MappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/DB2/DB2MappingSchema.cs
@@ -63,7 +63,7 @@ namespace LinqToDB.Internal.DataProvider.DB2
 			SetDataType(typeof(byte), new SqlDataType(DataType.Int16, typeof(byte)));
 			// in DB2 DECIMAL has 0 scale by default
 			SetDataType(typeof(decimal), new SqlDataType(DataType.Decimal, typeof(decimal), 18, 10));
-			SetDataType(typeof(ulong), new SqlDataType(DataType.Decimal, typeof(decimal), precision: 20, scale: 0));
+			SetDataType(typeof(ulong), new SqlDataType(DataType.Decimal, typeof(ulong), precision: 20, scale: 0));
 
 			SetValueToSqlConverter(typeof(Guid),     (sb, _,_,v) => ConvertBinaryToSql  (sb, ((Guid)v).ToByteArray()));
 			SetValueToSqlConverter(typeof(string),   (sb, _,_,v) => ConvertStringToSql  (sb, (string)v));

--- a/Source/LinqToDB/Internal/DataProvider/DB2/DB2SqlBuilderBase.cs
+++ b/Source/LinqToDB/Internal/DataProvider/DB2/DB2SqlBuilderBase.cs
@@ -434,10 +434,11 @@ END");
 				}
 				else if (paramValue.ProviderValue is decimal d)
 				{
-					if (dbDataType.Precision == null)
-						dbDataType = dbDataType.WithPrecision(DecimalHelper.GetPrecision(d));
-					if (dbDataType.Scale == null)
-						dbDataType = dbDataType.WithScale(DecimalHelper.GetScale(d));
+					var precision = DecimalHelper.GetPrecision(d);
+					var scale = DecimalHelper.GetScale(d);
+					if (precision == 0 && scale == 0)
+						precision = 1;
+					dbDataType = dbDataType.WithPrecision(precision).WithScale(scale);
 				}
 
 				if (dbDataType.Length > 32672)

--- a/Source/LinqToDB/Internal/DataProvider/DB2/DB2SqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/DataProvider/DB2/DB2SqlExpressionConvertVisitor.cs
@@ -79,16 +79,20 @@ namespace LinqToDB.Internal.DataProvider.DB2
 			var toType       = cast.ToType;
 			var argumentType = QueryHelper.GetDbDataType(cast.Expression, MappingSchema);
 
-			if (toType.SystemType == typeof(string) && argumentType.SystemType != typeof(string))
+			// type_func(null) is not allowed
+			if (argument is not SqlParameter p || !NullabilityContext.CanBeNull(p))
 			{
-				return new SqlFunction(cast.Type, "RTrim", new SqlFunction(MappingSchema.GetDbDataType(typeof(string)), "Char", argument));
+				if (toType.SystemType == typeof(string) && argumentType.SystemType != typeof(string))
+				{
+					return new SqlFunction(cast.Type, "RTrim", new SqlFunction(MappingSchema.GetDbDataType(typeof(string)), "Char", argument));
+				}
+
+				if (toType.Length > 0)
+					return new SqlFunction(cast.Type, toType.DataType.ToString(), argument, new SqlValue(toType.Length));
+
+				if (toType.Precision > 0)
+					return new SqlFunction(cast.Type, toType.DataType.ToString(), argument, new SqlValue(toType.Precision), new SqlValue(toType.Scale ?? 0));
 			}
-
-			if (toType.Length > 0)
-				return new SqlFunction(cast.Type, toType.DataType.ToString(), argument, new SqlValue(toType.Length));
-
-			if (toType.Precision > 0)
-				return new SqlFunction(cast.Type, toType.DataType.ToString(), argument, new SqlValue(toType.Precision), new SqlValue(toType.Scale ?? 0));
 
 			if (!cast.IsMandatory && QueryHelper.UnwrapNullablity(argument) is SqlParameter param)
 			{

--- a/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdMappingSchema.cs
@@ -31,6 +31,7 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 
 			SetDataType(typeof(string),  new SqlDataType(DataType.NVarChar, typeof(string), 255));
 			SetDataType(typeof(decimal), new SqlDataType(DataType.Decimal, typeof(decimal), 18, 10));
+			SetDataType(typeof(ulong), new SqlDataType(DataType.Decimal, typeof(ulong), precision: 20, scale: 0));
 
 			// firebird string literals can contain only limited set of characters, so we should encode them
 			SetValueToSqlConverter(typeof(string)  , (sb, _,o,v) => ConvertStringToSql (sb, o, (string)v));

--- a/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdSqlBuilder.Merge.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdSqlBuilder.Merge.cs
@@ -41,6 +41,14 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 					return rows[0][column] is SqlValue val && val.Value != null;
 				}
 
+				if (rows[0][column] is SqlValue
+					{
+						Value: uint or long or ulong or float or double or decimal or null
+					})
+				{
+					return true;
+				}
+
 				return false;
 			}
 

--- a/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdSqlBuilder.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdSqlBuilder.cs
@@ -731,6 +731,19 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 						precision = 1;
 					dataType = dataType.WithPrecision(precision).WithScale(scale);
 				}
+				else if (value is SqlParameter param)
+				{
+					var paramValue = param.GetParameterValue(OptimizationContext.EvaluationContext.ParameterValues);
+
+					if (paramValue.ProviderValue is decimal decValue)
+					{
+						var precision = DecimalHelper.GetPrecision(decValue);
+						var scale = DecimalHelper.GetScale(decValue);
+						if (precision == 0 && scale == 0)
+							precision = 1;
+						dataType = dataType.WithPrecision(precision).WithScale(scale);
+					}
+				}
 
 				base.BuildTypedExpression(dataType, value);
 			}

--- a/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdSqlBuilder.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdSqlBuilder.cs
@@ -285,10 +285,11 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 				}
 				else if (paramValue.ProviderValue is decimal d)
 				{
-					if (dbDataType.Precision == null)
-						dbDataType = dbDataType.WithPrecision(DecimalHelper.GetPrecision(d));
-					if (dbDataType.Scale == null)
-						dbDataType = dbDataType.WithScale(DecimalHelper.GetScale(d));
+					var precision = DecimalHelper.GetPrecision(d);
+					var scale = DecimalHelper.GetScale(d);
+					if (precision == 0 && scale == 0)
+						precision = 1;
+					dbDataType = dbDataType.WithPrecision(precision).WithScale(scale);
 				}
 
 				// TODO: temporary guard against cast to unknown type (Variant)
@@ -714,14 +715,25 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 
 				if (typeRequired)
 				{
-					if (dataType.DataType  == DataType.NChar)
+					if (dataType.DataType == DataType.NChar)
 						StringBuilder.Append(CultureInfo.InvariantCulture, $" AS CHAR({length}))");
 					else
 						StringBuilder.Append(CultureInfo.InvariantCulture, $" AS VARCHAR({length}))");
 				}
 			}
 			else
+			{
+				if (value is SqlValue { Value: decimal val })
+				{
+					var precision = DecimalHelper.GetPrecision(val);
+					var scale = DecimalHelper.GetScale(val);
+					if (precision == 0 && scale == 0)
+						precision = 1;
+					dataType = dataType.WithPrecision(precision).WithScale(scale);
+				}
+
 				base.BuildTypedExpression(dataType, value);
+			}
 		}
 	}
 }

--- a/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdSqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdSqlExpressionConvertVisitor.cs
@@ -206,5 +206,29 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 			}
 		}
 
+		protected override ISqlExpression WrapColumnExpression(ISqlExpression expr)
+		{
+			if (expr is SqlValue
+				{
+					Value: uint or long or ulong or float or double or decimal
+				} value)
+			{
+				expr = new SqlCastExpression(expr, value.ValueType, null, isMandatory: true);
+			}
+
+			if (expr is SqlParameter { IsQueryParameter: false } param)
+			{
+				var paramType = param.Type.SystemType.UnwrapNullableType();
+				if (paramType == typeof(uint)
+					|| paramType == typeof(long)
+					|| paramType == typeof(ulong)
+					|| paramType == typeof(float)
+					|| paramType == typeof(double)
+					|| paramType == typeof(decimal))
+					expr = new SqlCastExpression(expr, param.Type, null, isMandatory: true);
+			}
+
+			return base.WrapColumnExpression(expr);
+		}
 	}
 }

--- a/Source/LinqToDB/Internal/DataProvider/MySql/MySqlSqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/DataProvider/MySql/MySqlSqlExpressionConvertVisitor.cs
@@ -142,5 +142,22 @@ namespace LinqToDB.Internal.DataProvider.MySql
 					return base.ConvertSqlFunction(func);
 			}
 		}
+
+		protected override ISqlExpression WrapColumnExpression(ISqlExpression expr)
+		{
+			if (expr is SqlValue
+				{
+					Value: decimal
+				} value)
+			{
+				expr = new SqlCastExpression(expr, value.ValueType, null, isMandatory: true);
+			}
+			else if (expr is SqlParameter param && param.Type.SystemType.UnwrapNullableType() == typeof(decimal))
+			{
+				expr = new SqlCastExpression(expr, param.Type, null, isMandatory: true);
+			}
+
+			return base.WrapColumnExpression(expr);
+		}
 	}
 }

--- a/Source/LinqToDB/Internal/DataProvider/MySql/MySqlSqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/DataProvider/MySql/MySqlSqlExpressionConvertVisitor.cs
@@ -147,14 +147,20 @@ namespace LinqToDB.Internal.DataProvider.MySql
 		{
 			if (expr is SqlValue
 				{
-					Value: decimal
+					Value: decimal or uint or ulong or long or double
 				} value)
 			{
 				expr = new SqlCastExpression(expr, value.ValueType, null, isMandatory: true);
 			}
-			else if (expr is SqlParameter param && param.Type.SystemType.UnwrapNullableType() == typeof(decimal))
+			else if (expr is SqlParameter param)
 			{
-				expr = new SqlCastExpression(expr, param.Type, null, isMandatory: true);
+				var paramType = param.Type.SystemType.UnwrapNullableType();
+				if (paramType == typeof(uint)
+					|| paramType == typeof(ulong)
+					|| paramType == typeof(long)
+					|| paramType == typeof(double)
+					|| paramType == typeof(decimal))
+					expr = new SqlCastExpression(expr, param.Type, null, isMandatory: true);
 			}
 
 			return base.WrapColumnExpression(expr);

--- a/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLSqlBuilder.Merge.cs
+++ b/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLSqlBuilder.Merge.cs
@@ -15,6 +15,17 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 		protected override bool IsSqlValuesTableValueTypeRequired(SqlValuesTable source,
 			IReadOnlyList<List<ISqlExpression>>                                      rows, int row, int column)
 		{
+			if (row == 0)
+			{
+				if (rows[0][column] is SqlValue
+					{
+						Value: long or float or double or decimal
+					})
+				{
+					return true;
+				}
+			}
+
 			return row < 0
 				|| (row == 0
 					&& (

--- a/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLSqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLSqlExpressionConvertVisitor.cs
@@ -146,5 +146,30 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 			cast = FloorBeforeConvert(cast);
 			return base.ConvertConversion(cast);
 		}
+
+		protected override ISqlExpression WrapColumnExpression(ISqlExpression expr)
+		{
+			if (expr is SqlValue
+				{
+					Value: uint or long or ulong or float or double or decimal
+				} value)
+			{
+				expr = new SqlCastExpression(expr, value.ValueType, null, isMandatory: true);
+			}
+
+			if (expr is SqlParameter { IsQueryParameter: false } param)
+			{
+				var paramType = param.Type.SystemType.UnwrapNullableType();
+				if (paramType == typeof(uint)
+					|| paramType == typeof(long)
+					|| paramType == typeof(ulong)
+					|| paramType == typeof(float)
+					|| paramType == typeof(double)
+					|| paramType == typeof(decimal))
+					expr = new SqlCastExpression(expr, param.Type, null, isMandatory: true);
+			}
+
+			return base.WrapColumnExpression(expr);
+		}
 	}
 }

--- a/Source/LinqToDB/Internal/DataProvider/SapHana/SapHanaDataProvider.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SapHana/SapHanaDataProvider.cs
@@ -186,6 +186,11 @@ namespace LinqToDB.Internal.DataProvider.SapHana
 				parameter.DbType = DbType.Int64;
 				return;
 			}
+			if (dataType.DataType == DataType.UInt64)
+			{
+				parameter.DbType = DbType.Decimal;
+				return;
+			}
 
 			base.SetParameterType(dataConnection, parameter, dataType);
 		}

--- a/Source/LinqToDB/Internal/DataProvider/SapHana/SapHanaDataProvider.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SapHana/SapHanaDataProvider.cs
@@ -186,6 +186,7 @@ namespace LinqToDB.Internal.DataProvider.SapHana
 				parameter.DbType = DbType.Int64;
 				return;
 			}
+
 			if (dataType.DataType == DataType.UInt64)
 			{
 				parameter.DbType = DbType.Decimal;

--- a/Source/LinqToDB/Internal/DataProvider/SapHana/SapHanaSqlBuilder.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SapHana/SapHanaSqlBuilder.cs
@@ -306,7 +306,7 @@ namespace LinqToDB.Internal.DataProvider.SapHana
 			{
 				if (rows[0][column] is SqlValue
 					{
-						Value: uint or long or ulong or float or double or decimal// or null
+						Value: uint or long or ulong or float or double or decimal
 					})
 				{
 					return true;

--- a/Source/LinqToDB/Internal/DataProvider/SapHana/SapHanaSqlBuilder.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SapHana/SapHanaSqlBuilder.cs
@@ -299,5 +299,21 @@ namespace LinqToDB.Internal.DataProvider.SapHana
 
 			return base.GetProviderTypeName(dataContext, parameter);
 		}
+
+		protected override bool IsSqlValuesTableValueTypeRequired(SqlValuesTable source, IReadOnlyList<List<ISqlExpression>> rows, int row, int column)
+		{
+			if (row == 0)
+			{
+				if (rows[0][column] is SqlValue
+					{
+						Value: uint or long or ulong or float or double or decimal// or null
+					})
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
 	}
 }

--- a/Source/LinqToDB/Internal/DataProvider/SapHana/SapHanaSqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SapHana/SapHanaSqlExpressionConvertVisitor.cs
@@ -45,10 +45,5 @@ namespace LinqToDB.Internal.DataProvider.SapHana
 
 			return base.ConvertSqlBinaryExpression(element);
 		}
-
-		protected override ISqlExpression ConvertConversion(SqlCastExpression cast)
-		{
-			return base.ConvertConversion(cast);
-		}
 	}
 }

--- a/Source/LinqToDB/Internal/DataProvider/SapHana/SapHanaSqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SapHana/SapHanaSqlExpressionConvertVisitor.cs
@@ -1,4 +1,5 @@
-﻿using LinqToDB.Internal.SqlProvider;
+﻿using LinqToDB.Internal.Extensions;
+using LinqToDB.Internal.SqlProvider;
 using LinqToDB.Internal.SqlQuery;
 
 namespace LinqToDB.Internal.DataProvider.SapHana
@@ -44,6 +45,31 @@ namespace LinqToDB.Internal.DataProvider.SapHana
 			}
 
 			return base.ConvertSqlBinaryExpression(element);
+		}
+
+		protected override ISqlExpression WrapColumnExpression(ISqlExpression expr)
+		{
+			if (expr is SqlValue
+				{
+					Value: uint or long or ulong or float or double or decimal
+				} value)
+			{
+				expr = new SqlCastExpression(expr, value.ValueType, null, isMandatory: true);
+			}
+
+			if (expr is SqlParameter { IsQueryParameter: false } param)
+			{
+				var paramType = param.Type.SystemType.UnwrapNullableType();
+				if (paramType == typeof(uint)
+					|| paramType == typeof(long)
+					|| paramType == typeof(ulong)
+					|| paramType == typeof(float)
+					|| paramType == typeof(double)
+					|| paramType == typeof(decimal))
+				expr = new SqlCastExpression(expr, param.Type, null, isMandatory: true);
+			}
+
+			return base.WrapColumnExpression(expr);
 		}
 	}
 }

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/SqlServerSqlBuilder.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/SqlServerSqlBuilder.cs
@@ -521,6 +521,19 @@ namespace LinqToDB.Internal.DataProvider.SqlServer
 					precision = 1;
 				dataType = dataType.WithPrecision(precision).WithScale(scale);
 			}
+			else if (value is SqlParameter param)
+			{
+				var paramValue = param.GetParameterValue(OptimizationContext.EvaluationContext.ParameterValues);
+
+				if (paramValue.ProviderValue is decimal decValue)
+				{
+					var precision = DecimalHelper.GetPrecision(decValue);
+					var scale = DecimalHelper.GetScale(decValue);
+					if (precision == 0 && scale == 0)
+						precision = 1;
+					dataType = dataType.WithPrecision(precision).WithScale(scale);
+				}
+			}
 
 			base.BuildTypedExpression(dataType, value);
 		}

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/SqlServerSqlBuilder.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/SqlServerSqlBuilder.cs
@@ -510,5 +510,35 @@ namespace LinqToDB.Internal.DataProvider.SqlServer
 			if (statement.SqlQueryExtensions is not null)
 				BuildQueryExtensions(StringBuilder, statement.SqlQueryExtensions, "OPTION (", ", ", ")", Sql.QueryExtensionScope.QueryHint);
 		}
+
+		protected override void BuildTypedExpression(DbDataType dataType, ISqlExpression value)
+		{
+			if (value is SqlValue { Value: decimal val })
+			{
+				var precision = DecimalHelper.GetPrecision(val);
+				var scale = DecimalHelper.GetScale(val);
+				if (precision == 0 && scale == 0)
+					precision = 1;
+				dataType = dataType.WithPrecision(precision).WithScale(scale);
+			}
+
+			base.BuildTypedExpression(dataType, value);
+		}
+
+		protected override bool IsSqlValuesTableValueTypeRequired(SqlValuesTable source, IReadOnlyList<List<ISqlExpression>> rows, int row, int column)
+		{
+			if (row == 0)
+			{
+				if (rows[0][column] is SqlValue
+					{
+						Value: uint or long or ulong or float or double or decimal or null
+					})
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
 	}
 }

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/SqlServerSqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/SqlServerSqlExpressionConvertVisitor.cs
@@ -150,5 +150,29 @@ namespace LinqToDB.Internal.DataProvider.SqlServer
 			return base.ConvertSqlFunction(func);
 		}
 
+		protected override ISqlExpression WrapColumnExpression(ISqlExpression expr)
+		{
+			if (expr is SqlValue
+				{
+					Value: uint or long or ulong or float or double or decimal
+				} value)
+			{
+				expr = new SqlCastExpression(expr, value.ValueType, null, isMandatory: true);
+			}
+
+			if (expr is SqlParameter { IsQueryParameter: false } param)
+			{
+				var paramType = param.Type.SystemType.UnwrapNullableType();
+				if (paramType == typeof(uint)
+					|| paramType == typeof(long)
+					|| paramType == typeof(ulong)
+					|| paramType == typeof(float)
+					|| paramType == typeof(double)
+					|| paramType == typeof(decimal))
+					expr = new SqlCastExpression(expr, param.Type, null, isMandatory: true);
+			}
+
+			return base.WrapColumnExpression(expr);
+		}
 	}
 }

--- a/Source/LinqToDB/Internal/DataProvider/Sybase/SybaseSqlBuilder.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Sybase/SybaseSqlBuilder.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Text;
 
 using LinqToDB.DataProvider;
+using LinqToDB.Internal.Common;
 using LinqToDB.Internal.SqlProvider;
 using LinqToDB.Internal.SqlQuery;
 using LinqToDB.Mapping;
@@ -359,5 +360,35 @@ namespace LinqToDB.Internal.DataProvider.Sybase
 		}
 
 		protected override void BuildIsDistinctPredicate(SqlPredicate.IsDistinct expr) => BuildIsDistinctPredicateFallback(expr);
+
+		protected override bool IsSqlValuesTableValueTypeRequired(SqlValuesTable source, IReadOnlyList<List<ISqlExpression>> rows, int row, int column)
+		{
+			if (row == 0)
+			{
+				if (rows[0][column] is SqlValue
+					{
+						Value: uint or long or ulong or float or double or decimal or null
+					})
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		protected override void BuildTypedExpression(DbDataType dataType, ISqlExpression value)
+		{
+			if (value is SqlValue { Value: decimal val })
+			{
+				var precision = DecimalHelper.GetPrecision(val);
+				var scale = DecimalHelper.GetScale(val);
+				if (precision == 0 && scale == 0)
+					precision = 1;
+				dataType = dataType.WithPrecision(precision).WithScale(scale);
+			}
+
+			base.BuildTypedExpression(dataType, value);
+		}
 	}
 }

--- a/Source/LinqToDB/Internal/DataProvider/Sybase/SybaseSqlBuilder.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Sybase/SybaseSqlBuilder.cs
@@ -387,6 +387,19 @@ namespace LinqToDB.Internal.DataProvider.Sybase
 					precision = 1;
 				dataType = dataType.WithPrecision(precision).WithScale(scale);
 			}
+			else if (value is SqlParameter param)
+			{
+				var paramValue = param.GetParameterValue(OptimizationContext.EvaluationContext.ParameterValues);
+
+				if (paramValue.ProviderValue is decimal decValue)
+				{
+					var precision = DecimalHelper.GetPrecision(decValue);
+					var scale = DecimalHelper.GetScale(decValue);
+					if (precision == 0 && scale == 0)
+						precision = 1;
+					dataType = dataType.WithPrecision(precision).WithScale(scale);
+				}
+			}
 
 			base.BuildTypedExpression(dataType, value);
 		}

--- a/Source/LinqToDB/Internal/DataProvider/Sybase/SybaseSqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Sybase/SybaseSqlExpressionConvertVisitor.cs
@@ -92,8 +92,7 @@ namespace LinqToDB.Internal.DataProvider.Sybase
 			{
 				expr = new SqlCastExpression(expr, value.ValueType, null, isMandatory: true);
 			}
-
-			if (expr is SqlParameter param)
+			else if (expr is SqlParameter param)
 			{
 				var paramType = param.Type.SystemType.UnwrapNullableType();
 

--- a/Source/LinqToDB/Internal/DataProvider/Sybase/SybaseSqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Sybase/SybaseSqlExpressionConvertVisitor.cs
@@ -93,15 +93,25 @@ namespace LinqToDB.Internal.DataProvider.Sybase
 				expr = new SqlCastExpression(expr, value.ValueType, null, isMandatory: true);
 			}
 
-			if (expr is SqlParameter { IsQueryParameter: false } param)
+			if (expr is SqlParameter param)
 			{
 				var paramType = param.Type.SystemType.UnwrapNullableType();
-				if (paramType == typeof(uint)
-					|| paramType == typeof(long)
-					|| paramType == typeof(ulong)
-					|| paramType == typeof(float)
-					|| paramType == typeof(double)
-					|| paramType == typeof(decimal))
+
+				var wrap = paramType == typeof(uint)
+						|| paramType == typeof(long)
+						|| paramType == typeof(ulong)
+						|| paramType == typeof(float)
+						|| paramType == typeof(double)
+						|| paramType == typeof(decimal);
+
+				if (wrap && param.IsQueryParameter)
+				{
+					var paramValue = param.GetParameterValue(EvaluationContext.ParameterValues);
+
+					wrap = paramValue.ProviderValue == null;
+				}
+
+				if (wrap)
 					expr = new SqlCastExpression(expr, param.Type, null, isMandatory: true);
 			}
 

--- a/Tests/Linq/Linq/MappingTests.cs
+++ b/Tests/Linq/Linq/MappingTests.cs
@@ -11,6 +11,7 @@ using System.ServiceModel;
 using LinqToDB;
 using LinqToDB.Common;
 using LinqToDB.Data;
+using LinqToDB.Internal.Linq;
 using LinqToDB.Mapping;
 
 using NUnit.Framework;
@@ -1398,5 +1399,274 @@ namespace Tests.Linq
 
 			query.ToArray();
 		}
+
+		#region Issue 4955
+
+		record MappingTypingByConstant<T>(int Id, T Value);
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955")]
+		public void MappingTypingByConstant_FromEnumerable_Int64([DataSources(TestProvName.AllAccess)] string context, [Values(null, 1L)] long? first)
+		{
+			using var db = GetDataContext(context);
+
+			Query.ClearCaches();
+			Test(first);
+			Test(2147483648L);
+
+			void Test(long? value)
+			{
+				var res = db.Person
+					.InnerJoin(
+						new MappingTypingByConstant<long?>[] { new(1, value) }.AsQueryable(),
+						(entity, arg) => entity.ID == arg.Id,
+						(entity, arg) => new { arg.Id, arg.Value })
+					.ToArray();
+
+				Assert.That(res, Has.Length.EqualTo(1));
+				Assert.That(res[0].Value, Is.EqualTo(value));
+			}
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955")]
+		public void MappingTypingByConstant_FromQuery_Int64([DataSources(TestProvName.AllAccess)] string context, [Values] bool inline, [Values(null, 1L)] long? first)
+		{
+			using var db = GetDataContext(context);
+			db.InlineParameters = inline;
+
+			var value = first;
+			var query = db.Person.Select(r => new { Id = r.ID, Value = Sql.AsSql(value) }).AsSubQuery();
+			query.ClearCache();
+
+			var res = query.ToArray();
+			Assert.That(res, Has.Length.EqualTo(4));
+			Assert.That(res[0].Value, Is.EqualTo(value));
+
+			value = 2147483648L;
+
+			res = query.ToArray();
+			Assert.That(res, Has.Length.EqualTo(4));
+			Assert.That(res[0].Value, Is.EqualTo(value));
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955")]
+		public void MappingTypingByConstant_FromEnumerable_UInt64([DataSources(TestProvName.AllAccess)] string context, [Values(null, 1ul)] ulong? first)
+		{
+			using var db = GetDataContext(context);
+
+			Query.ClearCaches();
+			Test(first);
+			Test(2147483648ul);
+
+			void Test(ulong? value)
+			{
+				var res = db.Person
+					.InnerJoin(
+						new MappingTypingByConstant<ulong?>[] { new(1, Sql.AsSql(value)) }.AsQueryable(),
+						(entity, arg) => entity.ID == arg.Id,
+						(entity, arg) => new { arg.Id, arg.Value })
+					.ToArray();
+
+				Assert.That(res, Has.Length.EqualTo(1));
+				Assert.That(res[0].Value, Is.EqualTo(value));
+			}
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955")]
+		public void MappingTypingByConstant_FromQuery_UInt64([DataSources(TestProvName.AllAccess)] string context, [Values] bool inline, [Values(null, 1ul)] ulong? first)
+		{
+			using var db = GetDataContext(context);
+			db.InlineParameters = inline;
+
+			var value = first;
+			var query = db.Person.Select(r => new { Id = r.ID, Value = Sql.AsSql(value) }).AsSubQuery();
+			query.ClearCache();
+
+			var res = query.ToArray();
+			Assert.That(res, Has.Length.EqualTo(4));
+			Assert.That(res[0].Value, Is.EqualTo(value));
+
+			value = 2147483648ul;
+
+			res = query.ToArray();
+			Assert.That(res, Has.Length.EqualTo(4));
+			Assert.That(res[0].Value, Is.EqualTo(value));
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955")]
+		public void MappingTypingByConstant_FromEnumerable_UInt32([DataSources(TestProvName.AllAccess)] string context, [Values(null, 1u)] uint? first)
+		{
+			using var db = GetDataContext(context);
+
+			Query.ClearCaches();
+			Test(first);
+			Test(2147483648u);
+
+			void Test(uint? value)
+			{
+				var res = db.Person
+					.InnerJoin(
+						new MappingTypingByConstant<uint?>[] { new(1, value) }.AsQueryable(),
+						(entity, arg) => entity.ID == arg.Id,
+						(entity, arg) => new { arg.Id, arg.Value })
+					.ToArray();
+
+				Assert.That(res, Has.Length.EqualTo(1));
+				Assert.That(res[0].Value, Is.EqualTo(value));
+			}
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955")]
+		public void MappingTypingByConstant_FromQuery_UInt32([DataSources(TestProvName.AllAccess)] string context, [Values] bool inline, [Values(null, 1u)] uint? first)
+		{
+			using var db = GetDataContext(context);
+			db.InlineParameters = inline;
+
+			var value = first;
+			var query = db.Person.Select(r => new { Id = r.ID, Value = Sql.AsSql(value) }).AsSubQuery();
+			query.ClearCache();
+
+			var res = query.ToArray();
+			Assert.That(res, Has.Length.EqualTo(4));
+			Assert.That(res[0].Value, Is.EqualTo(value));
+
+			value = 2147483648u;
+
+			res = query.ToArray();
+			Assert.That(res, Has.Length.EqualTo(4));
+			Assert.That(res[0].Value, Is.EqualTo(value));
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955")]
+		public void MappingTypingByConstant_FromEnumerable_Decimal([DataSources(TestProvName.AllAccess)] string context, [Values] bool isNull)
+		{
+			using var db = GetDataContext(context);
+
+			Query.ClearCaches();
+			Test(isNull ? (decimal?)null : 1m);
+			Test(2147483648m);
+
+			void Test(decimal? value)
+			{
+				var res = db.Person
+					.InnerJoin(
+						new MappingTypingByConstant<decimal?>[] { new(1, value) }.AsQueryable(),
+						(entity, arg) => entity.ID == arg.Id,
+						(entity, arg) => new { arg.Id, arg.Value })
+					.ToArray();
+
+				Assert.That(res, Has.Length.EqualTo(1));
+				Assert.That(res[0].Value, Is.EqualTo(value));
+			}
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955")]
+		public void MappingTypingByConstant_FromQuery_Decimal([DataSources(TestProvName.AllAccess)] string context, [Values] bool inline, [Values] bool isNull)
+		{
+			using var db = GetDataContext(context);
+			db.InlineParameters = inline;
+
+			var value = isNull ? (decimal?)null : 1m;
+			var query = db.Person.Select(r => new { Id = r.ID, Value = Sql.AsSql(value) }).AsSubQuery();
+			query.ClearCache();
+
+			var res = query.ToArray();
+			Assert.That(res, Has.Length.EqualTo(4));
+			Assert.That(res[0].Value, Is.EqualTo(value));
+
+			value = 2147483648m;
+
+			res = query.ToArray();
+			Assert.That(res, Has.Length.EqualTo(4));
+			Assert.That(res[0].Value, Is.EqualTo(value));
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955")]
+		public void MappingTypingByConstant_FromEnumerable_Double([DataSources(TestProvName.AllAccess)] string context, [Values(null, 0D)] double? first)
+		{
+			using var db = GetDataContext(context);
+
+			Query.ClearCaches();
+			Test(first);
+			Test(3147483648D);
+
+			void Test(double? value)
+			{
+				var res = db.Person
+					.InnerJoin(
+						new MappingTypingByConstant<double?>[] { new(1, value) }.AsQueryable(),
+						(entity, arg) => entity.ID == arg.Id,
+						(entity, arg) => new { arg.Id, arg.Value })
+					.ToArray();
+
+				Assert.That(res, Has.Length.EqualTo(1));
+				Assert.That(res[0].Value, Is.EqualTo(value));
+			}
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955")]
+		public void MappingTypingByConstant_FromQuery_Double([DataSources] string context, [Values] bool inline, [Values(null, 0D)] double? first)
+		{
+			using var db = GetDataContext(context);
+			db.InlineParameters = inline;
+
+			var value = first;
+			var query = db.Person.Select(r => new { Id = r.ID, Value = Sql.AsSql(value) }).AsSubQuery();
+			query.ClearCache();
+
+			var res = query.ToArray();
+			Assert.That(res, Has.Length.EqualTo(4));
+			Assert.That(res[0].Value, Is.EqualTo(value));
+
+			value = 3147483648D;
+
+			res = query.ToArray();
+			Assert.That(res, Has.Length.EqualTo(4));
+			Assert.That(res[0].Value, Is.EqualTo(value));
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955")]
+		public void MappingTypingByConstant_FromEnumerable_Float([DataSources(TestProvName.AllAccess)] string context, [Values(null, 0F)] float? first)
+		{
+			using var db = GetDataContext(context);
+
+			Query.ClearCaches();
+			Test(first);
+			Test(3147483648F);
+
+			void Test(float? value)
+			{
+				var res = db.Person
+					.InnerJoin(
+						new MappingTypingByConstant<float?>[] { new(1, value) }.AsQueryable(),
+						(entity, arg) => entity.ID == arg.Id,
+						(entity, arg) => new { arg.Id, arg.Value })
+					.ToArray();
+
+				Assert.That(res, Has.Length.EqualTo(1));
+				Assert.That(res[0].Value, Is.EqualTo(value));
+			}
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955")]
+		public void MappingTypingByConstant_FromQuery_Float([DataSources] string context, [Values] bool inline, [Values(null, 0F)] float? first)
+		{
+			using var db = GetDataContext(context);
+			db.InlineParameters = inline;
+
+			var value = first;
+			var query = db.Person.Select(r => new { Id = r.ID, Value = Sql.AsSql(value) }).AsSubQuery();
+			query.ClearCache();
+
+			var res = query.ToArray();
+			Assert.That(res, Has.Length.EqualTo(4));
+			Assert.That(res[0].Value, Is.EqualTo(value));
+
+			value = 3147483648F;
+
+			res = query.ToArray();
+			Assert.That(res, Has.Length.EqualTo(4));
+			Assert.That(res[0].Value, Is.EqualTo(value));
+		}
+		#endregion
 	}
 }

--- a/Tests/Linq/Linq/MappingTests.cs
+++ b/Tests/Linq/Linq/MappingTests.cs
@@ -1404,6 +1404,7 @@ namespace Tests.Linq
 
 		record MappingTypingByConstant<T>(int Id, T Value);
 
+		[ActiveIssue("CAST to BIGINT doesn't work in MariaDB and MySQL 5.7", Configurations = [TestProvName.AllMariaDB, TestProvName.AllMySql57], SkipForLinqService = true)]
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955")]
 		public void MappingTypingByConstant_FromEnumerable_Int64([DataSources(TestProvName.AllAccess)] string context, [Values(null, 1L)] long? first)
 		{
@@ -1427,6 +1428,7 @@ namespace Tests.Linq
 			}
 		}
 
+		[ActiveIssue("CAST to BIGINT doesn't work in MariaDB", Configuration = TestProvName.AllMariaDB, SkipForLinqService = true)]
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955")]
 		public void MappingTypingByConstant_FromQuery_Int64([DataSources(TestProvName.AllAccess)] string context, [Values] bool inline, [Values(null, 1L)] long? first)
 		{

--- a/Tests/Linq/Linq/MappingTests.cs
+++ b/Tests/Linq/Linq/MappingTests.cs
@@ -1543,7 +1543,7 @@ namespace Tests.Linq
 
 			Query.ClearCaches();
 			Test(isNull ? (decimal?)null : 1m);
-			Test(2147483648m);
+			Test(2147483648.123m);
 
 			void Test(decimal? value)
 			{
@@ -1573,7 +1573,7 @@ namespace Tests.Linq
 			Assert.That(res, Has.Length.EqualTo(4));
 			Assert.That(res[0].Value, Is.EqualTo(value));
 
-			value = 2147483648m;
+			value = 2147483648.123m;
 
 			res = query.ToArray();
 			Assert.That(res, Has.Length.EqualTo(4));


### PR DESCRIPTION
Fix #4955

Problem: database/provider could infer wrong column type from literal or parameter for specific value resulting im mapping expression using wrong reader methods. When same query executed later with another value that is not compatible with generated reader - it fails during mapping.

Affects different databases in different way:
- for most of databases if for value we use literal of other type (e.g. for bigint generate int literal) - database infer not the type we expect
- for some databases/providers it also affects parameters, because they don't use type parameter information from parameter
- also it could affect NULL literal and/or null-valued parameters for some databases

Here we implement temporary fix (hopefully v7 will have new mapping subsystem that could handle it better) for numeric types as they main candidates, affected by this issue.


MySQL 5.7 and MariaDB cannot be fixed completely (MySQL 8+ works) as `CAST(x as SIGNED)` doesn't return BIGINT value despite documentation saying it
```sql
-- you can see it using following sql
create temporary table foo select CAST(1 as unsigned) as x

desc foo
```
