### PR TITLE
add INSERT query sql generation extension point before values clause (VALUES or SELECT)

### DIFF
--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -889,6 +889,10 @@ namespace LinqToDB.SqlProvider
 		{
 		}
 
+		protected virtual void BuildInsertValuesPrefix(SqlStatement statement, SqlInsertClause insertClause)
+		{
+		}
+
 		protected virtual void BuildOutputSubclause(SqlOutputClause? output)
 		{
 			if (output?.HasOutput == true)
@@ -998,6 +1002,8 @@ namespace LinqToDB.SqlProvider
 
 				BuildOutputSubclause(statement, insertClause);
 
+				BuildInsertValuesPrefix(statement, insertClause);
+
 				BuildEmptyInsert(insertClause);
 			}
 			else
@@ -1026,6 +1032,8 @@ namespace LinqToDB.SqlProvider
 				AppendIndent().AppendLine(")");
 
 				BuildOutputSubclause(statement, insertClause);
+
+				BuildInsertValuesPrefix(statement, insertClause);
 
 				if (statement.QueryType == QueryType.InsertOrUpdate ||
 					statement.QueryType == QueryType.MultiInsert ||

--- a/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/SqlProvider/BasicSqlBuilder.cs
@@ -889,7 +889,7 @@ namespace LinqToDB.SqlProvider
 		{
 		}
 
-		protected virtual void BuildInsertValuesPrefix(SqlStatement statement, SqlInsertClause insertClause)
+		protected virtual void BuildInsertValuesOverrideClause(SqlStatement statement, SqlInsertClause insertClause)
 		{
 		}
 
@@ -1002,7 +1002,7 @@ namespace LinqToDB.SqlProvider
 
 				BuildOutputSubclause(statement, insertClause);
 
-				BuildInsertValuesPrefix(statement, insertClause);
+				BuildInsertValuesOverrideClause(statement, insertClause);
 
 				BuildEmptyInsert(insertClause);
 			}
@@ -1033,7 +1033,7 @@ namespace LinqToDB.SqlProvider
 
 				BuildOutputSubclause(statement, insertClause);
 
-				BuildInsertValuesPrefix(statement, insertClause);
+				BuildInsertValuesOverrideClause(statement, insertClause);
 
 				if (statement.QueryType == QueryType.InsertOrUpdate ||
 					statement.QueryType == QueryType.MultiInsert ||


### PR DESCRIPTION
Fix #4973

Required for `OVERRIDING .. VALUE` clause generation (https://www.ibm.com/docs/en/i/7.6.0?topic=statements-insert) without copy-paste of base implementation.

