### PR TITLE
BulkCopy timeout fixes

### DIFF
--- a/Source/LinqToDB/Common/Configuration.cs
+++ b/Source/LinqToDB/Common/Configuration.cs
@@ -121,7 +121,7 @@ namespace LinqToDB.Common
 
 			/// <summary>
 			/// Controls behavior of bulk copy timeout if <see cref="BulkCopyOptions.BulkCopyTimeout"/> is not provided.
-			/// - if <c>true</c> - the current timeout on the <see cref="DataConnection"/> is used
+			/// - if <c>true</c> - the currently set command timeout on the <see cref="DataConnection"/> is used
 			/// - if <c>false</c> - command timeout is infinite.
 			/// Default value: <c>false</c>.
 			/// </summary>

--- a/Source/LinqToDB/Data/BulkCopyOptions.cs
+++ b/Source/LinqToDB/Data/BulkCopyOptions.cs
@@ -12,6 +12,16 @@ namespace LinqToDB.Data
 	/// </param>
 	/// <param name="BulkCopyTimeout">
 	/// Number of seconds for the operation to complete before it times out.
+	/// For native bulk copy this option works only for providers that support it:
+	/// <list type="bullet">
+	/// <item>DB2</item>
+	/// <item>Informix</item>
+	/// <item>MySql/MariaDB using MySqlConnector provider</item>
+	/// <item>Oracle</item>
+	/// <item>SAP HANA</item>
+	/// <item>SQL Server</item>
+	/// <item>SAP/Sybase ASE</item>
+	/// </list>
 	/// </param>
 	/// <param name="BulkCopyType">
 	/// Default bulk copy mode, used by <see cref="DataConnectionExtensions.BulkCopy{T}(DataConnection, IEnumerable{T})"/>

--- a/Source/LinqToDB/DataOptionsExtensions.cs
+++ b/Source/LinqToDB/DataOptionsExtensions.cs
@@ -895,7 +895,7 @@ namespace LinqToDB
 		#region DataContextOptions
 
 		/// <summary>
-		/// Command timeout or <c>null</c> for default timeout.
+		/// Command timeout in seconds or <c>null</c> for default timeout.
 		/// Default value: <c>null</c>.
 		/// </summary>
 		[Pure]
@@ -905,7 +905,7 @@ namespace LinqToDB
 		}
 
 		/// <summary>
-		/// Command timeout or <c>null</c> for default timeout.
+		/// Command timeout in seconds or <c>null</c> for default timeout.
 		/// Default value: <c>null</c>.
 		/// </summary>
 		[Pure]
@@ -1386,6 +1386,16 @@ namespace LinqToDB
 
 		/// <summary>
 		/// Number of seconds for the operation to complete before it times out.
+		/// For native bulk copy this option works only for providers that support it:
+		/// <list type="bullet">
+		/// <item>DB2</item>
+		/// <item>Informix</item>
+		/// <item>MySql/MariaDB using MySqlConnector provider</item>
+		/// <item>Oracle</item>
+		/// <item>SAP HANA</item>
+		/// <item>SQL Server</item>
+		/// <item>SAP/Sybase ASE</item>
+		/// </list>
 		/// </summary>
 		[Pure]
 		public static BulkCopyOptions WithBulkCopyTimeout(this BulkCopyOptions options, int? bulkCopyTimeout)
@@ -1585,6 +1595,16 @@ namespace LinqToDB
 
 		/// <summary>
 		/// Number of seconds for the operation to complete before it times out.
+		/// For native bulk copy this option works only for providers that support it:
+		/// <list type="bullet">
+		/// <item>DB2</item>
+		/// <item>Informix</item>
+		/// <item>MySql/MariaDB using MySqlConnector provider</item>
+		/// <item>Oracle</item>
+		/// <item>SAP HANA</item>
+		/// <item>SQL Server</item>
+		/// <item>SAP/Sybase ASE</item>
+		/// </list>
 		/// </summary>
 		[Pure]
 		public static DataOptions UseBulkCopyTimeout(this DataOptions options, int? bulkCopyTimeout)

--- a/Source/LinqToDB/Internal/DataProvider/DB2/DB2BulkCopyShared.cs
+++ b/Source/LinqToDB/Internal/DataProvider/DB2/DB2BulkCopyShared.cs
@@ -54,10 +54,8 @@ namespace LinqToDB.Internal.DataProvider.DB2
 					};
 				}
 
-				if (options.BulkCopyTimeout.HasValue)
-					bc.BulkCopyTimeout = options.BulkCopyTimeout.Value;
-				else if (LinqToDB.Common.Configuration.Data.BulkCopyUseConnectionCommandTimeout)
-					bc.BulkCopyTimeout = connection.ConnectionTimeout;
+				if (options.BulkCopyTimeout.HasValue || LinqToDB.Common.Configuration.Data.BulkCopyUseConnectionCommandTimeout)
+					bc.BulkCopyTimeout = options.BulkCopyTimeout ?? dataConnection.CommandTimeout;
 
 				bc.DestinationTableName = tableName;
 

--- a/Source/LinqToDB/Internal/DataProvider/Informix/InformixBulkCopy.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Informix/InformixBulkCopy.cs
@@ -164,10 +164,8 @@ namespace LinqToDB.Internal.DataProvider.Informix
 					};
 				}
 
-				if (options.BulkCopyTimeout.HasValue)
-					bc.BulkCopyTimeout = options.BulkCopyTimeout.Value;
-				else if (LinqToDB.Common.Configuration.Data.BulkCopyUseConnectionCommandTimeout)
-					bc.BulkCopyTimeout = connection.ConnectionTimeout;
+				if (options.BulkCopyTimeout.HasValue || LinqToDB.Common.Configuration.Data.BulkCopyUseConnectionCommandTimeout)
+					bc.BulkCopyTimeout = options.BulkCopyTimeout ?? dataConnection.CommandTimeout;
 
 				var tableName = GetTableName(sb, options, table);
 

--- a/Source/LinqToDB/Internal/DataProvider/MySql/MySqlBulkCopy.cs
+++ b/Source/LinqToDB/Internal/DataProvider/MySql/MySqlBulkCopy.cs
@@ -161,10 +161,8 @@ namespace LinqToDB.Internal.DataProvider.MySql
 				};
 			}
 
-			if (options.BulkCopyTimeout.HasValue)
-				bc.BulkCopyTimeout = options.BulkCopyTimeout.Value;
-			else if (LinqToDB.Common.Configuration.Data.BulkCopyUseConnectionCommandTimeout)
-				bc.BulkCopyTimeout = connection.ConnectionTimeout;
+			if (options.BulkCopyTimeout.HasValue || LinqToDB.Common.Configuration.Data.BulkCopyUseConnectionCommandTimeout)
+				bc.BulkCopyTimeout = options.BulkCopyTimeout ?? dataConnection.CommandTimeout;
 
 			var tableName = GetTableName(sb, options, table);
 
@@ -236,10 +234,8 @@ namespace LinqToDB.Internal.DataProvider.MySql
 				};
 			}
 
-			if (options.BulkCopyTimeout.HasValue)
-				bc.BulkCopyTimeout = options.BulkCopyTimeout.Value;
-			else if (LinqToDB.Common.Configuration.Data.BulkCopyUseConnectionCommandTimeout)
-				bc.BulkCopyTimeout = connection.ConnectionTimeout;
+			if (options.BulkCopyTimeout.HasValue || LinqToDB.Common.Configuration.Data.BulkCopyUseConnectionCommandTimeout)
+				bc.BulkCopyTimeout = options.BulkCopyTimeout ?? dataConnection.CommandTimeout;
 
 			var tableName = GetTableName(sb, options, table);
 
@@ -305,7 +301,8 @@ namespace LinqToDB.Internal.DataProvider.MySql
 				};
 			}
 
-			if (options.BulkCopyTimeout.HasValue) bc.BulkCopyTimeout = options.BulkCopyTimeout.Value;
+			if (options.BulkCopyTimeout.HasValue || LinqToDB.Common.Configuration.Data.BulkCopyUseConnectionCommandTimeout)
+				bc.BulkCopyTimeout = options.BulkCopyTimeout ?? dataConnection.CommandTimeout;
 
 			var tableName = GetTableName(sb, options, table);
 

--- a/Source/LinqToDB/Internal/DataProvider/Oracle/OracleBulkCopy.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Oracle/OracleBulkCopy.cs
@@ -103,7 +103,7 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 							opts.RowsCopiedCallback,
 							rc,
 							opts.MaxBatchSize,
-							opts.BulkCopyTimeout ?? (LinqToDB.Common.Configuration.Data.BulkCopyUseConnectionCommandTimeout ? connection.ConnectionTimeout : null)))
+							opts.BulkCopyTimeout ?? (LinqToDB.Common.Configuration.Data.BulkCopyUseConnectionCommandTimeout ? dataConnection.CommandTimeout : null)))
 						{
 							for (var i = 0; i < columns.Count; i++)
 								bc.AddColumn(i, columns[i]);

--- a/Source/LinqToDB/Internal/DataProvider/SapHana/SapHanaBulkCopy.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SapHana/SapHanaBulkCopy.cs
@@ -156,10 +156,8 @@ namespace LinqToDB.Internal.DataProvider.SapHana
 				if (options.MaxBatchSize.HasValue)
 					bc.BatchSize = options.MaxBatchSize.Value;
 
-				if (options.BulkCopyTimeout.HasValue)
-					bc.BulkCopyTimeout = options.BulkCopyTimeout.Value;
-				else if (LinqToDB.Common.Configuration.Data.BulkCopyUseConnectionCommandTimeout)
-					bc.BulkCopyTimeout = connection.ConnectionTimeout;
+				if (options.BulkCopyTimeout.HasValue || LinqToDB.Common.Configuration.Data.BulkCopyUseConnectionCommandTimeout)
+					bc.BulkCopyTimeout = options.BulkCopyTimeout ?? dataConnection.CommandTimeout;
 
 				var sqlBuilder = dataConnection.DataProvider.CreateSqlBuilder(table.DataContext.MappingSchema, dataConnection.Options);
 				var tableName  = GetTableName(sqlBuilder, options, table);
@@ -233,10 +231,8 @@ namespace LinqToDB.Internal.DataProvider.SapHana
 				if (options.MaxBatchSize.HasValue)
 					bc.BatchSize = options.MaxBatchSize.Value;
 
-				if (options.BulkCopyTimeout.HasValue)
-					bc.BulkCopyTimeout = options.BulkCopyTimeout.Value;
-				else if (LinqToDB.Common.Configuration.Data.BulkCopyUseConnectionCommandTimeout)
-					bc.BulkCopyTimeout = connection.ConnectionTimeout;
+				if (options.BulkCopyTimeout.HasValue || LinqToDB.Common.Configuration.Data.BulkCopyUseConnectionCommandTimeout)
+					bc.BulkCopyTimeout = options.BulkCopyTimeout ?? dataConnection.CommandTimeout;
 
 				var sqlBuilder = dataConnection.DataProvider.CreateSqlBuilder(table.DataContext.MappingSchema, dataConnection.Options);
 				var tableName  = GetTableName(sqlBuilder, options, table);

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/SqlServerBulkCopy.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/SqlServerBulkCopy.cs
@@ -175,10 +175,8 @@ namespace LinqToDB.Internal.DataProvider.SqlServer
 				if (options.MaxBatchSize.HasValue)
 					bc.BatchSize = options.MaxBatchSize.Value;
 
-				if (options.BulkCopyTimeout.HasValue)
-					bc.BulkCopyTimeout = options.BulkCopyTimeout.Value;
-				else if (LinqToDB.Common.Configuration.Data.BulkCopyUseConnectionCommandTimeout)
-					bc.BulkCopyTimeout = connection.ConnectionTimeout;
+				if (options.BulkCopyTimeout.HasValue || LinqToDB.Common.Configuration.Data.BulkCopyUseConnectionCommandTimeout)
+					bc.BulkCopyTimeout = options.BulkCopyTimeout ?? dataConnection.CommandTimeout;
 
 				var tableName = GetTableName(sb, options, table);
 
@@ -253,10 +251,8 @@ namespace LinqToDB.Internal.DataProvider.SqlServer
 				if (options.MaxBatchSize.HasValue)
 					bc.BatchSize = options.MaxBatchSize.Value;
 
-				if (options.BulkCopyTimeout.HasValue)
-					bc.BulkCopyTimeout = options.BulkCopyTimeout.Value;
-				else if (LinqToDB.Common.Configuration.Data.BulkCopyUseConnectionCommandTimeout)
-					bc.BulkCopyTimeout = connection.ConnectionTimeout;
+				if (options.BulkCopyTimeout.HasValue || LinqToDB.Common.Configuration.Data.BulkCopyUseConnectionCommandTimeout)
+					bc.BulkCopyTimeout = options.BulkCopyTimeout ?? dataConnection.CommandTimeout;
 
 				var tableName = GetTableName(sb, options, table);
 

--- a/Source/LinqToDB/Internal/DataProvider/Sybase/SybaseBulkCopy.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Sybase/SybaseBulkCopy.cs
@@ -184,10 +184,8 @@ namespace LinqToDB.Internal.DataProvider.Sybase
 				if (options.MaxBatchSize.HasValue)
 					bc.BatchSize = options.MaxBatchSize.Value;
 
-				if (options.BulkCopyTimeout.HasValue)
-					bc.BulkCopyTimeout = options.BulkCopyTimeout.Value;
-				else if (LinqToDB.Common.Configuration.Data.BulkCopyUseConnectionCommandTimeout)
-					bc.BulkCopyTimeout = connection.ConnectionTimeout;
+				if (options.BulkCopyTimeout.HasValue || LinqToDB.Common.Configuration.Data.BulkCopyUseConnectionCommandTimeout)
+					bc.BulkCopyTimeout = options.BulkCopyTimeout ?? dataConnection.CommandTimeout;
 
 				var tableName = GetTableName(sb, options, table);
 

--- a/Tests/Linq/Infrastructure/DataOptionsTests.cs
+++ b/Tests/Linq/Infrastructure/DataOptionsTests.cs
@@ -467,6 +467,123 @@ namespace Tests.Infrastructure
 				Assert.That(((IConfigurationID)db.Options).ConfigurationID, Is.EqualTo(optionsID));
 				Assert.That(((IConfigurationID)db).ConfigurationID,         Is.EqualTo(dbID));
 			}
+
+			db.CommandTimeout = 15;
+			using (Assert.EnterMultipleScope())
+			{
+				Assert.That(db.CommandTimeout, Is.EqualTo(15));
+				Assert.That(((IConfigurationID)db.Options).ConfigurationID, Is.EqualTo(optionsID));
+				Assert.That(((IConfigurationID)db).ConfigurationID, Is.EqualTo(dbID));
+			}
+
+			using (db.UseOptions<DataContextOptions>(o => o with { CommandTimeout = 25 }))
+			using (Assert.EnterMultipleScope())
+			{
+				Assert.That(db.CommandTimeout, Is.EqualTo(25));
+				Assert.That(((IConfigurationID)db.Options).ConfigurationID, Is.Not.EqualTo(optionsID));
+				Assert.That(((IConfigurationID)db).ConfigurationID, Is.Not.EqualTo(dbID));
+			}
+
+			using (Assert.EnterMultipleScope())
+			{
+				Assert.That(db.CommandTimeout, Is.EqualTo(15));
+				Assert.That(((IConfigurationID)db.Options).ConfigurationID, Is.EqualTo(optionsID));
+				Assert.That(((IConfigurationID)db).ConfigurationID, Is.EqualTo(dbID));
+			}
+
+			db.ResetCommandTimeout();
+			using (Assert.EnterMultipleScope())
+			{
+				Assert.That(db.CommandTimeout, Is.EqualTo(-1));
+				Assert.That(((IConfigurationID)db.Options).ConfigurationID, Is.EqualTo(optionsID));
+				Assert.That(((IConfigurationID)db).ConfigurationID, Is.EqualTo(dbID));
+			}
+
+			using (db.UseOptions<DataContextOptions>(o => o with { CommandTimeout = 35 }))
+			using (Assert.EnterMultipleScope())
+			{
+				Assert.That(db.CommandTimeout, Is.EqualTo(35));
+				Assert.That(((IConfigurationID)db.Options).ConfigurationID, Is.Not.EqualTo(optionsID));
+				Assert.That(((IConfigurationID)db).ConfigurationID, Is.Not.EqualTo(dbID));
+			}
+
+			using (Assert.EnterMultipleScope())
+			{
+				Assert.That(db.CommandTimeout, Is.EqualTo(-1));
+				Assert.That(((IConfigurationID)db.Options).ConfigurationID, Is.EqualTo(optionsID));
+				Assert.That(((IConfigurationID)db).ConfigurationID, Is.EqualTo(dbID));
+			}
+		}
+
+		[Test]
+		public void UseCommandTimeoutOnContextTest()
+		{
+			using var db = new DataContext(new DataOptions().UseCommandTimeout(30));
+
+			var commandTimeout = db.CommandTimeout;
+			var optionsID      = ((IConfigurationID)db.Options).ConfigurationID;
+			var dbID           = ((IConfigurationID)db).        ConfigurationID;
+
+			using (db.UseOptions<DataContextOptions>(o => o with { CommandTimeout = 45 }))
+			using (Assert.EnterMultipleScope())
+			{
+				Assert.That(db.CommandTimeout, Is.EqualTo(45));
+				Assert.That(((IConfigurationID)db.Options).ConfigurationID, Is.Not.EqualTo(optionsID));
+				Assert.That(((IConfigurationID)db).ConfigurationID, Is.Not.EqualTo(dbID));
+			}
+
+			using (Assert.EnterMultipleScope())
+			{
+				Assert.That(db.CommandTimeout, Is.EqualTo(commandTimeout));
+				Assert.That(((IConfigurationID)db.Options).ConfigurationID, Is.EqualTo(optionsID));
+				Assert.That(((IConfigurationID)db).ConfigurationID, Is.EqualTo(dbID));
+			}
+
+			db.CommandTimeout = 15;
+			using (Assert.EnterMultipleScope())
+			{
+				Assert.That(db.CommandTimeout, Is.EqualTo(15));
+				Assert.That(((IConfigurationID)db.Options).ConfigurationID, Is.EqualTo(optionsID));
+				Assert.That(((IConfigurationID)db).ConfigurationID, Is.EqualTo(dbID));
+			}
+
+			using (db.UseOptions<DataContextOptions>(o => o with { CommandTimeout = 25 }))
+			using (Assert.EnterMultipleScope())
+			{
+				Assert.That(db.CommandTimeout, Is.EqualTo(25));
+				Assert.That(((IConfigurationID)db.Options).ConfigurationID, Is.Not.EqualTo(optionsID));
+				Assert.That(((IConfigurationID)db).ConfigurationID, Is.Not.EqualTo(dbID));
+			}
+
+			using (Assert.EnterMultipleScope())
+			{
+				Assert.That(db.CommandTimeout, Is.EqualTo(15));
+				Assert.That(((IConfigurationID)db.Options).ConfigurationID, Is.EqualTo(optionsID));
+				Assert.That(((IConfigurationID)db).ConfigurationID, Is.EqualTo(dbID));
+			}
+
+			db.ResetCommandTimeout();
+			using (Assert.EnterMultipleScope())
+			{
+				Assert.That(db.CommandTimeout, Is.EqualTo(-1));
+				Assert.That(((IConfigurationID)db.Options).ConfigurationID, Is.EqualTo(optionsID));
+				Assert.That(((IConfigurationID)db).ConfigurationID, Is.EqualTo(dbID));
+			}
+
+			using (db.UseOptions<DataContextOptions>(o => o with { CommandTimeout = 35 }))
+			using (Assert.EnterMultipleScope())
+			{
+				Assert.That(db.CommandTimeout, Is.EqualTo(35));
+				Assert.That(((IConfigurationID)db.Options).ConfigurationID, Is.Not.EqualTo(optionsID));
+				Assert.That(((IConfigurationID)db).ConfigurationID, Is.Not.EqualTo(dbID));
+			}
+
+			using (Assert.EnterMultipleScope())
+			{
+				Assert.That(db.CommandTimeout, Is.EqualTo(-1));
+				Assert.That(((IConfigurationID)db.Options).ConfigurationID, Is.EqualTo(optionsID));
+				Assert.That(((IConfigurationID)db).ConfigurationID, Is.EqualTo(dbID));
+			}
 		}
 
 		[Test]


### PR DESCRIPTION
- fix BulkCopyUseConnectionCommandTimeout option implementation to use command timeout instead of connection timeout as it was intended to do
- add missing BulkCopyUseConnectionCommandTimeout handing to mysql bulk copy
- update xml-docs for BulkCopyTimeout option to specify which providers support it for native bulk copy
- update xml-docs to mention that timeouts are in seconds where it was missing
- update tests to ensure manually set timeout not lost after scoped changes to context options