### PR TITLE
Update RetryPolicy.ExponentialBase range validation

### DIFF
--- a/Source/LinqToDB/Common/Configuration.cs
+++ b/Source/LinqToDB/Common/Configuration.cs
@@ -507,7 +507,7 @@ namespace LinqToDB.Common
 			}
 
 			/// <summary>
-			/// The default base for the exponential function used to compute the delay between retries, must be positive.
+			/// The default base for the exponential function used to compute the delay between retries, must not be lesser than 1.
 			/// Default value: <c>2</c>.
 			/// </summary>
 			public static double DefaultExponentialBase

--- a/Source/LinqToDB/Data/RetryPolicy/RetryPolicyBase.cs
+++ b/Source/LinqToDB/Data/RetryPolicy/RetryPolicyBase.cs
@@ -29,7 +29,7 @@ namespace LinqToDB.Data.RetryPolicy
 				throw new ArgumentOutOfRangeException(nameof(maxRetryDelay));
 			if (randomFactor < 1.0)
 				throw new ArgumentOutOfRangeException(nameof(randomFactor));
-			if (exponentialBase <= 0.0)
+			if (exponentialBase < 1.0)
 				throw new ArgumentOutOfRangeException(nameof(exponentialBase));
 			if (coefficient.TotalMilliseconds < 0.0)
 				throw new ArgumentOutOfRangeException(nameof(coefficient));
@@ -50,7 +50,7 @@ namespace LinqToDB.Data.RetryPolicy
 		public double   RandomFactor    { get; }
 
 		/// <summary>
-		/// The base for the exponential function used to compute the delay between retries, must be positive.
+		/// The base for the exponential function used to compute the delay between retries, must not be lesser than 1.
 		/// </summary>
 		public double   ExponentialBase { get; }
 

--- a/Source/LinqToDB/Data/RetryPolicy/RetryPolicyOptions.cs
+++ b/Source/LinqToDB/Data/RetryPolicy/RetryPolicyOptions.cs
@@ -22,7 +22,7 @@ namespace LinqToDB.Data.RetryPolicy
 	/// The maximum random factor, must not be lesser than 1.
 	/// </param>
 	/// <param name="ExponentialBase">
-	/// The base for the exponential function used to compute the delay between retries, must be positive.
+	/// The base for the exponential function used to compute the delay between retries, must not be lesser than 1.
 	/// </param>
 	/// <param name="Coefficient">
 	/// The coefficient for the exponential function used to compute the delay between retries, must be nonnegative.

--- a/Source/LinqToDB/DataOptionsExtensions.cs
+++ b/Source/LinqToDB/DataOptionsExtensions.cs
@@ -1268,7 +1268,7 @@ namespace LinqToDB
 		}
 
 		/// <summary>
-		/// The base for the exponential function used to compute the delay between retries, must be positive.
+		/// The base for the exponential function used to compute the delay between retries, must not be lesser than 1.
 		/// Default value: <c>2</c>.
 		/// </summary>
 		[Pure]
@@ -1351,7 +1351,7 @@ namespace LinqToDB
 		}
 
 		/// <summary>
-		/// The base for the exponential function used to compute the delay between retries, must be positive.
+		/// The base for the exponential function used to compute the delay between retries, must not be lesser than 1.
 		/// Default value: <c>2</c>.
 		/// </summary>
 		[Pure]


### PR DESCRIPTION
Fix #4913

ExponentialBase value shouldn't be less that 1, but we validate it being positive.
It's copy-paste error from efcore. EFCore code still have incorrect range in documentation, but it is not an issue for them because they don't allow users to configure this option (no idea why we allow).