### PR TITLE
Update versioning

### DIFF
--- a/Build/Azure/pipelines/templates/build-vars.yml
+++ b/Build/Azure/pipelines/templates/build-vars.yml
@@ -32,10 +32,10 @@ variables:
   ef8AssemblyVersion: 8.2.0
   ef9AssemblyVersion: 9.1.0
   ${{ if eq(variables['Build.SourceBranchName'], 'release') }}:
-    packageVersion: 6.0.0-rc.2
-    ef3PackageVersion: 3.28.0-rc.2
-    ef8PackageVersion: 8.2.0-rc.2
-    ef9PackageVersion: 9.1.0-rc.2
+    packageVersion: 6.0.0-rc.3
+    ef3PackageVersion: 3.28.0-rc.3
+    ef8PackageVersion: 8.2.0-rc.3
+    ef9PackageVersion: 9.1.0-rc.3
   ${{ if ne(variables['Build.SourceBranchName'], 'release') }}:
     packageVersion: 6.0.0
     ef3PackageVersion: 3.28.0

--- a/Build/Azure/pipelines/templates/nuget-job.yml
+++ b/Build/Azure/pipelines/templates/nuget-job.yml
@@ -11,19 +11,19 @@ jobs:
 
   steps:
 
-  - powershell: echo "##vso[task.setvariable variable=packageVersion]$(packageVersion)-rc.$(Build.BuildId)"
+  - powershell: echo "##vso[task.setvariable variable=packageVersion]$(packageVersion)-dev.$(Build.BuildId)"
     condition: ne(variables['Build.SourceBranchName'], variables['release_branch'])
     displayName: Update nuget version
 
-  - powershell: echo "##vso[task.setvariable variable=ef3PackageVersion]$(ef3PackageVersion)-rc.$(Build.BuildId)"
+  - powershell: echo "##vso[task.setvariable variable=ef3PackageVersion]$(ef3PackageVersion)-dev.$(Build.BuildId)"
     condition: ne(variables['Build.SourceBranchName'], variables['release_branch'])
     displayName: Update nuget version
 
-  - powershell: echo "##vso[task.setvariable variable=ef8PackageVersion]$(ef8PackageVersion)-rc.$(Build.BuildId)"
+  - powershell: echo "##vso[task.setvariable variable=ef8PackageVersion]$(ef8PackageVersion)-dev.$(Build.BuildId)"
     condition: ne(variables['Build.SourceBranchName'], variables['release_branch'])
     displayName: Update nuget version
 
-  - powershell: echo "##vso[task.setvariable variable=ef9PackageVersion]$(ef9PackageVersion)-rc.$(Build.BuildId)"
+  - powershell: echo "##vso[task.setvariable variable=ef9PackageVersion]$(ef9PackageVersion)-dev.$(Build.BuildId)"
     condition: ne(variables['Build.SourceBranchName'], variables['release_branch'])
     displayName: Update nuget version
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
 	over dependencies like linq2db.cli
 	-->
 	<ItemGroup Label="Build: Analyzers and Tools">
-		<PackageVersion Include="Meziantou.Analyzer"                                    Version="2.0.208"                      />
+		<PackageVersion Include="Meziantou.Analyzer"                                    Version="2.0.210"                      />
 		<PackageVersion Include="Meziantou.Polyfill"                                    Version="1.0.49"                       />
 		<PackageVersion Include="Microsoft.CodeAnalysis.Analyzers"                      Version="5.0.0-1.25277.114"            />
 		<PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers"             Version="5.0.0-1.25277.114"            />
@@ -35,7 +35,7 @@
 		<PackageVersion Include="Microsoft.Extensions.DependencyModel"                  Version="9.0.7"                        />
 		<PackageVersion Include="Mono.TextTemplating"                                   Version="3.0.0"                        />
 		<PackageVersion Include="protobuf-net.Grpc"                                     Version="1.2.2"                        />
-		<PackageVersion Include="protobuf-net"                                          Version="3.2.55"                       />
+		<PackageVersion Include="protobuf-net"                                          Version="3.2.56"                       />
 
 		<PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"              Version="3.1.0"                        Condition="'$(TargetFramework)'=='netstandard2.0'" />
 		<PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"              Version="8.0.0"                        Condition="'$(TargetFramework)'=='net8.0'"         />
@@ -50,7 +50,7 @@
 	<ItemGroup Label="Database Providers">
 		<PackageVersion Include="AdoNetCore.AseClient"                                  Version="0.19.3-beta.1"                />
 		<PackageVersion Include="ClickHouse.Client"                                     Version="7.14.0"                       />
-		<PackageVersion Include="Devart.Data.Oracle"                                    Version="10.4.235"                     />
+		<PackageVersion Include="Devart.Data.Oracle"                                    Version="10.4.290"                     />
 		<PackageVersion Include="dotMorten.Microsoft.SqlServer.Types"                   Version="1.5.0"                        />
 		<!--<PackageVersion Include="dotMorten.Microsoft.SqlServer.Types"                   Version="2.5.0"                 />-->
 		<PackageVersion Include="FirebirdSql.Data.FirebirdClient"                       Version="10.3.3"                       />
@@ -141,7 +141,7 @@
 	</ItemGroup>
 
 	<ItemGroup Label="Examples">
-		<PackageVersion Include="linq2db.t4models"                                      Version="6.0.0-rc.1"                   />
+		<PackageVersion Include="linq2db.t4models"                                      Version="6.0.0-rc.2"                   />
 		<PackageVersion Include="Microsoft.Extensions.ObjectPool"                       Version="9.0.7"                        />
 		<PackageVersion Include="OpenTelemetry"                                         Version="1.12.0"                       />
 		<PackageVersion Include="OpenTelemetry.Exporter.Console"                        Version="1.12.0"                       />

--- a/NuGet/linq2db.Remote.Grpc.nuspec
+++ b/NuGet/linq2db.Remote.Grpc.nuspec
@@ -10,25 +10,25 @@
 				<dependency id="linq2db"           version="6.0.0"  />
 				<dependency id="Grpc.Net.Client"   version="2.71.0" />
 				<dependency id="protobuf-net.Grpc" version="1.2.2"  />
-				<dependency id="protobuf-net"      version="3.2.55" />
+				<dependency id="protobuf-net"      version="3.2.56" />
 			</group>
 			<group targetFramework="netstandard2.0">
 				<dependency id="linq2db"           version="6.0.0"  />
 				<dependency id="Grpc.Net.Client"   version="2.71.0" />
 				<dependency id="protobuf-net.Grpc" version="1.2.2"  />
-				<dependency id="protobuf-net"      version="3.2.55" />
+				<dependency id="protobuf-net"      version="3.2.56" />
 			</group>
 			<group targetFramework="net8.0">
 				<dependency id="linq2db"           version="6.0.0"  />
 				<dependency id="Grpc.Net.Client"   version="2.71.0" />
 				<dependency id="protobuf-net.Grpc" version="1.2.2"  />
-				<dependency id="protobuf-net"      version="3.2.55" />
+				<dependency id="protobuf-net"      version="3.2.56" />
 			</group>
 			<group targetFramework="net9.0">
 				<dependency id="linq2db"           version="6.0.0"  />
 				<dependency id="Grpc.Net.Client"   version="2.71.0" />
 				<dependency id="protobuf-net.Grpc" version="1.2.2"  />
-				<dependency id="protobuf-net"      version="3.2.55" />
+				<dependency id="protobuf-net"      version="3.2.56" />
 			</group>
 		</dependencies>
 	</metadata>


### PR DESCRIPTION
Dev build versions will use `-dev` suffix to not conflict with `-rc` from nuget.org

- bump version
- rebrand dev builds
- bump deps