### PR TITLE
Disabled wrong optimization code.

### DIFF
--- a/Source/LinqToDB/Internal/SqlProvider/SqlExpressionOptimizerVisitor.cs
+++ b/Source/LinqToDB/Internal/SqlProvider/SqlExpressionOptimizerVisitor.cs
@@ -631,6 +631,8 @@ namespace LinqToDB.Internal.SqlProvider
 			if (!ReferenceEquals(newElement, element))
 				return Visit(newElement);
 
+			/* TODO: it is buggy.
+
 			// Optimizations: PREDICATE vs (GROUP)
 			// 1. A OR (A AND B) => A
 			// 2. A AND (A OR B) => A
@@ -639,6 +641,8 @@ namespace LinqToDB.Internal.SqlProvider
 			newElement = OptimizeSimilarForSinglePredicate(element);
 			if (!ReferenceEquals(newElement, element))
 				return Visit(newElement);
+
+			*/
 
 			return element;
 		}

--- a/Tests/Linq/Linq/WhereTests.cs
+++ b/Tests/Linq/Linq/WhereTests.cs
@@ -2549,5 +2549,30 @@ namespace Tests.Linq
 							&& ((p4 <= p.ID && p.ID <= p4) || (p4 <= p.ID && p.ID <= p4))))
 				.ToArray();
 		}
+
+		[Test]
+		public void PredicateOptimization_SimilarInSearch1([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var noPersons = db.Person.Where(x => x.ID > 3 && (x.FirstName == "John" || x.FirstName == "Jane"));
+			var specificNoPersons = noPersons.Where(x => x.FirstName == "Jane");
+
+			AssertQuery(specificNoPersons);
+			AssertQuery(noPersons);
+		}
+
+		[Test]
+		public void PredicateOptimization_SimilarInSearch2([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var noPersons         = db.Person.Where(x => (x.FirstName == "John" || x.FirstName == "Jane") && x.ID > 3);
+			var specificNoPersons = noPersons.Where(x => x.FirstName == "Jane");
+
+			AssertQuery(specificNoPersons);
+			AssertQuery(noPersons);
+		}
+
 	}
 }


### PR DESCRIPTION
**Critical**

Optmizer may wrong optimize
```sql
x.Prop = 3 AND (x.Value = "A" OR x.Value = "B") AND x.Value = "A"
```
to
```sql
x.Value = "A"
```
