### PR TITLE
Obsolete IDataContext.CloseAfterUse property

### DIFF
--- a/Source/LinqToDB/Data/DataConnection.Linq.cs
+++ b/Source/LinqToDB/Data/DataConnection.Linq.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Data.Common;
 using System.Linq.Expressions;
 
@@ -22,6 +23,7 @@ namespace LinqToDB.Data
 		TableOptions     IDataContext.SupportedTableOptions => DataProvider.SupportedTableOptions;
 		Type             IDataContext.DataReaderType        => DataProvider.DataReaderType;
 
+		[Obsolete("This API will be removed in version 7. Use DataContext with SetKeepConnectionAlive[Async] instead."), EditorBrowsable(EditorBrowsableState.Never)]
 		bool             IDataContext.CloseAfterUse    { get; set; }
 
 		Expression IDataContext.GetReaderExpression(DbDataReader reader, int idx, Expression readerExpression, Type toType)

--- a/Source/LinqToDB/Data/DataReaderWrapper.cs
+++ b/Source/LinqToDB/Data/DataReaderWrapper.cs
@@ -63,8 +63,10 @@ namespace LinqToDB.Data
 				_dataConnection!.DataProvider.DisposeCommand(Command);
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (((IDataContext?)_dataConnection)?.CloseAfterUse == true)
 				_dataConnection.Close();
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		public async ValueTask DisposeAsync()
@@ -93,8 +95,10 @@ namespace LinqToDB.Data
 				await _dataConnection!.DataProvider.DisposeCommandAsync(Command).ConfigureAwait(false);
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (((IDataContext?)_dataConnection)?.CloseAfterUse == true)
 				await _dataConnection.CloseAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 	}
 }

--- a/Source/LinqToDB/DataContext.cs
+++ b/Source/LinqToDB/DataContext.cs
@@ -287,6 +287,7 @@ namespace LinqToDB
 		/// <summary>
 		/// Gets or sets flag to close context after query execution or leave it open.
 		/// </summary>
+		[Obsolete("This API will be removed in version 7. Use SetKeepConnectionAlive[Async] instead."), EditorBrowsable(EditorBrowsableState.Never)]
 		public bool CloseAfterUse { get; set; }
 
 		/// <summary>

--- a/Source/LinqToDB/IDataContext.cs
+++ b/Source/LinqToDB/IDataContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Data.Common;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
@@ -65,6 +66,7 @@ namespace LinqToDB
 		/// <summary>
 		/// Gets or sets flag to close context after query execution or leave it open.
 		/// </summary>
+		[Obsolete("This API will be removed in version 7. Use DataContext with SetKeepConnectionAlive[Async] instead."), EditorBrowsable(EditorBrowsableState.Never)]
 		bool                CloseAfterUse         { get; set; }
 
 		/// <summary>

--- a/Source/LinqToDB/Internal/DataProvider/BasicBulkCopy.cs
+++ b/Source/LinqToDB/Internal/DataProvider/BasicBulkCopy.cs
@@ -380,8 +380,10 @@ namespace LinqToDB.Internal.DataProvider
 
 					if (!helper.Execute())
 					{
+#pragma warning disable CS0618 // Type or member is obsolete
 						if (!helper.SuppressCloseAfterUse && helper.OriginalContext.CloseAfterUse)
 							helper.OriginalContext.Close();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 						return helper.RowsCopied;
 					}
@@ -399,8 +401,10 @@ namespace LinqToDB.Internal.DataProvider
 				helper.Execute();
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (!helper.SuppressCloseAfterUse && helper.OriginalContext.CloseAfterUse)
 				helper.OriginalContext.Close();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return helper.RowsCopied;
 		}
@@ -443,8 +447,10 @@ namespace LinqToDB.Internal.DataProvider
 					finishFunction(helper);
 					if (!await helper.ExecuteAsync(cancellationToken).ConfigureAwait(false))
 					{
+#pragma warning disable CS0618 // Type or member is obsolete
 						if (!helper.SuppressCloseAfterUse && helper.OriginalContext.CloseAfterUse)
 							await helper.OriginalContext.CloseAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 						return helper.RowsCopied;
 					}
@@ -462,8 +468,10 @@ namespace LinqToDB.Internal.DataProvider
 				await helper.ExecuteAsync(cancellationToken).ConfigureAwait(false);
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (!helper.SuppressCloseAfterUse && helper.OriginalContext.CloseAfterUse)
 				await helper.OriginalContext.CloseAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return helper.RowsCopied;
 		}
@@ -506,8 +514,10 @@ namespace LinqToDB.Internal.DataProvider
 					finishFunction(helper);
 					if (!await helper.ExecuteAsync(cancellationToken).ConfigureAwait(false))
 					{
+#pragma warning disable CS0618 // Type or member is obsolete
 						if (!helper.SuppressCloseAfterUse && helper.OriginalContext.CloseAfterUse)
 							await helper.OriginalContext.CloseAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 						return helper.RowsCopied;
 					}
@@ -525,8 +535,10 @@ namespace LinqToDB.Internal.DataProvider
 				await helper.ExecuteAsync(cancellationToken).ConfigureAwait(false);
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (!helper.SuppressCloseAfterUse && helper.OriginalContext.CloseAfterUse)
 				await helper.OriginalContext.CloseAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return helper.RowsCopied;
 		}

--- a/Source/LinqToDB/Internal/DataProvider/ClickHouse/ClickHouseBulkCopy.cs
+++ b/Source/LinqToDB/Internal/DataProvider/ClickHouse/ClickHouseBulkCopy.cs
@@ -232,8 +232,10 @@ namespace LinqToDB.Internal.DataProvider.ClickHouse
 					options.RowsCopiedCallback(rc);
 					if (rc.Abort)
 					{
+#pragma warning disable CS0618 // Type or member is obsolete
 						if (table.DataContext.CloseAfterUse)
 							table.DataContext.Close();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 						return rc;
 					}
@@ -247,8 +249,10 @@ namespace LinqToDB.Internal.DataProvider.ClickHouse
 			if (options.NotifyAfter != 0 && options.RowsCopiedCallback != null)
 				options.RowsCopiedCallback(rc);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (table.DataContext.CloseAfterUse)
 				table.DataContext.Close();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return rc;
 		}
@@ -346,8 +350,10 @@ namespace LinqToDB.Internal.DataProvider.ClickHouse
 						options.RowsCopiedCallback(rc);
 						if (rc.Abort)
 						{
+#pragma warning disable CS0618 // Type or member is obsolete
 							if (table.DataContext.CloseAfterUse)
 								await table.DataContext.CloseAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 							return rc;
 						}
@@ -361,8 +367,10 @@ namespace LinqToDB.Internal.DataProvider.ClickHouse
 				if (options.NotifyAfter != 0 && options.RowsCopiedCallback != null)
 					options.RowsCopiedCallback(rc);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				if (table.DataContext.CloseAfterUse)
 					await table.DataContext.CloseAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				return rc;
 			}
@@ -464,8 +472,10 @@ namespace LinqToDB.Internal.DataProvider.ClickHouse
 						options.RowsCopiedCallback(rc);
 						if (rc.Abort)
 						{
+#pragma warning disable CS0618 // Type or member is obsolete
 							if (table.DataContext.CloseAfterUse)
 								await table.DataContext.CloseAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 							return rc;
 						}
@@ -479,8 +489,10 @@ namespace LinqToDB.Internal.DataProvider.ClickHouse
 				if (options.NotifyAfter != 0 && options.RowsCopiedCallback != null)
 					options.RowsCopiedCallback(rc);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				if (table.DataContext.CloseAfterUse)
 					await table.DataContext.CloseAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				return rc;
 			}
@@ -583,8 +595,10 @@ namespace LinqToDB.Internal.DataProvider.ClickHouse
 				}
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (table.DataContext.CloseAfterUse)
 				await table.DataContext.CloseAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return rc;
 		}

--- a/Source/LinqToDB/Internal/DataProvider/DB2/DB2BulkCopyShared.cs
+++ b/Source/LinqToDB/Internal/DataProvider/DB2/DB2BulkCopyShared.cs
@@ -76,8 +76,10 @@ namespace LinqToDB.Internal.DataProvider.DB2
 					options.RowsCopiedCallback(rc);
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (table.DataContext.CloseAfterUse)
 				table.DataContext.Close();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return rc;
 		}

--- a/Source/LinqToDB/Internal/DataProvider/Informix/InformixBulkCopy.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Informix/InformixBulkCopy.cs
@@ -188,8 +188,10 @@ namespace LinqToDB.Internal.DataProvider.Informix
 					options.RowsCopiedCallback(rc);
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (table.DataContext.CloseAfterUse)
 				table.DataContext.Close();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return rc;
 		}

--- a/Source/LinqToDB/Internal/DataProvider/MySql/MySqlBulkCopy.cs
+++ b/Source/LinqToDB/Internal/DataProvider/MySql/MySqlBulkCopy.cs
@@ -199,8 +199,10 @@ namespace LinqToDB.Internal.DataProvider.MySql
 			if (options.NotifyAfter != 0 && options.RowsCopiedCallback != null)
 				options.RowsCopiedCallback(rc);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (table.DataContext.CloseAfterUse)
 				await table.DataContext.CloseAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return rc;
 		}
@@ -265,8 +267,10 @@ namespace LinqToDB.Internal.DataProvider.MySql
 			if (options.NotifyAfter != 0 && options.RowsCopiedCallback != null)
 				options.RowsCopiedCallback(rc);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (table.DataContext.CloseAfterUse)
 				table.DataContext.Close();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return rc;
 		}
@@ -338,8 +342,10 @@ namespace LinqToDB.Internal.DataProvider.MySql
 			if (options.NotifyAfter != 0 && options.RowsCopiedCallback != null)
 				options.RowsCopiedCallback(rc);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (table.DataContext.CloseAfterUse)
 				await table.DataContext.CloseAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return rc;
 		}

--- a/Source/LinqToDB/Internal/DataProvider/Oracle/OracleBulkCopy.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Oracle/OracleBulkCopy.cs
@@ -123,8 +123,10 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 								opts.RowsCopiedCallback(rc);
 						}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 						if (table.DataContext.CloseAfterUse)
 							table.DataContext.Close();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 						return rc;
 					}
@@ -265,8 +267,10 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 				{
 					if (!Execute(helper, list))
 					{
+#pragma warning disable CS0618 // Type or member is obsolete
 						if (!helper.SuppressCloseAfterUse && helper.OriginalContext.CloseAfterUse)
 							helper.OriginalContext.Close();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 						return helper.RowsCopied;
 					}
@@ -278,8 +282,10 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 			if (helper.CurrentCount > 0)
 				Execute(helper, list);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (!helper.SuppressCloseAfterUse && helper.OriginalContext.CloseAfterUse)
 				helper.OriginalContext.Close();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return helper.RowsCopied;
 		}
@@ -299,8 +305,10 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 				{
 					if (!await ExecuteAsync(helper, list, cancellationToken).ConfigureAwait(false))
 					{
+#pragma warning disable CS0618 // Type or member is obsolete
 						if (!helper.SuppressCloseAfterUse && helper.OriginalContext.CloseAfterUse)
 							await helper.OriginalContext.CloseAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 						return helper.RowsCopied;
 					}
@@ -314,8 +322,10 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 				await ExecuteAsync(helper, list, cancellationToken).ConfigureAwait(false);
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (!helper.SuppressCloseAfterUse && helper.OriginalContext.CloseAfterUse)
 				await helper.OriginalContext.CloseAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return helper.RowsCopied;
 		}
@@ -335,8 +345,10 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 				{
 					if (!await ExecuteAsync(helper, list, cancellationToken).ConfigureAwait(false))
 					{
+#pragma warning disable CS0618 // Type or member is obsolete
 						if (!helper.SuppressCloseAfterUse && helper.OriginalContext.CloseAfterUse)
 							await helper.OriginalContext.CloseAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 						return helper.RowsCopied;
 					}
@@ -350,8 +362,10 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 				await ExecuteAsync(helper, list, cancellationToken).ConfigureAwait(false);
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (!helper.SuppressCloseAfterUse && helper.OriginalContext.CloseAfterUse)
 				await helper.OriginalContext.CloseAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return helper.RowsCopied;
 		}

--- a/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
+++ b/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLBulkCopy.cs
@@ -232,8 +232,10 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 				writer.Dispose();
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (originalContext.CloseAfterUse)
 				originalContext.Close();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return rowsCopied;
 		}
@@ -353,8 +355,10 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 					.ConfigureAwait(false);
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (table.DataContext.CloseAfterUse)
 				await table.DataContext.CloseAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return rowsCopied;
 		}
@@ -476,8 +480,10 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 					.ConfigureAwait(false);
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (table.DataContext.CloseAfterUse)
 				await table.DataContext.CloseAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return rowsCopied;
 		}

--- a/Source/LinqToDB/Internal/DataProvider/SapHana/SapHanaBulkCopy.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SapHana/SapHanaBulkCopy.cs
@@ -188,8 +188,10 @@ namespace LinqToDB.Internal.DataProvider.SapHana
 						options.RowsCopiedCallback(rc);
 				}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				if (table.DataContext.CloseAfterUse)
 					await table.DataContext.CloseAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				return rc;
 			}
@@ -260,8 +262,10 @@ namespace LinqToDB.Internal.DataProvider.SapHana
 						options.RowsCopiedCallback(rc);
 				}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				if (table.DataContext.CloseAfterUse)
 					table.DataContext.Close();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				return rc;
 			}

--- a/Source/LinqToDB/Internal/DataProvider/SqlCe/SqlCeBulkCopy.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlCe/SqlCeBulkCopy.cs
@@ -23,8 +23,10 @@ namespace LinqToDB.Internal.DataProvider.SqlCe
 			{
 				helper.DataConnection.Execute("SET IDENTITY_INSERT " + helper.TableName + " OFF");
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				if (helper.OriginalContext.CloseAfterUse)
 					helper.OriginalContext.Close();
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			return ret;
@@ -48,8 +50,10 @@ namespace LinqToDB.Internal.DataProvider.SqlCe
 				await helper.DataConnection.ExecuteAsync("SET IDENTITY_INSERT " + helper.TableName + " OFF", cancellationToken)
 					.ConfigureAwait(false);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				if (helper.OriginalContext.CloseAfterUse)
 					await helper.OriginalContext.CloseAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			return ret;
@@ -73,8 +77,10 @@ namespace LinqToDB.Internal.DataProvider.SqlCe
 				await helper.DataConnection.ExecuteAsync("SET IDENTITY_INSERT " + helper.TableName + " OFF", cancellationToken)
 					.ConfigureAwait(false);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				if (helper.OriginalContext.CloseAfterUse)
 					await helper.OriginalContext.CloseAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			return ret;

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/SqlServerBulkCopy.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/SqlServerBulkCopy.cs
@@ -203,8 +203,10 @@ namespace LinqToDB.Internal.DataProvider.SqlServer
 					options.RowsCopiedCallback(rc);
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (table.DataContext.CloseAfterUse)
 				await table.DataContext.CloseAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return rc;
 		}
@@ -279,8 +281,10 @@ namespace LinqToDB.Internal.DataProvider.SqlServer
 					options.RowsCopiedCallback(rc);
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (table.DataContext.CloseAfterUse)
 				table.DataContext.Close();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return rc;
 		}
@@ -306,8 +310,10 @@ namespace LinqToDB.Internal.DataProvider.SqlServer
 			{
 				helper.DataConnection.Execute("SET IDENTITY_INSERT " + helper.TableName + " OFF");
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				if (helper.OriginalContext.CloseAfterUse)
 					helper.OriginalContext.Close();
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			return ret;
@@ -342,8 +348,10 @@ namespace LinqToDB.Internal.DataProvider.SqlServer
 				await helper.DataConnection.ExecuteAsync("SET IDENTITY_INSERT " + helper.TableName + " OFF", cancellationToken)
 					.ConfigureAwait(false);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				if (helper.OriginalContext.CloseAfterUse)
 					await helper.OriginalContext.CloseAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			return ret;
@@ -378,8 +386,10 @@ namespace LinqToDB.Internal.DataProvider.SqlServer
 				await helper.DataConnection.ExecuteAsync("SET IDENTITY_INSERT " + helper.TableName + " OFF", cancellationToken)
 					.ConfigureAwait(false);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				if (helper.OriginalContext.CloseAfterUse)
 					await helper.OriginalContext.CloseAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			return ret;

--- a/Source/LinqToDB/Internal/DataProvider/Sybase/SybaseBulkCopy.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Sybase/SybaseBulkCopy.cs
@@ -211,8 +211,10 @@ namespace LinqToDB.Internal.DataProvider.Sybase
 					options.RowsCopiedCallback(rc);
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (table.DataContext.CloseAfterUse)
 				table.DataContext.Close();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return rc;
 		}

--- a/Source/LinqToDB/Internal/Linq/QueryRunnerBase.cs
+++ b/Source/LinqToDB/Internal/Linq/QueryRunnerBase.cs
@@ -42,14 +42,18 @@ namespace LinqToDB.Internal.Linq
 
 		public virtual void Dispose()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (DataContext.CloseAfterUse)
 				DataContext.Close();
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		public virtual ValueTask DisposeAsync()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (DataContext.CloseAfterUse)
 				return new ValueTask(DataContext.CloseAsync());
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return default;
 		}

--- a/Source/LinqToDB/Remote/RemoteDataContextBase.cs
+++ b/Source/LinqToDB/Remote/RemoteDataContextBase.cs
@@ -287,6 +287,7 @@ namespace LinqToDB.Remote
 		internal MappingSchema   SerializationMappingSchema => _serializationMappingSchema ??= MappingSchema.CombineSchemas(Internal.Remote.SerializationMappingSchema.Instance, MappingSchema);
 
 		public  bool InlineParameters { get; set; }
+		[Obsolete("This API will be removed in version 7"), EditorBrowsable(EditorBrowsableState.Never)]
 		public  bool CloseAfterUse    { get; set; }
 
 		private List<string>? _queryHints;

--- a/Tests/Linq/Common/DisposeTests.cs
+++ b/Tests/Linq/Common/DisposeTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
 using System.Threading.Tasks;
 
 using LinqToDB;
@@ -13,6 +15,7 @@ namespace Tests.Common
 	[TestFixture]
 	public class DisposeTests : TestBase
 	{
+		[Obsolete("This API will be removed in version 7. Use DataContext with SetKeepConnectionAlive[Async] instead."), EditorBrowsable(EditorBrowsableState.Never)]
 		[Test]
 		public void DoubleDispose_DataConnection([IncludeDataSources(ProviderName.SQLiteClassic)] string context, [Values] bool closeAfterUse)
 		{
@@ -22,8 +25,9 @@ namespace Tests.Common
 			db.Dispose();
 		}
 
+		[Obsolete("This API will be removed in version 7. Use DataContext with SetKeepConnectionAlive[Async] instead."), EditorBrowsable(EditorBrowsableState.Never)]
 		[Test]
-		public void DoubleDispose_DataContext([IncludeDataSources(ProviderName.SQLiteClassic)] string context, [Values] bool closeAfterUse)
+		public void DoubleDispose_DataContext_Old([IncludeDataSources(ProviderName.SQLiteClassic)] string context, [Values] bool closeAfterUse)
 		{
 			using var db = new DataContext(context);
 			((IDataContext)db).CloseAfterUse = closeAfterUse;
@@ -31,6 +35,16 @@ namespace Tests.Common
 			db.Dispose();
 		}
 
+		[Test]
+		public void DoubleDispose_DataContext([IncludeDataSources(ProviderName.SQLiteClassic)] string context, [Values] bool closeAfterUse)
+		{
+			using var db = new DataContext(context);
+			db.SetKeepConnectionAlive(closeAfterUse);
+			_ = db.GetTable<Person>().ToArray();
+			db.Dispose();
+		}
+
+		[Obsolete("This API will be removed in version 7. Use DataContext with SetKeepConnectionAlive[Async] instead."), EditorBrowsable(EditorBrowsableState.Never)]
 		[Test]
 		public void DoubleDispose_RemoteDataContext([IncludeDataSources(true, ProviderName.SQLiteClassic)] string context, [Values] bool closeAfterUse)
 		{
@@ -43,6 +57,7 @@ namespace Tests.Common
 			db.Dispose();
 		}
 
+		[Obsolete("This API will be removed in version 7. Use DataContext with SetKeepConnectionAlive[Async] instead."), EditorBrowsable(EditorBrowsableState.Never)]
 		[Test]
 		public async ValueTask DoubleDisposeAsync_DataConnection([IncludeDataSources(ProviderName.SQLiteClassic)] string context, [Values] bool closeAfterUse)
 		{
@@ -52,8 +67,9 @@ namespace Tests.Common
 			await db.DisposeAsync();
 		}
 
+		[Obsolete("This API will be removed in version 7. Use DataContext with SetKeepConnectionAlive[Async] instead."), EditorBrowsable(EditorBrowsableState.Never)]
 		[Test]
-		public async ValueTask DoubleDisposeAsync_DataContext([IncludeDataSources(ProviderName.SQLiteClassic)] string context, [Values] bool closeAfterUse)
+		public async ValueTask DoubleDisposeAsync_DataContext_Old([IncludeDataSources(ProviderName.SQLiteClassic)] string context, [Values] bool closeAfterUse)
 		{
 			await using var db = new DataContext(context);
 			((IDataContext)db).CloseAfterUse = closeAfterUse;
@@ -61,6 +77,16 @@ namespace Tests.Common
 			await db.DisposeAsync();
 		}
 
+		[Test]
+		public async ValueTask DoubleDisposeAsync_DataContext([IncludeDataSources(ProviderName.SQLiteClassic)] string context, [Values] bool closeAfterUse)
+		{
+			await using var db = new DataContext(context);
+			await db.SetKeepConnectionAliveAsync(closeAfterUse);
+			_ = db.GetTable<Person>().ToArray();
+			await db.DisposeAsync();
+		}
+
+		[Obsolete("This API will be removed in version 7. Use DataContext with SetKeepConnectionAlive[Async] instead."), EditorBrowsable(EditorBrowsableState.Never)]
 		[Test]
 		public async ValueTask DoubleDisposeAsync_RemoteDataContext([IncludeDataSources(true, ProviderName.SQLiteClassic)] string context, [Values] bool closeAfterUse)
 		{

--- a/Tests/Model/TestDataCustomConnection.cs
+++ b/Tests/Model/TestDataCustomConnection.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Data.Common;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
@@ -103,6 +104,7 @@ namespace Tests.Model
 
 		public List<string> NextQueryHints => ((IDataContext)Connection).NextQueryHints;
 
+		[Obsolete("This API will be removed in version 7. Use DataContext with KeepConnectionAlive property instead."), EditorBrowsable(EditorBrowsableState.Never)]
 		public bool CloseAfterUse { get => ((IDataContext)Connection).CloseAfterUse; set => ((IDataContext)Connection).CloseAfterUse = value; }
 
 		public DataOptions Options => ((IDataContext)Connection).Options;


### PR DESCRIPTION
Requires #5067

This property was introduced to support internal infrastructure to handle lifetime of cloned connection, which is already gone. Because it wasn't documented and exposed on public interface it became misused.

For end-users we already have alternative solution with `DataContext.KeepConnectionAlive` flag

TODO:
- [ ] remove references to `CloseAfterUse` from readme files