### PR TITLE
v6 regression: Concat fom different sources + Count fails

### DIFF
--- a/Tests/Linq/Linq/ConcatUnionTests.cs
+++ b/Tests/Linq/Linq/ConcatUnionTests.cs
@@ -2282,6 +2282,71 @@ namespace Tests.Linq
 			var q = query1.UnionAll(query2).ToList();
 		}
 
+		[Test]
+		public void ConcatCountTest([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var q1 = db.Person.Select(_ => _.ID)
+				.Concat(db.Parent.Select(_ => _.ParentID))
+				.Count();
+
+			var q2 = Person.Select(_ => _.ID)
+				.Concat(Parent.Select(_ => _.ParentID))
+				.Count();
+
+			Assert.That(q1, Is.EqualTo(q2));
+		}
+
+		[Test]
+		public void ConcatUnionTest([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var q1 = db.Person.Select(_ => _.ID)
+				.Union(db.Parent.Select(_ => _.ParentID))
+				.Count();
+
+			var q2 = Person.Select(_ => _.ID)
+				.Union(Parent.Select(_ => _.ParentID))
+				.Count();
+
+			Assert.That(q1, Is.EqualTo(q2));
+		}
+
+		[Test]
+		public void ConcatCountTest2([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var q1 = db.Person.Select(_ => _.ID)
+				.Concat(db.Parent.Select(_ => _.ParentID))
+				.Select(_ => _)
+				.CountExt(_ => _);
+
+			var q2 = Person.Select(_ => _.ID)
+				.Concat(Parent.Select(_ => _.ParentID))
+				.Count();
+
+			Assert.That(q1, Is.EqualTo(q2));
+		}
+
+		[Test]
+		public void ConcatSumTest([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var q1 = db.Person.Select(_ => _.ID)
+				.Concat(db.Parent.Select(_ => _.ParentID))
+				.Sum();
+
+			var q2 = Person.Select(_ => _.ID)
+				.Concat(Parent.Select(_ => _.ParentID))
+				.Sum();
+
+			Assert.That(q1, Is.EqualTo(q2));
+		}
+
 		#region Issue 4220
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4220")]
 		public void Issue4220Test([DataSources] string context)


### PR DESCRIPTION
Only `ConcatCountTest` fails, generates wrong SQL:
```sql
  SELECT
   COUNT(*)
  FROM
   (
    SELECT
    	*
    FROM
    	[Person] [t1]
    UNION ALL
    SELECT
    	*
    FROM
    	[Parent] [t2]
   ) [t3]
```

other tests are just added to check for similar issues