### PR TITLE
Add some test helpers/sources

### DIFF
--- a/Tests/Base/Attributes/FeatureSources/CteContextSourceAttribute.cs
+++ b/Tests/Base/Attributes/FeatureSources/CteContextSourceAttribute.cs
@@ -6,7 +6,7 @@ using LinqToDB;
 namespace Tests
 {
 	[AttributeUsage(AttributeTargets.Parameter)]
-	public sealed class CteContextSourceAttribute : IncludeDataSourcesAttribute
+	public class CteContextSourceAttribute : IncludeDataSourcesAttribute
 	{
 		public static string[] CteSupportedProviders = new[]
 			{

--- a/Tests/Base/Attributes/FeatureSources/RecursiveCteContextSourceAttribute.cs
+++ b/Tests/Base/Attributes/FeatureSources/RecursiveCteContextSourceAttribute.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Linq;
+
+using LinqToDB;
+
+namespace Tests
+{
+	[AttributeUsage(AttributeTargets.Parameter)]
+	public sealed class RecursiveCteContextSourceAttribute : CteContextSourceAttribute
+	{
+		private static readonly string[] RecursiveCteUnsupportedProviders = new[]
+			{
+				TestProvName.AllSapHana,
+			}.SelectMany(_ => _.Split(',')).ToArray();
+
+		public RecursiveCteContextSourceAttribute() : this(true)
+		{
+		}
+
+		public RecursiveCteContextSourceAttribute(bool includeLinqService)
+			: base(includeLinqService, RecursiveCteUnsupportedProviders)
+		{
+		}
+
+		public RecursiveCteContextSourceAttribute(params string[] excludedProviders)
+			: base(RecursiveCteUnsupportedProviders.Concat(excludedProviders.SelectMany(_ => _.Split(','))).Distinct().ToArray())
+		{
+		}
+
+		public RecursiveCteContextSourceAttribute(bool includeLinqService, params string[] excludedProviders)
+			: base(includeLinqService, RecursiveCteUnsupportedProviders.Concat(excludedProviders.SelectMany(_ => _.Split(','))).Distinct().ToArray())
+		{
+		}
+	}
+}

--- a/Tests/Base/Attributes/RequiresCorrelatedSubqueryAttribute.cs
+++ b/Tests/Base/Attributes/RequiresCorrelatedSubqueryAttribute.cs
@@ -1,0 +1,15 @@
+﻿using LinqToDB;
+using LinqToDB.Internal.Common;
+
+namespace Tests
+{
+	public sealed class RequiresCorrelatedSubqueryAttribute: ThrowsForProviderAttribute
+	{
+		public RequiresCorrelatedSubqueryAttribute()
+			: base(typeof(LinqToDBException),
+			TestProvName.AllClickHouse)
+		{
+			ErrorMessage = ErrorHelper.Error_Correlated_Subqueries;
+		}
+	}
+}

--- a/Tests/Base/ProviderNameHelpers.cs
+++ b/Tests/Base/ProviderNameHelpers.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
+using LinqToDB;
+
 namespace Tests
 {
 	public static class ProviderNameHelpers
@@ -21,6 +23,14 @@ namespace Tests
 			}
 
 			return false;
+		}
+
+		/// <summary>
+		/// Provider returns number of affected records from Execute methods
+		/// </summary>
+		public static bool SupportsRowcount(this string context)
+		{
+			return !context.IsAnyOf(TestProvName.AllClickHouse);
 		}
 
 		public static bool IsUseParameters(this string context)

--- a/Tests/Linq/Linq/AssociationTests.cs
+++ b/Tests/Linq/Linq/AssociationTests.cs
@@ -266,8 +266,9 @@ namespace Tests.Linq
 			}
 		}
 
+		[RequiresCorrelatedSubquery]
 		[Test]
-		public void StackOverflow2([DataSources(ProviderName.SqlCe, TestProvName.AllClickHouse)] string context)
+		public void StackOverflow2([DataSources(ProviderName.SqlCe)] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -275,8 +276,9 @@ namespace Tests.Linq
 					from p in db.Parent5 where p.Children.Count != 0 select p);
 		}
 
+		[RequiresCorrelatedSubquery]
 		[Test]
-		public void StackOverflow3([DataSources(ProviderName.SqlCe, TestProvName.AllClickHouse)] string context)
+		public void StackOverflow3([DataSources(ProviderName.SqlCe)] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -285,7 +287,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void StackOverflow4([DataSources(ProviderName.SqlCe, TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void StackOverflow4([DataSources(ProviderName.SqlCe)] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -472,8 +475,9 @@ namespace Tests.Linq
 			}
 		}
 
+		[RequiresCorrelatedSubquery]
 		[Test]
-		public void LetTest1([DataSources(TestProvName.AllClickHouse)] string context)
+		public void LetTest1([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -485,8 +489,9 @@ namespace Tests.Linq
 					select new { p.ParentID, Count = chs.Count() });
 		}
 
+		[RequiresCorrelatedSubquery]
 		[Test]
-		public void LetTest2([DataSources(TestProvName.AllClickHouse)] string context)
+		public void LetTest2([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -866,8 +871,9 @@ namespace Tests.Linq
 			}
 		}
 
+		[RequiresCorrelatedSubquery]
 		[Test]
-		public void TestGenericAssociation3([DataSources(ProviderName.SqlCe, TestProvName.AllClickHouse)] string context)
+		public void TestGenericAssociation3([DataSources(ProviderName.SqlCe)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -1833,8 +1839,9 @@ namespace Tests.Linq
 			return query.Where(x => x.SubEntities.Any());
 		}
 
+		[RequiresCorrelatedSubquery]
 		[Test]
-		public void ViaInterfaceAndExtension([DataSources(TestProvName.AllClickHouse)] string context)
+		public void ViaInterfaceAndExtension([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			using var main = db.CreateLocalTable<MainEntity>();
@@ -1850,8 +1857,9 @@ namespace Tests.Linq
 			var result = query.ToArray();
 		}
 
+		[RequiresCorrelatedSubquery]
 		[Test]
-		public void ViaInterfaceOfType([DataSources(TestProvName.AllClickHouse)] string context)
+		public void ViaInterfaceOfType([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			using var main = db.CreateLocalTable<MainEntity>();

--- a/Tests/Linq/Linq/CalculatedColumnTests.cs
+++ b/Tests/Linq/Linq/CalculatedColumnTests.cs
@@ -64,7 +64,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllClickHouse, ErrorMessage = ErrorHelper.Error_Correlated_Subqueries)]
+		[RequiresCorrelatedSubquery]
 		public void CalculatedColumnTest1([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
@@ -84,7 +84,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllClickHouse, ErrorMessage = ErrorHelper.Error_Correlated_Subqueries)]
+		[RequiresCorrelatedSubquery]
 		public void CalculatedColumnTest2([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
@@ -102,7 +102,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllClickHouse, ErrorMessage = ErrorHelper.Error_Correlated_Subqueries)]
+		[RequiresCorrelatedSubquery]
 		public void CalculatedColumnTest3([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
@@ -129,7 +129,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllClickHouse, ErrorMessage = ErrorHelper.Error_Correlated_Subqueries)]
+		[RequiresCorrelatedSubquery]
 		public void CalculatedColumnTest4([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))

--- a/Tests/Linq/Linq/ConcatUnionTests.cs
+++ b/Tests/Linq/Linq/ConcatUnionTests.cs
@@ -166,8 +166,9 @@ namespace Tests.Linq
 					Where(p => p.Value1!.Value != 2));
 		}
 
+		[RequiresCorrelatedSubquery]
 		[Test]
-		public void Concat6([DataSources(ProviderName.SqlCe, TestProvName.AllClickHouse)] string context)
+		public void Concat6([DataSources(ProviderName.SqlCe)] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(

--- a/Tests/Linq/Linq/ConcurrencyTests.cs
+++ b/Tests/Linq/Linq/ConcurrencyTests.cs
@@ -38,7 +38,7 @@ namespace Tests.Linq
 		public void TestAutoIncrement([DataSources] string context)
 		{
 			// lack of rowcount support by clickhouse makes this API useless with ClickHouse
-			var skipCnt = context.IsAnyOf(TestProvName.AllClickHouse);
+			var skipCnt = !context.SupportsRowcount();
 			var ms      = new MappingSchema();
 
 			new FluentMappingBuilder(ms)
@@ -77,14 +77,14 @@ namespace Tests.Linq
 			record.Stamp--;
 			record.Value = "value 3";
 			cnt = db.UpdateOptimistic(record);
-			Assert.That(cnt, Is.Zero);
+			if (!skipCnt) Assert.That(cnt, Is.Zero);
 			record.Stamp++;
 			record.Value = "value 2";
 			AssertData(record);
 			record.Stamp--;
 
 			cnt = db.DeleteOptimistic(record);
-			Assert.That(cnt, Is.Zero);
+			if (!skipCnt) Assert.That(cnt, Is.Zero);
 			record.Stamp++;
 			AssertData(record);
 
@@ -109,7 +109,7 @@ namespace Tests.Linq
 		[Test]
 		public async ValueTask TestAutoIncrementAsync([DataSources] string context)
 		{
-			var skipCnt = context.IsAnyOf(TestProvName.AllClickHouse);
+			var skipCnt = !context.SupportsRowcount();
 			var ms      = new MappingSchema();
 
 			new FluentMappingBuilder(ms)
@@ -148,14 +148,14 @@ namespace Tests.Linq
 			record.Stamp--;
 			record.Value = "value 3";
 			cnt = await db.UpdateOptimisticAsync(record);
-			Assert.That(cnt, Is.Zero);
+			if (!skipCnt) Assert.That(cnt, Is.Zero);
 			record.Stamp++;
 			record.Value = "value 2";
 			AssertData(record);
 			record.Stamp--;
 
 			cnt = await db.DeleteOptimisticAsync(record);
-			Assert.That(cnt, Is.Zero);
+			if (!skipCnt) Assert.That(cnt, Is.Zero);
 			record.Stamp++;
 			AssertData(record);
 
@@ -180,7 +180,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestFiltered([DataSources] string context)
 		{
-			var skipCnt = context.IsAnyOf(TestProvName.AllClickHouse);
+			var skipCnt = !context.SupportsRowcount();
 			var ms      = new MappingSchema();
 
 			new FluentMappingBuilder(ms)
@@ -241,7 +241,7 @@ namespace Tests.Linq
 		[Test]
 		public async ValueTask TestFilteredAsync([DataSources] string context)
 		{
-			var skipCnt = context.IsAnyOf(TestProvName.AllClickHouse);
+			var skipCnt = !context.SupportsRowcount();
 			var ms      = new MappingSchema();
 
 			new FluentMappingBuilder(ms)
@@ -302,7 +302,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestGuid([DataSources] string context)
 		{
-			var skipCnt = context.IsAnyOf(TestProvName.AllClickHouse);
+			var skipCnt = !context.SupportsRowcount();
 			var ms      = new MappingSchema();
 
 			new FluentMappingBuilder(ms)
@@ -341,14 +341,14 @@ namespace Tests.Linq
 			record.Value = "value 3";
 			record.Stamp = Guid.NewGuid();
 			cnt = db.UpdateOptimistic(record);
-			Assert.That(cnt, Is.Zero);
+			if (!skipCnt) Assert.That(cnt, Is.Zero);
 			record.Stamp = dbStamp;
 			record.Value = "value 2";
 			AssertData(record, true);
 			record.Stamp = Guid.NewGuid();
 
 			cnt = db.DeleteOptimistic(record);
-			Assert.That(cnt, Is.Zero);
+			if (!skipCnt) Assert.That(cnt, Is.Zero);
 			record.Stamp = dbStamp;
 			AssertData(record, true);
 
@@ -379,7 +379,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestGuidString([DataSources] string context)
 		{
-			var skipCnt = context.IsAnyOf(TestProvName.AllClickHouse);
+			var skipCnt = !context.SupportsRowcount();
 			var ms      = new MappingSchema();
 
 			new FluentMappingBuilder(ms)
@@ -419,14 +419,14 @@ namespace Tests.Linq
 			record.Value = "value 3";
 			record.Stamp = Guid.NewGuid().ToString();
 			cnt = db.UpdateOptimistic(record);
-			Assert.That(cnt, Is.Zero);
+			if (!skipCnt) Assert.That(cnt, Is.Zero);
 			record.Stamp = dbStamp;
 			record.Value = "value 2";
 			AssertData(record, true);
 			record.Stamp = Guid.NewGuid().ToString();
 
 			cnt = db.DeleteOptimistic(record);
-			Assert.That(cnt, Is.Zero);
+			if (!skipCnt) Assert.That(cnt, Is.Zero);
 			record.Stamp = dbStamp;
 			AssertData(record, true);
 
@@ -460,7 +460,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestGuidBinary([DataSources(TestProvName.AllInformix)] string context)
 		{
-			var skipCnt = context.IsAnyOf(TestProvName.AllClickHouse);
+			var skipCnt = !context.SupportsRowcount();
 			var ms      = new MappingSchema();
 
 			new FluentMappingBuilder(ms)
@@ -501,14 +501,14 @@ namespace Tests.Linq
 			record.Value = "value 3";
 			record.Stamp = TestData.Guid2.ToByteArray();
 			cnt = db.UpdateOptimistic(record);
-			Assert.That(cnt, Is.Zero);
+			if (!skipCnt) Assert.That(cnt, Is.Zero);
 			record.Stamp = dbStamp;
 			record.Value = "value 2";
 			AssertData(record, true);
 			record.Stamp = TestData.Guid3.ToByteArray();
 
 			cnt = db.DeleteOptimistic(record);
-			Assert.That(cnt, Is.Zero);
+			if (!skipCnt) Assert.That(cnt, Is.Zero);
 			record.Stamp = dbStamp;
 			AssertData(record, true);
 
@@ -539,7 +539,7 @@ namespace Tests.Linq
 		[Test]
 		public async ValueTask TestTestGuidAsync([DataSources] string context)
 		{
-			var skipCnt = context.IsAnyOf(TestProvName.AllClickHouse);
+			var skipCnt = !context.SupportsRowcount();
 			var ms      = new MappingSchema();
 
 			new FluentMappingBuilder(ms)
@@ -578,14 +578,14 @@ namespace Tests.Linq
 			record.Value = "value 3";
 			record.Stamp = Guid.NewGuid();
 			cnt = await db.UpdateOptimisticAsync(record);
-			Assert.That(cnt, Is.Zero);
+			if (!skipCnt) Assert.That(cnt, Is.Zero);
 			record.Stamp = dbStamp;
 			record.Value = "value 2";
 			AssertData(record, true);
 			record.Stamp = Guid.NewGuid();
 
 			cnt = await db.DeleteOptimisticAsync(record);
-			Assert.That(cnt, Is.Zero);
+			if (!skipCnt) Assert.That(cnt, Is.Zero);
 			record.Stamp = dbStamp;
 			AssertData(record, true);
 
@@ -616,7 +616,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestCustomStrategy([DataSources] string context)
 		{
-			var skipCnt = context.IsAnyOf(TestProvName.AllClickHouse);
+			var skipCnt = !context.SupportsRowcount();
 			var ms      = new MappingSchema();
 
 			new FluentMappingBuilder(ms)
@@ -655,14 +655,14 @@ namespace Tests.Linq
 			record.Value = "value 3";
 			record.Stamp = "unknown-value";
 			cnt = db.UpdateOptimistic(record);
-			Assert.That(cnt, Is.Zero);
+			if (!skipCnt) Assert.That(cnt, Is.Zero);
 			record.Stamp = dbStamp;
 			record.Value = "value 2";
 			AssertData(record, true);
 			record.Stamp = "unknown-value";
 
 			cnt = db.DeleteOptimistic(record);
-			Assert.That(cnt, Is.Zero);
+			if (!skipCnt) Assert.That(cnt, Is.Zero);
 			record.Stamp = dbStamp;
 			AssertData(record, true);
 
@@ -693,7 +693,7 @@ namespace Tests.Linq
 		[Test]
 		public async ValueTask TestCustomStrategyAsync([DataSources] string context)
 		{
-			var skipCnt = context.IsAnyOf(TestProvName.AllClickHouse);
+			var skipCnt = !context.SupportsRowcount();
 			var ms      = new MappingSchema();
 
 			new FluentMappingBuilder(ms)
@@ -732,14 +732,14 @@ namespace Tests.Linq
 			record.Value = "value 3";
 			record.Stamp = "unknown-value";
 			cnt = await db.UpdateOptimisticAsync(record);
-			Assert.That(cnt, Is.Zero);
+			if (!skipCnt) Assert.That(cnt, Is.Zero);
 			record.Stamp = dbStamp;
 			record.Value = "value 2";
 			AssertData(record, true);
 			record.Stamp = "unknown-value";
 
 			cnt = await db.DeleteOptimisticAsync(record);
-			Assert.That(cnt, Is.Zero);
+			if (!skipCnt) Assert.That(cnt, Is.Zero);
 			record.Stamp = dbStamp;
 			AssertData(record, true);
 
@@ -770,7 +770,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestDbStrategy([IncludeDataSources(true, TestProvName.AllSqlServer)] string context)
 		{
-			var skipCnt = context.IsAnyOf(TestProvName.AllClickHouse);
+			var skipCnt = !context.SupportsRowcount();
 			var ms      = new MappingSchema();
 
 			new FluentMappingBuilder(ms)
@@ -810,14 +810,14 @@ namespace Tests.Linq
 			record.Value = "value 3";
 			record.Stamp[0] = (byte)(record.Stamp[0] + 1);
 			cnt = db.UpdateOptimistic(record);
-			Assert.That(cnt, Is.Zero);
+			if (!skipCnt) Assert.That(cnt, Is.Zero);
 			record.Stamp = dbStamp;
 			record.Value = "value 2";
 			AssertData(record, true);
 			record.Stamp[0] = (byte)(record.Stamp[0] + 1);
 
 			cnt = db.DeleteOptimistic(record);
-			Assert.That(cnt, Is.Zero);
+			if (!skipCnt) Assert.That(cnt, Is.Zero);
 			record.Stamp = dbStamp;
 			AssertData(record, true);
 
@@ -848,7 +848,7 @@ namespace Tests.Linq
 		[Test]
 		public async ValueTask TestDbStrategyAsync([IncludeDataSources(true, TestProvName.AllSqlServer)] string context)
 		{
-			var skipCnt = context.IsAnyOf(TestProvName.AllClickHouse);
+			var skipCnt = !context.SupportsRowcount();
 			var ms      = new MappingSchema();
 
 			new FluentMappingBuilder(ms)
@@ -888,14 +888,14 @@ namespace Tests.Linq
 			record.Value = "value 3";
 			record.Stamp[0] = (byte)(record.Stamp[0] + 1);
 			cnt = await db.UpdateOptimisticAsync(record);
-			Assert.That(cnt, Is.Zero);
+			if (!skipCnt) Assert.That(cnt, Is.Zero);
 			record.Stamp = dbStamp;
 			record.Value = "value 2";
 			AssertData(record, true);
 			record.Stamp[0] = (byte)(record.Stamp[0] + 1);
 
 			cnt = await db.DeleteOptimisticAsync(record);
-			Assert.That(cnt, Is.Zero);
+			if (!skipCnt) Assert.That(cnt, Is.Zero);
 			record.Stamp = dbStamp;
 			AssertData(record, true);
 
@@ -926,7 +926,7 @@ namespace Tests.Linq
 		[Test]
 		public void TestFilterExtension([IncludeDataSources(true, TestProvName.AllSqlServer)] string context)
 		{
-			var skipCnt = context.IsAnyOf(TestProvName.AllClickHouse);
+			var skipCnt = !context.SupportsRowcount();
 			var ms      = new MappingSchema();
 
 			new FluentMappingBuilder(ms)
@@ -966,14 +966,14 @@ namespace Tests.Linq
 			record.Value = "value 3";
 			record.Stamp[0] = (byte)(record.Stamp[0] + 1);
 			cnt = t.WhereKeyOptimistic(record).Update(r => new ConcurrencyTable<byte[]>() { Value = record.Value });
-			Assert.That(cnt, Is.Zero);
+			if (!skipCnt) Assert.That(cnt, Is.Zero);
 			record.Stamp = dbStamp;
 			record.Value = "value 2";
 			AssertData(record, true);
 			record.Stamp[0] = (byte)(record.Stamp[0] + 1);
 
 			cnt = t.WhereKeyOptimistic(record).Delete();
-			Assert.That(cnt, Is.Zero);
+			if (!skipCnt) Assert.That(cnt, Is.Zero);
 			record.Stamp = dbStamp;
 			AssertData(record, true);
 

--- a/Tests/Linq/Linq/ConvertExpressionTests.cs
+++ b/Tests/Linq/Linq/ConvertExpressionTests.cs
@@ -13,7 +13,7 @@ namespace Tests.Linq
 	public class ConvertExpressionTests : TestBase
 	{
 		[Test]
-		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllClickHouse, ErrorMessage = ErrorHelper.Error_Correlated_Subqueries)]
+		[RequiresCorrelatedSubquery]
 		public void Select1([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
@@ -27,7 +27,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllClickHouse, ErrorMessage = ErrorHelper.Error_Correlated_Subqueries)]
+		[RequiresCorrelatedSubquery]
 		public void Select2([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
@@ -43,7 +43,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllClickHouse, ErrorMessage = ErrorHelper.Error_Correlated_Subqueries)]
+		[RequiresCorrelatedSubquery]
 		public void Select3([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
@@ -59,7 +59,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllClickHouse, ErrorMessage = ErrorHelper.Error_Correlated_Subqueries)]
+		[RequiresCorrelatedSubquery]
 		public void Select4([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
@@ -74,8 +74,9 @@ namespace Tests.Linq
 						.Select(t => t.Sum(c => c.ChildID)));
 		}
 
+		[RequiresCorrelatedSubquery]
 		[Test]
-		public void Where1([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Where1([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -91,8 +92,9 @@ namespace Tests.Linq
 					select children2.Sum(c => c.ChildID));
 		}
 
+		[RequiresCorrelatedSubquery]
 		[Test]
-		public void Where2([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Where2([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -109,7 +111,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void Where3([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void Where3([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -269,8 +272,9 @@ namespace Tests.Linq
 		}
 
 		[Test]
+		[RequiresCorrelatedSubquery]
 		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllAccess, TestProvName.AllSybase, ErrorMessage = ErrorHelper.Error_OUTER_Joins)]
-		public void LetTest4([DataSources(TestProvName.AllInformix, TestProvName.AllClickHouse)] string context)
+		public void LetTest4([DataSources(TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -300,8 +304,9 @@ namespace Tests.Linq
 		}
 
 		[Test]
+		[RequiresCorrelatedSubquery]
 		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllAccess, TestProvName.AllSybase, ErrorMessage = ErrorHelper.Error_OUTER_Joins)]
-		public void LetTest41([DataSources(TestProvName.AllInformix, TestProvName.AllClickHouse)] string context)
+		public void LetTest41([DataSources(TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -331,8 +336,9 @@ namespace Tests.Linq
 		}
 
 		[Test]
+		[RequiresCorrelatedSubquery]
 		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllAccess, ErrorMessage = ErrorHelper.Error_OUTER_Joins)]
-		public void LetTest5([DataSources(TestProvName.AllOracle11, TestProvName.AllInformix, TestProvName.AllSybase, TestProvName.AllClickHouse)] string context)
+		public void LetTest5([DataSources(TestProvName.AllOracle11, TestProvName.AllInformix, TestProvName.AllSybase)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -362,8 +368,9 @@ namespace Tests.Linq
 		}
 
 		[Test]
+		[RequiresCorrelatedSubquery]
 		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllAccess, ErrorMessage = ErrorHelper.Error_OUTER_Joins)]
-		public void LetTest6([DataSources(TestProvName.AllOracle11, TestProvName.AllInformix, TestProvName.AllSybase, TestProvName.AllClickHouse)] string context)
+		public void LetTest6([DataSources(TestProvName.AllOracle11, TestProvName.AllInformix, TestProvName.AllSybase)] string context)
 		{
 			//LinqToDB.Common.Configuration.Linq.GenerateExpressionTest = true;
 
@@ -406,8 +413,9 @@ namespace Tests.Linq
 		}
 
 		[Test]
+		[RequiresCorrelatedSubquery]
 		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllAccess, ErrorMessage = ErrorHelper.Error_OUTER_Joins)]
-		public void LetTest61([DataSources(TestProvName.AllOracle11, TestProvName.AllInformix, TestProvName.AllSybase, TestProvName.AllClickHouse)] string context)
+		public void LetTest61([DataSources(TestProvName.AllOracle11, TestProvName.AllInformix, TestProvName.AllSybase)] string context)
 		{
 			//LinqToDB.Common.Configuration.Linq.GenerateExpressionTest = true;
 
@@ -451,7 +459,8 @@ namespace Tests.Linq
 
 		// PostgreSQL92 Uses 3 queries and we join results in wrong order. See LetTest71 with explicit sort
 		[Test]
-		public void LetTest7([DataSources(TestProvName.AllInformix, ProviderName.PostgreSQL92, TestProvName.AllSybase, TestProvName.AllAccess, TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void LetTest7([DataSources(TestProvName.AllInformix, ProviderName.PostgreSQL92, TestProvName.AllSybase, TestProvName.AllAccess)] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -485,8 +494,9 @@ namespace Tests.Linq
 		}
 
 		[Test]
+		[RequiresCorrelatedSubquery]
 		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllAccess, ErrorMessage = ErrorHelper.Error_OUTER_Joins)]
-		public void LetTest71([DataSources(TestProvName.AllOracle11, TestProvName.AllInformix, TestProvName.AllSybase, TestProvName.AllClickHouse)] string context)
+		public void LetTest71([DataSources(TestProvName.AllOracle11, TestProvName.AllInformix, TestProvName.AllSybase)] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -520,8 +530,9 @@ namespace Tests.Linq
 		}
 
 		[Test]
+		[RequiresCorrelatedSubquery]
 		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllAccess, TestProvName.AllSybase, ErrorMessage = ErrorHelper.Error_OUTER_Joins)]
-		public void LetTest8([DataSources(TestProvName.AllClickHouse)] string context)
+		public void LetTest8([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(

--- a/Tests/Linq/Linq/CountTests.cs
+++ b/Tests/Linq/Linq/CountTests.cs
@@ -47,7 +47,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void Count3([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void Count3([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -81,7 +82,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void Count7([DataSources(ProviderName.SqlCe, TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void Count7([DataSources(ProviderName.SqlCe)] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -449,7 +451,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SubQuery1([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void SubQuery1([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -462,7 +465,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SubQuery2([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void SubQuery2([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -475,7 +479,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SubQuery3([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void SubQuery3([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -488,7 +493,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SubQuery4([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void SubQuery4([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -497,7 +503,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SubQuery5([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void SubQuery5([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -506,7 +513,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SubQuery6([DataSources(ProviderName.SqlCe, TestProvName.AllSQLite, TestProvName.AllSybase, TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void SubQuery6([DataSources(ProviderName.SqlCe, TestProvName.AllSQLite, TestProvName.AllSybase)] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -515,7 +523,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SubQuery7([DataSources(ProviderName.SqlCe, TestProvName.AllOracle, TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void SubQuery7([DataSources(ProviderName.SqlCe, TestProvName.AllOracle)] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -548,7 +557,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void GroupJoin1([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void GroupJoin1([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -571,7 +581,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void GroupJoin2([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void GroupJoin2([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -598,7 +609,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void GroupJoin3([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void GroupJoin3([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -617,7 +629,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void GroupJoin4([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void GroupJoin4([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(

--- a/Tests/Linq/Linq/CteTests.cs
+++ b/Tests/Linq/Linq/CteTests.cs
@@ -597,7 +597,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void RecursiveTest([CteContextSource(true, ProviderName.DB2, TestProvName.AllSapHana, TestProvName.AllInformix)] string context)
+		public void RecursiveTest([RecursiveCteContextSource(true, ProviderName.DB2, TestProvName.AllInformix)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -717,9 +717,8 @@ namespace Tests.Linq
 			}
 		}
 
-		[ActiveIssue(3015, Configuration = TestProvName.AllSapHana)]
 		[Test]
-		public void RecursiveTest2([CteContextSource(true, ProviderName.DB2)] string context)
+		public void RecursiveTest2([RecursiveCteContextSource(true, ProviderName.DB2)] string context)
 		{
 			var hierarchyData = GeHirarchyData();
 
@@ -735,9 +734,8 @@ namespace Tests.Linq
 			}
 		}
 
-		[ActiveIssue(3015, Configuration = TestProvName.AllSapHana)]
 		[Test]
-		public void TestDoubleRecursion([CteContextSource(true, ProviderName.DB2)] string context)
+		public void TestDoubleRecursion([RecursiveCteContextSource(true, ProviderName.DB2)] string context)
 		{
 			var hierarchyData = GeHirarchyData();
 
@@ -761,9 +759,8 @@ namespace Tests.Linq
 			}
 		}
 
-		[ActiveIssue(3015, Configuration = TestProvName.AllSapHana)]
 		[Test]
-		public void RecursiveCount([CteContextSource(true, ProviderName.DB2)] string context)
+		public void RecursiveCount([RecursiveCteContextSource(true, ProviderName.DB2)] string context)
 		{
 			var hierarchyData = GeHirarchyData();
 
@@ -777,9 +774,9 @@ namespace Tests.Linq
 			}
 		}
 
-		[ActiveIssue(3015, Configurations = [TestProvName.AllSapHana, ProviderName.InformixDB2])]
+		[ActiveIssue(3015, Configurations = [ProviderName.InformixDB2])]
 		[Test]
-		public void RecursiveInsertInto([CteContextSource(true, ProviderName.DB2)] string context)
+		public void RecursiveInsertInto([RecursiveCteContextSource(true, ProviderName.DB2)] string context)
 		{
 			var hierarchyData = GeHirarchyData();
 
@@ -798,7 +795,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void RecursiveDeepNesting([CteContextSource(true, TestProvName.AllDB2, TestProvName.AllSapHana)] string context)
+		public void RecursiveDeepNesting([RecursiveCteContextSource(true, TestProvName.AllDB2)] string context)
 		{
 			using (var db   = GetDataContext(context))
 			using (var tree = db.CreateLocalTable<HierarchyTree>())
@@ -972,9 +969,8 @@ namespace Tests.Linq
 			}
 		}
 
-		[ActiveIssue(3015, Configuration = TestProvName.AllSapHana)]
 		[Test]
-		public void TestRecursiveScalar([CteContextSource] string context)
+		public void TestRecursiveScalar([RecursiveCteContextSource] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -1170,9 +1166,8 @@ namespace Tests.Linq
 		}
 
 		[Test(Description = "Test that we generate plain UNION without sub-queries (or query will be invalid)")]
-		public void Issue3359_MultipleSets([CteContextSource(
+		public void Issue3359_MultipleSets([RecursiveCteContextSource(
 			TestProvName.AllInformix,
-			TestProvName.AllSapHana,
 			TestProvName.AllOracle, // too many unions (ORA-32041: UNION ALL operation in recursive WITH clause must have only two branches)
 			TestProvName.AllPostgreSQL, // too many joins? (42P19: recursive reference to query "cte" must not appear within its non-recursive term)
 			ProviderName.DB2 // joins (SQL0345N  The fullselect of the recursive common table expression "cte" must be the UNION of two or more fullselects and cannot include column functions, GROUP BY clause, HAVING clause, ORDER BY clause, or an explicit join including an ON clause.)
@@ -1226,9 +1221,8 @@ namespace Tests.Linq
 			public string LastName  { get; }
 		}
 
-		[ActiveIssue(3015, Configuration = TestProvName.AllSapHana)]
 		[Test(Description = "record type support")]
-		public void Issue3357_RecordClass([CteContextSource] string context)
+		public void Issue3357_RecordClass([RecursiveCteContextSource] string context)
 		{
 			using var db = GetDataContext(context);
 
@@ -1247,9 +1241,8 @@ namespace Tests.Linq
 				query.ToArray());
 		}
 
-		[ActiveIssue(3015, Configuration = TestProvName.AllSapHana)]
 		[Test(Description = "record type support")]
-		public void Issue3357_RecordLikeClass([CteContextSource] string context)
+		public void Issue3357_RecordLikeClass([RecursiveCteContextSource] string context)
 		{
 			using var db = GetDataContext(context);
 
@@ -1329,7 +1322,7 @@ namespace Tests.Linq
 		}
 
 		[Test(Description = "Test that we don't need typing for non-sqlserver providers")]
-		public void Issue3360_TypeByOtherQuery_AllProviders([CteContextSource(ProviderName.DB2, TestProvName.AllSapHana)] string context)
+		public void Issue3360_TypeByOtherQuery_AllProviders([RecursiveCteContextSource(ProviderName.DB2)] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tb = db.CreateLocalTable<Issue3360Table>();
@@ -1396,7 +1389,7 @@ namespace Tests.Linq
 		}
 
 		[Test(Description = "Test that we don't need typing for non-sqlserver providers")]
-		public void Issue3360_TypeStringEnum_AllProviders([CteContextSource(ProviderName.DB2, TestProvName.AllSapHana)] string context)
+		public void Issue3360_TypeStringEnum_AllProviders([RecursiveCteContextSource(ProviderName.DB2)] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tb = db.CreateLocalTable<Issue3360WithEnum>();
@@ -1459,7 +1452,7 @@ namespace Tests.Linq
 		}
 
 		[Test(Description = "Test that we don't need typing for non-sqlserver providers")]
-		public void Issue3360_TypeByProjectionProperty_AllProviders([CteContextSource(ProviderName.DB2, TestProvName.AllSapHana)] string context)
+		public void Issue3360_TypeByProjectionProperty_AllProviders([RecursiveCteContextSource(ProviderName.DB2)] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tb = db.CreateLocalTable<Issue3360Table>();
@@ -1510,7 +1503,7 @@ namespace Tests.Linq
 
 		[ActiveIssue(Configurations = [TestProvName.AllSqlServer])]
 		[Test(Description = "Test CTE columns typing")]
-		public void Issue3360_NullGuidInAnchor([CteContextSource(TestProvName.AllFirebird, ProviderName.DB2, TestProvName.AllSapHana)] string context)
+		public void Issue3360_NullGuidInAnchor([RecursiveCteContextSource(TestProvName.AllFirebird, ProviderName.DB2)] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tb = db.CreateLocalTable<Issue3360NullInAnchor>();
@@ -1530,7 +1523,7 @@ namespace Tests.Linq
 
 		[ActiveIssue(Configurations = [TestProvName.AllSqlServer])]
 		[Test(Description = "Test CTE columns typing")]
-		public void Issue3360_NullEnumInAnchor([CteContextSource(ProviderName.DB2, TestProvName.AllSapHana)] string context)
+		public void Issue3360_NullEnumInAnchor([RecursiveCteContextSource(ProviderName.DB2)] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tb = db.CreateLocalTable<Issue3360NullInAnchor>();
@@ -1727,9 +1720,9 @@ namespace Tests.Linq
 
 		private record Issue3360NullsRecord(int Id, byte? Byte, byte? ByteN, Guid? Guid, Guid? GuidN, InvalidColumnIndexMappingEnum1? Enum, InvalidColumnIndexMappingEnum2? EnumN, bool? Bool, bool? BoolN);
 
-		[ActiveIssue(3015, Configurations = [TestProvName.AllClickHouse, TestProvName.AllFirebird, TestProvName.AllMySql, TestProvName.AllSqlServer, TestProvName.AllSapHana])]
+		[ActiveIssue(3015, Configurations = [TestProvName.AllClickHouse, TestProvName.AllFirebird, TestProvName.AllMySql, TestProvName.AllSqlServer])]
 		[Test(Description = "null literals in anchor query (for known problematic types)")]
-		public void Issue3360_NullsInAnchor([CteContextSource] string context)
+		public void Issue3360_NullsInAnchor([RecursiveCteContextSource] string context)
 		{
 			using var db    = GetDataContext(context);
 			using var table = db.CreateLocalTable(Issue3360Table1.Items);
@@ -1773,9 +1766,9 @@ namespace Tests.Linq
 			}
 		}
 
-		[ActiveIssue(3015, Configurations = [TestProvName.AllClickHouse, TestProvName.AllFirebird, TestProvName.AllMySql, TestProvName.AllSqlServer, TestProvName.AllSapHana])]
+		[ActiveIssue(3015, Configurations = [TestProvName.AllClickHouse, TestProvName.AllFirebird, TestProvName.AllMySql, TestProvName.AllSqlServer])]
 		[Test(Description = "double columns in anchor query")]
-		public void Issue3360_DoubleColumnSelection([CteContextSource] string context)
+		public void Issue3360_DoubleColumnSelection([RecursiveCteContextSource] string context)
 		{
 			using var db    = GetDataContext(context);
 			using var table = db.CreateLocalTable(Issue3360Table1.Items);
@@ -1821,7 +1814,7 @@ namespace Tests.Linq
 
 		[ActiveIssue(Configurations = [TestProvName.AllSQLite])]
 		[Test(Description = "literals in anchor query")]
-		public void Issue3360_LiteralsInAnchor([CteContextSource(TestProvName.AllInformix, TestProvName.AllSapHana)] string context)
+		public void Issue3360_LiteralsInAnchor([RecursiveCteContextSource(TestProvName.AllInformix)] string context)
 		{
 			using var db    = GetDataContext(context);
 			using var table = db.CreateLocalTable(Issue3360Table1.Items);
@@ -1894,7 +1887,7 @@ namespace Tests.Linq
 
 		[ActiveIssue(Configurations = [TestProvName.AllPostgreSQL, TestProvName.AllSqlServer])]
 		[Test(Description = "Test that other providers work")]
-		public void Issue2451_ComplexColumn_All([CteContextSource(ProviderName.DB2, TestProvName.AllSapHana)] string context)
+		public void Issue2451_ComplexColumn_All([RecursiveCteContextSource(ProviderName.DB2)] string context)
 		{
 			using var db = GetDataContext(context);
 
@@ -1950,9 +1943,8 @@ namespace Tests.Linq
 			public TestFolder? Parent { get; set; }
 		}
 
-		[ActiveIssue(3015, Configuration = TestProvName.AllSapHana)]
 		[Test(Description = "Recursive common table expression 'CTE' does not contain a top-level UNION ALL operator.")]
-		public void Issue2264([CteContextSource] string context)
+		public void Issue2264([RecursiveCteContextSource] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tb = db.CreateLocalTable<TestFolder>();
@@ -2177,7 +2169,7 @@ namespace Tests.Linq
 		}
 
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4366")]
-		public void Issue4366Test1([CteContextSource(TestProvName.AllSapHana)] string context)
+		public void Issue4366Test1([RecursiveCteContextSource] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tb = db.CreateLocalTable<Dto>();
@@ -2205,7 +2197,7 @@ namespace Tests.Linq
 		}
 
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4366")]
-		public void Issue4366Test2([CteContextSource(TestProvName.AllSapHana)] string context)
+		public void Issue4366Test2([RecursiveCteContextSource] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tb = db.CreateLocalTable<Dto>();
@@ -2267,7 +2259,7 @@ namespace Tests.Linq
 		// CH: probably this https://github.com/ClickHouse/ClickHouse/issues/64794
 		[ActiveIssue(Details = "Investigate expected SQL", Configuration = TestProvName.AllClickHouse)]
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4012")]
-		public void Issue4012Test([CteContextSource(TestProvName.AllSapHana)] string context)
+		public void Issue4012Test([RecursiveCteContextSource] string context)
 		{
 			using var db = GetDataContext(context);
 
@@ -2563,7 +2555,7 @@ namespace Tests.Linq
 		sealed record SequenceBuildFailedRecord(int Id);
 
 		[Test]
-		public void Issue_SequenceBuildFailed_1([CteContextSource(TestProvName.AllInformix, TestProvName.AllSapHana)] string context)
+		public void Issue_SequenceBuildFailed_1([RecursiveCteContextSource(TestProvName.AllInformix)] string context)
 		{
 			using var db = GetDataContext(context);
 
@@ -2624,7 +2616,7 @@ namespace Tests.Linq
 		}
 
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4968")]
-		public void Issue4968Test_Tuple_Select([CteContextSource(TestProvName.AllClickHouse, TestProvName.AllSapHana)] string context)
+		public void Issue4968Test_Tuple_Select([RecursiveCteContextSource(TestProvName.AllClickHouse)] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tm = db.CreateLocalTable<Issue4968Menu>();
@@ -2645,7 +2637,7 @@ namespace Tests.Linq
 		}
 
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4968")]
-		public void Issue4968Test_Tuple_Delete([CteContextSource(TestProvName.AllDB2, TestProvName.AllFirebird, TestProvName.AllInformix, TestProvName.AllMySqlWithCTE, TestProvName.AllClickHouse, TestProvName.AllSapHana)] string context)
+		public void Issue4968Test_Tuple_Delete([RecursiveCteContextSource(TestProvName.AllDB2, TestProvName.AllFirebird, TestProvName.AllInformix, TestProvName.AllMySqlWithCTE, TestProvName.AllClickHouse)] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tm = db.CreateLocalTable<Issue4968Menu>();
@@ -2666,7 +2658,7 @@ namespace Tests.Linq
 		}
 
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4968")]
-		public void Issue4968Test_Class_Select([CteContextSource(TestProvName.AllClickHouse, TestProvName.AllSapHana)] string context)
+		public void Issue4968Test_Class_Select([RecursiveCteContextSource(TestProvName.AllClickHouse)] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tm = db.CreateLocalTable<Issue4968Menu>();
@@ -2687,7 +2679,7 @@ namespace Tests.Linq
 		}
 
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4968")]
-		public void Issue4968Test_Class_Delete([CteContextSource(TestProvName.AllDB2, TestProvName.AllFirebird, TestProvName.AllInformix, TestProvName.AllMySqlWithCTE, TestProvName.AllClickHouse, TestProvName.AllSapHana)] string context)
+		public void Issue4968Test_Class_Delete([RecursiveCteContextSource(TestProvName.AllDB2, TestProvName.AllFirebird, TestProvName.AllInformix, TestProvName.AllMySqlWithCTE, TestProvName.AllClickHouse)] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tm = db.CreateLocalTable<Issue4968Menu>();

--- a/Tests/Linq/Linq/CteTests.cs
+++ b/Tests/Linq/Linq/CteTests.cs
@@ -2353,7 +2353,7 @@ namespace Tests.Linq
 			[Column(Precision = 10, Scale = 0)] public decimal StockOnHand { get; set; }
 		}
 
-		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllClickHouse, ErrorMessage = ErrorHelper.Error_Correlated_Subqueries)]
+		[RequiresCorrelatedSubquery]
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4717")]
 		public void Issue4717Test([CteContextSource] string context)
 		{

--- a/Tests/Linq/Linq/EagerLoadingTests.cs
+++ b/Tests/Linq/Linq/EagerLoadingTests.cs
@@ -1150,7 +1150,7 @@ FROM
 		}
 
 		[Test]
-		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllClickHouse, ErrorMessage = ErrorHelper.Error_Correlated_Subqueries)]
+		[RequiresCorrelatedSubquery]
 		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllAccess, TestProvName.AllFirebirdLess4, TestProvName.AllMySql57, TestProvName.AllSybase, TestProvName.AllOracle11, TestProvName.AllMariaDB, TestProvName.AllDB2, TestProvName.AllInformix, ErrorMessage = ErrorHelper.Error_OUTER_Joins)]
 		public void TestAggregate([DataSources] string context)
 		{
@@ -1181,7 +1181,7 @@ FROM
 		}
 
 		[Test]
-		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllClickHouse, ErrorMessage = ErrorHelper.Error_Correlated_Subqueries)]
+		[RequiresCorrelatedSubquery]
 		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllAccess, TestProvName.AllFirebirdLess4, TestProvName.AllMySql57, TestProvName.AllSybase, TestProvName.AllOracle11, TestProvName.AllMariaDB, TestProvName.AllDB2, TestProvName.AllInformix, ErrorMessage = ErrorHelper.Error_OUTER_Joins)]
 		public void TestAggregateAverage([DataSources] string context)
 		{
@@ -1937,8 +1937,9 @@ FROM
 			[Column] public decimal Value { get; set; }
 		}
 
+		[RequiresCorrelatedSubquery]
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/3226")]
-		public void Issue3226Test1([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Issue3226Test1([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			using var t1 = db.CreateLocalTable<Item>();
@@ -1969,7 +1970,7 @@ FROM
 				.ToList();
 		}
 
-		[ThrowsForProvider(typeof(LinqToDBException), providers: [TestProvName.AllClickHouse], ErrorMessage = ErrorHelper.Error_Correlated_Subqueries)]
+		[RequiresCorrelatedSubquery]
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/3226")]
 		public void Issue3226Test3([DataSources] string context)
 		{
@@ -1987,7 +1988,7 @@ FROM
 				.ToList();
 		}
 
-		[ThrowsForProvider(typeof(LinqToDBException), providers: [TestProvName.AllClickHouse], ErrorMessage = ErrorHelper.Error_Correlated_Subqueries)]
+		[RequiresCorrelatedSubquery]
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/3226")]
 		public void Issue3226Test4([DataSources] string context)
 		{

--- a/Tests/Linq/Linq/EagerLoadingTests.cs
+++ b/Tests/Linq/Linq/EagerLoadingTests.cs
@@ -3285,7 +3285,7 @@ FROM
 		sealed record CteRecord(int Id, int Value1, int Value2, int Value4, int Value5);
 
 		[Test]
-		public void CteCloning_Original([CteContextSource(TestProvName.AllSapHana)] string context)
+		public void CteCloning_Original([RecursiveCteContextSource] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tb = db.CreateLocalTable<CteTable>();
@@ -3392,7 +3392,7 @@ FROM
 		}
 
 		[Test]
-		public void CteCloning_RecursiveChain([CteContextSource(TestProvName.AllSapHana, TestProvName.AllOracle)] string context)
+		public void CteCloning_RecursiveChain([RecursiveCteContextSource(TestProvName.AllOracle)] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tb = db.CreateLocalTable<CteTable>();

--- a/Tests/Linq/Linq/ElementOperationTests.cs
+++ b/Tests/Linq/Linq/ElementOperationTests.cs
@@ -159,7 +159,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllClickHouse, ErrorMessage = ErrorHelper.Error_Correlated_Subqueries)]
+		[RequiresCorrelatedSubquery]
 		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllSQLite, TestProvName.AllAccess, TestProvName.AllFirebirdLess4, TestProvName.AllMySql57, TestProvName.AllSybase, TestProvName.AllOracle11, TestProvName.AllMariaDB, TestProvName.AllDB2, ErrorMessage = ErrorHelper.Error_OUTER_Joins)]
 		public void NestedFirstOrDefault4([DataSources(TestProvName.AllInformix, TestProvName.AllPostgreSQL9)] string context)
 		{

--- a/Tests/Linq/Linq/EnumMappingTests.cs
+++ b/Tests/Linq/Linq/EnumMappingTests.cs
@@ -464,7 +464,7 @@ namespace Tests.Linq
 				});
 
 				var cnt = db.GetTable<TestTable1>().Delete(r => r.Id == RID && r.TestField == TestEnum1.Value2);
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(1));
 			}
 		}
@@ -482,7 +482,7 @@ namespace Tests.Linq
 				});
 
 				var cnt = db.GetTable<TestTable2>().Delete(r => r.Id == RID && r.TestField == TestEnum21.Value2);
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(1));
 			}
 		}
@@ -500,7 +500,7 @@ namespace Tests.Linq
 				});
 
 				var cnt = db.GetTable<NullableTestTable1>().Delete(r => r.Id == RID && r.TestField == TestEnum1.Value2);
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(1));
 			}
 		}
@@ -518,7 +518,7 @@ namespace Tests.Linq
 				});
 
 				var cnt = db.GetTable<NullableTestTable2>().Delete(r => r.Id == RID && r.TestField == TestEnum21.Value2);
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(1));
 			}
 		}
@@ -877,7 +877,7 @@ namespace Tests.Linq
 					})
 					.Insert(db.GetTable<TestTable1>(), r => r);
 
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(result, Is.EqualTo(1));
 				Assert.That(db.GetTable<RawTable>().Where(r => r.Id == RID && r.TestField == VAL1).Count(), Is.EqualTo(1));
 			}
@@ -906,7 +906,7 @@ namespace Tests.Linq
 					})
 					.Insert(db.GetTable<TestTable2>(), r => r);
 
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(result, Is.EqualTo(1));
 				Assert.That(db.GetTable<RawTable>().Where(r => r.Id == RID && r.TestField == VAL1).Count(), Is.EqualTo(1));
 			}
@@ -935,7 +935,7 @@ namespace Tests.Linq
 					})
 					.Insert(db.GetTable<NullableTestTable1>(), r => r);
 
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(result, Is.EqualTo(1));
 				Assert.That(db.GetTable<RawTable>().Where(r => r.Id == RID && r.TestField == VAL1).Count(), Is.EqualTo(1));
 			}
@@ -964,7 +964,7 @@ namespace Tests.Linq
 					})
 					.Insert(db.GetTable<NullableTestTable2>(), r => r);
 
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(result, Is.EqualTo(1));
 				Assert.That(db.GetTable<RawTable>().Where(r => r.Id == RID && r.TestField == VAL1).Count(), Is.EqualTo(1));
 			}
@@ -983,7 +983,7 @@ namespace Tests.Linq
 				});
 
 				var cnt = db.GetTable<TestTable1>().Delete(r => r.Id == RID && r.TestField.Equals(TestEnum1.Value2));
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(1));
 			}
 		}
@@ -1001,7 +1001,7 @@ namespace Tests.Linq
 				});
 
 				var cnt = db.GetTable<TestTable2>().Delete(r => r.Id == RID && r.TestField.Equals(TestEnum21.Value2));
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(1));
 			}
 		}
@@ -1020,7 +1020,7 @@ namespace Tests.Linq
 
 				var cnt = db.GetTable<NullableTestTable1>().Delete(r => r.Id == RID && r.TestField.Equals(TestEnum1.Value2));
 
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(1));
 			}
 		}
@@ -1039,7 +1039,7 @@ namespace Tests.Linq
 
 				var cnt = db.GetTable<NullableTestTable2>().Delete(r => r.Id == RID && r.TestField.Equals(TestEnum21.Value2));
 
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(1));
 			}
 		}

--- a/Tests/Linq/Linq/EnumerableSourceTests.cs
+++ b/Tests/Linq/Linq/EnumerableSourceTests.cs
@@ -695,10 +695,10 @@ namespace Tests.Linq
 					select r;
 
 				var cnt = table.Insert(queryToInsert);
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(2));
 				cnt = table.Insert(queryToInsert);
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.Zero);
 
 				if (iteration > 1)

--- a/Tests/Linq/Linq/ExpressionsTests.cs
+++ b/Tests/Linq/Linq/ExpressionsTests.cs
@@ -156,7 +156,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void MethodExpression4([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void MethodExpression4([DataSources] string context)
 		{
 			var n = 3;
 
@@ -180,7 +181,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void MethodExpression5([DataSources(ProviderName.SqlCe, TestProvName.AllClickHouse)] string context, [Values(1, 2) ]int n)
+		[RequiresCorrelatedSubquery]
+		public void MethodExpression5([DataSources(ProviderName.SqlCe)] string context, [Values(1, 2) ]int n)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -202,7 +204,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void MethodExpression6([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void MethodExpression6([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -224,7 +227,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void MethodExpression7([DataSources(ProviderName.SqlCe, TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void MethodExpression7([DataSources(ProviderName.SqlCe)] string context)
 		{
 			var n = 2;
 
@@ -396,7 +400,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void AssociationMethodExpression([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void AssociationMethodExpression([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -407,8 +412,9 @@ namespace Tests.Linq
 					select GrandChildren(p).Count());
 		}
 
+		[RequiresCorrelatedSubquery]
 		[Test]
-		public async Task AssociationMethodExpressionAsync([DataSources(TestProvName.AllClickHouse)] string context)
+		public async Task AssociationMethodExpressionAsync([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -1035,7 +1041,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void Issue3472Test([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void Issue3472Test([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			if (db is DataConnection)

--- a/Tests/Linq/Linq/FunctionTests.cs
+++ b/Tests/Linq/Linq/FunctionTests.cs
@@ -510,7 +510,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void Sum2([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void Sum2([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(

--- a/Tests/Linq/Linq/GroupByTests.cs
+++ b/Tests/Linq/Linq/GroupByTests.cs
@@ -644,7 +644,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void Sum3([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void Sum3([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -845,7 +846,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllClickHouse, ErrorMessage = ErrorHelper.Error_Correlated_Subqueries)]
+		[RequiresCorrelatedSubquery]
 		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllAccess, TestProvName.AllFirebirdLess4, TestProvName.AllMySql57, TestProvName.AllSybase, TestProvName.AllOracle11, TestProvName.AllMariaDB, TestProvName.AllDB2, ErrorMessage = ErrorHelper.Error_OUTER_Joins)]
 		public void CountInGroup([DataSources] string context)
 		{
@@ -1323,7 +1324,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllClickHouse, ErrorMessage = ErrorHelper.Error_Correlated_Subqueries)]
+		[RequiresCorrelatedSubquery]
 		public void GroupByAggregate1([DataSources(ProviderName.SqlCe)] string context)
 		{
 			using (var db = GetDataContext(context))
@@ -1338,7 +1339,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllClickHouse, ErrorMessage = ErrorHelper.Error_Correlated_Subqueries)]
+		[RequiresCorrelatedSubquery]
 		public void GroupByAggregate11([DataSources(ProviderName.SqlCe)] string context)
 		{
 			using (var db = GetDataContext(context))
@@ -1355,7 +1356,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllClickHouse, ErrorMessage = ErrorHelper.Error_Correlated_Subqueries)]
+		[RequiresCorrelatedSubquery]
 		public void GroupByAggregate12([DataSources(ProviderName.SqlCe)] string context)
 		{
 			using (var db = GetDataContext(context))

--- a/Tests/Linq/Linq/IssueTests.cs
+++ b/Tests/Linq/Linq/IssueTests.cs
@@ -22,7 +22,8 @@ namespace Tests.Linq
 		// https://github.com/linq2db/linq2db/issues/38
 		//
 		[Test]
-		public void Issue38Test([DataSources(false, TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void Issue38Test([DataSources(false)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -93,7 +94,8 @@ namespace Tests.Linq
 		// https://github.com/linq2db/linq2db/issues/67
 		//
 		[Test]
-		public void Issue67Test([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void Issue67Test([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -111,8 +113,9 @@ namespace Tests.Linq
 			}
 		}
 
-		[Test()]
-		public void Issue75Test([DataSources(TestProvName.AllClickHouse)] string context)
+		[Test]
+		[RequiresCorrelatedSubquery]
+		public void Issue75Test([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -687,7 +690,7 @@ namespace Tests.Linq
 							intDataType = _
 						});
 
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(rows, Is.EqualTo(isNull ? 0 : 1));
 			}
 		}

--- a/Tests/Linq/Linq/JoinTests.cs
+++ b/Tests/Linq/Linq/JoinTests.cs
@@ -471,8 +471,9 @@ namespace Tests.Linq
 		}
 
 		[Test]
+		[RequiresCorrelatedSubquery]
 		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllAccess, ProviderName.Firebird25, TestProvName.AllMySql57, TestProvName.AllSybase, ErrorMessage = ErrorHelper.Error_OUTER_Joins)]
-		public void GroupJoin54([DataSources(TestProvName.AllClickHouse)] string context)
+		public void GroupJoin54([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -1204,7 +1205,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void JoinSubQuerySum([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void JoinSubQuerySum([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -3340,7 +3342,7 @@ namespace Tests.Linq
 		}
 
 		[ThrowsForProvider(typeof(LinqToDBException), providers: [TestProvName.AllSQLite, TestProvName.AllAccess, TestProvName.AllDB2, TestProvName.AllFirebirdLess4, TestProvName.AllInformix, TestProvName.AllMariaDB, TestProvName.AllMySql57, TestProvName.AllOracle11, TestProvName.AllSybase], ErrorMessage = ErrorHelper.Error_OUTER_Joins)]
-		[ThrowsForProvider(typeof(LinqToDBException), providers: [TestProvName.AllClickHouse], ErrorMessage = ErrorHelper.Error_Correlated_Subqueries)]
+		[RequiresCorrelatedSubquery]
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/3311")]
 		public void Issue3311Test3([DataSources] string context)
 		{

--- a/Tests/Linq/Linq/LoadWithTests.cs
+++ b/Tests/Linq/Linq/LoadWithTests.cs
@@ -99,7 +99,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void LoadWith3([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void LoadWith3([DataSources] string context)
 		{
 			var ms = new MappingSchema();
 			ms.SetConvertExpression<IEnumerable<Child>, ImmutableList<Child>>(t => ImmutableList.Create(t.ToArray()));
@@ -121,7 +122,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void LoadWithAsTable3([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void LoadWithAsTable3([DataSources] string context)
 		{
 			var ms = new MappingSchema();
 
@@ -153,7 +155,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void LoadWith4([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void LoadWith4([DataSources] string context)
 		{
 			var ms = new MappingSchema();
 			ms.SetGenericConvertProvider(typeof(EnumerableToImmutableListConvertProvider<>));
@@ -175,7 +178,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void LoadWith5([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void LoadWith5([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -196,7 +200,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void LoadWith6([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void LoadWith6([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 			{

--- a/Tests/Linq/Linq/OrderByDistinctTests.cs
+++ b/Tests/Linq/Linq/OrderByDistinctTests.cs
@@ -400,7 +400,7 @@ namespace Tests.Linq
 			}
 		}
 
-		[ThrowsForProvider(typeof(LinqToDBException), providers: [TestProvName.AllClickHouse], ErrorMessage = ErrorHelper.Error_Correlated_Subqueries)]
+		[RequiresCorrelatedSubquery]
 		[Test]
 		public void OrderBySubQuery([DataSources] string context)
 		{

--- a/Tests/Linq/Linq/OrderByTests.cs
+++ b/Tests/Linq/Linq/OrderByTests.cs
@@ -379,7 +379,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllClickHouse, ErrorMessage = ErrorHelper.Error_Correlated_Subqueries)]
+		[RequiresCorrelatedSubquery]
 		public void OrderByContinuous([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))

--- a/Tests/Linq/Linq/SetTests.cs
+++ b/Tests/Linq/Linq/SetTests.cs
@@ -118,7 +118,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllClickHouse, ErrorMessage = ErrorHelper.Error_Correlated_Subqueries)]
+		[RequiresCorrelatedSubquery]
 		public void Contains701([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))

--- a/Tests/Linq/Linq/SubQueryTests.cs
+++ b/Tests/Linq/Linq/SubQueryTests.cs
@@ -17,7 +17,8 @@ namespace Tests.Linq
 	public class SubQueryTests : TestBase
 	{
 		[Test]
-		public void Test1([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void Test1([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -30,7 +31,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void Test2([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void Test2([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -73,7 +75,8 @@ namespace Tests.Linq
 		static int _testValue = 3;
 
 		[Test]
-		public void Test5([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void Test5([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -110,7 +113,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void Test6([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void Test6([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -150,7 +154,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void Test7([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void Test7([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -279,7 +284,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SubSub1([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void SubSub1([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -314,9 +320,9 @@ namespace Tests.Linq
 		}
 
 		[Test]
+		[RequiresCorrelatedSubquery]
 		public void SubSub2([DataSources(
 			TestProvName.AllAccess,
-			TestProvName.AllClickHouse,
 			ProviderName.DB2,
 			TestProvName.AllOracle,
 			TestProvName.AllSybase,
@@ -407,7 +413,8 @@ namespace Tests.Linq
 		//}
 
 		[Test]
-		public void SubSub21([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void SubSub21([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -450,7 +457,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SubSub211([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void SubSub211([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -495,7 +503,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void SubSub212([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void SubSub212([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -538,9 +547,9 @@ namespace Tests.Linq
 		}
 
 		[Test]
+		[RequiresCorrelatedSubquery]
 		public void SubSub22([DataSources(
 			ProviderName.SqlCe, ProviderName.DB2,
-			TestProvName.AllClickHouse,
 			TestProvName.AllOracle, TestProvName.AllSapHana)]
 			string context)
 		{
@@ -587,7 +596,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void Count1([DataSources(ProviderName.SqlCe, TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void Count1([DataSources(ProviderName.SqlCe)] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -637,7 +647,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void Count3([DataSources(ProviderName.SqlCe, TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void Count3([DataSources(ProviderName.SqlCe)] string context)
 		{
 			using (var db = GetDataContext(context))
 				AreEqual(
@@ -966,8 +977,9 @@ namespace Tests.Linq
 			public IEnumerable<Review> Reviews { get; set; } = null!;
 		}
 
+		[RequiresCorrelatedSubquery]
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4458")]
-		public void Issue4458Test1([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Issue4458Test1([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			using var t1 = db.CreateLocalTable(Issue4458Item.Data);
@@ -997,8 +1009,9 @@ namespace Tests.Linq
 			}
 		}
 
+		[RequiresCorrelatedSubquery]
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4458")]
-		public void Issue4458Test2([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Issue4458Test2([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			using var t1 = db.CreateLocalTable(Issue4458Item.Data);

--- a/Tests/Linq/Linq/TagTests.cs
+++ b/Tests/Linq/Linq/TagTests.cs
@@ -301,7 +301,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void Test_SqlInsertOrUpdateStatement([DataSources(NOT_SUPPORTED, TestProvName.AllClickHouse)] string context)
+		public void Test_SqlInsertOrUpdateStatement([InsertOrUpdateDataSources(NOT_SUPPORTED)] string context)
 		{
 			var tag = "My Test";
 			var expected = $"/* {tag} */{Environment.NewLine}";

--- a/Tests/Linq/Mapping/ConversionTypeTests.cs
+++ b/Tests/Linq/Mapping/ConversionTypeTests.cs
@@ -176,17 +176,7 @@ namespace Tests.Mapping
 		}
 
 		[Test]
-		public void MergeTest([DataSources([
-			TestProvName.AllAccess,
-			TestProvName.AllClickHouse,
-			TestProvName.AllMariaDB,
-			TestProvName.AllMySql,
-			TestProvName.AllPostgreSQL,
-			ProviderName.SqlCe,
-			TestProvName.AllSQLite,
-			TestProvName.AllSqlServer2005,
-			])] string context,
-			[Values] bool inlineParameters)
+		public void MergeTest([MergeDataContextSource] string context, [Values] bool inlineParameters)
 		{
 			using var db = GetDataContext(context, _trimMappingSchema);
 

--- a/Tests/Linq/Mapping/FluentMappingBuildTests.cs
+++ b/Tests/Linq/Mapping/FluentMappingBuildTests.cs
@@ -12,7 +12,7 @@ namespace Tests.Mapping
 	public class FluentMappingBuildTests : TestBase
 	{
 		[Test]
-		public void InsertOrUpdatePrimaryKeyTest([DataSources(TestProvName.AllClickHouse, TestProvName.AllOracle)] string context)
+		public void InsertOrUpdatePrimaryKeyTest([InsertOrUpdateDataSources(TestProvName.AllOracle)] string context)
 		{
 			using var db  = GetDataContext(context);
 

--- a/Tests/Linq/Update/DeleteTests.cs
+++ b/Tests/Linq/Update/DeleteTests.cs
@@ -34,7 +34,7 @@ namespace Tests.xUpdate
 
 				Assert.That(db.Parent.Count (p => p.ParentID == parent.ParentID), Is.EqualTo(1));
 				var cnt = db.Parent.Delete(p => p.ParentID == parent.ParentID);
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(1));
 				Assert.That(db.Parent.Count (p => p.ParentID == parent.ParentID), Is.Zero);
 			}
@@ -53,7 +53,7 @@ namespace Tests.xUpdate
 
 				Assert.That(db.Parent.Count(p => p.ParentID == parent.ParentID), Is.EqualTo(1));
 				var cnt = db.Parent.Where(p => p.ParentID == parent.ParentID).Delete();
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(1));
 				Assert.That(db.Parent.Count(p => p.ParentID == parent.ParentID), Is.Zero);
 			}
@@ -119,7 +119,7 @@ namespace Tests.xUpdate
 
 					Assert.That(db.Parent.Count(_ => _.ParentID > 1000), Is.EqualTo(2));
 					var cnt = db.Parent.Delete(_ => values.Contains(_.ParentID));
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(cnt, Is.EqualTo(2));
 					Assert.That(db.Parent.Count(_ => _.ParentID > 1000), Is.Zero);
 				}
@@ -514,7 +514,7 @@ namespace Tests.xUpdate
 
 					var ret = db.Parent.Delete(p => list.Contains(p) );
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(ret, Is.EqualTo(2));
 				}
 				finally
@@ -628,10 +628,10 @@ namespace Tests.xUpdate
 			var deleted = db.Parent.Delete(c => c.ParentID == 1003) == 1;
 			using (Assert.EnterMultipleScope())
 			{
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(2));
 				Assert.That(left, Is.EqualTo(1));
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(deleted, Is.True);
 			}
 		}
@@ -656,10 +656,10 @@ namespace Tests.xUpdate
 			var deleted = db.Parent.Delete(c => c.ParentID > 1000) == 1;
 			using (Assert.EnterMultipleScope())
 			{
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(2));
 				Assert.That(left, Is.EqualTo(1));
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(deleted, Is.True);
 			}
 		}

--- a/Tests/Linq/Update/DeleteWithOutputTests.cs
+++ b/Tests/Linq/Update/DeleteWithOutputTests.cs
@@ -12,9 +12,11 @@ namespace Tests.xUpdate
 	[TestFixture]
 	public class DeleteWithOutputTests : TestBase
 	{
-		private const string FeatureDeleteOutputMultiple = $"{TestProvName.AllSqlServer},{TestProvName.AllFirebird5Plus},{TestProvName.AllMariaDB},{TestProvName.AllPostgreSQL},{TestProvName.AllSQLite}";
-		private const string FeatureDeleteOutputSingle   = $"{TestProvName.AllSqlServer},{TestProvName.AllFirebirdLess5},{TestProvName.AllMariaDB},{TestProvName.AllPostgreSQL},{TestProvName.AllSQLite}";
-		private const string FeatureDeleteOutputInto     = $"{TestProvName.AllSqlServer}";
+		private const string FeatureDeleteOutputMultipleWithExpressions = $"{TestProvName.AllSqlServer},{TestProvName.AllFirebird5Plus},{TestProvName.AllMariaDB},{TestProvName.AllPostgreSQL},{TestProvName.AllSQLite}";
+		private const string FeatureDeleteOutputMultiple                = $"{TestProvName.AllSqlServer},{TestProvName.AllFirebird5Plus},{TestProvName.AllMariaDB},{TestProvName.AllPostgreSQL},{TestProvName.AllSQLite}";
+		private const string FeatureDeleteOutputSingleWithExpressions   = $"{TestProvName.AllSqlServer},{TestProvName.AllFirebirdLess5},{TestProvName.AllMariaDB},{TestProvName.AllPostgreSQL},{TestProvName.AllSQLite}";
+		private const string FeatureDeleteOutputSingle                  = $"{TestProvName.AllSqlServer},{TestProvName.AllFirebirdLess5},{TestProvName.AllMariaDB},{TestProvName.AllPostgreSQL},{TestProvName.AllSQLite}";
+		private const string FeatureDeleteOutputInto                    = $"{TestProvName.AllSqlServer}";
 
 		[Table]
 		sealed class TableWithData
@@ -140,7 +142,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public void DeleteWithOutputProjectionFromQueryTest([IncludeDataSources(true, FeatureDeleteOutputMultiple)] string context, [Values(100, 200)] int param)
+		public void DeleteWithOutputProjectionFromQueryTest([IncludeDataSources(true, FeatureDeleteOutputMultipleWithExpressions)] string context, [Values(100, 200)] int param)
 		{
 			var sourceData    = GetSourceData();
 			using (var db     = GetDataContext(context))
@@ -172,7 +174,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public void DeleteWithOutputProjectionFromQueryTestSingleRecord([IncludeDataSources(true, FeatureDeleteOutputSingle)] string context, [Values(100, 200)] int param)
+		public void DeleteWithOutputProjectionFromQueryTestSingleRecord([IncludeDataSources(true, FeatureDeleteOutputSingleWithExpressions)] string context, [Values(100, 200)] int param)
 		{
 			var sourceData    = GetSourceData();
 			using (var db     = GetDataContext(context))
@@ -206,7 +208,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public async Task DeleteWithOutputProjectionFromQueryAsyncTest([IncludeDataSources(true, FeatureDeleteOutputMultiple)] string context, [Values(100, 200)] int param)
+		public async Task DeleteWithOutputProjectionFromQueryAsyncTest([IncludeDataSources(true, FeatureDeleteOutputMultipleWithExpressions)] string context, [Values(100, 200)] int param)
 		{
 			var sourceData    = GetSourceData();
 			using (var db     = GetDataContext(context))
@@ -238,7 +240,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public async Task DeleteWithOutputProjectionFromQueryAsyncTestSingleRecord([IncludeDataSources(true, FeatureDeleteOutputSingle)] string context, [Values(100, 200)] int param)
+		public async Task DeleteWithOutputProjectionFromQueryAsyncTestSingleRecord([IncludeDataSources(true, FeatureDeleteOutputSingleWithExpressions)] string context, [Values(100, 200)] int param)
 		{
 			var sourceData    = GetSourceData();
 			using (var db     = GetDataContext(context))
@@ -270,7 +272,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public void DeleteWithOutputFromQueryTest([IncludeDataSources(true, FeatureDeleteOutputMultiple)] string context, [Values(100, 200)] int param)
+		public void DeleteWithOutputFromQueryTest([IncludeDataSources(true, FeatureDeleteOutputMultipleWithExpressions)] string context, [Values(100, 200)] int param)
 		{
 			var sourceData    = GetSourceData();
 			using (var db     = GetDataContext(context))
@@ -305,7 +307,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public void DeleteWithOutputFromQueryTestSingleRecord([IncludeDataSources(true, FeatureDeleteOutputSingle)] string context, [Values(100, 200)] int param)
+		public void DeleteWithOutputFromQueryTestSingleRecord([IncludeDataSources(true, FeatureDeleteOutputSingleWithExpressions)] string context, [Values(100, 200)] int param)
 		{
 			var sourceData    = GetSourceData();
 			using (var db     = GetDataContext(context))
@@ -340,7 +342,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public async Task DeleteWithOutputFromQueryAsyncTest([IncludeDataSources(true, FeatureDeleteOutputMultiple)] string context, [Values(100, 200)] int param)
+		public async Task DeleteWithOutputFromQueryAsyncTest([IncludeDataSources(true, FeatureDeleteOutputMultipleWithExpressions)] string context, [Values(100, 200)] int param)
 		{
 			var sourceData    = GetSourceData();
 			using (var db     = GetDataContext(context))
@@ -375,7 +377,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public async Task DeleteWithOutputFromQueryAsyncTestSingleRecord([IncludeDataSources(true, FeatureDeleteOutputSingle)] string context, [Values(100, 200)] int param)
+		public async Task DeleteWithOutputFromQueryAsyncTestSingleRecord([IncludeDataSources(true, FeatureDeleteOutputSingleWithExpressions)] string context, [Values(100, 200)] int param)
 		{
 			var sourceData    = GetSourceData();
 			using (var db = GetDataContext(context))

--- a/Tests/Linq/Update/DynamicColumnsTests.cs
+++ b/Tests/Linq/Update/DynamicColumnsTests.cs
@@ -31,7 +31,7 @@ namespace Tests.xUpdate
 					.Value(c => Sql.Property<int>(c, ParentIDColumn), () => 1)
 					.Value(c => Sql.Property<int>(c, ChildIDColumn), () => id)
 					.Insert();
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(1));
 
 				Assert.That(db.Child.Count(c => Sql.Property<int>(c, ChildIDColumn) == id), Is.EqualTo(1));
@@ -101,7 +101,7 @@ namespace Tests.xUpdate
 					.Value(c => Sql.Property<string>(c, lastNameColumn), () => "The Dynamic")
 					.Value(c => Sql.Property<Gender>(c, "Gender"), () => Gender.Male)
 					.Insert();
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(1));
 
 				Assert.That(db.GetTable<MyClass>().Count(c =>
@@ -128,7 +128,7 @@ namespace Tests.xUpdate
 						.Where(c => Sql.Property<string>(c, "LastName") == "Limonadovy")
 						.Set(c => Sql.Property<string>(c, "FirstName"), () => "Johnny")
 						.Update();
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(1));
 
 				Assert.That(db.GetTable<MyClass>().Count(c => Sql.Property<string>(c, "FirstName") == "Johnny" && Sql.Property<string>(c, "LastName") == "Limonadovy"), Is.EqualTo(1));

--- a/Tests/Linq/Update/InsertTests.cs
+++ b/Tests/Linq/Update/InsertTests.cs
@@ -56,7 +56,7 @@ namespace Tests.xUpdate
 							BoolValue = true
 						});
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(
 							cnt, Is.EqualTo(Types.Select(_ => _.ID / 3).Distinct().Count()));
 				}
@@ -96,7 +96,7 @@ namespace Tests.xUpdate
 							.Value(t => t.BoolValue, t => true)
 						.Insert();
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(
 							cnt, Is.EqualTo(Types.Select(_ => _.ID / 3).Distinct().Count()));
 				}
@@ -124,7 +124,7 @@ namespace Tests.xUpdate
 							ParentID = 1,
 							ChildID  = id
 						});
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(cnt, Is.EqualTo(1));
 
 					Assert.That(db.Child.Count(c => c.ChildID == id), Is.EqualTo(1));
@@ -152,7 +152,7 @@ namespace Tests.xUpdate
 								.Value(c => c.ParentID, () => 1)
 								.Value(c => c.ChildID,  () => id)
 							.Insert();
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(cnt, Is.EqualTo(1));
 
 					Assert.That(db.Child.Count(c => c.ChildID == id), Is.EqualTo(1));
@@ -180,7 +180,7 @@ namespace Tests.xUpdate
 								.Value(c => c.ParentID, () => 1)
 								.Value(c => c.ChildID,  () => id)
 							.InsertAsync();
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(cnt, Is.EqualTo(1));
 
 					Assert.That(await db.Child.CountAsync(c => c.ChildID == id), Is.EqualTo(1));
@@ -210,7 +210,7 @@ namespace Tests.xUpdate
 								ParentID = c.ParentID,
 								ChildID  = id
 							});
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(cnt, Is.EqualTo(1));
 
 					Assert.That(db.Child.Count(c => c.ChildID == id), Is.EqualTo(1));
@@ -240,7 +240,7 @@ namespace Tests.xUpdate
 								ParentID = c.ParentID,
 								ChildID  = id
 							});
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(cnt, Is.EqualTo(1));
 
 					Assert.That(await db.Child.CountAsync(c => c.ChildID == id), Is.EqualTo(1));
@@ -271,7 +271,7 @@ namespace Tests.xUpdate
 							ChildID  = id
 						})
 						.Insert(db.Child, c => c);
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(cnt, Is.EqualTo(1));
 
 					Assert.That(db.Child.Count(c => c.ChildID == id), Is.EqualTo(1));
@@ -300,7 +300,7 @@ namespace Tests.xUpdate
 								.Value(c => c.ParentID, c  => c.ParentID)
 								.Value(c => c.ChildID,  () => id)
 							.Insert();
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(cnt, Is.EqualTo(1));
 
 					Assert.That(db.Child.Count(c => c.ChildID == id), Is.EqualTo(1));
@@ -346,7 +346,7 @@ namespace Tests.xUpdate
 								.Value(c => c.ParentID, c  => c.ParentID)
 								.Value(c => c.ChildID,  () => id)
 							.InsertAsync();
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(cnt, Is.EqualTo(1));
 
 					Assert.That(await db.Child.CountAsync(c => c.ChildID == id), Is.EqualTo(1));
@@ -375,7 +375,7 @@ namespace Tests.xUpdate
 								.Value(c => c.ParentID, c => c.ParentID)
 								.Value(c => c.ChildID,  id)
 							.Insert();
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(cnt, Is.EqualTo(1));
 
 					Assert.That(db.Child.Count(c => c.ChildID == id), Is.EqualTo(1));
@@ -402,7 +402,7 @@ namespace Tests.xUpdate
 								.Value(p => p.ParentID, c => c.ParentID + 1000)
 								.Value(p => p.Value1,   c => (int?)c.ChildID)
 							.Insert();
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(cnt, Is.EqualTo(1));
 
 					Assert.That(db.Parent.Count(p => p.Value1 == 11), Is.EqualTo(1));
@@ -442,7 +442,7 @@ namespace Tests.xUpdate
 					.Value(p => p.ModifiedOn, c => Sql.CurrentTimestamp)
 					.Insert();
 
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(affected, Is.EqualTo(2));
 			}
 		}
@@ -463,7 +463,7 @@ namespace Tests.xUpdate
 							.Value(c => c.ChildID,  () => id)
 							.Value(c => c.ParentID, 1)
 						.Insert();
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(cnt, Is.EqualTo(1));
 
 					Assert.That(db.Child.Count(c => c.ChildID == id), Is.EqualTo(1));
@@ -491,7 +491,7 @@ namespace Tests.xUpdate
 							.Value(c => c.ParentID, 1)
 							.Value(c => c.ChildID,  () => id)
 						.Insert();
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(cnt, Is.EqualTo(1));
 
 					Assert.That(db.Child.Count(c => c.ChildID == id), Is.EqualTo(1));
@@ -524,7 +524,7 @@ namespace Tests.xUpdate
 							ParentID = p.ParentID,
 							ChildID  = p.ParentID,
 						});
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(cnt, Is.EqualTo(1));
 
 					Assert.That(db.Child.Count(c => c.ParentID == id), Is.EqualTo(1));
@@ -703,7 +703,7 @@ namespace Tests.xUpdate
 							ParentID = 1001,
 							Value1   = p.Value1
 						});
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(cnt, Is.EqualTo(1));
 
 					Assert.That(db.Parent4.Count(_ => _.ParentID == id && _.Value1 == p.Value1), Is.EqualTo(1));
@@ -730,7 +730,7 @@ namespace Tests.xUpdate
 							.Value(_ => _.ParentID, id)
 							.Value(_ => _.Value1,   TypeValue.Value1)
 						.Insert();
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(cnt, Is.EqualTo(1));
 
 					Assert.That(db.Parent4.Count(_ => _.ParentID == id), Is.EqualTo(1));
@@ -757,7 +757,7 @@ namespace Tests.xUpdate
 							.Value(_ => _.ParentID, id)
 							.Value(_ => _.Value1,   () => TypeValue.Value1)
 						.Insert();
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(cnt, Is.EqualTo(1));
 
 					Assert.That(db.Parent4.Count(_ => _.ParentID == id), Is.EqualTo(1));
@@ -780,7 +780,7 @@ namespace Tests.xUpdate
 						.Value(p => p.ParentID, 1001)
 						.Value(p => p.Value1,   (int?)null)
 					.Insert();
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(1));
 
 				Assert.That(db.Parent.Count(p => p.ParentID == 1001), Is.EqualTo(1));
@@ -2047,7 +2047,7 @@ namespace Tests.xUpdate
 				vi = vi.Value(x => x.ID, 123).Value(x => x.FirstName, "John");
 
 				var cnt = vi.Insert();
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(1));
 				Assert.That(table.Count(x => x.ID == 123 && x.FirstName == "John"), Is.EqualTo(1));
 			}

--- a/Tests/Linq/Update/InsertWithOutputTests.cs
+++ b/Tests/Linq/Update/InsertWithOutputTests.cs
@@ -17,10 +17,12 @@ namespace Tests.xUpdate
 	[TestFixture]
 	public class InsertWithOutputTests : TestBase
 	{
-		private const string FeatureInsertOutputSingle     = $"{TestProvName.AllSqlServer},{TestProvName.AllFirebirdLess5},{TestProvName.AllMariaDB},{TestProvName.AllPostgreSQL},{TestProvName.AllSQLite}";
-		private const string FeatureInsertOutputMultiple   = $"{TestProvName.AllSqlServer},{TestProvName.AllFirebird5Plus},{TestProvName.AllMariaDB},{TestProvName.AllPostgreSQL},{TestProvName.AllSQLite}";
-		private const string FeatureInsertOutputWithSchema = $"{TestProvName.AllSqlServer},{TestProvName.AllFirebird},{TestProvName.AllMariaDB},{TestProvName.AllSQLite}";
-		private const string FeatureInsertOutputInto       = $"{TestProvName.AllSqlServer}";
+		private const string FeatureInsertOutputSingleWithExpressions   = $"{TestProvName.AllSqlServer},{TestProvName.AllFirebirdLess5},{TestProvName.AllMariaDB},{TestProvName.AllPostgreSQL},{TestProvName.AllSQLite}";
+		private const string FeatureInsertOutputSingle                  = $"{TestProvName.AllSqlServer},{TestProvName.AllFirebirdLess5},{TestProvName.AllMariaDB},{TestProvName.AllPostgreSQL},{TestProvName.AllSQLite}";
+		private const string FeatureInsertOutputMultipleWithExpressions = $"{TestProvName.AllSqlServer},{TestProvName.AllFirebird5Plus},{TestProvName.AllMariaDB},{TestProvName.AllPostgreSQL},{TestProvName.AllSQLite}";
+		private const string FeatureInsertOutputMultiple                = $"{TestProvName.AllSqlServer},{TestProvName.AllFirebird5Plus},{TestProvName.AllMariaDB},{TestProvName.AllPostgreSQL},{TestProvName.AllSQLite}";
+		private const string FeatureInsertOutputWithSchema              = $"{TestProvName.AllSqlServer},{TestProvName.AllFirebird},{TestProvName.AllMariaDB},{TestProvName.AllSQLite}";
+		private const string FeatureInsertOutputInto                    = $"{TestProvName.AllSqlServer}";
 
 		[Table]
 		sealed class TableWithData
@@ -54,7 +56,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public void InsertWithOutputProjectionFromQueryTest([IncludeDataSources(true, FeatureInsertOutputMultiple)] string context, [Values(100, 200)] int param)
+		public void InsertWithOutputProjectionFromQueryTest([IncludeDataSources(true, FeatureInsertOutputMultipleWithExpressions)] string context, [Values(100, 200)] int param)
 		{
 			var sourceData    = GetSourceData();
 			using (var db     = GetDataContext(context))
@@ -209,7 +211,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public void InsertWithOutputTest3([IncludeDataSources(true, FeatureInsertOutputSingle)] string context, [Values(100, 200)] int param)
+		public void InsertWithOutputTest3([IncludeDataSources(true, FeatureInsertOutputSingleWithExpressions)] string context, [Values(100, 200)] int param)
 		{
 			using (var db = GetDataContext(context))
 			{
@@ -248,7 +250,7 @@ namespace Tests.xUpdate
 		}
 
 		[Test]
-		public void InsertWithOutputTest4([IncludeDataSources(true, FeatureInsertOutputSingle)] string context, [Values(100, 200)] int param)
+		public void InsertWithOutputTest4([IncludeDataSources(true, FeatureInsertOutputSingleWithExpressions)] string context, [Values(100, 200)] int param)
 		{
 			using (var db = GetDataContext(context))
 			{

--- a/Tests/Linq/Update/UpdateTests.cs
+++ b/Tests/Linq/Update/UpdateTests.cs
@@ -38,7 +38,7 @@ namespace Tests.xUpdate
 				Assert.That(db.Parent.Count(p => p.ParentID == parent.ParentID), Is.EqualTo(1));
 
 				var cnt = db.Parent.Update(p => p.ParentID == parent.ParentID, p => new Parent { ParentID = p.ParentID + 1 });
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(1));
 
 				Assert.That(db.Parent.Count(p => p.ParentID == parent.ParentID + 1), Is.EqualTo(1));
@@ -58,7 +58,7 @@ namespace Tests.xUpdate
 				Assert.That(await db.Parent.CountAsync(p => p.ParentID == parent.ParentID), Is.EqualTo(1));
 
 				var cnt = await db.Parent.UpdateAsync(p => p.ParentID == parent.ParentID, p => new Parent { ParentID = p.ParentID + 1 });
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(1));
 
 				Assert.That(await db.Parent.CountAsync(p => p.ParentID == parent.ParentID + 1), Is.EqualTo(1));
@@ -78,7 +78,7 @@ namespace Tests.xUpdate
 				Assert.That(db.Parent.Count(p => p.ParentID == parent.ParentID), Is.EqualTo(1));
 
 				var cnt = db.Parent.Where(p => p.ParentID == parent.ParentID).Update(p => new Parent { ParentID = p.ParentID + 1 });
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(1));
 
 				Assert.That(db.Parent.Count(p => p.ParentID == parent.ParentID + 1), Is.EqualTo(1));
@@ -98,7 +98,7 @@ namespace Tests.xUpdate
 				Assert.That(await db.Parent.CountAsync(p => p.ParentID == parent.ParentID), Is.EqualTo(1));
 
 				var cnt = await db.Parent.Where(p => p.ParentID == parent.ParentID).UpdateAsync(p => new Parent { ParentID = p.ParentID + 1 });
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(1));
 
 				Assert.That(await db.Parent.CountAsync(p => p.ParentID == parent.ParentID + 1), Is.EqualTo(1));
@@ -218,7 +218,7 @@ namespace Tests.xUpdate
 						.Where(p => p.ParentID == id)
 							.Set(p => p.Value1, () => TypeValue.Value2)
 						.Update();
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(1));
 
 				Assert.That(db.Parent4.Count(p => p.ParentID == id && p.Value1 == TypeValue.Value2), Is.EqualTo(1));
@@ -240,7 +240,7 @@ namespace Tests.xUpdate
 						.Where(p => p.ParentID == id)
 							.Set(p => p.Value1, TypeValue.Value2)
 						.Update();
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(1));
 				Assert.That(db.Parent4.Count(p => p.ParentID == id && p.Value1 == TypeValue.Value2), Is.EqualTo(1));
 
@@ -248,7 +248,7 @@ namespace Tests.xUpdate
 						.Where(p => p.ParentID == id)
 							.Set(p => p.Value1, TypeValue.Value3)
 						.Update();
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(1));
 
 				Assert.That(db.Parent4.Count(p => p.ParentID == id && p.Value1 == TypeValue.Value3), Is.EqualTo(1));
@@ -694,7 +694,7 @@ namespace Tests.xUpdate
 						.Set(_ => _.Gender, _ => nullableGender.HasValue ? nullableGender.Value : _.Gender)
 						.Update();
 
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(1));
 
 				var obj = db.GetTable<ComplexPerson2>()
@@ -735,7 +735,7 @@ namespace Tests.xUpdate
 						.Set(_ => _.Name.LastName, _ => _.Name.FirstName)
 						.Update();
 
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(cnt, Is.EqualTo(1));
 
 				var obj = db.GetTable<ComplexPerson2>().First(_ => _.ID == id);
@@ -1278,7 +1278,8 @@ namespace Tests.xUpdate
 							Value1 = queryResult.Value.ParentID
 						});
 
-				Assert.That(cnt, Is.EqualTo(1));
+				if (context.SupportsRowcount())
+					Assert.That(cnt, Is.EqualTo(1));
 			}
 		}
 
@@ -2042,7 +2043,8 @@ namespace Tests.xUpdate
 				var data = main.OrderBy(_ => _.Id).ToArray();
 				using (Assert.EnterMultipleScope())
 				{
-					Assert.That(cnt, Is.EqualTo(1));
+					if (context.SupportsRowcount())
+						Assert.That(cnt, Is.EqualTo(1));
 					Assert.That(data[0].Field, Is.EqualTo("value 1"));
 					Assert.That(data[1].Field, Is.EqualTo("value 2"));
 					Assert.That(data[2].Field, Is.EqualTo("test"));
@@ -2069,7 +2071,8 @@ namespace Tests.xUpdate
 				var data = main.OrderBy(_ => _.Id).ToArray();
 				using (Assert.EnterMultipleScope())
 				{
-					Assert.That(cnt, Is.EqualTo(1));
+					if (context.SupportsRowcount())
+						Assert.That(cnt, Is.EqualTo(1));
 					Assert.That(data[0].Field, Is.EqualTo("value 1"));
 					Assert.That(data[1].Field, Is.EqualTo("value 2"));
 					Assert.That(data[2].Field, Is.EqualTo("test"));
@@ -2096,7 +2099,8 @@ namespace Tests.xUpdate
 				var data = main.OrderBy(_ => _.Id).ToArray();
 				using (Assert.EnterMultipleScope())
 				{
-					Assert.That(cnt, Is.EqualTo(1));
+					if (context.SupportsRowcount())
+						Assert.That(cnt, Is.EqualTo(1));
 					Assert.That(data[0].Field, Is.EqualTo("value 1"));
 					Assert.That(data[1].Field, Is.EqualTo("value 2"));
 					Assert.That(data[2].Field, Is.EqualTo("test"));
@@ -2123,7 +2127,8 @@ namespace Tests.xUpdate
 				var data = main.OrderBy(_ => _.Id).ToArray();
 				using (Assert.EnterMultipleScope())
 				{
-					Assert.That(cnt, Is.EqualTo(1));
+					if (context.SupportsRowcount())
+						Assert.That(cnt, Is.EqualTo(1));
 					Assert.That(data[0].Field, Is.EqualTo("value 1"));
 					Assert.That(data[1].Field, Is.EqualTo("value 2"));
 					Assert.That(data[2].Field, Is.EqualTo("test"));

--- a/Tests/Linq/UserTests/Issue0082Tests.cs
+++ b/Tests/Linq/UserTests/Issue0082Tests.cs
@@ -1,5 +1,7 @@
 ﻿using System.Linq;
 
+using LinqToDB;
+
 using NUnit.Framework;
 
 namespace Tests.UserTests
@@ -43,7 +45,8 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void Test2([DataSources(TestProvName.AllClickHouse)] string context)
+		[RequiresCorrelatedSubquery]
+		public void Test2([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 			{

--- a/Tests/Linq/UserTests/Issue1128Tests.cs
+++ b/Tests/Linq/UserTests/Issue1128Tests.cs
@@ -71,7 +71,7 @@ namespace Tests.UserTests
 			using (db.CreateLocalTable<FluentBase>())
 			{
 				var res = db.Insert<FluentBase>(new FluentDerived { Id = 1 });
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(res, Is.EqualTo(1));
 			}
 		}
@@ -85,7 +85,7 @@ namespace Tests.UserTests
 			using (db.CreateLocalTable<AttributeBase>())
 			{
 				var res = db.Insert<AttributeBase>(new AttributeDerived { Id = 1 });
-				if (!context.IsAnyOf(TestProvName.AllClickHouse))
+				if (context.SupportsRowcount())
 					Assert.That(res, Is.EqualTo(1));
 			}
 		}

--- a/Tests/Linq/UserTests/Issue681Tests.cs
+++ b/Tests/Linq/UserTests/Issue681Tests.cs
@@ -94,7 +94,7 @@ namespace Tests.UserTests
 
 		[Test]
 		public async Task TestInsertOrReplace(
-			[DataSources(TestProvName.AllClickHouse)] string context,
+			[InsertOrUpdateDataSources] string context,
 			[Values] bool withServer,
 			[Values] bool withDatabase,
 			[Values] bool withSchema)

--- a/Tests/Linq/UserTests/Issue873Tests.cs
+++ b/Tests/Linq/UserTests/Issue873Tests.cs
@@ -9,8 +9,9 @@ namespace Tests.UserTests
 	[TestFixture]
 	public class Issue873Tests : TestBase
 	{
+		[RequiresCorrelatedSubquery]
 		[Test]
-		public void Test([DataSources(ProviderName.SqlCe, TestProvName.AllClickHouse)] string context)
+		public void Test([DataSources(ProviderName.SqlCe)] string context)
 		{
 			using (var db = GetDataContext(context))
 			{

--- a/Tests/Linq/UserTests/SkipCustomTest.cs
+++ b/Tests/Linq/UserTests/SkipCustomTest.cs
@@ -54,7 +54,7 @@ namespace Tests.UserTests
 
 					var count = db.Insert(new TestTable() { Id = 1, Name = "John", Age = 15 });
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 
 					var r = db.GetTable<TestTable>().FirstOrDefault(t => t.Id == 1)!;
@@ -64,7 +64,7 @@ namespace Tests.UserTests
 
 					count = db.Insert(new TestTable() { Id = 2, Name = "Max", Age = 14 });
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 
 					r = db.GetTable<TestTable>().FirstOrDefault(t => t.Id == 2)!;

--- a/Tests/Linq/UserTests/SkipValuesOnInsertTest.cs
+++ b/Tests/Linq/UserTests/SkipValuesOnInsertTest.cs
@@ -86,7 +86,7 @@ namespace Tests.UserTests
 
 					var count = db.Insert(new TestTable() {Id = 1, Name = "John", Age = 14});
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 
 					var r = db.GetTable<TestTable>().FirstOrDefault(t => t.Id == 1)!;
@@ -96,7 +96,7 @@ namespace Tests.UserTests
 
 					count = db.Insert(new TestTable() {Id = 2, Name = "Max", Age = 15});
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 
 					r = db.GetTable<TestTable>().FirstOrDefault(t => t.Id == 2)!;
@@ -117,7 +117,7 @@ namespace Tests.UserTests
 
 					var count = db.Insert(new TestTable() {Id = 1, Name = "Paul", Age = 14});
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 
 					var r = db.GetTable<TestTable>().FirstOrDefault(t => t.Id == 1)!;
@@ -127,7 +127,7 @@ namespace Tests.UserTests
 
 					count = db.Insert(new TestTable() {Id = 2, Name = "Mary", Age = 15});
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 
 					r = db.GetTable<TestTable>().FirstOrDefault(t => t.Id == 2)!;
@@ -148,7 +148,7 @@ namespace Tests.UserTests
 
 					var count = db.Insert(new TestTable() {Id = 1, Name = "Smith", Age = 2});
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 
 					var r = db.GetTable<TestTable>().FirstOrDefault(t => t.Id == 1)!;
@@ -158,7 +158,7 @@ namespace Tests.UserTests
 
 					count = db.Insert(new TestTable() {Id = 2, Name = "Tommy", Age = 5});
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 
 					r = db.GetTable<TestTable>().FirstOrDefault(t => t.Id == 2)!;
@@ -179,7 +179,7 @@ namespace Tests.UserTests
 
 					var count = db.Insert(new TestTable() {Id = 1, Name = "Smith", Age = 55});
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 
 					var r = db.GetTable<TestTable>().FirstOrDefault(t => t.Id == 1)!;
@@ -189,7 +189,7 @@ namespace Tests.UserTests
 
 					count = db.Insert(new TestTable() {Id = 2, Name = "Tommy", Age = 50});
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 
 					r = db.GetTable<TestTable>().FirstOrDefault(t => t.Id == 2)!;
@@ -212,7 +212,7 @@ namespace Tests.UserTests
 					
 					var count = db.Insert(new TestTableNull() { Id = 1, Name = "Tommy", Age = null });
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 
 					var r = db.GetTable<TestTableNull>().FirstOrDefault(t => t.Id == 1)!;
@@ -237,7 +237,7 @@ namespace Tests.UserTests
 				{
 					var count = db.Insert(new TestTableFluent() { Id = 1, Name = null, Age = 2 });
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 
 					var r = db.GetTable<TestTableFluent>().FirstOrDefault(t => t.Id == 1)!;
@@ -257,7 +257,7 @@ namespace Tests.UserTests
 				{
 					var count = db.Insert(new TestTableEnum() { Id = 1, Name = "Max", Age = 20, Gender = TestTableEnum.GenderType.Male});
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 
 					var r = db.GetTable<TestTableEnum>().FirstOrDefault(t => t.Id == 1)!;
@@ -267,7 +267,7 @@ namespace Tests.UserTests
 
 					count = db.Insert(new TestTableEnum() { Id = 2, Name = "Jenny", Age = 25, Gender = TestTableEnum.GenderType.Female });
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 
 					r = db.GetTable<TestTableEnum>().FirstOrDefault(t => t.Id == 2)!;
@@ -287,7 +287,7 @@ namespace Tests.UserTests
 				{
 					var count = db.Insert(new TestTableMixed() { Id = 1, Name = "Jason", Age = 20 });
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 
 					var r = db.GetTable<TestTableMixed>().FirstOrDefault(t => t.Id == 1)!;
@@ -298,7 +298,7 @@ namespace Tests.UserTests
 					r.Name = "Max";
 					count = db.Update(r);
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 
 					r = db.GetTable<TestTableMixed>().FirstOrDefault(t => t.Id == 1)!;
@@ -307,7 +307,7 @@ namespace Tests.UserTests
 
 					count = db.Insert(new TestTableMixed() { Id = 2, Name = "John", Age = 25 });
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 
 					r = db.GetTable<TestTableMixed>().FirstOrDefault(t => t.Id == 2)!;
@@ -317,7 +317,7 @@ namespace Tests.UserTests
 
 					r.Name = "Jessy";
 					count = db.Update(r);
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 
 					r = db.GetTable<TestTableMixed>().FirstOrDefault(t => t.Id == 2)!;

--- a/Tests/Linq/UserTests/SkipValuesOnUpdateTest.cs
+++ b/Tests/Linq/UserTests/SkipValuesOnUpdateTest.cs
@@ -74,7 +74,7 @@ namespace Tests.UserTests
 				{
 					var count = db.Insert(new TestTable() { Id = 1, Name = "Manuel", Age = 14 });
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 
 					var r = db.GetTable<TestTable>().FirstOrDefault(t => t.Id == 1)!;
@@ -85,7 +85,7 @@ namespace Tests.UserTests
 					r.Name = "Jacob";
 					r.Age = 15;
 					count = db.Update(r);
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 					r = db.GetTable<TestTable>().FirstOrDefault(t => t.Id == 1)!;
 					Assert.That(r, Is.Not.Null);
@@ -98,7 +98,7 @@ namespace Tests.UserTests
 					r.Name = "John";
 					r.Age = 22;
 					count = db.Update(r);
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 					r = db.GetTable<TestTable>().FirstOrDefault(t => t.Id == 1)!;
 					Assert.That(r, Is.Not.Null);
@@ -121,7 +121,7 @@ namespace Tests.UserTests
 
 					var count = db.Insert(new TestTable() { Id = 1, Name = "Smith", Age = 2 });
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 
 					var r = db.GetTable<TestTable>().FirstOrDefault(t => t.Id == 1)!;
@@ -132,7 +132,7 @@ namespace Tests.UserTests
 					r.Name = "Franki";
 					r.Age = 15;
 					count = db.Update(r);
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 					r = db.GetTable<TestTable>().FirstOrDefault(t => t.Id == 1)!;
 					Assert.That(r, Is.Not.Null);
@@ -145,7 +145,7 @@ namespace Tests.UserTests
 					r.Name = "Jack";
 					r.Age = 2;
 					count = db.Update(r);
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 					r = db.GetTable<TestTable>().FirstOrDefault(t => t.Id == 1)!;
 					Assert.That(r, Is.Not.Null);
@@ -167,7 +167,7 @@ namespace Tests.UserTests
 				{
 					var count = db.Insert(new TestTableNull() { Id = 1, Name = "Tommy", Age = null });
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 					var r = db.GetTable<TestTableNull>().FirstOrDefault(t => t.Id == 1)!;
 
@@ -177,7 +177,7 @@ namespace Tests.UserTests
 					r.Name = "Jack";
 					r.Age = 2;
 					count = db.Update(r);
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 					r = db.GetTable<TestTableNull>().FirstOrDefault(t => t.Id == 1)!;
 					Assert.That(r, Is.Not.Null);
@@ -190,7 +190,7 @@ namespace Tests.UserTests
 					r.Name = "Franki";
 					r.Age = null;
 					count = db.Update(r);
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 					r = db.GetTable<TestTableNull>().FirstOrDefault(t => t.Id == 1)!;
 					Assert.That(r, Is.Not.Null);
@@ -215,7 +215,7 @@ namespace Tests.UserTests
 				{
 					var count = db.Insert(new TestTableFluent() { Id = 1, Name = null, Age = 2 });
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 
 					var r = db.GetTable<TestTableFluent>().FirstOrDefault(t => t.Id == 1)!;
@@ -226,7 +226,7 @@ namespace Tests.UserTests
 					r.Name = "Franki";
 					r.Age = 18;
 					count = db.Update(r);
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 					r = db.GetTable<TestTableFluent>().FirstOrDefault(t => t.Id == 1)!;
 					Assert.That(r, Is.Not.Null);
@@ -239,7 +239,7 @@ namespace Tests.UserTests
 					r.Name = "Jack";
 					r.Age = 2;
 					count = db.Update(r);
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 					r = db.GetTable<TestTableFluent>().FirstOrDefault(t => t.Id == 1)!;
 					Assert.That(r, Is.Not.Null);
@@ -261,7 +261,7 @@ namespace Tests.UserTests
 				{
 					var count = db.Insert(new TestTableEnum() { Id = 1, Name = "Max", Age = 20, Gender = TestTableEnum.GenderType.Female });
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 
 					var r = db.GetTable<TestTableEnum>().FirstOrDefault(t => t.Id == 1)!;
@@ -273,7 +273,7 @@ namespace Tests.UserTests
 					r.Age = 2;
 					r.Gender = TestTableEnum.GenderType.Male;
 					count = db.Update(r);
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 					r = db.GetTable<TestTableEnum>().FirstOrDefault(t => t.Id == 1)!;
 					Assert.That(r, Is.Not.Null);
@@ -288,7 +288,7 @@ namespace Tests.UserTests
 					r.Age = 20;
 					r.Gender = TestTableEnum.GenderType.Female;
 					count = db.Update(r);
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 					r = db.GetTable<TestTableEnum>().FirstOrDefault(t => t.Id == 1)!;
 					Assert.That(r, Is.Not.Null);

--- a/Tests/Linq/UserTests/SkipValuesTestCache.cs
+++ b/Tests/Linq/UserTests/SkipValuesTestCache.cs
@@ -29,7 +29,7 @@ namespace Tests.UserTests
 				{
 					var count = db.Insert(new TestTable() { Id = 1, Name = "John", Age = value });
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 
 					var r = db.GetTable<TestTable>().FirstOrDefault(t => t.Id == 1)!;
@@ -47,7 +47,7 @@ namespace Tests.UserTests
 					r.Age = value;
 					count = db.Update(r);
 
-					if (!context.IsAnyOf(TestProvName.AllClickHouse))
+					if (context.SupportsRowcount())
 						Assert.That(count, Is.GreaterThan(0));
 					r = db.GetTable<TestTable>().FirstOrDefault(t => t.Id == 1)!;
 					Assert.That(r, Is.Not.Null);


### PR DESCRIPTION
Part of #4954 task

Shouldn't affect baselines, just adds some generalization to tests:
- test source attribute for providers with recursive CTE support (needed for YDB)
- correlated subquery support error attribute (needed for YDB)
- rowcount support helper method (needed for YDB)
- test sources for providers that support only simple (single column) OUTPUT expression (needed for YDB)
- add existing InsertOrUpdate and Merge attributes to tests that were missing them