### PR TITLE
v6 regression: nullable constant definition with as keyword fails

### DIFF
--- a/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuildVisitor.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuildVisitor.cs
@@ -2140,7 +2140,6 @@ namespace LinqToDB.Internal.Linq.Builder
 					break;
 				}
 
-				case ExpressionType.TypeAs:
 				case ExpressionType.Convert:
 				case ExpressionType.ConvertChecked:
 				{

--- a/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuildVisitor.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuildVisitor.cs
@@ -2140,6 +2140,7 @@ namespace LinqToDB.Internal.Linq.Builder
 					break;
 				}
 
+				case ExpressionType.TypeAs:
 				case ExpressionType.Convert:
 				case ExpressionType.ConvertChecked:
 				{

--- a/Source/LinqToDB/Internal/Linq/Builder/SelectContext.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/SelectContext.cs
@@ -147,7 +147,8 @@ namespace LinqToDB.Internal.Linq.Builder
 				if (Body.NodeType == ExpressionType.TypeAs)
 				{
 					result = Builder.Project(this, path, null, 0, flags, Body, true);
-					return result;
+					if (result is not SqlErrorExpression)
+						return result;
 				}
 
 				result = Body;

--- a/Tests/Linq/Linq/ConditionalTests.cs
+++ b/Tests/Linq/Linq/ConditionalTests.cs
@@ -268,15 +268,5 @@ namespace Tests.Linq
 
 			AssertQuery(query);
 		}
-
-		[Test]
-		public void ConditionWithConstAsSql([DataSources]string context)
-		{
-			using var db = GetDataContext(context);
-
-			var greatest = db.SelectQuery(() => Sql.AsSql(((int?)1 ?? (int?)null) >= ((int?)null ?? (int?)1) ? (int?)1 : (int?)null)).First();
-
-			Assert.That(greatest, Is.EqualTo(1 as int?));
-		}
 	}
 }

--- a/Tests/Linq/Linq/ConditionalTests.cs
+++ b/Tests/Linq/Linq/ConditionalTests.cs
@@ -269,5 +269,14 @@ namespace Tests.Linq
 			AssertQuery(query);
 		}
 
+		[Test]
+		public void ConditionWithConstAsSql([DataSources]string context)
+		{
+			using var db = GetDataContext(context);
+
+			var greatest = db.SelectQuery(() => Sql.AsSql(((int?)1 ?? (int?)null) >= ((int?)null ?? (int?)1) ? (int?)1 : (int?)null)).First();
+
+			Assert.That(greatest, Is.EqualTo(1 as int?));
+		}
 	}
 }

--- a/Tests/Linq/Linq/ConstantTests.cs
+++ b/Tests/Linq/Linq/ConstantTests.cs
@@ -291,13 +291,15 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void NullableTypeConstantDefininitionAsSql([DataSources] string context)
+		public void NullableTypeConstantDefininitionAsSqlThrows([DataSources(TestProvName.AllSQLite)] string context)
 		{
 			using var db = GetDataContext(context);
 
-			var one = db.SelectQuery(() => Sql.AsSql(1 as int?)).First();
-
-			Assert.That(one, Is.EqualTo(1 as int?));
+			Assert.Throws<LinqToDBException> (() =>
+				{
+					db.SelectQuery(() => Sql.AsSql(1 as int?)).First();
+				}, "The LINQ expression '(1 as int?)' could not be converted to SQL.")
+			;
 		}
 
 		[Test]

--- a/Tests/Linq/Linq/ConstantTests.cs
+++ b/Tests/Linq/Linq/ConstantTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 
+using LinqToDB;
 using LinqToDB.Mapping;
 
 using NUnit.Framework;
@@ -269,5 +270,44 @@ namespace Tests.Linq
 			query2.GetCacheMissCount().ShouldBe(cacheMissCount);
 		}
 
+		[Test]
+		public void NullableTypeConstantDefininition([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var one = db.SelectQuery(() => 1 as int?).First();
+
+			Assert.That(one, Is.EqualTo(1 as int?));
+		}
+
+		[Test]
+		public void NullableTypeConstantDefininition2([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var one = db.SelectQuery(() => (int?)1).First();
+
+			Assert.That(one, Is.EqualTo(1 as int?));
+		}
+
+		[Test]
+		public void NullableTypeConstantDefininitionAsSql([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var one = db.SelectQuery(() => Sql.AsSql(1 as int?)).First();
+
+			Assert.That(one, Is.EqualTo(1 as int?));
+		}
+
+		[Test]
+		public void NullableTypeConstantDefininitionAsSql2([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var one = db.SelectQuery(() => Sql.AsSql((int?)1)).First();
+
+			Assert.That(one, Is.EqualTo(1 as int?));
+		}
 	}
 }


### PR DESCRIPTION
to bug or not to bug...

we can define nullable constant in two ways:
   * `(int?)1` - this is converted to SQL
   * `1 as int?` - this fails, and in geneal it is discussionable, those both are not the same, `as` is not `convert` it is [try_convert](https://learn.microsoft.com/ru-ru/sql/t-sql/functions/try-convert-transact-sql?view=sql-server-ver17) but in any way this is regression
