### PR TITLE
Fix IDataContext passing for queryable associations as extension methods.

### DIFF
--- a/Source/LinqToDB/Internal/Extensions/SharedTypeExtensions.cs
+++ b/Source/LinqToDB/Internal/Extensions/SharedTypeExtensions.cs
@@ -144,12 +144,6 @@ namespace LinqToDB.Internal.Extensions
 			}
 		}
 
-		/// <summary>
-		///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-		///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-		///     any release. You should only use it directly in your code with extreme caution and knowing that
-		///     doing so can result in application failures when updating to a new Entity Framework Core release.
-		/// </summary>
 		public static string DisplayName(this Type type, bool fullName = true, bool compilable = false)
 		{
 			var stringBuilder = new StringBuilder();


### PR DESCRIPTION
Fix IDataContext passing for queryable associations as extension methods.