### PR TITLE
possibility to disable convert of timespan member accesses (which only…

### DIFF
--- a/Source/LinqToDB/Internal/Linq/Builder/Visitors/ExposeExpressionVisitor.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/Visitors/ExposeExpressionVisitor.cs
@@ -623,33 +623,35 @@ namespace LinqToDB.Internal.Linq.Builder.Visitors
 				return expr;
 			}
 
-			if (node.Member.DeclaringType == typeof(TimeSpan) && node.Expression != null)
+			if (!DataContext.Options.SqlOptions.DisableBuiltInTimeSpanConversion)
 			{
-				switch (node.Expression.NodeType)
+				if (node.Member.DeclaringType == typeof(TimeSpan) && node.Expression != null)
 				{
-					case ExpressionType.Subtract:
-					case ExpressionType.SubtractChecked:
+					switch (node.Expression.NodeType)
+					{
+						case ExpressionType.Subtract:
+						case ExpressionType.SubtractChecked:
 
-						Sql.DateParts datePart;
+							Sql.DateParts datePart;
 
-						switch (node.Member.Name)
-						{
-							case "TotalMilliseconds": datePart = Sql.DateParts.Millisecond; break;
-							case "TotalSeconds"     : datePart = Sql.DateParts.Second;      break;
-							case "TotalMinutes"     : datePart = Sql.DateParts.Minute;      break;
-							case "TotalHours"       : datePart = Sql.DateParts.Hour;        break;
-							case "TotalDays"        : datePart = Sql.DateParts.Day;         break;
-							default                 : return null;
-						}
+							switch (node.Member.Name)
+							{
+								case "TotalMilliseconds": datePart = Sql.DateParts.Millisecond; break;
+								case "TotalSeconds": datePart = Sql.DateParts.Second; break;
+								case "TotalMinutes": datePart = Sql.DateParts.Minute; break;
+								case "TotalHours": datePart = Sql.DateParts.Hour; break;
+								case "TotalDays": datePart = Sql.DateParts.Day; break;
+								default: return null;
+							}
 
-						var ex = (BinaryExpression)node.Expression;
-						if (ex.Left.Type == typeof(DateTime)
-							&& ex.Right.Type == typeof(DateTime))
-						{
-							var method = MemberHelper.MethodOf(
+							var ex = (BinaryExpression)node.Expression;
+							if (ex.Left.Type == typeof(DateTime)
+								&& ex.Right.Type == typeof(DateTime))
+							{
+								var method = MemberHelper.MethodOf(
 										() => Sql.DateDiff(Sql.DateParts.Day, DateTime.MinValue, DateTime.MinValue));
 
-							var call   =
+								var call   =
 										Expression.Convert(
 											Expression.Call(
 												null,
@@ -659,14 +661,14 @@ namespace LinqToDB.Internal.Linq.Builder.Visitors
 												Expression.Convert(ex.Left,  typeof(DateTime?))),
 											typeof(double));
 
-							return call;
-						}
-						else
-						{
-							var method = MemberHelper.MethodOf(
+								return call;
+							}
+							else
+							{
+								var method = MemberHelper.MethodOf(
 										() => Sql.DateDiff(Sql.DateParts.Day, DateTimeOffset.MinValue, DateTimeOffset.MinValue));
 
-							var call =
+								var call =
 								Expression.Convert(
 									Expression.Call(
 										null,
@@ -676,8 +678,9 @@ namespace LinqToDB.Internal.Linq.Builder.Visitors
 										Expression.Convert(ex.Left, typeof(DateTimeOffset?))),
 									typeof(double));
 
-							return call;
-						}
+								return call;
+							}
+					}
 				}
 			}
 

--- a/Source/LinqToDB/SqlOptions.cs
+++ b/Source/LinqToDB/SqlOptions.cs
@@ -39,10 +39,15 @@ namespace LinqToDB
 	/// </code>
 	/// </example>
 	/// </param>
+	/// <param name="DisableBuiltInTimeSpanConversion">
+	/// If <c>true</c>, it disables built-in TimeSpan member access conversions in ExposeExpressionVisitor to allow external conversion via ExtensionAttribute.
+	/// Default value: <c>false</c>.
+	/// </param>
 	public sealed record SqlOptions
 	(
 		bool EnableConstantExpressionInOrderBy = false,
-		bool GenerateFinalAliases              = false
+		bool GenerateFinalAliases              = false,
+		bool DisableBuiltInTimeSpanConversion  = false
 	)
 		: IOptionSet
 	{
@@ -54,6 +59,7 @@ namespace LinqToDB
 		{
 			EnableConstantExpressionInOrderBy = original.EnableConstantExpressionInOrderBy;
 			GenerateFinalAliases              = original.GenerateFinalAliases;
+			DisableBuiltInTimeSpanConversion  = original.DisableBuiltInTimeSpanConversion;
 		}
 
 		int? _configurationID;


### PR DESCRIPTION
… works in some special cases), so outside conversion via ExtensionAttribute could be used