### PR TITLE
Oracle: use NVL for 2 arguments COALESCE

### DIFF
--- a/Source/LinqToDB/Internal/Common/EnumerableHelper.cs
+++ b/Source/LinqToDB/Internal/Common/EnumerableHelper.cs
@@ -203,5 +203,38 @@ namespace LinqToDB.Internal.Common
 				}
 			}
 		}
+	
+		/// <summary>
+		/// Applies <paramref name="map"/> to each element in a readonly <paramref name="source"/>.
+		/// If all elements are the same reference, the source collection is returned unchanged.
+		/// If at least one element changed, a new collection is built and returned.
+		/// </summary>
+		internal static IReadOnlyList<T> MapList<T>(this IReadOnlyList<T> source, Func<T, T> map)
+		{
+			T[]? result = null;
+
+			for (int i = 0; i < source.Count; i++)
+			{
+				var srcItem = source[i];
+				var newItem = map(srcItem);
+
+				if (!ReferenceEquals(srcItem, newItem))
+				{
+					if (result == null)
+					{
+						result = new T[source.Count];						
+						for (int j = 0; j < i; j++) result[j] = source[j];
+					}
+
+					result[i] = newItem;
+				}
+				else if (result != null)
+				{
+					result[i] = srcItem;
+				}
+			}
+
+			return result ?? source;
+		}
 	}
 }

--- a/Source/LinqToDB/Internal/Common/EnumerableHelper.cs
+++ b/Source/LinqToDB/Internal/Common/EnumerableHelper.cs
@@ -209,7 +209,7 @@ namespace LinqToDB.Internal.Common
 		/// If all elements are the same reference, the source collection is returned unchanged.
 		/// If at least one element changed, a new collection is built and returned.
 		/// </summary>
-		internal static IReadOnlyList<T> MapList<T>(this IReadOnlyList<T> source, Func<T, T> map)
+		internal static IReadOnlyList<T> MapList<T>(this IReadOnlyList<T> source, Func<T, T> map) where T: class
 		{
 			T[]? result = null;
 

--- a/Source/LinqToDB/Internal/Common/EnumerableHelper.cs
+++ b/Source/LinqToDB/Internal/Common/EnumerableHelper.cs
@@ -203,7 +203,6 @@ namespace LinqToDB.Internal.Common
 				}
 			}
 		}
-	
 		/// <summary>
 		/// Applies <paramref name="map"/> to each element in a readonly <paramref name="source"/>.
 		/// If all elements are the same reference, the source collection is returned unchanged.
@@ -222,7 +221,7 @@ namespace LinqToDB.Internal.Common
 				{
 					if (result == null)
 					{
-						result = new T[source.Count];						
+						result = new T[source.Count];
 						for (int j = 0; j < i; j++) result[j] = source[j];
 					}
 

--- a/Source/LinqToDB/Internal/Common/Polyfills.cs
+++ b/Source/LinqToDB/Internal/Common/Polyfills.cs
@@ -7,7 +7,7 @@ namespace System.Linq
 {
 #if NET462
 	internal static class EnumerablePolyfills
-	{		
+	{
 		public static IEnumerable<T> Append<T>(this IEnumerable<T> source, T element)
 			=> source.Concat([element]);
 	}

--- a/Source/LinqToDB/Internal/Common/Polyfills.cs
+++ b/Source/LinqToDB/Internal/Common/Polyfills.cs
@@ -1,7 +1,6 @@
 ﻿// Useful methods that are available in current .net releases
 
 using System.Collections.Generic;
-using System.Collections.Generic;
 
 namespace System.Linq
 {

--- a/Source/LinqToDB/Internal/Common/Polyfills.cs
+++ b/Source/LinqToDB/Internal/Common/Polyfills.cs
@@ -1,7 +1,7 @@
 ﻿// Useful methods that are available in current .net releases
 
 using System.Collections.Generic;
-using System.Linq;
+using System.Collections.Generic;
 
 namespace System.Linq
 {

--- a/Source/LinqToDB/Internal/Common/Polyfills.cs
+++ b/Source/LinqToDB/Internal/Common/Polyfills.cs
@@ -1,0 +1,15 @@
+﻿// Useful methods that are available in current .net releases
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace System.Linq
+{
+#if NET462
+	internal static class EnumerablePolyfills
+	{		
+		public static IEnumerable<T> Append<T>(this IEnumerable<T> source, T element)
+			=> source.Concat([element]);
+	}
+#endif
+}

--- a/Source/LinqToDB/Internal/DataProvider/Oracle/Oracle11SqlOptimizer.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Oracle/Oracle11SqlOptimizer.cs
@@ -175,24 +175,14 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 			{
 				if (e is SelectQuery { HasSetOperators: true } query)
 				{
-					IEnumerable<SelectQuery> queries = [query, .. query.SetOperators.Select(o => o.SelectQuery)];
+					IEnumerable<List<SqlColumn>> setsColumns = [query.Select.Columns, .. query.SetOperators.Select(o => o.SelectQuery.Select.Columns)];
 
 					for (var i = 0; i < query.Select.Columns.Count; i++)
 					{
-						if (OracleSqlExpressionConvertVisitor.NeedsCharTypeCorrection(mappingSchema, queries.Select(q => q.Select.Columns[i].Expression)))
+						if (mappingSchema.HasInconsistentCharset(setsColumns.Select(cols => cols[i].Expression)))
 						{
-							foreach (var qry in queries)
-							{
-								var type = QueryHelper.GetDbDataType(qry.Select.Columns[i].Expression, mappingSchema);
-								if (type.DataType is DataType.Char or DataType.VarChar)
-								{
-									qry.Select.Columns[i].Expression = new SqlCastExpression(
-										qry.Select.Columns[i].Expression,
-										type.WithDataType(type.DataType is DataType.Char ? DataType.NChar : DataType.NVarChar),
-										null,
-										isMandatory: true);
-								}
-							}
+							foreach (var cols in setsColumns)
+								cols[i].Expression = mappingSchema.FixCharset(cols[i].Expression);
 						}
 					}
 				}

--- a/Source/LinqToDB/Internal/DataProvider/Oracle/OracleExtensions.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Oracle/OracleExtensions.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+
+using LinqToDB.Internal.SqlQuery;
+using LinqToDB.Mapping;
+
+namespace LinqToDB.Internal.DataProvider.Oracle
+{
+	// Extensions methods/helpers specific to Oracle DataProvider
+	internal static class OracleExtensions
+	{
+		// Check if all expressions have a consistent charset (CHAR vs NCHAR, or VARCHAR vs NVARCHAR).
+		public static bool HasInconsistentCharset(this MappingSchema mappingSchema, IEnumerable<ISqlExpression> expressions)
+		{
+			var hasChar = false;
+			var hasNChar = false;
+
+			foreach (var expr in expressions)
+			{
+				var type = QueryHelper.GetDbDataType(expr, mappingSchema);
+
+				hasChar  |= type.DataType is DataType.Char or DataType.VarChar;
+				hasNChar |= type.DataType is DataType.NChar or DataType.NVarChar;
+
+				if (hasChar & hasNChar)
+					return true;
+			}
+
+			return false;
+		}
+
+		// If expr is of type CHAR (resp. VARCHAR), cast it to NCHAR (resp. NVARCHAR).
+		// This is used in conjunction with `HasInconsistentCharset` to unify charset of incompatible expressions.
+		public static ISqlExpression FixCharset(this MappingSchema mappingSchema, ISqlExpression expr)
+		{
+			var type = QueryHelper.GetDbDataType(expr, mappingSchema);
+			return type.DataType switch
+			{
+				// Note that TO_NCHAR(x) works on CHAR type too, but it always returns NVARCHAR2, not NCHAR.
+				DataType.VarChar => new SqlFunction(type.WithDataType(DataType.NVarChar), "To_NChar", expr),
+				DataType.Char => new SqlCastExpression(expr, type.WithDataType(DataType.NChar), null, isMandatory: true),
+				_ => expr,
+			};
+		}
+
+	}
+}

--- a/Source/LinqToDB/Internal/DataProvider/Oracle/OracleSqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Oracle/OracleSqlExpressionConvertVisitor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
+using LinqToDB.Internal.Common;
 using LinqToDB.Internal.Extensions;
 using LinqToDB.Internal.SqlProvider;
 using LinqToDB.Internal.SqlQuery;
@@ -19,7 +20,7 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 
 		#region LIKE
 
-		protected static string[] OracleLikeCharactersToEscape = {"%", "_"};
+		protected static readonly string[] OracleLikeCharactersToEscape = ["%", "_"];
 
 		public override string[] LikeCharactersToEscape => OracleLikeCharactersToEscape;
 
@@ -169,59 +170,40 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 			};
 		}
 
-		protected internal override IQueryElement VisitSqlCoalesceExpression(SqlCoalesceExpression element)
+		public override ISqlExpression ConvertCoalesce(SqlCoalesceExpression element)
 		{
-			if (NeedsCharTypeCorrection(MappingSchema, element.Expressions))
+			// If there are exactly two arguments, we prefer proprietary NVL over COALESCE because:
+			// 1. It's more concise SQL (but NVL doesn't support 3+ arguments).
+			// 2. It reduces the risk of regression from v5.x to v6.0, which replaced NVL with COALESCE in Oracle DataProvider.
+			//    One notable difference is that NVL supports different charsets NVL('a', N'a'),
+			//    whereas COALESCE fails with "ORA-12704: character set mismatch".
+			//    We attempt to unify charsets in COALESCE below but it does not always work, 
+			//    for if model doesn't accurately indicate charset (which still worked with NVL in 5.x).
+			if (element.Expressions is [var first, var second])
 			{
-				for (var i = 0; i < element.Expressions.Length; i++)
-				{
-					var type = QueryHelper.GetDbDataType(element.Expressions[i], MappingSchema);
-
-					if (type.DataType is DataType.Char or DataType.VarChar)
-					{
-						element.Expressions[i] = new SqlCastExpression(
-							element.Expressions[i],
-							type.WithDataType(type.DataType is DataType.Char ? DataType.NChar : DataType.NVarChar),
-							null,
-							isMandatory: true);
-					}
-				}
+				if (first is SqlValue { Value: null }) return second;
+				if (second is SqlValue { Value: null }) return first;
+				var type = QueryHelper.GetDbDataType(first, MappingSchema);
+				return new SqlFunction(type, "Nvl", parametersNullability: ParametersNullabilityType.IfAllParametersNullable, element.Expressions);
 			}
 
-			return base.VisitSqlCoalesceExpression(element);
+			if (MappingSchema.HasInconsistentCharset(element.Expressions))
+			{				
+				for (var i = 0; i < element.Expressions.Length; i++)
+					element.Expressions[i] = MappingSchema.FixCharset(element.Expressions[i]);
+			}
+
+			return base.ConvertCoalesce(element);
 		}
 
 		protected override ISqlExpression ConvertSqlCondition(SqlConditionExpression element)
 		{
-			if (NeedsCharTypeCorrection(MappingSchema, [element.TrueValue, element.FalseValue]))
+			if (MappingSchema.HasInconsistentCharset([element.TrueValue, element.FalseValue]))
 			{
-				var type = QueryHelper.GetDbDataType(element.TrueValue, MappingSchema);
-
-				if (type.DataType is DataType.Char or DataType.VarChar)
-				{
-					var trueValue = new SqlCastExpression(
-						element.TrueValue,
-						type.WithDataType(type.DataType is DataType.Char ? DataType.NChar : DataType.NVarChar),
-						null,
-						isMandatory: true);
-
-					return new SqlConditionExpression(element.Condition, trueValue, element.FalseValue);
-				}
-				else
-				{
-					type = QueryHelper.GetDbDataType(element.FalseValue, MappingSchema);
-
-					if (type.DataType is DataType.Char or DataType.VarChar)
-					{
-						var falseValue = new SqlCastExpression(
-							element.FalseValue,
-							type.WithDataType(type.DataType is DataType.Char ? DataType.NChar : DataType.NVarChar),
-							null,
-							isMandatory: true);
-
-						return new SqlConditionExpression(element.Condition, element.TrueValue, falseValue);
-					}
-				}
+				return new SqlConditionExpression(
+					element.Condition, 
+					MappingSchema.FixCharset(element.TrueValue), 
+					MappingSchema.FixCharset(element.FalseValue));
 			}
 
 			return base.ConvertSqlCondition(element);
@@ -233,20 +215,10 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 			{
 				for (var i = 0; i < element.Rows[0].Count; i++)
 				{
-					if (NeedsCharTypeCorrection(MappingSchema, element.Rows.Select(r => r[i])))
+					if (MappingSchema.HasInconsistentCharset(element.Rows.Select(r => r[i])))
 					{
 						foreach (var row in element.Rows)
-						{
-							var type = QueryHelper.GetDbDataType(row[i], MappingSchema);
-							if (type.DataType is DataType.Char or DataType.VarChar)
-							{
-								row[i] = new SqlCastExpression(
-									row[i],
-									type.WithDataType(type.DataType is DataType.Char ? DataType.NChar : DataType.NVarChar),
-									null,
-									isMandatory: true);
-							}
-						}
+							row[i] = MappingSchema.FixCharset(row[i]);
 					}
 				}
 			}
@@ -256,78 +228,25 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 
 		protected override ISqlExpression ConvertSqlCaseExpression(SqlCaseExpression element)
 		{
-			if (NeedsCharTypeCorrection(MappingSchema, element.Cases.Select(c => c.ResultExpression).Concat(element.ElseExpression == null ? [] : [element.ElseExpression])))
+			var expressions = element.Cases.Select(c => c.ResultExpression);
+			if (element.ElseExpression is {} elseCase) 
+				expressions = expressions.Append(elseCase);
+
+			if (MappingSchema.HasInconsistentCharset(expressions))
 			{
-				ISqlExpression? elseExpr = null;
-				List<SqlCaseExpression.CaseItem>? cases = null;
-
-				for (var i = 0; i < element.Cases.Count; i++)
+				var cases = element.Cases.MapList(x =>
 				{
-					var caseItem = element.Cases[i];
-					var type = QueryHelper.GetDbDataType(caseItem.ResultExpression, MappingSchema);
+					var caseExpr = x.ResultExpression;
+					var fixedExpr = MappingSchema.FixCharset(caseExpr);
+					return ReferenceEquals(caseExpr, fixedExpr) ? x : new SqlCaseExpression.CaseItem(x.Condition, fixedExpr);
+				});
 
-					if (type.DataType is DataType.Char or DataType.VarChar)
-					{
-						if (cases == null)
-						{
-							cases = new(element.Cases.Count);
-							cases.AddRange(element.Cases.Take(i));
-						}
+				var elseExpr = element.ElseExpression is {} expr ? MappingSchema.FixCharset(expr) : null;
 
-						cases.Add(new SqlCaseExpression.CaseItem(
-							caseItem.Condition,
-							new SqlCastExpression(
-								caseItem.ResultExpression,
-								type.WithDataType(type.DataType is DataType.Char ? DataType.NChar : DataType.NVarChar),
-								null,
-								isMandatory: true)));
-					}
-					else if (cases != null)
-					{
-						cases.Add(caseItem);
-					}
-				}
-
-				if (element.ElseExpression != null)
-				{
-					var type = QueryHelper.GetDbDataType(element.ElseExpression, MappingSchema);
-
-					if (type.DataType is DataType.Char or DataType.VarChar)
-					{
-						elseExpr = new SqlCastExpression(
-							element.ElseExpression,
-							type.WithDataType(type.DataType is DataType.Char ? DataType.NChar : DataType.NVarChar),
-							null,
-							isMandatory: true);
-					}
-				}
-
-				if (elseExpr != null || cases != null)
-				{
-					return new SqlCaseExpression(element.Type, cases ?? element.Cases, elseExpr ?? element.ElseExpression);
-				}
+				return new SqlCaseExpression(element.Type, cases, elseExpr);
 			}
 
 			return base.ConvertSqlCaseExpression(element);
-		}
-
-		internal static bool NeedsCharTypeCorrection(MappingSchema mappingSchema, IEnumerable<ISqlExpression> expressions)
-		{
-			var hasChar = false;
-			var hasNChar = false;
-
-			foreach (var expr in expressions)
-			{
-				var type = QueryHelper.GetDbDataType(expr, mappingSchema);
-
-				hasChar  = hasChar  || type.DataType is DataType.Char or DataType.VarChar;
-				hasNChar = hasNChar || type.DataType is DataType.NChar or DataType.NVarChar;
-
-				if (hasChar && hasNChar)
-					return true;
-			}
-
-			return false;
 		}
 
 		protected override ISqlExpression ConvertConversion(SqlCastExpression cast)

--- a/Source/LinqToDB/Internal/DataProvider/Oracle/OracleSqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Oracle/OracleSqlExpressionConvertVisitor.cs
@@ -178,7 +178,7 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 			//    One notable difference is that NVL supports different charsets NVL('a', N'a'),
 			//    whereas COALESCE fails with "ORA-12704: character set mismatch".
 			//    We attempt to unify charsets in COALESCE below but it does not always work, 
-			//    for if model doesn't accurately indicate charset (which still worked with NVL in 5.x).
+			//    for example if model doesn't accurately indicate charset (which still worked with NVL in 5.x).
 			if (element.Expressions is [var first, var second])
 			{
 				if (first is SqlValue { Value: null }) return second;

--- a/Source/LinqToDB/Internal/DataProvider/Oracle/OracleSqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Oracle/OracleSqlExpressionConvertVisitor.cs
@@ -177,7 +177,7 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 			// 2. It reduces the risk of regression from v5.x to v6.0, which replaced NVL with COALESCE in Oracle DataProvider.
 			//    One notable difference is that NVL supports different charsets NVL('a', N'a'),
 			//    whereas COALESCE fails with "ORA-12704: character set mismatch".
-			//    We attempt to unify charsets in COALESCE below but it does not always work, 
+			//    We attempt to unify charsets in COALESCE below but it does not always work,
 			//    for example if model doesn't accurately indicate charset (which still worked with NVL in 5.x).
 			if (element.Expressions is [var first, var second])
 			{
@@ -188,7 +188,7 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 			}
 
 			if (MappingSchema.HasInconsistentCharset(element.Expressions))
-			{				
+			{
 				for (var i = 0; i < element.Expressions.Length; i++)
 					element.Expressions[i] = MappingSchema.FixCharset(element.Expressions[i]);
 			}
@@ -201,8 +201,8 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 			if (MappingSchema.HasInconsistentCharset([element.TrueValue, element.FalseValue]))
 			{
 				return new SqlConditionExpression(
-					element.Condition, 
-					MappingSchema.FixCharset(element.TrueValue), 
+					element.Condition,
+					MappingSchema.FixCharset(element.TrueValue),
 					MappingSchema.FixCharset(element.FalseValue));
 			}
 
@@ -229,7 +229,7 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 		protected override ISqlExpression ConvertSqlCaseExpression(SqlCaseExpression element)
 		{
 			var expressions = element.Cases.Select(c => c.ResultExpression);
-			if (element.ElseExpression is {} elseCase) 
+			if (element.ElseExpression is {} elseCase)
 				expressions = expressions.Append(elseCase);
 
 			if (MappingSchema.HasInconsistentCharset(expressions))

--- a/Source/LinqToDB/Internal/SqlProvider/SqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/SqlProvider/SqlExpressionConvertVisitor.cs
@@ -1216,7 +1216,7 @@ namespace LinqToDB.Internal.SqlProvider
 				if (element.Expressions[i] is SqlValue { Value: null })
 				{
 					if (element.Expressions.Length == 2)
-						return element.Expressions[(i + 1) % 2];
+						return element.Expressions[i ^ 1];
 					else
 					{
 						var newElements = new ISqlExpression[element.Expressions.Length - 1];


### PR DESCRIPTION
Main change in this PR is using proprietary `NVL` in Oracle when `COALESCE` only has 2 arguments.
It's more concise but also it does not fail because of inconsistent charset, which I encountered as a regression when upgrading to v6.

For 3+ arguments I stick to `COALESCE` because it's just cleaner than `NVL(a, NVL(b, NVL(c)))` especially when involved expressions are large. If linq2db does not detect the charset inconsistency then unfortunately it means user has to handle it.

I took the opportunity to refactor the code around charset mismatch detection and handling, with no intended behavior change.