### PR TITLE
Fix UnionAll + string member access (.Length, IsNullOrEmpty)

### DIFF
--- a/Source/LinqToDB/Internal/DataProvider/Informix/InformixSqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Informix/InformixSqlExpressionConvertVisitor.cs
@@ -300,7 +300,7 @@ namespace LinqToDB.Internal.DataProvider.Informix
 
 					var value     = func.Parameters[0];
 					var valueType = Factory.GetDbDataType(value);
-					var funcType  = Factory.GetDbDataType(value);
+					var funcType  = Factory.GetDbDataType(typeof(int));
 
 					var valueString = Factory.Add(valueType, value, Factory.Value(valueType, "."));
 					var valueLength = Factory.Function(funcType, "CHAR_LENGTH", valueString);

--- a/Source/LinqToDB/Internal/DataProvider/SqlCe/SqlCeSqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlCe/SqlCeSqlExpressionConvertVisitor.cs
@@ -61,7 +61,7 @@ namespace LinqToDB.Internal.DataProvider.SqlCe
 
 					var value     = func.Parameters[0];
 					var valueType = Factory.GetDbDataType(value);
-					var funcType  = Factory.GetDbDataType(value);
+					var funcType  = Factory.GetDbDataType(typeof(int));
 
 					var valueString = Factory.Add(valueType, value, Factory.Value(valueType, "."));
 					var valueLength = Factory.Function(funcType, "LEN", valueString);

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/SqlServerSqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/SqlServerSqlExpressionConvertVisitor.cs
@@ -138,7 +138,7 @@ namespace LinqToDB.Internal.DataProvider.SqlServer
 
 					var value     = func.Parameters[0];
 					var valueType = Factory.GetDbDataType(value);
-					var funcType  = Factory.GetDbDataType(value);
+					var funcType  = Factory.GetDbDataType(typeof(int));
 
 					var valueString = Factory.Add(valueType, value, Factory.Value(valueType, "."));
 					var valueLength = Factory.Function(funcType, "LEN", valueString);

--- a/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuildVisitor.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuildVisitor.cs
@@ -1460,9 +1460,12 @@ namespace LinqToDB.Internal.Linq.Builder
 				var translated = MakeWithCache(context.BuildContext, node);
 				if (!IsSame(translated, node) && translated is not SqlErrorExpression)
 				{
-					if (translated is DefaultValueExpression && _buildPurpose is BuildPurpose.Expression)
+					if (translated is DefaultValueExpression defaultValue
+						&& (_buildPurpose is BuildPurpose.Expression || defaultValue.MappingSchema == null))
 					{
-						// skip DefaultValueExpression in expression mode, it should be result from SelectContext that projection is wrong.
+						// skip DefaultValueExpression when:
+						// - in expression mode (projection is wrong, will retry via HandleMember)
+						// - MappingSchema is null (unresolved member on terminal expression, e.g., .Length on UnionAll column)
 					}
 					else
 					{

--- a/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -1298,6 +1298,16 @@ namespace LinqToDB.Internal.Linq.Builder
 				{
 					if (body is SqlPlaceholderExpression placeholder)
 					{
+						// Placeholder is a terminal SQL expression. If there are remaining path members
+						// (e.g., navigating .Length on a column), it cannot be resolved through projection.
+						// Return error so caller falls back to member translation pipeline.
+						if (next != null && member != null)
+						{
+							if (strict)
+								return CreateSqlError(nextPath![0]);
+							return new DefaultValueExpression(null, nextPath![0].Type, true);
+						}
+
 						return placeholder;
 					}
 
@@ -1435,6 +1445,16 @@ namespace LinqToDB.Internal.Linq.Builder
 						}
 
 						//throw new InvalidOperationException();
+					}
+
+					// Body is a terminal expression (e.g. SqlPathExpression) that cannot be navigated further.
+					// If there are remaining path members (e.g., .Length on a column), return error
+					// so caller falls back to member translation pipeline.
+					if (next != null && member != null && body is SqlPathExpression)
+					{
+						if (strict)
+							return CreateSqlError(nextPath![0]);
+						return new DefaultValueExpression(null, nextPath![0].Type, true);
 					}
 
 					return body;

--- a/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -1545,7 +1545,7 @@ namespace LinqToDB.Internal.Linq.Builder
 					if (strict)
 						return CreateSqlError(nextPath![0]);
 
-					return new DefaultValueExpression(MappingSchema, nextPath![0].Type, true);
+					return new DefaultValueExpression(null, nextPath![0].Type, true);
 				}
 
 				case ExpressionType.MemberInit:
@@ -1648,7 +1648,7 @@ namespace LinqToDB.Internal.Linq.Builder
 					if (strict)
 						return CreateSqlError(nextPath![0]);
 
-					return new DefaultValueExpression(MappingSchema, nextPath![0].Type, true);
+					return new DefaultValueExpression(null, nextPath![0].Type, true);
 
 				}
 				case ExpressionType.Conditional:

--- a/Tests/Linq/UserTests/Issue5458Tests.cs
+++ b/Tests/Linq/UserTests/Issue5458Tests.cs
@@ -1,128 +1,95 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 
 using LinqToDB;
 using LinqToDB.Mapping;
 
 using NUnit.Framework;
 
+using Shouldly;
+
 namespace Tests.UserTests
 {
+	/// <summary>
+	/// <see href="https://github.com/linq2db/linq2db/issues/5458"/>
+	/// </summary>
 	[TestFixture]
 	public class Issue5458Tests : TestBase
 	{
 		[Table]
-		public class MessageEventDTO
+		sealed class StringTable
 		{
-			[Column, PrimaryKey] public int EventID { get; set; }
-			[Column] public Guid MessageId { get; set; }
-			[Column] public Guid? MessageClassId { get; set; }
-			[Column] public string? MessageKey { get; set; }
-			[Column] public string? MessageLanguage1 { get; set; }
-			[Column] public string? MessageLanguage2 { get; set; }
-			[Column] public string? MessageLanguage3 { get; set; }
-			[Column] public string? MessageLanguage4 { get; set; }
-			[Column] public string? TranslatedMessage1 { get; set; }
-			[Column] public string? TranslatedMessage2 { get; set; }
-			[Column] public string? TranslatedMessage3 { get; set; }
-			[Column] public string? TranslatedMessage4 { get; set; }
+			[Column, PrimaryKey] public int     Id    { get; set; }
+			[Column]             public string? Value { get; set; }
 		}
 
 		[Table]
-		public class MessageDTO
+		sealed class OtherTable
 		{
-			[Column, PrimaryKey] public Guid Id { get; set; }
-			[Column] public Guid? AvailabilityGroupId { get; set; }
-			[Column] public string? TextName { get; set; }
+			[Column, PrimaryKey] public int Id { get; set; }
 		}
 
-		[Table]
-		public class MessageClassDTO
+		sealed class ResultDTO
 		{
-			[Column, PrimaryKey] public Guid Id { get; set; }
-		}
-
-
-		[Table]
-		public class AvailabilityGroupDTO
-		{
-			[Column, PrimaryKey] public Guid Id { get; set; }
-		}
-
-		[Table]
-		public class RefMessageEventAvailabilityGroupDTO
-		{
-			[Column, PrimaryKey] public int EventId { get; set; }
-			[Column] public Guid AvailabilityGroupId { get; set; }
-		}
-
-		[Table]
-		public class MessageAdditionalInformationDTO
-		{
-			[Column, PrimaryKey] public int EventId { get; set; }
-			[Column] public string? Language { get; set; }
-			[Column] public string? MessageKey { get; set; }
-		}
-
-		[Table]
-		public class MessageEventCombinedDTO
-		{
-			public MessageEventDTO? MessageEventDTO { get; set; }
-			public MessageClassDTO? MessageClassDTO { get; set; }
-			public MessageDTO? MessageDTO { get; set; }
-			public string? Language { get; set; }
-			public string? TranslatedMessage { get; set; }
-			public AvailabilityGroupDTO? AvailabilityGroup { get; set; }
-			public MessageAdditionalInformationDTO? MessageAdditionalInformationDTO { get; set; }
+			public StringTable? Entity            { get; set; }
+			public string?      TranslatedMessage { get; set; }
 		}
 
 		[Test]
-		public void UnionAllCausesWrongQuery([IncludeDataSources(TestProvName.AllSqlServer2019Plus)] string context)
+		public void UnionAllWithJoinAndIsNullOrEmpty([DataSources] string context)
 		{
+			using var db     = GetDataContext(context);
+			using var table  = db.CreateLocalTable(new[]
+			{
+				new StringTable { Id = 1, Value = "hello" },
+				new StringTable { Id = 2, Value = null    },
+			});
+			using var table2 = db.CreateLocalTable(new[] { new OtherTable { Id = 1 }, new OtherTable { Id = 2 } });
+
+			var query =
+				from t in table.Where(t => t.Id <= 1).UnionAll(table.Where(t => t.Id > 1))
+				join o in db.GetTable<OtherTable>() on t.Id equals o.Id
+				select new ResultDTO
+				{
+					Entity            = t,
+					TranslatedMessage = !string.IsNullOrEmpty(t.Value) ? t.Value : "default",
+				};
+
+			var result = query.OrderBy(r => r.Entity!.Id).ToList();
+
+			result.Count.ShouldBe(2);
+			result[0].TranslatedMessage.ShouldBe("hello");
+			result[1].TranslatedMessage.ShouldBe("default");
+		}
+
+		[Test]
+		public void UnionAllStringIsNullOrEmpty([DataSources] string context)
+		{
+			var data = new[]
+			{
+				new StringTable { Id = 1, Value = "hello" },
+				new StringTable { Id = 2, Value = ""      },
+				new StringTable { Id = 3, Value = null    },
+			};
+
 			using var db    = GetDataContext(context);
-			using var table1 = db.CreateLocalTable<MessageDTO>([new MessageDTO { Id = TestData.Guid1, TextName = "a"}]);
-			using var table2 = db.CreateLocalTable<MessageClassDTO>([new MessageClassDTO { Id = TestData.Guid2 }]);
-			using var table3 = db.CreateLocalTable<AvailabilityGroupDTO>();
-			using var table4 = db.CreateLocalTable<RefMessageEventAvailabilityGroupDTO>();
-			using var table5 = db.CreateLocalTable<AvailabilityGroupDTO>();
-			using var table6 = db.CreateLocalTable<MessageAdditionalInformationDTO>();
-			using var table7 = db.CreateLocalTable<MessageEventDTO>([new MessageEventDTO { EventID = 123, MessageClassId = TestData.Guid2, MessageId= TestData.Guid1, MessageLanguage1 = "de" }]);
-			using var table8 = db.CreateLocalTable<MessageEventDTO>("Common_MessageSystem_EventsA");
+			using var table = db.CreateLocalTable(data);
 
-			var language = "de";
-			var useArchiveTable = true;
+			var query =
+				table.Where(t => t.Id <= 2)
+				.UnionAll(table.Where(t => t.Id > 2))
+				.Select(t => new
+				{
+					t.Id,
+					IsEmpty = string.IsNullOrEmpty(t.Value),
+				})
+				.OrderBy(t => t.Id);
 
-			var evtQry = (IQueryable<MessageEventDTO>)db.GetTable<MessageEventDTO>();
-			if (useArchiveTable)
-				evtQry = evtQry.UnionAll(((ITable<MessageEventDTO>)db.GetTable<MessageEventDTO>()).TableName("Common_MessageSystem_EventsA"));
-			var q = from evt in evtQry
-					join msg in db.GetTable<MessageDTO>() on evt.MessageId equals msg.Id
-					join mclass in db.GetTable<MessageClassDTO>() on evt.MessageClassId equals mclass.Id
-					join a in db.GetTable<AvailabilityGroupDTO>() on msg.AvailabilityGroupId equals a.Id into aj
-					from a in aj.DefaultIfEmpty()
-					join aRef in db.GetTable<RefMessageEventAvailabilityGroupDTO>() on evt.EventID equals aRef.EventId into aRefj
-					from aRef in aRefj.DefaultIfEmpty()
-					join a2 in db.GetTable<AvailabilityGroupDTO>() on aRef.AvailabilityGroupId equals a2.Id into a2j
-					from a2 in a2j.DefaultIfEmpty()
-					join msgAddI in db.GetTable<MessageAdditionalInformationDTO>().Where(m => m.Language == language) on evt.MessageKey equals msgAddI.MessageKey into msgAddI2
-					from msgAddI in msgAddI2.DefaultIfEmpty()
-					select new MessageEventCombinedDTO
-					{
-						MessageEventDTO = evt,
-						MessageClassDTO = mclass,
-						MessageDTO = msg,
-						Language = language,
-						TranslatedMessage = !string.IsNullOrEmpty(evt.MessageLanguage1)
-							? (evt.MessageLanguage4 == language ? evt.TranslatedMessage4 : (evt.MessageLanguage3 == language ? evt.TranslatedMessage3 : (evt.MessageLanguage2 == language ? evt.TranslatedMessage2 : evt.TranslatedMessage1)))
-							: msg.TextName,
-						AvailabilityGroup = a ?? a2,
-						MessageAdditionalInformationDTO = msgAddI
-					};
+			var result = query.ToList();
 
-			var actual = q
-				.ToList();
-
-			Assert.That(actual, Has.Count.EqualTo(1));
+			result.Count.ShouldBe(3);
+			result[0].IsEmpty.ShouldBeFalse();
+			result[1].IsEmpty.ShouldBeTrue();
+			result[2].IsEmpty.ShouldBeTrue();
 		}
 	}
 }

--- a/Tests/Linq/UserTests/Issue5458Tests.cs
+++ b/Tests/Linq/UserTests/Issue5458Tests.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Linq;
+
+using LinqToDB;
+using LinqToDB.Mapping;
+
+using NUnit.Framework;
+
+namespace Tests.UserTests
+{
+	[TestFixture]
+	public class Issue5458Tests : TestBase
+	{
+		[Table]
+		public class MessageEventDTO
+		{
+			[Column, PrimaryKey] public int EventID { get; set; }
+			[Column] public Guid MessageId { get; set; }
+			[Column] public Guid? MessageClassId { get; set; }
+			[Column] public string? MessageKey { get; set; }
+			[Column] public string? MessageLanguage1 { get; set; }
+			[Column] public string? MessageLanguage2 { get; set; }
+			[Column] public string? MessageLanguage3 { get; set; }
+			[Column] public string? MessageLanguage4 { get; set; }
+			[Column] public string? TranslatedMessage1 { get; set; }
+			[Column] public string? TranslatedMessage2 { get; set; }
+			[Column] public string? TranslatedMessage3 { get; set; }
+			[Column] public string? TranslatedMessage4 { get; set; }
+		}
+
+		[Table]
+		public class MessageDTO
+		{
+			[Column, PrimaryKey] public Guid Id { get; set; }
+			[Column] public Guid? AvailabilityGroupId { get; set; }
+			[Column] public string? TextName { get; set; }
+		}
+
+		[Table]
+		public class MessageClassDTO
+		{
+			[Column, PrimaryKey] public Guid Id { get; set; }
+		}
+
+
+		[Table]
+		public class AvailabilityGroupDTO
+		{
+			[Column, PrimaryKey] public Guid Id { get; set; }
+		}
+
+		[Table]
+		public class RefMessageEventAvailabilityGroupDTO
+		{
+			[Column, PrimaryKey] public int EventId { get; set; }
+			[Column] public Guid AvailabilityGroupId { get; set; }
+		}
+
+		[Table]
+		public class MessageAdditionalInformationDTO
+		{
+			[Column, PrimaryKey] public int EventId { get; set; }
+			[Column] public string? Language { get; set; }
+			[Column] public string? MessageKey { get; set; }
+		}
+
+		[Table]
+		public class MessageEventCombinedDTO
+		{
+			public MessageEventDTO? MessageEventDTO { get; set; }
+			public MessageClassDTO? MessageClassDTO { get; set; }
+			public MessageDTO? MessageDTO { get; set; }
+			public string? Language { get; set; }
+			public string? TranslatedMessage { get; set; }
+			public AvailabilityGroupDTO? AvailabilityGroup { get; set; }
+			public MessageAdditionalInformationDTO? MessageAdditionalInformationDTO { get; set; }
+		}
+
+		[Test]
+		public void UnionAllCausesWrongQuery([IncludeDataSources(TestProvName.AllSqlServer2019Plus)] string context)
+		{
+			using var db    = GetDataContext(context);
+			using var table1 = db.CreateLocalTable<MessageDTO>([new MessageDTO { Id = TestData.Guid1, TextName = "a"}]);
+			using var table2 = db.CreateLocalTable<MessageClassDTO>([new MessageClassDTO { Id = TestData.Guid2 }]);
+			using var table3 = db.CreateLocalTable<AvailabilityGroupDTO>();
+			using var table4 = db.CreateLocalTable<RefMessageEventAvailabilityGroupDTO>();
+			using var table5 = db.CreateLocalTable<AvailabilityGroupDTO>();
+			using var table6 = db.CreateLocalTable<MessageAdditionalInformationDTO>();
+			using var table7 = db.CreateLocalTable<MessageEventDTO>([new MessageEventDTO { EventID = 123, MessageClassId = TestData.Guid2, MessageId= TestData.Guid1, MessageLanguage1 = "de" }]);
+			using var table8 = db.CreateLocalTable<MessageEventDTO>("Common_MessageSystem_EventsA");
+
+			var language = "de";
+			var useArchiveTable = true;
+
+			var evtQry = (IQueryable<MessageEventDTO>)db.GetTable<MessageEventDTO>();
+			if (useArchiveTable)
+				evtQry = evtQry.UnionAll(((ITable<MessageEventDTO>)db.GetTable<MessageEventDTO>()).TableName("Common_MessageSystem_EventsA"));
+			var q = from evt in evtQry
+					join msg in db.GetTable<MessageDTO>() on evt.MessageId equals msg.Id
+					join mclass in db.GetTable<MessageClassDTO>() on evt.MessageClassId equals mclass.Id
+					join a in db.GetTable<AvailabilityGroupDTO>() on msg.AvailabilityGroupId equals a.Id into aj
+					from a in aj.DefaultIfEmpty()
+					join aRef in db.GetTable<RefMessageEventAvailabilityGroupDTO>() on evt.EventID equals aRef.EventId into aRefj
+					from aRef in aRefj.DefaultIfEmpty()
+					join a2 in db.GetTable<AvailabilityGroupDTO>() on aRef.AvailabilityGroupId equals a2.Id into a2j
+					from a2 in a2j.DefaultIfEmpty()
+					join msgAddI in db.GetTable<MessageAdditionalInformationDTO>().Where(m => m.Language == language) on evt.MessageKey equals msgAddI.MessageKey into msgAddI2
+					from msgAddI in msgAddI2.DefaultIfEmpty()
+					select new MessageEventCombinedDTO
+					{
+						MessageEventDTO = evt,
+						MessageClassDTO = mclass,
+						MessageDTO = msg,
+						Language = language,
+						TranslatedMessage = !string.IsNullOrEmpty(evt.MessageLanguage1)
+							? (evt.MessageLanguage4 == language ? evt.TranslatedMessage4 : (evt.MessageLanguage3 == language ? evt.TranslatedMessage3 : (evt.MessageLanguage2 == language ? evt.TranslatedMessage2 : evt.TranslatedMessage1)))
+							: msg.TextName,
+						AvailabilityGroup = a ?? a2,
+						MessageAdditionalInformationDTO = msgAddI
+					};
+
+			var actual = q
+				.ToList();
+
+			Assert.That(actual, Has.Count.EqualTo(1));
+		}
+	}
+}

--- a/Tests/Linq/UserTests/Issue5458Tests.cs
+++ b/Tests/Linq/UserTests/Issue5458Tests.cs
@@ -62,7 +62,7 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void UnionAllStringIsNullOrEmpty([DataSources] string context)
+		public void UnionAllStringIsNullOrEmpty([DataSources(TestProvName.AllSybase)] string context)
 		{
 			var data = new[]
 			{


### PR DESCRIPTION
## Summary

Fixes #5458 — `string.IsNullOrEmpty()` and `.Length` on UnionAll columns produced wrong SQL (missing `LENGTH()` call, comparing column value to `0` instead).

### Root cause

`string.IsNullOrEmpty(x)` expands to `x == null || x.Length == 0`. On UnionAll columns, `.Length` couldn't be resolved through projection (terminal `SqlPlaceholderExpression`/`SqlPathExpression`), and the fallback to member translation (`LENGTH()`) was not triggered.

### Changes

- **ExpressionBuilder.SqlBuilder.cs** (`Project` method): return error/`DefaultValueExpression(null)` when encountering remaining path members on terminal expressions, instead of returning the terminal expression itself
- **ExpressionBuildVisitor.cs** (`VisitMember`): skip `DefaultValueExpression` with null `MappingSchema` for all build purposes (not just Expression), allowing `HandleMember` to try member translation (`.Length` → `LENGTH()`)
- **ExpressionBuilder.SqlBuilder.cs** (`Project` method): use null `MappingSchema` consistently for all unresolved member returns, distinguishing them from legitimate defaults (e.g., `DefaultIfEmpty`)
- **Informix/SqlCe/SqlServer**: fix `LENGTH`/`LEN`/`CHAR_LENGTH` return type from `GetDbDataType(value)` to `GetDbDataType(typeof(int))`

## Test plan

- [x] `UnionAllWithJoinAndIsNullOrEmpty` — original issue repro (join + entity projection + IsNullOrEmpty)
- [x] `UnionAllStringIsNullOrEmpty` — simpler case (UnionAll + Select with IsNullOrEmpty, no join)
- [x] `TestDefaultExpression_08/09` — no regression on `DefaultIfEmpty(default(T))`