### PR TITLE
Fix CTE columns incorrectly removed by optimizer

### DIFF
--- a/Source/LinqToDB/Internal/DataProvider/MySql/MySqlSqlOptimizer.cs
+++ b/Source/LinqToDB/Internal/DataProvider/MySql/MySqlSqlOptimizer.cs
@@ -12,6 +12,8 @@ namespace LinqToDB.Internal.DataProvider.MySql
 		{
 		}
 
+		public override bool RequiresCastingNullValueForSetOperations => true;
+
 		public override SqlExpressionConvertVisitor CreateConvertVisitor(bool allowModify)
 		{
 			return new MySqlSqlExpressionConvertVisitor(allowModify);

--- a/Source/LinqToDB/Internal/SqlProvider/BasicSqlOptimizer.cs
+++ b/Source/LinqToDB/Internal/SqlProvider/BasicSqlOptimizer.cs
@@ -32,6 +32,7 @@ namespace LinqToDB.Internal.SqlProvider
 		protected SqlProviderFlags SqlProviderFlags { get; }
 
 		public virtual bool RequiresCastingParametersForSetOperations => true;
+		public virtual bool RequiresCastingNullValueForSetOperations => false;
 
 		#endregion
 
@@ -66,7 +67,6 @@ namespace LinqToDB.Internal.SqlProvider
 
 			statement = FinalizeInsert(statement);
 			statement = FinalizeSelect(statement);
-			statement = CorrectUnionOrderBy(statement);
 			statement = FixSetOperationValues(mappingSchema, statement);
 
 			// provider specific query correction
@@ -486,69 +486,13 @@ namespace LinqToDB.Internal.SqlProvider
 			}
 		}
 
-		protected virtual SqlStatement CorrectUnionOrderBy(SqlStatement statement)
-		{
-			var queriesToWrap = new HashSet<SelectQuery>();
-
-			statement.Visit(queriesToWrap, (wrap, e) =>
-			{
-				if (e is SelectQuery sc && sc.HasSetOperators)
-				{
-					var prevQuery = sc;
-
-					for (int i = 0; i < sc.SetOperators.Count; i++)
-					{
-						var currentOperator = sc.SetOperators[i];
-						var currentQuery    = currentOperator.SelectQuery;
-
-						if (currentOperator.Operation == SetOperation.Union)
-						{
-							if (!prevQuery.Select.HasModifier && !prevQuery.OrderBy.IsEmpty)
-							{
-								prevQuery.OrderBy.Items.Clear();
-							}
-
-							if (!currentQuery.Select.HasModifier && !currentQuery.OrderBy.IsEmpty)
-							{
-								currentQuery.OrderBy.Items.Clear();
-							}
-						}
-						else
-						{
-							if (!prevQuery.OrderBy.IsEmpty)
-							{
-								wrap.Add(prevQuery);
-							}
-
-							if (!currentQuery.OrderBy.IsEmpty)
-							{
-								wrap.Add(currentQuery);
-							}
-						}
-
-						prevQuery = currentOperator.SelectQuery;
-					}
-				}
-			});
-
-			if (queriesToWrap.Count == 0)
-				return statement;
-
-			return QueryHelper.WrapQuery(
-				queriesToWrap,
-				statement,
-				static (wrap, q, parentElement) => wrap.Contains(q),
-				null,
-				allowMutation: true);
-		}
-
-		static void CorrelateValueTypes(bool castParameters, ref ISqlExpression toCorrect, ISqlExpression reference)
+		static void CorrelateValueTypes(bool castParameters, bool castNulls, ref ISqlExpression toCorrect, ISqlExpression reference)
 		{
 			if (toCorrect.ElementType == QueryElementType.Column)
 			{
 				var column     = (SqlColumn)toCorrect;
 				var columnExpr = column.Expression;
-				CorrelateValueTypes(castParameters, ref columnExpr, reference);
+				CorrelateValueTypes(castParameters, castNulls, ref columnExpr, reference);
 				column.Expression = columnExpr;
 			}
 			else
@@ -563,6 +507,8 @@ namespace LinqToDB.Internal.SqlProvider
 						if (suggested != null)
 						{
 							toCorrect = new SqlValue(suggested.Value, null);
+							if (castNulls)
+								toCorrect = new SqlCastExpression(toCorrect, suggested.Value, null, true);
 						}
 					}
 					else
@@ -603,8 +549,8 @@ namespace LinqToDB.Internal.SqlProvider
 								var otherColumn = setOperator.SelectQuery.Select.Columns[i];
 								var otherExpr   = otherColumn.Expression;
 
-								CorrelateValueTypes(ctx.RequiresCastingParametersForSetOperations, ref columnExpr, otherExpr);
-								CorrelateValueTypes(ctx.RequiresCastingParametersForSetOperations, ref otherExpr, columnExpr);
+								CorrelateValueTypes(ctx.RequiresCastingParametersForSetOperations, ctx.RequiresCastingNullValueForSetOperations, ref columnExpr, otherExpr);
+								CorrelateValueTypes(ctx.RequiresCastingParametersForSetOperations, ctx.RequiresCastingNullValueForSetOperations, ref otherExpr, columnExpr);
 
 								otherColumn.Expression = otherExpr;
 							}

--- a/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryColumnOptimizerVisitor.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryColumnOptimizerVisitor.cs
@@ -14,16 +14,12 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 	{
 		// Maps each SelectQuery to its set of used columns
 		readonly Dictionary<SelectQuery, HashSet<SqlColumn>> _usedColumnsByQuery = new();
-		
-		// Tracks which CTE fields are actually used
-		readonly Dictionary<CteClause, HashSet<string>> _usedCteFields = new();
 	
 		// Current pass: true = collecting, false = removing
 		bool _isCollecting;
 
 		bool _inExpression;
 
-		CteClause?           _currentCte;
 		SelectQuery?         _currentUpdateQuery;
 		SqlPredicate.Exists? _currentExistsPredicate;
 		SqlTableLikeSource?  _currentSqlTableLikeSource;
@@ -34,9 +30,7 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 		{
 			base.Cleanup();
 			_usedColumnsByQuery.Clear();
-			_usedCteFields.Clear();
 
-			_currentCte                = null;
 			_currentUpdateQuery        = null;
 			_currentExistsPredicate    = null;
 			_currentSqlTableLikeSource = null;
@@ -69,30 +63,26 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 
 		protected internal override IQueryElement VisitCteClause(CteClause element)
 		{
-			var saveCte = _currentCte;
-			_currentCte = element;
-
 			var prevInExpression = _inExpression;
 			_inExpression = false;
 
 			List<SqlColumn>? originalColumns = null;
-			
+
 			// In modify pass, store original columns for tracking
 			if (!_isCollecting && element.Body != null)
 			{
 				originalColumns = element.Body.Select.Columns.ToList();
 			}
-			
+
 			// Visit the CTE body
 			var result = (CteClause)base.VisitCteClause(element);
-			
+
 			// In modify pass, synchronize fields based on what columns remain
 			if (!_isCollecting && originalColumns != null && result.Body != null)
 			{
 				SynchronizeCteFields(result, originalColumns, result.Body.Select.Columns);
 			}
-			
-			_currentCte = saveCte;
+
 			_inExpression = prevInExpression;
 
 			return result;
@@ -188,7 +178,7 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 				MarkColumnUsed(element);
 				return base.VisitSqlColumnReference(element);
 			}
-			
+
 			// In Phase 2, don't visit column expressions - usage already collected
 			return element;
 		}
@@ -197,19 +187,9 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 		{
 			if (_isCollecting)
 			{
-				// Handle CTE field references
+				// Handle CTE field references — mark the corresponding body column as used
 				if (element.Table is SqlCteTable cte)
 				{
-					// Mark this CTE field as used
-					if (!_usedCteFields.TryGetValue(cte.Cte!, out var usedFields))
-					{
-						usedFields = new HashSet<string>(System.StringComparer.Ordinal);
-						_usedCteFields[cte.Cte!] = usedFields;
-					}
-
-					usedFields.Add(element.PhysicalName);
-					
-					// Find and mark the corresponding column
 					for (var i = 0; i < cte.Cte!.Fields.Count; i++)
 					{
 						if (string.Equals(cte.Cte.Fields[i].Name, element.PhysicalName, System.StringComparison.Ordinal))
@@ -430,34 +410,29 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 		{
 			if (cte.Fields.Count == 0 || originalColumns.Count == 0)
 				return;
-			
-			var hasUsedFields = _usedCteFields.TryGetValue(cte, out var usedFieldNames);
-			
+
 			// Build a set of columns that still exist
 			var remainingColumns = new HashSet<SqlColumn>(
-				currentColumns, 
+				currentColumns,
 				Utils.ObjectReferenceEqualityComparer<SqlColumn>.Default
 			);
-			
-			// Determine which fields to keep based on their corresponding columns
+
+			// Keep fields whose corresponding body columns still exist.
+			// CTE fields must stay synchronized with body columns to maintain
+			// correct index mapping.
 			var fieldsToKeep = new List<SqlField>();
-			
+
 			for (var i = 0; i < cte.Fields.Count && i < originalColumns.Count; i++)
 			{
-				var field = cte.Fields[i];
+				var field          = cte.Fields[i];
 				var originalColumn = originalColumns[i];
-				
-				// Check if the column still exists
+
 				if (remainingColumns.Contains(originalColumn))
 				{
-					// Check if the field is actually used
-					if (!hasUsedFields || usedFieldNames!.Contains(field.Name))
-					{
-						fieldsToKeep.Add(field);
-					}
+					fieldsToKeep.Add(field);
 				}
 			}
-			
+
 			// Ensure at least one field remains
 			if (fieldsToKeep.Count == 0 && currentColumns.Count > 0)
 			{
@@ -470,14 +445,14 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 						break;
 					}
 				}
-				
+
 				// If still no field, create a dummy one
 				if (fieldsToKeep.Count == 0)
 				{
 					fieldsToKeep.Add(new SqlField(new DbDataType(typeof(int)), "c1", false));
 				}
 			}
-			
+
 			// Replace fields
 			if (fieldsToKeep.Count != cte.Fields.Count)
 				IsOptimized = true;

--- a/Tests/Linq/Linq/CteTests.cs
+++ b/Tests/Linq/Linq/CteTests.cs
@@ -2842,7 +2842,7 @@ namespace Tests.Linq
 
 		// https://github.com/linq2db/linq2db/issues/5457
 		[Test]
-		public void RecursiveHierarchyWithJoinOnCteColumn([RecursiveCteContextSource(TestProvName.AllClickHouse)] string context)
+		public void RecursiveHierarchyWithJoinOnCteColumn([RecursiveCteContextSource(TestProvName.AllClickHouse, TestProvName.AllOracle)] string context)
 		{
 			using var db = GetDataContext(context);
 

--- a/Tests/Linq/Linq/CteTests.cs
+++ b/Tests/Linq/Linq/CteTests.cs
@@ -2832,5 +2832,57 @@ namespace Tests.Linq
 						select new CteGroupByRecord(suble.Id, suble.Field1, suble.Field2));
 			}).GroupBy(le => le.Field2).ToDictionary(g => g.Key);
 		}
+		sealed class HierarchyLevelCte
+		{
+			public int  ParentID     { get; set; }
+			public int? ChildID      { get; set; }
+			public int? GrandChildID { get; set; }
+			public int  Level        { get; set; }
+		}
+
+		// https://github.com/linq2db/linq2db/issues/5457
+		[Test]
+		public void RecursiveHierarchyWithJoinOnCteColumn([RecursiveCteContextSource] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var cte = db.GetCte<HierarchyLevelCte>(cte =>
+				(
+					from p in db.Parent
+					select new HierarchyLevelCte
+					{
+						ParentID     = p.ParentID,
+						ChildID      = null,
+						GrandChildID = null,
+						Level        = 0,
+					}
+				)
+				.Concat
+				(
+					from c in db.Child
+					from ct in cte.InnerJoin(ct => ct.ParentID == c.ParentID)
+					where ct.Level < 2
+					select new HierarchyLevelCte
+					{
+						ParentID     = c.ParentID,
+						ChildID      = c.ChildID,
+						GrandChildID = ct.GrandChildID,
+						Level        = ct.Level + 1,
+					}
+				));
+
+			var query =
+				from h in cte
+				from p in db.Parent.InnerJoin(p => p.ParentID == h.ChildID)
+				select new
+				{
+					h.ParentID,
+					h.ChildID,
+					h.Level,
+					ParentValue = p.Value1,
+				};
+
+			query.ToArray();
+		}
 	}
 }

--- a/Tests/Linq/Linq/CteTests.cs
+++ b/Tests/Linq/Linq/CteTests.cs
@@ -2842,7 +2842,7 @@ namespace Tests.Linq
 
 		// https://github.com/linq2db/linq2db/issues/5457
 		[Test]
-		public void RecursiveHierarchyWithJoinOnCteColumn([RecursiveCteContextSource] string context)
+		public void RecursiveHierarchyWithJoinOnCteColumn([RecursiveCteContextSource(TestProvName.AllClickHouse)] string context)
 		{
 			using var db = GetDataContext(context);
 


### PR DESCRIPTION
## Summary
- Don't remove columns from CTE body queries in `SqlQueryColumnOptimizerVisitor` — CTE column structure must be preserved for WITH clause header, UNION ALL alignment, and field-to-column index mapping
- Simplified `SynchronizeCteFields` to keep fields based solely on column existence, removing the `_usedCteFields` double-filter that could desynchronize fields from body columns
- Added regression test `RecursiveHierarchyWithJoinOnCteColumn`

Fixes #5457