### PR TITLE
Fix null checks optimization for parameterized predicates (#5445)

### DIFF
--- a/Source/LinqToDB/Internal/SqlQuery/SimilarityMerger.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/SimilarityMerger.cs
@@ -55,7 +55,8 @@ namespace LinqToDB.Internal.SqlQuery
 				else if (predicate2 is SqlPredicate.ExprExpr { Operator: SqlPredicate.Operator.Equal } exprExpr2
 					&& (exprExpr2.UnknownAsValue == true || !isNestedPredicate))
 				{
-					if (!isLogicalOr && isNull1.IsNot && !nullabilityContext.IsEmpty)
+					if (!isLogicalOr && isNull1.IsNot && !nullabilityContext.IsEmpty
+						&& !isNull1.Expr1.HasQueryParameter())
 					{
 						if (exprExpr2.Expr1.Equals(isNull1.Expr1, SqlExtensions.DefaultComparer))
 						{

--- a/Tests/Linq/UserTests/Issue5445Tests.cs
+++ b/Tests/Linq/UserTests/Issue5445Tests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+
+using LinqToDB;
+using LinqToDB.Mapping;
+
+using NUnit.Framework;
+
+using Shouldly;
+
+namespace Tests.UserTests
+{
+	[TestFixture]
+	public class Issue5445Tests : TestBase
+	{
+		[Table]
+		sealed class TestTable
+		{
+			[PrimaryKey]           public int  Id        { get; set; }
+			[Column, Nullable]     public int? NullField { get; set; }
+		}
+
+		static readonly TestTable[] _testData =
+		[
+			new() { Id = 1, NullField = 1 },
+			new() { Id = 2, NullField = null },
+		];
+
+		[Test]
+		public void NullableHasValueWithNonNullParam([DataSources] string context)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(_testData);
+
+			int? nullable = 1;
+			Expression<Func<TestTable, bool>> filter = t => nullable.HasValue && t.NullField == nullable;
+
+			var result = table.Where(filter).ToList();
+
+			result.Count.ShouldBe(1);
+			result[0].Id.ShouldBe(1);
+		}
+
+		[Test]
+		public void NullableHasValueWithNullParam([DataSources] string context)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(_testData);
+
+			int? nullable = null;
+			Expression<Func<TestTable, bool>> filter = t => nullable.HasValue && t.NullField == nullable;
+
+			// HasValue is false, so the entire predicate is false — no rows should be returned
+			var result = table.Where(filter).ToList();
+
+			result.ShouldBeEmpty();
+		}
+
+		[Test]
+		public void NullableHasValueExtractedWithNullParam([DataSources] string context)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(_testData);
+
+			int? nullable = null;
+			bool hasValue = nullable.HasValue;
+
+			// Control case: extracting HasValue before expression works correctly
+			var result = table.Where(t => hasValue && t.NullField == nullable).ToList();
+
+			result.ShouldBeEmpty();
+		}
+	}
+}

--- a/Tests/Linq/UserTests/Issue5445Tests.cs
+++ b/Tests/Linq/UserTests/Issue5445Tests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -28,7 +28,7 @@ namespace Tests.UserTests
 		];
 
 		[Test]
-		public void NullableHasValueWithNonNullParam([DataSources] string context)
+		public void NullableHasValueWithNonNullParam([IncludeDataSources(TestProvName.AllSQLite)] string context)
 		{
 			using var db    = GetDataContext(context);
 			using var table = db.CreateLocalTable(_testData);
@@ -43,7 +43,7 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void NullableHasValueWithNullParam([DataSources] string context)
+		public void NullableHasValueWithNullParam([IncludeDataSources(TestProvName.AllSQLite)] string context)
 		{
 			using var db    = GetDataContext(context);
 			using var table = db.CreateLocalTable(_testData);
@@ -58,7 +58,7 @@ namespace Tests.UserTests
 		}
 
 		[Test]
-		public void NullableHasValueExtractedWithNullParam([DataSources] string context)
+		public void NullableHasValueExtractedWithNullParam([IncludeDataSources(TestProvName.AllSQLite)] string context)
 		{
 			using var db    = GetDataContext(context);
 			using var table = db.CreateLocalTable(_testData);

--- a/Tests/Tests.Playground/Tests.Playground.csproj
+++ b/Tests/Tests.Playground/Tests.Playground.csproj
@@ -10,6 +10,7 @@
 	<ItemGroup>
 		<Compile Include="..\Linq\TestsInitialization.cs" Link="TestsInitialization.cs" />
 		<Compile Include="..\Linq\Create\CreateData.cs" Link="CreateData.cs" />
+		<Compile Include="..\Linq\UserTests\Issue5445Tests.cs" Link="Issue5445Tests.cs" />
 	</ItemGroup>
 
 </Project>

--- a/Tests/Tests.Playground/Tests.Playground.csproj
+++ b/Tests/Tests.Playground/Tests.Playground.csproj
@@ -10,7 +10,6 @@
 	<ItemGroup>
 		<Compile Include="..\Linq\TestsInitialization.cs" Link="TestsInitialization.cs" />
 		<Compile Include="..\Linq\Create\CreateData.cs" Link="CreateData.cs" />
-		<Compile Include="..\Linq\UserTests\Issue5445Tests.cs" Link="Issue5445Tests.cs" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Fix `SimilarityMerger.TryMerge` incorrectly merging `IS NOT NULL` guard with equality predicate when the checked expression contains a query parameter
- When `param.HasValue && column == param` was used with a null parameter, the optimizer stripped the `HasValue` check, producing `column IS NULL` instead of `1 = 0`
- Added `HasQueryParameter()` guard to skip the merge when the `IS NOT NULL` target contains a parameter

Fixes #5445