### PR TITLE
Improve "now" translation to support TZ and UTC variations

### DIFF
--- a/Source/LinqToDB/CompatibilitySuppressions.xml
+++ b/Source/LinqToDB/CompatibilitySuppressions.xml
@@ -247,6 +247,34 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:LinqToDB.Internal.DataProvider.Translation.DateFunctionsTranslatorBase.TranslateSqlCurrentTimestamp(LinqToDB.Linq.Translation.ITranslationContext,System.Linq.Expressions.MemberExpression,LinqToDB.Linq.Translation.TranslationFlags)</Target>
+    <Left>lib/net10.0/linq2db.dll</Left>
+    <Right>lib/net10.0/linq2db.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:LinqToDB.Internal.DataProvider.Translation.DateFunctionsTranslatorBase.TranslateSqlCurrentTimestampUtc(LinqToDB.Linq.Translation.ITranslationContext,LinqToDB.DbDataType,LinqToDB.Linq.Translation.TranslationFlags)</Target>
+    <Left>lib/net10.0/linq2db.dll</Left>
+    <Right>lib/net10.0/linq2db.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:LinqToDB.Internal.DataProvider.Translation.DateFunctionsTranslatorBase.TranslateSqlCurrentTimestampUtc(LinqToDB.Linq.Translation.ITranslationContext,System.Linq.Expressions.MemberExpression,LinqToDB.Linq.Translation.TranslationFlags)</Target>
+    <Left>lib/net10.0/linq2db.dll</Left>
+    <Right>lib/net10.0/linq2db.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:LinqToDB.Internal.DataProvider.Translation.DateFunctionsTranslatorBase.TranslateSqlGetDate(LinqToDB.Linq.Translation.ITranslationContext,LinqToDB.Linq.Translation.TranslationFlags)</Target>
+    <Left>lib/net10.0/linq2db.dll</Left>
+    <Right>lib/net10.0/linq2db.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:LinqToDB.Internal.DataProvider.Translation.ProviderMemberTranslatorDefault.ConvertToString(LinqToDB.Linq.Translation.ITranslationContext,System.Linq.Expressions.MethodCallExpression,LinqToDB.Linq.Translation.TranslationFlags)</Target>
     <Left>lib/net10.0/linq2db.dll</Left>
     <Right>lib/net10.0/linq2db.dll</Right>
@@ -618,6 +646,34 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:LinqToDB.Internal.DataProvider.Translation.DateFunctionsTranslatorBase.TranslateSqlCurrentTimestamp(LinqToDB.Linq.Translation.ITranslationContext,System.Linq.Expressions.MemberExpression,LinqToDB.Linq.Translation.TranslationFlags)</Target>
+    <Left>lib/net462/linq2db.dll</Left>
+    <Right>lib/net462/linq2db.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:LinqToDB.Internal.DataProvider.Translation.DateFunctionsTranslatorBase.TranslateSqlCurrentTimestampUtc(LinqToDB.Linq.Translation.ITranslationContext,LinqToDB.DbDataType,LinqToDB.Linq.Translation.TranslationFlags)</Target>
+    <Left>lib/net462/linq2db.dll</Left>
+    <Right>lib/net462/linq2db.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:LinqToDB.Internal.DataProvider.Translation.DateFunctionsTranslatorBase.TranslateSqlCurrentTimestampUtc(LinqToDB.Linq.Translation.ITranslationContext,System.Linq.Expressions.MemberExpression,LinqToDB.Linq.Translation.TranslationFlags)</Target>
+    <Left>lib/net462/linq2db.dll</Left>
+    <Right>lib/net462/linq2db.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:LinqToDB.Internal.DataProvider.Translation.DateFunctionsTranslatorBase.TranslateSqlGetDate(LinqToDB.Linq.Translation.ITranslationContext,LinqToDB.Linq.Translation.TranslationFlags)</Target>
+    <Left>lib/net462/linq2db.dll</Left>
+    <Right>lib/net462/linq2db.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:LinqToDB.Internal.DataProvider.Translation.ProviderMemberTranslatorDefault.ConvertToString(LinqToDB.Linq.Translation.ITranslationContext,System.Linq.Expressions.MethodCallExpression,LinqToDB.Linq.Translation.TranslationFlags)</Target>
     <Left>lib/net462/linq2db.dll</Left>
     <Right>lib/net462/linq2db.dll</Right>
@@ -989,6 +1045,34 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:LinqToDB.Internal.DataProvider.Translation.DateFunctionsTranslatorBase.TranslateSqlCurrentTimestamp(LinqToDB.Linq.Translation.ITranslationContext,System.Linq.Expressions.MemberExpression,LinqToDB.Linq.Translation.TranslationFlags)</Target>
+    <Left>lib/net8.0/linq2db.dll</Left>
+    <Right>lib/net8.0/linq2db.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:LinqToDB.Internal.DataProvider.Translation.DateFunctionsTranslatorBase.TranslateSqlCurrentTimestampUtc(LinqToDB.Linq.Translation.ITranslationContext,LinqToDB.DbDataType,LinqToDB.Linq.Translation.TranslationFlags)</Target>
+    <Left>lib/net8.0/linq2db.dll</Left>
+    <Right>lib/net8.0/linq2db.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:LinqToDB.Internal.DataProvider.Translation.DateFunctionsTranslatorBase.TranslateSqlCurrentTimestampUtc(LinqToDB.Linq.Translation.ITranslationContext,System.Linq.Expressions.MemberExpression,LinqToDB.Linq.Translation.TranslationFlags)</Target>
+    <Left>lib/net8.0/linq2db.dll</Left>
+    <Right>lib/net8.0/linq2db.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:LinqToDB.Internal.DataProvider.Translation.DateFunctionsTranslatorBase.TranslateSqlGetDate(LinqToDB.Linq.Translation.ITranslationContext,LinqToDB.Linq.Translation.TranslationFlags)</Target>
+    <Left>lib/net8.0/linq2db.dll</Left>
+    <Right>lib/net8.0/linq2db.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:LinqToDB.Internal.DataProvider.Translation.ProviderMemberTranslatorDefault.ConvertToString(LinqToDB.Linq.Translation.ITranslationContext,System.Linq.Expressions.MethodCallExpression,LinqToDB.Linq.Translation.TranslationFlags)</Target>
     <Left>lib/net8.0/linq2db.dll</Left>
     <Right>lib/net8.0/linq2db.dll</Right>
@@ -1354,6 +1438,34 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:LinqToDB.Internal.DataProvider.Sybase.Translation.SybaseMemberTranslator.DateFunctionsTranslator.DatePartToStr(LinqToDB.Sql.DateParts)</Target>
+    <Left>lib/net9.0/linq2db.dll</Left>
+    <Right>lib/net9.0/linq2db.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:LinqToDB.Internal.DataProvider.Translation.DateFunctionsTranslatorBase.TranslateSqlCurrentTimestamp(LinqToDB.Linq.Translation.ITranslationContext,System.Linq.Expressions.MemberExpression,LinqToDB.Linq.Translation.TranslationFlags)</Target>
+    <Left>lib/net9.0/linq2db.dll</Left>
+    <Right>lib/net9.0/linq2db.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:LinqToDB.Internal.DataProvider.Translation.DateFunctionsTranslatorBase.TranslateSqlCurrentTimestampUtc(LinqToDB.Linq.Translation.ITranslationContext,LinqToDB.DbDataType,LinqToDB.Linq.Translation.TranslationFlags)</Target>
+    <Left>lib/net9.0/linq2db.dll</Left>
+    <Right>lib/net9.0/linq2db.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:LinqToDB.Internal.DataProvider.Translation.DateFunctionsTranslatorBase.TranslateSqlCurrentTimestampUtc(LinqToDB.Linq.Translation.ITranslationContext,System.Linq.Expressions.MemberExpression,LinqToDB.Linq.Translation.TranslationFlags)</Target>
+    <Left>lib/net9.0/linq2db.dll</Left>
+    <Right>lib/net9.0/linq2db.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:LinqToDB.Internal.DataProvider.Translation.DateFunctionsTranslatorBase.TranslateSqlGetDate(LinqToDB.Linq.Translation.ITranslationContext,LinqToDB.Linq.Translation.TranslationFlags)</Target>
     <Left>lib/net9.0/linq2db.dll</Left>
     <Right>lib/net9.0/linq2db.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -1737,6 +1849,34 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:LinqToDB.Internal.DataProvider.Sybase.Translation.SybaseMemberTranslator.DateFunctionsTranslator.DatePartToStr(LinqToDB.Sql.DateParts)</Target>
+    <Left>lib/netstandard2.0/linq2db.dll</Left>
+    <Right>lib/netstandard2.0/linq2db.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:LinqToDB.Internal.DataProvider.Translation.DateFunctionsTranslatorBase.TranslateSqlCurrentTimestamp(LinqToDB.Linq.Translation.ITranslationContext,System.Linq.Expressions.MemberExpression,LinqToDB.Linq.Translation.TranslationFlags)</Target>
+    <Left>lib/netstandard2.0/linq2db.dll</Left>
+    <Right>lib/netstandard2.0/linq2db.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:LinqToDB.Internal.DataProvider.Translation.DateFunctionsTranslatorBase.TranslateSqlCurrentTimestampUtc(LinqToDB.Linq.Translation.ITranslationContext,LinqToDB.DbDataType,LinqToDB.Linq.Translation.TranslationFlags)</Target>
+    <Left>lib/netstandard2.0/linq2db.dll</Left>
+    <Right>lib/netstandard2.0/linq2db.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:LinqToDB.Internal.DataProvider.Translation.DateFunctionsTranslatorBase.TranslateSqlCurrentTimestampUtc(LinqToDB.Linq.Translation.ITranslationContext,System.Linq.Expressions.MemberExpression,LinqToDB.Linq.Translation.TranslationFlags)</Target>
+    <Left>lib/netstandard2.0/linq2db.dll</Left>
+    <Right>lib/netstandard2.0/linq2db.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:LinqToDB.Internal.DataProvider.Translation.DateFunctionsTranslatorBase.TranslateSqlGetDate(LinqToDB.Linq.Translation.ITranslationContext,LinqToDB.Linq.Translation.TranslationFlags)</Target>
     <Left>lib/netstandard2.0/linq2db.dll</Left>
     <Right>lib/netstandard2.0/linq2db.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/Source/LinqToDB/CompatibilitySuppressions.xml
+++ b/Source/LinqToDB/CompatibilitySuppressions.xml
@@ -3,6 +3,13 @@
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:LinqToDB.Internal.DataProvider.SqlServer.Translation.SqlServer2005MemberTranslator.DateFunctionsTranslator2005</Target>
+    <Left>lib/net10.0/linq2db.dll</Left>
+    <Right>lib/net10.0/linq2db.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:LinqToDB.Internal.SqlQuery.SqlSimpleCaseExpression</Target>
     <Left>lib/net10.0/linq2db.dll</Left>
     <Right>lib/net10.0/linq2db.dll</Right>
@@ -31,6 +38,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:LinqToDB.Internal.DataProvider.SqlServer.Translation.SqlServer2005MemberTranslator.DateFunctionsTranslator2005</Target>
+    <Left>lib/net462/linq2db.dll</Left>
+    <Right>lib/net462/linq2db.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:LinqToDB.Internal.SqlQuery.SqlSimpleCaseExpression</Target>
     <Left>lib/net462/linq2db.dll</Left>
     <Right>lib/net462/linq2db.dll</Right>
@@ -59,6 +73,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:LinqToDB.Internal.DataProvider.SqlServer.Translation.SqlServer2005MemberTranslator.DateFunctionsTranslator2005</Target>
+    <Left>lib/net8.0/linq2db.dll</Left>
+    <Right>lib/net8.0/linq2db.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:LinqToDB.Internal.SqlQuery.SqlSimpleCaseExpression</Target>
     <Left>lib/net8.0/linq2db.dll</Left>
     <Right>lib/net8.0/linq2db.dll</Right>
@@ -83,6 +104,13 @@
     <Target>T:LinqToDB.Internal.SqlQuery.Visitors.SqlQueryNestingValidationVisitor</Target>
     <Left>lib/net8.0/linq2db.dll</Left>
     <Right>lib/net8.0/linq2db.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:LinqToDB.Internal.DataProvider.SqlServer.Translation.SqlServer2005MemberTranslator.DateFunctionsTranslator2005</Target>
+    <Left>lib/net9.0/linq2db.dll</Left>
+    <Right>lib/net9.0/linq2db.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
@@ -118,6 +146,13 @@
     <Target>T:System.Data.Linq.Binary</Target>
     <Left>lib/netstandard2.0/linq2db.dll</Left>
     <Right>lib/net462/linq2db.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:LinqToDB.Internal.DataProvider.SqlServer.Translation.SqlServer2005MemberTranslator.DateFunctionsTranslator2005</Target>
+    <Left>lib/netstandard2.0/linq2db.dll</Left>
+    <Right>lib/netstandard2.0/linq2db.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>

--- a/Source/LinqToDB/Internal/DataProvider/Access/AccessDataProvider.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Access/AccessDataProvider.cs
@@ -131,6 +131,9 @@ namespace LinqToDB.Internal.DataProvider.Access
 				value = d.ToDateTime(TimeOnly.MinValue);
 #endif
 
+			if (value is DateTimeOffset dto)
+				value = dto.DateTime;
+
 			if (Provider == AccessProvider.ODBC)
 			{
 				switch (dataType.DataType)
@@ -168,10 +171,11 @@ namespace LinqToDB.Internal.DataProvider.Access
 				OleDbType? type = null;
 				switch (dataType.DataType)
 				{
-					case DataType.DateTime:
-					case DataType.DateTime2: type = OleDbType.Date; break;
-					case DataType.Text: type = OleDbType.LongVarChar; break;
-					case DataType.NText: type = OleDbType.LongVarWChar; break;
+					case DataType.DateTimeOffset:
+					case DataType.DateTime      :
+					case DataType.DateTime2     : type = OleDbType.Date; break;
+					case DataType.Text          : type = OleDbType.LongVarChar; break;
+					case DataType.NText         : type = OleDbType.LongVarWChar; break;
 				}
 
 				if (type != null)
@@ -189,12 +193,12 @@ namespace LinqToDB.Internal.DataProvider.Access
 					// "Data type mismatch in criteria expression" fix for culture-aware number decimal separator
 					// unfortunately, regular fix using ExecuteScope=>InvariantCultureRegion
 					// doesn't work for all situations
-					case DataType.Decimal:
+					case DataType.Decimal   :
 					case DataType.VarNumeric: parameter.DbType = DbType.AnsiString; return;
-					case DataType.DateTime:
-					case DataType.DateTime2: parameter.DbType = DbType.DateTime; return;
-					case DataType.Text: parameter.DbType = DbType.AnsiString; return;
-					case DataType.NText: parameter.DbType = DbType.String; return;
+					case DataType.DateTime  :
+					case DataType.DateTime2 : parameter.DbType = DbType.DateTime; return;
+					case DataType.Text      : parameter.DbType = DbType.AnsiString; return;
+					case DataType.NText     : parameter.DbType = DbType.String; return;
 				}
 			}
 			else
@@ -219,17 +223,18 @@ namespace LinqToDB.Internal.DataProvider.Access
 
 				switch (dataType.DataType)
 				{
-					case DataType.SByte: parameter.DbType = DbType.Byte; return;
-					case DataType.UInt16: parameter.DbType = DbType.Int16; return;
-					case DataType.UInt32:
-					case DataType.UInt64:
-					case DataType.Int64: parameter.DbType = DbType.Int32; return;
-					case DataType.Money:
-					case DataType.SmallMoney:
-					case DataType.VarNumeric:
-					case DataType.Decimal: parameter.DbType = DbType.AnsiString; return;
+					case DataType.DateTimeOffset: parameter.DbType = DbType.DateTime; return;
+					case DataType.SByte         : parameter.DbType = DbType.Byte; return;
+					case DataType.UInt16        : parameter.DbType = DbType.Int16; return;
+					case DataType.UInt32        :
+					case DataType.UInt64        :
+					case DataType.Int64         : parameter.DbType = DbType.Int32; return;
+					case DataType.Money         :
+					case DataType.SmallMoney    :
+					case DataType.VarNumeric    :
+					case DataType.Decimal       : parameter.DbType = DbType.AnsiString; return;
 					// fallback
-					case DataType.Variant: parameter.DbType = DbType.Binary; return;
+					case DataType.Variant       : parameter.DbType = DbType.Binary; return;
 				}
 			}
 

--- a/Source/LinqToDB/Internal/DataProvider/Access/AccessMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Access/AccessMappingSchema.cs
@@ -25,11 +25,12 @@ namespace LinqToDB.Internal.DataProvider.Access
 			// in Access DECIMAL=DECIMAL(18,0)
 			SetDataType(typeof(decimal), new SqlDataType(DataType.Decimal, typeof(decimal), 18, 10));
 
-			SetValueToSqlConverter(typeof(bool),     (sb,_,_,v) => sb.Append((bool)v));
-			SetValueToSqlConverter(typeof(Guid),     (sb,_,_,v) => sb.Append(CultureInfo.InvariantCulture, $"'{(Guid)v:B}'"));
-			SetValueToSqlConverter(typeof(DateTime), (sb,_,_,v) => ConvertDateTimeToSql(sb, (DateTime)v));
+			SetValueToSqlConverter(typeof(bool),           (sb,_,_,v) => sb.Append((bool)v));
+			SetValueToSqlConverter(typeof(Guid),           (sb,_,_,v) => sb.Append(CultureInfo.InvariantCulture, $"'{(Guid)v:B}'"));
+			SetValueToSqlConverter(typeof(DateTime),       (sb,_,_,v) => ConvertDateTimeToSql(sb, (DateTime)v));
+			SetValueToSqlConverter(typeof(DateTimeOffset), (sb,_,_,v) => ConvertDateTimeToSql(sb, ((DateTimeOffset)v).DateTime));
 #if SUPPORTS_DATEONLY
-			SetValueToSqlConverter(typeof(DateOnly), (sb,_,_,v) => ConvertDateOnlyToSql(sb, (DateOnly)v));
+			SetValueToSqlConverter(typeof(DateOnly),       (sb,_,_,v) => ConvertDateOnlyToSql(sb, (DateOnly)v));
 #endif
 
 			SetDataType(typeof(string), new SqlDataType(DataType.NVarChar, typeof(string), 255));

--- a/Source/LinqToDB/Internal/DataProvider/Access/Translation/AccessMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Access/Translation/AccessMemberTranslator.cs
@@ -190,7 +190,7 @@ namespace LinqToDB.Internal.DataProvider.Access.Translation
 				return timePart;
 			}
 
-			protected override ISqlExpression? TranslateSqlGetDate(ITranslationContext translationContext, TranslationFlags translationFlags)
+			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
 				var factory       = translationContext.ExpressionFactory;
 				var nowExpression = factory.NotNullExpression(factory.GetDbDataType(typeof(DateTime)), "Now");

--- a/Source/LinqToDB/Internal/DataProvider/Access/Translation/AccessMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Access/Translation/AccessMemberTranslator.cs
@@ -74,6 +74,11 @@ namespace LinqToDB.Internal.DataProvider.Access.Translation
 				return resultExpression;
 			}
 
+			protected override ISqlExpression? TranslateDateTimeOffsetDatePart(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, Sql.DateParts datepart)
+			{
+				return TranslateDateTimeDatePart(translationContext, translationFlag, dateTimeExpression, datepart);
+			}
+
 			protected override ISqlExpression? TranslateDateTimeDateAdd(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, ISqlExpression increment,
 				Sql.DateParts                                                       datepart)
 			{
@@ -188,6 +193,12 @@ namespace LinqToDB.Internal.DataProvider.Access.Translation
 				var timePart = factory.Function(factory.GetDbDataType(typeof(TimeSpan)), "TimeValue", dateExpression);
 
 				return timePart;
+			}
+
+			protected override ISqlExpression? TranslateServerNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				return factory.NotNullExpression(factory.GetDbDataType(typeof(DateTime)), "Now");
 			}
 
 			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)

--- a/Source/LinqToDB/Internal/DataProvider/Access/Translation/AccessMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Access/Translation/AccessMemberTranslator.cs
@@ -206,6 +206,11 @@ namespace LinqToDB.Internal.DataProvider.Access.Translation
 				var nowExpression = factory.NotNullExpression(factory.GetDbDataType(typeof(DateTime)), "Now");
 				return nowExpression;
 			}
+
+			protected override ISqlExpression? TranslateZonedNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				return translationContext.ExpressionFactory.NotNullExpression(dbDataType, "Now");
+			}
 		}
 
 		protected class MathMemberTranslator : MathMemberTranslatorBase

--- a/Source/LinqToDB/Internal/DataProvider/Access/Translation/AccessMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Access/Translation/AccessMemberTranslator.cs
@@ -197,8 +197,7 @@ namespace LinqToDB.Internal.DataProvider.Access.Translation
 
 			protected override ISqlExpression? TranslateServerNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
-				var factory = translationContext.ExpressionFactory;
-				return factory.NotNullExpression(factory.GetDbDataType(typeof(DateTime)), "Now");
+				return TranslateNow(translationContext, translationFlags);
 			}
 
 			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)

--- a/Source/LinqToDB/Internal/DataProvider/ClickHouse/Translation/ClickHouseMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/ClickHouse/Translation/ClickHouseMemberTranslator.cs
@@ -216,16 +216,17 @@ namespace LinqToDB.Internal.DataProvider.ClickHouse.Translation
 				return CommonTruncationToTime(translationContext, dateExpression);
 			}
 
-			protected override ISqlExpression? TranslateSqlGetDate(ITranslationContext translationContext, TranslationFlags translationFlags)
+			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
 				var factory     = translationContext.ExpressionFactory;
 				var nowFunction = factory.Function(factory.GetDbDataType(typeof(DateTime)), "now", ParametersNullabilityType.NotNullable);
 				return nowFunction;
 			}
 
-			protected override ISqlExpression? TranslateSqlCurrentTimestampUtc(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			protected override ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
 				var factory = translationContext.ExpressionFactory;
+				var dbDataType = factory.GetDbDataType(typeof(DateTime));
 				return factory.Function(dbDataType, "now", factory.Value("UTC"));
 			}
 		}

--- a/Source/LinqToDB/Internal/DataProvider/ClickHouse/Translation/ClickHouseMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/ClickHouse/Translation/ClickHouseMemberTranslator.cs
@@ -216,6 +216,13 @@ namespace LinqToDB.Internal.DataProvider.ClickHouse.Translation
 				return CommonTruncationToTime(translationContext, dateExpression);
 			}
 
+			protected override ISqlExpression? TranslateServerNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			{
+				// CURRENT_TIMESTAMP is alias for now(), but due to CH parser bugs doesn't work sometimes
+				// see CurrentTimestampUpdate test to check if it is fixed in newer versions
+				return TranslateNow(translationContext, translationFlags);
+			}
+
 			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
 				var factory     = translationContext.ExpressionFactory;

--- a/Source/LinqToDB/Internal/DataProvider/ClickHouse/Translation/ClickHouseMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/ClickHouse/Translation/ClickHouseMemberTranslator.cs
@@ -236,6 +236,19 @@ namespace LinqToDB.Internal.DataProvider.ClickHouse.Translation
 				var dbDataType = factory.GetDbDataType(typeof(DateTime));
 				return factory.Function(dbDataType, "now", factory.Value("UTC"));
 			}
+
+			protected override ISqlExpression? TranslateZonedNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				var factory     = translationContext.ExpressionFactory;
+				var nowFunction = factory.Function(dbDataType, "now", ParametersNullabilityType.NotNullable);
+				return nowFunction;
+			}
+
+			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				return factory.Function(dbDataType, "now", factory.Value("UTC"));
+			}
 		}
 
 		protected class MathMemberTranslator : MathMemberTranslatorBase

--- a/Source/LinqToDB/Internal/DataProvider/DB2/DB2DataProvider.cs
+++ b/Source/LinqToDB/Internal/DataProvider/DB2/DB2DataProvider.cs
@@ -105,7 +105,9 @@ namespace LinqToDB.Internal.DataProvider.DB2
 
 		protected override IMemberTranslator CreateMemberTranslator()
 		{
-			return new DB2MemberTranslator();
+			return Version == DB2Version.zOS
+				? new DB2zOSMemberTranslator()
+				: new DB2MemberTranslator();
 		}
 
 		public override ISqlBuilder CreateSqlBuilder(MappingSchema mappingSchema, DataOptions dataOptions)

--- a/Source/LinqToDB/Internal/DataProvider/DB2/DB2MappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/DB2/DB2MappingSchema.cs
@@ -203,7 +203,118 @@ namespace LinqToDB.Internal.DataProvider.DB2
 
 		internal static readonly DB2MappingSchema Instance = new ();
 
-		public sealed class DB2zOSMappingSchema() : LockedMappingSchema(ProviderName.DB2zOS, DB2ProviderAdapter.Instance.MappingSchema, Instance);
+		public sealed class DB2zOSMappingSchema : LockedMappingSchema
+		{
+#if SUPPORTS_COMPOSITE_FORMAT
+			private static readonly CompositeFormat TIMESTAMP_TZ_0_FORMAT = CompositeFormat.Parse("'{0:yyyy-MM-dd-HH.mm.sszzz}'");
+			private static readonly CompositeFormat TIMESTAMP_TZ_1_FORMAT = CompositeFormat.Parse("'{0:yyyy-MM-dd-HH.mm.ss.fzzz}'");
+			private static readonly CompositeFormat TIMESTAMP_TZ_2_FORMAT = CompositeFormat.Parse("'{0:yyyy-MM-dd-HH.mm.ss.ffzzz}'");
+			private static readonly CompositeFormat TIMESTAMP_TZ_3_FORMAT = CompositeFormat.Parse("'{0:yyyy-MM-dd-HH.mm.ss.fffzzz}'");
+			private static readonly CompositeFormat TIMESTAMP_TZ_4_FORMAT = CompositeFormat.Parse("'{0:yyyy-MM-dd-HH.mm.ss.ffffzzz}'");
+			private static readonly CompositeFormat TIMESTAMP_TZ_5_FORMAT = CompositeFormat.Parse("'{0:yyyy-MM-dd-HH.mm.ss.fffffzzz}'");
+			private static readonly CompositeFormat TIMESTAMP_TZ_6_FORMAT = CompositeFormat.Parse("'{0:yyyy-MM-dd-HH.mm.ss.ffffffzzz}'");
+			private static readonly CompositeFormat TIMESTAMP_TZ_7_FORMAT = CompositeFormat.Parse("'{0:yyyy-MM-dd-HH.mm.ss.fffffffzzz}'");
+#else
+			private const string TIMESTAMP_TZ_0_FORMAT = "'{0:yyyy-MM-dd-HH.mm.sszzz}'";
+			private const string TIMESTAMP_TZ_1_FORMAT = "'{0:yyyy-MM-dd-HH.mm.ss.fzzz}'";
+			private const string TIMESTAMP_TZ_2_FORMAT = "'{0:yyyy-MM-dd-HH.mm.ss.ffzzz}'";
+			private const string TIMESTAMP_TZ_3_FORMAT = "'{0:yyyy-MM-dd-HH.mm.ss.fffzzz}'";
+			private const string TIMESTAMP_TZ_4_FORMAT = "'{0:yyyy-MM-dd-HH.mm.ss.ffffzzz}'";
+			private const string TIMESTAMP_TZ_5_FORMAT = "'{0:yyyy-MM-dd-HH.mm.ss.fffffzzz}'";
+			private const string TIMESTAMP_TZ_6_FORMAT = "'{0:yyyy-MM-dd-HH.mm.ss.ffffffzzz}'";
+			private const string TIMESTAMP_TZ_7_FORMAT = "'{0:yyyy-MM-dd-HH.mm.ss.fffffffzzz}'";
+#endif
+
+			private static readonly string[] DateParseFormats = new[]
+			{
+				"yyyy-MM-dd",
+				"yyyy-MM-dd-HH.mm.ss",
+				"yyyy-MM-dd-HH.mm.ss.f",
+				"yyyy-MM-dd-HH.mm.ss.ff",
+				"yyyy-MM-dd-HH.mm.ss.fff",
+				"yyyy-MM-dd-HH.mm.ss.ffff",
+				"yyyy-MM-dd-HH.mm.ss.fffff",
+				"yyyy-MM-dd-HH.mm.ss.ffffff",
+				"yyyy-MM-dd-HH.mm.ss.fffffff",
+				"yyyy-MM-dd-HH.mm.ss.ffffffff",
+				"yyyy-MM-dd-HH.mm.ss.fffffffff",
+				"yyyy-MM-dd-HH.mm.ss.ffffffffff",
+				"yyyy-MM-dd-HH.mm.ss.fffffffffff",
+				"yyyy-MM-dd-HH.mm.ss.ffffffffffff",
+				"yyyy-MM-dd-HH.mm.sszzz",
+				"yyyy-MM-dd-HH.mm.ss.fzzz",
+				"yyyy-MM-dd-HH.mm.ss.ffzzz",
+				"yyyy-MM-dd-HH.mm.ss.fffzzz",
+				"yyyy-MM-dd-HH.mm.ss.ffffzzz",
+				"yyyy-MM-dd-HH.mm.ss.fffffzzz",
+				"yyyy-MM-dd-HH.mm.ss.ffffffzzz",
+				"yyyy-MM-dd-HH.mm.ss.fffffffzzz",
+				"yyyy-MM-dd-HH.mm.ss.ffffffffzzz",
+				"yyyy-MM-dd-HH.mm.ss.fffffffffzzz",
+				"yyyy-MM-dd-HH.mm.ss.ffffffffffzzz",
+				"yyyy-MM-dd-HH.mm.ss.fffffffffffzzz",
+				"yyyy-MM-dd-HH.mm.ss.ffffffffffffzzz",
+			};
+
+			public DB2zOSMappingSchema()
+				: base(ProviderName.DB2zOS, DB2ProviderAdapter.Instance.MappingSchema, Instance)
+			{
+				SetValueToSqlConverter(typeof(DateTimeOffset), (sb, dt, _, v) => ConvertDateTimeOffsetToSql(sb, dt, (DateTimeOffset)v));
+
+				SetConverter<string, DateTimeOffset>(ParseDateTimeOffset);
+			}
+
+			static DateTimeOffset ParseDateTimeOffset(string value)
+			{
+				if (DateTimeOffset.TryParse(value, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None, out var res))
+					return res;
+
+				return DateTimeOffset.ParseExact(
+					value,
+					DateParseFormats,
+					CultureInfo.InvariantCulture,
+					DateTimeStyles.None);
+			}
+
+			static void ConvertDateTimeOffsetToSql(StringBuilder stringBuilder, SqlDataType type, DateTimeOffset value)
+			{
+				stringBuilder.AppendFormat(CultureInfo.InvariantCulture, GetTimestampTzFormat(type), value);
+			}
+
+			static
+#if SUPPORTS_COMPOSITE_FORMAT
+			CompositeFormat
+#else
+			string
+#endif
+			GetTimestampTzFormat(SqlDataType type)
+			{
+				var precision = type.Type.Precision;
+
+				if (precision == null && type.Type.DbType != null)
+				{
+					var dbtype = type.Type.DbType.ToLowerInvariant();
+					if (dbtype.StartsWith("timestamp(", StringComparison.Ordinal))
+					{
+						if (int.TryParse(dbtype.AsSpan(10, dbtype.Length - 11), NumberStyles.Integer, NumberFormatInfo.InvariantInfo, out var fromDbType))
+							precision = fromDbType;
+					}
+				}
+
+				precision = precision is null or < 0 ? 6 : (precision > 7 ? 7 : precision);
+				return precision switch
+				{
+					0    => TIMESTAMP_TZ_0_FORMAT,
+					1    => TIMESTAMP_TZ_1_FORMAT,
+					2    => TIMESTAMP_TZ_2_FORMAT,
+					3    => TIMESTAMP_TZ_3_FORMAT,
+					4    => TIMESTAMP_TZ_4_FORMAT,
+					5    => TIMESTAMP_TZ_5_FORMAT,
+					>= 7 => TIMESTAMP_TZ_7_FORMAT, // DB2 supports up to 12 digits
+					_    => TIMESTAMP_TZ_6_FORMAT, // default precision
+				};
+			}
+		}
 
 		public sealed class DB2LUWMappingSchema() : LockedMappingSchema(ProviderName.DB2LUW, DB2ProviderAdapter.Instance.MappingSchema, Instance);
 	}

--- a/Source/LinqToDB/Internal/DataProvider/DB2/DB2MappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/DB2/DB2MappingSchema.cs
@@ -65,22 +65,26 @@ namespace LinqToDB.Internal.DataProvider.DB2
 			SetDataType(typeof(decimal), new SqlDataType(DataType.Decimal, typeof(decimal), 18, 10));
 			SetDataType(typeof(ulong), new SqlDataType(DataType.Decimal, typeof(ulong), precision: 20, scale: 0));
 
-			SetValueToSqlConverter(typeof(Guid),     (sb, _,_,v) => ConvertBinaryToSql  (sb, ((Guid)v).ToByteArray()));
-			SetValueToSqlConverter(typeof(string),   (sb, _,_,v) => ConvertStringToSql  (sb, (string)v));
-			SetValueToSqlConverter(typeof(char),     (sb, _,_,v) => ConvertCharToSql    (sb, (char)v));
-			SetValueToSqlConverter(typeof(byte[]),   (sb, _,_,v) => ConvertBinaryToSql  (sb, (byte[])v));
-			SetValueToSqlConverter(typeof(Binary),   (sb, _,_,v) => ConvertBinaryToSql  (sb, ((Binary)v).ToArray()));
-			SetValueToSqlConverter(typeof(TimeSpan), (sb, _,_,v) => ConvertTimeToSql    (sb, (TimeSpan)v));
-			SetValueToSqlConverter(typeof(DateTime), (sb,dt,_,v) => ConvertDateTimeToSql(sb, dt, (DateTime)v));
+			SetValueToSqlConverter(typeof(Guid),           (sb, _,_,v) => ConvertBinaryToSql  (sb, ((Guid)v).ToByteArray()));
+			SetValueToSqlConverter(typeof(string),         (sb, _,_,v) => ConvertStringToSql  (sb, (string)v));
+			SetValueToSqlConverter(typeof(char),           (sb, _,_,v) => ConvertCharToSql    (sb, (char)v));
+			SetValueToSqlConverter(typeof(byte[]),         (sb, _,_,v) => ConvertBinaryToSql  (sb, (byte[])v));
+			SetValueToSqlConverter(typeof(Binary),         (sb, _,_,v) => ConvertBinaryToSql  (sb, ((Binary)v).ToArray()));
+			SetValueToSqlConverter(typeof(TimeSpan),       (sb, _,_,v) => ConvertTimeToSql    (sb, (TimeSpan)v));
+			SetValueToSqlConverter(typeof(DateTime),       (sb,dt,_,v) => ConvertDateTimeToSql(sb, dt, (DateTime)v));
+			SetValueToSqlConverter(typeof(DateTimeOffset), (sb,dt,_,v) => ConvertDateTimeToSql(sb, dt, ((DateTimeOffset)v).DateTime));
 
 			// set reader conversions from literals
 			SetConverter<string, DateTime>(ParseDateTime);
+			SetConverter<string, DateTimeOffset>(ParseDateTimeOffset);
 
 #if SUPPORTS_DATEONLY
 			SetValueToSqlConverter(typeof(DateOnly), (sb,dt,_,v) => ConvertDateOnlyToSql(sb, (DateOnly)v));
 			SetConverter<string, DateOnly>(ParseDateOnly);
 #endif
 		}
+
+		static DateTimeOffset ParseDateTimeOffset(string value) => new DateTimeOffset(ParseDateTime(value));
 
 		static DateTime ParseDateTime(string value)
 		{

--- a/Source/LinqToDB/Internal/DataProvider/DB2/DB2zOSSqlBuilder.cs
+++ b/Source/LinqToDB/Internal/DataProvider/DB2/DB2zOSSqlBuilder.cs
@@ -29,6 +29,14 @@ namespace LinqToDB.Internal.DataProvider.DB2
 		{
 			switch (type.DataType)
 			{
+				case DataType.DateTimeOffset:
+				{
+					StringBuilder.Append("TIMESTAMP");
+					if (type.Precision is not null and not 6)
+						StringBuilder.Append(CultureInfo.InvariantCulture, $"({type.Precision})");
+					StringBuilder.Append(" WITH TIME ZONE");
+					return;
+				}
 				case DataType.VarBinary:
 					// https://www.ibm.com/docs/en/db2-for-zos/12?topic=strings-varying-length-binary
 					var length = type.Length is null or > 32704 or < 1 ? 32704 : type.Length;

--- a/Source/LinqToDB/Internal/DataProvider/DB2/Translation/DB2MemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/DB2/Translation/DB2MemberTranslator.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -260,9 +261,10 @@ namespace LinqToDB.Internal.DataProvider.DB2.Translation
 				return dateFunction;
 			}
 
-			protected override ISqlExpression? TranslateSqlCurrentTimestampUtc(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			protected override ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
 				var factory = translationContext.ExpressionFactory;
+				var dbDataType = factory.GetDbDataType(typeof(DateTime));
 				// For CURRENT TIMEZONE there is no type
 				return factory.Sub(dbDataType, factory.Expression(dbDataType, "CURRENT TIMESTAMP"), factory.Expression(factory.GetDbDataType(typeof(int)), "CURRENT TIMEZONE"));
 			}

--- a/Source/LinqToDB/Internal/DataProvider/DB2/Translation/DB2MemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/DB2/Translation/DB2MemberTranslator.cs
@@ -206,6 +206,11 @@ namespace LinqToDB.Internal.DataProvider.DB2.Translation
 				return resultExpression;
 			}
 
+			protected override ISqlExpression? TranslateDateTimeOffsetDatePart(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, Sql.DateParts datepart)
+			{
+				return TranslateDateTimeDatePart(translationContext, translationFlag, dateTimeExpression, datepart);
+			}
+
 			protected override ISqlExpression? TranslateDateTimeDateAdd(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, ISqlExpression increment,
 				Sql.DateParts datepart)
 			{
@@ -259,6 +264,11 @@ namespace LinqToDB.Internal.DataProvider.DB2.Translation
 				var dateFunction = translationContext.ExpressionFactory.Function(QueryHelper.GetDbDataType(dateExpression, translationContext.MappingSchema), "DATE", dateExpression);
 
 				return dateFunction;
+			}
+
+			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			{
+				return null;
 			}
 
 			protected override ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)

--- a/Source/LinqToDB/Internal/DataProvider/DB2/Translation/DB2MemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/DB2/Translation/DB2MemberTranslator.cs
@@ -278,6 +278,13 @@ namespace LinqToDB.Internal.DataProvider.DB2.Translation
 				// For CURRENT TIMEZONE there is no type
 				return factory.Sub(dbDataType, factory.Expression(dbDataType, "CURRENT TIMESTAMP"), factory.Expression(factory.GetDbDataType(typeof(int)), "CURRENT TIMEZONE"));
 			}
+
+			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				// For CURRENT TIMEZONE there is no type
+				return factory.Sub(dbDataType, factory.Expression(dbDataType, "CURRENT TIMESTAMP"), factory.Expression(factory.GetDbDataType(typeof(int)), "CURRENT TIMEZONE"));
+			}
 		}
 
 		protected class DB2MathMemberTranslator : MathMemberTranslatorBase

--- a/Source/LinqToDB/Internal/DataProvider/DB2/Translation/DB2zOSMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/DB2/Translation/DB2zOSMemberTranslator.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+using LinqToDB.Internal.DataProvider.Translation;
+using LinqToDB.Internal.SqlQuery;
+using LinqToDB.Linq.Translation;
+
+namespace LinqToDB.Internal.DataProvider.DB2.Translation
+{
+	public class DB2zOSMemberTranslator : DB2MemberTranslator
+	{
+		protected override IMemberTranslator CreateDateMemberTranslator()
+		{
+			return new ZOsDateFunctionsTranslator();
+		}
+
+		protected class ZOsDateFunctionsTranslator : DateFunctionsTranslator
+		{
+			protected override ISqlExpression? TranslateServerNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				var dbType = factory.GetDbDataType(typeof(DateTime));
+				return factory.NotNullExpression(dbType, "CURRENT TIMESTAMP WITH TIME ZONE");
+			}
+		}
+	}
+}

--- a/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdDataProvider.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdDataProvider.cs
@@ -59,6 +59,9 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 			SetProviderField<DbDataReader, TimeSpan, DateTime>((r,i) => r.GetDateTime(i) - new DateTime(1970, 1, 1));
 			SetProviderField<DbDataReader, DateTime, DateTime>((r,i) => GetDateTime(r.GetDateTime(i)));
 
+			if (Adapter.FbZonedDateTimeType != null)
+				SetProviderField<DbDataReader, DateTimeOffset>(Adapter.FbZonedDateTimeType, (r, i) => new DateTimeOffset(GetDateTime(r.GetDateTime(i)), default), "TIMESTAMP WITH TIME ZONE");
+
 			SetToType<DbDataReader, byte[], string>("VARCHAR", (r, i) => r.GetFieldValue<byte[]>(i));
 			SetToType<DbDataReader, Binary, string>("VARCHAR", (r, i) => new Binary(r.GetFieldValue<byte[]>(i)));
 

--- a/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdDataProvider.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdDataProvider.cs
@@ -88,7 +88,12 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 
 		protected override IMemberTranslator CreateMemberTranslator()
 		{
-			return Version == FirebirdVersion.v5 ? new Firebird5MemberTranslator() : new FirebirdMemberTranslator();
+			return Version switch
+			{
+				>= FirebirdVersion.v5 => new Firebird5MemberTranslator(),
+				>= FirebirdVersion.v4 => new Firebird4MemberTranslator(),
+				_                     => new FirebirdMemberTranslator(),
+			};
 		}
 
 		protected override IIdentifierService CreateIdentifierService()

--- a/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdMappingSchema.cs
@@ -34,14 +34,15 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 			SetDataType(typeof(ulong), new SqlDataType(DataType.Decimal, typeof(ulong), precision: 20, scale: 0));
 
 			// firebird string literals can contain only limited set of characters, so we should encode them
-			SetValueToSqlConverter(typeof(string)  , (sb, _,o,v) => ConvertStringToSql (sb, o, (string)v));
-			SetValueToSqlConverter(typeof(char)    , (sb, _,o,v) => ConvertCharToSql   (sb, o, (char)v));
-			SetValueToSqlConverter(typeof(byte[])  , (sb, _,_,v) => ConvertBinaryToSql (sb, (byte[])v));
-			SetValueToSqlConverter(typeof(Binary)  , (sb, _,_,v) => ConvertBinaryToSql (sb, ((Binary)v).ToArray()));
-			SetValueToSqlConverter(typeof(DateTime), (sb,dt,_,v) => BuildDateTime      (sb, dt, (DateTime)v));
-			SetValueToSqlConverter(typeof(Guid)    , (sb,dt,_,v) => ConvertGuidToSql   (sb, dt, (Guid)v));
+			SetValueToSqlConverter(typeof(string)  ,       (sb, _,o,v) => ConvertStringToSql (sb, o, (string)v));
+			SetValueToSqlConverter(typeof(char)    ,       (sb, _,o,v) => ConvertCharToSql   (sb, o, (char)v));
+			SetValueToSqlConverter(typeof(byte[])  ,       (sb, _,_,v) => ConvertBinaryToSql (sb, (byte[])v));
+			SetValueToSqlConverter(typeof(Binary)  ,       (sb, _,_,v) => ConvertBinaryToSql (sb, ((Binary)v).ToArray()));
+			SetValueToSqlConverter(typeof(DateTime),       (sb,dt,_,v) => BuildDateTime      (sb, dt, (DateTime)v));
+			SetValueToSqlConverter(typeof(DateTimeOffset), (sb,dt,_,v) => BuildDateTime      (sb, dt, ((DateTimeOffset)v).DateTime));
+			SetValueToSqlConverter(typeof(Guid)    ,       (sb,dt,_,v) => ConvertGuidToSql   (sb, dt, (Guid)v));
 #if SUPPORTS_DATEONLY
-			SetValueToSqlConverter(typeof(DateOnly), (sb,dt,_,v) => BuildDateOnly(sb, dt, (DateOnly)v));
+			SetValueToSqlConverter(typeof(DateOnly),       (sb,dt,_,v) => BuildDateOnly(sb, dt, (DateOnly)v));
 #endif
 
 			SetDataType(typeof(bool), new SqlDataType(DataType.Boolean, typeof(bool), "BOOLEAN"));

--- a/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdMappingSchema.cs
@@ -16,15 +16,15 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 	public sealed class FirebirdMappingSchema : LockedMappingSchema
 	{
 #if SUPPORTS_COMPOSITE_FORMAT
-		private static readonly CompositeFormat DATE_FORMAT        = CompositeFormat.Parse("CAST('{0:yyyy-MM-dd}' AS {1})");
-		private static readonly CompositeFormat DATETIME_FORMAT    = CompositeFormat.Parse("CAST('{0:yyyy-MM-dd HH:mm:ss}' AS {1})");
-		private static readonly CompositeFormat TIMESTAMP_FORMAT   = CompositeFormat.Parse("CAST('{0:yyyy-MM-dd HH:mm:ss.ffff}' AS {1})");
-		private static readonly CompositeFormat TIMESTAMPTZ_FORMAT = CompositeFormat.Parse("TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.ffff zzz}'");
+		private static readonly CompositeFormat DATE_FORMAT        = CompositeFormat.Parse("DATE '{0:yyyy-MM-dd}'");
+		private static readonly CompositeFormat DATETIME_FORMAT    = CompositeFormat.Parse("TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss}'");
+		private static readonly CompositeFormat TIMESTAMP_FORMAT   = CompositeFormat.Parse("TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.ffff}'");
+		//private static readonly CompositeFormat TIMESTAMPTZ_FORMAT = CompositeFormat.Parse("TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.ffff zzz}'");
 #else
-		private const string DATE_FORMAT        = "CAST('{0:yyyy-MM-dd}' AS {1})";
-		private const string DATETIME_FORMAT    = "CAST('{0:yyyy-MM-dd HH:mm:ss}' AS {1})";
-		private const string TIMESTAMP_FORMAT   = "CAST('{0:yyyy-MM-dd HH:mm:ss.ffff}' AS {1})";
-		private const string TIMESTAMPTZ_FORMAT = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.ffff zzz}'";
+		private const string DATE_FORMAT        = "DATE '{0:yyyy-MM-dd}'";
+		private const string DATETIME_FORMAT    = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss}'";
+		private const string TIMESTAMP_FORMAT   = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.ffff}'";
+		//private const string TIMESTAMPTZ_FORMAT = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.ffff zzz}'";
 #endif
 
 		FirebirdMappingSchema() : base(ProviderName.Firebird)
@@ -44,7 +44,7 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 			SetValueToSqlConverter(typeof(DateTimeOffset), (sb,dt,_,v) => BuildDateTime      (sb, dt, ((DateTimeOffset)v).DateTime));
 			SetValueToSqlConverter(typeof(Guid)    ,       (sb,dt,_,v) => ConvertGuidToSql   (sb, dt, (Guid)v));
 #if SUPPORTS_DATEONLY
-			SetValueToSqlConverter(typeof(DateOnly),       (sb,dt,_,v) => BuildDateOnly(sb, dt, (DateOnly)v));
+			SetValueToSqlConverter(typeof(DateOnly),       (sb,dt,_,v) => BuildDateOnly(sb, (DateOnly)v));
 #endif
 
 			SetDataType(typeof(bool), new SqlDataType(DataType.Boolean, typeof(bool), "BOOLEAN"));
@@ -89,7 +89,6 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 
 		static void BuildDateTime(StringBuilder stringBuilder, SqlDataType dt, DateTime value)
 		{
-			var dbType = dt.Type.DbType ?? (dt.Type.DataType == DataType.Date ? "date" : "timestamp");
 			var format = TIMESTAMP_FORMAT;
 
 			if (value.Millisecond == 0)
@@ -97,13 +96,13 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 					? DATE_FORMAT
 					: DATETIME_FORMAT;
 
-			stringBuilder.AppendFormat(CultureInfo.InvariantCulture, format, value, dbType);
+			stringBuilder.AppendFormat(CultureInfo.InvariantCulture, format, value);
 		}
 
 #if SUPPORTS_DATEONLY
-		static void BuildDateOnly(StringBuilder stringBuilder, SqlDataType dt, DateOnly value)
+		static void BuildDateOnly(StringBuilder stringBuilder, DateOnly value)
 		{
-			stringBuilder.AppendFormat(CultureInfo.InvariantCulture, DATE_FORMAT, value, dt.Type.DbType ?? "date");
+			stringBuilder.AppendFormat(CultureInfo.InvariantCulture, DATE_FORMAT, value);
 		}
 #endif
 
@@ -226,12 +225,13 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 			}
 		}
 
-		static void BuildDateTimeOffset(StringBuilder stringBuilder, SqlDataType dt, DateTimeOffset value)
-		{
-			var format = TIMESTAMPTZ_FORMAT;
+		// unused for now
+		//static void BuildDateTimeOffset(StringBuilder stringBuilder, SqlDataType dt, DateTimeOffset value)
+		//{
+		//	var format = TIMESTAMPTZ_FORMAT;
 
-			stringBuilder.AppendFormat(CultureInfo.InvariantCulture, TIMESTAMPTZ_FORMAT, value);
-		}
+		//	stringBuilder.AppendFormat(CultureInfo.InvariantCulture, TIMESTAMPTZ_FORMAT, value);
+		//}
 
 		internal static MappingSchema Instance { get; } = new FirebirdMappingSchema();
 

--- a/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdMappingSchema.cs
@@ -17,12 +17,10 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 	{
 #if SUPPORTS_COMPOSITE_FORMAT
 		private static readonly CompositeFormat DATE_FORMAT        = CompositeFormat.Parse("DATE '{0:yyyy-MM-dd}'");
-		private static readonly CompositeFormat DATETIME_FORMAT    = CompositeFormat.Parse("TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss}'");
 		private static readonly CompositeFormat TIMESTAMP_FORMAT   = CompositeFormat.Parse("TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.ffff}'");
 		//private static readonly CompositeFormat TIMESTAMPTZ_FORMAT = CompositeFormat.Parse("TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.ffff zzz}'");
 #else
 		private const string DATE_FORMAT        = "DATE '{0:yyyy-MM-dd}'";
-		private const string DATETIME_FORMAT    = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss}'";
 		private const string TIMESTAMP_FORMAT   = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.ffff}'";
 		//private const string TIMESTAMPTZ_FORMAT = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.ffff zzz}'";
 #endif
@@ -89,7 +87,7 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 
 		static void BuildDateTime(StringBuilder stringBuilder, SqlDataType dt, DateTime value)
 		{
-			var format = dt.Type.DataType == DataType.Date ? DATE_FORMAT : DATETIME_FORMAT;
+			var format = dt.Type.DataType == DataType.Date ? DATE_FORMAT : TIMESTAMP_FORMAT;
 
 			stringBuilder.AppendFormat(CultureInfo.InvariantCulture, format, value);
 		}

--- a/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdMappingSchema.cs
@@ -16,13 +16,15 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 	public sealed class FirebirdMappingSchema : LockedMappingSchema
 	{
 #if SUPPORTS_COMPOSITE_FORMAT
-		private static readonly CompositeFormat DATE_FORMAT      = CompositeFormat.Parse("CAST('{0:yyyy-MM-dd}' AS {1})");
-		private static readonly CompositeFormat DATETIME_FORMAT  = CompositeFormat.Parse("CAST('{0:yyyy-MM-dd HH:mm:ss}' AS {1})");
-		private static readonly CompositeFormat TIMESTAMP_FORMAT = CompositeFormat.Parse("CAST('{0:yyyy-MM-dd HH:mm:ss.fff}' AS {1})");
+		private static readonly CompositeFormat DATE_FORMAT        = CompositeFormat.Parse("CAST('{0:yyyy-MM-dd}' AS {1})");
+		private static readonly CompositeFormat DATETIME_FORMAT    = CompositeFormat.Parse("CAST('{0:yyyy-MM-dd HH:mm:ss}' AS {1})");
+		private static readonly CompositeFormat TIMESTAMP_FORMAT   = CompositeFormat.Parse("CAST('{0:yyyy-MM-dd HH:mm:ss.ffff}' AS {1})");
+		private static readonly CompositeFormat TIMESTAMPTZ_FORMAT = CompositeFormat.Parse("TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.ffff zzz}'");
 #else
-		private const string DATE_FORMAT      = "CAST('{0:yyyy-MM-dd}' AS {1})";
-		private const string DATETIME_FORMAT  = "CAST('{0:yyyy-MM-dd HH:mm:ss}' AS {1})";
-		private const string TIMESTAMP_FORMAT = "CAST('{0:yyyy-MM-dd HH:mm:ss.fff}' AS {1})";
+		private const string DATE_FORMAT        = "CAST('{0:yyyy-MM-dd}' AS {1})";
+		private const string DATETIME_FORMAT    = "CAST('{0:yyyy-MM-dd HH:mm:ss}' AS {1})";
+		private const string TIMESTAMP_FORMAT   = "CAST('{0:yyyy-MM-dd HH:mm:ss.ffff}' AS {1})";
+		private const string TIMESTAMPTZ_FORMAT = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.ffff zzz}'";
 #endif
 
 		FirebirdMappingSchema() : base(ProviderName.Firebird)
@@ -224,6 +226,13 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 			}
 		}
 
+		static void BuildDateTimeOffset(StringBuilder stringBuilder, SqlDataType dt, DateTimeOffset value)
+		{
+			var format = TIMESTAMPTZ_FORMAT;
+
+			stringBuilder.AppendFormat(CultureInfo.InvariantCulture, TIMESTAMPTZ_FORMAT, value);
+		}
+
 		internal static MappingSchema Instance { get; } = new FirebirdMappingSchema();
 
 		public class Firebird25MappingSchemaBase : LockedMappingSchema
@@ -251,9 +260,25 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 
 		public sealed class Firebird3MappingSchema() : LockedMappingSchema(ProviderName.Firebird3, FirebirdProviderAdapter.Instance.MappingSchema, Instance);
 
-		public sealed class Firebird4MappingSchema() : LockedMappingSchema(ProviderName.Firebird4, FirebirdProviderAdapter.Instance.MappingSchema, Instance);
+		public sealed class Firebird4MappingSchema : LockedMappingSchema
+		{
+			public Firebird4MappingSchema()
+				: base(ProviderName.Firebird4, FirebirdProviderAdapter.Instance.MappingSchema, Instance)
+			{
+				// Disabled for now, as FB client goes banana (v10.3.4)
+				//SetValueToSqlConverter(typeof(DateTimeOffset), (sb, dt, _, v) => BuildDateTimeOffset(sb, dt, (DateTimeOffset)v));
+			}
+		}
 
-		public sealed class Firebird5MappingSchema() : LockedMappingSchema(ProviderName.Firebird5, FirebirdProviderAdapter.Instance.MappingSchema, Instance);
+		public sealed class Firebird5MappingSchema : LockedMappingSchema
+		{
+			public Firebird5MappingSchema()
+				: base(ProviderName.Firebird5, FirebirdProviderAdapter.Instance.MappingSchema, Instance)
+			{
+				// see above
+				//SetValueToSqlConverter(typeof(DateTimeOffset), (sb, dt, _, v) => BuildDateTimeOffset(sb, dt, (DateTimeOffset)v));
+			}
+		}
 
 		sealed class FirebirdRemoteMappingSchema(string configuration) : LockedMappingSchema(configuration, Instance);
 

--- a/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdMappingSchema.cs
@@ -89,12 +89,7 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 
 		static void BuildDateTime(StringBuilder stringBuilder, SqlDataType dt, DateTime value)
 		{
-			var format = TIMESTAMP_FORMAT;
-
-			if (value.Millisecond == 0)
-				format = value.Hour == 0 && value.Minute == 0 && value.Second == 0
-					? DATE_FORMAT
-					: DATETIME_FORMAT;
+			var format = dt.Type.DataType == DataType.Date ? DATE_FORMAT : DATETIME_FORMAT;
 
 			stringBuilder.AppendFormat(CultureInfo.InvariantCulture, format, value);
 		}

--- a/Source/LinqToDB/Internal/DataProvider/Firebird/Translation/Firebird4MemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Firebird/Translation/Firebird4MemberTranslator.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+using LinqToDB.Internal.DataProvider.Translation;
+using LinqToDB.Internal.SqlQuery;
+using LinqToDB.Linq.Translation;
+
+namespace LinqToDB.Internal.DataProvider.Firebird.Translation
+{
+	public class Firebird4MemberTranslator : FirebirdMemberTranslator
+	{
+		protected override IMemberTranslator CreateDateMemberTranslator()
+		{
+			return new Firebird4DateFunctionsTranslator();
+		}
+
+		protected class Firebird4DateFunctionsTranslator : FirebirdDateFunctionsTranslator
+		{
+			protected override ISqlExpression? TranslateServerNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				var dbDataType = factory.GetDbDataType(typeof(DateTime));
+				return factory.NotNullExpression(dbDataType, "CURRENT_TIMESTAMP");
+			}
+
+			protected override ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				var dbDataType = factory.GetDbDataType(typeof(DateTime));
+				return factory.NotNullExpression(dbDataType, "CURRENT_TIMESTAMP AT TIME ZONE 'UTC'");
+			}
+		}
+	}
+}

--- a/Source/LinqToDB/Internal/DataProvider/Firebird/Translation/Firebird4MemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Firebird/Translation/Firebird4MemberTranslator.cs
@@ -28,6 +28,12 @@ namespace LinqToDB.Internal.DataProvider.Firebird.Translation
 				var dbDataType = factory.GetDbDataType(typeof(DateTime));
 				return factory.NotNullExpression(dbDataType, "CURRENT_TIMESTAMP AT TIME ZONE 'UTC'");
 			}
+
+			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				return factory.NotNullExpression(dbDataType, "CURRENT_TIMESTAMP AT TIME ZONE 'UTC'");
+			}
 		}
 	}
 }

--- a/Source/LinqToDB/Internal/DataProvider/Firebird/Translation/Firebird5MemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Firebird/Translation/Firebird5MemberTranslator.cs
@@ -4,7 +4,7 @@ using LinqToDB.Linq.Translation;
 
 namespace LinqToDB.Internal.DataProvider.Firebird.Translation
 {
-	public class Firebird5MemberTranslator : FirebirdMemberTranslator
+	public class Firebird5MemberTranslator : Firebird4MemberTranslator
 	{
 		protected override IMemberTranslator CreateDateMemberTranslator()
 		{
@@ -16,7 +16,7 @@ namespace LinqToDB.Internal.DataProvider.Firebird.Translation
 			return new Firebird5StringMemberTranslator();
 		}
 
-		protected class Firebird5DateFunctionsTranslator : FirebirdDateFunctionsTranslator
+		protected class Firebird5DateFunctionsTranslator : Firebird4DateFunctionsTranslator
 		{
 			protected override ISqlExpression? TranslateDateTimeDatePart(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, Sql.DateParts datepart)
 			{

--- a/Source/LinqToDB/Internal/DataProvider/Firebird/Translation/FirebirdMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Firebird/Translation/FirebirdMemberTranslator.cs
@@ -237,7 +237,7 @@ namespace LinqToDB.Internal.DataProvider.Firebird.Translation
 				return cast;
 			}
 
-			protected override ISqlExpression? TranslateSqlGetDate(ITranslationContext translationContext, TranslationFlags translationFlags)
+			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
 				var factory = translationContext.ExpressionFactory;
 				return factory.NotNullExpression(factory.GetDbDataType(typeof(DateTime)), "LOCALTIMESTAMP");

--- a/Source/LinqToDB/Internal/DataProvider/Firebird/Translation/FirebirdMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Firebird/Translation/FirebirdMemberTranslator.cs
@@ -131,6 +131,11 @@ namespace LinqToDB.Internal.DataProvider.Firebird.Translation
 				return resultExpression;
 			}
 
+			protected override ISqlExpression? TranslateDateTimeOffsetDatePart(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, Sql.DateParts datepart)
+			{
+				return TranslateDateTimeDatePart(translationContext, translationFlag, dateTimeExpression, datepart);
+			}
+
 			protected override ISqlExpression? TranslateDateTimeDateAdd(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, ISqlExpression increment,
 				Sql.DateParts                                                       datepart)
 			{
@@ -239,8 +244,7 @@ namespace LinqToDB.Internal.DataProvider.Firebird.Translation
 
 			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
-				var factory = translationContext.ExpressionFactory;
-				return factory.NotNullExpression(factory.GetDbDataType(typeof(DateTime)), "LOCALTIMESTAMP");
+				return null;
 			}
 		}
 

--- a/Source/LinqToDB/Internal/DataProvider/Informix/InformixMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Informix/InformixMappingSchema.cs
@@ -38,7 +38,7 @@ namespace LinqToDB.Internal.DataProvider.Informix
 			SetValueToSqlConverter(typeof(string),         (sb, _,_,v) => ConvertStringToSql  (sb, (string)v));
 			SetValueToSqlConverter(typeof(char),           (sb, _,_,v) => ConvertCharToSql    (sb, (char)v));
 			SetValueToSqlConverter(typeof(DateTime),       (sb,dt,o,v) => ConvertDateTimeToSql(sb, dt, o, (DateTime)v));
-			SetValueToSqlConverter(typeof(DateTimeOffset), (sb, dt,o,v) => ConvertDateTimeToSql(sb, dt, o, ((DateTimeOffset)v).DateTime));
+			SetValueToSqlConverter(typeof(DateTimeOffset), (sb,dt,o,v) => ConvertDateTimeToSql(sb, dt, o, ((DateTimeOffset)v).DateTime));
 			SetValueToSqlConverter(typeof(TimeSpan),       (sb, _,_,v) => BuildIntervalLiteral(sb, (TimeSpan)v));
 
 #if SUPPORTS_DATEONLY

--- a/Source/LinqToDB/Internal/DataProvider/Informix/InformixMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Informix/InformixMappingSchema.cs
@@ -35,10 +35,11 @@ namespace LinqToDB.Internal.DataProvider.Informix
 			SetDataType(typeof(string), new SqlDataType(DataType.NVarChar, typeof(string), 255));
 			SetDataType(typeof(byte),   new SqlDataType(DataType.Int16,    typeof(byte)));
 
-			SetValueToSqlConverter(typeof(string),   (sb, _,_,v) => ConvertStringToSql  (sb, (string)v));
-			SetValueToSqlConverter(typeof(char),     (sb, _,_,v) => ConvertCharToSql    (sb, (char)v));
-			SetValueToSqlConverter(typeof(DateTime), (sb,dt,o,v) => ConvertDateTimeToSql(sb, dt, o, (DateTime)v));
-			SetValueToSqlConverter(typeof(TimeSpan), (sb, _,_,v) => BuildIntervalLiteral(sb, (TimeSpan)v));
+			SetValueToSqlConverter(typeof(string),         (sb, _,_,v) => ConvertStringToSql  (sb, (string)v));
+			SetValueToSqlConverter(typeof(char),           (sb, _,_,v) => ConvertCharToSql    (sb, (char)v));
+			SetValueToSqlConverter(typeof(DateTime),       (sb,dt,o,v) => ConvertDateTimeToSql(sb, dt, o, (DateTime)v));
+			SetValueToSqlConverter(typeof(DateTimeOffset), (sb, dt,o,v) => ConvertDateTimeToSql(sb, dt, o, ((DateTimeOffset)v).DateTime));
+			SetValueToSqlConverter(typeof(TimeSpan),       (sb, _,_,v) => BuildIntervalLiteral(sb, (TimeSpan)v));
 
 #if SUPPORTS_DATEONLY
 			SetValueToSqlConverter(typeof(DateOnly), (sb,dt,_,v) => ConvertDateOnlyToSql(sb, (DateOnly)v));

--- a/Source/LinqToDB/Internal/DataProvider/Informix/Translation/InformixMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Informix/Translation/InformixMemberTranslator.cs
@@ -316,18 +316,19 @@ namespace LinqToDB.Internal.DataProvider.Informix.Translation
 				return result;
 			}
 
-			protected override ISqlExpression? TranslateSqlGetDate(ITranslationContext translationContext, TranslationFlags translationFlags)
+			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
 				var factory          = translationContext.ExpressionFactory;
 				var currentTimeStamp = factory.NotNullExpression(factory.GetDbDataType(typeof(DateTime)), "CURRENT");
 				return currentTimeStamp;
 			}
 
-			protected override ISqlExpression? TranslateSqlCurrentTimestampUtc(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			protected override ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
 				// "datetime(1970-01-01 00:00:00) year to second + (dbinfo('utc_current')/86400)::int::char(9)::interval day(9) to day + (mod(dbinfo('utc_current'), 86400))::char(5)::interval second(5) to second
 
 				var factory = translationContext.ExpressionFactory;
+				var dbDataType = factory.GetDbDataType(typeof(DateTime));
 
 				return factory.Expression(dbDataType,
 					"datetime(1970-01-01 00:00:00) year to second + (dbinfo('utc_current')/86400)::int::char(9)::interval day(9) to day + (mod(dbinfo('utc_current'), 86400))::char(5)::interval second(5) to second", Precedence.Additive);

--- a/Source/LinqToDB/Internal/DataProvider/Informix/Translation/InformixMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Informix/Translation/InformixMemberTranslator.cs
@@ -335,9 +335,14 @@ namespace LinqToDB.Internal.DataProvider.Informix.Translation
 
 			protected override ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
-				var factory = translationContext.ExpressionFactory;
+				var factory    = translationContext.ExpressionFactory;
 				var dbDataType = factory.GetDbDataType(typeof(DateTime));
+				return factory.Function(dbDataType, "DBINFO", factory.Value("utc_to_datetime"), factory.Function(dbDataType, "DBINFO", factory.Value("utc_current")));
+			}
 
+			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
 				return factory.Function(dbDataType, "DBINFO", factory.Value("utc_to_datetime"), factory.Function(dbDataType, "DBINFO", factory.Value("utc_current")));
 			}
 		}

--- a/Source/LinqToDB/Internal/DataProvider/Informix/Translation/InformixMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Informix/Translation/InformixMemberTranslator.cs
@@ -234,6 +234,11 @@ namespace LinqToDB.Internal.DataProvider.Informix.Translation
 				}
 			}
 
+			protected override ISqlExpression? TranslateDateTimeOffsetDatePart(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, Sql.DateParts datepart)
+			{
+				return TranslateDateTimeDatePart(translationContext, translationFlag, dateTimeExpression, datepart);
+			}
+
 			protected override ISqlExpression? TranslateDateTimeDateAdd(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, ISqlExpression increment, Sql.DateParts datepart)
 			{
 				var factory = translationContext.ExpressionFactory;
@@ -316,22 +321,24 @@ namespace LinqToDB.Internal.DataProvider.Informix.Translation
 				return result;
 			}
 
-			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			protected override ISqlExpression? TranslateServerNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
 				var factory          = translationContext.ExpressionFactory;
 				var currentTimeStamp = factory.NotNullExpression(factory.GetDbDataType(typeof(DateTime)), "CURRENT");
 				return currentTimeStamp;
 			}
 
+			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			{
+				return null;
+			}
+
 			protected override ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
-				// "datetime(1970-01-01 00:00:00) year to second + (dbinfo('utc_current')/86400)::int::char(9)::interval day(9) to day + (mod(dbinfo('utc_current'), 86400))::char(5)::interval second(5) to second
-
 				var factory = translationContext.ExpressionFactory;
 				var dbDataType = factory.GetDbDataType(typeof(DateTime));
 
-				return factory.Expression(dbDataType,
-					"datetime(1970-01-01 00:00:00) year to second + (dbinfo('utc_current')/86400)::int::char(9)::interval day(9) to day + (mod(dbinfo('utc_current'), 86400))::char(5)::interval second(5) to second", Precedence.Additive);
+				return factory.Function(dbDataType, "DBINFO", factory.Value("utc_to_datetime"), factory.Function(dbDataType, "DBINFO", factory.Value("utc_current")));
 			}
 		}
 

--- a/Source/LinqToDB/Internal/DataProvider/MySql/MySqlDataProvider.cs
+++ b/Source/LinqToDB/Internal/DataProvider/MySql/MySqlDataProvider.cs
@@ -30,31 +30,31 @@ namespace LinqToDB.Internal.DataProvider.MySql
 			: base(name, GetMappingSchema(provider, version), MySqlProviderAdapter.GetInstance(provider))
 		{
 			Provider = provider;
-			Version  = version;
+			Version = version;
 
-			SqlProviderFlags.IsSubQueryOrderBySupported        = true;
-			SqlProviderFlags.IsUnionAllOrderBySupported        = true;
+			SqlProviderFlags.IsSubQueryOrderBySupported = true;
+			SqlProviderFlags.IsUnionAllOrderBySupported = true;
 			SqlProviderFlags.IsCommonTableExpressionsSupported = version > MySqlVersion.MySql57;
-			SqlProviderFlags.IsUpdateFromSupported             = false;
-			SqlProviderFlags.IsNamingQueryBlockSupported       = true;
-			SqlProviderFlags.IsDistinctFromSupported           = true;
-			SqlProviderFlags.SupportsPredicatesComparison      = true;
-			SqlProviderFlags.IsAllSetOperationsSupported       = version > MySqlVersion.MySql57;
-			SqlProviderFlags.IsDistinctSetOperationsSupported  = version > MySqlVersion.MySql57;
+			SqlProviderFlags.IsUpdateFromSupported = false;
+			SqlProviderFlags.IsNamingQueryBlockSupported = true;
+			SqlProviderFlags.IsDistinctFromSupported = true;
+			SqlProviderFlags.SupportsPredicatesComparison = true;
+			SqlProviderFlags.IsAllSetOperationsSupported = version > MySqlVersion.MySql57;
+			SqlProviderFlags.IsDistinctSetOperationsSupported = version > MySqlVersion.MySql57;
 			// MariaDB still lacking it
 			// https://jira.mariadb.org/browse/MDEV-6373
 			// https://jira.mariadb.org/browse/MDEV-19078
-			SqlProviderFlags.IsApplyJoinSupported              = version == MySqlVersion.MySql80;
+			SqlProviderFlags.IsApplyJoinSupported = version == MySqlVersion.MySql80;
 			SqlProviderFlags.IsCrossApplyJoinSupportsCondition = version == MySqlVersion.MySql80;
 			SqlProviderFlags.IsOuterApplyJoinSupportsCondition = version == MySqlVersion.MySql80;
-			SqlProviderFlags.IsWindowFunctionsSupported        = Version >= MySqlVersion.MySql80;
+			SqlProviderFlags.IsWindowFunctionsSupported = Version >= MySqlVersion.MySql80;
 
 			SqlProviderFlags.IsSubqueryWithParentReferenceInJoinConditionSupported = false;
-			SqlProviderFlags.SupportedCorrelatedSubqueriesLevel                    = version is > MySqlVersion.MySql57 and not MySqlVersion.MariaDB10 ? null : 1;
+			SqlProviderFlags.SupportedCorrelatedSubqueriesLevel = version is > MySqlVersion.MySql57 and not MySqlVersion.MariaDB10 ? null : 1;
 			SqlProviderFlags.CalculateSupportedCorrelatedLevelWithAggregateQueries = true;
-			SqlProviderFlags.RowConstructorSupport                                 = RowFeature.Equality | RowFeature.Comparisons | RowFeature.CompareToSelect | RowFeature.In;
+			SqlProviderFlags.RowConstructorSupport = RowFeature.Equality | RowFeature.Comparisons | RowFeature.CompareToSelect | RowFeature.In;
 
-			SqlProviderFlags.IsUpdateTakeSupported                   = true;
+			SqlProviderFlags.IsUpdateTakeSupported = true;
 			SqlProviderFlags.IsTakeWithInAllAnySomeSubquerySupported = false;
 
 			_sqlOptimizer = new MySqlSqlOptimizer(SqlProviderFlags);
@@ -70,6 +70,10 @@ namespace LinqToDB.Internal.DataProvider.MySql
 			{
 				SetProviderField<DateTimeOffset>(Adapter.GetDateTimeOffsetMethodName, Adapter.DataReaderType);
 				SetToTypeField(typeof(DateTimeOffset), Adapter.GetDateTimeOffsetMethodName, Adapter.DataReaderType);
+			}
+			else if (Provider == MySqlProvider.MySqlData)
+			{
+				SetProviderField<DbDataReader, DateTimeOffset, DateTime>((r, i) => new DateTimeOffset(r.GetDateTime(i), default));
 			}
 
 			SetProviderField(Adapter.MySqlDateTimeType, Adapter.GetMySqlDateTimeMethodName, Adapter.DataReaderType);

--- a/Source/LinqToDB/Internal/DataProvider/MySql/MySqlMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/MySql/MySqlMappingSchema.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Data.Linq;
+using System.Globalization;
 using System.Text;
 
 using LinqToDB.Data;
@@ -14,13 +15,20 @@ namespace LinqToDB.Internal.DataProvider.MySql
 {
 	public sealed class MySqlMappingSchema : LockedMappingSchema
 	{
+#if SUPPORTS_COMPOSITE_FORMAT
+		private static readonly CompositeFormat TIMESTAMP_FORMAT = CompositeFormat.Parse("CONVERT_TZ('{0:yyyy-MM-dd HH:mm:ss.ffffff}', '{0:zzz}', 'UTC')");
+#else
+		private const string TIMESTAMP_FORMAT = "CONVERT_TZ('{0:yyyy-MM-dd HH:mm:ss.ffffff}', '{0:zzz}', 'UTC')";
+#endif
+
 		MySqlMappingSchema() : base(ProviderName.MySql)
 		{
-			SetValueToSqlConverter(typeof(string), (sb,_,_,v) => ConvertStringToSql(sb, (string)v));
-			SetValueToSqlConverter(typeof(char),   (sb,_,_,v) => ConvertCharToSql  (sb, (char)v));
-			SetValueToSqlConverter(typeof(byte[]), (sb,_,_,v) => ConvertBinaryToSql(sb, (byte[])v));
-			SetValueToSqlConverter(typeof(Binary), (sb,_,_,v) => ConvertBinaryToSql(sb, ((Binary)v).ToArray()));
-			SetValueToSqlConverter(typeof(float[]),(sb,_,_,v) => ConvertVectorToSql(sb, (float[])v));
+			SetValueToSqlConverter(typeof(string),         (sb,_,_,v) => ConvertStringToSql        (sb, (string)v));
+			SetValueToSqlConverter(typeof(char),           (sb,_,_,v) => ConvertCharToSql          (sb, (char)v));
+			SetValueToSqlConverter(typeof(byte[]),         (sb,_,_,v) => ConvertBinaryToSql        (sb, (byte[])v));
+			SetValueToSqlConverter(typeof(Binary),         (sb,_,_,v) => ConvertBinaryToSql        (sb, ((Binary)v).ToArray()));
+			SetValueToSqlConverter(typeof(float[]),        (sb,_,_,v) => ConvertVectorToSql        (sb, (float[])v));
+			SetValueToSqlConverter(typeof(DateTimeOffset), (sb,_,_,v) => ConvertDateTimeOffsetToSql(sb, (DateTimeOffset)v));
 
 			SetDataType(typeof(string),  new SqlDataType(DataType.NVarChar, typeof(string)));
 			SetDataType(typeof(decimal), new SqlDataType(DataType.Decimal, typeof(decimal), 29, 10));
@@ -97,6 +105,11 @@ namespace LinqToDB.Internal.DataProvider.MySql
 				stringBuilder.AppendByteArrayAsHexViaLookup32(BitConverter.GetBytes(val));
 		}
 
+		static void ConvertDateTimeOffsetToSql(StringBuilder stringBuilder, DateTimeOffset value)
+		{
+			stringBuilder.AppendFormat(CultureInfo.InvariantCulture, TIMESTAMP_FORMAT, value);
+		}
+
 		internal static readonly MySqlMappingSchema     Instance          = new ();
 		internal static readonly MySql57MappingSchema   MySql57Instance   = new ();
 		internal static readonly MySql80MappingSchema   MySql80Instance   = new ();
@@ -104,7 +117,25 @@ namespace LinqToDB.Internal.DataProvider.MySql
 
 		public sealed class MySql57MappingSchema() : LockedMappingSchema(ProviderName.MySql57, Instance);
 
-		public sealed class MySql80MappingSchema() : LockedMappingSchema(ProviderName.MySql80, Instance);
+		public sealed class MySql80MappingSchema : LockedMappingSchema
+		{
+#if SUPPORTS_COMPOSITE_FORMAT
+			private static readonly CompositeFormat TIMESTAMP_FORMAT = CompositeFormat.Parse("TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.ffffffzzz}'");
+#else
+			private const string TIMESTAMP_FORMAT = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.ffffffzzz}'";
+#endif
+
+			public MySql80MappingSchema()
+				: base(ProviderName.MySql80, Instance)
+			{
+				SetValueToSqlConverter(typeof(DateTimeOffset), (sb, _, _, v) => ConvertDateTimeOffsetToSql(sb, (DateTimeOffset)v));
+			}
+
+			static void ConvertDateTimeOffsetToSql(StringBuilder stringBuilder, DateTimeOffset value)
+			{
+				stringBuilder.AppendFormat(CultureInfo.InvariantCulture, TIMESTAMP_FORMAT, value);
+			}
+		}
 
 		public sealed class MariaDB10MappingSchema() : LockedMappingSchema(ProviderName.MariaDB10, Instance);
 

--- a/Source/LinqToDB/Internal/DataProvider/MySql/MySqlMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/MySql/MySqlMappingSchema.cs
@@ -16,9 +16,9 @@ namespace LinqToDB.Internal.DataProvider.MySql
 	public sealed class MySqlMappingSchema : LockedMappingSchema
 	{
 #if SUPPORTS_COMPOSITE_FORMAT
-		private static readonly CompositeFormat TIMESTAMP_FORMAT = CompositeFormat.Parse("CONVERT_TZ('{0:yyyy-MM-dd HH:mm:ss.ffffff}', '{0:zzz}', 'UTC')");
+		private static readonly CompositeFormat TIMESTAMP_FORMAT = CompositeFormat.Parse("CONVERT_TZ('{0:yyyy-MM-dd HH:mm:ss.ffffff}', '{0:zzz}', '+00:00')");
 #else
-		private const string TIMESTAMP_FORMAT = "CONVERT_TZ('{0:yyyy-MM-dd HH:mm:ss.ffffff}', '{0:zzz}', 'UTC')";
+		private const string TIMESTAMP_FORMAT = "CONVERT_TZ('{0:yyyy-MM-dd HH:mm:ss.ffffff}', '{0:zzz}', '+00:00')";
 #endif
 
 		MySqlMappingSchema() : base(ProviderName.MySql)

--- a/Source/LinqToDB/Internal/DataProvider/MySql/Translation/MySqlMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/MySql/Translation/MySqlMemberTranslator.cs
@@ -215,9 +215,11 @@ namespace LinqToDB.Internal.DataProvider.MySql.Translation
 				return factory.Function(factory.GetDbDataType(dateExpression), "Date", dateExpression);
 			}
 
-			protected override ISqlExpression? TranslateSqlCurrentTimestampUtc(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			protected override ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
-				return translationContext.ExpressionFactory.Function(dbDataType, "UTC_TIMESTAMP");
+				var factory = translationContext.ExpressionFactory;
+				var dbDataType = factory.GetDbDataType(typeof(DateTime));
+				return factory.Function(dbDataType, "UTC_TIMESTAMP");
 			}
 		}
 

--- a/Source/LinqToDB/Internal/DataProvider/MySql/Translation/MySqlMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/MySql/Translation/MySqlMemberTranslator.cs
@@ -122,6 +122,11 @@ namespace LinqToDB.Internal.DataProvider.MySql.Translation
 				return resultExpression;
 			}
 
+			protected override ISqlExpression? TranslateDateTimeOffsetDatePart(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, Sql.DateParts datepart)
+			{
+				return TranslateDateTimeDatePart(translationContext, translationFlag, dateTimeExpression, datepart);
+			}
+
 			protected override ISqlExpression? TranslateDateTimeDateAdd(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, ISqlExpression increment,
 				Sql.DateParts                                                       datepart)
 			{
@@ -213,6 +218,18 @@ namespace LinqToDB.Internal.DataProvider.MySql.Translation
 				var factory = translationContext.ExpressionFactory;
 
 				return factory.Function(factory.GetDbDataType(dateExpression), "Date", dateExpression);
+			}
+
+			protected override ISqlExpression? TranslateServerNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				var dbDataType = factory.GetDbDataType(typeof(DateTime));
+				return factory.NotNullExpression(dbDataType, "CURRENT_TIMESTAMP");
+			}
+
+			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			{
+				return null;
 			}
 
 			protected override ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)

--- a/Source/LinqToDB/Internal/DataProvider/MySql/Translation/MySqlMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/MySql/Translation/MySqlMemberTranslator.cs
@@ -238,6 +238,12 @@ namespace LinqToDB.Internal.DataProvider.MySql.Translation
 				var dbDataType = factory.GetDbDataType(typeof(DateTime));
 				return factory.Function(dbDataType, "UTC_TIMESTAMP");
 			}
+
+			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				return factory.Function(dbDataType, "UTC_TIMESTAMP");
+			}
 		}
 
 		protected class MySqlStringMemberTranslator : StringMemberTranslatorBase

--- a/Source/LinqToDB/Internal/DataProvider/Oracle/Translation/OracleMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Oracle/Translation/OracleMemberTranslator.cs
@@ -225,10 +225,21 @@ namespace LinqToDB.Internal.DataProvider.Oracle.Translation
 				return dateFunc;
 			}
 
-			protected override ISqlExpression? TranslateSqlCurrentTimestampUtc(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			protected override ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
 				var factory = translationContext.ExpressionFactory;
+				var dbDataType = factory.GetDbDataType(typeof(DateTime));
 				return factory.Function(dbDataType, "SYS_EXTRACT_UTC", factory.Fragment("SYSTIMESTAMP"));
+			}
+
+			protected override ISqlExpression? TranslateZonedNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				return translationContext.ExpressionFactory.NotNullExpression(dbDataType, "SYSTIMESTAMP");
+			}
+
+			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				return translationContext.ExpressionFactory.NotNullExpression(dbDataType, "SYSTIMESTAMP AT TIME ZONE 'UTC'");
 			}
 		}
 

--- a/Source/LinqToDB/Internal/DataProvider/Oracle/Translation/OracleMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Oracle/Translation/OracleMemberTranslator.cs
@@ -246,7 +246,7 @@ namespace LinqToDB.Internal.DataProvider.Oracle.Translation
 
 			protected override ISqlExpression? TranslateZonedNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
 			{
-				return translationContext.ExpressionFactory.NotNullExpression(dbDataType, "LOCALTIMESTAMP");
+				return translationContext.ExpressionFactory.NotNullExpression(dbDataType, "CURRENT_TIMESTAMP");
 			}
 
 			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)

--- a/Source/LinqToDB/Internal/DataProvider/Oracle/Translation/OracleMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Oracle/Translation/OracleMemberTranslator.cs
@@ -118,6 +118,11 @@ namespace LinqToDB.Internal.DataProvider.Oracle.Translation
 				return resultExpression;
 			}
 
+			protected override ISqlExpression? TranslateDateTimeOffsetDatePart(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, Sql.DateParts datepart)
+			{
+				return TranslateDateTimeDatePart(translationContext, translationFlag, dateTimeExpression, datepart);
+			}
+
 			protected override ISqlExpression? TranslateDateTimeDateAdd(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, ISqlExpression increment,
 				Sql.DateParts                                                       datepart)
 			{
@@ -232,11 +237,16 @@ namespace LinqToDB.Internal.DataProvider.Oracle.Translation
 				return factory.Function(dbDataType, "SYS_EXTRACT_UTC", factory.Fragment("SYSTIMESTAMP"));
 			}
 
+			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				var dbDataType = factory.GetDbDataType(typeof(DateTime));
+				return translationContext.ExpressionFactory.NotNullExpression(dbDataType, "LOCALTIMESTAMP");
+			}
+
 			protected override ISqlExpression? TranslateZonedNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
 			{
-				// SYSTIMESTAMP user server timezone
-				// CURRENT_TIMESTAMP ise session (user) timezone
-				return translationContext.ExpressionFactory.NotNullExpression(dbDataType, "CURRENT_TIMESTAMP");
+				return translationContext.ExpressionFactory.NotNullExpression(dbDataType, "LOCALTIMESTAMP");
 			}
 
 			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)

--- a/Source/LinqToDB/Internal/DataProvider/Oracle/Translation/OracleMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Oracle/Translation/OracleMemberTranslator.cs
@@ -234,7 +234,9 @@ namespace LinqToDB.Internal.DataProvider.Oracle.Translation
 
 			protected override ISqlExpression? TranslateZonedNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
 			{
-				return translationContext.ExpressionFactory.NotNullExpression(dbDataType, "SYSTIMESTAMP");
+				// SYSTIMESTAMP user server timezone
+				// CURRENT_TIMESTAMP ise session (user) timezone
+				return translationContext.ExpressionFactory.NotNullExpression(dbDataType, "CURRENT_TIMESTAMP");
 			}
 
 			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)

--- a/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
+++ b/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
@@ -67,7 +67,7 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 			SetCharField("bpchar"   , (r,i) => r.GetString(i).TrimEnd(' '));
 			SetCharField("character", (r,i) => r.GetString(i).TrimEnd(' '));
 
-			SetProviderField<DbDataReader, DateTimeOffset, DateTime>((rd, i) => rd.GetFieldValue<DateTimeOffset>(i));
+			SetProviderField<DbDataReader, DateTimeOffset, DateTime>((rd, i) => rd.GetFieldValue<DateTimeOffset>(i), "timestamp with time zone");
 
 			if (Adapter.SupportsBigInteger)
 				SetProviderField<DbDataReader, BigInteger, decimal>((rd, idx) => rd.GetFieldValue<BigInteger>(idx));

--- a/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
+++ b/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
@@ -67,7 +67,7 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 			SetCharField("bpchar"   , (r,i) => r.GetString(i).TrimEnd(' '));
 			SetCharField("character", (r,i) => r.GetString(i).TrimEnd(' '));
 
-			SetProviderField<DbDataReader, DateTimeOffset, DateTime>((rd, i) => ConvertDateTimeToDateTimeOffset(rd.GetDateTime(i)));
+			SetProviderField<DbDataReader, DateTimeOffset, DateTime>((rd, i) => rd.GetFieldValue<DateTimeOffset>(i));
 
 			if (Adapter.SupportsBigInteger)
 				SetProviderField<DbDataReader, BigInteger, decimal>((rd, idx) => rd.GetFieldValue<BigInteger>(idx));
@@ -83,19 +83,6 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 			_sqlOptimizer = new PostgreSQLSqlOptimizer(SqlProviderFlags);
 
 			ConfigureTypes();
-		}
-
-		static DateTimeOffset ConvertDateTimeToDateTimeOffset(DateTime dateTime)
-		{
-			// +/-infinity values returned as min/max DateTime
-			// and fail conversion to DateTimeOffset if local timezone offset is not +00:00 (for min or max value respectively)
-			if (dateTime == DateTime.MinValue)
-				return DateTimeOffset.MinValue;
-
-			if (dateTime == DateTime.MaxValue)
-				return DateTimeOffset.MaxValue;
-
-			return (DateTimeOffset)dateTime;
 		}
 
 		protected override IMemberTranslator CreateMemberTranslator()

--- a/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
@@ -210,5 +210,5 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 		public sealed class PostgreSQL15MappingSchema() : LockedMappingSchema(ProviderName.PostgreSQL15, NpgsqlProviderAdapter.GetInstance().MappingSchema, Instance);
 
 		public sealed class PostgreSQL18MappingSchema() : LockedMappingSchema(ProviderName.PostgreSQL18, NpgsqlProviderAdapter.GetInstance().MappingSchema, Instance);
-			}
-		}
+	}
+}

--- a/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
@@ -20,13 +20,15 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 	public sealed class PostgreSQLMappingSchema : LockedMappingSchema
 	{
 #if SUPPORTS_COMPOSITE_FORMAT
-		private static readonly CompositeFormat DATE_FORMAT       = CompositeFormat.Parse("'{0:yyyy-MM-dd}'::{1}");
-		private static readonly CompositeFormat TIMESTAMP0_FORMAT = CompositeFormat.Parse("'{0:yyyy-MM-dd HH:mm:ss}'::{1}");
-		private static readonly CompositeFormat TIMESTAMP3_FORMAT = CompositeFormat.Parse("'{0:yyyy-MM-dd HH:mm:ss.fff}'::{1}");
+		private static readonly CompositeFormat DATE_FORMAT        = CompositeFormat.Parse("'{0:yyyy-MM-dd}'::{1}");
+		private static readonly CompositeFormat TIMESTAMP0_FORMAT  = CompositeFormat.Parse("'{0:yyyy-MM-dd HH:mm:ss}'::{1}");
+		private static readonly CompositeFormat TIMESTAMP3_FORMAT  = CompositeFormat.Parse("'{0:yyyy-MM-dd HH:mm:ss.fff}'::{1}");
+		private static readonly CompositeFormat TIMESTAMPTZ_FORMAT = CompositeFormat.Parse("'{0:yyyy-MM-dd HH:mm:ss.ffffffzzz}'::timestamptz");
 #else
-		private const string DATE_FORMAT       = "'{0:yyyy-MM-dd}'::{1}";
-		private const string TIMESTAMP0_FORMAT = "'{0:yyyy-MM-dd HH:mm:ss}'::{1}";
-		private const string TIMESTAMP3_FORMAT = "'{0:yyyy-MM-dd HH:mm:ss.fff}'::{1}";
+		private const string DATE_FORMAT        = "'{0:yyyy-MM-dd}'::{1}";
+		private const string TIMESTAMP0_FORMAT  = "'{0:yyyy-MM-dd HH:mm:ss}'::{1}";
+		private const string TIMESTAMP3_FORMAT  = "'{0:yyyy-MM-dd HH:mm:ss.fff}'::{1}";
+		private const string TIMESTAMPTZ_FORMAT = "'{0:yyyy-MM-dd HH:mm:ss.ffffffzzz}'::timestamptz";
 #endif
 
 		PostgreSQLMappingSchema() : base(ProviderName.PostgreSQL)
@@ -36,14 +38,15 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 			AddScalarType(typeof(IPAddress), DataType.Udt);
 			AddScalarType(typeof(PhysicalAddress), DataType.Udt);
 
-			SetValueToSqlConverter(typeof(bool),       (sb, _,_,v) => sb.Append((bool)v));
-			SetValueToSqlConverter(typeof(string),     (sb, _,_,v) => ConvertStringToSql(sb, (string)v));
-			SetValueToSqlConverter(typeof(char),       (sb, _,_,v) => ConvertCharToSql  (sb, (char)v));
-			SetValueToSqlConverter(typeof(byte[]),     (sb, _,_,v) => ConvertBinaryToSql(sb, (byte[])v));
-			SetValueToSqlConverter(typeof(Binary),     (sb, _,_,v) => ConvertBinaryToSql(sb, ((Binary)v).ToArray()));
-			SetValueToSqlConverter(typeof(Guid),       (sb, _,_,v) => sb.AppendFormat(CultureInfo.InvariantCulture, "'{0:D}'::uuid", (Guid)v));
-			SetValueToSqlConverter(typeof(DateTime),   (sb,dt,_,v) => BuildDateTime(sb, dt, (DateTime)v));
-			SetValueToSqlConverter(typeof(BigInteger), (sb, _,_,v) => sb.Append(((BigInteger)v).ToString(CultureInfo.InvariantCulture)));
+			SetValueToSqlConverter(typeof(bool),           (sb, _,_,v) => sb.Append((bool)v));
+			SetValueToSqlConverter(typeof(string),         (sb, _,_,v) => ConvertStringToSql(sb, (string)v));
+			SetValueToSqlConverter(typeof(char),           (sb, _,_,v) => ConvertCharToSql  (sb, (char)v));
+			SetValueToSqlConverter(typeof(byte[]),         (sb, _,_,v) => ConvertBinaryToSql(sb, (byte[])v));
+			SetValueToSqlConverter(typeof(Binary),         (sb, _,_,v) => ConvertBinaryToSql(sb, ((Binary)v).ToArray()));
+			SetValueToSqlConverter(typeof(Guid),           (sb, _,_,v) => sb.AppendFormat(CultureInfo.InvariantCulture, "'{0:D}'::uuid", (Guid)v));
+			SetValueToSqlConverter(typeof(DateTime),       (sb,dt,_,v) => BuildDateTime(sb, dt, (DateTime)v));
+			SetValueToSqlConverter(typeof(DateTimeOffset), (sb, _,_,v) => BuildDateTimeOffset(sb, (DateTimeOffset)v));
+			SetValueToSqlConverter(typeof(BigInteger),     (sb, _,_,v) => sb.Append(((BigInteger)v).ToString(CultureInfo.InvariantCulture)));
 
 			// adds floating point special values support
 			SetValueToSqlConverter(typeof(float) , (sb,_,_,v) =>
@@ -155,6 +158,11 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 			}
 
 			stringBuilder.AppendFormat(CultureInfo.InvariantCulture, format, value, dbType);
+		}
+
+		static void BuildDateTimeOffset(StringBuilder stringBuilder, DateTimeOffset value)
+		{
+			stringBuilder.AppendFormat(CultureInfo.InvariantCulture, TIMESTAMPTZ_FORMAT, value);
 		}
 
 #if SUPPORTS_DATEONLY

--- a/Source/LinqToDB/Internal/DataProvider/PostgreSQL/Translation/PostgreSQLMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/PostgreSQL/Translation/PostgreSQLMemberTranslator.cs
@@ -237,13 +237,25 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL.Translation
 				return resultExpression;
 			}
 
-			protected override ISqlExpression? TranslateSqlCurrentTimestampUtc(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			protected override ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
 				var factory = translationContext.ExpressionFactory;
+				var dbDataType = factory.GetDbDataType(typeof(DateTime));
 
 				// timezone('UTC', now()) returns timestamp without tz
 				// https://www.postgresql.org/docs/current/functions-datetime.html
-				return factory.Function(dbDataType.WithDataType(DataType.DateTime2), "timezone", factory.Value("UTC"), factory.Function(dbDataType.WithDataType(DataType.DateTimeOffset), "now"));
+				return factory.Function(dbDataType, "timezone", factory.Value("UTC"), factory.Function(dbDataType.WithDataType(DataType.DateTimeOffset), "now"));
+			}
+
+			protected override ISqlExpression? TranslateZonedNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				return translationContext.ExpressionFactory.Function(dbDataType, "now");
+			}
+
+			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				// Postgres does not store original timezone, Now and UtcNow are the same instant.
+				return translationContext.ExpressionFactory.Function(dbDataType, "now");
 			}
 		}
 

--- a/Source/LinqToDB/Internal/DataProvider/PostgreSQL/Translation/PostgreSQLMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/PostgreSQL/Translation/PostgreSQLMemberTranslator.cs
@@ -261,11 +261,6 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL.Translation
 				return factory.Function(dbDataType, "timezone", factory.Value("UTC"), factory.Function(dbDataType.WithDataType(DataType.DateTimeOffset), "now"));
 			}
 
-			protected override ISqlExpression? TranslateZonedNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
-			{
-				return null;
-			}
-
 			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
 			{
 				// Postgres does not store original timezone, Now and UtcNow are the same instant.

--- a/Source/LinqToDB/Internal/DataProvider/PostgreSQL/Translation/PostgreSQLMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/PostgreSQL/Translation/PostgreSQLMemberTranslator.cs
@@ -237,6 +237,20 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL.Translation
 				return resultExpression;
 			}
 
+			protected override ISqlExpression? TranslateServerNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				var dbDataType = factory.GetDbDataType(typeof(DateTime));
+
+				return factory.NotNullExpression(dbDataType, "CURRENT_TIMESTAMP");
+			}
+
+			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			{
+				// LOCALTIMESTAMP can only used wth session timezone set, which is false for Npgsql by default
+				return null;
+			}
+
 			protected override ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
 				var factory = translationContext.ExpressionFactory;
@@ -249,7 +263,7 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL.Translation
 
 			protected override ISqlExpression? TranslateZonedNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
 			{
-				return translationContext.ExpressionFactory.Function(dbDataType, "now");
+				return null;
 			}
 
 			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)

--- a/Source/LinqToDB/Internal/DataProvider/SQLite/SQLiteMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SQLite/SQLiteMappingSchema.cs
@@ -11,25 +11,28 @@ namespace LinqToDB.Internal.DataProvider.SQLite
 {
 	public sealed class SQLiteMappingSchema : LockedMappingSchema
 	{
-		internal const string DATE_FORMAT_RAW  = "yyyy-MM-dd";
+		internal const string DATE_FORMAT_RAW                   = "yyyy-MM-dd";
 #if SUPPORTS_COMPOSITE_FORMAT
-		private static readonly CompositeFormat DATE_FORMAT     = CompositeFormat.Parse("'{0:yyyy-MM-dd}'");
-		private static readonly CompositeFormat DATETIME_FORMAT = CompositeFormat.Parse("'{0:yyyy-MM-dd HH:mm:ss.fff}'");
+		private static readonly CompositeFormat DATE_FORMAT           = CompositeFormat.Parse("'{0:yyyy-MM-dd}'");
+		private static readonly CompositeFormat DATETIME_FORMAT       = CompositeFormat.Parse("'{0:yyyy-MM-dd HH:mm:ss.fff}'");
+		private static readonly CompositeFormat DATETIMEOFFSET_FORMAT = CompositeFormat.Parse("'{0:yyyy-MM-dd HH:mm:ss.fffzzz}'");
 #else
-		private  const string DATE_FORMAT      = "'{0:yyyy-MM-dd}'";
-		private  const string DATETIME_FORMAT = "'{0:yyyy-MM-dd HH:mm:ss.fff}'";
+		private  const string DATE_FORMAT           = "'{0:yyyy-MM-dd}'";
+		private  const string DATETIME_FORMAT       = "'{0:yyyy-MM-dd HH:mm:ss.fff}'";
+		private  const string DATETIMEOFFSET_FORMAT = "'{0:yyyy-MM-dd HH:mm:ss.fffzzz}'";
 #endif
 
 		SQLiteMappingSchema() : base(ProviderName.SQLite)
 		{
 			SetConvertExpression<string,TimeSpan>(s => DateTime.Parse(s, null, DateTimeStyles.NoCurrentDateDefault).TimeOfDay);
 
-			SetValueToSqlConverter(typeof(Guid),     (sb, dt,_,v) => ConvertGuidToSql    (sb, dt, (Guid)v));
-			SetValueToSqlConverter(typeof(DateTime), (sb, dt,_,v) => ConvertDateTimeToSql(sb, dt, (DateTime)v));
-			SetValueToSqlConverter(typeof(string),   (sb, _,_,v) => ConvertStringToSql  (sb, (string)v));
-			SetValueToSqlConverter(typeof(char),     (sb, _,_,v) => ConvertCharToSql    (sb, (char)v));
-			SetValueToSqlConverter(typeof(byte[]),   (sb, _,_,v) => ConvertBinaryToSql  (sb, (byte[])v));
-			SetValueToSqlConverter(typeof(Binary),   (sb, _,_,v) => ConvertBinaryToSql  (sb, ((Binary)v).ToArray()));
+			SetValueToSqlConverter(typeof(Guid),           (sb,dt,_,v) => ConvertGuidToSql    (sb, dt, (Guid)v));
+			SetValueToSqlConverter(typeof(DateTime),       (sb,dt,_,v) => ConvertDateTimeToSql(sb, dt, (DateTime)v));
+			SetValueToSqlConverter(typeof(DateTimeOffset), (sb, _,_,v) => ConvertDateTimeOffsetToSql(sb, (DateTimeOffset)v));
+			SetValueToSqlConverter(typeof(string),         (sb, _,_,v) => ConvertStringToSql  (sb, (string)v));
+			SetValueToSqlConverter(typeof(char),           (sb, _,_,v) => ConvertCharToSql    (sb, (char)v));
+			SetValueToSqlConverter(typeof(byte[]),         (sb, _,_,v) => ConvertBinaryToSql  (sb, (byte[])v));
+			SetValueToSqlConverter(typeof(Binary),         (sb, _,_,v) => ConvertBinaryToSql  (sb, ((Binary)v).ToArray()));
 
 #if SUPPORTS_DATEONLY
 			SetValueToSqlConverter(typeof(DateOnly), (sb,_,_,v) => ConvertDateOnlyToSql(sb, (DateOnly)v));
@@ -78,6 +81,11 @@ namespace LinqToDB.Internal.DataProvider.SQLite
 				format = DATETIME_FORMAT;
 
 			stringBuilder.AppendFormat(CultureInfo.InvariantCulture, format, value);
+		}
+
+		static void ConvertDateTimeOffsetToSql(StringBuilder stringBuilder, DateTimeOffset value)
+		{
+			stringBuilder.AppendFormat(CultureInfo.InvariantCulture, DATETIMEOFFSET_FORMAT, value);
 		}
 
 #if SUPPORTS_DATEONLY

--- a/Source/LinqToDB/Internal/DataProvider/SQLite/Translation/SQLiteMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SQLite/Translation/SQLiteMemberTranslator.cs
@@ -213,9 +213,17 @@ namespace LinqToDB.Internal.DataProvider.SQLite.Translation
 				return resultExpression;
 			}
 
-			protected override ISqlExpression? TranslateSqlCurrentTimestampUtc(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
 				var factory = translationContext.ExpressionFactory;
+				var dbDataType = factory.GetDbDataType(typeof(DateTime));
+				return factory.Function(dbDataType, "DATETIME", factory.Value("now"), factory.Value("localtime"));
+			}
+
+			protected override ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				var dbDataType = factory.GetDbDataType(typeof(DateTime));
 				return factory.Function(dbDataType, "DATETIME", factory.Value("now"));
 			}
 		}

--- a/Source/LinqToDB/Internal/DataProvider/SQLite/Translation/SQLiteMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SQLite/Translation/SQLiteMemberTranslator.cs
@@ -90,6 +90,11 @@ namespace LinqToDB.Internal.DataProvider.SQLite.Translation
 				return resultExpression;
 			}
 
+			protected override ISqlExpression? TranslateDateTimeOffsetDatePart(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, Sql.DateParts datepart)
+			{
+				return TranslateDateTimeDatePart(translationContext, translationFlag, dateTimeExpression, datepart);
+			}
+
 			ISqlExpression StrFTime(ISqlExpressionFactory factory, DbDataType resultDbType, string format, ISqlExpression date)
 			{
 				return factory.Function(resultDbType, StrFTimeFuncName, ParametersNullabilityType.SameAsSecondParameter, factory.Value(format), date);
@@ -213,6 +218,13 @@ namespace LinqToDB.Internal.DataProvider.SQLite.Translation
 				return resultExpression;
 			}
 
+			protected override ISqlExpression? TranslateServerNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				var dbDataType = factory.GetDbDataType(typeof(DateTime));
+				return factory.Function(dbDataType, "DATETIME", factory.Value("now"), factory.Value("localtime"));
+			}
+
 			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
 				var factory = translationContext.ExpressionFactory;
@@ -224,7 +236,7 @@ namespace LinqToDB.Internal.DataProvider.SQLite.Translation
 			{
 				var factory = translationContext.ExpressionFactory;
 				var dbDataType = factory.GetDbDataType(typeof(DateTime));
-				return factory.Function(dbDataType, "DATETIME", factory.Value("now"));
+				return factory.NotNullExpression(dbDataType, "CURRENT_TIMESTAMP");
 			}
 		}
 

--- a/Source/LinqToDB/Internal/DataProvider/SQLite/Translation/SQLiteMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SQLite/Translation/SQLiteMemberTranslator.cs
@@ -236,6 +236,18 @@ namespace LinqToDB.Internal.DataProvider.SQLite.Translation
 				var dbDataType = factory.GetDbDataType(typeof(DateTime));
 				return factory.NotNullExpression(dbDataType, "CURRENT_TIMESTAMP");
 			}
+
+			protected override ISqlExpression? TranslateZonedNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				return factory.Function(dbDataType, "DATETIME", factory.Value("now"), factory.Value("localtime"));
+			}
+
+			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				return factory.NotNullExpression(dbDataType, "CURRENT_TIMESTAMP");
+			}
 		}
 
 		protected class StringMemberTranslator : StringMemberTranslatorBase

--- a/Source/LinqToDB/Internal/DataProvider/SQLite/Translation/SQLiteMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SQLite/Translation/SQLiteMemberTranslator.cs
@@ -220,9 +220,7 @@ namespace LinqToDB.Internal.DataProvider.SQLite.Translation
 
 			protected override ISqlExpression? TranslateServerNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
-				var factory = translationContext.ExpressionFactory;
-				var dbDataType = factory.GetDbDataType(typeof(DateTime));
-				return factory.Function(dbDataType, "DATETIME", factory.Value("now"), factory.Value("localtime"));
+				return TranslateNow(translationContext, translationFlags);
 			}
 
 			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)

--- a/Source/LinqToDB/Internal/DataProvider/SapHana/SapHanaMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SapHana/SapHanaMappingSchema.cs
@@ -14,16 +14,29 @@ namespace LinqToDB.Internal.DataProvider.SapHana
 {
 	public sealed class SapHanaMappingSchema : LockedMappingSchema
 	{
+#if SUPPORTS_COMPOSITE_FORMAT
+		private static readonly CompositeFormat TIMESTAMP_FORMAT = CompositeFormat.Parse("TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.fffffff}'");
+#else
+		private const string TIMESTAMP_FORMAT  = "TIMESTAMP '{0:yyyy-MM-dd HH:mm:ss.fffffff}'";
+#endif
+
 		SapHanaMappingSchema() : base(ProviderName.SapHana)
 		{
 			SetDataType(typeof(string), new SqlDataType(DataType.NVarChar, typeof(string), 255));
 			SetDataType(typeof(float[]), new SqlDataType(new DbDataType(typeof(float[]), DataType.Vector32, "REAL_VECTOR")));
 
-			SetValueToSqlConverter(typeof(string), (sb,_,_,v) => ConvertStringToSql(sb, (string)v));
-			SetValueToSqlConverter(typeof(char)  , (sb,_,_,v) => ConvertCharToSql  (sb, (char)v));
-			SetValueToSqlConverter(typeof(byte[]), (sb,_,_,v) => ConvertBinaryToSql(sb, (byte[])v));
-			SetValueToSqlConverter(typeof(Binary), (sb,_,_,v) => ConvertBinaryToSql(sb, ((Binary)v).ToArray()));
+			SetValueToSqlConverter(typeof(string),         (sb,_,_,v) => ConvertStringToSql(sb, (string)v));
+			SetValueToSqlConverter(typeof(char)  ,         (sb,_,_,v) => ConvertCharToSql  (sb, (char)v));
+			SetValueToSqlConverter(typeof(byte[]),         (sb,_,_,v) => ConvertBinaryToSql(sb, (byte[])v));
+			SetValueToSqlConverter(typeof(Binary),         (sb,_,_,v) => ConvertBinaryToSql(sb, ((Binary)v).ToArray()));
+			SetValueToSqlConverter(typeof(DateTime),       (sb,_,_,v) => BuildTimeStamp(sb, (DateTime)v));
+			SetValueToSqlConverter(typeof(DateTimeOffset), (sb,_,_,v) => BuildTimeStamp(sb, ((DateTimeOffset)v).DateTime));
 			SetDataType(typeof(decimal), new SqlDataType(DataType.Decimal, typeof(decimal), 38, 10));
+		}
+
+		static void BuildTimeStamp(StringBuilder stringBuilder, DateTime value)
+		{
+			stringBuilder.AppendFormat(CultureInfo.InvariantCulture, TIMESTAMP_FORMAT, value);
 		}
 
 		static readonly Action<StringBuilder, int> AppendConversionAction = AppendConversion;

--- a/Source/LinqToDB/Internal/DataProvider/SapHana/Translation/SapHanaMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SapHana/Translation/SapHanaMemberTranslator.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -243,9 +244,11 @@ namespace LinqToDB.Internal.DataProvider.SapHana.Translation
 				return factory.Function(factory.GetDbDataType(dateExpression), "To_Date", dateExpression);
 			}
 
-			protected override ISqlExpression? TranslateSqlCurrentTimestampUtc(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			protected override ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
-				return translationContext.ExpressionFactory.Expression(dbDataType, "CURRENT_UTCTIMESTAMP");
+				var factory = translationContext.ExpressionFactory;
+				var dbDataType = factory.GetDbDataType(typeof(DateTime));
+				return factory.Expression(dbDataType, "CURRENT_UTCTIMESTAMP");
 			}
 		}
 

--- a/Source/LinqToDB/Internal/DataProvider/SapHana/Translation/SapHanaMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SapHana/Translation/SapHanaMemberTranslator.cs
@@ -118,6 +118,11 @@ namespace LinqToDB.Internal.DataProvider.SapHana.Translation
 				}
 			}
 
+			protected override ISqlExpression? TranslateDateTimeOffsetDatePart(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, Sql.DateParts datepart)
+			{
+				return TranslateDateTimeDatePart(translationContext, translationFlag, dateTimeExpression, datepart);
+			}
+
 			protected override ISqlExpression? TranslateDateTimeDateAdd(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, ISqlExpression increment,
 				Sql.DateParts                                                       datepart)
 			{
@@ -244,11 +249,34 @@ namespace LinqToDB.Internal.DataProvider.SapHana.Translation
 				return factory.Function(factory.GetDbDataType(dateExpression), "To_Date", dateExpression);
 			}
 
+			protected override ISqlExpression? TranslateServerNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				var dbDataType = factory.GetDbDataType(typeof(DateTime));
+				return factory.NotNullExpression(dbDataType, "CURRENT_TIMESTAMP");
+			}
+
+			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			{
+				return null;
+			}
+
 			protected override ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
 				var factory = translationContext.ExpressionFactory;
 				var dbDataType = factory.GetDbDataType(typeof(DateTime));
 				return factory.Expression(dbDataType, "CURRENT_UTCTIMESTAMP");
+			}
+
+			protected override ISqlExpression? TranslateZonedNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				return null;
+			}
+
+			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				return factory.NotNullExpression(dbDataType, "CURRENT_UTCTIMESTAMP");
 			}
 		}
 

--- a/Source/LinqToDB/Internal/DataProvider/SapHana/Translation/SapHanaMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SapHana/Translation/SapHanaMemberTranslator.cs
@@ -265,7 +265,13 @@ namespace LinqToDB.Internal.DataProvider.SapHana.Translation
 			{
 				var factory = translationContext.ExpressionFactory;
 				var dbDataType = factory.GetDbDataType(typeof(DateTime));
-				return factory.Expression(dbDataType, "CURRENT_UTCTIMESTAMP");
+				return factory.NotNullExpression(dbDataType, "CURRENT_UTCTIMESTAMP");
+			}
+
+			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				return factory.NotNullExpression(dbDataType, "CURRENT_UTCTIMESTAMP");
 			}
 		}
 

--- a/Source/LinqToDB/Internal/DataProvider/SapHana/Translation/SapHanaMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SapHana/Translation/SapHanaMemberTranslator.cs
@@ -267,17 +267,6 @@ namespace LinqToDB.Internal.DataProvider.SapHana.Translation
 				var dbDataType = factory.GetDbDataType(typeof(DateTime));
 				return factory.Expression(dbDataType, "CURRENT_UTCTIMESTAMP");
 			}
-
-			protected override ISqlExpression? TranslateZonedNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
-			{
-				return null;
-			}
-
-			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
-			{
-				var factory = translationContext.ExpressionFactory;
-				return factory.NotNullExpression(dbDataType, "CURRENT_UTCTIMESTAMP");
-			}
 		}
 
 		protected class SapHanaMathMemberTranslator : MathMemberTranslatorBase

--- a/Source/LinqToDB/Internal/DataProvider/SqlCe/SqlCeDataProvider.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlCe/SqlCeDataProvider.cs
@@ -83,6 +83,9 @@ namespace LinqToDB.Internal.DataProvider.SqlCe
 				value = d.ToDateTime(TimeOnly.MinValue);
 #endif
 
+			if (value is DateTimeOffset dto)
+				value = dto.LocalDateTime;
+
 			switch (dataType.DataType)
 			{
 				case DataType.Xml :
@@ -126,22 +129,23 @@ namespace LinqToDB.Internal.DataProvider.SqlCe
 
 			switch (dataType.DataType)
 			{
-				case DataType.SByte      : parameter.DbType = DbType.Int16;             return;
-				case DataType.UInt16     : parameter.DbType = DbType.Int32;             return;
-				case DataType.UInt32     : parameter.DbType = DbType.Int64;             return;
-				case DataType.UInt64     : parameter.DbType = DbType.Decimal;           return;
-				case DataType.VarNumeric : parameter.DbType = DbType.Decimal;           return;
-				case DataType.Char       :
-				case DataType.NChar      : parameter.DbType = DbType.String;            return;
-				case DataType.Date       :
-				case DataType.DateTime2  : parameter.DbType = DbType.DateTime;          return;
-				case DataType.Money      : parameter.DbType = DbType.Currency;          return;
-				case DataType.Text       :
-				case DataType.VarChar    :
-				case DataType.NText      : parameter.DbType = DbType.String;            return;
-				case DataType.Timestamp  :
-				case DataType.Binary     :
-				case DataType.Image      : parameter.DbType = DbType.Binary;            return;
+				case DataType.SByte         : parameter.DbType = DbType.Int16;             return;
+				case DataType.UInt16        : parameter.DbType = DbType.Int32;             return;
+				case DataType.UInt32        : parameter.DbType = DbType.Int64;             return;
+				case DataType.UInt64        : parameter.DbType = DbType.Decimal;           return;
+				case DataType.VarNumeric    : parameter.DbType = DbType.Decimal;           return;
+				case DataType.Char          :
+				case DataType.NChar         : parameter.DbType = DbType.String;            return;
+				case DataType.Date          :
+				case DataType.DateTimeOffset:
+				case DataType.DateTime2     : parameter.DbType = DbType.DateTime;          return;
+				case DataType.Money         : parameter.DbType = DbType.Currency;          return;
+				case DataType.Text          :
+				case DataType.VarChar       :
+				case DataType.NText         : parameter.DbType = DbType.String;            return;
+				case DataType.Timestamp     :
+				case DataType.Binary        :
+				case DataType.Image         : parameter.DbType = DbType.Binary;            return;
 			}
 
 			base.SetParameterType(dataConnection, parameter, dataType);

--- a/Source/LinqToDB/Internal/DataProvider/SqlCe/SqlCeMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlCe/SqlCeMappingSchema.cs
@@ -15,6 +15,12 @@ namespace LinqToDB.Internal.DataProvider.SqlCe
 {
 	public sealed class SqlCeMappingSchema : LockedMappingSchema
 	{
+#if SUPPORTS_COMPOSITE_FORMAT
+		private static readonly CompositeFormat DATETIME_FORMAT = CompositeFormat.Parse("'{0:yyyy-MM-dd HH:mm:ss.fff}'");
+#else
+		private const string DATETIME_FORMAT = "'{0:yyyy-MM-dd HH:mm:ss.fff}'";
+#endif
+
 		public SqlCeMappingSchema() : base(ProviderName.SqlCe)
 		{
 			SetConvertExpression<SqlXml,XmlReader>(
@@ -42,10 +48,17 @@ namespace LinqToDB.Internal.DataProvider.SqlCe
 			// in SQLCE DECIMAL=DECIMAL(18,0)
 			SetDataType(typeof(decimal), new SqlDataType(DataType.Decimal, typeof(decimal), 18, 10));
 
-			SetValueToSqlConverter(typeof(string), (sb,_,_,v) => ConvertStringToSql(sb, (string)v));
-			SetValueToSqlConverter(typeof(char),   (sb,_,_,v) => ConvertCharToSql  (sb, (char)v));
-			SetValueToSqlConverter(typeof(byte[]), (sb,_,_,v) => ConvertBinaryToSql(sb, (byte[])v));
-			SetValueToSqlConverter(typeof(Binary), (sb,_,_,v) => ConvertBinaryToSql(sb, ((Binary)v).ToArray()));
+			SetValueToSqlConverter(typeof(string),         (sb,_,_,v) => ConvertStringToSql(sb, (string)v));
+			SetValueToSqlConverter(typeof(char),           (sb,_,_,v) => ConvertCharToSql  (sb, (char)v));
+			SetValueToSqlConverter(typeof(byte[]),         (sb,_,_,v) => ConvertBinaryToSql(sb, (byte[])v));
+			SetValueToSqlConverter(typeof(Binary),         (sb,_,_,v) => ConvertBinaryToSql(sb, ((Binary)v).ToArray()));
+			SetValueToSqlConverter(typeof(DateTime),       (sb,_,_,v) => BuildDateTime(sb, (DateTime)v));
+			SetValueToSqlConverter(typeof(DateTimeOffset), (sb,_,_,v) => BuildDateTime(sb, ((DateTimeOffset)v).DateTime));
+		}
+
+		static void BuildDateTime(StringBuilder stringBuilder, DateTime value)
+		{
+			stringBuilder.AppendFormat(CultureInfo.InvariantCulture, DATETIME_FORMAT, value);
 		}
 
 		static void ConvertBinaryToSql(StringBuilder stringBuilder, byte[] value)

--- a/Source/LinqToDB/Internal/DataProvider/SqlCe/Translation/SqlCeMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlCe/Translation/SqlCeMemberTranslator.cs
@@ -218,7 +218,7 @@ namespace LinqToDB.Internal.DataProvider.SqlCe.Translation
 				return cast;
 			}
 
-			protected override ISqlExpression? TranslateSqlGetDate(ITranslationContext translationContext, TranslationFlags translationFlags)
+			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
 				var factory = translationContext.ExpressionFactory;
 

--- a/Source/LinqToDB/Internal/DataProvider/SqlCe/Translation/SqlCeMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlCe/Translation/SqlCeMemberTranslator.cs
@@ -223,6 +223,12 @@ namespace LinqToDB.Internal.DataProvider.SqlCe.Translation
 				return cast;
 			}
 
+			protected override ISqlExpression? TranslateServerNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			{
+				// SQL CE is embedded and don't have own timezone
+				return TranslateNow(translationContext, translationFlags);
+			}
+
 			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
 				var factory = translationContext.ExpressionFactory;
@@ -230,10 +236,10 @@ namespace LinqToDB.Internal.DataProvider.SqlCe.Translation
 				return factory.Function(factory.GetDbDataType(typeof(DateTime)), "GetDate", ParametersNullabilityType.NotNullable);
 			}
 
-			protected override ISqlExpression? TranslateServerNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			protected override ISqlExpression? TranslateZonedNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
 			{
-				// SQL CE is embedded and don't have own timezone
-				return TranslateNow(translationContext, translationFlags);
+				var factory = translationContext.ExpressionFactory;
+				return factory.Function(dbDataType, "GetDate", ParametersNullabilityType.NotNullable);
 			}
 		}
 

--- a/Source/LinqToDB/Internal/DataProvider/SqlCe/Translation/SqlCeMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlCe/Translation/SqlCeMemberTranslator.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 using System.Linq.Expressions;
 
@@ -96,6 +96,11 @@ namespace LinqToDB.Internal.DataProvider.SqlCe.Translation
 				var resultExpression = factory.Function(intDbType, "DatePart", ParametersNullabilityType.SameAsSecondParameter, factory.NotNullExpression(intDbType, partStr), dateTimeExpression);
 
 				return resultExpression;
+			}
+
+			protected override ISqlExpression? TranslateDateTimeOffsetDatePart(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, Sql.DateParts datepart)
+			{
+				return TranslateDateTimeDatePart(translationContext, translationFlag, dateTimeExpression, datepart);
 			}
 
 			public static string? DatePartToStr(Sql.DateParts part, bool forDateAdd)
@@ -223,6 +228,12 @@ namespace LinqToDB.Internal.DataProvider.SqlCe.Translation
 				var factory = translationContext.ExpressionFactory;
 
 				return factory.Function(factory.GetDbDataType(typeof(DateTime)), "GetDate", ParametersNullabilityType.NotNullable);
+			}
+
+			protected override ISqlExpression? TranslateServerNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			{
+				// SQL CE is embedded and don't have own timezone
+				return TranslateNow(translationContext, translationFlags);
 			}
 		}
 

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/SqlServerDataProvider.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/SqlServerDataProvider.cs
@@ -255,7 +255,9 @@ namespace LinqToDB.Internal.DataProvider.SqlServer
 			{
 				>= SqlServerVersion.v2022 => new SqlServer2022MemberTranslator(),
 				>= SqlServerVersion.v2017 => new SqlServer2017MemberTranslator(),
+				>= SqlServerVersion.v2016 => new SqlServer2016MemberTranslator(),
 				>= SqlServerVersion.v2012 => new SqlServer2012MemberTranslator(),
+				>= SqlServerVersion.v2008 => new SqlServer2008MemberTranslator(),
 				SqlServerVersion.v2005 => new SqlServer2005MemberTranslator(),
 				_ => new SqlServerMemberTranslator(),
 			};

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/SqlServerDataProvider.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/SqlServerDataProvider.cs
@@ -619,28 +619,34 @@ namespace LinqToDB.Internal.DataProvider.SqlServer
 			switch (dataType.DataType)
 			{
 				// including provider-specific fallbacks
-				case DataType.Text: parameter.DbType = DbType.AnsiString; break;
-				case DataType.NText: parameter.DbType = DbType.String; break;
-				case DataType.Binary:
-				case DataType.Timestamp:
-				case DataType.Image: parameter.DbType = DbType.Binary; break;
-				case DataType.SmallMoney:
-				case DataType.Money: parameter.DbType = DbType.Currency; break;
-				case DataType.SmallDateTime: parameter.DbType = DbType.DateTime; break;
-				case DataType.Structured: parameter.DbType = DbType.Object; break;
-				case DataType.Xml: parameter.DbType = DbType.Xml; break;
-				case DataType.SByte: parameter.DbType = DbType.Int16; break;
-				case DataType.UInt16: parameter.DbType = DbType.Int32; break;
-				case DataType.UInt32: parameter.DbType = DbType.Int64; break;
-				case DataType.UInt64:
-				case DataType.VarNumeric: parameter.DbType = DbType.Decimal; break;
-				case DataType.DateTime2:
+				case DataType.Text          : parameter.DbType = DbType.AnsiString;                       break;
+				case DataType.NText         : parameter.DbType = DbType.String;                           break;
+				case DataType.Binary        :
+				case DataType.Timestamp     :
+				case DataType.Image         : parameter.DbType = DbType.Binary;                           break;
+				case DataType.SmallMoney    :
+				case DataType.Money         : parameter.DbType = DbType.Currency;                         break;
+				case DataType.SmallDateTime : parameter.DbType = DbType.DateTime;                         break;
+				case DataType.Structured    : parameter.DbType = DbType.Object;                           break;
+				case DataType.Xml           : parameter.DbType = DbType.Xml;                              break;
+				case DataType.SByte         : parameter.DbType = DbType.Int16;                            break;
+				case DataType.UInt16        : parameter.DbType = DbType.Int32;                            break;
+				case DataType.UInt32        : parameter.DbType = DbType.Int64;                            break;
+				case DataType.UInt64        :
+				case DataType.VarNumeric    : parameter.DbType = DbType.Decimal;                          break;
+				case DataType.DateTimeOffset:
+					parameter.DbType =
+						Version == SqlServerVersion.v2005 ?
+							DbType.DateTime :
+							DbType.DateTimeOffset;
+					break;
+				case DataType.DateTime2     :
 					parameter.DbType =
 						Version == SqlServerVersion.v2005 ?
 							DbType.DateTime :
 							DbType.DateTime2;
 					break;
-				default: base.SetParameterType(dataConnection, parameter, dataType); break;
+				default                     : base.SetParameterType(dataConnection, parameter, dataType); break;
 			}
 		}
 

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2005MemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2005MemberTranslator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -44,6 +45,13 @@ namespace LinqToDB.Internal.DataProvider.SqlServer.Translation
 				var dateAdd  = factory.Function(dateType, "DateAdd", ParametersNullabilityType.SameAsSecondParameter, datePart, dateDiff, factory.Value(intDataType, 0));
 
 				return dateAdd;
+			}
+
+			protected override ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				var dbDataType = factory.GetDbDataType(typeof(DateTime));
+				return factory.NotNullExpression(dbDataType, "GETUTCDATE()");	// Higher-precision [datetime2] SYSUTCDATETIME() only available in 2008+
 			}
 		}
 	}

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2005MemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2005MemberTranslator.cs
@@ -1,13 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
+﻿using System.Linq.Expressions;
 
 using LinqToDB;
 using LinqToDB.Internal.DataProvider.Translation;
 using LinqToDB.Internal.SqlQuery;
 using LinqToDB.Linq.Translation;
-using LinqToDB.SqlQuery;
 
 namespace LinqToDB.Internal.DataProvider.SqlServer.Translation
 {

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2005MemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2005MemberTranslator.cs
@@ -20,7 +20,7 @@ namespace LinqToDB.Internal.DataProvider.SqlServer.Translation
 
 		protected override IMemberTranslator CreateDateMemberTranslator()
 		{
-			return new DateFunctionsTranslator2005();
+			return new SqlServer2005DateFunctionsTranslator();
 		}
 
 		protected class SqlTypes2005Translation : SqlTypesTranslation
@@ -29,7 +29,7 @@ namespace LinqToDB.Internal.DataProvider.SqlServer.Translation
 				=> MakeSqlTypeExpression(translationContext, memberExpression, t => t.WithDataType(DataType.DateTime));
 		}
 
-		protected class DateFunctionsTranslator2005 : SqlServerDateFunctionsTranslator
+		protected class SqlServer2005DateFunctionsTranslator : SqlServerDateFunctionsTranslator
 		{
 			protected override ISqlExpression? TranslateDateTimeTruncationToDate(ITranslationContext translationContext, ISqlExpression dateExpression, TranslationFlags translationFlags)
 			{
@@ -45,13 +45,6 @@ namespace LinqToDB.Internal.DataProvider.SqlServer.Translation
 				var dateAdd  = factory.Function(dateType, "DateAdd", ParametersNullabilityType.SameAsSecondParameter, datePart, dateDiff, factory.Value(intDataType, 0));
 
 				return dateAdd;
-			}
-
-			protected override ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)
-			{
-				var factory = translationContext.ExpressionFactory;
-				var dbDataType = factory.GetDbDataType(typeof(DateTime));
-				return factory.NotNullExpression(dbDataType, "GETUTCDATE()");	// Higher-precision [datetime2] SYSUTCDATETIME() only available in 2008+
 			}
 		}
 	}

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2008MemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2008MemberTranslator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Linq.Expressions;
 
 using LinqToDB.Internal.DataProvider.Translation;
 using LinqToDB.Internal.SqlQuery;
@@ -12,6 +13,17 @@ namespace LinqToDB.Internal.DataProvider.SqlServer.Translation
 		protected override IMemberTranslator CreateDateMemberTranslator()
 		{
 			return new SqlServer2008DateFunctionsTranslator();
+		}
+
+		protected override IMemberTranslator CreateSqlTypesTranslator()
+		{
+			return new SqlTypes2008Translation();
+		}
+
+		protected class SqlTypes2008Translation : SqlTypes2005Translation
+		{
+			protected override Expression? ConvertDate(ITranslationContext translationContext, MemberExpression memberExpression, TranslationFlags translationFlags)
+				=> MakeSqlTypeExpression(translationContext, memberExpression, t => t.WithDataType(DataType.Date));
 		}
 
 		protected class SqlServer2008DateFunctionsTranslator : SqlServer2005DateFunctionsTranslator

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2008MemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2008MemberTranslator.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+using LinqToDB.Internal.DataProvider.Translation;
+using LinqToDB.Internal.SqlQuery;
+using LinqToDB.Linq.Translation;
+using LinqToDB.SqlQuery;
+
+namespace LinqToDB.Internal.DataProvider.SqlServer.Translation
+{
+	public class SqlServer2008MemberTranslator : SqlServer2005MemberTranslator
+	{
+		protected override IMemberTranslator CreateDateMemberTranslator()
+		{
+			return new SqlServer2008DateFunctionsTranslator();
+		}
+
+		protected class SqlServer2008DateFunctionsTranslator : SqlServer2005DateFunctionsTranslator
+		{
+			protected override ISqlExpression? TranslateDateTimeTruncationToDate(ITranslationContext translationContext, ISqlExpression dateExpression, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				var cast    = factory.Cast(dateExpression, factory.GetDbDataType(dateExpression).WithDataType(DataType.Date), true);
+
+				return cast;
+			}
+
+			protected override ISqlExpression? TranslateZonedNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				return factory.Function(dbDataType, "SYSDATETIMEOFFSET");
+			}
+
+			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				// Cast to datetimeoffset uses 00:00 timezone by default
+				// Better syntax AT TIME ZONE 'UTC' only available in 2016+
+				return factory.NotNullExpression(dbDataType, "CAST(SYSUTCDATETIME() AS datetimeoffset)");
+			}
+		}
+	}
+}

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2008MemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2008MemberTranslator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -26,10 +27,11 @@ namespace LinqToDB.Internal.DataProvider.SqlServer.Translation
 				return cast;
 			}
 
-			protected override ISqlExpression? TranslateZonedNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			protected override ISqlExpression TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
 				var factory = translationContext.ExpressionFactory;
-				return factory.Function(dbDataType, "SYSDATETIMEOFFSET");
+				var dbDataType = factory.GetDbDataType(typeof(DateTime));
+				return factory.Function(dbDataType, "SYSUTCDATETIME");
 			}
 
 			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
@@ -37,7 +39,7 @@ namespace LinqToDB.Internal.DataProvider.SqlServer.Translation
 				var factory = translationContext.ExpressionFactory;
 				// Cast to datetimeoffset uses 00:00 timezone by default
 				// Better syntax AT TIME ZONE 'UTC' only available in 2016+
-				return factory.NotNullExpression(dbDataType, "CAST(SYSUTCDATETIME() AS datetimeoffset)");
+				return factory.Cast(TranslateUtcNow(translationContext, translationFlags), dbDataType);
 			}
 		}
 	}

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2008MemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2008MemberTranslator.cs
@@ -1,12 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 
 using LinqToDB.Internal.DataProvider.Translation;
 using LinqToDB.Internal.SqlQuery;
 using LinqToDB.Linq.Translation;
-using LinqToDB.SqlQuery;
 
 namespace LinqToDB.Internal.DataProvider.SqlServer.Translation
 {

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2012MemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2012MemberTranslator.cs
@@ -34,6 +34,14 @@ namespace LinqToDB.Internal.DataProvider.SqlServer.Translation
 
 				return resultExpression;
 			}
+
+			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				// Cast to datetimeoffset uses 00:00 timezone by default
+				// Better syntax AT TIME ZONE 'UTC' only available in 2016+
+				return factory.NotNullExpression(dbDataType, "CAST(SYSUTCDATETIME() AS datetimeoffset)");
+			}
 		}
 
 		protected override IMemberTranslator CreateDateMemberTranslator()

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2012MemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2012MemberTranslator.cs
@@ -5,9 +5,9 @@ using LinqToDB.Linq.Translation;
 
 namespace LinqToDB.Internal.DataProvider.SqlServer.Translation
 {
-	public class SqlServer2012MemberTranslator : SqlServerMemberTranslator
+	public class SqlServer2012MemberTranslator : SqlServer2008MemberTranslator
 	{
-		protected class SqlServer2012DateFunctionsTranslator : SqlServerDateFunctionsTranslator
+		protected class SqlServer2012DateFunctionsTranslator : SqlServer2008DateFunctionsTranslator
 		{
 			protected override ISqlExpression? TranslateMakeDateTime(
 				ITranslationContext translationContext,
@@ -33,14 +33,6 @@ namespace LinqToDB.Internal.DataProvider.SqlServer.Translation
 					: factory.Function(resulType, "DATETIMEFROMPARTS",  year, month, day, hour, minute, second, millisecond);
 
 				return resultExpression;
-			}
-
-			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
-			{
-				var factory = translationContext.ExpressionFactory;
-				// Cast to datetimeoffset uses 00:00 timezone by default
-				// Better syntax AT TIME ZONE 'UTC' only available in 2016+
-				return factory.NotNullExpression(dbDataType, "CAST(SYSUTCDATETIME() AS datetimeoffset)");
 			}
 		}
 

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2016MemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2016MemberTranslator.cs
@@ -1,11 +1,6 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
-
-using LinqToDB.Internal.DataProvider.Translation;
+﻿using LinqToDB.Internal.DataProvider.Translation;
 using LinqToDB.Internal.SqlQuery;
 using LinqToDB.Linq.Translation;
-using LinqToDB.SqlQuery;
 
 namespace LinqToDB.Internal.DataProvider.SqlServer.Translation
 {

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2016MemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2016MemberTranslator.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+using LinqToDB.Internal.DataProvider.Translation;
+using LinqToDB.Internal.SqlQuery;
+using LinqToDB.Linq.Translation;
+using LinqToDB.SqlQuery;
+
+namespace LinqToDB.Internal.DataProvider.SqlServer.Translation
+{
+	public class SqlServer2016MemberTranslator : SqlServer2012MemberTranslator
+	{
+		protected override IMemberTranslator CreateDateMemberTranslator()
+		{
+			return new SqlServer2016DateFunctionsTranslator();
+		}
+
+		protected class SqlServer2016DateFunctionsTranslator : SqlServer2012DateFunctionsTranslator
+		{
+			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				return factory.NotNullExpression(dbDataType, "SYSDATETIMEOFFSET() AT TIME ZONE 'UTC'");
+			}
+		}
+	}
+}

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2017MemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2017MemberTranslator.cs
@@ -11,9 +11,23 @@ namespace LinqToDB.Internal.DataProvider.SqlServer.Translation
 {
 	public class SqlServer2017MemberTranslator : SqlServer2012MemberTranslator
 	{
+		protected override IMemberTranslator CreateDateMemberTranslator()
+		{
+			return new SqlServer2017DateFunctionsTranslator();
+		}
+
 		protected override IMemberTranslator CreateStringMemberTranslator()
 		{
 			return new SqlServer2017StringMemberTranslator();
+		}
+
+		protected class SqlServer2017DateFunctionsTranslator : SqlServer2012DateFunctionsTranslator
+		{
+			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				return factory.NotNullExpression(dbDataType, "SYSDATETIMEOFFSET() AT TIME ZONE 'UTC'");
+			}
 		}
 
 		protected class SqlServer2017StringMemberTranslator : SqlServerStringMemberTranslator

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2017MemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2017MemberTranslator.cs
@@ -9,25 +9,11 @@ using LinqToDB.SqlQuery;
 
 namespace LinqToDB.Internal.DataProvider.SqlServer.Translation
 {
-	public class SqlServer2017MemberTranslator : SqlServer2012MemberTranslator
+	public class SqlServer2017MemberTranslator : SqlServer2016MemberTranslator
 	{
-		protected override IMemberTranslator CreateDateMemberTranslator()
-		{
-			return new SqlServer2017DateFunctionsTranslator();
-		}
-
 		protected override IMemberTranslator CreateStringMemberTranslator()
 		{
 			return new SqlServer2017StringMemberTranslator();
-		}
-
-		protected class SqlServer2017DateFunctionsTranslator : SqlServer2012DateFunctionsTranslator
-		{
-			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
-			{
-				var factory = translationContext.ExpressionFactory;
-				return factory.NotNullExpression(dbDataType, "SYSDATETIMEOFFSET() AT TIME ZONE 'UTC'");
-			}
 		}
 
 		protected class SqlServer2017StringMemberTranslator : SqlServerStringMemberTranslator

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServerMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServerMemberTranslator.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -178,15 +178,29 @@ namespace LinqToDB.Internal.DataProvider.SqlServer.Translation
 				return TranslateDateTimeTruncationToDate(translationContext, dateExpression, translationFlags);
 			}
 
-			protected override ISqlExpression? TranslateSqlGetDate(ITranslationContext translationContext, TranslationFlags translationFlags)
+			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
 				var factory = translationContext.ExpressionFactory;
 				return factory.NotNullExpression(factory.GetDbDataType(typeof(DateTime)), "CURRENT_TIMESTAMP");
 			}
 
-			protected override ISqlExpression? TranslateSqlCurrentTimestampUtc(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			protected override ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
-				return translationContext.ExpressionFactory.Function(dbDataType, "SYSUTCDATETIME");
+				var factory = translationContext.ExpressionFactory;
+				var dbDataType = factory.GetDbDataType(typeof(DateTime));
+				return factory.Function(dbDataType, "SYSUTCDATETIME");
+			}
+
+			protected override ISqlExpression? TranslateZonedNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				return factory.Function(dbDataType, "SYSDATETIMEOFFSET");
+			}
+
+			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				return factory.NotNullExpression(dbDataType, "SYSDATETIMEOFFSET() AT TIME ZONE 'UTC'");
 			}
 		}
 

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServerMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServerMemberTranslator.cs
@@ -196,12 +196,6 @@ namespace LinqToDB.Internal.DataProvider.SqlServer.Translation
 				var factory = translationContext.ExpressionFactory;
 				return factory.Function(dbDataType, "SYSDATETIMEOFFSET");
 			}
-
-			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
-			{
-				var factory = translationContext.ExpressionFactory;
-				return factory.NotNullExpression(dbDataType, "SYSDATETIMEOFFSET() AT TIME ZONE 'UTC'");
-			}
 		}
 
 		protected class SqlServerMathMemberTranslator : MathMemberTranslatorBase

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServerMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServerMemberTranslator.cs
@@ -165,14 +165,6 @@ namespace LinqToDB.Internal.DataProvider.SqlServer.Translation
 				return resultExpression;
 			}
 
-			protected override ISqlExpression? TranslateDateTimeTruncationToDate(ITranslationContext translationContext, ISqlExpression dateExpression, TranslationFlags translationFlags)
-			{
-				var factory = translationContext.ExpressionFactory;
-				var cast    = factory.Cast(dateExpression, factory.GetDbDataType(dateExpression).WithDataType(DataType.Date), true);
-
-				return cast;
-			}
-
 			protected override ISqlExpression? TranslateDateTimeOffsetTruncationToDate(ITranslationContext translationContext, ISqlExpression dateExpression, TranslationFlags translationFlags)
 			{
 				return TranslateDateTimeTruncationToDate(translationContext, dateExpression, translationFlags);
@@ -184,17 +176,9 @@ namespace LinqToDB.Internal.DataProvider.SqlServer.Translation
 				return factory.NotNullExpression(factory.GetDbDataType(typeof(DateTime)), "CURRENT_TIMESTAMP");
 			}
 
-			protected override ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)
-			{
-				var factory = translationContext.ExpressionFactory;
-				var dbDataType = factory.GetDbDataType(typeof(DateTime));
-				return factory.Function(dbDataType, "SYSUTCDATETIME");
-			}
-
 			protected override ISqlExpression? TranslateZonedNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
 			{
-				var factory = translationContext.ExpressionFactory;
-				return factory.Function(dbDataType, "SYSDATETIMEOFFSET");
+				return null;
 			}
 		}
 

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServerMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServerMemberTranslator.cs
@@ -176,12 +176,6 @@ namespace LinqToDB.Internal.DataProvider.SqlServer.Translation
 				return null;
 			}
 
-			protected override ISqlExpression? TranslateZonedNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
-			{
-				// cannot be translated as server 'don't know client's timezone
-				return null;
-			}
-
 			protected override ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
 				var factory = translationContext.ExpressionFactory;

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServerMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServerMemberTranslator.cs
@@ -172,13 +172,21 @@ namespace LinqToDB.Internal.DataProvider.SqlServer.Translation
 
 			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
-				var factory = translationContext.ExpressionFactory;
-				return factory.NotNullExpression(factory.GetDbDataType(typeof(DateTime)), "CURRENT_TIMESTAMP");
+				// cannot be translated as server 'don't know client's timezone
+				return null;
 			}
 
 			protected override ISqlExpression? TranslateZonedNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
 			{
+				// cannot be translated as server 'don't know client's timezone
 				return null;
+			}
+
+			protected override ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				var dbDataType = factory.GetDbDataType(typeof(DateTime));
+				return factory.Function(dbDataType, "GETUTCDATE");
 			}
 		}
 

--- a/Source/LinqToDB/Internal/DataProvider/Sybase/SybaseDataProvider.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Sybase/SybaseDataProvider.cs
@@ -58,6 +58,8 @@ namespace LinqToDB.Internal.DataProvider.Sybase
 			SetCharFieldToType<char>("char",  DataTools.GetCharExpression);
 			SetCharFieldToType<char>("nchar", DataTools.GetCharExpression);
 
+			SetProviderField<DbDataReader, DateTimeOffset, DateTime>((r, i) => new DateTimeOffset(r.GetDateTime(i), default));
+
 			SetProviderField<DbDataReader, TimeSpan,DateTime>((r,i) => r.GetDateTime(i) - new DateTime(1900, 1, 1));
 			SetField<DbDataReader, DateTime>("time", (r,i) => GetDateTimeAsTime(r.GetDateTime(i)));
 

--- a/Source/LinqToDB/Internal/DataProvider/Sybase/SybaseMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Sybase/SybaseMappingSchema.cs
@@ -12,24 +12,33 @@ namespace LinqToDB.Internal.DataProvider.Sybase
 	public sealed class SybaseMappingSchema : LockedMappingSchema
 	{
 #if SUPPORTS_COMPOSITE_FORMAT
-		private static readonly CompositeFormat TIME3_FORMAT = CompositeFormat.Parse("'{0:hh\\:mm\\:ss\\.fff}'");
+		private static readonly CompositeFormat TIME3_FORMAT    = CompositeFormat.Parse("'{0:hh\\:mm\\:ss\\.fff}'");
+		private static readonly CompositeFormat DATETIME_FORMAT = CompositeFormat.Parse("'{0:yyyy-MM-dd HH:mm:ss.fff}'");
 #else
-		private const string TIME3_FORMAT= "'{0:hh\\:mm\\:ss\\.fff}'";
+		private const string TIME3_FORMAT    = "'{0:hh\\:mm\\:ss\\.fff}'";
+		private const string DATETIME_FORMAT = "'{0:yyyy-MM-dd HH:mm:ss.fff}'";
 #endif
 
 		SybaseMappingSchema() : base(ProviderName.Sybase)
 		{
-			SetValueToSqlConverter(typeof(string)  , (sb, _,_,v) => ConvertStringToSql  (sb, (string)v));
-			SetValueToSqlConverter(typeof(char)    , (sb, _,_,v) => ConvertCharToSql    (sb, (char)v));
-			SetValueToSqlConverter(typeof(TimeSpan), (sb,dt,_,v) => ConvertTimeSpanToSql(sb, dt, (TimeSpan)v));
-			SetValueToSqlConverter(typeof(byte[])  , (sb, _,_,v) => ConvertBinaryToSql  (sb, (byte[])v));
-			SetValueToSqlConverter(typeof(Binary)  , (sb, _,_,v) => ConvertBinaryToSql  (sb, ((Binary)v).ToArray()));
+			SetValueToSqlConverter(typeof(string)  ,       (sb, _,_,v) => ConvertStringToSql  (sb, (string)v));
+			SetValueToSqlConverter(typeof(char)    ,       (sb, _,_,v) => ConvertCharToSql    (sb, (char)v));
+			SetValueToSqlConverter(typeof(TimeSpan),       (sb,dt,_,v) => ConvertTimeSpanToSql(sb, dt, (TimeSpan)v));
+			SetValueToSqlConverter(typeof(byte[])  ,       (sb, _,_,v) => ConvertBinaryToSql  (sb, (byte[])v));
+			SetValueToSqlConverter(typeof(Binary)  ,       (sb, _,_,v) => ConvertBinaryToSql  (sb, ((Binary)v).ToArray()));
+			SetValueToSqlConverter(typeof(DateTime),       (sb,_,_, v) => BuildDateTime(sb, (DateTime)v));
+			SetValueToSqlConverter(typeof(DateTimeOffset), (sb,_,_, v) => BuildDateTime(sb, ((DateTimeOffset)v).DateTime));
 
 			SetDataType(typeof(string),  new SqlDataType(DataType.NVarChar, typeof(string), 255));
 			// in ASE DECIMAL=DECIMAL(18,0)
 			SetDataType(typeof(decimal), new SqlDataType(DataType.Decimal,  typeof(decimal), 18, 10));
 
 			SetDefaultValue(typeof(DateTime), new DateTime(1753, 1, 1));
+		}
+
+		static void BuildDateTime(StringBuilder stringBuilder, DateTime value)
+		{
+			stringBuilder.AppendFormat(CultureInfo.InvariantCulture, DATETIME_FORMAT, value);
 		}
 
 		static void ConvertBinaryToSql(StringBuilder stringBuilder, byte[] value)

--- a/Source/LinqToDB/Internal/DataProvider/Sybase/Translation/SybaseMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Sybase/Translation/SybaseMemberTranslator.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 using System.Linq.Expressions;
 
@@ -177,15 +177,17 @@ namespace LinqToDB.Internal.DataProvider.Sybase.Translation
 				return convertFunc;
 			}
 
-			protected override ISqlExpression? TranslateSqlGetDate(ITranslationContext translationContext, TranslationFlags translationFlags)
+			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
 				var factory = translationContext.ExpressionFactory;
 				return factory.Function(factory.GetDbDataType(typeof(DateTime)), "GetDate", ParametersNullabilityType.NotNullable);
 			}
 
-			protected override ISqlExpression? TranslateSqlCurrentTimestampUtc(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			protected override ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
-				return translationContext.ExpressionFactory.Function(dbDataType, "GETUTCDATE");
+				var factory = translationContext.ExpressionFactory;
+				var dbDataType = factory.GetDbDataType(typeof(DateTime));
+				return factory.Function(dbDataType, "GETUTCDATE");
 			}
 		}
 

--- a/Source/LinqToDB/Internal/DataProvider/Sybase/Translation/SybaseMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Sybase/Translation/SybaseMemberTranslator.cs
@@ -84,6 +84,11 @@ namespace LinqToDB.Internal.DataProvider.Sybase.Translation
 				return resultExpression;
 			}
 
+			protected override ISqlExpression? TranslateDateTimeOffsetDatePart(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, Sql.DateParts datepart)
+			{
+				return TranslateDateTimeDatePart(translationContext, translationFlag, dateTimeExpression, datepart);
+			}
+
 			protected override ISqlExpression? TranslateDateTimeDateAdd(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, ISqlExpression increment,
 				Sql.DateParts                                                       datepart)
 			{
@@ -177,16 +182,27 @@ namespace LinqToDB.Internal.DataProvider.Sybase.Translation
 				return convertFunc;
 			}
 
-			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			protected override ISqlExpression? TranslateServerNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
 				var factory = translationContext.ExpressionFactory;
 				return factory.Function(factory.GetDbDataType(typeof(DateTime)), "GetDate", ParametersNullabilityType.NotNullable);
+			}
+
+			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			{
+				return null;
 			}
 
 			protected override ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
 				var factory = translationContext.ExpressionFactory;
 				var dbDataType = factory.GetDbDataType(typeof(DateTime));
+				return factory.Function(dbDataType, "GETUTCDATE");
+			}
+
+			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
 				return factory.Function(dbDataType, "GETUTCDATE");
 			}
 		}

--- a/Source/LinqToDB/Internal/DataProvider/Translation/DateFunctionsTranslatorBase.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Translation/DateFunctionsTranslatorBase.cs
@@ -616,7 +616,7 @@ namespace LinqToDB.Internal.DataProvider.Translation
 		{
 			var translated = TranslateUtcNow(translationContext, translationFlags);
 			if (translated == null)
-				return SqlErrorExpression.EnsureError(memberExpression);
+				return null;
 			return translationContext.CreatePlaceholder(translated, memberExpression);
 		}
 
@@ -626,7 +626,7 @@ namespace LinqToDB.Internal.DataProvider.Translation
 
 			var translated = TranslateZonedNow(translationContext, dbType, translationFlags);
 			if (translated == null)
-				return SqlErrorExpression.EnsureError(memberExpression);
+				return null;
 			return translationContext.CreatePlaceholder(translated, memberExpression);
 		}
 
@@ -636,7 +636,7 @@ namespace LinqToDB.Internal.DataProvider.Translation
 
 			var translated = TranslateZonedUtcNow(translationContext, dbType, translationFlags);
 			if (translated == null)
-				return SqlErrorExpression.EnsureError(memberExpression);
+				return null;
 			return translationContext.CreatePlaceholder(translated, memberExpression);
 		}
 

--- a/Source/LinqToDB/Internal/DataProvider/Translation/DateFunctionsTranslatorBase.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Translation/DateFunctionsTranslatorBase.cs
@@ -59,20 +59,20 @@ namespace LinqToDB.Internal.DataProvider.Translation
 			Registration.RegisterMethod((DateTime dt) => dt.AddMilliseconds(0), (tc, mc, tf) => TranslateDateTimeAddMember(tc, mc, tf, Sql.DateParts.Millisecond));
 
 			Registration.RegisterMethod((DateTime dt) => Sql.DatePart(Sql.DateParts.Year, dt), TranslateDateTimeSqlDatepart);
-			Registration.RegisterMember((DateTime dt) => Sql.CurrentTimestamp, TranslateSqlCurrentTimestamp);
-
-			Registration.RegisterMethod(() => Sql.GetDate(), TranslateSqlGetDate);
-			Registration.RegisterReplacement(() => DateTime.Now,          () => Sql.GetDate());
-			Registration.RegisterReplacement(() => Sql.CurrentTimestamp2, () => Sql.GetDate());
-
-			Registration.RegisterMember(() => DateTime.UtcNow,         TranslateSqlCurrentTimestampUtc);
-			Registration.RegisterMember(() => Sql.CurrentTimestampUtc, TranslateSqlCurrentTimestampUtc);
+			
+			Registration.RegisterMethod(() => Sql.GetDate(), 	     TranslateSqlGetDate);
+			Registration.RegisterMember(() => Sql.CurrentTimestamp,  TranslateNow);
+			Registration.RegisterMember(() => Sql.CurrentTimestamp2, TranslateNow);
+			Registration.RegisterMember(() => DateTime.Now,          TranslateNow);
+			
+			Registration.RegisterMember(() => DateTime.UtcNow,         TranslateUtcNow);
+			Registration.RegisterMember(() => Sql.CurrentTimestampUtc, TranslateUtcNow);
 		}
 
 		void RegisterDateTimeOffset()
 		{
-			Registration.RegisterMember(() => DateTimeOffset.Now,      TranslateSqlCurrentTimestampUtc);
-			Registration.RegisterMember(() => DateTimeOffset.UtcNow,   TranslateSqlCurrentTimestampUtc);
+			Registration.RegisterMember(() => DateTimeOffset.Now,      TranslateZonedNow);
+			Registration.RegisterMember(() => DateTimeOffset.UtcNow,   TranslateZonedUtcNow);
 
 			Registration.RegisterMember((DateTimeOffset dt) => dt.Year, (tc,        me, tf) => TranslateDateTimeOffsetMember(tc, me, tf, Sql.DateParts.Year));
 			Registration.RegisterMember((DateTimeOffset dt) => dt.Month, (tc,       me, tf) => TranslateDateTimeOffsetMember(tc, me, tf, Sql.DateParts.Month));
@@ -231,7 +231,7 @@ namespace LinqToDB.Internal.DataProvider.Translation
 
 		Expression? TranslateSqlGetDate(ITranslationContext translationContext, MethodCallExpression methodCall, TranslationFlags translationFlags)
 		{
-			var translated = TranslateSqlGetDate(translationContext, translationFlags);
+			var translated = TranslateNow(translationContext, translationFlags);
 			if (translated == null)
 				return null;
 
@@ -604,6 +604,42 @@ namespace LinqToDB.Internal.DataProvider.Translation
 		}
 #endif
 
+		Expression? TranslateNow(ITranslationContext translationContext, MemberExpression memberExpression, TranslationFlags translationFlags)
+		{
+			var translated = TranslateNow(translationContext, translationFlags);
+			if (translated == null)
+				return SqlErrorExpression.EnsureError(memberExpression);
+			return translationContext.CreatePlaceholder(translated, memberExpression);
+		}
+
+		Expression? TranslateUtcNow(ITranslationContext translationContext, MemberExpression memberExpression, TranslationFlags translationFlags)
+		{
+			var translated = TranslateUtcNow(translationContext, translationFlags);
+			if (translated == null)
+				return SqlErrorExpression.EnsureError(memberExpression);
+			return translationContext.CreatePlaceholder(translated, memberExpression);
+		}
+
+		Expression? TranslateZonedNow(ITranslationContext translationContext, MemberExpression memberExpression, TranslationFlags translationFlags)
+		{
+			var dbType = translationContext.CurrentColumnDescriptor?.GetDbDataType(true) ?? translationContext.ExpressionFactory.GetDbDataType(memberExpression.Type);
+
+			var translated = TranslateZonedNow(translationContext, dbType, translationFlags);
+			if (translated == null)
+				return SqlErrorExpression.EnsureError(memberExpression);
+			return translationContext.CreatePlaceholder(translated, memberExpression);
+		}
+
+		Expression? TranslateZonedUtcNow(ITranslationContext translationContext, MemberExpression memberExpression, TranslationFlags translationFlags)
+		{
+			var dbType = translationContext.CurrentColumnDescriptor?.GetDbDataType(true) ?? translationContext.ExpressionFactory.GetDbDataType(memberExpression.Type);
+
+			var translated = TranslateZonedUtcNow(translationContext, dbType, translationFlags);
+			if (translated == null)
+				return SqlErrorExpression.EnsureError(memberExpression);
+			return translationContext.CreatePlaceholder(translated, memberExpression);
+		}
+
 		#region Methods to override
 
 		protected virtual ISqlExpression? TranslateDateTimeDatePart(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, Sql.DateParts datepart)
@@ -662,34 +698,28 @@ namespace LinqToDB.Internal.DataProvider.Translation
 			return cast;
 		}
 
-		protected virtual Expression? TranslateSqlCurrentTimestamp(ITranslationContext translationContext, MemberExpression memberExpression, TranslationFlags translationFlags)
+		protected virtual ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 		{
-			var translated = TranslateSqlGetDate(translationContext, translationFlags);
-			if (translated == null)
-				return SqlErrorExpression.EnsureError(memberExpression);
-			return translationContext.CreatePlaceholder(translated, memberExpression);
-		}
-
-		protected virtual Expression? TranslateSqlCurrentTimestampUtc(ITranslationContext translationContext, MemberExpression memberExpression, TranslationFlags translationFlags)
-		{
-			var dbType = translationContext.CurrentColumnDescriptor?.GetDbDataType(true) ?? translationContext.ExpressionFactory.GetDbDataType(memberExpression.Type);
-
-			var translated = TranslateSqlCurrentTimestampUtc(translationContext, dbType, translationFlags);
-			if (translated == null)
-				return null;
-			return translationContext.CreatePlaceholder(translated, memberExpression);
-		}
-
-		protected virtual ISqlExpression? TranslateSqlGetDate(ITranslationContext translationContext, TranslationFlags translationFlags)
-		{
-			var factory       = translationContext.ExpressionFactory;
+			var factory = translationContext.ExpressionFactory;
 			var currentTimeStamp = factory.NotNullExpression(factory.GetDbDataType(typeof(DateTime)), "CURRENT_TIMESTAMP");
 			return currentTimeStamp;
 		}
 
-		protected virtual ISqlExpression? TranslateSqlCurrentTimestampUtc(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+		protected virtual ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 		{
 			return null;
+		}
+
+		protected virtual ISqlExpression? TranslateZonedNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+		{
+			// Most RDBMS don't have a mapping for DateTimeOffset
+			return TranslateNow(translationContext, translationFlags);
+		}
+
+		protected virtual ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+		{
+			// Most RDBMS don't have a mapping for DateTimeOffset
+			return TranslateUtcNow(translationContext, translationFlags);
 		}
 
 		protected virtual ISqlExpression? TranslateMakeDateTime(

--- a/Source/LinqToDB/Internal/DataProvider/Translation/DateFunctionsTranslatorBase.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Translation/DateFunctionsTranslatorBase.cs
@@ -59,12 +59,10 @@ namespace LinqToDB.Internal.DataProvider.Translation
 			Registration.RegisterMethod((DateTime dt) => dt.AddMilliseconds(0), (tc, mc, tf) => TranslateDateTimeAddMember(tc, mc, tf, Sql.DateParts.Millisecond));
 
 			Registration.RegisterMethod((DateTime dt) => Sql.DatePart(Sql.DateParts.Year, dt), TranslateDateTimeSqlDatepart);
-			
 			Registration.RegisterMethod(() => Sql.GetDate(), 	     TranslateSqlGetDate);
 			Registration.RegisterMember(() => Sql.CurrentTimestamp,  TranslateNow);
 			Registration.RegisterMember(() => Sql.CurrentTimestamp2, TranslateNow);
 			Registration.RegisterMember(() => DateTime.Now,          TranslateNow);
-			
 			Registration.RegisterMember(() => DateTime.UtcNow,         TranslateUtcNow);
 			Registration.RegisterMember(() => Sql.CurrentTimestampUtc, TranslateUtcNow);
 		}

--- a/Source/LinqToDB/Internal/DataProvider/Translation/DateFunctionsTranslatorBase.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Translation/DateFunctionsTranslatorBase.cs
@@ -59,10 +59,11 @@ namespace LinqToDB.Internal.DataProvider.Translation
 			Registration.RegisterMethod((DateTime dt) => dt.AddMilliseconds(0), (tc, mc, tf) => TranslateDateTimeAddMember(tc, mc, tf, Sql.DateParts.Millisecond));
 
 			Registration.RegisterMethod((DateTime dt) => Sql.DatePart(Sql.DateParts.Year, dt), TranslateDateTimeSqlDatepart);
-			Registration.RegisterMethod(() => Sql.GetDate(), 	     TranslateSqlGetDate);
-			Registration.RegisterMember(() => Sql.CurrentTimestamp,  TranslateServerNow);
-			Registration.RegisterMember(() => Sql.CurrentTimestamp2, TranslateNow);
-			Registration.RegisterMember(() => DateTime.Now,          TranslateNow);
+
+			Registration.RegisterMethod(() => Sql.GetDate(),           TranslateSqlGetDate);
+			Registration.RegisterMember(() => Sql.CurrentTimestamp,    TranslateServerNow);
+			Registration.RegisterMember(() => Sql.CurrentTimestamp2,   TranslateNow);
+			Registration.RegisterMember(() => DateTime.Now,            TranslateNow);
 			Registration.RegisterMember(() => DateTime.UtcNow,         TranslateUtcNow);
 			Registration.RegisterMember(() => Sql.CurrentTimestampUtc, TranslateUtcNow);
 		}

--- a/Source/LinqToDB/Internal/DataProvider/Translation/DateFunctionsTranslatorBase.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Translation/DateFunctionsTranslatorBase.cs
@@ -62,7 +62,7 @@ namespace LinqToDB.Internal.DataProvider.Translation
 
 			Registration.RegisterMethod(() => Sql.GetDate(),           TranslateSqlGetDate);
 			Registration.RegisterMember(() => Sql.CurrentTimestamp,    TranslateServerNow);
-			Registration.RegisterMember(() => Sql.CurrentTimestamp2,   TranslateNow);
+			Registration.RegisterMember(() => Sql.CurrentTimestamp2,   TranslateServerNow);
 			Registration.RegisterMember(() => DateTime.Now,            TranslateNow);
 			Registration.RegisterMember(() => DateTime.UtcNow,         TranslateUtcNow);
 			Registration.RegisterMember(() => Sql.CurrentTimestampUtc, TranslateUtcNow);
@@ -230,7 +230,7 @@ namespace LinqToDB.Internal.DataProvider.Translation
 
 		Expression? TranslateSqlGetDate(ITranslationContext translationContext, MethodCallExpression methodCall, TranslationFlags translationFlags)
 		{
-			var translated = TranslateNow(translationContext, translationFlags);
+			var translated = TranslateServerNow(translationContext, translationFlags);
 			if (translated == null)
 				return null;
 

--- a/Source/LinqToDB/Internal/DataProvider/Translation/DateFunctionsTranslatorBase.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Translation/DateFunctionsTranslatorBase.cs
@@ -60,7 +60,7 @@ namespace LinqToDB.Internal.DataProvider.Translation
 
 			Registration.RegisterMethod((DateTime dt) => Sql.DatePart(Sql.DateParts.Year, dt), TranslateDateTimeSqlDatepart);
 			Registration.RegisterMethod(() => Sql.GetDate(), 	     TranslateSqlGetDate);
-			Registration.RegisterMember(() => Sql.CurrentTimestamp,  TranslateNow);
+			Registration.RegisterMember(() => Sql.CurrentTimestamp,  TranslateServerNow);
 			Registration.RegisterMember(() => Sql.CurrentTimestamp2, TranslateNow);
 			Registration.RegisterMember(() => DateTime.Now,          TranslateNow);
 			Registration.RegisterMember(() => DateTime.UtcNow,         TranslateUtcNow);
@@ -602,11 +602,19 @@ namespace LinqToDB.Internal.DataProvider.Translation
 		}
 #endif
 
+		Expression? TranslateServerNow(ITranslationContext translationContext, MemberExpression memberExpression, TranslationFlags translationFlags)
+		{
+			var translated = TranslateServerNow(translationContext, translationFlags);
+			if (translated == null)
+				return SqlErrorExpression.EnsureError(memberExpression);
+			return translationContext.CreatePlaceholder(translated, memberExpression);
+		}
+
 		Expression? TranslateNow(ITranslationContext translationContext, MemberExpression memberExpression, TranslationFlags translationFlags)
 		{
 			var translated = TranslateNow(translationContext, translationFlags);
 			if (translated == null)
-				return SqlErrorExpression.EnsureError(memberExpression);
+				return null;
 			return translationContext.CreatePlaceholder(translated, memberExpression);
 		}
 
@@ -694,6 +702,13 @@ namespace LinqToDB.Internal.DataProvider.Translation
 			var cast    = factory.Cast(dateExpression, factory.GetDbDataType(typeof(TimeSpan)).WithDataType(DataType.Time), true);
 
 			return cast;
+		}
+
+		protected virtual ISqlExpression? TranslateServerNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+		{
+			var factory = translationContext.ExpressionFactory;
+			var currentTimeStamp = factory.NotNullExpression(factory.GetDbDataType(typeof(DateTime)), "CURRENT_TIMESTAMP");
+			return currentTimeStamp;
 		}
 
 		protected virtual ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)

--- a/Source/LinqToDB/Internal/DataProvider/Ydb/Translation/YdbMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Ydb/Translation/YdbMemberTranslator.cs
@@ -397,9 +397,11 @@ namespace LinqToDB.Internal.DataProvider.Ydb.Translation
 				return cast;
 			}
 
-			protected override ISqlExpression? TranslateSqlCurrentTimestampUtc(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			protected override ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
-				return translationContext.ExpressionFactory.Function(dbDataType, "CurrentUtcTimestamp");
+				var factory = translationContext.ExpressionFactory;
+				var dbDataType = factory.GetDbDataType(typeof(DateTime));
+				return factory.Function(dbDataType, "CurrentUtcTimestamp");
 			}
 
 			protected override ISqlExpression? TranslateDateTimeDatePart(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, Sql.DateParts datepart)
@@ -521,7 +523,7 @@ namespace LinqToDB.Internal.DataProvider.Ydb.Translation
 			//			ITranslationContext translationContext, ISqlExpression dateExpression, TranslationFlags translationFlags)
 			//		=> TranslateDateTimeTruncationToDate(translationContext, dateExpression, translationFlags);
 
-			protected override ISqlExpression? TranslateSqlGetDate(ITranslationContext translationContext, TranslationFlags translationFlags)
+			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
 				var factory = translationContext.ExpressionFactory;
 				return factory.Function(factory.GetDbDataType(typeof(DateTime)), "CurrentUtcTimestamp");

--- a/Source/LinqToDB/Internal/DataProvider/Ydb/Translation/YdbMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Ydb/Translation/YdbMemberTranslator.cs
@@ -415,6 +415,12 @@ namespace LinqToDB.Internal.DataProvider.Ydb.Translation
 				return factory.Function(dbDataType, "CurrentUtcTimestamp");
 			}
 
+			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				return factory.Function(dbDataType, "CurrentUtcTimestamp");
+			}
+
 			protected override ISqlExpression? TranslateDateTimeDatePart(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, Sql.DateParts datepart)
 			{
 				var f       = translationContext.ExpressionFactory;

--- a/Source/LinqToDB/Internal/DataProvider/Ydb/Translation/YdbMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Ydb/Translation/YdbMemberTranslator.cs
@@ -415,11 +415,6 @@ namespace LinqToDB.Internal.DataProvider.Ydb.Translation
 				return factory.Function(dbDataType, "CurrentUtcTimestamp");
 			}
 
-			protected override ISqlExpression? TranslateZonedNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
-			{
-				return null;
-			}
-
 			protected override ISqlExpression? TranslateDateTimeDatePart(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, Sql.DateParts datepart)
 			{
 				var f       = translationContext.ExpressionFactory;

--- a/Source/LinqToDB/Internal/DataProvider/Ydb/Translation/YdbMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Ydb/Translation/YdbMemberTranslator.cs
@@ -371,8 +371,7 @@ namespace LinqToDB.Internal.DataProvider.Ydb.Translation
 		{
 			protected override ISqlExpression? TranslateDateTimeOffsetDatePart(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, Sql.DateParts datepart)
 			{
-				//return base.TranslateDateTimeOffsetDatePart(translationContext, translationFlag, dateTimeExpression, datepart);
-				throw new NotSupportedException("11");
+				return TranslateDateTimeDatePart(translationContext, translationFlag, dateTimeExpression, datepart);
 			}
 
 			protected override ISqlExpression? TranslateDateTimeOffsetTruncationToDate(ITranslationContext translationContext, ISqlExpression dateExpression, TranslationFlags translationFlags)
@@ -397,11 +396,28 @@ namespace LinqToDB.Internal.DataProvider.Ydb.Translation
 				return cast;
 			}
 
+			protected override ISqlExpression? TranslateServerNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				var dbDataType = factory.GetDbDataType(typeof(DateTime));
+				return factory.Function(dbDataType, "CurrentUtcTimestamp");
+			}
+
+			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			{
+				return null;
+			}
+
 			protected override ISqlExpression? TranslateUtcNow(ITranslationContext translationContext, TranslationFlags translationFlags)
 			{
 				var factory = translationContext.ExpressionFactory;
 				var dbDataType = factory.GetDbDataType(typeof(DateTime));
 				return factory.Function(dbDataType, "CurrentUtcTimestamp");
+			}
+
+			protected override ISqlExpression? TranslateZonedNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				return null;
 			}
 
 			protected override ISqlExpression? TranslateDateTimeDatePart(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, Sql.DateParts datepart)
@@ -522,12 +538,6 @@ namespace LinqToDB.Internal.DataProvider.Ydb.Translation
 			//	protected override ISqlExpression? TranslateDateTimeOffsetTruncationToDate(
 			//			ITranslationContext translationContext, ISqlExpression dateExpression, TranslationFlags translationFlags)
 			//		=> TranslateDateTimeTruncationToDate(translationContext, dateExpression, translationFlags);
-
-			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
-			{
-				var factory = translationContext.ExpressionFactory;
-				return factory.Function(factory.GetDbDataType(typeof(DateTime)), "CurrentUtcTimestamp");
-			}
 		}
 
 		protected class MathMemberTranslator : MathMemberTranslatorBase

--- a/Source/LinqToDB/Mapping/ValueToSqlConverter.cs
+++ b/Source/LinqToDB/Mapping/ValueToSqlConverter.cs
@@ -53,7 +53,6 @@ namespace LinqToDB.Mapping
 			SetConverter(typeof(double),         (sb,_,_,v) => sb.Append(((double)   v).ToString("G17", _numberFormatInfo)));
 			SetConverter(typeof(decimal),        (sb,_,_,v) => sb.Append(((decimal)  v).ToString(_numberFormatInfo)));
 			SetConverter(typeof(DateTime),       (sb,_,_,v) => BuildDateTime(sb, (DateTime)v));
-			SetConverter(typeof(DateTimeOffset), (sb,_,_,v) => BuildDateTime(sb, ((DateTimeOffset)v).DateTime));
 			SetConverter(typeof(string),         (sb,_,_,v) => BuildString  (sb, (string)v));
 			SetConverter(typeof(Guid),           (sb,_,_,v) => sb.Append('\'').Append(((Guid)v).ToString()).Append('\''));
 

--- a/Source/LinqToDB/Mapping/ValueToSqlConverter.cs
+++ b/Source/LinqToDB/Mapping/ValueToSqlConverter.cs
@@ -39,22 +39,22 @@ namespace LinqToDB.Mapping
 
 		internal void SetDefaults()
 		{
-			SetConverter(typeof(bool),           (sb,_,_,v) => sb.Append((bool)      v ? '1' : '0'));
-			SetConverter(typeof(char),           (sb,_,_,v) => BuildChar(sb, (char)  v));
-			SetConverter(typeof(sbyte),          (sb,_,_,v) => sb.Append(((sbyte)    v).ToString(NumberFormatInfo.InvariantInfo)));
-			SetConverter(typeof(byte),           (sb,_,_,v) => sb.Append(((byte)     v).ToString(NumberFormatInfo.InvariantInfo)));
-			SetConverter(typeof(short),          (sb,_,_,v) => sb.Append(((short)    v).ToString(NumberFormatInfo.InvariantInfo)));
-			SetConverter(typeof(ushort),         (sb,_,_,v) => sb.Append(((ushort)   v).ToString(NumberFormatInfo.InvariantInfo)));
-			SetConverter(typeof(int),            (sb,_,_,v) => sb.Append(((int)      v).ToString(NumberFormatInfo.InvariantInfo)));
-			SetConverter(typeof(uint),           (sb,_,_,v) => sb.Append(((uint)     v).ToString(NumberFormatInfo.InvariantInfo)));
-			SetConverter(typeof(long),           (sb,_,_,v) => sb.Append(((long)     v).ToString(NumberFormatInfo.InvariantInfo)));
-			SetConverter(typeof(ulong),          (sb,_,_,v) => sb.Append(((ulong)    v).ToString(NumberFormatInfo.InvariantInfo)));
-			SetConverter(typeof(float),          (sb,_,_,v) => sb.Append(((float)    v).ToString("G9", _numberFormatInfo)));
-			SetConverter(typeof(double),         (sb,_,_,v) => sb.Append(((double)   v).ToString("G17", _numberFormatInfo)));
-			SetConverter(typeof(decimal),        (sb,_,_,v) => sb.Append(((decimal)  v).ToString(_numberFormatInfo)));
-			SetConverter(typeof(DateTime),       (sb,_,_,v) => BuildDateTime(sb, (DateTime)v));
-			SetConverter(typeof(string),         (sb,_,_,v) => BuildString  (sb, (string)v));
-			SetConverter(typeof(Guid),           (sb,_,_,v) => sb.Append('\'').Append(((Guid)v).ToString()).Append('\''));
+			SetConverter(typeof(bool),       (sb,_,_,v) => sb.Append((bool)      v ? '1' : '0'));
+			SetConverter(typeof(char),       (sb,_,_,v) => BuildChar(sb, (char)  v));
+			SetConverter(typeof(sbyte),      (sb,_,_,v) => sb.Append(((sbyte)    v).ToString(NumberFormatInfo.InvariantInfo)));
+			SetConverter(typeof(byte),       (sb,_,_,v) => sb.Append(((byte)     v).ToString(NumberFormatInfo.InvariantInfo)));
+			SetConverter(typeof(short),      (sb,_,_,v) => sb.Append(((short)    v).ToString(NumberFormatInfo.InvariantInfo)));
+			SetConverter(typeof(ushort),     (sb,_,_,v) => sb.Append(((ushort)   v).ToString(NumberFormatInfo.InvariantInfo)));
+			SetConverter(typeof(int),        (sb,_,_,v) => sb.Append(((int)      v).ToString(NumberFormatInfo.InvariantInfo)));
+			SetConverter(typeof(uint),       (sb,_,_,v) => sb.Append(((uint)     v).ToString(NumberFormatInfo.InvariantInfo)));
+			SetConverter(typeof(long),       (sb,_,_,v) => sb.Append(((long)     v).ToString(NumberFormatInfo.InvariantInfo)));
+			SetConverter(typeof(ulong),      (sb,_,_,v) => sb.Append(((ulong)    v).ToString(NumberFormatInfo.InvariantInfo)));
+			SetConverter(typeof(float),      (sb,_,_,v) => sb.Append(((float)    v).ToString("G9", _numberFormatInfo)));
+			SetConverter(typeof(double),     (sb,_,_,v) => sb.Append(((double)   v).ToString("G17", _numberFormatInfo)));
+			SetConverter(typeof(decimal),    (sb,_,_,v) => sb.Append(((decimal)  v).ToString(_numberFormatInfo)));
+			SetConverter(typeof(DateTime),   (sb,_,_,v) => BuildDateTime(sb, (DateTime)v));
+			SetConverter(typeof(string),     (sb,_,_,v) => BuildString  (sb, (string)v));
+			SetConverter(typeof(Guid),       (sb,_,_,v) => sb.Append('\'').Append(((Guid)v).ToString()).Append('\''));
 
 			SetConverter(typeof(SqlBoolean), (sb,_,_,v) => sb.Append((SqlBoolean)v ? '1' : '0'));
 			SetConverter(typeof(SqlByte),    (sb,_,_,v) => sb.Append(((SqlByte)   v).ToString()));

--- a/Source/LinqToDB/Mapping/ValueToSqlConverter.cs
+++ b/Source/LinqToDB/Mapping/ValueToSqlConverter.cs
@@ -39,22 +39,23 @@ namespace LinqToDB.Mapping
 
 		internal void SetDefaults()
 		{
-			SetConverter(typeof(bool),       (sb,_,_,v) => sb.Append((bool)      v ? '1' : '0'));
-			SetConverter(typeof(char),       (sb,_,_,v) => BuildChar(sb, (char)  v));
-			SetConverter(typeof(sbyte),      (sb,_,_,v) => sb.Append(((sbyte)    v).ToString(NumberFormatInfo.InvariantInfo)));
-			SetConverter(typeof(byte),       (sb,_,_,v) => sb.Append(((byte)     v).ToString(NumberFormatInfo.InvariantInfo)));
-			SetConverter(typeof(short),      (sb,_,_,v) => sb.Append(((short)    v).ToString(NumberFormatInfo.InvariantInfo)));
-			SetConverter(typeof(ushort),     (sb,_,_,v) => sb.Append(((ushort)   v).ToString(NumberFormatInfo.InvariantInfo)));
-			SetConverter(typeof(int),        (sb,_,_,v) => sb.Append(((int)      v).ToString(NumberFormatInfo.InvariantInfo)));
-			SetConverter(typeof(uint),       (sb,_,_,v) => sb.Append(((uint)     v).ToString(NumberFormatInfo.InvariantInfo)));
-			SetConverter(typeof(long),       (sb,_,_,v) => sb.Append(((long)     v).ToString(NumberFormatInfo.InvariantInfo)));
-			SetConverter(typeof(ulong),      (sb,_,_,v) => sb.Append(((ulong)    v).ToString(NumberFormatInfo.InvariantInfo)));
-			SetConverter(typeof(float),      (sb,_,_,v) => sb.Append(((float)    v).ToString("G9", _numberFormatInfo)));
-			SetConverter(typeof(double),     (sb,_,_,v) => sb.Append(((double)   v).ToString("G17", _numberFormatInfo)));
-			SetConverter(typeof(decimal),    (sb,_,_,v) => sb.Append(((decimal)  v).ToString(_numberFormatInfo)));
-			SetConverter(typeof(DateTime),   (sb,_,_,v) => BuildDateTime(sb, (DateTime)v));
-			SetConverter(typeof(string),     (sb,_,_,v) => BuildString  (sb, (string)v));
-			SetConverter(typeof(Guid),       (sb,_,_,v) => sb.Append('\'').Append(((Guid)v).ToString()).Append('\''));
+			SetConverter(typeof(bool),           (sb,_,_,v) => sb.Append((bool)      v ? '1' : '0'));
+			SetConverter(typeof(char),           (sb,_,_,v) => BuildChar(sb, (char)  v));
+			SetConverter(typeof(sbyte),          (sb,_,_,v) => sb.Append(((sbyte)    v).ToString(NumberFormatInfo.InvariantInfo)));
+			SetConverter(typeof(byte),           (sb,_,_,v) => sb.Append(((byte)     v).ToString(NumberFormatInfo.InvariantInfo)));
+			SetConverter(typeof(short),          (sb,_,_,v) => sb.Append(((short)    v).ToString(NumberFormatInfo.InvariantInfo)));
+			SetConverter(typeof(ushort),         (sb,_,_,v) => sb.Append(((ushort)   v).ToString(NumberFormatInfo.InvariantInfo)));
+			SetConverter(typeof(int),            (sb,_,_,v) => sb.Append(((int)      v).ToString(NumberFormatInfo.InvariantInfo)));
+			SetConverter(typeof(uint),           (sb,_,_,v) => sb.Append(((uint)     v).ToString(NumberFormatInfo.InvariantInfo)));
+			SetConverter(typeof(long),           (sb,_,_,v) => sb.Append(((long)     v).ToString(NumberFormatInfo.InvariantInfo)));
+			SetConverter(typeof(ulong),          (sb,_,_,v) => sb.Append(((ulong)    v).ToString(NumberFormatInfo.InvariantInfo)));
+			SetConverter(typeof(float),          (sb,_,_,v) => sb.Append(((float)    v).ToString("G9", _numberFormatInfo)));
+			SetConverter(typeof(double),         (sb,_,_,v) => sb.Append(((double)   v).ToString("G17", _numberFormatInfo)));
+			SetConverter(typeof(decimal),        (sb,_,_,v) => sb.Append(((decimal)  v).ToString(_numberFormatInfo)));
+			SetConverter(typeof(DateTime),       (sb,_,_,v) => BuildDateTime(sb, (DateTime)v));
+			SetConverter(typeof(DateTimeOffset), (sb,_,_,v) => BuildDateTime(sb, ((DateTimeOffset)v).DateTime));
+			SetConverter(typeof(string),         (sb,_,_,v) => BuildString  (sb, (string)v));
+			SetConverter(typeof(Guid),           (sb,_,_,v) => sb.Append('\'').Append(((Guid)v).ToString()).Append('\''));
 
 			SetConverter(typeof(SqlBoolean), (sb,_,_,v) => sb.Append((SqlBoolean)v ? '1' : '0'));
 			SetConverter(typeof(SqlByte),    (sb,_,_,v) => sb.Append(((SqlByte)   v).ToString()));

--- a/Source/LinqToDB/Sql/Sql.cs
+++ b/Source/LinqToDB/Sql/Sql.cs
@@ -1154,21 +1154,34 @@ namespace LinqToDB
 		#region DateTime Functions
 
 		/// <summary>
-		/// Returns current date and time. Alias for <see cref="DateTime.Now"/>.
+		/// Returns the current date and time on the database server.
+		/// Emits a provider-specific "now" expression: <c>CURRENT_TIMESTAMP</c> on most providers
+		/// (DB2, MySQL, Oracle, PostgreSQL, SAP HANA, SQL Server, SQLite, Firebird 4+);
+		/// <c>GetDate()</c> on Sybase and SQL CE; <c>Now</c> on Access; <c>CURRENT</c> on Informix;
+		/// <c>now()</c> on ClickHouse; <c>CurrentUtcTimestamp()</c> on YDB (note: returns UTC, not local);
+		/// <c>CURRENT TIMESTAMP WITH TIME ZONE</c> on DB2 z/OS.
+		/// When evaluated client-side, returns <see cref="DateTime.Now"/>.
 		/// </summary>
+		/// <returns>Current date and time as reported by the server (or <see cref="DateTime.Now"/> client-side).</returns>
 		public static DateTime GetDate() => DateTime.Now;
 
 		/// <summary>
-		/// Returns server timestamp.
+		/// Server-side-only equivalent of the ANSI SQL <c>CURRENT_TIMESTAMP</c> keyword.
+		/// Produces the same SQL as <see cref="GetDate"/> on every provider — see that member for the per-provider mapping.
+		/// Use <see cref="CurrentTimestamp2"/> for a dual-mode variant evaluable on the client,
+		/// or <see cref="CurrentTimestampUtc"/> for a UTC-specific variant.
 		/// </summary>
+		/// <exception cref="ServerSideOnlyException">Property is server-side-only.</exception>
 		[ServerSideOnly]
 		public static DateTime CurrentTimestamp => throw new ServerSideOnlyException(nameof(CurrentTimestamp));
 
 		public static DateTime CurrentTimestampUtc => DateTime.UtcNow;
 
 		/// <summary>
-		/// Returns client timestamp.
+		/// Dual-mode counterpart of <see cref="CurrentTimestamp"/>: emits the same server-side SQL but is also evaluable in-process.
+		/// When evaluated client-side, returns <see cref="DateTime.Now"/>.
 		/// </summary>
+		/// <returns>Current date and time as reported by the server (or <see cref="DateTime.Now"/> client-side).</returns>
 		public static DateTime CurrentTimestamp2 => DateTime.Now;
 
 		[Function(PN.SqlServer , "SYSDATETIMEOFFSET", ServerSideOnly = true, CanBeNull = false)]

--- a/Source/LinqToDB/Sql/Sql.cs
+++ b/Source/LinqToDB/Sql/Sql.cs
@@ -1158,11 +1158,17 @@ namespace LinqToDB
 			return DateTime.Now;
 		}
 
+		/// <summary>
+		/// Returns server timestamp.
+		/// </summary>
 		[ServerSideOnly]
 		public static DateTime CurrentTimestamp => throw new ServerSideOnlyException(nameof(CurrentTimestamp));
 
 		public static DateTime CurrentTimestampUtc => DateTime.UtcNow;
 
+		/// <summary>
+		/// Returns client timestamp.
+		/// </summary>
 		public static DateTime CurrentTimestamp2 => DateTime.Now;
 
 		[Function(PN.SqlServer , "SYSDATETIMEOFFSET", ServerSideOnly = true, CanBeNull = false)]

--- a/Source/LinqToDB/Sql/Sql.cs
+++ b/Source/LinqToDB/Sql/Sql.cs
@@ -1153,10 +1153,10 @@ namespace LinqToDB
 
 		#region DateTime Functions
 
-		public static DateTime GetDate()
-		{
-			return DateTime.Now;
-		}
+		/// <summary>
+		/// Returns current date and time. Alias for <see cref="DateTime.Now"/>.
+		/// </summary>
+		public static DateTime GetDate() => DateTime.Now;
 
 		/// <summary>
 		/// Returns server timestamp.

--- a/Tests/Linq/DataProvider/PostgreSQLTests.cs
+++ b/Tests/Linq/DataProvider/PostgreSQLTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Data.Linq;
@@ -3144,16 +3144,16 @@ $function$
 			Assert.That(db.LastQuery, Does.Contain("timezone('UTC', now())"));
 
 			_ = tb.Where(r => r.Timestamp == DateTimeOffset.UtcNow).ToList();
-			Assert.That(db.LastQuery, Does.Contain("timezone('UTC', now())"));
+			Assert.That(db.LastQuery, Does.Contain("now()"));
 
 			_ = tb.Where(r => r.TimestampN == DateTimeOffset.UtcNow).ToList();
-			Assert.That(db.LastQuery, Does.Contain("timezone('UTC', now())"));
+			Assert.That(db.LastQuery, Does.Contain("now()"));
 
 			_ = tb.Where(r => r.TimestampTZ == DateTimeOffset.UtcNow).ToList();
-			Assert.That(db.LastQuery, Does.Contain("timezone('UTC', now())"));
+			Assert.That(db.LastQuery, Does.Contain("now()"));
 
 			_ = tb.Where(r => r.TimestampTZN == DateTimeOffset.UtcNow).ToList();
-			Assert.That(db.LastQuery, Does.Contain("timezone('UTC', now())"));
+			Assert.That(db.LastQuery, Does.Contain("now()"));
 		}
 	}
 

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -77,7 +77,8 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 			{
 				var q = from p in db.Person where p.ID == 1 select new { Now = Sql.AsSql(Sql.GetDate()) };
-				Assert.That(q.ToList().First().Now.Year, Is.EqualTo(DateTime.Now.Year));
+				var sqlNow = q.First().Now;
+				Assert.That(sqlNow.Subtract(DateTime.Now).Duration().TotalMinutes, Is.LessThan(2));
 			}
 		}
 
@@ -88,7 +89,8 @@ namespace Tests.Linq
 			using (var db = GetDataContext(context))
 			{
 				var q = from p in db.Person where p.ID == 1 select new { Now = Sql.CurrentTimestamp };
-				Assert.That(q.ToList().First().Now.Year, Is.EqualTo(DateTime.Now.Year));
+				var sqlNow = q.First().Now;
+				Assert.That((sqlNow - DateTime.Now).Duration().TotalMinutes, Is.LessThan(2));
 			}
 		}
 
@@ -98,7 +100,7 @@ namespace Tests.Linq
 			var delta = Sql.CurrentTimestampUtc - DateTime.UtcNow;
 			using (Assert.EnterMultipleScope())
 			{
-				Assert.That(delta.Between(TimeSpan.FromSeconds(-1), TimeSpan.FromSeconds(1)), Is.True);
+				Assert.That(delta.Duration().TotalSeconds, Is.LessThan(2));
 				Assert.That(Sql.CurrentTimestampUtc.Kind, Is.EqualTo(DateTimeKind.Utc));
 			}
 		}
@@ -115,9 +117,9 @@ namespace Tests.Linq
 				var dbUtcNow = db.Select(() => Sql.CurrentTimestampUtc);
 
 				var now   = DateTime.UtcNow;
-				var delta = now - dbUtcNow;
+				var delta = (now - dbUtcNow).Duration();
 				Assert.That(
-					delta.Between(TimeSpan.FromSeconds(-120), TimeSpan.FromSeconds(120)), Is.True,
+					delta.TotalMinutes, Is.LessThan(2),
 					$"{now}, {dbUtcNow}, {delta}");
 
 				// we don't set kind and rely on provider's behavior
@@ -140,14 +142,57 @@ namespace Tests.Linq
 				var dbTzNow = db.Select(() => Sql.CurrentTzTimestamp);
 
 				var now   = DateTimeOffset.Now;
-				var delta = now - dbTzNow;
+				var delta = (now - dbTzNow).Duration();
 				Assert.That(
-					delta.Between(TimeSpan.FromSeconds(-120), TimeSpan.FromSeconds(120)), Is.True,
+					delta.TotalMinutes, Is.LessThan(2),
 					$"{now}, {dbTzNow}, {delta}");
 			}
 		}
 
-		[ActiveIssue("Test is broken")]
+		[Test]
+		public void DateTimeOffsetNow(
+			[IncludeDataSources(TestProvName.AllSqlServer2008Plus, TestProvName.AllOracle, TestProvName.AllPostgreSQL10Plus, TestProvName.AllClickHouse)]
+			string context)
+		{
+			using (new DisableBaseline("Server-side date generation test"))
+			using (var db = GetDataContext(context))
+			{
+				var dbTzNow = db.Select(() => DateTimeOffset.Now);
+
+				var now   = DateTimeOffset.Now;
+				var delta = (now - dbTzNow).Duration();
+				Assert.That(
+					delta.TotalMinutes, Is.LessThan(2),
+					$"{now}, {dbTzNow}, {delta}");
+				
+				// Postgres and ClickHouse don't store TZ offset in their native TIMESTAMP WITH TIME ZONE type
+				if (context.IsAnyOf(ProviderName.SqlServer, ProviderName.Oracle))
+					Assert.That(dbTzNow.Offset, Is.EqualTo(now.Offset));
+			}
+		}
+
+		[Test]
+		public void DateTimeOffsetNowUtc(
+			[IncludeDataSources(TestProvName.AllSqlServer2016Plus, TestProvName.AllOracle, TestProvName.AllPostgreSQL10Plus, TestProvName.AllClickHouse)]
+			string context)
+		{
+			using (new DisableBaseline("Server-side date generation test"))
+			using (var db = GetDataContext(context))
+			{
+				var dbTzNow = db.Select(() => DateTimeOffset.UtcNow);
+
+				var now   = DateTimeOffset.UtcNow;
+				var delta = (now - dbTzNow).Duration();
+				Assert.That(
+					delta.TotalMinutes, Is.LessThan(2),
+					$"{now}, {dbTzNow}, {delta}");
+
+				// Postgres and ClickHouse don't store TZ offset in their native TIMESTAMP WITH TIME ZONE type
+				if (context.IsAnyOf(ProviderName.SqlServer, ProviderName.Oracle))
+					Assert.That(dbTzNow.Offset, Is.EqualTo(TimeSpan.Zero));
+			}
+		}		
+
 		[Test]
 		public void CurrentTimestampUtcClientSideParameter(
 			[IncludeDataSources(true, TestProvName.AllFirebird, ProviderName.SqlCe)]
@@ -158,8 +203,8 @@ namespace Tests.Linq
 			{
 				var dbUtcNow = db.Select(() => Sql.CurrentTimestampUtc);
 
-				var delta = dbUtcNow - DateTime.UtcNow;
-				Assert.That(delta.Between(TimeSpan.FromSeconds(-5), TimeSpan.FromSeconds(5)), Is.True);
+				var delta = (dbUtcNow - DateTime.UtcNow).Duration();
+				Assert.That(delta.TotalSeconds, Is.LessThan(5));
 
 				// we don't set kind and rely on provider's behavior
 				// Most providers return Unspecified, but at least it shouldn't be Local
@@ -211,7 +256,8 @@ namespace Tests.Linq
 					where p.ID == 1 
 					select new { Now = Sql.AsSql(DateTime.Now) };
 
-				Assert.That(q.ToList().First().Now.Year, Is.EqualTo(DateTime.Now.Year));
+				var sqlNow = q.First().Now;
+				Assert.That((sqlNow - DateTime.Now).Duration().TotalMinutes, Is.LessThan(2));
 			}
 		}
 

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -164,7 +164,6 @@ namespace Tests.Linq
 				Assert.That(
 					delta.TotalMinutes, Is.LessThan(5),
 					$"{now}, {dbTzNow}, {delta}");
-				
 				// Postgres and ClickHouse don't store TZ offset in their native TIMESTAMP WITH TIME ZONE type
 				if (context.IsAnyOf(ProviderName.SqlServer, ProviderName.Oracle))
 					Assert.That(dbTzNow.Offset, Is.EqualTo(now.Offset));
@@ -191,7 +190,7 @@ namespace Tests.Linq
 				if (context.IsAnyOf(ProviderName.SqlServer, ProviderName.Oracle))
 					Assert.That(dbTzNow.Offset, Is.EqualTo(TimeSpan.Zero));
 			}
-		}		
+		}
 
 		[Test]
 		public void CurrentTimestampUtcClientSideParameter(

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -78,7 +78,7 @@ namespace Tests.Linq
 			{
 				var q = from p in db.Person where p.ID == 1 select new { Now = Sql.AsSql(Sql.GetDate()) };
 				var sqlNow = q.First().Now;
-				Assert.That(sqlNow.Subtract(DateTime.Now).Duration().TotalMinutes, Is.LessThan(2));
+				Assert.That(sqlNow.Subtract(DateTime.Now).Duration().TotalMinutes, Is.LessThan(5));
 			}
 		}
 
@@ -90,7 +90,7 @@ namespace Tests.Linq
 			{
 				var q = from p in db.Person where p.ID == 1 select new { Now = Sql.CurrentTimestamp };
 				var sqlNow = q.First().Now;
-				Assert.That((sqlNow - DateTime.Now).Duration().TotalMinutes, Is.LessThan(2));
+				Assert.That((sqlNow - DateTime.Now).Duration().TotalMinutes, Is.LessThan(5));
 			}
 		}
 
@@ -100,7 +100,7 @@ namespace Tests.Linq
 			var delta = Sql.CurrentTimestampUtc - DateTime.UtcNow;
 			using (Assert.EnterMultipleScope())
 			{
-				Assert.That(delta.Duration().TotalSeconds, Is.LessThan(2));
+				Assert.That(delta.Duration().TotalSeconds, Is.LessThan(5));
 				Assert.That(Sql.CurrentTimestampUtc.Kind, Is.EqualTo(DateTimeKind.Utc));
 			}
 		}
@@ -119,7 +119,7 @@ namespace Tests.Linq
 				var now   = DateTime.UtcNow;
 				var delta = (now - dbUtcNow).Duration();
 				Assert.That(
-					delta.TotalMinutes, Is.LessThan(2),
+					delta.TotalMinutes, Is.LessThan(5),
 					$"{now}, {dbUtcNow}, {delta}");
 
 				// we don't set kind and rely on provider's behavior
@@ -144,7 +144,7 @@ namespace Tests.Linq
 				var now   = DateTimeOffset.Now;
 				var delta = (now - dbTzNow).Duration();
 				Assert.That(
-					delta.TotalMinutes, Is.LessThan(2),
+					delta.TotalMinutes, Is.LessThan(5),
 					$"{now}, {dbTzNow}, {delta}");
 			}
 		}
@@ -162,7 +162,7 @@ namespace Tests.Linq
 				var now   = DateTimeOffset.Now;
 				var delta = (now - dbTzNow).Duration();
 				Assert.That(
-					delta.TotalMinutes, Is.LessThan(2),
+					delta.TotalMinutes, Is.LessThan(5),
 					$"{now}, {dbTzNow}, {delta}");
 				
 				// Postgres and ClickHouse don't store TZ offset in their native TIMESTAMP WITH TIME ZONE type
@@ -184,7 +184,7 @@ namespace Tests.Linq
 				var now   = DateTimeOffset.UtcNow;
 				var delta = (now - dbTzNow).Duration();
 				Assert.That(
-					delta.TotalMinutes, Is.LessThan(2),
+					delta.TotalMinutes, Is.LessThan(5),
 					$"{now}, {dbTzNow}, {delta}");
 
 				// Postgres and ClickHouse don't store TZ offset in their native TIMESTAMP WITH TIME ZONE type
@@ -255,7 +255,7 @@ namespace Tests.Linq
 					select new { Now = Sql.AsSql(DateTime.Now) };
 
 				var sqlNow = q.First().Now;
-				Assert.That((sqlNow - DateTime.Now).Duration().TotalMinutes, Is.LessThan(2));
+				Assert.That((sqlNow - DateTime.Now).Duration().TotalMinutes, Is.LessThan(5));
 			}
 		}
 

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -150,9 +150,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void DateTimeOffsetNow(
-			[IncludeDataSources(TestProvName.AllSqlServer2008Plus, TestProvName.AllOracle, TestProvName.AllPostgreSQL10Plus, TestProvName.AllClickHouse)]
-			string context)
+		public void DateTimeOffsetNow([DataSources] string context)
 		{
 			using (new DisableBaseline("Server-side date generation test"))
 			using (var db = GetDataContext(context))
@@ -164,16 +162,16 @@ namespace Tests.Linq
 				Assert.That(
 					delta.TotalMinutes, Is.LessThan(5),
 					$"{now}, {dbTzNow}, {delta}");
-				// Postgres and ClickHouse don't store TZ offset in their native TIMESTAMP WITH TIME ZONE type
-				if (context.IsAnyOf(ProviderName.SqlServer, ProviderName.Oracle))
+
+				// Postgres and ClickHouse normalize TIMESTAMP WITH TIME ZONE to UTC internally
+				// and don't preserve the original offset on read.
+				if (!context.IsAnyOf(TestProvName.AllPostgreSQL, TestProvName.AllClickHouse))
 					Assert.That(dbTzNow.Offset, Is.EqualTo(now.Offset));
 			}
 		}
 
 		[Test]
-		public void DateTimeOffsetNowUtc(
-			[IncludeDataSources(TestProvName.AllSqlServer2016Plus, TestProvName.AllOracle, TestProvName.AllPostgreSQL10Plus, TestProvName.AllClickHouse)]
-			string context)
+		public void DateTimeOffsetNowUtc([DataSources] string context)
 		{
 			using (new DisableBaseline("Server-side date generation test"))
 			using (var db = GetDataContext(context))
@@ -186,9 +184,7 @@ namespace Tests.Linq
 					delta.TotalMinutes, Is.LessThan(5),
 					$"{now}, {dbTzNow}, {delta}");
 
-				// Postgres and ClickHouse don't store TZ offset in their native TIMESTAMP WITH TIME ZONE type
-				if (context.IsAnyOf(ProviderName.SqlServer, ProviderName.Oracle))
-					Assert.That(dbTzNow.Offset, Is.EqualTo(TimeSpan.Zero));
+				Assert.That(dbTzNow.Offset, Is.EqualTo(TimeSpan.Zero));
 			}
 		}
 

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -206,12 +206,10 @@ namespace Tests.Linq
 				var delta = (dbUtcNow - DateTime.UtcNow).Duration();
 				Assert.That(delta.TotalSeconds, Is.LessThan(5));
 
-				// we don't set kind and rely on provider's behavior
-				// Most providers return Unspecified, but at least it shouldn't be Local
-				if (context.IsAnyOf(ProviderName.ClickHouseOctonica, ProviderName.ClickHouseDriver))
-					Assert.That(dbUtcNow.Kind, Is.EqualTo(DateTimeKind.Utc));
-				else
-					Assert.That(dbUtcNow.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+				// We don't set kind and rely on provider's behavior
+				// UTC is best/correct, most providers return Unspecified,
+				// but at least it shouldn't be Local.
+				Assert.That(dbUtcNow.Kind, Is.Not.EqualTo(DateTimeKind.Local));
 			}
 		}
 

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -79,10 +79,21 @@ namespace Tests.Linq
 				var q = from p in db.Person where p.ID == 1 select new { Now = Sql.AsSql(Sql.GetDate()) };
 				var sqlNow = q.First().Now;
 
-				var now = context.IsAnyOf(TestProvName.AllClickHouse, ProviderName.Ydb)
-					? DateTime.UtcNow
+				// Sql.GetDate() and Sql.CurrentTimestamp emit identical server-side SQL — keep this list aligned with CurrentTimestamp.
+				var now    = sqlNow.Kind is DateTimeKind.Utc
+						|| context.IsAnyOf(
+							TestProvName.AllSapHana,
+							ProviderName.ClickHouseMySql, ProviderName.ClickHouseDriver,
+							TestProvName.AllInformix,
+							TestProvName.AllDB2,
+							TestProvName.AllMySql,
+							TestProvName.AllSybase,
+							TestProvName.AllFirebirdLess4,
+							ProviderName.Ydb)
+					? DateTime.Now.ToUniversalTime()
 					: DateTime.Now;
-				Assert.That(sqlNow.Subtract(now).Duration().TotalMinutes, Is.LessThan(5));
+
+				Assert.That((sqlNow - now).Duration().TotalMinutes, Is.LessThan(5));
 			}
 		}
 
@@ -108,6 +119,35 @@ namespace Tests.Linq
 							TestProvName.AllMySql,
 							TestProvName.AllSybase,
 							TestProvName.AllFirebirdLess4)
+					? DateTime.Now.ToUniversalTime()
+					: DateTime.Now;
+
+				Assert.That((sqlNow - now).Duration().TotalMinutes, Is.LessThan(5));
+			}
+		}
+
+		[Test]
+		public void CurrentTimestamp2([DataSources] string context, [Values] bool inline)
+		{
+			using (new DisableBaseline("Server-side date generation test"))
+			using (var db = GetDataContext(context))
+			{
+				db.InlineParameters = inline;
+
+				var q      = from p in db.Person where p.ID == 1 select new { Now = Sql.CurrentTimestamp2 };
+				var sqlNow = q.First().Now;
+
+				// Sql.CurrentTimestamp2 emits the same server-side SQL as Sql.CurrentTimestamp — keep this list aligned.
+				var now    = sqlNow.Kind is DateTimeKind.Utc
+						|| context.IsAnyOf(
+							TestProvName.AllSapHana,
+							ProviderName.ClickHouseMySql, ProviderName.ClickHouseDriver,
+							TestProvName.AllInformix,
+							TestProvName.AllDB2,
+							TestProvName.AllMySql,
+							TestProvName.AllSybase,
+							TestProvName.AllFirebirdLess4,
+							ProviderName.Ydb)
 					? DateTime.Now.ToUniversalTime()
 					: DateTime.Now;
 
@@ -313,7 +353,6 @@ namespace Tests.Linq
 		[Test]
 		public void CurrentTimestamp2Update([DataSources] string context)
 		{
-			using var bs = new DisableBaseline("Current time in literals/parameters");
 			using var db = GetDataContext(context);
 
 			(

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -185,10 +185,12 @@ namespace Tests.Linq
 
 				// ClickHouse, PGSQL: session timezone used when set explicitly for connection
 				// MySql/MariaDB, YDB: returns UTC
+				// Oracle: Extract for TSTZ use UTC value
 				var returnsUtc = context.IsAnyOf(
 					TestProvName.AllPostgreSQL,
 					TestProvName.AllClickHouse,
 					TestProvName.AllMySql,
+					TestProvName.AllOracle,
 					ProviderName.Ydb);
 				var kind       = returnsUtc
 					? DateTimeKind.Utc
@@ -213,7 +215,8 @@ namespace Tests.Linq
 					$"{now}, {row.Full}");
 
 				// Offset preserved on TZ-aware-non-normalized providers
-				if (returnsUtc)
+				// Oracle: see above
+				if (returnsUtc && !context.IsAnyOf(TestProvName.AllOracle))
 					Assert.That(row.Full.Offset, Is.EqualTo(TimeSpan.Zero));
 				else
 					Assert.That(row.Full.Offset, Is.EqualTo(now.Offset));

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -114,7 +114,7 @@ namespace Tests.Linq
 			using (new DisableBaseline("Server-side date generation test"))
 			using (var db = GetDataContext(context))
 			{
-				var dbUtcNow = db.Select(() => Sql.CurrentTimestampUtc);
+				var dbUtcNow = db.Select(() => Sql.AsSql(Sql.CurrentTimestampUtc));
 
 				var now   = DateTime.UtcNow;
 				var delta = (now - dbUtcNow).Duration();
@@ -139,7 +139,7 @@ namespace Tests.Linq
 			using (new DisableBaseline("Server-side date generation test"))
 			using (var db = GetDataContext(context))
 			{
-				var dbTzNow = db.Select(() => Sql.CurrentTzTimestamp);
+				var dbTzNow = db.Select(() => Sql.AsSql(Sql.CurrentTzTimestamp));
 
 				var now   = DateTimeOffset.Now;
 				var delta = (now - dbTzNow).Duration();
@@ -155,7 +155,7 @@ namespace Tests.Linq
 			using (new DisableBaseline("Server-side date generation test"))
 			using (var db = GetDataContext(context))
 			{
-				var dbTzNow = db.Select(() => DateTimeOffset.Now);
+				var dbTzNow = db.Select(() => Sql.AsSql(DateTimeOffset.Now));
 
 				var now   = DateTimeOffset.Now;
 				var delta = (now - dbTzNow).Duration();
@@ -176,7 +176,7 @@ namespace Tests.Linq
 			using (new DisableBaseline("Server-side date generation test"))
 			using (var db = GetDataContext(context))
 			{
-				var dbTzNow = db.Select(() => DateTimeOffset.UtcNow);
+				var dbTzNow = db.Select(() => Sql.AsSql(DateTimeOffset.UtcNow));
 
 				var now   = DateTimeOffset.UtcNow;
 				var delta = (now - dbTzNow).Duration();
@@ -184,7 +184,9 @@ namespace Tests.Linq
 					delta.TotalMinutes, Is.LessThan(5),
 					$"{now}, {dbTzNow}, {delta}");
 
-				Assert.That(dbTzNow.Offset, Is.EqualTo(TimeSpan.Zero));
+				// SQL 2005 cannot return time with UTC timezone
+				if (!context.IsAnyOf(TestProvName.AllSqlServer2005))
+					Assert.That(dbTzNow.Offset, Is.EqualTo(TimeSpan.Zero));
 			}
 		}
 
@@ -196,7 +198,7 @@ namespace Tests.Linq
 			using (new DisableBaseline("Server-side date generation test"))
 			using (var db = GetDataContext(context))
 			{
-				var dbUtcNow = db.Select(() => Sql.CurrentTimestampUtc);
+				var dbUtcNow = db.Select(() => Sql.AsSql(Sql.CurrentTimestampUtc));
 
 				var delta = (dbUtcNow - DateTime.UtcNow).Duration();
 				Assert.That(delta.TotalSeconds, Is.LessThan(5));

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -78,7 +78,11 @@ namespace Tests.Linq
 			{
 				var q = from p in db.Person where p.ID == 1 select new { Now = Sql.AsSql(Sql.GetDate()) };
 				var sqlNow = q.First().Now;
-				Assert.That(sqlNow.Subtract(DateTime.Now).Duration().TotalMinutes, Is.LessThan(5));
+
+				var now = context.IsAnyOf(TestProvName.AllClickHouse)
+					? DateTime.UtcNow
+					: DateTime.Now;
+				Assert.That(sqlNow.Subtract(now).Duration().TotalMinutes, Is.LessThan(5));
 			}
 		}
 

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -79,7 +79,7 @@ namespace Tests.Linq
 				var q = from p in db.Person where p.ID == 1 select new { Now = Sql.AsSql(Sql.GetDate()) };
 				var sqlNow = q.First().Now;
 
-				var now = context.IsAnyOf(TestProvName.AllClickHouse)
+				var now = context.IsAnyOf(TestProvName.AllClickHouse, ProviderName.Ydb)
 					? DateTime.UtcNow
 					: DateTime.Now;
 				Assert.That(sqlNow.Subtract(now).Duration().TotalMinutes, Is.LessThan(5));
@@ -310,17 +310,18 @@ namespace Tests.Linq
 		[Test]
 		public void CurrentTimestamp2Update([DataSources] string context)
 		{
+			using var bs = new DisableBaseline("Current time in literals/parameters");
 			using var db = GetDataContext(context);
 
-				(
-					from p in db.Types where p.ID == 100000 select p
-				)
-				.Update(t => new LinqDataTypes
-				{
+			(
+				from p in db.Types where p.ID == 100000 select p
+			)
+			.Update(t => new LinqDataTypes
+			{
 				BoolValue = true,
 				DateTimeValue = Sql.CurrentTimestamp2,
-				});
-			}
+			});
+		}
 
 		[Test]
 		public void Now([DataSources] string context, [Values] bool inline)

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -83,14 +83,31 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void CurrentTimestamp([DataSources] string context)
+		public void CurrentTimestamp([DataSources] string context, [Values] bool inline)
 		{
 			using (new DisableBaseline("Server-side date generation test"))
 			using (var db = GetDataContext(context))
 			{
-				var q = from p in db.Person where p.ID == 1 select new { Now = Sql.CurrentTimestamp };
+				db.InlineParameters = inline;
+
+				var q      = from p in db.Person where p.ID == 1 select new { Now = Sql.CurrentTimestamp };
 				var sqlNow = q.First().Now;
-				Assert.That((sqlNow - DateTime.Now).Duration().TotalMinutes, Is.LessThan(5));
+
+				// Sybase, MySQL, MariaDB, DB2 LUW, INFORMIX, SAP HANA return UTC as it doesn't have timezone information
+				// ClickHouse returns UTC, but strangely works for Octonica
+				var now    = sqlNow.Kind is DateTimeKind.Utc
+						|| context.IsAnyOf(
+							TestProvName.AllSapHana,
+							ProviderName.ClickHouseMySql, ProviderName.ClickHouseDriver,
+							TestProvName.AllInformix,
+							TestProvName.AllDB2,
+							TestProvName.AllMySql,
+							TestProvName.AllSybase,
+							TestProvName.AllFirebirdLess4)
+					? DateTime.Now.ToUniversalTime()
+					: DateTime.Now;
+
+				Assert.That((sqlNow - now).Duration().TotalMinutes, Is.LessThan(5));
 			}
 		}
 
@@ -150,43 +167,104 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void DateTimeOffsetNow([DataSources] string context)
+		public void DateTimeOffsetNow([DataSources] string context, [Values] bool inline)
 		{
 			using (new DisableBaseline("Server-side date generation test"))
 			using (var db = GetDataContext(context))
 			{
-				var dbTzNow = db.Select(() => Sql.AsSql(DateTimeOffset.Now));
+				db.InlineParameters = inline;
 
-				var now   = DateTimeOffset.Now;
-				var delta = (now - dbTzNow).Duration();
+				var row = db.Person.Where(p => p.ID == 1)
+					.Select(_ => Sql.AsSql(DateTimeOffset.Now))
+					.Select(v => new { Full = v, v.Year, v.Month, v.Day, v.Hour, v.Minute, v.Second })
+					.First();
+
+				// ClickHouse, PGSQL: session timezone used when set explicitly for connection
+				// MySql/MariaDB, YDB: returns UTC
+				var returnsUtc = context.IsAnyOf(
+					TestProvName.AllPostgreSQL,
+					TestProvName.AllClickHouse,
+					TestProvName.AllMySql,
+					ProviderName.Ydb);
+				var kind       = returnsUtc
+					? DateTimeKind.Utc
+					: DateTimeKind.Local;
+
+				var dbParts = new DateTime(row.Year, row.Month, row.Day, row.Hour, row.Minute, row.Second, kind);
+				var now     = DateTimeOffset.Now;
+
+				// Component check — what the server actually generated, no ADO.NET TZ coercion.
+				// Most providers return local time + local offset → components match local wall-clock.
+				// Postgres / ClickHouse / Ydb normalize to UTC internally → components are UTC.
+				var expectedParts = returnsUtc ? DateTime.UtcNow : DateTime.Now;
+
 				Assert.That(
-					delta.TotalMinutes, Is.LessThan(5),
-					$"{now}, {dbTzNow}, {delta}");
+					(expectedParts - dbParts).Duration().TotalMinutes, Is.LessThan(5),
+					$"expected {expectedParts:O}, db parts {dbParts:O}");
 
-				// Postgres and ClickHouse normalize TIMESTAMP WITH TIME ZONE to UTC internally
-				// and don't preserve the original offset on read.
-				if (!context.IsAnyOf(TestProvName.AllPostgreSQL, TestProvName.AllClickHouse))
-					Assert.That(dbTzNow.Offset, Is.EqualTo(now.Offset));
+				// Round-trip instant matches on every provider — on plain-timestamp providers
+				// ADO.NET attaches the client's local offset, which equals the server's offset.
+				Assert.That(
+					(now - row.Full).Duration().TotalMinutes, Is.LessThan(5),
+					$"{now}, {row.Full}");
+
+				// Offset preserved on TZ-aware-non-normalized providers
+				if (returnsUtc)
+					Assert.That(row.Full.Offset, Is.EqualTo(TimeSpan.Zero));
+				else
+					Assert.That(row.Full.Offset, Is.EqualTo(now.Offset));
 			}
 		}
 
 		[Test]
-		public void DateTimeOffsetNowUtc([DataSources] string context)
+		public void DateTimeOffsetNowUtc([DataSources] string context, [Values] bool inline)
 		{
 			using (new DisableBaseline("Server-side date generation test"))
 			using (var db = GetDataContext(context))
 			{
-				var dbTzNow = db.Select(() => Sql.AsSql(DateTimeOffset.UtcNow));
+				db.InlineParameters = inline;
 
-				var now   = DateTimeOffset.UtcNow;
-				var delta = (now - dbTzNow).Duration();
+				var row = db.Person.Where(p => p.ID == 1)
+					.Select(_ => Sql.AsSql(DateTimeOffset.UtcNow))
+					.Select(v => new { Full = v, v.Year, v.Month, v.Day, v.Hour, v.Minute, v.Second })
+					.First();
+
+				var dbParts = new DateTime(row.Year, row.Month, row.Day, row.Hour, row.Minute, row.Second);
+				var nowUtc  = DateTime.UtcNow;
+				var now     = DateTimeOffset.UtcNow;
+
+				// Components are always UTC for UtcNow on every provider — authoritative correctness check.
 				Assert.That(
-					delta.TotalMinutes, Is.LessThan(5),
-					$"{now}, {dbTzNow}, {delta}");
+					(nowUtc - dbParts).Duration().TotalMinutes, Is.LessThan(5),
+					$"client UTC {nowUtc:O}, db parts {dbParts:O}");
 
-				// SQL 2005 cannot return time with UTC timezone
-				if (!context.IsAnyOf(TestProvName.AllSqlServer2005))
-					Assert.That(dbTzNow.Offset, Is.EqualTo(TimeSpan.Zero));
+				// Round-trip Full:
+				//   TZ-aware providers (offset 0 returned): full is the correct UTC instant.
+				//   Plain-timestamp providers (SQL CE, SQL Server 2005) cannot return a zero offset;
+				//   ADO.NET attaches the client's local offset to the UTC value, breaking the instant.
+				//   The wall-clock part of Full still holds the right UTC value — compare Full.DateTime.
+				if (context.IsAnyOf(
+					TestProvName.AllSqlServer2005,
+					ProviderName.SqlCe,
+					TestProvName.AllSapHana,
+					TestProvName.AllInformix,
+					TestProvName.AllDB2,
+					TestProvName.AllMySql,
+					TestProvName.AllSQLite,
+					TestProvName.AllAccess,
+					TestProvName.AllFirebirdLess4))
+				{
+					Assert.That(
+						(nowUtc - row.Full.DateTime).Duration().TotalMinutes, Is.LessThan(5),
+						$"client UTC {nowUtc:O}, db full.DateTime {row.Full.DateTime:O}");
+				}
+				else
+				{
+					Assert.That(
+						(now - row.Full).Duration().TotalMinutes, Is.LessThan(5),
+						$"{now}, {row.Full}");
+					Assert.That(row.Full.Offset, Is.EqualTo(TimeSpan.Zero));
+				}
 			}
 		}
 
@@ -241,18 +319,63 @@ namespace Tests.Linq
 			}
 
 		[Test]
-		public void Now([DataSources] string context)
+		public void Now([DataSources] string context, [Values] bool inline)
 		{
 			using (new DisableBaseline("Server-side date generation test"))
 			using (var db = GetDataContext(context))
 			{
-				var q = 
-					from p in db.Person 
-					where p.ID == 1 
-					select new { Now = Sql.AsSql(DateTime.Now) };
+				db.InlineParameters = inline;
 
-				var sqlNow = q.First().Now;
-				Assert.That((sqlNow - DateTime.Now).Duration().TotalMinutes, Is.LessThan(5));
+				var row = db.Person.Where(p => p.ID == 1)
+					.Select(_ => Sql.AsSql(DateTime.Now))
+					.Select(v => new { Full = v, v.Year, v.Month, v.Day, v.Hour, v.Minute, v.Second })
+					.First();
+
+				// ClickHouse: requires session time zone set otherwise returns in server timezone
+				// YDB: returns UTC
+				var isUtc = context.IsAnyOf(TestProvName.AllClickHouse, ProviderName.Ydb);
+				var kind  = isUtc ? DateTimeKind.Utc : DateTimeKind.Local;
+
+				var dbParts = new DateTime(row.Year, row.Month, row.Day, row.Hour, row.Minute, row.Second, kind);
+				var now     = isUtc ? DateTime.UtcNow : DateTime.Now;
+
+				// Server-side value correctness, no ADO.NET coercion in the path
+				Assert.That(
+					(now - dbParts).Duration().TotalMinutes, Is.LessThan(5),
+					$"client {now:O}, db parts {dbParts:O}");
+
+				// Round-tripped DateTime carries no offset, so it matches on every provider
+				Assert.That(
+					(now - row.Full).Duration().TotalMinutes, Is.LessThan(5),
+					$"client {now:O}, db full {row.Full:O}");
+			}
+		}
+
+		[Test]
+		public void UtcNow([DataSources] string context, [Values] bool inline)
+		{
+			using (new DisableBaseline("Server-side date generation test"))
+			using (var db = GetDataContext(context))
+			{
+				db.InlineParameters = inline;
+
+				var row = db.Person.Where(p => p.ID == 1)
+					.Select(_ => Sql.AsSql(DateTime.UtcNow))
+					.Select(v => new { Full = v, v.Year, v.Month, v.Day, v.Hour, v.Minute, v.Second })
+					.First();
+
+				var dbParts = new DateTime(row.Year, row.Month, row.Day, row.Hour, row.Minute, row.Second);
+				var now     = DateTime.UtcNow;
+
+				Assert.That(
+					(now - dbParts).Duration().TotalMinutes, Is.LessThan(5),
+					$"client {now:O}, db parts {dbParts:O}");
+
+				Assert.That(
+					(now - row.Full).Duration().TotalMinutes, Is.LessThan(5),
+					$"client {now:O}, db full {row.Full:O}");
+
+				Assert.That(row.Full.Kind, Is.Not.EqualTo(DateTimeKind.Local));
 			}
 		}
 

--- a/Tests/Linq/Linq/DateTimeOffsetTests.cs
+++ b/Tests/Linq/Linq/DateTimeOffsetTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Runtime.InteropServices;
 
@@ -107,7 +107,7 @@ namespace Tests.Linq
 			var data = new[]
 			{
 				new DateTimeOffsetTable { TransactionId = 1, TransactionDate = DateTimeOffset.MinValue },
-				new DateTimeOffsetTable { TransactionId = 2, TransactionDate = DateTimeOffset.MaxValue },
+				new DateTimeOffsetTable { TransactionId = 2, TransactionDate = DateTimeOffset.MaxValue.AddTicks(-9) },
 			};
 
 			using var db    = GetDataContext(context);

--- a/Tests/Linq/Linq/DateTimeOffsetTests.cs
+++ b/Tests/Linq/Linq/DateTimeOffsetTests.cs
@@ -107,6 +107,7 @@ namespace Tests.Linq
 			var data = new[]
 			{
 				new DateTimeOffsetTable { TransactionId = 1, TransactionDate = DateTimeOffset.MinValue },
+				// -9 to trim value to pgsql precision (6)
 				new DateTimeOffsetTable { TransactionId = 2, TransactionDate = DateTimeOffset.MaxValue.AddTicks(-9) },
 			};
 


### PR DESCRIPTION
Fixes #5436 

In RDBMS that support timestamps with time zone, and actually store the offset, we need 4 different translations to capture the nuances of `Now` and `UtcNow` in both `DateTime` and `DateTimeOffset` variations.

Most RDBMS don't support time zones so that doesn't change much in their provider code.
For compatibility with current releases, in those providers `DateTimeOffset.Now | UtcNow` do not throw an error but are "downgraded" into `DateTime.Now | UtcNow` expressions.

I improved current tests that were validating the server-side "now" generation by _only checking the year!_ It immediately showed me that SQLite `DateTime.Now` translation was incorrect (generated UTC time instead of local), which I fixed in this PR.
I added `DateTimeOffset.[Utc]Now` test coverage.

Let's see how other providers tests go 😏

## Follow-up commit

- Split `TranslateNow` into `TranslateNow` (client `DateTime.Now`) and `TranslateServerNow` (`Sql.CurrentTimestamp`) so providers can override per side; base now returns `null` instead of an error when client-side translation is unavailable.
- New `Firebird4MemberTranslator` and `DB2zOSMemberTranslator` overriding `TranslateServerNow` for `CURRENT_TIMESTAMP` / `CURRENT TIMESTAMP WITH TIME ZONE`; Firebird4 also overrides `TranslateUtcNow` with `AT TIME ZONE 'UTC'`.
- Per-provider `*MemberTranslator.cs` and `*MappingSchema.cs` updates for the new server-now hook and `DateTimeOffset` formatting.
- `ValueToSqlConverter` default for `DateTimeOffset` (downgrades to `DateTime` via `.DateTime`).
- `Sql.CurrentTimestamp` / `CurrentTimestamp2` get XML doc; `DateTimeFunctionsTests` expanded.
