### PR TITLE
Fix PostgreSQL array parameter query cache misses

### DIFF
--- a/Source/LinqToDB/Internal/DataProvider/PostgreSQL/NpgsqlProviderAdapter.cs
+++ b/Source/LinqToDB/Internal/DataProvider/PostgreSQL/NpgsqlProviderAdapter.cs
@@ -6,17 +6,16 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Net;
-using System.Net.NetworkInformation;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
-using LinqToDB;
 using LinqToDB.Common;
 using LinqToDB.Data;
 using LinqToDB.Expressions;
 using LinqToDB.Internal.Expressions;
 using LinqToDB.Internal.Expressions.Types;
+using LinqToDB.Internal.Extensions;
 using LinqToDB.Mapping;
 
 namespace LinqToDB.Internal.DataProvider.PostgreSQL
@@ -487,11 +486,15 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 					{
 						mappingSchema.AddScalarType(type, null, true, dataType);
 						mappingSchema.AddScalarType(type.MakeArrayType(), null, true, dataType | DataType.Array);
+						mappingSchema.AddScalarType(type.MakeListType(), null, true, dataType | DataType.Array);
+						mappingSchema.AddScalarType(type.MakeIReadOnlyListType(), null, true, dataType | DataType.Array);
 					}
 					else
 					{
 						mappingSchema.AddScalarType(type, dataType);
 						mappingSchema.AddScalarType(type.MakeArrayType(), dataType | DataType.Array);
+						mappingSchema.AddScalarType(type.MakeListType(), dataType | DataType.Array);
+						mappingSchema.AddScalarType(type.MakeIReadOnlyListType(), dataType | DataType.Array);
 					}
 				}
 			}

--- a/Source/LinqToDB/Internal/DataProvider/PostgreSQL/NpgsqlProviderAdapter.cs
+++ b/Source/LinqToDB/Internal/DataProvider/PostgreSQL/NpgsqlProviderAdapter.cs
@@ -275,18 +275,18 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 
 				// date/time types
 				if (npgsqlDateType != null)
-					AddUdtType(npgsqlDateType);
+					AddScalarType(npgsqlDateType);
 				if (npgsqlDateTimeType != null)
-					AddUdtType(npgsqlDateTimeType);
+					AddScalarType(npgsqlDateTimeType);
 				if (npgsqlTimeSpanType != null)
 				{
-					mappingSchema.AddScalarType(npgsqlTimeSpanType, DataType.Interval);
+					AddScalarType(npgsqlTimeSpanType, DataType.Interval);
 				}
 
 				Expression? npgsqlIntervalReader = null;
 				if (npgsqlIntervalType != null)
 				{
-					mappingSchema.AddScalarType(npgsqlIntervalType, DataType.Interval);
+					AddScalarType(npgsqlIntervalType, DataType.Interval);
 
 					var reader  = Expression.Parameter(typeof(DbDataReader));
 					var ordinal = Expression.Parameter(typeof(int));
@@ -321,9 +321,7 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 				}
 
 				// inet types
-				AddUdtType(npgsqlInetType);
-				AddUdtType(typeof(IPAddress));
-				AddUdtType(typeof(PhysicalAddress));
+				AddScalarType(npgsqlInetType);
 				// npgsql4 obsoletes NpgsqlInetType and returns ValueTuple<IPAddress, int>
 				// we should be able to map it properly
 				// Note that obsoletion was removed in v8
@@ -362,7 +360,7 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 				// Cidr was extracted from NpgsqlInet in Npgsql 8
 				if (npgsqlCidrType != null)
 				{
-					AddUdtType(npgsqlCidrType);
+					AddScalarType(npgsqlCidrType);
 
 					// (IPAddress, int) => NpgsqlCidr
 					var valueTypeType = Type.GetType("System.ValueTuple`2", false);
@@ -389,7 +387,7 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 				}
 
 				// ranges
-				AddUdtType(npgsqlRangeTType);
+				AddScalarType(npgsqlRangeTType);
 
 				// Range To Parameter conversons
 				{
@@ -431,16 +429,16 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 				}
 
 				// spatial types
-				AddUdtType(npgsqlPointType);
-				AddUdtType(npgsqlLSegType);
-				AddUdtType(npgsqlBoxType);
-				AddUdtType(npgsqlPathType);
-				AddUdtType(npgsqlCircleType);
-				AddUdtType(npgsqlPolygonType);
-				AddUdtType(npgsqlLineType);
+				AddScalarType(npgsqlPointType);
+				AddScalarType(npgsqlLSegType);
+				AddScalarType(npgsqlBoxType);
+				AddScalarType(npgsqlPathType);
+				AddScalarType(npgsqlCircleType);
+				AddScalarType(npgsqlPolygonType);
+				AddScalarType(npgsqlLineType);
 
 				if (npgsqlCubeType != null)
-					AddUdtType(npgsqlCubeType);
+					AddScalarType(npgsqlCubeType);
 
 				var connectionFactory = typeMapper.BuildTypedFactory<string, NpgsqlConnection, DbConnection>(connectionString => new NpgsqlConnection(connectionString));
 
@@ -483,13 +481,17 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 					beginBinaryImportAsync,
 					typeMapper.Wrap<NpgsqlConnection>);
 
-				void AddUdtType(Type type)
+				void AddScalarType(Type type, DataType dataType = DataType.Udt)
 				{
 					if (!type.IsValueType)
-						mappingSchema.AddScalarType(type, null, true, DataType.Udt);
+					{
+						mappingSchema.AddScalarType(type, null, true, dataType);
+						mappingSchema.AddScalarType(type.MakeArrayType(), null, true, dataType | DataType.Array);
+					}
 					else
 					{
-						mappingSchema.AddScalarType(type, DataType.Udt);
+						mappingSchema.AddScalarType(type, dataType);
+						mappingSchema.AddScalarType(type.MakeArrayType(), dataType | DataType.Array);
 					}
 				}
 			}

--- a/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
@@ -31,7 +31,7 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 		{
 			ColumnNameComparer = StringComparer.OrdinalIgnoreCase;
 
-			AddScalarType(typeof(IPAddress));
+			AddScalarType(typeof(IPAddress), DataType.Udt);
 			AddScalarType(typeof(PhysicalAddress), DataType.Udt);
 
 			SetValueToSqlConverter(typeof(bool),       (sb, _,_,v) => sb.Append((bool)v));
@@ -87,28 +87,28 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 			// PostgreSQL natively supports array types, so we register them as scalar
 			// to enable proper query cache key comparison (arrays use reference equality by default) and parameter detection.
 			// https://www.npgsql.org/doc/types/basic.html#read-mappings
-			AddScalarType(typeof(bool[]),           DataType.Array | DataType.Boolean);
-			AddScalarType(typeof(char[]),           DataType.Array | DataType.NChar);
-			AddScalarType(typeof(sbyte[]),          DataType.Array | DataType.Int16);
-			AddScalarType(typeof(short[]),          DataType.Array | DataType.Int16);
-			AddScalarType(typeof(int[]),            DataType.Array | DataType.Int32);
-			AddScalarType(typeof(uint[]),           DataType.Array | DataType.Int32);
-			AddScalarType(typeof(long[]),           DataType.Array | DataType.Int64);
-			AddScalarType(typeof(float[]),          DataType.Array | DataType.Single);
-			AddScalarType(typeof(double[]),         DataType.Array | DataType.Double);
-			AddScalarType(typeof(decimal[]),        DataType.Array | DataType.Decimal);
-			AddScalarType(typeof(string[]),         DataType.Array | DataType.NText);
-			AddScalarType(typeof(Guid[]),           DataType.Array | DataType.Guid);
-			AddScalarType(typeof(DateTime[]),       DataType.Array | DataType.DateTime);
-			AddScalarType(typeof(DateTimeOffset[]), DataType.Array | DataType.DateTimeOffset);
-			AddScalarType(typeof(TimeSpan[]),       DataType.Array | DataType.Time);
-			AddScalarType(typeof(BigInteger[]),     DataType.Array | DataType.VarNumeric);
-			AddScalarType(typeof(BitArray[]),       DataType.Array | DataType.BitArray);
-			AddScalarType(typeof(IPAddress),        DataType.Array | DataType.Udt);
-			AddScalarType(typeof(PhysicalAddress),  DataType.Array | DataType.Udt);
+			AddScalarType(typeof(bool[]),            DataType.Array | DataType.Boolean);
+			AddScalarType(typeof(char[]),            DataType.Array | DataType.NChar);
+			AddScalarType(typeof(sbyte[]),           DataType.Array | DataType.Int16);
+			AddScalarType(typeof(short[]),           DataType.Array | DataType.Int16);
+			AddScalarType(typeof(int[]),             DataType.Array | DataType.Int32);
+			AddScalarType(typeof(uint[]),            DataType.Array | DataType.Int32);
+			AddScalarType(typeof(long[]),            DataType.Array | DataType.Int64);
+			AddScalarType(typeof(float[]),           DataType.Array | DataType.Single);
+			AddScalarType(typeof(double[]),          DataType.Array | DataType.Double);
+			AddScalarType(typeof(decimal[]),         DataType.Array | DataType.Decimal);
+			AddScalarType(typeof(string[]),          DataType.Array | DataType.NText);
+			AddScalarType(typeof(Guid[]),            DataType.Array | DataType.Guid);
+			AddScalarType(typeof(DateTime[]),        DataType.Array | DataType.DateTime);
+			AddScalarType(typeof(DateTimeOffset[]),  DataType.Array | DataType.DateTimeOffset);
+			AddScalarType(typeof(TimeSpan[]),        DataType.Array | DataType.Time);
+			AddScalarType(typeof(BigInteger[]),      DataType.Array | DataType.VarNumeric);
+			AddScalarType(typeof(BitArray[]),        DataType.Array | DataType.BitArray);
+			AddScalarType(typeof(IPAddress[]),       DataType.Array | DataType.Udt);
+			AddScalarType(typeof(PhysicalAddress[]), DataType.Array | DataType.Udt);
 #if SUPPORTS_DATEONLY
-			AddScalarType(typeof(DateOnly[]),       DataType.Array | DataType.Date);
-			AddScalarType(typeof(TimeOnly[]),       DataType.Array | DataType.Time);
+			AddScalarType(typeof(DateOnly[]),        DataType.Array | DataType.Date);
+			AddScalarType(typeof(TimeOnly[]),        DataType.Array | DataType.Time);
 #endif
 		}
 

--- a/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Data.Linq;
 using System.Globalization;
 using System.Net;
@@ -30,6 +31,7 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 		{
 			ColumnNameComparer = StringComparer.OrdinalIgnoreCase;
 
+			AddScalarType(typeof(IPAddress));
 			AddScalarType(typeof(PhysicalAddress), DataType.Udt);
 
 			SetValueToSqlConverter(typeof(bool),       (sb, _,_,v) => sb.Append((bool)v));
@@ -83,11 +85,14 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 			SetConvertExpression<ulong , DataParameter>(value => new DataParameter(null, (decimal)value , DataType.Decimal) /*{ Precision = 20, Scale = 0 }*/);
 
 			// PostgreSQL natively supports array types, so we register them as scalar
-			// to enable proper query cache key comparison (arrays use reference equality by default).
+			// to enable proper query cache key comparison (arrays use reference equality by default) and parameter detection.
+			// https://www.npgsql.org/doc/types/basic.html#read-mappings
 			AddScalarType(typeof(bool[]),           DataType.Array | DataType.Boolean);
 			AddScalarType(typeof(char[]),           DataType.Array | DataType.NChar);
+			AddScalarType(typeof(sbyte[]),          DataType.Array | DataType.Int16);
 			AddScalarType(typeof(short[]),          DataType.Array | DataType.Int16);
 			AddScalarType(typeof(int[]),            DataType.Array | DataType.Int32);
+			AddScalarType(typeof(uint[]),           DataType.Array | DataType.Int32);
 			AddScalarType(typeof(long[]),           DataType.Array | DataType.Int64);
 			AddScalarType(typeof(float[]),          DataType.Array | DataType.Single);
 			AddScalarType(typeof(double[]),         DataType.Array | DataType.Double);
@@ -98,6 +103,9 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 			AddScalarType(typeof(DateTimeOffset[]), DataType.Array | DataType.DateTimeOffset);
 			AddScalarType(typeof(TimeSpan[]),       DataType.Array | DataType.Time);
 			AddScalarType(typeof(BigInteger[]),     DataType.Array | DataType.VarNumeric);
+			AddScalarType(typeof(BitArray[]),       DataType.Array | DataType.BitArray);
+			AddScalarType(typeof(IPAddress),        DataType.Array | DataType.Udt);
+			AddScalarType(typeof(PhysicalAddress),  DataType.Array | DataType.Udt);
 #if SUPPORTS_DATEONLY
 			AddScalarType(typeof(DateOnly[]),       DataType.Array | DataType.Date);
 			AddScalarType(typeof(TimeOnly[]),       DataType.Array | DataType.Time);

--- a/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
@@ -35,17 +35,17 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 			AddScalarType(typeof(IPAddress), DataType.Udt);
 			AddScalarType(typeof(PhysicalAddress), DataType.Udt);
 
-			SetValueToSqlConverter(typeof(bool), (sb, _, _, v) => sb.Append((bool)v));
-			SetValueToSqlConverter(typeof(string), (sb, _, _, v) => ConvertStringToSql(sb, (string)v));
-			SetValueToSqlConverter(typeof(char), (sb, _, _, v) => ConvertCharToSql(sb, (char)v));
-			SetValueToSqlConverter(typeof(byte[]), (sb, _, _, v) => ConvertBinaryToSql(sb, (byte[])v));
-			SetValueToSqlConverter(typeof(Binary), (sb, _, _, v) => ConvertBinaryToSql(sb, ((Binary)v).ToArray()));
-			SetValueToSqlConverter(typeof(Guid), (sb, _, _, v) => sb.AppendFormat(CultureInfo.InvariantCulture, "'{0:D}'::uuid", (Guid)v));
-			SetValueToSqlConverter(typeof(DateTime), (sb, dt, _, v) => BuildDateTime(sb, dt, (DateTime)v));
-			SetValueToSqlConverter(typeof(BigInteger), (sb, _, _, v) => sb.Append(((BigInteger)v).ToString(CultureInfo.InvariantCulture)));
+			SetValueToSqlConverter(typeof(bool),       (sb, _,_,v) => sb.Append((bool)v));
+			SetValueToSqlConverter(typeof(string),     (sb, _,_,v) => ConvertStringToSql(sb, (string)v));
+			SetValueToSqlConverter(typeof(char),       (sb, _,_,v) => ConvertCharToSql  (sb, (char)v));
+			SetValueToSqlConverter(typeof(byte[]),     (sb, _,_,v) => ConvertBinaryToSql(sb, (byte[])v));
+			SetValueToSqlConverter(typeof(Binary),     (sb, _,_,v) => ConvertBinaryToSql(sb, ((Binary)v).ToArray()));
+			SetValueToSqlConverter(typeof(Guid),       (sb, _,_,v) => sb.AppendFormat(CultureInfo.InvariantCulture, "'{0:D}'::uuid", (Guid)v));
+			SetValueToSqlConverter(typeof(DateTime),   (sb,dt,_,v) => BuildDateTime(sb, dt, (DateTime)v));
+			SetValueToSqlConverter(typeof(BigInteger), (sb, _,_,v) => sb.Append(((BigInteger)v).ToString(CultureInfo.InvariantCulture)));
 
 			// adds floating point special values support
-			SetValueToSqlConverter(typeof(float), (sb, _, _, v) =>
+			SetValueToSqlConverter(typeof(float) , (sb,_,_,v) =>
 			{
 				var f = (float)v;
 				var quote = float.IsNaN(f) || float.IsInfinity(f);
@@ -53,7 +53,7 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 				sb.AppendFormat(CultureInfo.InvariantCulture, "{0:G9}", f);
 				if (quote) sb.Append("'::float4");
 			});
-			SetValueToSqlConverter(typeof(double), (sb, _, _, v) =>
+			SetValueToSqlConverter(typeof(double), (sb,_,_,v) =>
 			{
 				var d = (double)v;
 				var quote = double.IsNaN(d) || double.IsInfinity(d);
@@ -62,11 +62,11 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 				if (quote) sb.Append("'::float8");
 			});
 
-			AddScalarType(typeof(string), DataType.Text);
-			AddScalarType(typeof(TimeSpan), DataType.Interval);
+			AddScalarType(typeof(string),    DataType.Text);
+			AddScalarType(typeof(TimeSpan),  DataType.Interval);
 
 #if SUPPORTS_DATEONLY
-			SetValueToSqlConverter(typeof(DateOnly), (sb, dt, _, v) => BuildDate(sb, dt, (DateOnly)v));
+			SetValueToSqlConverter(typeof(DateOnly), (sb,dt,_,v) => BuildDate(sb, dt, (DateOnly)v));
 
 			// backward compat:
 			// npgsql 10 returns TimeOnly instead of DateTime as before
@@ -76,14 +76,14 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 #endif
 
 			// npgsql doesn't support unsigned types except byte (and sbyte)
-			SetConvertExpression<ushort, DataParameter>(value => new DataParameter(null, (int)value, DataType.Int32));
-			SetConvertExpression<uint, DataParameter>(value => new DataParameter(null, (long)value, DataType.Int64));
+			SetConvertExpression<ushort , DataParameter>(value => new DataParameter(null, (int  )value, DataType.Int32));
+			SetConvertExpression<uint   , DataParameter>(value => new DataParameter(null, (long )value, DataType.Int64));
 
 			var ulongType = new SqlDataType(DataType.Decimal, typeof(ulong), 20, 0);
 			// set type for proper SQL type generation
-			AddScalarType(typeof(ulong), ulongType);
+			AddScalarType(typeof(ulong ), ulongType);
 
-			SetConvertExpression<ulong, DataParameter>(value => new DataParameter(null, (decimal)value, DataType.Decimal) /*{ Precision = 20, Scale = 0 }*/);
+			SetConvertExpression<ulong , DataParameter>(value => new DataParameter(null, (decimal)value , DataType.Decimal) /*{ Precision = 20, Scale = 0 }*/);
 
 			// PostgreSQL natively supports array types, so we register them as scalar
 			// to enable proper query cache key comparison (arrays use reference equality by default) and parameter detection.

--- a/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Data.Linq;
 using System.Globalization;
 using System.Net;
@@ -73,6 +74,9 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 			SetConvertExpression<TimeOnly, DateTime>(value => new DateTime(default, value), conversionType: ConversionType.FromDatabase);
 
 			AddScalarType(typeof(IPNetwork), new SqlDataType(new DbDataType(typeof(IPNetwork), DataType.Undefined, "cidr")));
+			AddScalarType(typeof(IPNetwork[]), new SqlDataType(new DbDataType(typeof(IPNetwork[]), DataType.Array, "cidr[]")));
+			AddScalarType(typeof(List<IPNetwork>), new SqlDataType(new DbDataType(typeof(List<IPNetwork>), DataType.Array, "cidr[]")));
+			AddScalarType(typeof(IReadOnlyList<IPNetwork>), new SqlDataType(new DbDataType(typeof(IReadOnlyList<IPNetwork>), DataType.Array, "cidr[]")));
 #endif
 
 			// npgsql doesn't support unsigned types except byte (and sbyte)
@@ -82,6 +86,9 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 			var ulongType = new SqlDataType(DataType.Decimal, typeof(ulong), 20, 0);
 			// set type for proper SQL type generation
 			AddScalarType(typeof(ulong ), ulongType);
+			AddScalarType(typeof(ulong[]), new SqlDataType(DataType.Decimal | DataType.Array, typeof(ulong[]), 20, 0));
+			AddScalarType(typeof(List<ulong>), new SqlDataType(DataType.Decimal | DataType.Array, typeof(List<ulong>), 20, 0));
+			AddScalarType(typeof(IReadOnlyList<ulong>), new SqlDataType(DataType.Decimal | DataType.Array, typeof(IReadOnlyList<ulong>), 20, 0));
 
 			SetConvertExpression<ulong , DataParameter>(value => new DataParameter(null, (decimal)value , DataType.Decimal) /*{ Precision = 20, Scale = 0 }*/);
 
@@ -93,16 +100,16 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 			AddScalarArray(typeof(sbyte),           DataType.Int16);
 			AddScalarArray(typeof(short),           DataType.Int16);
 			AddScalarArray(typeof(int),             DataType.Int32);
-			AddScalarArray(typeof(uint),            DataType.Int32);
+			AddScalarArray(typeof(uint),            DataType.UInt32);
 			AddScalarArray(typeof(long),            DataType.Int64);
 			AddScalarArray(typeof(float),           DataType.Single);
 			AddScalarArray(typeof(double),          DataType.Double);
 			AddScalarArray(typeof(decimal),         DataType.Decimal);
-			AddScalarArray(typeof(string),          DataType.NText);
+			AddScalarArray(typeof(string),          DataType.Text);
 			AddScalarArray(typeof(Guid),            DataType.Guid);
 			AddScalarArray(typeof(DateTime),        DataType.DateTime);
 			AddScalarArray(typeof(DateTimeOffset),  DataType.DateTimeOffset);
-			AddScalarArray(typeof(TimeSpan),        DataType.Time);
+			AddScalarArray(typeof(TimeSpan),        DataType.Interval);
 			AddScalarArray(typeof(BigInteger),      DataType.VarNumeric);
 			AddScalarArray(typeof(BitArray),        DataType.BitArray);
 			AddScalarArray(typeof(IPAddress),       DataType.Udt);

--- a/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
@@ -81,6 +81,27 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 			AddScalarType(typeof(ulong ), ulongType);
 
 			SetConvertExpression<ulong , DataParameter>(value => new DataParameter(null, (decimal)value , DataType.Decimal) /*{ Precision = 20, Scale = 0 }*/);
+
+			// PostgreSQL natively supports array types, so we register them as scalar
+			// to enable proper query cache key comparison (arrays use reference equality by default).
+			AddScalarType(typeof(bool[]),           DataType.Array | DataType.Boolean);
+			AddScalarType(typeof(char[]),           DataType.Array | DataType.NChar);
+			AddScalarType(typeof(short[]),          DataType.Array | DataType.Int16);
+			AddScalarType(typeof(int[]),            DataType.Array | DataType.Int32);
+			AddScalarType(typeof(long[]),           DataType.Array | DataType.Int64);
+			AddScalarType(typeof(float[]),          DataType.Array | DataType.Single);
+			AddScalarType(typeof(double[]),         DataType.Array | DataType.Double);
+			AddScalarType(typeof(decimal[]),        DataType.Array | DataType.Decimal);
+			AddScalarType(typeof(string[]),         DataType.Array | DataType.NText);
+			AddScalarType(typeof(Guid[]),           DataType.Array | DataType.Guid);
+			AddScalarType(typeof(DateTime[]),       DataType.Array | DataType.DateTime);
+			AddScalarType(typeof(DateTimeOffset[]), DataType.Array | DataType.DateTimeOffset);
+			AddScalarType(typeof(TimeSpan[]),       DataType.Array | DataType.Time);
+			AddScalarType(typeof(BigInteger[]),     DataType.Array | DataType.VarNumeric);
+#if SUPPORTS_DATEONLY
+			AddScalarType(typeof(DateOnly[]),       DataType.Array | DataType.Date);
+			AddScalarType(typeof(TimeOnly[]),       DataType.Array | DataType.Time);
+#endif
 		}
 
 		static void BuildDateTime(StringBuilder stringBuilder, SqlDataType dt, DateTime value)

--- a/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLMappingSchema.cs
@@ -9,6 +9,7 @@ using System.Text;
 
 using LinqToDB.Data;
 using LinqToDB.Internal.Common;
+using LinqToDB.Internal.Extensions;
 using LinqToDB.Internal.Mapping;
 using LinqToDB.Mapping;
 using LinqToDB.SqlQuery;
@@ -34,17 +35,17 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 			AddScalarType(typeof(IPAddress), DataType.Udt);
 			AddScalarType(typeof(PhysicalAddress), DataType.Udt);
 
-			SetValueToSqlConverter(typeof(bool),       (sb, _,_,v) => sb.Append((bool)v));
-			SetValueToSqlConverter(typeof(string),     (sb, _,_,v) => ConvertStringToSql(sb, (string)v));
-			SetValueToSqlConverter(typeof(char),       (sb, _,_,v) => ConvertCharToSql  (sb, (char)v));
-			SetValueToSqlConverter(typeof(byte[]),     (sb, _,_,v) => ConvertBinaryToSql(sb, (byte[])v));
-			SetValueToSqlConverter(typeof(Binary),     (sb, _,_,v) => ConvertBinaryToSql(sb, ((Binary)v).ToArray()));
-			SetValueToSqlConverter(typeof(Guid),       (sb, _,_,v) => sb.AppendFormat(CultureInfo.InvariantCulture, "'{0:D}'::uuid", (Guid)v));
-			SetValueToSqlConverter(typeof(DateTime),   (sb,dt,_,v) => BuildDateTime(sb, dt, (DateTime)v));
-			SetValueToSqlConverter(typeof(BigInteger), (sb, _,_,v) => sb.Append(((BigInteger)v).ToString(CultureInfo.InvariantCulture)));
+			SetValueToSqlConverter(typeof(bool), (sb, _, _, v) => sb.Append((bool)v));
+			SetValueToSqlConverter(typeof(string), (sb, _, _, v) => ConvertStringToSql(sb, (string)v));
+			SetValueToSqlConverter(typeof(char), (sb, _, _, v) => ConvertCharToSql(sb, (char)v));
+			SetValueToSqlConverter(typeof(byte[]), (sb, _, _, v) => ConvertBinaryToSql(sb, (byte[])v));
+			SetValueToSqlConverter(typeof(Binary), (sb, _, _, v) => ConvertBinaryToSql(sb, ((Binary)v).ToArray()));
+			SetValueToSqlConverter(typeof(Guid), (sb, _, _, v) => sb.AppendFormat(CultureInfo.InvariantCulture, "'{0:D}'::uuid", (Guid)v));
+			SetValueToSqlConverter(typeof(DateTime), (sb, dt, _, v) => BuildDateTime(sb, dt, (DateTime)v));
+			SetValueToSqlConverter(typeof(BigInteger), (sb, _, _, v) => sb.Append(((BigInteger)v).ToString(CultureInfo.InvariantCulture)));
 
 			// adds floating point special values support
-			SetValueToSqlConverter(typeof(float) , (sb,_,_,v) =>
+			SetValueToSqlConverter(typeof(float), (sb, _, _, v) =>
 			{
 				var f = (float)v;
 				var quote = float.IsNaN(f) || float.IsInfinity(f);
@@ -52,7 +53,7 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 				sb.AppendFormat(CultureInfo.InvariantCulture, "{0:G9}", f);
 				if (quote) sb.Append("'::float4");
 			});
-			SetValueToSqlConverter(typeof(double), (sb,_,_,v) =>
+			SetValueToSqlConverter(typeof(double), (sb, _, _, v) =>
 			{
 				var d = (double)v;
 				var quote = double.IsNaN(d) || double.IsInfinity(d);
@@ -61,11 +62,11 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 				if (quote) sb.Append("'::float8");
 			});
 
-			AddScalarType(typeof(string),    DataType.Text);
-			AddScalarType(typeof(TimeSpan),  DataType.Interval);
+			AddScalarType(typeof(string), DataType.Text);
+			AddScalarType(typeof(TimeSpan), DataType.Interval);
 
 #if SUPPORTS_DATEONLY
-			SetValueToSqlConverter(typeof(DateOnly), (sb,dt,_,v) => BuildDate(sb, dt, (DateOnly)v));
+			SetValueToSqlConverter(typeof(DateOnly), (sb, dt, _, v) => BuildDate(sb, dt, (DateOnly)v));
 
 			// backward compat:
 			// npgsql 10 returns TimeOnly instead of DateTime as before
@@ -75,41 +76,47 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 #endif
 
 			// npgsql doesn't support unsigned types except byte (and sbyte)
-			SetConvertExpression<ushort , DataParameter>(value => new DataParameter(null, (int  )value, DataType.Int32));
-			SetConvertExpression<uint   , DataParameter>(value => new DataParameter(null, (long )value, DataType.Int64));
+			SetConvertExpression<ushort, DataParameter>(value => new DataParameter(null, (int)value, DataType.Int32));
+			SetConvertExpression<uint, DataParameter>(value => new DataParameter(null, (long)value, DataType.Int64));
 
 			var ulongType = new SqlDataType(DataType.Decimal, typeof(ulong), 20, 0);
 			// set type for proper SQL type generation
-			AddScalarType(typeof(ulong ), ulongType);
+			AddScalarType(typeof(ulong), ulongType);
 
-			SetConvertExpression<ulong , DataParameter>(value => new DataParameter(null, (decimal)value , DataType.Decimal) /*{ Precision = 20, Scale = 0 }*/);
+			SetConvertExpression<ulong, DataParameter>(value => new DataParameter(null, (decimal)value, DataType.Decimal) /*{ Precision = 20, Scale = 0 }*/);
 
 			// PostgreSQL natively supports array types, so we register them as scalar
 			// to enable proper query cache key comparison (arrays use reference equality by default) and parameter detection.
 			// https://www.npgsql.org/doc/types/basic.html#read-mappings
-			AddScalarType(typeof(bool[]),            DataType.Array | DataType.Boolean);
-			AddScalarType(typeof(char[]),            DataType.Array | DataType.NChar);
-			AddScalarType(typeof(sbyte[]),           DataType.Array | DataType.Int16);
-			AddScalarType(typeof(short[]),           DataType.Array | DataType.Int16);
-			AddScalarType(typeof(int[]),             DataType.Array | DataType.Int32);
-			AddScalarType(typeof(uint[]),            DataType.Array | DataType.Int32);
-			AddScalarType(typeof(long[]),            DataType.Array | DataType.Int64);
-			AddScalarType(typeof(float[]),           DataType.Array | DataType.Single);
-			AddScalarType(typeof(double[]),          DataType.Array | DataType.Double);
-			AddScalarType(typeof(decimal[]),         DataType.Array | DataType.Decimal);
-			AddScalarType(typeof(string[]),          DataType.Array | DataType.NText);
-			AddScalarType(typeof(Guid[]),            DataType.Array | DataType.Guid);
-			AddScalarType(typeof(DateTime[]),        DataType.Array | DataType.DateTime);
-			AddScalarType(typeof(DateTimeOffset[]),  DataType.Array | DataType.DateTimeOffset);
-			AddScalarType(typeof(TimeSpan[]),        DataType.Array | DataType.Time);
-			AddScalarType(typeof(BigInteger[]),      DataType.Array | DataType.VarNumeric);
-			AddScalarType(typeof(BitArray[]),        DataType.Array | DataType.BitArray);
-			AddScalarType(typeof(IPAddress[]),       DataType.Array | DataType.Udt);
-			AddScalarType(typeof(PhysicalAddress[]), DataType.Array | DataType.Udt);
+			AddScalarArray(typeof(bool),            DataType.Boolean);
+			AddScalarArray(typeof(char),            DataType.NChar);
+			AddScalarArray(typeof(sbyte),           DataType.Int16);
+			AddScalarArray(typeof(short),           DataType.Int16);
+			AddScalarArray(typeof(int),             DataType.Int32);
+			AddScalarArray(typeof(uint),            DataType.Int32);
+			AddScalarArray(typeof(long),            DataType.Int64);
+			AddScalarArray(typeof(float),           DataType.Single);
+			AddScalarArray(typeof(double),          DataType.Double);
+			AddScalarArray(typeof(decimal),         DataType.Decimal);
+			AddScalarArray(typeof(string),          DataType.NText);
+			AddScalarArray(typeof(Guid),            DataType.Guid);
+			AddScalarArray(typeof(DateTime),        DataType.DateTime);
+			AddScalarArray(typeof(DateTimeOffset),  DataType.DateTimeOffset);
+			AddScalarArray(typeof(TimeSpan),        DataType.Time);
+			AddScalarArray(typeof(BigInteger),      DataType.VarNumeric);
+			AddScalarArray(typeof(BitArray),        DataType.BitArray);
+			AddScalarArray(typeof(IPAddress),       DataType.Udt);
+			AddScalarArray(typeof(PhysicalAddress), DataType.Udt);
 #if SUPPORTS_DATEONLY
-			AddScalarType(typeof(DateOnly[]),        DataType.Array | DataType.Date);
-			AddScalarType(typeof(TimeOnly[]),        DataType.Array | DataType.Time);
+			AddScalarArray(typeof(DateOnly),        DataType.Date);
+			AddScalarArray(typeof(TimeOnly),        DataType.Time);
 #endif
+			void AddScalarArray(Type type, DataType dataType)
+			{
+				AddScalarType(type.MakeArrayType(),         DataType.Array | dataType);
+				AddScalarType(type.MakeListType(),          DataType.Array | dataType);
+				AddScalarType(type.MakeIReadOnlyListType(), DataType.Array | dataType);
+			}
 		}
 
 		static void BuildDateTime(StringBuilder stringBuilder, SqlDataType dt, DateTime value)

--- a/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLSchemaProvider.cs
+++ b/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLSchemaProvider.cs
@@ -13,6 +13,7 @@ using LinqToDB;
 using LinqToDB.Common;
 using LinqToDB.Data;
 using LinqToDB.Internal.Common;
+using LinqToDB.Internal.Extensions;
 using LinqToDB.Internal.SchemaProvider;
 using LinqToDB.SchemaProvider;
 using LinqToDB.SqlQuery;
@@ -704,13 +705,13 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 				"tsrange"        or
 				"tstzrange"      => _provider.Adapter.NpgsqlRangeTType.MakeGenericType(typeof(DateTime)),
 
-				"int4multirange" => typeof(List<>).MakeGenericType(_provider.Adapter.NpgsqlRangeTType.MakeGenericType(typeof(int))),
-				"int8multirange" => typeof(List<>).MakeGenericType(_provider.Adapter.NpgsqlRangeTType.MakeGenericType(typeof(long))),
-				"nummultirange"  => typeof(List<>).MakeGenericType(_provider.Adapter.NpgsqlRangeTType.MakeGenericType(typeof(decimal))),
+				"int4multirange" => _provider.Adapter.NpgsqlRangeTType.MakeGenericType(typeof(int)).MakeListType(),
+				"int8multirange" => _provider.Adapter.NpgsqlRangeTType.MakeGenericType(typeof(long)).MakeListType(),
+				"nummultirange"  => _provider.Adapter.NpgsqlRangeTType.MakeGenericType(typeof(decimal)).MakeListType(),
 
 				"datemultirange" or
 				"tsmultirange"   or
-				"tstzmultirange" => typeof(List<>).MakeGenericType(_provider.Adapter.NpgsqlRangeTType.MakeGenericType(typeof(DateTime))),
+				"tstzmultirange" => _provider.Adapter.NpgsqlRangeTType.MakeGenericType(typeof(DateTime)).MakeListType(),
 
 				_ => foundType,
 			};

--- a/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLSqlBuilder.cs
+++ b/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLSqlBuilder.cs
@@ -61,7 +61,7 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 
 		protected override void BuildDataTypeFromDataType(DbDataType type, bool forCreateTable, bool canBeNull)
 		{
-			switch (type.DataType)
+			switch (type.DataType & ~DataType.Array)
 			{
 				case DataType.Decimal       :
 					StringBuilder.Append("decimal");
@@ -138,6 +138,9 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 
 				default                      : base.BuildDataTypeFromDataType(type, forCreateTable, canBeNull); break;
 			}
+
+			if (type.DataType.HasFlag(DataType.Array))
+				StringBuilder.Append("[]");
 		}
 
 		protected sealed override bool IsReserved(string word)

--- a/Source/LinqToDB/Internal/Expressions/InternalExtensions.cs
+++ b/Source/LinqToDB/Internal/Expressions/InternalExtensions.cs
@@ -18,46 +18,6 @@ namespace LinqToDB.Internal.Expressions
 {
 	static class InternalExtensions
 	{
-		#region IsConstant
-
-		public static bool IsConstantable(this Type type, bool includingArrays)
-		{
-			if (
-				type.IsEnum
-				|| type.TypeCode
-					is TypeCode.Int16
-					or TypeCode.Int32
-					or TypeCode.Int64
-					or TypeCode.UInt16
-					or TypeCode.UInt32
-					or TypeCode.UInt64
-					or TypeCode.SByte
-					or TypeCode.Byte
-					or TypeCode.Decimal
-					or TypeCode.Double
-					or TypeCode.Single
-					or TypeCode.Boolean
-					or TypeCode.String
-					or TypeCode.Char
-			)
-			{
-				return true;
-			}
-
-			if (type.IsNullableType)
-				return type.GetGenericArguments()[0].IsConstantable(includingArrays);
-
-			if (includingArrays && type.IsArray)
-				return type.GetElementType()!.IsConstantable(includingArrays);
-
-			if (type == typeof(Sql.SqlID))
-				return true;
-
-			return false;
-		}
-
-		#endregion
-
 		#region Path
 		public static void Path<TContext>(this Expression expr, Expression path, TContext context, Action<TContext, Expression, Expression> func)
 		{

--- a/Source/LinqToDB/Internal/Extensions/MappingExtensions.cs
+++ b/Source/LinqToDB/Internal/Extensions/MappingExtensions.cs
@@ -106,6 +106,9 @@ namespace LinqToDB.Internal.Extensions
 			return mappingSchema.GetAttribute<Sql.TableFunctionAttribute>(member.ReflectedType!, member);
 		}
 
+		/// <summary>
+		/// Returns <see langword="true" /> if <paramref name="type"/> is not registered in <paramref name="mappingSchema"/> as scalar type and implements <see cref="IEnumerable{T}"/>.
+		/// </summary>
 		public static bool IsCollectionType(this MappingSchema mappingSchema, Type type)
 		{
 			if (mappingSchema.IsScalarType(type))

--- a/Source/LinqToDB/Internal/Extensions/TypeExtensions.cs
+++ b/Source/LinqToDB/Internal/Extensions/TypeExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace LinqToDB.Internal.Extensions
 {
@@ -22,6 +23,16 @@ namespace LinqToDB.Internal.Extensions
 			/// </summary>
 			public bool IsMemoryExtensionsType => type == typeof(MemoryExtensions);
 #endif
+
+			/// <summary>
+			/// Returns <see cref="List{T}"/> type, where T is <paramref name="type"/>.
+			/// </summary>
+			public Type MakeListType() => typeof(List<>).MakeGenericType(type);
+
+			/// <summary>
+			/// Returns <see cref="IReadOnlyList{T}"/> type, where T is <paramref name="type"/>.
+			/// </summary>
+			public Type MakeIReadOnlyListType() => typeof(IReadOnlyList<>).MakeGenericType(type);
 		}
 	}
 }

--- a/Source/LinqToDB/Internal/Linq/Builder/EagerLoading.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/EagerLoading.cs
@@ -12,10 +12,13 @@ namespace LinqToDB.Internal.Linq.Builder
 		{
 			if (!mappingSchema.IsCollectionType(type))
 				return type;
+
 			if (type.IsArray)
 				return type.GetElementType()!;
+
 			if (typeof(IGrouping<,>).IsSameOrParentOf(type))
 				return type.GetGenericArguments()[1];
+
 			return type.GetGenericArguments()[0];
 		}
 	}

--- a/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -850,7 +850,8 @@ namespace LinqToDB.Internal.Linq.Builder
 				if (!forSearch)
 					return type.IsNullableOrReferenceType;
 
-				return MappingSchema.IsCollectionType(type);
+				return MappingSchema.IsCollectionType(type)
+					|| !MappingSchema.IsScalarType(type);
 			}
 
 			// Do not modify parameters

--- a/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -850,13 +850,7 @@ namespace LinqToDB.Internal.Linq.Builder
 				if (!forSearch)
 					return type.IsNullableOrReferenceType;
 
-				if (MappingSchema.IsCollectionType(type))
-					return true;
-
-				if (!MappingSchema.IsScalarType(type))
-					return true;
-
-				return false;
+				return MappingSchema.IsCollectionType(type);
 			}
 
 			// Do not modify parameters

--- a/Source/LinqToDB/Internal/Linq/Builder/LoadWithBuilder.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/LoadWithBuilder.cs
@@ -21,11 +21,14 @@ namespace LinqToDB.Internal.Linq.Builder
 		static void CheckFilterFunc(Type expectedType, Type filterType, MappingSchema mappingSchema)
 		{
 			var propType = expectedType;
+
 			if (mappingSchema.IsCollectionType(expectedType))
 				propType = EagerLoading.GetEnumerableElementType(expectedType, mappingSchema);
+
 			var itemType = typeof(Expression<>).IsSameOrParentOf(filterType) ?
 				filterType.GetGenericArguments()[0].GetGenericArguments()[0].GetGenericArguments()[0] :
 				filterType.GetGenericArguments()[0].GetGenericArguments()[0];
+
 			if (propType != itemType)
 				throw new LinqToDBException("Invalid filter function usage.");
 		}

--- a/Source/LinqToDB/Internal/Linq/Builder/ParametersContext.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/ParametersContext.cs
@@ -418,7 +418,7 @@ namespace LinqToDB.Internal.Linq.Builder
 
 		static bool HasDbMapping(MappingSchema mappingSchema, Type testedType, out LambdaExpression? convertExpr)
 		{
-			if (mappingSchema.IsScalarType(testedType))
+			if (mappingSchema.IsScalarType(testedType) && testedType != typeof(object))
 			{
 				convertExpr = null;
 				return true;

--- a/Source/LinqToDB/Internal/Linq/Builder/ParametersContext.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/ParametersContext.cs
@@ -418,7 +418,7 @@ namespace LinqToDB.Internal.Linq.Builder
 
 		static bool HasDbMapping(MappingSchema mappingSchema, Type testedType, out LambdaExpression? convertExpr)
 		{
-			if (mappingSchema.IsScalarType(testedType) && testedType != typeof(object))
+			if (mappingSchema.IsScalarType(testedType))
 			{
 				convertExpr = null;
 				return true;
@@ -440,13 +440,6 @@ namespace LinqToDB.Internal.Linq.Builder
 
 			if (notNullable != testedType)
 				return HasDbMapping(mappingSchema, notNullable, out convertExpr);
-
-			// TODO: Workaround, we need good TypeMapping approach
-			if (mappingSchema.IsCollectionType(testedType))
-			{
-				convertExpr = null;
-				return HasDbMapping(mappingSchema, EagerLoading.GetEnumerableElementType(testedType, mappingSchema), out _);
-			}
 
 			if (!testedType.IsEnum)
 				return false;

--- a/Source/LinqToDB/Internal/Linq/ExpressionCacheHelpers.cs
+++ b/Source/LinqToDB/Internal/Linq/ExpressionCacheHelpers.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq.Expressions;
 
-using LinqToDB.Internal.SqlQuery;
 using LinqToDB.Mapping;
 
 namespace LinqToDB.Internal.Linq
@@ -10,18 +9,14 @@ namespace LinqToDB.Internal.Linq
 	{
 		public static bool ShouldRemoveConstantFromCache(ConstantExpression node, MappingSchema mappingSchema)
 		{
-			if (!mappingSchema.IsScalarType(node.Type) && node.Value != null)
+			// EntityDescriptor: Handling UseTableDescriptor case.
+			if (node.Value is null or EntityDescriptor or FormattableString or RawSqlString)
+				return false;
+
+			if (!mappingSchema.IsScalarType(node.Type) &&
+				!mappingSchema.IsScalarType(node.Value.GetType()))
 			{
-				var valueType = node.Value.GetType();
-
-				// Handling UseTableDescriptor case.
-				if (valueType == typeof(EntityDescriptor))
-					return false;
-
-				if (!mappingSchema.IsScalarType(valueType))
-				{
-					return node.Value is not (Array or FormattableString or RawSqlString);
-				}
+				return node.Value is not Array;
 			}
 
 			return false;

--- a/Source/LinqToDB/Internal/Linq/Table{T}.cs
+++ b/Source/LinqToDB/Internal/Linq/Table{T}.cs
@@ -15,7 +15,7 @@ namespace LinqToDB.Internal.Linq
 	{
 		public Table(IDataContext dataContext)
 		{
-			var expression = dataContext.MappingSchema.IsScalarType(typeof(T))
+			var expression = dataContext.MappingSchema.IsScalarType(typeof(T)) && typeof(T) != typeof(object)
 				? null
 				: Expression.Call(Methods.LinqToDB.GetTable.MakeGenericMethod(typeof(T)),
 					SqlQueryRootExpression.Create(dataContext.MappingSchema, dataContext.GetType()));
@@ -34,7 +34,7 @@ namespace LinqToDB.Internal.Linq
 
 		internal Table(IDataContext dataContext, EntityDescriptor? tableDescriptor)
 		{
-			var expression = dataContext.MappingSchema.IsScalarType(typeof(T))
+			var expression = dataContext.MappingSchema.IsScalarType(typeof(T)) && typeof(T) != typeof(object)
 				? null
 				: Expression.Call(Methods.LinqToDB.GetTable.MakeGenericMethod(typeof(T)),
 					SqlQueryRootExpression.Create(dataContext.MappingSchema, dataContext.GetType()));

--- a/Source/LinqToDB/Internal/Linq/Table{T}.cs
+++ b/Source/LinqToDB/Internal/Linq/Table{T}.cs
@@ -15,7 +15,7 @@ namespace LinqToDB.Internal.Linq
 	{
 		public Table(IDataContext dataContext)
 		{
-			var expression = dataContext.MappingSchema.IsScalarType(typeof(T)) && typeof(T) != typeof(object)
+			var expression = dataContext.MappingSchema.IsScalarType(typeof(T))
 				? null
 				: Expression.Call(Methods.LinqToDB.GetTable.MakeGenericMethod(typeof(T)),
 					SqlQueryRootExpression.Create(dataContext.MappingSchema, dataContext.GetType()));
@@ -34,7 +34,7 @@ namespace LinqToDB.Internal.Linq
 
 		internal Table(IDataContext dataContext, EntityDescriptor? tableDescriptor)
 		{
-			var expression = dataContext.MappingSchema.IsScalarType(typeof(T)) && typeof(T) != typeof(object)
+			var expression = dataContext.MappingSchema.IsScalarType(typeof(T))
 				? null
 				: Expression.Call(Methods.LinqToDB.GetTable.MakeGenericMethod(typeof(T)),
 					SqlQueryRootExpression.Create(dataContext.MappingSchema, dataContext.GetType()));

--- a/Tests/Linq/DataProvider/PostgreSQLArrayTests.cs
+++ b/Tests/Linq/DataProvider/PostgreSQLArrayTests.cs
@@ -1,0 +1,257 @@
+﻿using System;
+using System.Linq;
+
+using LinqToDB;
+using LinqToDB.DataProvider.PostgreSQL;
+using LinqToDB.Mapping;
+
+using NUnit.Framework;
+
+using Shouldly;
+
+namespace Tests.DataProvider
+{
+	[TestFixture]
+	public class PostgreSQLArrayTests : TestBase
+	{
+		[Table]
+		sealed class AllTypesValueTable
+		{
+			[Column] public int      Id           { get; set; }
+			[Column] public int      IntValue     { get; set; }
+			[Column] public long     LongValue    { get; set; }
+			[Column] public double   DoubleValue  { get; set; }
+			[Column] public decimal  DecimalValue { get; set; }
+			[Column] public string   StrValue     { get; set; } = null!;
+			[Column] public bool     BoolValue    { get; set; }
+			[Column] public short    ShortValue   { get; set; }
+			[Column] public float    FloatValue   { get; set; }
+			[Column] public Guid     GuidValue    { get; set; }
+			[Column] public DateTime DateValue    { get; set; }
+
+			public static AllTypesValueTable[] Seed()
+			{
+				return
+				[
+					new() { Id = 1, IntValue = 10, LongValue = 100, DoubleValue = 1.1, DecimalValue = 1.1m, StrValue = "A", BoolValue = true,  ShortValue = 1, FloatValue = 1.1f, GuidValue = new Guid("00000001-0000-0000-0000-000000000000"), DateValue = new DateTime(2024, 1, 1) },
+					new() { Id = 2, IntValue = 20, LongValue = 200, DoubleValue = 2.2, DecimalValue = 2.2m, StrValue = "B", BoolValue = false, ShortValue = 2, FloatValue = 2.2f, GuidValue = new Guid("00000002-0000-0000-0000-000000000000"), DateValue = new DateTime(2024, 2, 1) },
+					new() { Id = 3, IntValue = 30, LongValue = 300, DoubleValue = 3.3, DecimalValue = 3.3m, StrValue = "C", BoolValue = true,  ShortValue = 3, FloatValue = 3.3f, GuidValue = new Guid("00000003-0000-0000-0000-000000000000"), DateValue = new DateTime(2024, 3, 1) },
+				];
+			}
+		}
+
+		[Test]
+		public void ArrayParameterCacheTest_Int([IncludeDataSources(TestProvName.AllPostgreSQL)] string context, [Values(1, 2)] int iteration)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(AllTypesValueTable.Seed());
+
+			var arr = iteration == 1 ? new[] { 10, 20 } : new[] { 30 };
+
+			var query  = table.Where(t => Sql.Ext.PostgreSQL().ValueIsEqualToAny(t.IntValue, arr));
+			var miss   = query.GetCacheMissCount();
+			var result = query.ToArray();
+
+			if (iteration == 1)
+				result.Length.ShouldBe(2);
+			else
+			{
+				query.GetCacheMissCount().ShouldBe(miss);
+				result.Length.ShouldBe(1);
+			}
+		}
+
+		[Test]
+		public void ArrayParameterCacheTest_Long([IncludeDataSources(TestProvName.AllPostgreSQL)] string context, [Values(1, 2)] int iteration)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(AllTypesValueTable.Seed());
+
+			var arr = iteration == 1 ? new[] { 100L, 200L } : new[] { 300L };
+
+			var query  = table.Where(t => Sql.Ext.PostgreSQL().ValueIsEqualToAny(t.LongValue, arr));
+			var miss   = query.GetCacheMissCount();
+			var result = query.ToArray();
+
+			if (iteration == 1)
+				result.Length.ShouldBe(2);
+			else
+			{
+				query.GetCacheMissCount().ShouldBe(miss);
+				result.Length.ShouldBe(1);
+			}
+		}
+
+		[Test]
+		public void ArrayParameterCacheTest_Short([IncludeDataSources(TestProvName.AllPostgreSQL)] string context, [Values(1, 2)] int iteration)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(AllTypesValueTable.Seed());
+
+			var arr = iteration == 1 ? new short[] { 1, 2 } : new short[] { 3 };
+
+			var query  = table.Where(t => Sql.Ext.PostgreSQL().ValueIsEqualToAny(t.ShortValue, arr));
+			var miss   = query.GetCacheMissCount();
+			var result = query.ToArray();
+
+			if (iteration == 1)
+				result.Length.ShouldBe(2);
+			else
+			{
+				query.GetCacheMissCount().ShouldBe(miss);
+				result.Length.ShouldBe(1);
+			}
+		}
+
+		[Test]
+		public void ArrayParameterCacheTest_String([IncludeDataSources(TestProvName.AllPostgreSQL)] string context, [Values(1, 2)] int iteration)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(AllTypesValueTable.Seed());
+
+			var arr = iteration == 1 ? new[] { "A", "B" } : new[] { "C" };
+
+			var query  = table.Where(t => Sql.Ext.PostgreSQL().ValueIsEqualToAny(t.StrValue, arr));
+			var miss   = query.GetCacheMissCount();
+			var result = query.ToArray();
+
+			if (iteration == 1)
+				result.Length.ShouldBe(2);
+			else
+			{
+				query.GetCacheMissCount().ShouldBe(miss);
+				result.Length.ShouldBe(1);
+			}
+		}
+
+		[Test]
+		public void ArrayParameterCacheTest_Double([IncludeDataSources(TestProvName.AllPostgreSQL)] string context, [Values(1, 2)] int iteration)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(AllTypesValueTable.Seed());
+
+			var arr = iteration == 1 ? new[] { 1.1, 2.2 } : new[] { 3.3 };
+
+			var query  = table.Where(t => Sql.Ext.PostgreSQL().ValueIsEqualToAny(t.DoubleValue, arr));
+			var miss   = query.GetCacheMissCount();
+			var result = query.ToArray();
+
+			if (iteration == 1)
+				result.Length.ShouldBe(2);
+			else
+			{
+				query.GetCacheMissCount().ShouldBe(miss);
+				result.Length.ShouldBe(1);
+			}
+		}
+
+		[Test]
+		public void ArrayParameterCacheTest_Decimal([IncludeDataSources(TestProvName.AllPostgreSQL)] string context, [Values(1, 2)] int iteration)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(AllTypesValueTable.Seed());
+
+			var arr = iteration == 1 ? new[] { 1.1m, 2.2m } : new[] { 3.3m };
+
+			var query  = table.Where(t => Sql.Ext.PostgreSQL().ValueIsEqualToAny(t.DecimalValue, arr));
+			var miss   = query.GetCacheMissCount();
+			var result = query.ToArray();
+
+			if (iteration == 1)
+				result.Length.ShouldBe(2);
+			else
+			{
+				query.GetCacheMissCount().ShouldBe(miss);
+				result.Length.ShouldBe(1);
+			}
+		}
+
+		[Test]
+		public void ArrayParameterCacheTest_Float([IncludeDataSources(TestProvName.AllPostgreSQL)] string context, [Values(1, 2)] int iteration)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(AllTypesValueTable.Seed());
+
+			var arr = iteration == 1 ? new[] { 1.1f, 2.2f } : new[] { 3.3f };
+
+			var query  = table.Where(t => Sql.Ext.PostgreSQL().ValueIsEqualToAny(t.FloatValue, arr));
+			var miss   = query.GetCacheMissCount();
+			var result = query.ToArray();
+
+			if (iteration == 1)
+				result.Length.ShouldBe(2);
+			else
+			{
+				query.GetCacheMissCount().ShouldBe(miss);
+				result.Length.ShouldBe(1);
+			}
+		}
+
+		[Test]
+		public void ArrayParameterCacheTest_Guid([IncludeDataSources(TestProvName.AllPostgreSQL)] string context, [Values(1, 2)] int iteration)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(AllTypesValueTable.Seed());
+
+			var arr = iteration == 1
+				? new[] { new Guid("00000001-0000-0000-0000-000000000000"), new Guid("00000002-0000-0000-0000-000000000000") }
+				: new[] { new Guid("00000003-0000-0000-0000-000000000000") };
+
+			var query  = table.Where(t => Sql.Ext.PostgreSQL().ValueIsEqualToAny(t.GuidValue, arr));
+			var miss   = query.GetCacheMissCount();
+			var result = query.ToArray();
+
+			if (iteration == 1)
+				result.Length.ShouldBe(2);
+			else
+			{
+				query.GetCacheMissCount().ShouldBe(miss);
+				result.Length.ShouldBe(1);
+			}
+		}
+
+		[Test]
+		public void ArrayParameterCacheTest_DateTime([IncludeDataSources(TestProvName.AllPostgreSQL)] string context, [Values(1, 2)] int iteration)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(AllTypesValueTable.Seed());
+
+			var arr = iteration == 1
+				? new[] { new DateTime(2024, 1, 1), new DateTime(2024, 2, 1) }
+				: new[] { new DateTime(2024, 3, 1) };
+
+			var query  = table.Where(t => Sql.Ext.PostgreSQL().ValueIsEqualToAny(t.DateValue, arr));
+			var miss   = query.GetCacheMissCount();
+			var result = query.ToArray();
+
+			if (iteration == 1)
+				result.Length.ShouldBe(2);
+			else
+			{
+				query.GetCacheMissCount().ShouldBe(miss);
+				result.Length.ShouldBe(1);
+			}
+		}
+
+		[Test]
+		public void ArrayParameterCacheTest_Bool([IncludeDataSources(TestProvName.AllPostgreSQL)] string context, [Values(1, 2)] int iteration)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(AllTypesValueTable.Seed());
+
+			var arr = iteration == 1 ? new[] { true } : new[] { false };
+
+			var query  = table.Where(t => Sql.Ext.PostgreSQL().ValueIsEqualToAny(t.BoolValue, arr));
+			var miss   = query.GetCacheMissCount();
+			var result = query.ToArray();
+
+			if (iteration == 1)
+				result.Length.ShouldBe(2);
+			else
+			{
+				query.GetCacheMissCount().ShouldBe(miss);
+				result.Length.ShouldBe(1);
+			}
+		}
+	}
+}

--- a/Tests/Linq/UserTests/Issue5302Tests.cs
+++ b/Tests/Linq/UserTests/Issue5302Tests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 
 using LinqToDB;
 using LinqToDB.DataProvider.PostgreSQL;

--- a/Tests/Linq/UserTests/Issue5302Tests.cs
+++ b/Tests/Linq/UserTests/Issue5302Tests.cs
@@ -1,0 +1,67 @@
+using System.Linq;
+
+using LinqToDB;
+using LinqToDB.DataProvider.PostgreSQL;
+using LinqToDB.Mapping;
+
+using NUnit.Framework;
+
+using Shouldly;
+
+namespace Tests.UserTests
+{
+	/// <summary>
+	/// Performance regression with query compilation — array parameters in Sql.Extension cause cache misses.
+	/// https://github.com/linq2db/linq2db/issues/5302
+	/// </summary>
+	[TestFixture]
+	public class Issue5302Tests : TestBase
+	{
+		[Table]
+		public class Warehouse
+		{
+			[Column, PrimaryKey] public int     Id                   { get; set; }
+			[Column            ] public int     ClearingWarehouseId  { get; set; }
+			[Column            ] public bool    IsActive             { get; set; }
+		}
+
+		/// <summary>
+		/// Reproduces the issue: query using ValueIsEqualToAny with array causes cache miss on every execution.
+		/// </summary>
+		[Test]
+		public void ValueIsEqualToAnyCacheTest([IncludeDataSources(TestProvName.AllPostgreSQL)] string context, [Values(1, 2)] int iteration)
+		{
+			var testData = new[]
+			{
+				new Warehouse { Id = 1, ClearingWarehouseId = 10, IsActive = true  },
+				new Warehouse { Id = 2, ClearingWarehouseId = 20, IsActive = true  },
+				new Warehouse { Id = 3, ClearingWarehouseId = 30, IsActive = false },
+			};
+
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(testData);
+
+			var isActive     = iteration == 1;
+			var warehouseIds = iteration == 1 ? new[] { 10, 20 } : new[] { 30 };
+
+			var query = table
+				.Where(w => w.IsActive == isActive)
+				.Where(w => Sql.Ext.PostgreSQL().ValueIsEqualToAny(w.ClearingWarehouseId, warehouseIds));
+
+			var cacheMiss = query.GetCacheMissCount();
+			var result    = query.ToArray();
+
+			if (iteration == 1)
+			{
+				result.Length.ShouldBe(2);
+				result.Select(r => r.Id).OrderBy(id => id).ToArray().ShouldBe(new[] { 1, 2 });
+			}
+			else
+			{
+				query.GetCacheMissCount().ShouldBe(cacheMiss);
+				result.Length.ShouldBe(1);
+				result[0].Id.ShouldBe(3);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #5302

Array parameters in `Sql.Extension` methods (e.g. `ValueIsEqualToAny`) caused query cache misses on every execution because arrays were compared by reference in the cache key comparison.

Register primitive array types as scalar in `PostgreSQLMappingSchema` so they are treated as normal parameters instead of going through `MarkAsValue` path.