### PR TITLE
Bump versions for 6.3.0 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,11 +1,11 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<!-- Update to next after release -->
-		<Version>6.2.1</Version>
-		<EF3Version>3.31.0</EF3Version>
-		<EF8Version>8.5.0</EF8Version>
-		<EF9Version>9.4.0</EF9Version>
-		<EF10Version>10.3.0</EF10Version>
+		<Version>6.3.0</Version>
+		<EF3Version>3.32.0</EF3Version>
+		<EF8Version>8.6.0</EF8Version>
+		<EF9Version>9.5.0</EF9Version>
+		<EF10Version>10.4.0</EF10Version>
 		
 		<!-- Baselines update on next major release -->
 		<BaselineVersion>6.0.0</BaselineVersion>


### PR DESCRIPTION
## Summary
Bump versions in `Directory.Build.props` to match the 6.3.0 milestone:

- `<Version>`: 6.2.1 → 6.3.0
- `<EF3Version>`: 3.31.0 → 3.32.0
- `<EF8Version>`: 8.5.0 → 8.6.0
- `<EF9Version>`: 9.4.0 → 9.5.0
- `<EF10Version>`: 10.3.0 → 10.4.0

## Test plan
- [ ] Full build succeeds
- [ ] Packages produced with version 6.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)