### PR TITLE
Fix PostgreSQL cache misses in Unnest/GenerateSeries/GenerateSubscripts and core FromSqlScalar

### DIFF
--- a/Source/LinqToDB/DataExtensions.cs
+++ b/Source/LinqToDB/DataExtensions.cs
@@ -1547,12 +1547,20 @@ namespace LinqToDB
 			ArgumentNullException.ThrowIfNull(dataContext);
 			ArgumentNullException.ThrowIfNull(sql);
 
+			var arguments = sql.GetArguments();
+			var methodInfo = MethodHelper.GetMethodInfo(System.Runtime.CompilerServices.FormattableStringFactory.Create,
+				sql.Format, arguments);
+			var argumentsExpr = GenerateArray(arguments);
+
+			var formattableStringExpr =
+				Expression.Call(null, methodInfo, Expression.Constant(sql.Format), argumentsExpr);
+
 			return new ExpressionQueryImpl<TEntity>(
 				dataContext,
 				Expression.Call(
 					null,
 					MethodHelper.GetMethodInfo(FromSqlScalar<TEntity>, dataContext, sql),
-					SqlQueryRootExpression.Create(dataContext), Expression.Constant(sql)));
+					SqlQueryRootExpression.Create(dataContext), formattableStringExpr));
 		}
 
 		/// <summary>

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLExtensions.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLExtensions.cs
@@ -97,7 +97,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 
 		[ExpressionMethod(nameof(UnnestImpl))]
 		public static IQueryable<T> Unnest<T>(this IDataContext dc, T[] array)
-			=> dc.FromSqlScalar<T>($"UNNEST({array})");
+			=> dc.QueryFromExpression(() => dc.FromSqlScalar<T>($"UNNEST({array})"));
 
 		static Expression<Func<IDataContext, T[], IQueryable<T>>> UnnestImpl<T>()
 		{
@@ -112,8 +112,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 
 		[ExpressionMethod(nameof(UnnestWithOrdinalityImpl))]
 		public static IQueryable<Ordinality<T>> UnnestWithOrdinality<T>(this IDataContext dc, T[] array)
-			//TODO: can be executable when we finish queryable arrays
-			=> throw new ServerSideOnlyException(nameof(UnnestWithOrdinality));
+			=> dc.QueryFromExpression(() => dc.FromSql<Ordinality<T>>($"UNNEST({array}) WITH ORDINALITY {Sql.AliasExpr()}(value, idx)"));
 
 		static Expression<Func<IDataContext, T[], IQueryable<Ordinality<T>>>> UnnestWithOrdinalityImpl<T>()
 		{
@@ -265,12 +264,10 @@ namespace LinqToDB.DataProvider.PostgreSQL
 
 		#region generate_series
 
-		static Func<IDataContext, int, int, IQueryable<int>>? _generateSeriesIntFunc;
-
 		[ExpressionMethod(nameof(GenerateSeriesIntImpl))]
 		public static IQueryable<int> GenerateSeries(this IDataContext dc, [ExprParameter] int start, [ExprParameter] int stop)
 		{
-			return (_generateSeriesIntFunc ??= GenerateSeriesIntImpl().CompileExpression())(dc, start, stop);
+			return dc.QueryFromExpression(() => dc.FromSqlScalar<int>($"GENERATE_SERIES({start}, {stop})"));
 		}
 
 		static Expression<Func<IDataContext, int, int, IQueryable<int>>> GenerateSeriesIntImpl()
@@ -278,12 +275,10 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			return (dc, start, stop) => dc.FromSqlScalar<int>($"GENERATE_SERIES({start}, {stop})");
 		}
 
-		static Func<IDataContext, int, int, int, IQueryable<int>>? _generateSeriesIntStepFunc;
-
 		[ExpressionMethod(nameof(GenerateSeriesIntStepImpl))]
 		public static IQueryable<int> GenerateSeries(this IDataContext dc, [ExprParameter] int start, [ExprParameter] int stop, [ExprParameter] int step)
 		{
-			return (_generateSeriesIntStepFunc ??= GenerateSeriesIntStepImpl().CompileExpression())(dc, start, stop, step);
+			return dc.QueryFromExpression(() => dc.FromSqlScalar<int>($"GENERATE_SERIES({start}, {stop}, {step})"));
 		}
 
 		static Expression<Func<IDataContext, int, int, int, IQueryable<int>>> GenerateSeriesIntStepImpl()
@@ -291,12 +286,10 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			return (dc, start, stop, step) => dc.FromSqlScalar<int>($"GENERATE_SERIES({start}, {stop}, {step})");
 		}
 
-		static Func<IDataContext, DateTime, DateTime, TimeSpan, IQueryable<DateTime>>? _generateSeriesDateFunc;
-
 		[ExpressionMethod(nameof(GenerateSeriesDateImpl))]
 		public static IQueryable<DateTime> GenerateSeries(this IDataContext dc, [ExprParameter] DateTime start, [ExprParameter] DateTime stop, [ExprParameter] TimeSpan step)
 		{
-			return (_generateSeriesDateFunc ??= GenerateSeriesDateImpl().CompileExpression())(dc, start, stop, step);
+			return dc.QueryFromExpression(() => dc.FromSqlScalar<DateTime>($"GENERATE_SERIES({start}, {stop}, {step})"));
 		}
 
 		static Expression<Func<IDataContext, DateTime, DateTime, TimeSpan, IQueryable<DateTime>>> GenerateSeriesDateImpl()
@@ -309,18 +302,16 @@ namespace LinqToDB.DataProvider.PostgreSQL
 
 		[ExpressionMethod(nameof(GenerateSubscriptsImpl))]
 		public static IQueryable<int> GenerateSubscripts<T>(this IDataContext dc, T[] array, int dimension)
-			//TODO: can be executable when we finish queryable arrays
-			=> throw new ServerSideOnlyException(nameof(GenerateSubscripts));
+			=> dc.QueryFromExpression(() => dc.FromSqlScalar<int>($"GENERATE_SUBSCRIPTS({array}, {dimension})"));
 
-			static Expression<Func<IDataContext, T[], int, IQueryable<int>>> GenerateSubscriptsImpl<T>()
+		static Expression<Func<IDataContext, T[], int, IQueryable<int>>> GenerateSubscriptsImpl<T>()
 		{
 			return (dc, array, dimension) => dc.FromSqlScalar<int>($"GENERATE_SUBSCRIPTS({array}, {dimension})");
 		}
 
 		[ExpressionMethod(nameof(GenerateSubscriptsReverseImpl))]
 		public static IQueryable<int> GenerateSubscripts<T>(this IDataContext dc, T[] array, int dimension, bool reverse)
-			//TODO: can be executable when we finish queryable arrays
-			=> throw new ServerSideOnlyException(nameof(GenerateSubscripts));
+			=> dc.QueryFromExpression(() => dc.FromSqlScalar<int>($"GENERATE_SUBSCRIPTS({array}, {dimension}, {reverse})"));
 
 		static Expression<Func<IDataContext, T[], int, bool, IQueryable<int>>> GenerateSubscriptsReverseImpl<T>()
 		{

--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLExtensions.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLExtensions.cs
@@ -97,7 +97,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 
 		[ExpressionMethod(nameof(UnnestImpl))]
 		public static IQueryable<T> Unnest<T>(this IDataContext dc, T[] array)
-			=> dc.QueryFromExpression(() => dc.FromSqlScalar<T>($"UNNEST({array})"));
+			=> dc.QueryFromExpression(() => dc.Unnest(array));
 
 		static Expression<Func<IDataContext, T[], IQueryable<T>>> UnnestImpl<T>()
 		{
@@ -112,7 +112,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 
 		[ExpressionMethod(nameof(UnnestWithOrdinalityImpl))]
 		public static IQueryable<Ordinality<T>> UnnestWithOrdinality<T>(this IDataContext dc, T[] array)
-			=> dc.QueryFromExpression(() => dc.FromSql<Ordinality<T>>($"UNNEST({array}) WITH ORDINALITY {Sql.AliasExpr()}(value, idx)"));
+			=> dc.QueryFromExpression(() => dc.UnnestWithOrdinality(array));
 
 		static Expression<Func<IDataContext, T[], IQueryable<Ordinality<T>>>> UnnestWithOrdinalityImpl<T>()
 		{
@@ -267,7 +267,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 		[ExpressionMethod(nameof(GenerateSeriesIntImpl))]
 		public static IQueryable<int> GenerateSeries(this IDataContext dc, [ExprParameter] int start, [ExprParameter] int stop)
 		{
-			return dc.QueryFromExpression(() => dc.FromSqlScalar<int>($"GENERATE_SERIES({start}, {stop})"));
+			return dc.QueryFromExpression(() => dc.GenerateSeries(start, stop));
 		}
 
 		static Expression<Func<IDataContext, int, int, IQueryable<int>>> GenerateSeriesIntImpl()
@@ -278,7 +278,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 		[ExpressionMethod(nameof(GenerateSeriesIntStepImpl))]
 		public static IQueryable<int> GenerateSeries(this IDataContext dc, [ExprParameter] int start, [ExprParameter] int stop, [ExprParameter] int step)
 		{
-			return dc.QueryFromExpression(() => dc.FromSqlScalar<int>($"GENERATE_SERIES({start}, {stop}, {step})"));
+			return dc.QueryFromExpression(() => dc.GenerateSeries(start, stop, step));
 		}
 
 		static Expression<Func<IDataContext, int, int, int, IQueryable<int>>> GenerateSeriesIntStepImpl()
@@ -289,7 +289,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 		[ExpressionMethod(nameof(GenerateSeriesDateImpl))]
 		public static IQueryable<DateTime> GenerateSeries(this IDataContext dc, [ExprParameter] DateTime start, [ExprParameter] DateTime stop, [ExprParameter] TimeSpan step)
 		{
-			return dc.QueryFromExpression(() => dc.FromSqlScalar<DateTime>($"GENERATE_SERIES({start}, {stop}, {step})"));
+			return dc.QueryFromExpression(() => dc.GenerateSeries(start, stop, step));
 		}
 
 		static Expression<Func<IDataContext, DateTime, DateTime, TimeSpan, IQueryable<DateTime>>> GenerateSeriesDateImpl()
@@ -302,7 +302,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 
 		[ExpressionMethod(nameof(GenerateSubscriptsImpl))]
 		public static IQueryable<int> GenerateSubscripts<T>(this IDataContext dc, T[] array, int dimension)
-			=> dc.QueryFromExpression(() => dc.FromSqlScalar<int>($"GENERATE_SUBSCRIPTS({array}, {dimension})"));
+			=> dc.QueryFromExpression(() => dc.GenerateSubscripts(array, dimension));
 
 		static Expression<Func<IDataContext, T[], int, IQueryable<int>>> GenerateSubscriptsImpl<T>()
 		{
@@ -311,7 +311,7 @@ namespace LinqToDB.DataProvider.PostgreSQL
 
 		[ExpressionMethod(nameof(GenerateSubscriptsReverseImpl))]
 		public static IQueryable<int> GenerateSubscripts<T>(this IDataContext dc, T[] array, int dimension, bool reverse)
-			=> dc.QueryFromExpression(() => dc.FromSqlScalar<int>($"GENERATE_SUBSCRIPTS({array}, {dimension}, {reverse})"));
+			=> dc.QueryFromExpression(() => dc.GenerateSubscripts(array, dimension, reverse));
 
 		static Expression<Func<IDataContext, T[], int, bool, IQueryable<int>>> GenerateSubscriptsReverseImpl<T>()
 		{

--- a/Tests/Linq/DataProvider/PostgreSQLExtensionsTests.cs
+++ b/Tests/Linq/DataProvider/PostgreSQLExtensionsTests.cs
@@ -9,6 +9,8 @@ using LinqToDB.Mapping;
 
 using NUnit.Framework;
 
+using Shouldly;
+
 namespace Tests.DataProvider
 {
 	[TestFixture]
@@ -51,7 +53,7 @@ namespace Tests.DataProvider
 		}
 
 		[Test]
-		public void Unnest([IncludeDataSources(TestProvName.AllPostgreSQL95Plus)] string context)
+		public void Unnest([IncludeDataSources(TestProvName.AllPostgreSQL95Plus)] string context, [Values(1, 2)] int iteration)
 		{
 			var testData = SampleClass.Seed();
 			using var db = GetDataContext(context);
@@ -61,7 +63,12 @@ namespace Tests.DataProvider
 						where v.StartsWith("V")
 						select v;
 
+			var cacheMissCount = query.GetCacheMissCount();
+
 			var actual = query.ToArray();
+
+			if (iteration == 1)
+				query.GetCacheMissCount().ShouldBe(cacheMissCount);
 
 			var expected = from t in testData
 						   from v in t.StrArray

--- a/Tests/Linq/DataProvider/PostgreSQLExtensionsTests.cs
+++ b/Tests/Linq/DataProvider/PostgreSQLExtensionsTests.cs
@@ -67,7 +67,7 @@ namespace Tests.DataProvider
 
 			var actual = query.ToArray();
 
-			if (iteration == 1)
+			if (iteration > 1)
 				query.GetCacheMissCount().ShouldBe(cacheMissCount);
 
 			var expected = from t in testData
@@ -443,6 +443,177 @@ namespace Tests.DataProvider
 				select new { a.Id };
 
 			_ = query.ToArray();
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5480")]
+		public void FromSqlScalarCache([IncludeDataSources(TestProvName.AllPostgreSQL95Plus)] string context, [Values(1, 2)] int iteration)
+		{
+			var testData = SampleClass.Seed();
+			using var db = GetDataContext(context);
+			using var table = db.CreateLocalTable(testData);
+
+			var data = iteration == 1 ? new[] { 1, 5, 42 } : new[] { 2, 3 };
+
+			var query = table.InnerJoin(db.QueryFromExpression(() => db.FromSqlScalar<int>($"UNNEST({data})")), (t, k) => t.Id == k, (t, k) => t);
+
+			var cacheMissCount = query.GetCacheMissCount();
+
+			_ = query.ToArray();
+
+			if (iteration > 1)
+			{
+				query.GetCacheMissCount().ShouldBe(cacheMissCount);
+			}
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5480")]
+		public void UnnestCache([IncludeDataSources(TestProvName.AllPostgreSQL95Plus)] string context, [Values(1, 2)] int iteration)
+		{
+			var       testData = SampleClass.Seed();
+			using var db       = GetDataContext(context);
+			using var table    = db.CreateLocalTable(testData);
+
+			var data = iteration == 1 ? new[] { 1, 5, 42 } : new[] { 2, 3 };
+
+			var query = table.InnerJoin(db.Unnest(data), (t, k) => t.Id == k, (t, k) => t);
+
+			var cacheMissCount = query.GetCacheMissCount();
+
+			_ = query.ToArray();
+
+			if (iteration > 1)
+			{
+				query.GetCacheMissCount().ShouldBe(cacheMissCount);
+			}
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5480")]
+		public void UnnestWithOrdinalityCache([IncludeDataSources(TestProvName.AllPostgreSQL95Plus)] string context, [Values(1, 2)] int iteration)
+		{
+			var       testData = SampleClass.Seed();
+			using var db       = GetDataContext(context);
+			using var table    = db.CreateLocalTable(testData);
+
+			var data = iteration == 1 ? new[] { 1, 5, 42 } : new[] { 2, 3 };
+
+			var query = table.InnerJoin(db.UnnestWithOrdinality(data), (t, k) => t.Id == k.Value, (t, k) => t);
+
+			var cacheMissCount = query.GetCacheMissCount();
+
+			_ = query.ToArray();
+
+			if (iteration > 1)
+			{
+				query.GetCacheMissCount().ShouldBe(cacheMissCount);
+			}
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5480")]
+		public void GenerateSubscriptsCache([IncludeDataSources(TestProvName.AllPostgreSQL95Plus)] string context, [Values(1, 2)] int iteration)
+		{
+			var       testData = SampleClass.Seed();
+			using var db       = GetDataContext(context);
+			using var table    = db.CreateLocalTable(testData);
+
+			var data = iteration == 1 ? new[] { 1, 5, 42 } : new[] { 2, 3 };
+
+			var query = table.InnerJoin(db.GenerateSubscripts(data, 1), (t, k) => t.Id == k, (t, k) => t);
+
+			var cacheMissCount = query.GetCacheMissCount();
+
+			_ = query.ToArray();
+
+			if (iteration > 1)
+			{
+				query.GetCacheMissCount().ShouldBe(cacheMissCount);
+			}
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5480")]
+		public void GenerateSubscriptsReverseCache([IncludeDataSources(TestProvName.AllPostgreSQL95Plus)] string context, [Values(1, 2)] int iteration)
+		{
+			var       testData = SampleClass.Seed();
+			using var db       = GetDataContext(context);
+			using var table    = db.CreateLocalTable(testData);
+
+			var data = iteration == 1 ? new[] { 1, 5, 42 } : new[] { 2, 3 };
+
+			var query = table.InnerJoin(db.GenerateSubscripts(data, 1, true), (t, k) => t.Id == k, (t, k) => t);
+
+			var cacheMissCount = query.GetCacheMissCount();
+
+			_ = query.ToArray();
+
+			if (iteration > 1)
+			{
+				query.GetCacheMissCount().ShouldBe(cacheMissCount);
+			}
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5480")]
+		public void GenerateSeriesIntCache([IncludeDataSources(TestProvName.AllPostgreSQL95Plus)] string context, [Values(1, 2)] int iteration)
+		{
+			var       testData = SampleClass.Seed();
+			using var db       = GetDataContext(context);
+			using var table    = db.CreateLocalTable(testData);
+
+			var start = iteration == 1 ? 1 : 3;
+			var stop  = iteration == 1 ? 5 : 7;
+
+			var query = table.InnerJoin(db.GenerateSeries(start, stop), (t, k) => t.Id == k, (t, k) => t);
+
+			var cacheMissCount = query.GetCacheMissCount();
+
+			_ = query.ToArray();
+
+			if (iteration > 1)
+			{
+				query.GetCacheMissCount().ShouldBe(cacheMissCount);
+			}
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5480")]
+		public void GenerateSeriesIntStepCache([IncludeDataSources(TestProvName.AllPostgreSQL95Plus)] string context, [Values(1, 2)] int iteration)
+		{
+			var       testData = SampleClass.Seed();
+			using var db       = GetDataContext(context);
+			using var table    = db.CreateLocalTable(testData);
+
+			var start = iteration == 1 ? 1 : 2;
+			var stop  = iteration == 1 ? 9 : 10;
+			var step  = iteration == 1 ? 2 : 3;
+
+			var query = table.InnerJoin(db.GenerateSeries(start, stop, step), (t, k) => t.Id == k, (t, k) => t);
+
+			var cacheMissCount = query.GetCacheMissCount();
+
+			_ = query.ToArray();
+
+			if (iteration > 1)
+			{
+				query.GetCacheMissCount().ShouldBe(cacheMissCount);
+			}
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5480")]
+		public void GenerateSeriesDateCache([IncludeDataSources(TestProvName.AllPostgreSQL95Plus)] string context, [Values(1, 2)] int iteration)
+		{
+			using var db = GetDataContext(context);
+
+			var start = iteration == 1 ? new DateTime(2024, 1, 1) : new DateTime(2024, 2, 1);
+			var stop  = iteration == 1 ? new DateTime(2024, 1, 5) : new DateTime(2024, 2, 10);
+			var step  = iteration == 1 ? TimeSpan.FromDays(1)     : TimeSpan.FromDays(2);
+
+			var query = db.GenerateSeries(start, stop, step);
+
+			var cacheMissCount = query.GetCacheMissCount();
+
+			_ = query.ToArray();
+
+			if (iteration > 1)
+			{
+				query.GetCacheMissCount().ShouldBe(cacheMissCount);
+			}
 		}
 	}
 }

--- a/Tests/Linq/DataProvider/PostgreSQLExtensionsTests.cs
+++ b/Tests/Linq/DataProvider/PostgreSQLExtensionsTests.cs
@@ -454,7 +454,7 @@ namespace Tests.DataProvider
 
 			var data = iteration == 1 ? new[] { 1, 5, 42 } : new[] { 2, 3 };
 
-			var query = table.InnerJoin(db.QueryFromExpression(() => db.FromSqlScalar<int>($"UNNEST({data})")), (t, k) => t.Id == k, (t, k) => t);
+			var query = table.InnerJoin(db.FromSqlScalar<int>($"UNNEST({data})"), (t, k) => t.Id == k, (t, k) => t);
 
 			var cacheMissCount = query.GetCacheMissCount();
 


### PR DESCRIPTION
## Summary
- Wrap `Unnest`, `UnnestWithOrdinality`, `GenerateSeries`, and `GenerateSubscripts` IQueryable extensions with `QueryFromExpression` so the produced expression tree is cache-friendly and does not force a mapper recompile per call.
- Enable `UnnestWithOrdinality` and both `GenerateSubscripts` overloads that previously threw `ServerSideOnlyException`.
- Fix core `FromSqlScalar(FormattableString)` to split `FormattableString` arguments via `GenerateArray` (mirroring `FromSql(FormattableString)`), so interpolated array/value arguments do not break the query cache.

Fixes [#5480](https://github.com/linq2db/linq2db/issues/5480).