### PR TITLE
Add AsQueryable parameterization API

### DIFF
--- a/Source/LinqToDB/Internal/DataProvider/DB2/DB2SqlBuilderBase.Merge.cs
+++ b/Source/LinqToDB/Internal/DataProvider/DB2/DB2SqlBuilderBase.Merge.cs
@@ -28,6 +28,11 @@ namespace LinqToDB.Internal.DataProvider.DB2
 			if (row == -1)
 				return true;
 
+			// DB2 rejects untyped parameter markers inside VALUES (SQL0418N) — wrap any parameter
+			// cell in CAST(... AS <type>) so it has explicit type information.
+			if (rows[row][column] is SqlParameter)
+				return true;
+
 			if (row != 0)
 				return false;
 

--- a/Source/LinqToDB/Internal/Linq/Builder/EnumerableBuilder.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/EnumerableBuilder.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -106,11 +106,22 @@ namespace LinqToDB.Internal.Linq.Builder
 			var sourceArg   = mc.Arguments[0];
 			var configureArg = mc.Arguments[2];
 
+			// The configured overload expects a materialised IEnumerable<T>. Traverse the source
+			// expression first to resolve closures / context refs, then verify it can be evaluated on
+			// the client. An inline array that references outer query state (e.g.
+			// `from t in db.Person from v in new[] { new Row { Id = t.ID } }.AsQueryable(db, b => b.Parameterize())`)
+			// cannot be compiled — reject with a clear error; the user should use the 2-arg
+			// AsQueryable(IDataContext) overload, which has EnumerableContextDynamic for per-element
+			// expressions.
+			var traversedSource = builder.BuildTraverseExpression(sourceArg);
+			if (!builder.CanBeEvaluatedOnClient(traversedSource))
+				return BuildSequenceResult.Error(mc, "AsQueryable configure: source could not be evaluated on the client; ensure the source is a materialised IEnumerable<T> (use the 2-arg AsQueryable(IDataContext) overload for sources referencing outer query state).");
+
 			var configureLambda = configureArg.UnwrapLambda();
 			if (!TryParseConfigure(elementType, configureLambda, out var defaultForceParameter, out var rowParameter, out var excepted, out var parseError))
-				throw new LinqToDBException(parseError);
+				return BuildSequenceResult.Error(mc, parseError);
 
-			var param = builder.ParametersContext.BuildParameter(buildInfo.Parent, sourceArg, null,
+			var param = builder.ParametersContext.BuildParameter(buildInfo.Parent, traversedSource, null,
 				buildParameterType: ParametersContext.BuildParameterType.InPredicate);
 
 			if (param == null)
@@ -134,15 +145,18 @@ namespace LinqToDB.Internal.Linq.Builder
 			LambdaExpression                                configureLambda,
 			out bool                                        defaultForceParameter,
 			out ParameterExpression?                        rowParameter,
-			out IReadOnlyList<Expression>?                  excepted,
+			out IReadOnlyList<MemberExpression>?            excepted,
 			out string                                      error)
 		{
-			defaultForceParameter = true;     // default mode is Parameterize when nothing else specified
+			// Initial value is unreachable in practice — the interface design forces every chain
+			// through Parameterize() or Inline() before Except is available — but we still need
+			// a defined value before the loop runs.
+			defaultForceParameter = true;
 			rowParameter          = null;
 			excepted              = null;
 			error                 = string.Empty;
 
-			List<Expression>? exceptedList = null;
+			List<MemberExpression>? exceptedList = null;
 
 			var builderParameter = configureLambda.Parameters[0];
 			var current          = configureLambda.Body;
@@ -170,7 +184,7 @@ namespace LinqToDB.Internal.Linq.Builder
 							return false;
 						}
 
-						exceptedList ??= new List<Expression>();
+						exceptedList ??= new List<MemberExpression>();
 						rowParameter ??= Expression.Parameter(elementType, "p");
 
 						foreach (var item in nae.Expressions)
@@ -178,14 +192,17 @@ namespace LinqToDB.Internal.Linq.Builder
 							var lambda = item.UnwrapLambda();
 
 							// Substitute the per-selector lambda parameter with our shared rowParameter so
-							// every Excepted entry has the same root.
-							var rerooted = lambda.GetBody(rowParameter);
+							// every Excepted entry has the same root, then strip the implicit boxing
+							// Convert that Expression<Func<T, object?>> adds.
+							var rerooted = lambda.GetBody(rowParameter).UnwrapConvert();
 
-							// Strip the implicit boxing Convert that Expression<Func<T, object?>> adds.
-							while (rerooted.NodeType is ExpressionType.Convert or ExpressionType.ConvertChecked)
-								rerooted = ((UnaryExpression)rerooted).Operand;
+							if (rerooted is not MemberExpression memberAccess)
+							{
+								error = $"AsQueryable configure: Except(...) selector must be a member access on the lambda parameter; got '{lambda.Body}'.";
+								return false;
+							}
 
-							var leaf = rerooted;
+							Expression leaf = memberAccess;
 							while (leaf is MemberExpression me)
 								leaf = me.Expression!;
 
@@ -195,7 +212,7 @@ namespace LinqToDB.Internal.Linq.Builder
 								return false;
 							}
 
-							exceptedList.Add(rerooted);
+							exceptedList.Add(memberAccess);
 						}
 
 						current = call.Object ?? call.Arguments[0];

--- a/Source/LinqToDB/Internal/Linq/Builder/EnumerableBuilder.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/EnumerableBuilder.cs
@@ -1,16 +1,25 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 
+using LinqToDB.Expressions;
+using LinqToDB.Internal.Expressions;
 using LinqToDB.Internal.Extensions;
+using LinqToDB.Internal.Reflection;
+using LinqToDB.Linq;
 
 namespace LinqToDB.Internal.Linq.Builder
 {
+	[BuildsMethodCall(nameof(LinqExtensions.AsQueryable))]
 	[BuildsExpression(ExpressionType.Constant, ExpressionType.Call, ExpressionType.MemberAccess, ExpressionType.NewArrayInit)]
 	sealed class EnumerableBuilder : ISequenceBuilder
 	{
+		public static bool CanBuildMethod(MethodCallExpression call)
+			=> call.IsSameGenericMethod(Methods.LinqToDB.AsQueryableConfigured);
+
 		public static bool CanBuild(Expression expr, ExpressionBuilder builder)
 		{
 			if (expr.NodeType == ExpressionType.NewArrayInit)
@@ -34,13 +43,17 @@ namespace LinqToDB.Internal.Linq.Builder
 			{
 				while (expr is { NodeType: ExpressionType.MemberAccess })
 					expr = ((MemberExpression)expr).Expression;
-				
+
 				return expr is null or { NodeType: ExpressionType.Constant };
 			}
 		}
 
 		public BuildSequenceResult BuildSequence(ExpressionBuilder builder, BuildInfo buildInfo)
 		{
+			// Configured 3-arg form: source.AsQueryable(dataContext, configure).
+			if (buildInfo.Expression is MethodCallExpression mc && mc.IsSameGenericMethod(Methods.LinqToDB.AsQueryableConfigured))
+				return BuildConfigured(builder, mc, buildInfo);
+
 			var collectionType = typeof(IEnumerable<>).GetGenericType(buildInfo.Expression.Type) ??
 			                     throw new InvalidOperationException();
 
@@ -52,7 +65,7 @@ namespace LinqToDB.Internal.Linq.Builder
 				var expressions = ((NewArrayExpression)buildInfo.Expression).Expressions.Select(e =>
 						builder.UpdateNesting(buildInfo.Parent!, builder.BuildSqlExpression(buildInfo.Parent, e)))
 					.ToArray();
-				
+
 				var dynamicContext = new EnumerableContextDynamic(
 					builder.GetTranslationModifier(),
 					buildInfo.Parent,
@@ -84,5 +97,127 @@ namespace LinqToDB.Internal.Linq.Builder
 		{
 			return true;
 		}
+
+		#region Configured 3-arg AsQueryable
+
+		static BuildSequenceResult BuildConfigured(ExpressionBuilder builder, MethodCallExpression mc, BuildInfo buildInfo)
+		{
+			var elementType = mc.Method.GetGenericArguments()[0];
+			var sourceArg   = mc.Arguments[0];
+			var configureArg = mc.Arguments[2];
+
+			var configureLambda = configureArg.UnwrapLambda();
+			if (!TryParseConfigure(elementType, configureLambda, out var defaultForceParameter, out var rowParameter, out var excepted, out var parseError))
+				throw new LinqToDBException(parseError);
+
+			var param = builder.ParametersContext.BuildParameter(buildInfo.Parent, sourceArg, null,
+				buildParameterType: ParametersContext.BuildParameterType.InPredicate);
+
+			if (param == null)
+				return BuildSequenceResult.Error(mc);
+
+			var parameterization = new EnumerableParameterizationConfig(defaultForceParameter, rowParameter, excepted);
+
+			var enumerableContext = new EnumerableContext(
+				builder.GetTranslationModifier(),
+				builder,
+				param,
+				buildInfo.SelectQuery,
+				elementType,
+				parameterization);
+
+			return BuildSequenceResult.FromContext(enumerableContext);
+		}
+
+		static bool TryParseConfigure(
+			Type                                            elementType,
+			LambdaExpression                                configureLambda,
+			out bool                                        defaultForceParameter,
+			out ParameterExpression?                        rowParameter,
+			out IReadOnlyList<Expression>?                  excepted,
+			out string                                      error)
+		{
+			defaultForceParameter = true;     // default mode is Parameterize when nothing else specified
+			rowParameter          = null;
+			excepted              = null;
+			error                 = string.Empty;
+
+			List<Expression>? exceptedList = null;
+
+			var builderParameter = configureLambda.Parameters[0];
+			var current          = configureLambda.Body;
+
+			while (current is MethodCallExpression call)
+			{
+				switch (call.Method.Name)
+				{
+					case nameof(IAsQueryableBuilder<>.Parameterize):
+						defaultForceParameter = true;
+						current = call.Object ?? call.Arguments[0];
+						break;
+
+					case nameof(IAsQueryableBuilder<>.Inline):
+						defaultForceParameter = false;
+						current = call.Object ?? call.Arguments[0];
+						break;
+
+					case nameof(IAsQueryableExceptBuilder<>.Except):
+					{
+						var membersArg = call.Arguments[call.Arguments.Count - 1];
+						if (membersArg is not NewArrayExpression nae)
+						{
+							error = "AsQueryable configure: Except(...) argument must be a member-selector array literal.";
+							return false;
+						}
+
+						exceptedList ??= new List<Expression>();
+						rowParameter ??= Expression.Parameter(elementType, "p");
+
+						foreach (var item in nae.Expressions)
+						{
+							var lambda = item.UnwrapLambda();
+
+							// Substitute the per-selector lambda parameter with our shared rowParameter so
+							// every Excepted entry has the same root.
+							var rerooted = lambda.GetBody(rowParameter);
+
+							// Strip the implicit boxing Convert that Expression<Func<T, object?>> adds.
+							while (rerooted.NodeType is ExpressionType.Convert or ExpressionType.ConvertChecked)
+								rerooted = ((UnaryExpression)rerooted).Operand;
+
+							var leaf = rerooted;
+							while (leaf is MemberExpression me)
+								leaf = me.Expression!;
+
+							if (!ReferenceEquals(leaf, rowParameter))
+							{
+								error = $"AsQueryable configure: Except(...) selector must be a member access on the lambda parameter; got '{lambda.Body}'.";
+								return false;
+							}
+
+							exceptedList.Add(rerooted);
+						}
+
+						current = call.Object ?? call.Arguments[0];
+						break;
+					}
+
+					default:
+						error = $"AsQueryable configure: unsupported method '{call.Method.Name}' in chain.";
+						return false;
+				}
+			}
+
+			if (current != builderParameter)
+			{
+				error = "AsQueryable configure: chain root must be the lambda parameter.";
+				return false;
+			}
+
+			excepted = exceptedList;
+			return true;
+		}
+
+		#endregion
 	}
 }

--- a/Source/LinqToDB/Internal/Linq/Builder/EnumerableContext.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/EnumerableContext.cs
@@ -230,6 +230,9 @@ namespace LinqToDB.Internal.Linq.Builder
 
 				if (accessor.Type == typeof(DataParameter))
 				{
+					// Columns whose mapping returns DataParameter are always rendered as parameters
+					// regardless of EnumerableParameterizationConfig — the DataParameter carries provider
+					// metadata (Direction/Size/DbType) that would be lost if inlined as a literal.
 					var localGenerator = new ExpressionGenerator();
 					var variable = localGenerator.AssignToVariable(accessor);
 					localGenerator.AddExpression(

--- a/Source/LinqToDB/Internal/Linq/Builder/EnumerableContext.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/EnumerableContext.cs
@@ -23,20 +23,24 @@ namespace LinqToDB.Internal.Linq.Builder
 
 		public override bool AutomaticAssociations => false;
 
-		public EnumerableContext(TranslationModifier translationModifier, ExpressionBuilder builder, ISqlExpression source, SelectQuery query, Type elementType)
+		readonly EnumerableParameterizationConfig? _parameterization;
+
+		public EnumerableContext(TranslationModifier translationModifier, ExpressionBuilder builder, ISqlExpression source, SelectQuery query, Type elementType, EnumerableParameterizationConfig? parameterization = null)
 			: base(translationModifier, builder, elementType, query)
 		{
-			Table = new SqlValuesTable(source);
+			Table             = new SqlValuesTable(source);
+			_parameterization = parameterization;
 
 			SelectQuery.From.Table(Table);
 		}
 
-		EnumerableContext(TranslationModifier translationModifier, ExpressionBuilder builder, Expression expression, SelectQuery query, SqlValuesTable table, Type elementType)
+		EnumerableContext(TranslationModifier translationModifier, ExpressionBuilder builder, Expression expression, SelectQuery query, SqlValuesTable table, Type elementType, EnumerableParameterizationConfig? parameterization)
 			: base(translationModifier, builder, elementType, query)
 		{
-			Parent     = null;
-			Table      = table;
-			Expression = expression;
+			Parent            = null;
+			Table             = table;
+			Expression        = expression;
+			_parameterization = parameterization;
 		}
 
 		static readonly ConstructorInfo _parameterConstructor =
@@ -242,6 +246,15 @@ namespace LinqToDB.Internal.Linq.Builder
 				{
 					accessor = accessor.EnsureType<object>();
 
+					if (_parameterization?.ShouldForceParameter(me) == true)
+					{
+						return Expression.New(
+							_parameterConstructor,
+							Expression.Constant(dbDataType),
+							Expression.Constant(me.Member.Name),
+							accessor);
+					}
+
 					var valueExpr = Expression.New(
 						_sqlValueConstructor,
 						Expression.Constant(dbDataType),
@@ -296,7 +309,7 @@ namespace LinqToDB.Internal.Linq.Builder
 		public override IBuildContext Clone(CloningContext context)
 		{
 			var result = new EnumerableContext(TranslationModifier, Builder, Expression!, context.CloneElement(SelectQuery),
-				context.CloneElement(Table), ElementType);
+				context.CloneElement(Table), ElementType, _parameterization);
 
 			context.RegisterCloned(this, result);
 

--- a/Source/LinqToDB/Internal/Linq/Builder/EnumerableParameterizationConfig.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/EnumerableParameterizationConfig.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+using LinqToDB.Internal.Expressions;
+
+namespace LinqToDB.Internal.Linq.Builder
+{
+	/// <summary>
+	/// Per-column parameter/inline rendering selector for <see cref="EnumerableContext"/>.
+	/// </summary>
+	sealed class EnumerableParameterizationConfig
+	{
+		public EnumerableParameterizationConfig(bool defaultForceParameter, ParameterExpression? parameter, IReadOnlyList<Expression>? excepted)
+		{
+			DefaultForceParameter = defaultForceParameter;
+			Parameter             = parameter;
+			Excepted              = excepted;
+		}
+
+		/// <summary>
+		/// Default rendering for every cell: <see langword="true"/> = SqlParameter, <see langword="false"/> = SqlValue.
+		/// </summary>
+		public bool DefaultForceParameter { get; }
+
+		/// <summary>
+		/// Lambda parameter used as the root for every <see cref="Excepted"/> expression. Null when no overrides.
+		/// </summary>
+		public ParameterExpression? Parameter { get; }
+
+		/// <summary>
+		/// Member access expressions (rooted at <see cref="Parameter"/>) whose mode flips relative to the default.
+		/// </summary>
+		public IReadOnlyList<Expression>? Excepted { get; }
+
+		public bool ShouldForceParameter(Expression accessExpression)
+		{
+			var force = DefaultForceParameter;
+
+			if (Excepted == null || Parameter == null || Excepted.Count == 0)
+				return force;
+
+			var rerooted = ReRootToParameter(accessExpression, Parameter);
+			if (rerooted == null)
+				return force;
+
+			foreach (var excepted in Excepted)
+			{
+				if (ExpressionEqualityComparer.Instance.Equals(excepted, rerooted))
+					return !force;
+			}
+
+			return force;
+		}
+
+		static Expression? ReRootToParameter(Expression access, ParameterExpression parameter)
+		{
+			if (access is MemberExpression me)
+			{
+				var inner = me.Expression == null ? null : ReRootToParameter(me.Expression, parameter);
+				if (inner == null)
+					return null;
+
+				return Expression.MakeMemberAccess(inner, me.Member);
+			}
+
+			// Replace the chain root with the stored parameter only when the type matches.
+			return access.Type == parameter.Type ? parameter : null;
+		}
+	}
+}

--- a/Source/LinqToDB/Internal/Linq/Builder/EnumerableParameterizationConfig.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/EnumerableParameterizationConfig.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq.Expressions;
 
 using LinqToDB.Internal.Expressions;
@@ -10,7 +10,7 @@ namespace LinqToDB.Internal.Linq.Builder
 	/// </summary>
 	sealed class EnumerableParameterizationConfig
 	{
-		public EnumerableParameterizationConfig(bool defaultForceParameter, ParameterExpression? parameter, IReadOnlyList<Expression>? excepted)
+		public EnumerableParameterizationConfig(bool defaultForceParameter, ParameterExpression? parameter, IReadOnlyList<MemberExpression>? excepted)
 		{
 			DefaultForceParameter = defaultForceParameter;
 			Parameter             = parameter;
@@ -30,7 +30,7 @@ namespace LinqToDB.Internal.Linq.Builder
 		/// <summary>
 		/// Member access expressions (rooted at <see cref="Parameter"/>) whose mode flips relative to the default.
 		/// </summary>
-		public IReadOnlyList<Expression>? Excepted { get; }
+		public IReadOnlyList<MemberExpression>? Excepted { get; }
 
 		public bool ShouldForceParameter(Expression accessExpression)
 		{

--- a/Source/LinqToDB/Internal/Reflection/Methods.cs
+++ b/Source/LinqToDB/Internal/Reflection/Methods.cs
@@ -201,8 +201,9 @@ namespace LinqToDB.Internal.Reflection
 
 			public static readonly MethodInfo Select              = MemberHelper.MethodOfGeneric<IDataContext>(dc => dc.Select(() => 1));
 
-			public static readonly MethodInfo AsQueryable         = MemberHelper.MethodOfGeneric<IQueryable<object>>(q => q.AsQueryable(null!));
-			public static readonly MethodInfo AsSubQuery          = MemberHelper.MethodOfGeneric<IQueryable<object>>(q => q.AsSubQuery());
+			public static readonly MethodInfo AsQueryable           = MemberHelper.MethodOfGeneric<IQueryable<object>>(q => q.AsQueryable(null!));
+			public static readonly MethodInfo AsQueryableConfigured = MemberHelper.MethodOfGeneric<IEnumerable<object>>(e => e.AsQueryable(null!, b => b.Parameterize()));
+			public static readonly MethodInfo AsSubQuery            = MemberHelper.MethodOfGeneric<IQueryable<object>>(q => q.AsSubQuery());
 
 			public static readonly MethodInfo TagQuery            = MemberHelper.MethodOfGeneric<IQueryable<object>>(q => q.TagQuery(string.Empty));
 

--- a/Source/LinqToDB/Linq/IAsQueryableBuilder.cs
+++ b/Source/LinqToDB/Linq/IAsQueryableBuilder.cs
@@ -1,6 +1,5 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 
 namespace LinqToDB.Linq
@@ -8,8 +7,9 @@ namespace LinqToDB.Linq
 	/// <summary>
 	/// Initial stage of <see cref="LinqExtensions.AsQueryable{T}(IEnumerable{T},IDataContext,Expression{Func{IAsQueryableBuilder{T},IAsQueryableExceptBuilder{T}}})"/>
 	/// configuration. The caller must pick a default rendering mode (<see cref="Parameterize"/> or <see cref="Inline"/>)
-	/// before any further configuration is available. All chain methods are marker-only and throw at runtime;
-	/// the chain is captured as an expression tree and interpreted at query-build time.
+	/// before any further configuration is available. All chain methods are marker-only — the chain is captured as an
+	/// expression tree and interpreted at query-build time. Calling them outside an <see cref="Expression"/> context
+	/// is undefined behaviour.
 	/// </summary>
 	/// <typeparam name="T">Element type of the source enumerable.</typeparam>
 	public interface IAsQueryableBuilder<T>

--- a/Source/LinqToDB/Linq/IAsQueryableBuilder.cs
+++ b/Source/LinqToDB/Linq/IAsQueryableBuilder.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace LinqToDB.Linq
+{
+	/// <summary>
+	/// Initial stage of <see cref="LinqExtensions.AsQueryable{T}(IEnumerable{T},IDataContext,Expression{Func{IAsQueryableBuilder{T},IAsQueryableExceptBuilder{T}}})"/>
+	/// configuration. The caller must pick a default rendering mode (<see cref="Parameterize"/> or <see cref="Inline"/>)
+	/// before any further configuration is available. All chain methods are marker-only and throw at runtime;
+	/// the chain is captured as an expression tree and interpreted at query-build time.
+	/// </summary>
+	/// <typeparam name="T">Element type of the source enumerable.</typeparam>
+	public interface IAsQueryableBuilder<T>
+	{
+		/// <summary>
+		/// Render every column of every row as a SQL parameter.
+		/// </summary>
+		IAsQueryableExceptBuilder<T> Parameterize();
+
+		/// <summary>
+		/// Render every column of every row as an inlined SQL literal.
+		/// </summary>
+		IAsQueryableExceptBuilder<T> Inline();
+	}
+}

--- a/Source/LinqToDB/Linq/IAsQueryableBuilder.cs
+++ b/Source/LinqToDB/Linq/IAsQueryableBuilder.cs
@@ -20,7 +20,9 @@ namespace LinqToDB.Linq
 		IAsQueryableExceptBuilder<T> Parameterize();
 
 		/// <summary>
-		/// Render every column of every row as an inlined SQL literal.
+		/// Render every column of every row as an inlined SQL literal. Columns whose mapping produces a
+		/// <see cref="LinqToDB.Data.DataParameter"/> are always rendered as SQL parameters regardless of this
+		/// setting, because the <c>DataParameter</c> carries provider metadata that cannot be inlined.
 		/// </summary>
 		IAsQueryableExceptBuilder<T> Inline();
 	}

--- a/Source/LinqToDB/Linq/IAsQueryableExceptBuilder.cs
+++ b/Source/LinqToDB/Linq/IAsQueryableExceptBuilder.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Linq.Expressions;
+
+namespace LinqToDB.Linq
+{
+	/// <summary>
+	/// Configuration stage exposed after the rendering mode has been chosen via
+	/// <see cref="IAsQueryableBuilder{T}.Parameterize"/> or <see cref="IAsQueryableBuilder{T}.Inline"/>.
+	/// Allows per-member overrides via <see cref="Except"/>.
+	/// </summary>
+	/// <typeparam name="T">Element type of the source enumerable.</typeparam>
+	public interface IAsQueryableExceptBuilder<T>
+	{
+		/// <summary>
+		/// Flips the chosen mode for the listed members: under <see cref="IAsQueryableBuilder{T}.Parameterize"/>
+		/// the listed members are inlined as literals; under <see cref="IAsQueryableBuilder{T}.Inline"/> they
+		/// are rendered as parameters. Selectors are member-access chains rooted at the row, e.g.
+		/// <c>p =&gt; p.Id</c> or <c>p =&gt; p.Address.Zip</c>.
+		/// </summary>
+		IAsQueryableExceptBuilder<T> Except(params Expression<Func<T, object?>>[] members);
+	}
+}

--- a/Source/LinqToDB/Linq/IAsQueryableExceptBuilder.cs
+++ b/Source/LinqToDB/Linq/IAsQueryableExceptBuilder.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq.Expressions;
 
 namespace LinqToDB.Linq
@@ -15,7 +15,7 @@ namespace LinqToDB.Linq
 		/// Flips the chosen mode for the listed members: under <see cref="IAsQueryableBuilder{T}.Parameterize"/>
 		/// the listed members are inlined as literals; under <see cref="IAsQueryableBuilder{T}.Inline"/> they
 		/// are rendered as parameters. Selectors are member-access chains rooted at the row, e.g.
-		/// <c>p =&gt; p.Id</c> or <c>p =&gt; p.Address.Zip</c>.
+		/// <c>p =&gt; p.Id</c> or <c>p =&gt; p.Address.Zip</c>. An empty member list is a no-op.
 		/// </summary>
 		IAsQueryableExceptBuilder<T> Except(params Expression<Func<T, object?>>[] members);
 	}

--- a/Source/LinqToDB/LinqExtensions/LinqExtensions.AsQueryable.cs
+++ b/Source/LinqToDB/LinqExtensions/LinqExtensions.AsQueryable.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;

--- a/Source/LinqToDB/LinqExtensions/LinqExtensions.AsQueryable.cs
+++ b/Source/LinqToDB/LinqExtensions/LinqExtensions.AsQueryable.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+using JetBrains.Annotations;
+
+using LinqToDB.Internal.Expressions;
+using LinqToDB.Internal.Linq;
+using LinqToDB.Internal.Reflection;
+using LinqToDB.Linq;
+
+namespace LinqToDB
+{
+	public static partial class LinqExtensions
+	{
+		/// <summary>
+		/// Converts a generic <see cref="IEnumerable{T}"/> to a Linq To DB query, with explicit control
+		/// over per-column parameterisation. Compared to <see cref="AsQueryable{TElement}(IEnumerable{TElement},IDataContext)"/>,
+		/// this overload renders the source as a multi-row <c>VALUES</c> clause where each cell is either
+		/// a SQL parameter or an inlined SQL literal, according to the configuration lambda.
+		/// </summary>
+		/// <typeparam name="TElement">The type of the elements of <paramref name="source"/>.</typeparam>
+		/// <param name="source">A sequence to convert.</param>
+		/// <param name="dataContext">Database connection context.</param>
+		/// <param name="configure">
+		/// Configuration chain. Examples:
+		/// <c>b =&gt; b.Parameterize()</c>,
+		/// <c>b =&gt; b.Inline()</c>,
+		/// <c>b =&gt; b.Parameterize().Except(p =&gt; p.Id, p =&gt; p.CreatedDate)</c>.
+		/// </param>
+		/// <returns>An <see cref="IQueryable{T}"/> that represents the input sequence.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="source"/>, <paramref name="dataContext"/> or <paramref name="configure"/> is <see langword="null"/>.
+		/// </exception>
+		public static IQueryable<TElement> AsQueryable<TElement>(
+			                this IEnumerable<TElement>                                                                          source,
+			                     IDataContext                                                                                   dataContext,
+			[InstantHandle]      Expression<Func<IAsQueryableBuilder<TElement>, IAsQueryableExceptBuilder<TElement>>> configure)
+		{
+			ArgumentNullException.ThrowIfNull(source);
+			ArgumentNullException.ThrowIfNull(dataContext);
+			ArgumentNullException.ThrowIfNull(configure);
+
+			var query = new ExpressionQueryImpl<TElement>(dataContext,
+				Expression.Call(
+					null,
+					MethodHelper.GetMethodInfo(AsQueryable, source, dataContext, configure),
+					Expression.Constant(source),
+					SqlQueryRootExpression.Create(dataContext),
+					Expression.Quote(configure)));
+
+			return query;
+		}
+	}
+}

--- a/Source/LinqToDB/LinqExtensions/LinqExtensions.AsQueryable.cs
+++ b/Source/LinqToDB/LinqExtensions/LinqExtensions.AsQueryable.cs
@@ -33,6 +33,11 @@ namespace LinqToDB
 		/// <exception cref="ArgumentNullException">
 		/// <paramref name="source"/>, <paramref name="dataContext"/> or <paramref name="configure"/> is <see langword="null"/>.
 		/// </exception>
+		/// <exception cref="LinqToDBException">
+		/// Thrown at query-build time when the <paramref name="configure"/> chain contains an unsupported call,
+		/// or when <c>Except(...)</c> receives a selector that is not a member access on the lambda parameter
+		/// (for example <c>p =&gt; p.Id + 1</c>, <c>p =&gt; p</c>, or a captured external member).
+		/// </exception>
 		public static IQueryable<TElement> AsQueryable<TElement>(
 			                this IEnumerable<TElement>                                                                          source,
 			                     IDataContext                                                                                   dataContext,

--- a/Source/LinqToDB/PublicAPI/PublicAPI.Unshipped.txt
+++ b/Source/LinqToDB/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,3 +1,10 @@
 #nullable enable
+LinqToDB.Linq.IAsQueryableBuilder<T>
+LinqToDB.Linq.IAsQueryableBuilder<T>.Inline() -> LinqToDB.Linq.IAsQueryableExceptBuilder<T>!
+LinqToDB.Linq.IAsQueryableBuilder<T>.Parameterize() -> LinqToDB.Linq.IAsQueryableExceptBuilder<T>!
+LinqToDB.Linq.IAsQueryableExceptBuilder<T>
+LinqToDB.Linq.IAsQueryableExceptBuilder<T>.Except(params System.Linq.Expressions.Expression<System.Func<T, object?>>![]! members) -> LinqToDB.Linq.IAsQueryableExceptBuilder<T>!
+static LinqToDB.LinqExtensions.AsQueryable<TElement>(this System.Collections.Generic.IEnumerable<TElement>! source, LinqToDB.IDataContext! dataContext, System.Linq.Expressions.Expression<System.Func<LinqToDB.Linq.IAsQueryableBuilder<TElement>!, LinqToDB.Linq.IAsQueryableExceptBuilder<TElement>!>>! configure) -> System.Linq.IQueryable<TElement>!
+static readonly LinqToDB.Internal.Reflection.Methods.LinqToDB.AsQueryableConfigured -> System.Reflection.MethodInfo!
 LinqToDB.Internal.Common.ErrorHelper.Oracle
 const LinqToDB.Internal.Common.ErrorHelper.Oracle.Error_ColumnSubqueryShouldNotContainParentIsNotNull = "Column expression should not contain parent's IS NOT NULL condition." -> string!

--- a/Tests/Linq/Linq/EnumerableSourceTests.AsQueryable.cs
+++ b/Tests/Linq/Linq/EnumerableSourceTests.AsQueryable.cs
@@ -30,7 +30,7 @@ namespace Tests.Linq
 
 		[Test]
 		public void AsQueryable_Parameterize_AllParameters(
-			[DataSources(TestProvName.AllAccess)] string context)
+			[DataSources(TestProvName.AllAccess, TestProvName.AllClickHouse)] string context)
 		{
 			using var db = GetDataContext(context);
 
@@ -50,7 +50,7 @@ namespace Tests.Linq
 
 		[Test]
 		public void AsQueryable_Inline_AllInlined(
-			[DataSources(TestProvName.AllAccess)] string context)
+			[DataSources(TestProvName.AllAccess, TestProvName.AllClickHouse)] string context)
 		{
 			using var db = GetDataContext(context);
 
@@ -69,7 +69,7 @@ namespace Tests.Linq
 
 		[Test]
 		public void AsQueryable_Parameterize_ExceptId_InlinesId(
-			[DataSources(TestProvName.AllAccess)] string context)
+			[DataSources(TestProvName.AllAccess, TestProvName.AllClickHouse)] string context)
 		{
 			using var db = GetDataContext(context);
 
@@ -93,7 +93,7 @@ namespace Tests.Linq
 
 		[Test]
 		public void AsQueryable_Inline_ExceptData_ParameterisesData(
-			[DataSources(TestProvName.AllAccess)] string context)
+			[DataSources(TestProvName.AllAccess, TestProvName.AllClickHouse)] string context)
 		{
 			using var db = GetDataContext(context);
 
@@ -118,7 +118,7 @@ namespace Tests.Linq
 
 		[Test]
 		public void AsQueryable_Parameterize_CacheStable_AcrossDataChanges(
-			[DataSources(TestProvName.AllAccess)] string context)
+			[DataSources(TestProvName.AllAccess, TestProvName.AllClickHouse)] string context)
 		{
 			using var db = GetDataContext(context);
 
@@ -143,7 +143,7 @@ namespace Tests.Linq
 
 		[Test]
 		public void AsQueryable_Parameterize_CacheHit_AcrossIterations(
-			[DataSources(TestProvName.AllAccess)] string context,
+			[DataSources(TestProvName.AllAccess, TestProvName.AllClickHouse)] string context,
 			[Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);
@@ -184,7 +184,7 @@ namespace Tests.Linq
 
 		[Test]
 		public void AsQueryable_Parameterize_ExceptId_CacheHit_AcrossIterations(
-			[DataSources(TestProvName.AllAccess)] string context,
+			[DataSources(TestProvName.AllAccess, TestProvName.AllClickHouse)] string context,
 			[Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);
@@ -204,7 +204,7 @@ namespace Tests.Linq
 
 		[Test]
 		public void AsQueryable_Parameterize_ScalarIntList(
-			[DataSources(TestProvName.AllAccess)] string context)
+			[DataSources(TestProvName.AllAccess, TestProvName.AllClickHouse)] string context)
 		{
 			using var db = GetDataContext(context);
 
@@ -222,7 +222,7 @@ namespace Tests.Linq
 
 		[Test]
 		public void AsQueryable_Parameterize_InlineArray(
-			[DataSources(TestProvName.AllAccess)] string context)
+			[DataSources(TestProvName.AllAccess, TestProvName.AllClickHouse)] string context)
 		{
 			using var db = GetDataContext(context);
 
@@ -267,7 +267,7 @@ namespace Tests.Linq
 
 		[Test]
 		public void AsQueryable_JoinPerson_CacheHit_AcrossIterations(
-			[DataSources(TestProvName.AllAccess)] string context,
+			[DataSources(TestProvName.AllAccess, TestProvName.AllClickHouse)] string context,
 			[Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);

--- a/Tests/Linq/Linq/EnumerableSourceTests.AsQueryable.cs
+++ b/Tests/Linq/Linq/EnumerableSourceTests.AsQueryable.cs
@@ -136,6 +136,77 @@ namespace Tests.Linq
 		}
 
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/5424")]
+		public void AsQueryable_Parameterize_CacheHit_AcrossIterations(
+			[IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL93Plus)] string context,
+			[Values(1, 2)] int iteration)
+		{
+			using var db = GetDataContext(context);
+
+			var rows = new List<ParamRow>
+			{
+				new() { Id = 1 + iteration, Data = "Data " + iteration },
+				new() { Id = 2 + iteration, Data = "More " + iteration },
+			};
+
+			var query     = rows.AsQueryable(db, b => b.Parameterize());
+			var cacheMiss = query.GetCacheMissCount();
+
+			query.ToArray();
+
+			if (iteration > 1)
+				query.GetCacheMissCount().ShouldBe(cacheMiss);
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5424")]
+		public void AsQueryable_Inline_CacheHit_AcrossIterations(
+			[IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL93Plus)] string context,
+			[Values(1, 2)] int iteration)
+		{
+			using var db = GetDataContext(context);
+
+			// Even in Inline mode, the LINQ expression tree shape doesn't change with row values —
+			// the per-row SqlValues are produced from the materialised source at execution time.
+			// The compiled query is reused across iterations.
+			var rows = new List<ParamRow>
+			{
+				new() { Id = 1 + iteration, Data = "Data " + iteration },
+				new() { Id = 2 + iteration, Data = "More " + iteration },
+			};
+
+			var query     = rows.AsQueryable(db, b => b.Inline());
+			var cacheMiss = query.GetCacheMissCount();
+
+			query.ToArray();
+
+			if (iteration > 1)
+				query.GetCacheMissCount().ShouldBe(cacheMiss);
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5424")]
+		public void AsQueryable_Parameterize_ExceptId_CacheHit_AcrossIterations(
+			[IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL93Plus)] string context,
+			[Values(1, 2)] int iteration)
+		{
+			using var db = GetDataContext(context);
+
+			// Id is inlined (Except flips it from parameter to literal); Data is parameterised.
+			// The IR shape is the same across iterations regardless of values, so the cache hits.
+			var rows = new List<ParamRow>
+			{
+				new() { Id = 1 + iteration, Data = "Data " + iteration },
+				new() { Id = 2 + iteration, Data = "More " + iteration },
+			};
+
+			var query     = rows.AsQueryable(db, b => b.Parameterize().Except(p => p.Id));
+			var cacheMiss = query.GetCacheMissCount();
+
+			query.ToArray();
+
+			if (iteration > 1)
+				query.GetCacheMissCount().ShouldBe(cacheMiss);
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5424")]
 		public void AsQueryable_Parameterize_ScalarIntList(
 			[IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL93Plus)] string context,
 			[Values(1, 2)] int iteration)

--- a/Tests/Linq/Linq/EnumerableSourceTests.AsQueryable.cs
+++ b/Tests/Linq/Linq/EnumerableSourceTests.AsQueryable.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 using LinqToDB;
@@ -30,8 +30,7 @@ namespace Tests.Linq
 
 		[Test]
 		public void AsQueryable_Parameterize_AllParameters(
-			[DataSources(TestProvName.AllAccess)] string context,
-			[Values(1, 2)] int iteration)
+			[DataSources(TestProvName.AllAccess)] string context)
 		{
 			using var db = GetDataContext(context);
 
@@ -51,8 +50,7 @@ namespace Tests.Linq
 
 		[Test]
 		public void AsQueryable_Inline_AllInlined(
-			[DataSources(TestProvName.AllAccess)] string context,
-			[Values(1, 2)] int iteration)
+			[DataSources(TestProvName.AllAccess)] string context)
 		{
 			using var db = GetDataContext(context);
 
@@ -71,12 +69,12 @@ namespace Tests.Linq
 
 		[Test]
 		public void AsQueryable_Parameterize_ExceptId_InlinesId(
-			[DataSources(TestProvName.AllAccess)] string context,
-			[Values(1, 2)] int iteration)
+			[DataSources(TestProvName.AllAccess)] string context)
 		{
 			using var db = GetDataContext(context);
 
-			var rows  = BuildParamRows(2);
+			// Distinctive seed → Ids 7777, 7778 — unlikely to occur incidentally in generated SQL.
+			var rows  = BuildParamRows(2, seed: 7777);
 			var query = rows.AsQueryable(db, b => b.Parameterize().Except(p => p.Id));
 
 			var sql    = query.ToSqlQuery().Sql;
@@ -84,30 +82,38 @@ namespace Tests.Linq
 
 			result.Count.ShouldBe(2);
 
-			// Id is inlined as a literal; Data is parameterised.
-			sql.ShouldNotContain("'Data 0'");
-			sql.ShouldNotContain("'Data 1'");
+			// Id is inlined as a literal — must appear directly in the SQL.
+			sql.ShouldContain("7777");
+			sql.ShouldContain("7778");
+
+			// Data is parameterised — literal must NOT appear in the SQL.
+			sql.ShouldNotContain("'Data 7777'");
+			sql.ShouldNotContain("'Data 7778'");
 		}
 
 		[Test]
 		public void AsQueryable_Inline_ExceptData_ParameterisesData(
-			[DataSources(TestProvName.AllAccess)] string context,
-			[Values(1, 2)] int iteration)
+			[DataSources(TestProvName.AllAccess)] string context)
 		{
 			using var db = GetDataContext(context);
 
-			var rows  = BuildParamRows(2);
+			// Distinctive seed → Ids 7777, 7778 — unlikely to occur incidentally in generated SQL.
+			var rows  = BuildParamRows(2, seed: 7777);
 			var query = rows.AsQueryable(db, b => b.Inline().Except(p => p.Data));
 
 			var sql    = query.ToSqlQuery().Sql;
 			var result = query.ToList();
 
 			result.Count.ShouldBe(2);
-			result[0].Data.ShouldBe("Data 0");
+			result[0].Data.ShouldBe("Data 7777");
 
-			// Data is parameterised, so the literal must not appear in SQL.
-			sql.ShouldNotContain("'Data 0'");
-			sql.ShouldNotContain("'Data 1'");
+			// Id is inlined as a literal — must appear directly in the SQL.
+			sql.ShouldContain("7777");
+			sql.ShouldContain("7778");
+
+			// Data is parameterised — literal must NOT appear in the SQL.
+			sql.ShouldNotContain("'Data 7777'");
+			sql.ShouldNotContain("'Data 7778'");
 		}
 
 		[Test]
@@ -198,8 +204,7 @@ namespace Tests.Linq
 
 		[Test]
 		public void AsQueryable_Parameterize_ScalarIntList(
-			[DataSources(TestProvName.AllAccess)] string context,
-			[Values(1, 2)] int iteration)
+			[DataSources(TestProvName.AllAccess)] string context)
 		{
 			using var db = GetDataContext(context);
 
@@ -217,11 +222,14 @@ namespace Tests.Linq
 
 		[Test]
 		public void AsQueryable_Parameterize_InlineArray(
-			[DataSources(TestProvName.AllAccess)] string context,
-			[Values(1, 2)] int iteration)
+			[DataSources(TestProvName.AllAccess)] string context)
 		{
 			using var db = GetDataContext(context);
 
+			// Standalone inline-array source: expression-tree preprocessing folds the array literal to a
+			// ConstantExpression before EnumerableBuilder sees it, so this is functionally equivalent to
+			// passing a materialised IEnumerable<T>. The configured form's NewArrayExpression reject only
+			// fires when the array literal is captured inside an outer lambda (e.g. SelectMany).
 			var query = new[]
 			{
 				new ParamRow { Id = 0, Data = "Data 0" },
@@ -235,6 +243,26 @@ namespace Tests.Linq
 
 			sql.ShouldNotContain("'Data 0'");
 			sql.ShouldNotContain("'Data 1'");
+		}
+
+		[Test]
+		public void AsQueryable_Parameterize_InlineArrayInSelectMany_Throws(
+			[IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataContext(context);
+
+			// Inline array referencing the outer table (`t.ID`, `t.FirstName`) — the configured overload
+			// can't materialise this client-side and has no per-element expression machinery. Reject
+			// up-front; user should use the 2-arg AsQueryable(IDataContext) overload, which routes
+			// through EnumerableContextDynamic for outer-referencing element expressions.
+			var query =
+				from t in db.Person
+				from v in new[] { new ParamRow { Id = t.ID, Data = t.FirstName } }.AsQueryable(db, b => b.Parameterize())
+				select t;
+
+			var act = () => query.ToArray();
+
+			act.ShouldThrow<LinqToDBException>().Message.ShouldContain("AsQueryable configure");
 		}
 
 		[Test]
@@ -284,6 +312,84 @@ namespace Tests.Linq
 
 			if (iteration > 1)
 				query.GetCacheMissCount().ShouldBe(cacheMiss);
+		}
+
+		sealed class NestedAddr
+		{
+			public string? Zip { get; set; }
+		}
+
+		sealed class NestedRow
+		{
+			public int         Id      { get; set; }
+			public NestedAddr? Address { get; set; }
+		}
+
+		[Test]
+		public void AsQueryable_Parameterize_ExceptNestedMember_InlinesNested(
+			[IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var rows = new List<NestedRow>
+			{
+				new() { Id = 7777, Address = new NestedAddr { Zip = "Z7777" } },
+				new() { Id = 7778, Address = new NestedAddr { Zip = "Z7778" } },
+			};
+
+			// Projection accesses p.Address.Zip so the builder actually visits the nested member —
+			// without it the builder only flattens top-level scalars and never asks the parameterization
+			// config about the nested path.
+			var query = from p in rows.AsQueryable(db, b => b.Parameterize().Except(p => p.Address!.Zip))
+						select new { p.Id, Zip = p.Address!.Zip };
+
+			var sql    = query.ToSqlQuery().Sql;
+			var result = query.ToList();
+
+			result.Count.ShouldBe(2);
+
+			// Address.Zip is inlined as a literal (Except flips it from parameter to literal);
+			// Id stays parameterised under the Parameterize default.
+			sql.ShouldContain("'Z7777'");
+			sql.ShouldContain("'Z7778'");
+		}
+
+		[Test]
+		public void AsQueryable_Except_NonMemberSelector_Throws(
+			[IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var rows = BuildParamRows(2);
+			var act  = () => rows.AsQueryable(db, b => b.Parameterize().Except(p => p.Id + 1)).ToSqlQuery();
+
+			act.ShouldThrow<LinqToDBException>().Message.ShouldContain("AsQueryable configure");
+		}
+
+		[Test]
+		public void AsQueryable_Except_BareParameter_Throws(
+			[IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var rows = BuildParamRows(2);
+			var act  = () => rows.AsQueryable(db, b => b.Parameterize().Except(p => p)).ToSqlQuery();
+
+			act.ShouldThrow<LinqToDBException>().Message.ShouldContain("AsQueryable configure");
+		}
+
+		[Test]
+		public void AsQueryable_Except_CapturedExternalMember_Throws(
+			[IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var rows  = BuildParamRows(2);
+			var other = new ParamRow { Id = 99, Data = "X" };
+
+			var act = () => rows.AsQueryable(db, b => b.Parameterize().Except(p => other.Id)).ToSqlQuery();
+
+			act.ShouldThrow<LinqToDBException>().Message.ShouldContain("AsQueryable configure");
 		}
 
 		#endregion

--- a/Tests/Linq/Linq/EnumerableSourceTests.AsQueryable.cs
+++ b/Tests/Linq/Linq/EnumerableSourceTests.AsQueryable.cs
@@ -30,7 +30,7 @@ namespace Tests.Linq
 
 		[Test]
 		public void AsQueryable_Parameterize_AllParameters(
-			[DataSources] string context,
+			[DataSources(TestProvName.AllAccess)] string context,
 			[Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);
@@ -51,7 +51,7 @@ namespace Tests.Linq
 
 		[Test]
 		public void AsQueryable_Inline_AllInlined(
-			[DataSources] string context,
+			[DataSources(TestProvName.AllAccess)] string context,
 			[Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);
@@ -71,7 +71,7 @@ namespace Tests.Linq
 
 		[Test]
 		public void AsQueryable_Parameterize_ExceptId_InlinesId(
-			[DataSources] string context,
+			[DataSources(TestProvName.AllAccess)] string context,
 			[Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);
@@ -91,7 +91,7 @@ namespace Tests.Linq
 
 		[Test]
 		public void AsQueryable_Inline_ExceptData_ParameterisesData(
-			[DataSources] string context,
+			[DataSources(TestProvName.AllAccess)] string context,
 			[Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);
@@ -112,7 +112,7 @@ namespace Tests.Linq
 
 		[Test]
 		public void AsQueryable_Parameterize_CacheStable_AcrossDataChanges(
-			[DataSources] string context)
+			[DataSources(TestProvName.AllAccess)] string context)
 		{
 			using var db = GetDataContext(context);
 
@@ -137,21 +137,19 @@ namespace Tests.Linq
 
 		[Test]
 		public void AsQueryable_Parameterize_CacheHit_AcrossIterations(
-			[DataSources] string context,
+			[DataSources(TestProvName.AllAccess)] string context,
 			[Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);
 
-			var rows = new List<ParamRow>
-			{
-				new() { Id = 1 + iteration, Data = "Data " + iteration },
-				new() { Id = 2 + iteration, Data = "More " + iteration },
-			};
+			// Vary both the row count and the values across iterations — the IR shape stays the
+			// same so the compiled query must be reused.
+			var rows = BuildParamRows(iteration + 1, seed: iteration * 10);
 
 			var query     = rows.AsQueryable(db, b => b.Parameterize());
 			var cacheMiss = query.GetCacheMissCount();
 
-			query.ToArray();
+			_ = query.ToArray();
 
 			if (iteration > 1)
 				query.GetCacheMissCount().ShouldBe(cacheMiss);
@@ -159,24 +157,20 @@ namespace Tests.Linq
 
 		[Test]
 		public void AsQueryable_Inline_CacheHit_AcrossIterations(
-			[DataSources] string context,
+			[DataSources(TestProvName.AllAccess)] string context,
 			[Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);
 
-			// Even in Inline mode, the LINQ expression tree shape doesn't change with row values —
-			// the per-row SqlValues are produced from the materialised source at execution time.
-			// The compiled query is reused across iterations.
-			var rows = new List<ParamRow>
-			{
-				new() { Id = 1 + iteration, Data = "Data " + iteration },
-				new() { Id = 2 + iteration, Data = "More " + iteration },
-			};
+			// Even in Inline mode, the LINQ expression tree shape doesn't change with row count or
+			// values — the per-row SqlValues are produced from the materialised source at execution
+			// time. The compiled query is reused across iterations.
+			var rows = BuildParamRows(iteration + 1, seed: iteration * 10);
 
 			var query     = rows.AsQueryable(db, b => b.Inline());
 			var cacheMiss = query.GetCacheMissCount();
 
-			query.ToArray();
+			_ = query.ToArray();
 
 			if (iteration > 1)
 				query.GetCacheMissCount().ShouldBe(cacheMiss);
@@ -184,23 +178,19 @@ namespace Tests.Linq
 
 		[Test]
 		public void AsQueryable_Parameterize_ExceptId_CacheHit_AcrossIterations(
-			[DataSources] string context,
+			[DataSources(TestProvName.AllAccess)] string context,
 			[Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);
 
 			// Id is inlined (Except flips it from parameter to literal); Data is parameterised.
-			// The IR shape is the same across iterations regardless of values, so the cache hits.
-			var rows = new List<ParamRow>
-			{
-				new() { Id = 1 + iteration, Data = "Data " + iteration },
-				new() { Id = 2 + iteration, Data = "More " + iteration },
-			};
+			// The IR shape is the same across iterations regardless of row count or values, so the cache hits.
+			var rows = BuildParamRows(iteration + 1, seed: iteration * 10);
 
 			var query     = rows.AsQueryable(db, b => b.Parameterize().Except(p => p.Id));
 			var cacheMiss = query.GetCacheMissCount();
 
-			query.ToArray();
+			_ = query.ToArray();
 
 			if (iteration > 1)
 				query.GetCacheMissCount().ShouldBe(cacheMiss);
@@ -208,7 +198,7 @@ namespace Tests.Linq
 
 		[Test]
 		public void AsQueryable_Parameterize_ScalarIntList(
-			[DataSources] string context,
+			[DataSources(TestProvName.AllAccess)] string context,
 			[Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);
@@ -227,7 +217,7 @@ namespace Tests.Linq
 
 		[Test]
 		public void AsQueryable_Parameterize_InlineArray(
-			[DataSources] string context,
+			[DataSources(TestProvName.AllAccess)] string context,
 			[Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);
@@ -245,6 +235,55 @@ namespace Tests.Linq
 
 			sql.ShouldNotContain("'Data 0'");
 			sql.ShouldNotContain("'Data 1'");
+		}
+
+		[Test]
+		public void AsQueryable_JoinPerson_CacheHit_AcrossIterations(
+			[DataSources(TestProvName.AllAccess)] string context,
+			[Values(1, 2)] int iteration)
+		{
+			using var db = GetDataContext(context);
+
+			// Vary both the row count and the values across iterations — the IR shape stays
+			// stable, so the compiled query must be reused.
+			var rows = BuildParamRows(iteration + 1, seed: iteration * 10);
+
+			var query =
+				from p in db.Person
+				join r in rows.AsQueryable(db, b => b.Parameterize()) on p.ID equals r.Id
+				select p;
+
+			var cacheMiss = query.GetCacheMissCount();
+			_ = query.ToArray();
+
+			if (iteration > 1)
+				query.GetCacheMissCount().ShouldBe(cacheMiss);
+		}
+
+		[Test]
+		public void AsQueryable_CrossApply_CacheHit_AcrossIterations(
+			[IncludeDataSources(
+				TestProvName.AllSqlServer2008Plus,
+				TestProvName.AllPostgreSQL93Plus,
+				TestProvName.AllOracle12Plus,
+				TestProvName.AllMySqlWithApply)] string context,
+			[Values(1, 2)] int iteration)
+		{
+			using var db = GetDataContext(context);
+
+			var rows = BuildParamRows(iteration + 1, seed: iteration * 10);
+
+			// SelectMany with Where on the outer row → CROSS APPLY shape.
+			var query =
+				from p in db.Person
+				from r in rows.AsQueryable(db, b => b.Parameterize()).Where(r => r.Id == p.ID)
+				select p;
+
+			var cacheMiss = query.GetCacheMissCount();
+			_ = query.ToArray();
+
+			if (iteration > 1)
+				query.GetCacheMissCount().ShouldBe(cacheMiss);
 		}
 
 		#endregion

--- a/Tests/Linq/Linq/EnumerableSourceTests.AsQueryable.cs
+++ b/Tests/Linq/Linq/EnumerableSourceTests.AsQueryable.cs
@@ -1,0 +1,181 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using LinqToDB;
+
+using NUnit.Framework;
+
+using Shouldly;
+
+namespace Tests.Linq
+{
+	[TestFixture]
+	public partial class EnumerableSourceTests : TestBase
+	{
+		#region AsQueryable parameterisation (issue 5424)
+
+		sealed class ParamRow
+		{
+			public int     Id   { get; set; }
+			public string? Data { get; set; }
+		}
+
+		static List<ParamRow> BuildParamRows(int count, int seed = 0)
+		{
+			var list = new List<ParamRow>(count);
+			for (var i = 0; i < count; i++)
+				list.Add(new ParamRow { Id = i + seed, Data = "Data " + (i + seed) });
+			return list;
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5424")]
+		public void AsQueryable_Parameterize_AllParameters(
+			[IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL93Plus)] string context,
+			[Values(1, 2)] int iteration)
+		{
+			using var db = GetDataContext(context);
+
+			var rows  = BuildParamRows(2);
+			var query = rows.AsQueryable(db, b => b.Parameterize());
+
+			var sql    = query.ToSqlQuery().Sql;
+			var result = query.ToList();
+
+			result.Count.ShouldBe(2);
+			result[0].Id.ShouldBe(0);
+			result[0].Data.ShouldBe("Data 0");
+
+			sql.ShouldNotContain("'Data 0'");
+			sql.ShouldNotContain("'Data 1'");
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5424")]
+		public void AsQueryable_Inline_AllInlined(
+			[IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL93Plus)] string context,
+			[Values(1, 2)] int iteration)
+		{
+			using var db = GetDataContext(context);
+
+			var rows  = BuildParamRows(2);
+			var query = rows.AsQueryable(db, b => b.Inline());
+
+			var sql    = query.ToSqlQuery().Sql;
+			var result = query.ToList();
+
+			result.Count.ShouldBe(2);
+			result[1].Data.ShouldBe("Data 1");
+
+			sql.ShouldContain("'Data 0'");
+			sql.ShouldContain("'Data 1'");
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5424")]
+		public void AsQueryable_Parameterize_ExceptId_InlinesId(
+			[IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL93Plus)] string context,
+			[Values(1, 2)] int iteration)
+		{
+			using var db = GetDataContext(context);
+
+			var rows  = BuildParamRows(2);
+			var query = rows.AsQueryable(db, b => b.Parameterize().Except(p => p.Id));
+
+			var sql    = query.ToSqlQuery().Sql;
+			var result = query.ToList();
+
+			result.Count.ShouldBe(2);
+
+			// Id is inlined as a literal; Data is parameterised.
+			sql.ShouldNotContain("'Data 0'");
+			sql.ShouldNotContain("'Data 1'");
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5424")]
+		public void AsQueryable_Inline_ExceptData_ParameterisesData(
+			[IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL93Plus)] string context,
+			[Values(1, 2)] int iteration)
+		{
+			using var db = GetDataContext(context);
+
+			var rows  = BuildParamRows(2);
+			var query = rows.AsQueryable(db, b => b.Inline().Except(p => p.Data));
+
+			var sql    = query.ToSqlQuery().Sql;
+			var result = query.ToList();
+
+			result.Count.ShouldBe(2);
+			result[0].Data.ShouldBe("Data 0");
+
+			// Data is parameterised, so the literal must not appear in SQL.
+			sql.ShouldNotContain("'Data 0'");
+			sql.ShouldNotContain("'Data 1'");
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5424")]
+		public void AsQueryable_Parameterize_CacheStable_AcrossDataChanges(
+			[IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL93Plus)] string context)
+		{
+			using var db = GetDataContext(context);
+
+			// First call — populates the cache.
+			var firstRows  = BuildParamRows(2, seed: 0);
+			var firstQuery = firstRows.AsQueryable(db, b => b.Parameterize());
+			firstQuery.ToList();
+
+			var cacheMissBefore = firstQuery.GetCacheMissCount();
+
+			// Second call with different content but identical shape — must hit the cache.
+			var secondRows  = BuildParamRows(2, seed: 100);
+			var secondQuery = secondRows.AsQueryable(db, b => b.Parameterize());
+			var secondList  = secondQuery.ToList();
+
+			secondQuery.GetCacheMissCount().ShouldBe(cacheMissBefore);
+
+			secondList.Count.ShouldBe(2);
+			secondList[0].Id.ShouldBe(100);
+			secondList[1].Id.ShouldBe(101);
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5424")]
+		public void AsQueryable_Parameterize_ScalarIntList(
+			[IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL93Plus)] string context,
+			[Values(1, 2)] int iteration)
+		{
+			using var db = GetDataContext(context);
+
+			var values = new[] { 10, 20, 30 };
+			var query  = values.AsQueryable(db, b => b.Parameterize());
+
+			var sql    = query.ToSqlQuery().Sql;
+			var result = query.ToList();
+
+			result.OrderBy(x => x).ShouldBe(new[] { 10, 20, 30 });
+
+			// Scalar values are parameterised — assert the SQL is non-empty.
+			sql.ShouldNotBeNullOrEmpty();
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5424")]
+		public void AsQueryable_Parameterize_InlineArray(
+			[IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL93Plus)] string context,
+			[Values(1, 2)] int iteration)
+		{
+			using var db = GetDataContext(context);
+
+			var query = new[]
+			{
+				new ParamRow { Id = 0, Data = "Data 0" },
+				new ParamRow { Id = 1, Data = "Data 1" },
+			}.AsQueryable(db, b => b.Parameterize());
+
+			var sql    = query.ToSqlQuery().Sql;
+			var result = query.ToList();
+
+			result.Count.ShouldBe(2);
+
+			sql.ShouldNotContain("'Data 0'");
+			sql.ShouldNotContain("'Data 1'");
+		}
+
+		#endregion
+	}
+}

--- a/Tests/Linq/Linq/EnumerableSourceTests.AsQueryable.cs
+++ b/Tests/Linq/Linq/EnumerableSourceTests.AsQueryable.cs
@@ -28,9 +28,9 @@ namespace Tests.Linq
 			return list;
 		}
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/5424")]
+		[Test]
 		public void AsQueryable_Parameterize_AllParameters(
-			[IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL93Plus)] string context,
+			[DataSources] string context,
 			[Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);
@@ -49,9 +49,9 @@ namespace Tests.Linq
 			sql.ShouldNotContain("'Data 1'");
 		}
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/5424")]
+		[Test]
 		public void AsQueryable_Inline_AllInlined(
-			[IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL93Plus)] string context,
+			[DataSources] string context,
 			[Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);
@@ -69,9 +69,9 @@ namespace Tests.Linq
 			sql.ShouldContain("'Data 1'");
 		}
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/5424")]
+		[Test]
 		public void AsQueryable_Parameterize_ExceptId_InlinesId(
-			[IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL93Plus)] string context,
+			[DataSources] string context,
 			[Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);
@@ -89,9 +89,9 @@ namespace Tests.Linq
 			sql.ShouldNotContain("'Data 1'");
 		}
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/5424")]
+		[Test]
 		public void AsQueryable_Inline_ExceptData_ParameterisesData(
-			[IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL93Plus)] string context,
+			[DataSources] string context,
 			[Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);
@@ -110,9 +110,9 @@ namespace Tests.Linq
 			sql.ShouldNotContain("'Data 1'");
 		}
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/5424")]
+		[Test]
 		public void AsQueryable_Parameterize_CacheStable_AcrossDataChanges(
-			[IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL93Plus)] string context)
+			[DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 
@@ -135,9 +135,9 @@ namespace Tests.Linq
 			secondList[1].Id.ShouldBe(101);
 		}
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/5424")]
+		[Test]
 		public void AsQueryable_Parameterize_CacheHit_AcrossIterations(
-			[IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL93Plus)] string context,
+			[DataSources] string context,
 			[Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);
@@ -157,9 +157,9 @@ namespace Tests.Linq
 				query.GetCacheMissCount().ShouldBe(cacheMiss);
 		}
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/5424")]
+		[Test]
 		public void AsQueryable_Inline_CacheHit_AcrossIterations(
-			[IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL93Plus)] string context,
+			[DataSources] string context,
 			[Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);
@@ -182,9 +182,9 @@ namespace Tests.Linq
 				query.GetCacheMissCount().ShouldBe(cacheMiss);
 		}
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/5424")]
+		[Test]
 		public void AsQueryable_Parameterize_ExceptId_CacheHit_AcrossIterations(
-			[IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL93Plus)] string context,
+			[DataSources] string context,
 			[Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);
@@ -206,9 +206,9 @@ namespace Tests.Linq
 				query.GetCacheMissCount().ShouldBe(cacheMiss);
 		}
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/5424")]
+		[Test]
 		public void AsQueryable_Parameterize_ScalarIntList(
-			[IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL93Plus)] string context,
+			[DataSources] string context,
 			[Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);
@@ -225,9 +225,9 @@ namespace Tests.Linq
 			sql.ShouldNotBeNullOrEmpty();
 		}
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/5424")]
+		[Test]
 		public void AsQueryable_Parameterize_InlineArray(
-			[IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL93Plus)] string context,
+			[DataSources] string context,
 			[Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);

--- a/Tests/Linq/Linq/EnumerableSourceTests.AsQueryable.cs
+++ b/Tests/Linq/Linq/EnumerableSourceTests.AsQueryable.cs
@@ -35,7 +35,7 @@ namespace Tests.Linq
 			using var db = GetDataContext(context);
 
 			var rows  = BuildParamRows(2);
-			var query = rows.AsQueryable(db, b => b.Parameterize());
+			var query = rows.AsQueryable(db, b => b.Parameterize()).OrderBy(r => r.Id);
 
 			var sql    = query.ToSqlQuery().Sql;
 			var result = query.ToList();
@@ -55,7 +55,7 @@ namespace Tests.Linq
 			using var db = GetDataContext(context);
 
 			var rows  = BuildParamRows(2);
-			var query = rows.AsQueryable(db, b => b.Inline());
+			var query = rows.AsQueryable(db, b => b.Inline()).OrderBy(r => r.Id);
 
 			var sql    = query.ToSqlQuery().Sql;
 			var result = query.ToList();
@@ -99,7 +99,7 @@ namespace Tests.Linq
 
 			// Distinctive seed → Ids 7777, 7778 — unlikely to occur incidentally in generated SQL.
 			var rows  = BuildParamRows(2, seed: 7777);
-			var query = rows.AsQueryable(db, b => b.Inline().Except(p => p.Data));
+			var query = rows.AsQueryable(db, b => b.Inline().Except(p => p.Data)).OrderBy(r => r.Id);
 
 			var sql    = query.ToSqlQuery().Sql;
 			var result = query.ToList();
@@ -124,14 +124,14 @@ namespace Tests.Linq
 
 			// First call — populates the cache.
 			var firstRows  = BuildParamRows(2, seed: 0);
-			var firstQuery = firstRows.AsQueryable(db, b => b.Parameterize());
+			var firstQuery = firstRows.AsQueryable(db, b => b.Parameterize()).OrderBy(r => r.Id);
 			firstQuery.ToList();
 
 			var cacheMissBefore = firstQuery.GetCacheMissCount();
 
 			// Second call with different content but identical shape — must hit the cache.
 			var secondRows  = BuildParamRows(2, seed: 100);
-			var secondQuery = secondRows.AsQueryable(db, b => b.Parameterize());
+			var secondQuery = secondRows.AsQueryable(db, b => b.Parameterize()).OrderBy(r => r.Id);
 			var secondList  = secondQuery.ToList();
 
 			secondQuery.GetCacheMissCount().ShouldBe(cacheMissBefore);

--- a/Tests/Linq/Linq/EnumerableSourceTests.AsQueryable.cs
+++ b/Tests/Linq/Linq/EnumerableSourceTests.AsQueryable.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 using LinqToDB;
@@ -9,7 +10,6 @@ using Shouldly;
 
 namespace Tests.Linq
 {
-	[TestFixture]
 	public partial class EnumerableSourceTests : TestBase
 	{
 		#region AsQueryable parameterisation (issue 5424)
@@ -390,6 +390,43 @@ namespace Tests.Linq
 			var act = () => rows.AsQueryable(db, b => b.Parameterize().Except(p => other.Id)).ToSqlQuery();
 
 			act.ShouldThrow<LinqToDBException>().Message.ShouldContain("AsQueryable configure");
+		}
+
+		// Regression coverage for the configured 3-arg overload inside CompiledQuery.Compile with the
+		// IEnumerable<T> source supplied as a compiled-query parameter. The configured path's
+		// BuildTraverseExpression on sourceArg lets a free ParameterExpression flow through
+		// CanBeEvaluatedOnClient, so the chain compiles and executes for any per-iteration enumerable.
+		static readonly Func<IDataContext, IEnumerable<ParamRow>, IEnumerable<ParamRow>> _compiledConfiguredAsQueryable =
+			CompiledQuery.Compile<IDataContext, IEnumerable<ParamRow>, IEnumerable<ParamRow>>(
+				(db, rows) => rows.AsQueryable(db, b => b.Parameterize()).OrderBy(r => r.Id));
+
+		[Test]
+		public void AsQueryable_Configured_CompiledQuery_WithEnumerableParam(
+			[IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using var ctx = GetDataContext(context);
+
+			// First invocation: 2 rows starting at id 0.
+			var rows1   = BuildParamRows(2);
+			var result1 = _compiledConfiguredAsQueryable(ctx, rows1).ToList();
+
+			result1.Count.ShouldBe(2);
+			result1[0].Id.ShouldBe(0);
+			result1[0].Data.ShouldBe("Data 0");
+			result1[1].Id.ShouldBe(1);
+			result1[1].Data.ShouldBe("Data 1");
+
+			// Second invocation through the same compiled delegate, with a different row count and seed.
+			// Proves the compiled query is reusable across distinct enumerable arguments — the static
+			// field is built once and the rows[] payload flows through as a runtime parameter on each call.
+			var rows2   = BuildParamRows(3, seed: 100);
+			var result2 = _compiledConfiguredAsQueryable(ctx, rows2).ToList();
+
+			result2.Count.ShouldBe(3);
+			result2[0].Id.ShouldBe(100);
+			result2[0].Data.ShouldBe("Data 100");
+			result2[2].Id.ShouldBe(102);
+			result2[2].Data.ShouldBe("Data 102");
 		}
 
 		#endregion

--- a/Tests/Linq/Linq/EnumerableSourceTests.cs
+++ b/Tests/Linq/Linq/EnumerableSourceTests.cs
@@ -14,7 +14,7 @@ using Tests.Model;
 namespace Tests.Linq
 {
 	[TestFixture]
-	public class EnumerableSourceTests : TestBase
+	public partial class EnumerableSourceTests : TestBase
 	{
 		[Test]
 		public void ApplyJoinArray(

--- a/Tests/Tests.Playground/Tests.Playground.csproj
+++ b/Tests/Tests.Playground/Tests.Playground.csproj
@@ -8,8 +8,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<Compile Include="..\Linq\TestsInitialization.cs" Link="TestsInitialization.cs" />
-		<Compile Include="..\Linq\Create\CreateData.cs" Link="CreateData.cs" />
+		<Compile Include="..\Linq\TestsInitialization.cs"                       Link="TestsInitialization.cs" />
+		<Compile Include="..\Linq\Create\CreateData.cs"                         Link="CreateData.cs" />
+		<Compile Include="..\Linq\YdbToDoAttributes.cs"                         Link="YdbToDoAttributes.cs" />
+		<Compile Include="..\Linq\Linq\EnumerableSourceTests.cs"                Link="EnumerableSourceTests.cs" />
+		<Compile Include="..\Linq\Linq\EnumerableSourceTests.AsQueryable.cs"    Link="EnumerableSourceTests.AsQueryable.cs" />
 	</ItemGroup>
 
 </Project>

--- a/Tests/Tests.Playground/Tests.Playground.csproj
+++ b/Tests/Tests.Playground/Tests.Playground.csproj
@@ -10,9 +10,6 @@
 	<ItemGroup>
 		<Compile Include="..\Linq\TestsInitialization.cs"                       Link="TestsInitialization.cs" />
 		<Compile Include="..\Linq\Create\CreateData.cs"                         Link="CreateData.cs" />
-		<Compile Include="..\Linq\YdbToDoAttributes.cs"                         Link="YdbToDoAttributes.cs" />
-		<Compile Include="..\Linq\Linq\EnumerableSourceTests.cs"                Link="EnumerableSourceTests.cs" />
-		<Compile Include="..\Linq\Linq\EnumerableSourceTests.AsQueryable.cs"    Link="EnumerableSourceTests.AsQueryable.cs" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adds an `AsQueryable` overload that gives per-column control over how an `IEnumerable<T>` is rendered into the resulting `VALUES (...)` clause.

```csharp
data.AsQueryable(db, b => b.Parameterize())
data.AsQueryable(db, b => b.Inline())
data.AsQueryable(db, b => b.Parameterize().Except(p => p.Id))
data.AsQueryable(db, b => b.Inline().Except(p => p.Address.Zip))
```

The chain is type-safe — `Parameterize()` or `Inline()` must come first, after which only `Except(...)` is available, so misuse doesn't compile.

DB2: extends `IsSqlValuesTableValueTypeRequired` to wrap parameter cells in `CAST(@p AS <type>)` — DB2 rejects untyped parameter markers inside `VALUES` (SQL0418N).

ClickHouse: parameterised `VALUES` isn't supported (parameters are disabled at multiple layers in the data provider); the relevant `Parameterize` tests skip ClickHouse.

Closes #5424.
