### PR TITLE
More relaxed converter check on rows

### DIFF
--- a/Source/LinqToDB/Internal/Expressions/SqlPlaceholderExpression.cs
+++ b/Source/LinqToDB/Internal/Expressions/SqlPlaceholderExpression.cs
@@ -27,7 +27,7 @@ namespace LinqToDB.Internal.Expressions
 
 			if (null != sql.Find(e => e is SelectQuery sc && ReferenceEquals(sc, selectQuery)))
 			{
-				throw new InvalidOperationException($"Wrong select query.");
+				throw new InvalidOperationException("Wrong select query.");
 			}
 
 #endif
@@ -203,7 +203,7 @@ namespace LinqToDB.Internal.Expressions
 
 		public bool Equals(SqlPlaceholderExpression? other)
 		{
-			return 
+			return
 				other != null                                                &&
 				Equals(SelectQuery, other.SelectQuery)                       &&
 			    ExpressionEqualityComparer.Instance.Equals(Path, other.Path) &&

--- a/Source/LinqToDB/Internal/Linq/Builder/UpdateBuilder.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/UpdateBuilder.cs
@@ -487,8 +487,13 @@ namespace LinqToDB.Internal.Linq.Builder
 							{
 								if (QueryHelper.GetUnderlyingExpression(placeholderUpdate.Sql) is SqlRowExpression valuesRow && valuesRow.Values.Length > i)
 								{
-									var underlying = QueryHelper.GetUnderlyingField(valuesRow.Values[i]);
-									if (underlying != null)
+									// SqlParameter and SqlValue should have the value they hold be converted
+									// but this is unsupported because when the SqlParameter was built the
+									// column context was not available because of Sql.Row.
+									//
+									// Setting a direct value doesn't need to be in a Row(..),
+									// as Row and scalar setters can be mixed, so this isn't a strong limitation.
+									if (valuesRow.Values[i] is not (SqlParameter or SqlValue))
 										throwConversionError = false;
 								}
 							}
@@ -575,7 +580,7 @@ namespace LinqToDB.Internal.Linq.Builder
 					ParseSet(builder, buildContext, currentPath, f.Expression, v.Expression, envelopes, false);
 				}
 			}
-			else 
+			else
 			{
 				envelopes.Add(new SetExpressionEnvelope(correctedField.UnwrapConvert(), valueExpression, forceParameters));
 			}

--- a/Tests/Linq/Linq/SqlRowTests.cs
+++ b/Tests/Linq/Linq/SqlRowTests.cs
@@ -33,7 +33,7 @@ namespace Tests.Linq
 		public void ServerSideOnly([DataSources] string context)
 		{
 			// SqlRow type can't be instantiated client-side,
-			// it's purely a LINQ construct that is converted into SQl code.
+			// it's purely a LINQ construct that is converted into SQL code.
 
 			using var db   = GetDataContext(context);
 			using var ints = SetupIntsTable(db);
@@ -665,10 +665,10 @@ namespace Tests.Linq
 			var updated = table.Single(x => x.Id == 2);
 
 			count.ShouldBe(1);
-			updated.One.ShouldBe(2);    // When converted to .net, converter divides by 100
+			updated.One.ShouldBe(2);    // When converted to .NET, converter divides by 100
 			updated.Two.ShouldBe(200);
 
-			// Literals values should be converted but this isn't supported yet
+			// Literal values should be converted but this isn't supported yet
 			// because column context is lost in Row when building parameters.
 			Shouldly.Should.Throw<LinqToDBException>(() =>
 				table

--- a/Tests/Linq/Linq/SqlRowTests.cs
+++ b/Tests/Linq/Linq/SqlRowTests.cs
@@ -641,23 +641,25 @@ namespace Tests.Linq
 		{
 			var data = new ConvertedInts[]
 			{
-				new() { Id = 1, One = 100, Two = 200 },
-				new() { Id = 2, One = 8100, Two = 8200 },
+				// Note: linq2db applied *100 conversion when inserting into db
+				new() { Id = 1, Cents = 1, Ints = 2 },
+				new() { Id = 2, Cents = 81, Ints = 82 },
 			};
 
 			using var db   = GetDataContext(context);
 			using var table = db.CreateLocalTable(data);
 
 			// Assignment between SQL expressions doesn't go through converters
-			// So in DB x.One will be set to 200
 			int count = table
 				.Where(x => x.Id == 2)
 				.Set(
-					x => Row(x.One, x.Two),
+					x => Row(x.Cents, x.Ints),
 					x => (
 						from src in table
 						where src.Id == x.Id - 1
-						select Row(src.One + 100, src.Two * src.One)
+						// Note: linq2db applies *100 conversion to constant `1` in `Cents + 1`,
+						// so Cents = Cents + 100.
+						select Row(src.Cents + 1, src.Ints * src.Cents)
 					).Single()
 				)
 				.Update();
@@ -665,8 +667,8 @@ namespace Tests.Linq
 			var updated = table.Single(x => x.Id == 2);
 
 			count.ShouldBe(1);
-			updated.One.ShouldBe(2);    // When converted to .net, converter divides by 100
-			updated.Two.ShouldBe(200);
+			updated.Cents.ShouldBe(2);   // Conversion /100 when read back from db
+			updated.Ints.ShouldBe(200);  // Was computed as 100 * 2 in SQL update
 
 			// Literals values should be converted but this isn't supported yet
 			// because column context is lost in Row when building parameters.
@@ -674,11 +676,11 @@ namespace Tests.Linq
 				table
 					.Where(x => x.Id == 2)
 					.Set(
-						x => Row(x.One, x.Two),
+						x => Row(x.Cents, x.Ints),
 						x => (
 							from src in table
 							where src.Id == x.Id - 1
-							select Row(3, src.Two * src.One)
+							select Row(3, src.Ints * src.Cents)
 						).Single()
 					)
 					.Update());
@@ -689,11 +691,11 @@ namespace Tests.Linq
 				table
 					.Where(x => x.Id == 2)
 					.Set(
-						x => Row(x.One, x.Two),
+						x => Row(x.Cents, x.Ints),
 						x => (
 							from src in table
 							where src.Id == x.Id - 1
-							select Row(i, src.Two * src.One)
+							select Row(i, src.Ints * src.Cents)
 						).Single()
 					)
 					.Update());
@@ -738,9 +740,8 @@ namespace Tests.Linq
 			public int Id { get; set; }
 
 			[ValueConverter(ConverterType = typeof(CentsConverter))]
-			public int One { get; set; }
-			[ValueConverter(ConverterType = typeof(CentsConverter))]
-			public int Two { get; set; }
+			public int Cents { get; set; }
+			public int Ints { get; set; }
 		}
 
 		// Stores values in cents

--- a/Tests/Linq/Linq/SqlRowTests.cs
+++ b/Tests/Linq/Linq/SqlRowTests.cs
@@ -32,9 +32,9 @@ namespace Tests.Linq
 		[Test]
 		public void ServerSideOnly([DataSources] string context)
 		{
-			// SqlRow type can't be instantiated client-side, 
+			// SqlRow type can't be instantiated client-side,
 			// it's purely a LINQ construct that is converted into SQl code.
-			
+
 			using var db   = GetDataContext(context);
 			using var ints = SetupIntsTable(db);
 
@@ -260,7 +260,7 @@ namespace Tests.Linq
 					Row((int?)0, 7, 9),
 					Row((int?)null, -1, i.Four)))
 				.ShouldBe(1);
-			
+
 			ints.Count(i => Row((int?)i.One, i.Two, i.Four).In(
 					Row((int?)i.One, i.One * 2, i.Four - 1),
 					Row((int?)0, 7, 9),
@@ -291,7 +291,7 @@ namespace Tests.Linq
 					Row((int?)0, 7, 9),
 					Row((int?)null, -1, i.Four)))
 				.ShouldBe(0);
-			
+
 			ints.Count(i => Row((int?)i.One, i.Three, i.Four).NotIn(
 					Row((int?)i.One, i.One * 2, i.Four - 1),
 					Row((int?)0, 7, 9),
@@ -470,14 +470,14 @@ namespace Tests.Linq
 			using var ints = SetupIntsTable(db);
 			using var ints2 = SetupIntsTable(db, "Ints2");
 
-			ints.Count(x => Row(x.One, x.Two, x.Three) == 
+			ints.Count(x => Row(x.One, x.Two, x.Three) ==
 				(from y in ints2
 				 where y.Nil == null
 				 select Row(y.One, y.One + 1, 3)).Single())
 				.ShouldBe(1);
 
 			// Because operator == is defined for `object`, .Single() is not required
-			ints.Count(x => Row(x.One, x.Two, x.Three) == 
+			ints.Count(x => Row(x.One, x.Two, x.Three) ==
 				(from y in ints2
 				 where y.Nil == null
 				 select Row(y.One, y.One + 1, 3)))
@@ -553,8 +553,8 @@ namespace Tests.Linq
 			using var db    = GetDataContext(context);
 			using var table = db.CreateLocalTable(data);
 
-			table.Count(t => 
-					t.Int > 0 && 
+			table.Count(t =>
+					t.Int > 0 &&
 					Row(t.Str, t.Double, t.Bool) == Row("One", 1.0, true) &&
 					table.Any(u => Row(2, u.Date) > Row(u.Int, t.Date)))
 				.ShouldBe(1);
@@ -631,6 +631,74 @@ namespace Tests.Linq
 				});
 		}
 
+		[Test]
+		public void UpdateRowWithConverters(
+			[IncludeDataSources(true,
+				ProviderName.DB2,
+				TestProvName.AllPostgreSQL95Plus,
+				TestProvName.AllSQLite,
+				TestProvName.AllOracle)] string context)
+		{
+			var data = new ConvertedInts[]
+			{
+				new() { Id = 1, One = 100, Two = 200 },
+				new() { Id = 2, One = 8100, Two = 8200 },
+			};
+
+			using var db   = GetDataContext(context);
+			using var table = db.CreateLocalTable(data);
+
+			// Assignment between SQL expressions doesn't go through converters
+			// So in DB x.One will be set to 200
+			int count = table
+				.Where(x => x.Id == 2)
+				.Set(
+					x => Row(x.One, x.Two),
+					x => (
+						from src in table
+						where src.Id == x.Id - 1
+						select Row(src.One + 100, src.Two * src.One)
+					).Single()
+				)
+				.Update();
+
+			var updated = table.Single(x => x.Id == 2);
+
+			count.ShouldBe(1);
+			updated.One.ShouldBe(2);    // When converted to .net, converter divides by 100
+			updated.Two.ShouldBe(200);
+
+			// Literals values should be converted but this isn't supported yet
+			// because column context is lost in Row when building parameters.
+			Shouldly.Should.Throw<LinqToDBException>(() =>
+				table
+					.Where(x => x.Id == 2)
+					.Set(
+						x => Row(x.One, x.Two),
+						x => (
+							from src in table
+							where src.Id == x.Id - 1
+							select Row(3, src.Two * src.One)
+						).Single()
+					)
+					.Update());
+
+			// Parameters values should be converted as well, and aren't supported either.
+			int i = 4;
+			Shouldly.Should.Throw<LinqToDBException>(() =>
+				table
+					.Where(x => x.Id == 2)
+					.Set(
+						x => Row(x.One, x.Two),
+						x => (
+							from src in table
+							where src.Id == x.Id - 1
+							select Row(i, src.Two * src.One)
+						).Single()
+					)
+					.Update());
+		}
+
 		sealed class Ints : IEquatable<Ints>
 		{
 			[PrimaryKey]
@@ -663,6 +731,20 @@ namespace Tests.Linq
 			public double   Double { get; set; }
 			public bool     Bool   { get; set; }
 		}
+
+		sealed class ConvertedInts
+		{
+			[PrimaryKey]
+			public int Id { get; set; }
+
+			[ValueConverter(ConverterType = typeof(CentsConverter))]
+			public int One { get; set; }
+			[ValueConverter(ConverterType = typeof(CentsConverter))]
+			public int Two { get; set; }
+		}
+
+		// Stores values in cents
+		sealed class CentsConverter() : ValueConverter<int, int>(net => 100 * net, sql => sql / 100, false);
 
 		#region Issue 3631
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/3631")]


### PR DESCRIPTION
Fixes #5438 

Idea is to forbid using a parameter or literal that would need a conversion in a ROW assignment, like `row(a, b) = row(12, localVariable)` if `a` or `b` are columns with value converters. This is because converters are not applied properly inside `row` expressions.

On the other hand, we want to allow any SQL expression, which would not be converted anyway, like:
`row(a, b) = row(t.x + t.y, t.z * 2)`.

Added a basic test with SQL expressions and two expected exceptions for literal and parameter.