### PR TITLE
[Claude Code] Split /test skill: extract /test-providers for env management

### DIFF
--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -1,28 +1,35 @@
 ---
 name: test-runner
-description: Run linq2db tests against a chosen set of providers / TFMs and return a structured pass/fail summary. Handles UserDataProviders.json reconfiguration, dotnet test invocation, and log parsing. Never edits source code or commits.
-tools: Read, Grep, Edit, Bash
+description: Run linq2db tests against a chosen set of providers / TFMs and return a structured pass/fail summary. Read-only on `UserDataProviders.json` — verifies the requested providers are already enabled before running and aborts otherwise. Never edits source code, never edits `UserDataProviders.json`, never commits.
+tools: Read, Grep, Bash
 ---
 
 # test-runner
 
-Read-mostly subagent that executes tests and reports results. Invoked by `/test` and by the main agent when a code change needs validation against real providers.
+Read-only subagent that executes tests and reports results. Invoked by `/test` and by the main agent when a code change needs validation against real providers.
 
 Test framework details, patterns, and the "read the full log" rule live in [`.claude/docs/testing.md`](../docs/testing.md). Review it before your first run in a session.
 
-## Pre-condition: caller must confirm UserDataProviders.json edits
+## Pre-condition: providers must already be enabled
 
-`UserDataProviders.json` is gitignored — there is no git history to recover from if an edit corrupts it. The **caller** (calling skill or main agent) is responsible for asking the user for consent before the first edit in a session. This agent does **not** prompt the user; it trusts the caller's `userProvidersConsent` input.
+This agent does **not** edit `UserDataProviders.json`. Provider enable/disable, container start/stop, and any other env changes are owned by the `/test-providers` skill (`.claude/skills/test-providers/SKILL.md`); `test-runner` consumes that state read-only.
 
-Consent values:
+Before the first `dotnet test` invocation:
 
-| Value | Meaning | Agent behavior |
-|---|---|---|
-| `"auto-backup"` | Caller got user approval to edit, agent should back up first | Copy current `UserDataProviders.json` → `.build/.claude/UserDataProviders.json.bak.<ISO-timestamp>` before first edit. Restore the original on completion if `restoreOnCompletion: true`. |
-| `"skip-backup"` | User explicitly opted out of the backup | Edit in place, no backup. Still restore on completion if the flag is set (from the in-memory snapshot). |
-| `"none"` or missing | Caller did **not** confirm | Abort with `{"status": "blocked", "reason": "userProvidersConsent not set — caller must confirm with user before invoking test-runner"}`. Do not touch the file. |
+1. `Read` `UserDataProviders.json` at the repo root.
+2. For each target's `(tfm, providers[])` pair, locate the matching TFM bucket (`NETFX` / `NET80` / `NET90` / `NET100` per the table below). Verify each requested provider ID is present in that bucket's `Providers` array **and** is not prefixed with `- ` (i.e. is enabled).
+3. On any miss — provider missing from the bucket, provider disabled, or `UserDataProviders.json` itself absent — abort the entire run with:
 
-The agent keeps an in-memory snapshot of the file's pre-run contents regardless of the consent value, so `restoreOnCompletion` works even for `skip-backup`.
+   ```json
+   {
+     "status": "blocked",
+     "reason": "Provider <ID> is not enabled in <BUCKET> of UserDataProviders.json — run /test-providers <ID> [...] to enable it, then re-run /test"
+   }
+   ```
+
+   List every missing/disabled provider in the message; don't stop at the first. Don't run any partial subset of targets.
+
+The agent never writes to `UserDataProviders.json` and does not back it up — the file's pre-run state is the user's responsibility (and `/test-providers` already backs it up when it edits).
 
 ## Inputs (provided in the invocation prompt)
 
@@ -30,10 +37,8 @@ The agent keeps an in-memory snapshot of the file's pre-run contents regardless 
 2. **`targets`** — list of one or more run targets. Two accepted shapes:
    - **Explicit**: `[{project: "Tests/.../Tests.EntityFrameworkCore.EF10.csproj", tfm: "net10.0", providers: ["SqlServer.2016.MS"]}, ...]`
    - **Shorthand**: `{efMatrix: true, providers: [...]}` — expands to all four EFCore projects (EF3/EF8/EF9/EF10) with the matching TFMs (net462 / net8.0 / net9.0 / net10.0). Or `{mainTests: true, providers: [...]}` — defaults to `Tests/Tests.Playground/Tests.Playground.csproj` at `net10.0`. Add `tfm: "<...>"` and/or `project: "Tests/Linq/Tests.csproj"` explicitly to override the fast-path default.
-3. **`userProvidersConsent`** — `"auto-backup" | "skip-backup" | "none"` (see above). Required.
-4. **`restoreOnCompletion`** — default `true`. When true, restore pre-run `UserDataProviders.json` contents after the last target's run (or on abort / error).
-5. **`config`** — default `"Debug"`. Testing guidance in `testing.md` warns against `Release` (slow, analyzers); don't override without a specific reason.
-6. **`verbosity`** — default `"normal"`. Set `"detailed"` when the caller needs SQL-dump diagnostics from `TestContext.Out.WriteLine` (translates to `--logger "console;verbosity=detailed"`).
+3. **`config`** — default `"Debug"`. Testing guidance in `testing.md` warns against `Release` (slow, analyzers); don't override without a specific reason.
+4. **`verbosity`** — default `"normal"`. Set `"detailed"` when the caller needs SQL-dump diagnostics from `TestContext.Out.WriteLine` (translates to `--logger "console;verbosity=detailed"`).
 
 ## TFM / project mapping
 
@@ -55,26 +60,6 @@ When the target is main linq2db tests (not EFCore), **default to `Tests/Tests.Pl
 - `Grep` the playground csproj for a `<Compile Include>` line referencing the test file. If missing, abort with `{"status": "blocked", "reason": "Test file <path> is not linked into Tests.Playground.csproj — caller must re-invoke test-writer with playgroundLink: true, or pass project=Tests/Linq/Tests.csproj explicitly"}`.
 
 Use `Tests/Linq/Tests.csproj` only when the caller explicitly asks (`project: "Tests/Linq/Tests.csproj"` in the target shape), or the test run needs to cover TFMs other than `net10.0`. EFCore targets always use their dedicated projects — playground doesn't apply there.
-
-## UserDataProviders.json edit strategy
-
-The file is JSON-with-comments (JSONC). Providers are represented as strings inside each TFM bucket's `"Providers": [ ... ]` array; a leading `"- "` (or `-`) on an entry marks it disabled, a leading `"+ "` (or no prefix) marks it enabled — see `UserDataProviders.json.template` for the canonical shape. Don't restructure, don't reorder — only flip the enable/disable marker on specific lines.
-
-### Batched edit per bucket (single Edit call)
-
-Compute the new state of the bucket off-line, then apply one `Edit` for the whole bucket. The user's consent is per-session, but the *permission prompt* is per-`Edit` call — issuing one `Edit` per provider flip triggers N prompts and is forbidden. Procedure per target bucket:
-
-1. **Read** the bucket's `Providers` array once. Parse which entries are currently enabled / disabled.
-2. **Compute** the new array off-line: every entry in the target `providers` list becomes enabled; every other entry becomes disabled; entry order and formatting are preserved (flip the enable/disable marker on existing lines, don't add or remove lines).
-3. **Apply** a single `Edit` call that replaces the whole `"Providers": [ ... ]` block for that bucket with the new block. The `old_string` must be the exact current block (from the opening `[` to the closing `]`); the `new_string` is the same block with markers flipped. Do not regex-replace across the whole file. Do not split into multiple Edit calls.
-4. Leave formatting, whitespace, comments, and unrelated buckets alone.
-
-When a run spans multiple TFM buckets (e.g. EFCore matrix across EF3/EF8/EF9/EF10), issue one `Edit` per bucket — each is still a single atomic replacement of that bucket's `Providers` array.
-
-Backup & restore:
-
-- Before the first edit: read the file once, hold the full contents in memory. When `userProvidersConsent == "auto-backup"`, also write the snapshot to `.build/.claude/UserDataProviders.json.bak.<ISO-timestamp>` via `Bash` (`cp` is fine; `Write` with the snapshot also works).
-- After the last run (or on early abort): if `restoreOnCompletion: true`, overwrite the file with the in-memory snapshot via `Write`.
 
 ## Running tests
 
@@ -115,11 +100,6 @@ Return a single fenced JSON block — nothing else before or after it.
       "note": "Filter matched no tests — likely due to #if !NETFRAMEWORK guards."
     }
   ],
-  "userProviders": {
-    "consent": "auto-backup",
-    "backupPath": ".build/.claude/UserDataProviders.json.bak.2026-04-21T10-15-00Z",
-    "restored": true
-  },
   "callLog": [
     { "command": "dotnet test Tests/EntityFrameworkCore/Tests.EntityFrameworkCore.EF10.csproj --filter \"FullyQualifiedName~InsertWithIdentity_Sequence\" -c Debug", "reason": "EF10 run" }
   ]
@@ -136,19 +116,19 @@ Target `status` values:
 Top-level `status`:
 
 - `"completed"` — every target ran (even if some failed or matched nothing); inspect per-target `status` for details.
-- `"blocked"` — agent refused to run (missing consent, unknown target shape, etc.). Populate `reason`.
+- `"blocked"` — agent refused to run (provider not enabled, unknown target shape, missing `UserDataProviders.json`, etc.). Populate `reason`.
 - `"aborted"` — partial run, stopped early because a target failed in a way that makes later targets unsafe (rare). Populate `reason`.
 
 Rules:
 
-- Always include `callLog[]` (every `dotnet test` invocation + any `cp` backup call).
-- Always include `userProviders` with the consent value used, the backup path (when produced), and whether restore ran.
+- Always include `callLog[]` (every `dotnet test` invocation).
 - Failures carry the NUnit-reported error message verbatim, plus the top stack frame if present. Do not paraphrase.
 
 ## Don'ts
 
-- No commits, no pushes, no source edits. The only file this agent writes is `UserDataProviders.json` (under the consent rules above) and the backup under `.build/.claude/`.
+- No file writes of any kind. This agent does not edit `UserDataProviders.json`, source files, baselines, or anything else. If a target needs a different env, abort with a `blocked` status pointing the caller at `/test-providers`.
+- No commits, no pushes.
 - Do not run tests in `Release` config unless the caller explicitly sets `config: "Release"`.
-- Do not prompt the user. Any missing consent / unclear input is an error the caller must resolve.
+- Do not prompt the user. Unclear input or a provider mismatch is an error the caller resolves.
 - Do not skip log lines. If the log is very long, still read it fully — the first failure's setup lines are usually the root cause, not the final summary.
 - Do not run multiple targets in parallel. EF3/EF8/EF9/EF10 against SQL Server share database names; parallel runs corrupt state.

--- a/.claude/docs/test-databases.md
+++ b/.claude/docs/test-databases.md
@@ -1,6 +1,6 @@
 # Test databases
 
-Reference table mapping every test-provider family to its local-development database setup. Consumed by `/test` and `/fix-issue` when they need to stand up a provider before running tests.
+Reference table mapping every test-provider family to its local-development database setup. The single entry point that *acts* on this table is the `/test-providers` skill (`.claude/skills/test-providers/SKILL.md`) — it edits `UserDataProviders.json` and runs the `docker container inspect` / `docker start` / `docker stop` / setup-script sequences below. `/test` and `test-runner` consume the resulting state read-only and never touch containers or `UserDataProviders.json` themselves.
 
 ## Reading this table
 
@@ -9,11 +9,11 @@ Reference table mapping every test-provider family to its local-development data
 - **Setup script** — Windows `.cmd` under `Data/Setup Scripts/`. Creates + starts the container (destroys any prior instance with the same name). Must be run from that directory: `cd "Data/Setup Scripts" && <script>.cmd`.
 - **Container name** — the `--name` Docker assigns. Used for `docker container inspect <name>` / `docker start <name>` / `docker stop <name>`.
 - **Image** — the Docker image tag the script pulls. Used for `docker image inspect <image>` to decide whether the setup script needs to run (pull costs minutes).
-- **Preference rank** — which version `/test` proposes by default when the user asks for that family and hasn't picked a specific version. Lower = preferred.
+- **Preference rank** — which version `/test-providers` proposes by default when the user asks for that family and hasn't picked a specific version. Lower = preferred.
 
 ## Preferred provider order (cross-family)
 
-When a test targets "any provider" or the user hasn't picked a family, `/test` proposes providers in this order:
+When the user hasn't picked a family and `/test-providers` is asked to propose a default set (or `/test` is asked to choose a small subset to run against the currently enabled providers), prefer this order:
 
 1. **SQLite** — no docker, runs from NuGet packages, always available.
 2. **SQL Server** — prefer `SqlServer.2016` / `SqlServer.2016.MS` (typically reachable via a local non-docker SQL Server Express / Developer instance on the dev machine — zero startup cost). Fall back to docker only if the user explicitly asks for docker, or the local instance is unavailable.
@@ -128,7 +128,7 @@ Oracle 18+ images are large and add very little test value until per-version dia
 
 ## Heavy providers (ask first)
 
-These containers either take a long time to initialize, use a lot of RAM, or pull very large images. `/test` and `/fix-issue` must **confirm with the user** before proposing or starting any of them, even when the test scope would naturally include them.
+These containers either take a long time to initialize, use a lot of RAM, or pull very large images. `/test-providers` must **confirm with the user** before proposing or starting any of them, even when the requested provider list would naturally include them. `/test` never starts containers — if a user-requested filter implies a heavy provider, the skill points at `/test-providers` for the start.
 
 | Provider | Provider IDs | Setup script | Container | Image | Cost |
 |---|---|---|---|---|---|
@@ -139,9 +139,9 @@ These containers either take a long time to initialize, use a lot of RAM, or pul
 
 Confirmation prompt should spell out the expected cost (startup time / memory) so the user can decide whether to skip that provider for the session.
 
-## Docker lifecycle (for skills)
+## Docker lifecycle (for `/test-providers`)
 
-Before running tests against a non-SQLite provider, a skill should go through this sequence:
+Canonical sequence for `/test-providers` to bring a non-SQLite provider's container up before `/test` runs against it. No other skill or agent is expected to drive this directly.
 
 1. `docker image inspect <image>` — succeeds if the image layer is cached locally. Failure means the setup script needs to run (which pulls the image).
 2. `docker container inspect <container>` — succeeds with status `running`, `exited`, or `created`; fails if the container doesn't exist.

--- a/.claude/docs/testing.md
+++ b/.claude/docs/testing.md
@@ -19,9 +19,11 @@ dotnet test Tests/Tests.Playground/Tests.Playground.csproj --filter "FullyQualif
 ## Test Database Configuration
 
 Tests run against multiple database providers. Configuration comes from `UserDataProviders.json` (gitignored, user-specific). To get started:
-1. Copy `UserDataProviders.json.template` to `UserDataProviders.json`
-2. This gives you SQLite-based testing out of the box
-3. Add connection strings for other databases as needed
+1. Copy `UserDataProviders.json.template` to `UserDataProviders.json` (or run `/test-providers reset`, which does the same thing under explicit confirmation and writes a backup of any existing file).
+2. This gives you SQLite-based testing out of the box.
+3. Add connection strings for other databases as needed.
+
+After the file exists, `/test-providers` is the supported way to enable / disable providers per TFM bucket and to start the docker containers behind them. `/test` reads the resulting state but never edits it — see [`.claude/skills/test-providers/SKILL.md`](../skills/test-providers/SKILL.md).
 
 ## Database initialization
 

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -9,7 +9,7 @@ User-triggered orchestrator. Turns a GitHub issue number into:
 
 1. A clean working branch named `issue/<n>-<kebab-slug>`.
 2. A regression test that currently demonstrates the bug (pre-fix) and passes (post-fix).
-3. A confirmed provider matrix + database lifecycle managed by `/test`.
+3. A confirmed provider matrix; env (containers + `UserDataProviders.json`) is configured via `/test-providers`, then the test runs through `/test`.
 
 The skill **does not** write the fix itself — that's the user's call. It owns the "read issue → repro → test" loop around the fix.
 
@@ -21,6 +21,7 @@ The skill **does not** write the fix itself — that's the user's call. It owns 
 - **Test-writer agent contract**: `.claude/agents/test-writer.md`
 - **Test-runner agent contract**: `.claude/agents/test-runner.md`
 - **Composable `/test` skill**: `.claude/skills/test/SKILL.md` — `/fix-issue` delegates the write + run flow to `/test`'s step-3/step-4 procedures.
+- **`/test-providers` skill** (env management): `.claude/skills/test-providers/SKILL.md` — used in step 5 to enable the confirmed provider set and start the matching containers before the test run.
 
 ## When to run
 
@@ -93,15 +94,24 @@ On `status: "written"`, show the user:
 - The build-check result if the agent ran one
 - A `Read` snippet of the new test body for quick visual confirmation
 
-### 5. Run the test (delegate to /test's run flow)
+### 5. Configure env, then run the test
 
-Chain into the **Run flow** documented in `.claude/skills/test/SKILL.md` — specifically:
+Two phases — env first via `/test-providers`, then the actual run via `/test`. `/fix-issue` does not edit `UserDataProviders.json` or call `docker` directly; it composes the two skills.
+
+**5a. Configure env via `/test-providers`.** Hand off the provider set confirmed in step 2 (don't re-ask) — invoke `/test-providers <provider> [<provider>…]` so it enables exactly that set per TFM bucket and starts the matching containers. The skill will:
+
+- show the JSON + container diff and ask for a single confirmation,
+- back up `UserDataProviders.json` to `.build/.claude/`,
+- start any containers that are stopped or missing (running `Data/Setup Scripts/<script>.cmd` for missing ones),
+- flag heavy providers (DB2 / Informix / SAP HANA / SAP ASE) with their cost note before any startup.
+
+If the user already ran `/test-providers` for the same set earlier in the session, this is a no-op confirmation and proceeds without re-editing anything.
+
+**5b. Run via `/test`.** Then chain into `/test`'s **Run flow**:
 
 1. **3.1 Determine project + TFM.** For main tests, default to `Tests/Tests.Playground/Tests.Playground.csproj` at `net10.0` (the test file is already linked via step 4). For EFCore tests, use the appropriate `Tests.EntityFrameworkCore.EFx.csproj`.
-2. **3.2 Confirm providers.** Use the set confirmed in step 2 of this skill — don't re-ask. Still show the final list + container-lifecycle plan ("will start `pgsql18`; `sql2016` uses local instance") and wait for a single `go` / `edit`.
-3. **3.3 Docker lifecycle.** Walk each non-SQLite, non-local-SQL-Server provider through `docker image inspect` → `docker container inspect` → start/create decision as described in `test-databases.md`. Track `startedByUs[<container>] = true` for step 7.
-4. **3.4 UserDataProviders.json consent.** First edit of the session → prompt for `auto-backup` / `skip-backup` / `cancel`. Reuse the choice for subsequent runs.
-5. **3.5 Invoke test-runner.** Pass the filter `FullyQualifiedName~<test-name>`, the confirmed targets, and the consent.
+2. **3.2 Resolve target providers.** Use the set confirmed in step 2 of this skill — pass it through to `test-runner` verbatim. `/test` does not re-prompt and does not edit any env state.
+3. **3.3 Invoke test-runner.** Filter `FullyQualifiedName~<test-name>`, the confirmed targets, default config / verbosity. If `test-runner` aborts with a "Provider X not enabled" block, that means step 5a didn't actually enable the right set — fix it via `/test-providers` and resume here, don't fix the env from inside `/fix-issue`.
 
 ### 6. Report the result
 
@@ -113,18 +123,14 @@ Relay the agent's per-target summary verbatim. If the pre-fix expectation from s
 
 Do not auto-commit even when the result looks clean. The user drives commits (per `.claude/docs/agent-rules.md` → *Git commit rules*).
 
-### 7. Container cleanup prompt
-
-Per `/test`'s step 3.6 — for every container the skill started in step 5, ask the user whether to `docker stop` them. Default to leave running. Only stop what the user explicitly names.
-
-### 8. Hand-off
+### 7. Hand-off
 
 Finish with a short summary:
 - Branch: `issue/<n>-<slug>`
 - Test: `<path>:<line>` (name + fixture)
 - Provider matrix: `[<providers>]`
-- Containers left running: `[<names>]` (if any were started)
 - Pre-fix test state: `fails as expected` / `passes unexpectedly` / `errored`
+- One-line nudge: "Run `/test-providers stop` when you're done with the containers." — only if step 5a actually started any.
 
 Stop. The user continues from here — they write the fix, commit, push, and open the PR on their own terms (or via `/review-pr` / an ad-hoc commit request).
 
@@ -133,7 +139,7 @@ Stop. The user continues from here — they write the fix, commit, push, and ope
 - Do not write the fix code. This skill's scope ends at "test is in place and its current state is understood". Fixes are the user's responsibility, because fix strategy almost always involves judgment calls on SQL / translator design that shouldn't be made silently.
 - Do not commit automatically. Even after a successful write+run, wait for explicit `commit` (per agent-rules). The branch is fine in a dirty state until the user decides.
 - Do not push the branch or open a PR. `/fix-issue` is a local workflow; `git push` / `gh pr create` require explicit user asks (agent-rules).
-- Do not re-prompt the user for answers already given in step 2. Reuse provider confirmation, slug, consent values through the whole session.
-- Do not invoke `test-runner` without first running the full `/test` step-3 sequence (docker + consent). Skipping those is how corrupted `UserDataProviders.json` files happen.
+- Do not re-prompt the user for answers already given in step 2. Reuse the confirmed provider set + slug through the whole session.
+- Do not edit `UserDataProviders.json` or invoke `docker` directly. Env management routes through `/test-providers` (step 5a). If a run aborts because a provider isn't enabled, fix it via `/test-providers` and re-run — don't patch the file from here.
 - Do not expand scope. If the issue mentions three providers but only one actually exhibits the bug, raise the discrepancy to the user rather than quietly pruning; they may want the regression to cover the other two providers as a baseline.
 - Do not propose heavy providers (DB2 / Informix / SAP HANA / SAP ASE) silently. Flag their cost per `.claude/docs/test-databases.md` → *Heavy providers*.

--- a/.claude/skills/test-providers/SKILL.md
+++ b/.claude/skills/test-providers/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: test-providers
+description: Configure the local test environment — enable / disable test-provider entries in `UserDataProviders.json` per TFM bucket, manage the docker containers those providers need (start / stop / setup-script run), and reset the file from `UserDataProviders.json.template`. Owns every edit to `UserDataProviders.json` and every `docker start` / `docker stop` call across the `.claude/` toolset; `/test` and `test-runner` consume the resulting state read-only.
+---
+
+# test-providers
+
+User-triggered workflow for managing the local test environment that `/test` runs against. The single concern of this skill is making `UserDataProviders.json` and the docker containers behind it match what the user wants — it never runs tests and never builds anything.
+
+Shared reference material:
+
+- **Test database catalog** (provider IDs → setup script → container → image → preference): [`.claude/docs/test-databases.md`](../../docs/test-databases.md)
+- **`UserDataProviders.json` shape**: see `UserDataProviders.json.template` at the repo root and the **Test Database Configuration** section of [`.claude/docs/testing.md`](../../docs/testing.md)
+
+## When to run
+
+Only when the user explicitly invokes `/test-providers` — typically before a `/test run …` to make sure the right providers are enabled and their containers are up, or after a session to stop containers the user no longer needs. Do not invoke this skill from inside `/test`, from `test-runner`, or from any other skill — the boundary is intentional, and `/test` is allowed to fail when the env doesn't match (the user re-runs `/test-providers` to fix it).
+
+## Accepted arg shapes
+
+`/test-providers` parses one of the shapes below from the args. On ambiguity, stop and ask with a single numbered prompt.
+
+| Arg shape | Intent |
+|---|---|
+| empty | Show current per-TFM enabled-provider set + container statuses for any container referenced by an enabled provider, then ask what to do. |
+| `<provider> [<provider>…]` (e.g. `SQLite.MS PostgreSQL.18`) | **Set** mode. Mark exactly the listed providers enabled in the affected TFM bucket(s) and disable every other provider in those buckets. Start the corresponding containers if needed. **Default scope is `NET100` only** — see *Bucket scope* below to widen. |
+| `add <provider> [...]` | **Additive** mode. Mark the listed providers enabled in the affected TFM bucket(s) without changing the rest. Start containers as needed. **Default scope is `NET100` only.** |
+| `remove <provider> [...]` | **Subtractive** mode. Mark the listed providers disabled in the affected TFM bucket(s). Does not stop containers (user does that explicitly via `stop`). **Default scope is `NET100` only.** |
+| `stop` / `stop <container> [...]` | Stop all (or named) containers we have records of from this session. No `UserDataProviders.json` edit. |
+| `reset` | Restore `UserDataProviders.json` from `UserDataProviders.json.template` after explicit confirmation. Does not touch containers. |
+
+Provider IDs are the strings under each TFM bucket's `Providers` array (e.g. `SQLite.MS`, `PostgreSQL.18`, `SqlServer.2016.MS`). Container names match the **Container** column of `test-databases.md`.
+
+### Bucket scope
+
+Every Set / add / remove invocation accepts an optional `in <bucket>[,<bucket>...]` clause anywhere in the args. The clause selects which TFM bucket(s) of `UserDataProviders.json` get edited:
+
+- **No clause** → `NET100` only (the user's default workflow target).
+- **`in <bucket>[,<bucket>...]`** → the named buckets only (`NETFX`, `NET80`, `NET90`, `NET100`).
+- **`in all`** → every TFM bucket present in the file.
+
+Examples:
+
+- `/test-providers SQLite.MS PostgreSQL.18` — edits `NET100` only.
+- `/test-providers in NETFX,NET100 SQLite.MS Firebird.5` — edits `NETFX` and `NET100`, leaves `NET80` and `NET90` alone.
+- `/test-providers add Oracle.12 in all` — adds `Oracle.12.Managed` (after family-rule normalisation) to every bucket.
+
+The clause may appear before or after the provider list; parse it once, then strip it before family-rule normalisation runs on the remaining args.
+
+## Provider name shortcuts and family rules
+
+Family rules normalise loosely-typed provider tokens to the variant the user actually wants. Apply them **only when the input is not fully qualified** — an explicit, full provider ID (e.g. `Oracle.12.Native`, `SqlServer.2019`, `Access.Jet.OleDb`) always wins and passes through unchanged.
+
+### Family-variant shortcuts
+
+| User input form | Resolved to |
+|---|---|
+| `Access` (bare family) | `Access.Ace.Odbc` |
+| `MySql` / `MySql.<v>` (no variant suffix) | `MySqlConnector.<v>` (with `<v>` resolved per *Bare-family version* below) |
+| `Oracle` / `Oracle.<v>` (no variant suffix) | `Oracle.<v>.Managed` |
+| `ClickHouse` / `Clickhouse` (bare family) | `ClickHouse.MySql` |
+| `SapHana` (bare family) | `SapHana.Native` |
+| `SqlServer` / `SqlServer.<v>` (no variant suffix) | `SqlServer.<v>.MS` |
+
+Anything that already has an explicit variant suffix bypasses the table:
+
+- `Oracle.12.Native`, `Oracle.12.Devart.OCI` — explicit, pass through.
+- `MySql.8.0` — literal-ID-as-typed (this is the System.Data.MySqlClient variant in `UserDataProviders.json`); explicit, pass through.
+- `SqlServer.2019` — System.Data.SqlClient variant; explicit, pass through.
+- `Access.Jet.OleDb`, `ClickHouse.Octonica`, `SapHana.Odbc`, `Sybase` — explicit, pass through.
+
+### Bare-family version
+
+When a family rule needs a version (the user typed `Oracle`, `MySql`, `SqlServer`, `PostgreSQL`, `Firebird`, `MariaDB`, etc. with no version) pick the version this way:
+
+1. Check the **per-family overrides** table below. If the family has an override, use it.
+2. Otherwise, scan the affected TFM bucket's `Providers` array for entries that match the family. Parse the version segment of each ID (the piece between the family name and the variant suffix). Pick the largest by lexical-numeric comparison (`9.5 < 10 < 12 < 18`, `2014 < 2019 < 2022`).
+3. If the bucket has no entries for that family at all, fall back to the **default version** noted in `.claude/docs/test-databases.md` for that family.
+
+Skip entries listed in the **per-family exclusions** table below when computing the latest. Excluded IDs are never picked as the bare-family default — they're only enabled when the user types the full ID explicitly.
+
+#### Per-family overrides
+
+| Family | Bare-family default |
+|---|---|
+| `SqlServer` | `SqlServer.2019.MS` (user-pinned workflow target — overrides "latest available") |
+
+Other families currently have no override; extend this table when the user identifies more.
+
+#### Per-family exclusions
+
+| Family | Excluded IDs (never auto-resolved by family or version rules) |
+|---|---|
+| `SqlServer` | `SqlServer.SA`, `SqlServer.SA.MS`, `SqlServer.Contained`, `SqlServer.Contained.MS`, `SqlServer.Northwind`, `SqlServer.Northwind.MS`, `SqlServer.Azure`, `SqlServer.Azure.MS` (special-purpose configs not used on the dev desktop) |
+
+Explicit input still wins for excluded IDs — the user can enable `SqlServer.Azure.MS` by typing it verbatim, and Step 4's *Normalised inputs* block will be empty for that token.
+
+### Sticky entries (never auto-disable, never auto-modify)
+
+Two entries in `UserDataProviders.json` are protected from the skill's automatic mutations:
+
+- **`TestNoopProvider`** — when **Set** mode sweeps a bucket to disable everything not in the user's request, it skips this ID. A previously-enabled `TestNoopProvider` stays enabled. (User-driven `remove TestNoopProvider` still works — the sticky rule only blocks the implicit-disable sweep.)
+- **`"DefaultConfiguration": "SQLite.MS"`** — never read, written, added, or removed by this skill. Per-bucket `Edit` calls replace only the `"Providers": [...]` array; the surrounding bucket keys (`BasedOn`, `DefaultConfiguration`) stay byte-for-byte identical.
+
+## Permission-prompt discipline
+
+Every Bash call is allowlist-matched as one opaque string, so:
+
+- One Bash call per command. No `&&` / `||` / `;` chaining; no shell control flow. (Also enforced by the rules in `.claude/docs/agent-rules.md`.)
+- Batch independent inspects in a single assistant turn (multiple parallel Bash tool calls), not one chained string.
+- Setup scripts under `Data/Setup Scripts/<name>.cmd` must be run from that directory — issue `cd "Data/Setup Scripts" && <script>.cmd` is **not** allowed; use the script's documented invocation form via a single command (e.g. invoke through `pwsh -NoProfile -File ...` if a sequence is required, or just `Data/Setup\ Scripts/<script>.cmd` from the repo root if the script supports it). When the script truly requires a `cd` first, wrap the two-step sequence in a small pwsh under `.build/.claude/` rather than chaining.
+
+## Steps
+
+### 1. Resolve intent
+
+Parse args in this order:
+
+1. **Mode token.** First positional token decides the mode: `add`, `remove`, `stop`, `reset`, or (anything else) Set mode.
+2. **Bucket-scope clause.** Look anywhere in the remaining args for `in <bucket>[,<bucket>...]` or `in all`. Strip it from the args; record the resolved bucket list (default `["NET100"]` when absent). See *Bucket scope* in the **Accepted arg shapes** section.
+3. **Family-rule normalisation** (Set / add / remove only). For each remaining provider token, apply the **Family-variant shortcuts** and **Bare-family version** rules from the **Provider name shortcuts and family rules** section. Keep an internal record `rewrites: [{from, to, reason}]` of every token that changed — this drives the *Normalised inputs* block in step 4. Tokens that are already fully qualified (or match an exclusion list and were typed explicitly) record `from === to` and don't appear in the rewrites list.
+4. **Ambiguity check.** If a bare token could plausibly be a provider ID or a container name (rare — most container names like `pgsql18` don't collide with provider IDs), stop and ask. Do not guess.
+
+After this step, the agent has: `{ mode, buckets[], providers[], rewrites[] }`. Subsequent steps consume this normalised structure, never the raw user input.
+
+### 2. Read current state
+
+Always read state before computing any change. Batch the calls in one turn:
+
+1. **`Read` `UserDataProviders.json`** at the repo root. Parse the per-TFM `Providers` arrays and `MyConnectionStrings.BaselinesPath` (string or absent).
+2. **For each container referenced by a currently-enabled provider OR explicitly named in the user's args** (look up via `test-databases.md`): one Bash call per container running `docker container inspect <name>` and one per image running `docker image inspect <image>`. All inspects can be issued in a single message (parallel tool calls).
+3. Build an in-memory map: `{ container -> { exists, status, imageCached } }`. Treat `inspect` exit code != 0 as "not present".
+
+For empty args (status mode), report the snapshot and ask what to do; don't proceed past this step until the user picks an arg shape.
+
+### 3. Compute target state
+
+#### Affected TFM buckets
+
+Use the `buckets[]` list resolved in step 1. Default is `["NET100"]`; widened only if the user passed an `in …` clause. Buckets not in the list are completely untouched — no read, no edit, not even a no-op replacement of their `Providers` array.
+
+#### Provider-set / add / remove modes
+
+Per affected TFM bucket:
+
+- **Set mode** — every entry whose ID is in the (normalised) target list becomes enabled (drop a leading `- ` if present); every other entry in the same bucket becomes disabled (add a leading `- ` if absent), **with one exception: `TestNoopProvider` is sticky and is skipped by the disable sweep — see *Sticky entries* in the family-rules section above**.
+- **Add mode** — listed entries become enabled; every other entry is left untouched.
+- **Remove mode** — listed entries become disabled; every other entry is left untouched. The sticky rule for `TestNoopProvider` does **not** apply to Remove mode — if the user explicitly types `remove TestNoopProvider`, honour it (it's an explicit choice, not a sweep).
+
+Preserve order, formatting, comments, and unrelated buckets exactly. Don't restructure, don't sort, don't add or remove array entries — only flip the enable/disable marker on existing lines. The file is JSONC (JSON with comments); single-line `//` comments and trailing commas are valid and must be preserved verbatim.
+
+#### `DefaultConfiguration` is immutable
+
+The per-bucket replacement edit (step 5b) covers **only** the `"Providers": [ ... ]` array. The surrounding bucket keys — `BasedOn`, `DefaultConfiguration`, and any others — stay byte-for-byte identical. Do not read these to make decisions, do not write them, do not re-emit them. If a bucket has no `DefaultConfiguration` today, do not add one. If it has `"DefaultConfiguration": "SQLite.MS"` today, do not change it to anything else.
+
+#### Missing provider IDs
+
+If a requested provider ID isn't present in the current bucket's `Providers` array, surface it explicitly in step 4 and ask the user whether to copy from the template (which has the full provider list) or skip the missing one. Do not auto-insert.
+
+#### Container plan
+
+For every container that the **target** enabled-provider set references (post-edit), compute one of:
+
+- `running` — container exists and `inspect` returned `running`. No action.
+- `will-start` — container exists and status is `exited` / `created`. Action: `docker start <name>`.
+- `will-create` — container does not exist. Action: run `Data/Setup Scripts/<script>.cmd` (which creates and starts it; pulls the image if not cached).
+- `image-pull-needed` — same as `will-create` but the image isn't cached locally either; setup script will pull. Surface the cost note when it's a heavy provider (DB2 / Informix / SAP HANA / SAP ASE — see **Heavy providers (ask first)** in `test-databases.md`).
+
+Local non-docker SQL Server providers (`SqlServer.2005` … `SqlServer.2016` per `test-databases.md` → **Local (non-docker) SQL Server**) need no container action — note in the plan as `local-instance`.
+
+### 4. Confirm with user
+
+Show a single confirmation block in three sections:
+
+**Normalised inputs** (only when step 1 produced rewrites — omit the section entirely otherwise):
+
+```
+Oracle      → Oracle.23.Managed       (bare-family + family rule)
+MySql       → MySqlConnector.8.0       (bare-family + family rule)
+SqlServer   → SqlServer.2019.MS        (bare-family + family rule + override)
+Oracle.12   → Oracle.12.Managed        (family rule)
+```
+
+This is the user's chance to spot an unintended rewrite before any edit applies. If the user objects, restart from step 1 with their corrected input — do not patch the rewrite locally.
+
+**`UserDataProviders.json`** — per affected TFM bucket, list:
+
+```
+NET100  enable: PostgreSQL.18
+        disable: Oracle.11.Native, Oracle.12.Native
+        sticky: TestNoopProvider (kept enabled)
+        no-change: 14 entries
+```
+
+**Containers** — one row each:
+
+```
+pgsql18   running         (no action)
+sql2022   will-start      (docker start)
+hana2     will-create     (run Data/Setup Scripts/saphana2.cmd)
+                          ⚠ heavy: ~5–10 min startup, very high RAM (per test-databases.md)
+```
+
+Also include:
+
+- The backup target path: `.build/.claude/UserDataProviders.json.bak.<ISO-timestamp>`.
+- Whether `BaselinesPath` is currently set; if unset, ask in this same prompt whether to set it (propose `c:\\GitHub\\linq2db.bls` per `testing.md`'s **Enabling baselines locally**) — same numbered list, so the user can answer everything at once.
+
+Wait for an explicit go-ahead before any mutation. On a refusal, stop cleanly — no partial application.
+
+### 5. Apply
+
+Run the confirmed plan. Order matters: **JSON edits first, then container actions** — if a setup script fails after a JSON edit, the user can re-run `/test-providers` to fix the container without re-typing the provider list, but a JSON edit after a successful container start would leave a half-applied state if the edit fails.
+
+#### 5a. Backup
+
+On the first edit per session, copy the current file:
+
+```
+cp UserDataProviders.json .build/.claude/UserDataProviders.json.bak.<ISO-timestamp>
+```
+
+Single Bash call. Skip if the user explicitly chose `skip-backup` in the consent prompt; in either case keep an in-memory copy of the pre-edit contents for the duration of this `/test-providers` invocation in case the user aborts after the edit.
+
+If the consent prompt was `cancel`, abort here — no edit, no container action.
+
+#### 5b. JSON edit (one Edit per affected bucket)
+
+Per affected TFM bucket:
+
+1. The `old_string` is the exact current `"Providers": [ … ]` block from the opening `[` to the closing `]`.
+2. The `new_string` is the same block with markers flipped per step 3. Do not reorder, do not regex-replace across the whole file, and do not split into one `Edit` per provider — that triggers N permission prompts. One `Edit` per bucket.
+3. Leave whitespace, comments, and unrelated buckets exactly as they were.
+
+If the user agreed in step 4 to set `BaselinesPath`: a separate `Edit` call inserts the `"BaselinesPath": "c:\\GitHub\\linq2db.bls"` field into the `MyConnectionStrings` block (see the example in `testing.md` → **Enabling baselines locally**).
+
+#### 5c. Container actions
+
+For each `will-start` container: `docker start <name>` (one Bash call per container; can be parallelised across multiple tool calls in a single turn when the containers are independent — they almost always are).
+
+For each `will-create` container: `Data/Setup Scripts/<script>.cmd` (one Bash call per script). These can take minutes; do not run more than two heavy-provider scripts in parallel because they compete heavily for I/O and RAM.
+
+Record `startedByUs[<container>] = true` for every container we transitioned from `exited` / `created` / missing to `running`. Persist this map in memory for the lifetime of the agent session (read by step 6 of `stop` mode).
+
+### 6. Stop mode
+
+Triggered by `/test-providers stop` (with or without container names). Branches:
+
+1. **Read state.** `docker container inspect` every container we have records of from this session (the `startedByUs` map). For containers the user named explicitly, also inspect those even if not in the map.
+2. **Confirm.** Present a numbered list of running containers with their state and ask which to stop (`1,3`, `all`, `none`). Default on empty reply is `none` — never auto-stop.
+3. **Stop.** One Bash call per chosen container: `docker stop <name>`. Update the in-memory state map.
+4. **Report.** What stopped, what stayed running.
+
+Do not edit `UserDataProviders.json` in stop mode — the file is independent of container state, and disabling a provider doesn't require stopping its container.
+
+### 7. Reset mode
+
+Triggered by `/test-providers reset`.
+
+1. **Confirm explicitly.** Reset overwrites the user's local enable/disable choices and any custom `MyConnectionStrings` entries. Make this clear in the prompt and require an explicit go-ahead.
+2. **Backup.** Copy `UserDataProviders.json` to `.build/.claude/UserDataProviders.json.bak.<ISO-timestamp>` (single Bash call). Same backup rules as step 5a; not skippable for reset (the destruction is wholesale).
+3. **Apply.** `cp UserDataProviders.json.template UserDataProviders.json` (single Bash call).
+4. **Report** the backup path. Do not touch containers.
+
+### 8. Report
+
+End with a concise summary:
+
+- Per affected TFM bucket: enabled-now, disabled-now, no-change counts.
+- Per container: state transition (e.g. `pgsql18: exited → running`).
+- Backup path.
+- Any deferred items (heavy provider the user declined to start, BaselinesPath nudge skipped, etc.).
+- One-liner: "Run `/test-providers stop` when you're done with the containers."
+
+## Don'ts
+
+- Do not run `dotnet test` or `dotnet build`. That's `/test`'s job; this skill never invokes the test pipeline.
+- Do not silently edit `UserDataProviders.json`. Step 4's confirmation is mandatory on every edit, including `add` / `remove` / `reset`.
+- Do not start heavy providers (DB2 / Informix / SAP HANA / SAP ASE) without surfacing the cost note from `test-databases.md`.
+- Do not auto-stop containers. The user must name what to stop, or pick `all`. Empty reply means "leave running".
+- Do not regex-replace across the whole `UserDataProviders.json` or restructure it. Per-bucket batched `Edit` only — see step 5b.
+- Do not edit `UserDataProviders.json.template`. The template is the source of truth for `reset`; don't drift it from upstream.
+- Do not call `test-runner` or invoke `/test`. The boundary is one-way: `/test` reads the state this skill left behind, never the other direction.
+- Do not edit TFM buckets the user didn't ask for. Default scope is `NET100` only; widen exclusively via the `in <bucket>` clause. `NETFX`, `NET80`, and `NET90` should diff byte-for-byte clean after a default invocation.
+- Do not flip `TestNoopProvider` to disabled in Set mode's sweep. It's sticky — see *Sticky entries* in the family-rules section.
+- Do not touch `DefaultConfiguration`. Per-bucket edits replace only the `Providers` array; surrounding keys stay byte-for-byte identical.
+- Do not auto-correct fully-qualified provider IDs. The family rules apply only to bare-family / version-only inputs; `Oracle.12.Native` (and similar explicit variants) pass through unchanged even when the family rule would prefer Managed.

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test
-description: Write a new linq2db test, run an existing test / filter, or both. Orchestrates the `test-writer` and `test-runner` agents, handles the `UserDataProviders.json` consent prompt, and reports a single pass/fail summary at the end.
+description: Write a new linq2db test, run an existing test / filter, or both. Orchestrates the `test-writer` and `test-runner` agents and reports a single pass/fail summary at the end. Env management (docker containers, `UserDataProviders.json`) lives in the `/test-providers` skill, not here — `/test` reads the configured state but never edits it.
 ---
 
 # /test
@@ -29,9 +29,11 @@ If the args are ambiguous (e.g. a phrase like "bulk copy identity test" that cou
 
 ## Steps
 
-**Never bypass /test to call `test-runner` directly.** The skill gates docker state (3.3), `UserDataProviders.json` consent (3.4), `CreateDatabase` injection (3.5), and baselines diff (3.6). Calling `test-runner` directly skips all four — connection-refused, empty-DB, or no-consent failures typically trace back to exactly that bypass. If the user says "run tests…", invoke `/test`, never `Agent(test-runner)`.
+**Never bypass /test to call `test-runner` directly.** The skill gates `CreateDatabase` injection (step 3.3) and the baselines diff (step 3.4). Calling `test-runner` directly skips both — empty-DB failures and missed baselines drift typically trace back to exactly that bypass. If the user says "run tests…", invoke `/test`, never `Agent(test-runner)`.
 
-**Permission-prompt discipline.** Every `Bash` call is evaluated against the allowlist. When `test-runner` runs, its only shell calls are `dotnet test` invocations (and optionally a `cp` for the backup). The skill itself should not issue `dotnet build` or `dotnet test` — delegate to the agent.
+**Env management is out of scope.** Docker container lifecycle and `UserDataProviders.json` edits are owned by `/test-providers` (`.claude/skills/test-providers/SKILL.md`). `/test` does not start, stop, or inspect containers, and does not edit `UserDataProviders.json` — `test-runner` is read-only on it (see the agent contract). If a run fails because a container is down or a provider is disabled, surface the failure as-is and tell the user to run `/test-providers <provider> [...]` to fix the env, then re-run `/test`. Do not pre-validate env state, do not auto-dispatch to `/test-providers`.
+
+**Permission-prompt discipline.** Every `Bash` call is evaluated against the allowlist. When `test-runner` runs, its only shell calls are `dotnet test` invocations. The skill itself should not issue `dotnet build` or `dotnet test` — delegate to the agent.
 
 ### 1. Resolve intent
 
@@ -64,105 +66,47 @@ Resolve `{project, tfm}` for each run:
 - **EFCore test** — expand to all four projects (EF3/EF8/EF9/EF10). Use `{efMatrix: true, providers: [...]}` shorthand on the agent.
 - **Explicit filter → specific test** — read the test's attributes to infer `[DataSources]` family and EFCore-vs-main. When the filter matches tests across both main and EFCore projects (rare but possible), ask the user to pick.
 
-#### 3.2 Confirm providers (always)
+#### 3.2 Resolve target providers
 
-Provider selection is **always confirmed with the user**, even when the filter's `[DataSources]` would nominally expand to every enabled provider. Running against "all providers" is rarely what the user wants — most test databases are expensive to start, and the user usually has one or two in mind.
+Provider state is owned by `/test-providers` and read by `test-runner` from `UserDataProviders.json`. `/test` does **not** propose providers, edit the file, or pre-validate that the requested set is enabled — that's the user's job ahead of running `/test`.
 
-**Proposal algorithm.** Consult `.claude/docs/test-databases.md` and propose, in this order:
+Determine the provider list to pass to `test-runner` per target:
 
-1. **SQLite** — always first, always enabled (no docker, no startup cost).
-2. **SQL Server** — `SqlServer.2016` / `SqlServer.2016.MS` via local non-docker instance (default); fall back to `SqlServer.2022.MS` (docker) if the user asks for docker or the local instance is unavailable.
-3. **PostgreSQL** — `PostgreSQL.18` (default); or the "dialect-anchor" set (9.2, 9.3, 9.5, 13, 15, 18) if the user wants full Postgres dialect coverage.
-4. The specific provider family the test targets, when the filter or `[IncludeDataSources]` already pins one (e.g. a `MergeTests.Oracle.*` filter pins Oracle — default `oracle11` + `oracle12`).
-5. Any additional providers the test-writer declared in its output's `dataSources` — confirm whether to include each.
-6. **Heavy providers** (DB2 / Informix / SAP HANA / SAP ASE) are *never* proposed silently. Surface them only if the test's filter / attributes require them, and always flag the cost per the "Heavy providers" section of `test-databases.md`.
+- **User named providers in `/test` args** (e.g. `/test run Issue5177Test on PostgreSQL.18, SQLite.MS`) — pass that list through verbatim. If a named provider isn't currently enabled in the matching TFM bucket, `test-runner` will abort with a "Provider X not enabled" message pointing at `/test-providers`; relay that as-is.
+- **No providers in args** — `Read` the relevant TFM bucket of `UserDataProviders.json` once, list the currently enabled providers, and ask the user to confirm or narrow before passing the set through. Do **not** silently default to "every enabled provider" — most users want a small subset for a single-test run.
 
-Present the proposal as a numbered list with per-provider notes (local vs docker; preferred default). Ask the user to confirm or edit before moving on. Example:
+If the test was just authored by the write flow, the test-writer's `dataSources` output is a hint about scope, not a provider list — still pass the user's explicit choice (or confirmed read-back) to `test-runner`.
 
-> I'll run `Issue5177Test` against these providers by default:
->
-> 1. `SQLite.MS` — always on, no startup cost.
-> 2. `SqlServer.2016.MS` — assumed local non-docker instance; say the word if you want docker instead.
-> 3. `PostgreSQL.18` — will need to start the `pgsql18` container (see 3.3 below).
->
-> OK as-is, or want to add/remove?
-
-Record the user's confirmed list; skip this prompt on subsequent runs in the same session that use the same provider set.
-
-#### 3.3 Docker lifecycle (mandatory — per non-SQLite provider)
-
-`test-runner` does not verify container state — if you invoke it with a provider whose container is down, every test fails with "connection refused" before linq2db code runs. The checks below are the only protection.
-
-For each confirmed provider that isn't SQLite or a local non-docker SQL Server:
-
-1. Look up the container name + image via `.claude/docs/test-databases.md`.
-2. `docker image inspect <image>` via Bash — succeeds if the image layer is cached locally.
-3. `docker container inspect <container>` via Bash — succeeds with the container status (`running`, `exited`, `created`) or fails if the container doesn't exist.
-4. Decision tree:
-   - **Container running** — use as-is; do not touch.
-   - **Container exited/created** — `docker start <container>`. Record `startedByUs[<container>] = true` for end-of-run cleanup prompt.
-   - **Container missing OR image missing** — ask the user (single prompt, numbered options): "Run `Data/Setup Scripts/<script>.cmd` now? (creates + starts the container, may pull the image)". On confirmation, run the script via Bash. Record `startedByUs[<container>] = true`.
-5. For heavy providers (per `test-databases.md`), prefix the startup prompt with the cost note ("SAP HANA typically takes 5–10 min to become ready and uses several GB of RAM — proceed?").
-
-Batch the `docker image inspect` + `docker container inspect` checks across all providers in a single turn (independent calls). Record the full lifecycle state (`running-existing` / `started-by-us` / `created-by-us`) for each container so step 3.6 can offer to stop only the ones we started.
-
-#### 3.4 UserDataProviders.json consent
-
-**Before any call to `test-runner`**, check whether the run will require editing `UserDataProviders.json` (compare the current enabled providers per TFM bucket to the targets). If an edit is needed AND this is the **first** edit of the session:
-
-Prompt the user once:
-
-> `UserDataProviders.json` is gitignored and holds your local test config. Running this target needs to change the enabled providers per TFM bucket. Options:
->
-> 1. **auto-backup** — I copy the current file to `.build/.claude/UserDataProviders.json.bak.<timestamp>` before editing, and restore the original after the run. (recommended)
-> 2. **skip-backup** — edit in place without a backup copy, still restore the original from an in-memory snapshot after the run.
-> 3. **cancel** — abort, don't touch the file.
->
-> Choose 1, 2, or 3.
-
-Record the choice. For subsequent runs in the same session, don't re-prompt — pass the same consent value through.
-
-#### 3.5 Invoke test-runner
+#### 3.3 Invoke test-runner
 
 Call `test-runner` with:
 - `testPattern` — the `--filter` value. **Always prepend `FullyQualifiedName~CreateData.CreateDatabase|`** unless the filter is already `CreateDatabase`-only or the user explicitly overrides. See `.claude/docs/testing.md` → **Database initialization** for why.
 - `targets` — resolved in 3.1 / 3.2. Prefer the shorthand forms when applicable; remember `{mainTests: true, providers: [...]}` defaults to Playground at `net10.0`, so only set explicit `project` / `tfm` when overriding.
-- `userProvidersConsent` — the choice from 3.4 (`"auto-backup"` / `"skip-backup"`).
-- `restoreOnCompletion` — default `true`. Offer to flip to `false` when the user intends to keep the current provider set for follow-up manual runs.
 - `config` — `"Debug"` unless the user asked for Release.
 - `verbosity` — `"normal"`; flip to `"detailed"` when the user needs SQL-dump output from `TestContext.Out.WriteLine`.
 
-#### 3.6 Baselines diff (when baselines are written)
+`test-runner` is read-only on `UserDataProviders.json` — there is no `userProvidersConsent` or `restoreOnCompletion` input, and no provider edits happen as a side effect of the run. If the agent reports `status: "blocked"` with a missing-provider message, relay it to the user with a one-liner: "Run `/test-providers <provider>` to enable it, then re-run `/test`."
+
+#### 3.4 Baselines diff (when baselines are written)
 
 If `UserDataProviders.json` → `MyConnectionStrings.BaselinesPath` is set **and** the run touched at least one provider whose baselines live under that path:
 
 1. **Before** calling `test-runner`, snapshot `BaselinesPath` with `snap-baselines.ps1` (stdin manifest `{ paths: [BaselinesPath], outFile: ".build/.claude/baselines-pre-<run-id>.json" }`).
 2. **After** the run, diff the snapshot with `diff-baselines.ps1` (stdin manifest `{ preFile, paths: [BaselinesPath] }`). For up to five entries in the returned `changed[]`, `Read` the post-run file and show a 3–5-line excerpt; cite the rest by count (e.g. "15 more files changed under `Firebird.5/...`"). Treat `added[]` / `removed[]` the same way.
 3. If a file is on the `.claude/docs/testing.md` → **Known flaky baselines** list, note it explicitly and skip its preview.
-4. If `BaselinesPath` is **unset** and the user's change is expected to move baselines (new SQL emission, new provider path), offer to set it before the run — propose `c:\\GitHub\\linq2db.bls` and wait for confirmation. Otherwise skip silently.
+4. If `BaselinesPath` is **unset** and the user's change is expected to move baselines, mention it once: "Set `BaselinesPath` via `/test-providers` if you want diffs." Do not edit the file from here — that's `/test-providers` step 4. Skip the snapshot/diff for this run.
 
-#### 3.7 Report + container cleanup prompt
+#### 3.5 Report
 
 Relay the agent's per-target summary:
 
 - One row per target: `<project> (<tfm>) — passed/failed/none_matched · N passed, M failed, K skipped`
 - For `failed` targets, include the first failure's message + top stack frame.
 - For `none_matched` targets, cite the agent's `note` (usually a `#if !NETFRAMEWORK` guard).
-- Backup path (when `auto-backup`) so the user can inspect / roll back manually if needed.
-- Whether `UserDataProviders.json` was restored.
 
-Then — for every container recorded as `started-by-us` or `created-by-us` in step 3.3 — ask the user whether to stop it:
+If any failure looks like an env problem (connection refused, "Provider X not enabled" block, missing schema), point at `/test-providers` for the fix — do not investigate or auto-repair from here. Otherwise just relay the agent's output verbatim.
 
-> I started these containers for this run. Stop them now, or leave running for follow-up tests?
->
-> 1. `pgsql18` — started by me, running since <time>.
-> 2. `sql2022` — I created it from scratch (image pull + setup script); running since <time>.
->
-> Reply with numbers to stop (e.g. `1,2`), `all` to stop all, or `none` to leave running.
-
-Default to **leave running** on an empty reply — the user may want follow-up runs and the container is cheap to keep. Only stop what the user explicitly named. Never auto-stop; always ask.
-
-Finally, if the branch is on an open PR and the local run uncovered no regressions, mention the `/azp run` option (see `.claude/docs/ci-tests.md`). Do not auto-post — just surface it; the user decides.
+Finally, if the branch is on an open PR and the local run uncovered no regressions, mention the `/azp run` option (see `.claude/docs/ci-tests.md`). Do not auto-post — just surface it; the user decides. If containers were started for this run via `/test-providers`, remind the user once: "Run `/test-providers stop` when you're done with the containers."
 
 ### 4. Write-and-run (chain)
 
@@ -173,12 +117,13 @@ Execute the **Write flow** first. Before chaining to the **Run flow**:
 
 ### 5. End-of-session housekeeping
 
-When the session ends (last turn before user moves on), and `UserDataProviders.json` was edited with `restoreOnCompletion: false` at any point, remind the user: the file is still in its edited state; the pre-edit backup (if one was taken) is at the path shown earlier.
+If containers were started during the session via `/test-providers`, remind the user once that they're still running and `/test-providers stop` will shut them down. Do not auto-stop them, do not invoke `/test-providers` from here.
 
 ## Don'ts
 
-- Do not invoke `test-runner` without a resolved `userProvidersConsent`. The agent will refuse; avoid the round-trip.
+- Do not edit `UserDataProviders.json` or invoke `docker` commands from `/test`. Env changes route through `/test-providers` exclusively. If the run needs a different provider set or a stopped container started, tell the user — don't fix it.
 - Do not run tests in `Release` config by default — analyzers + banned-API checks are slow and rarely what the user wants for a single-test run.
 - Do not edit source files yourself. Writing is `test-writer`'s job; running is `test-runner`'s job. The skill only orchestrates and relays.
 - Do not run targets in parallel. The agents won't anyway (sequential is built into `test-runner`), but do not try to fan out multiple agent invocations with overlapping target sets either.
 - Do not suppress or skim the agent's output. If the agent reports a failure, relay the verbatim error message; don't paraphrase.
+- Do not pre-validate the env state before invoking `test-runner`. Trust the user; let the agent's own provider-check abort surface any mismatch. Auto-fix attempts here defeat the boundary.


### PR DESCRIPTION
## Summary

Refactor of the `.claude/` testing toolset to separate env management from test execution.

- New `/test-providers` skill owns every `UserDataProviders.json` edit and every `docker start`/`docker stop` call across `.claude/`. Supports Set / `add` / `remove` / `stop` / `reset` modes plus an `in <bucket>` clause for TFM scope.
- `/test` no longer edits env. If a container is down or a provider is disabled, the run fails and the user re-runs `/test-providers` to fix it. No pre-flight validation.
- `test-runner` is now read-only on `UserDataProviders.json` — no `userProvidersConsent`, no `restoreOnCompletion`. Verifies enable state and aborts with a `blocked` status otherwise. Frontmatter `tools:` drops `Edit`.
- `/fix-issue` step 5 split into 5a (`/test-providers`) + 5b (`/test`); container-cleanup step removed (now `/test-providers stop`'s job).

`/test-providers` user-tailored rules baked into the skill:
- Family shortcuts: `Access`→`Access.Ace.Odbc`, `MySql`→`MySqlConnector.<v>`, `Oracle`→`Oracle.<v>.Managed`, `SqlServer`→`SqlServer.2019.MS` (override), `ClickHouse`→`ClickHouse.MySql`, `SapHana`→`SapHana.Native`.
- Default bucket scope is `NET100`; widen via `in <bucket>` clause.
- Sticky entries: `TestNoopProvider` (skipped by Set-mode disable sweep), `DefaultConfiguration` (never modified).
- `SqlServer.{SA,Contained,Northwind,Azure}{,.MS}` excluded from family auto-resolution; explicit input still wins.

## Test plan
- [ ] `/test-providers SQLite.MS PostgreSQL.18` — only `NET100` changes; backup file appears under `.build/.claude/`.
- [ ] `/test run <filter>` — no consent prompt, no docker calls, no `UserDataProviders.json` edits.
- [ ] Disable a provider manually, then `/test run` against it — `test-runner` aborts with `blocked` pointing at `/test-providers`.
- [ ] `/test-providers stop` — stops containers without touching the JSON.
- [ ] `/test-providers reset` — restores from template with backup.