### PR TITLE
Translate Enum.HasFlag

### DIFF
--- a/Source/LinqToDB/Internal/DataProvider/Translation/ProviderMemberTranslatorDefault.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Translation/ProviderMemberTranslatorDefault.cs
@@ -180,6 +180,17 @@ namespace LinqToDB.Internal.DataProvider.Translation
 				return true;
 			}
 
+			// Column-level guard — catches [Column(DataType=…)] / [ValueConverter] overrides
+			// on the property. The type-level check above only sees [MapValue] mappings, which
+			// are keyed on Type; a column whose property has no [MapValue] but is stored via
+			// NVarChar+ValueConverter must also fall through. ColumnDescriptor.GetConvertedDbDataType()
+			// returns the post-conversion SystemType (the converter's target type when one is
+			// attached, otherwise the enum's default-from-enum mapping when present).
+			if (QueryHelper.GetColumnDescriptor(valueSql)?.GetConvertedDbDataType().SystemType.IsIntegerType == false)
+			{
+				return false;
+			}
+
 			if (!translationContext.TranslateToSqlExpression(flagExpr, out var flagSql))
 			{
 				translated = translationContext.CreateErrorExpression(flagExpr, type: methodCall.Type);

--- a/Source/LinqToDB/Internal/DataProvider/Translation/ProviderMemberTranslatorDefault.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Translation/ProviderMemberTranslatorDefault.cs
@@ -134,11 +134,68 @@ namespace LinqToDB.Internal.DataProvider.Translation
 			return true;
 		}
 
+		static Expression UnwrapEnumBoxing(Expression expression)
+		{
+			// Enum.HasFlag is declared on System.Enum, so call sites carry a Convert(x, typeof(Enum))
+			// wrapper around an enum-typed receiver/argument. The SQL translator can't lower that
+			// abstract-type boxing for parameter/closure-captured locals, so strip it.
+			while (expression is UnaryExpression { NodeType: ExpressionType.Convert } unary
+				&& unary.Type == typeof(Enum)
+				&& unary.Operand.Type.IsEnum)
+			{
+				expression = unary.Operand;
+			}
+
+			return expression;
+		}
+
+		protected bool ProcessHasFlag(ITranslationContext translationContext, MethodCallExpression methodCall, out Expression? translated)
+		{
+			translated = null;
+
+			if (methodCall.Method.DeclaringType != typeof(Enum) ||
+				!string.Equals(methodCall.Method.Name, nameof(Enum.HasFlag), StringComparison.Ordinal) ||
+				methodCall.Arguments.Count != 1 ||
+				methodCall.Object == null)
+			{
+				return false;
+			}
+
+			var valueExpr = UnwrapEnumBoxing(methodCall.Object);
+			var flagExpr  = UnwrapEnumBoxing(methodCall.Arguments[0]);
+
+			if (!translationContext.TranslateToSqlExpression(valueExpr, out var valueSql))
+			{
+				translated = translationContext.CreateErrorExpression(valueExpr, type: methodCall.Type);
+				return true;
+			}
+
+			if (!translationContext.TranslateToSqlExpression(flagExpr, out var flagSql))
+			{
+				translated = translationContext.CreateErrorExpression(flagExpr, type: methodCall.Type);
+				return true;
+			}
+
+			var factory   = translationContext.ExpressionFactory;
+			var dbType    = factory.GetDbDataType(valueSql);
+			var andExpr   = factory.Binary(dbType, valueSql, "&", flagSql);
+			var equalPred = factory.Equal(andExpr, flagSql);
+
+			var sc = factory.SearchCondition();
+			sc.Add(equalPred);
+
+			translated = translationContext.CreatePlaceholder(sc, methodCall);
+			return true;
+		}
+
 		public virtual Expression? TranslateMethodCall(ITranslationContext translationContext, MethodCallExpression methodCall, TranslationFlags translationFlags)
 		{
 			Expression? translated;
 
 			if (ProcessGetValueOrDefault(translationContext, methodCall, out translated))
+				return translated;
+
+			if (ProcessHasFlag(translationContext, methodCall, out translated))
 				return translated;
 
 			return null;

--- a/Source/LinqToDB/Internal/DataProvider/Translation/ProviderMemberTranslatorDefault.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Translation/ProviderMemberTranslatorDefault.cs
@@ -197,9 +197,15 @@ namespace LinqToDB.Internal.DataProvider.Translation
 				return true;
 			}
 
+			// Column-level guard for case when flag comes from column
+			if (QueryHelper.GetColumnDescriptor(flagSql)?.GetConvertedDbDataType().SystemType.IsIntegerType == false)
+			{
+				return false;
+			}
+
 			var factory   = translationContext.ExpressionFactory;
 			var dbType    = factory.GetDbDataType(valueSql);
-			var andExpr   = factory.Binary(dbType, valueSql, "&", flagSql);
+			var andExpr   = factory.BitAnd(dbType, valueSql, flagSql);
 			var equalPred = factory.Equal(andExpr, flagSql);
 
 			var sc = factory.SearchCondition();

--- a/Source/LinqToDB/Internal/DataProvider/Translation/ProviderMemberTranslatorDefault.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Translation/ProviderMemberTranslatorDefault.cs
@@ -164,6 +164,16 @@ namespace LinqToDB.Internal.DataProvider.Translation
 			var valueExpr = UnwrapEnumBoxing(methodCall.Object);
 			var flagExpr  = UnwrapEnumBoxing(methodCall.Arguments[0]);
 
+			// Bitwise-AND translation is only valid when the enum is stored as an integer.
+			// Enums mapped to non-integer types (e.g. [MapValue("foo")] → NVarChar) must fall through.
+			var enumType = valueExpr.Type.UnwrapNullableType();
+			if (!enumType.IsEnum)
+				return false;
+
+			var underlyingDataType = translationContext.MappingSchema.GetUnderlyingDataType(enumType, out _);
+			if (!underlyingDataType.Type.SystemType.IsIntegerType)
+				return false;
+
 			if (!translationContext.TranslateToSqlExpression(valueExpr, out var valueSql))
 			{
 				translated = translationContext.CreateErrorExpression(valueExpr, type: methodCall.Type);

--- a/Source/LinqToDB/Internal/DataProvider/Translation/SqlExpressionFactoryExtensions.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Translation/SqlExpressionFactoryExtensions.cs
@@ -177,6 +177,12 @@ namespace LinqToDB.Internal.DataProvider.Translation
 		}
 
 		[SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "factory is an extension point")]
+		public static ISqlExpression BitAnd(this ISqlExpressionFactory factory, DbDataType dbDataType, ISqlExpression x, ISqlExpression y)
+		{
+			return new SqlBinaryExpression(dbDataType, x, "&", y, precedence: Precedence.Bitwise);
+		}
+
+		[SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "factory is an extension point")]
 		public static ISqlExpression Sub(this ISqlExpressionFactory factory, DbDataType dbDataType, ISqlExpression x, ISqlExpression y)
 		{
 			return new SqlBinaryExpression(dbDataType, x, "-", y, Precedence.Subtraction);

--- a/Tests/Linq/Linq/ExpressionsTests.cs
+++ b/Tests/Linq/Linq/ExpressionsTests.cs
@@ -40,8 +40,6 @@ namespace Tests.Linq
 			Expressions.MapBinary((long v, int s) => v >> s, (v, s) => Shr(v, s));
 			Expressions.MapBinary((int  v, int s) => v << s, (v, s) => Shl(v, s));
 			Expressions.MapBinary((int  v, int s) => v >> s, (v, s) => Shr(v, s));
-			Expressions.MapMember((Enum e, Enum e2) => e.HasFlag(e2),
-				(t, flag) => (Sql.ConvertTo<int>.From(t) & Sql.ConvertTo<int>.From(flag)) != 0);
 		}
 
 		[Test]
@@ -80,7 +78,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		public void MapHasFlag([IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context, [Values (FlagsEnum.Flag1, FlagsEnum.Flag3)] FlagsEnum flag)
+		public void MapHasFlag([DataSources] string context, [Values(FlagsEnum.Flag1, FlagsEnum.Flag3, FlagsEnum.All)] FlagsEnum flag)
 		{
 			var data = Enumerable.Range(1, 10).Select(i => new MappingTestClass
 				{

--- a/Tests/Linq/Linq/ExpressionsTests.cs
+++ b/Tests/Linq/Linq/ExpressionsTests.cs
@@ -130,6 +130,47 @@ namespace Tests.Linq
 			Assert.Throws<LinqToDBException>(() => query.ToArray());
 		}
 
+		[Flags]
+		public enum ConverterMappedFlagsEnum
+		{
+			Flag1 = 0x1,
+			Flag2 = 0x2,
+			Flag3 = 0x4,
+		}
+
+		sealed class FlagsEnumToStringConverter : ValueConverter<ConverterMappedFlagsEnum, string>
+		{
+			public FlagsEnumToStringConverter() : base(
+				v => v.ToString(),
+				s => Enum.Parse<ConverterMappedFlagsEnum>(s),
+				handlesNulls: true)
+			{
+			}
+		}
+
+		[Table]
+		sealed class ConverterMappedFlagsTable
+		{
+			[Column] public int Id { get; set; }
+
+			[Column(DataType = DataType.NVarChar, Length = 30)]
+			[ValueConverter(ConverterType = typeof(FlagsEnumToStringConverter))]
+			public ConverterMappedFlagsEnum Flags { get; set; }
+		}
+
+		[Test]
+		public void HasFlag_OnConverterMappedEnum_FailsToTranslate([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable<ConverterMappedFlagsTable>();
+
+			var query = from t in table
+						where t.Flags.HasFlag(ConverterMappedFlagsEnum.Flag1)
+						select t;
+
+			Assert.Throws<LinqToDBException>(() => query.ToArray());
+		}
+
 		static int Count1(Parent p) { return p.Children.Count(c => c.ChildID > 0); }
 
 		[Test]

--- a/Tests/Linq/Linq/ExpressionsTests.cs
+++ b/Tests/Linq/Linq/ExpressionsTests.cs
@@ -171,6 +171,21 @@ namespace Tests.Linq
 			Assert.Throws<LinqToDBException>(() => query.ToArray());
 		}
 
+		[Test]
+		public void HasFlag_OnConverterMappedEnum_ByColumn_FailsToTranslate([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable<ConverterMappedFlagsTable>();
+
+			var value = ConverterMappedFlagsEnum.Flag1;
+
+			var query = from t in table
+						where value.HasFlag(t.Flags)
+						select t;
+
+			Assert.Throws<LinqToDBException>(() => query.ToArray());
+		}
+
 		static int Count1(Parent p) { return p.Children.Count(c => c.ChildID > 0); }
 
 		[Test]

--- a/Tests/Linq/Linq/ExpressionsTests.cs
+++ b/Tests/Linq/Linq/ExpressionsTests.cs
@@ -101,6 +101,35 @@ namespace Tests.Linq
 			AreEqualWithComparer(expected, query);
 		}
 
+		[Flags]
+		public enum StringMappedFlagsEnum
+		{
+			[MapValue("F1")] Flag1 = 0x1,
+			[MapValue("F2")] Flag2 = 0x2,
+			[MapValue("F3")] Flag3 = 0x4,
+		}
+
+		[Table]
+		sealed class StringMappedFlagsTable
+		{
+			[Column] public int                   Id    { get; set; }
+			[Column(DataType = DataType.NVarChar, Length = 10)]
+			public StringMappedFlagsEnum          Flags { get; set; }
+		}
+
+		[Test]
+		public void HasFlag_OnStringMappedEnum_FailsToTranslate([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable<StringMappedFlagsTable>();
+
+			var query = from t in table
+						where t.Flags.HasFlag(StringMappedFlagsEnum.Flag1)
+						select t;
+
+			Assert.Throws<LinqToDBException>(() => query.ToArray());
+		}
+
 		static int Count1(Parent p) { return p.Children.Count(c => c.ChildID > 0); }
 
 		[Test]


### PR DESCRIPTION
- Translate `Enum.HasFlag(other)` to `(value & other) == other` in `ProviderMemberTranslatorDefault`. Per-provider bitwise lowering is already handled by existing `SqlExpressionConvertVisitor`s.
- Use `== b`, not `!= 0`, to match CLR semantics on composite flags: `HasFlag(b)` requires *all* bits of `b` to be set.
- Drop the corresponding `Expressions.MapMember` workaround from `ExpressionsTests`'s static ctor.
- Broaden `MapHasFlag` to `[DataSources]` and add `FlagsEnum.All` to `[Values]` to cover composite flags.

Fixes #3040
