### PR TITLE
Add regression test for #5125

### DIFF
--- a/Tests/Linq/UserTests/Issue5125Tests.cs
+++ b/Tests/Linq/UserTests/Issue5125Tests.cs
@@ -30,7 +30,7 @@ namespace Tests.UserTests
 			public string Expr1 { get; set; } = null!;
 
 			private static Expression<Func<InterpolatedTest5125, IDataContext, string>> Expr1Impl() =>
-				(e, ctx) => !string.IsNullOrEmpty(e.StrVal) ? e.StrVal : e.IntVal.ToString();
+				(e, ctx) => !string.IsNullOrEmpty(e.StrVal) ? e.StrVal! : e.IntVal.ToString();
 
 			[System.Diagnostics.CodeAnalysis.AllowNull]
 			[ExpressionMethod(nameof(Expr2Impl))]

--- a/Tests/Linq/UserTests/Issue5125Tests.cs
+++ b/Tests/Linq/UserTests/Issue5125Tests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+
+using LinqToDB;
+using LinqToDB.Mapping;
+
+using NUnit.Framework;
+
+namespace Tests.UserTests
+{
+	[TestFixture]
+	public class Issue5125Tests : TestBase
+	{
+		// Faithful repro of issue #5125 (https://github.com/linq2db/linq2db/issues/5125):
+		// non-nullable `string` properties with [AllowNull] + [ExpressionMethod] containing
+		// `string.IsNullOrEmpty`, projected to the entity itself via `new T { ... }` after
+		// OrderBy on a calculated expression. Confirmed reproducible on v6.0.0-rc.3 with
+		// `42P01: missing FROM-clause entry for table "x_1"` on PostgreSQL; this test pins
+		// the fix from PR #5126 and guards against regression.
+		[Table("InterpolatedTest5125", IsColumnAttributeRequired = false)]
+		public class InterpolatedTest5125
+		{
+			public int     Id     { get; set; }
+			public string? StrVal { get; set; }
+			public int     IntVal { get; set; }
+
+			[System.Diagnostics.CodeAnalysis.AllowNull]
+			[ExpressionMethod(nameof(Expr1Impl))]
+			public string Expr1 { get; set; } = null!;
+
+			private static Expression<Func<InterpolatedTest5125, IDataContext, string>> Expr1Impl() =>
+				(e, ctx) => !string.IsNullOrEmpty(e.StrVal) ? e.StrVal : e.IntVal.ToString();
+
+			[System.Diagnostics.CodeAnalysis.AllowNull]
+			[ExpressionMethod(nameof(Expr2Impl))]
+			public string Expr2 { get; set; } = null!;
+
+			private static Expression<Func<InterpolatedTest5125, IDataContext, string>> Expr2Impl() =>
+				(e, ctx) => $"{(!string.IsNullOrEmpty(e.StrVal) ? e.StrVal : e.IntVal.ToString())}";
+		}
+
+		[Test]
+		public void TestIssue5125_Repro([IncludeDataSources(true, TestProvName.AllPostgreSQL)] string context)
+		{
+			var data = new[]
+			{
+				new InterpolatedTest5125 { Id = 1, StrVal = null,     IntVal = 11 },
+				new InterpolatedTest5125 { Id = 2, StrVal = "",       IntVal = 12 },
+				new InterpolatedTest5125 { Id = 3, StrVal = "Value3", IntVal = 13 },
+			};
+
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable(data);
+
+			var query = tb
+				.OrderBy(x => x.Expr1)
+				.Select(x => new InterpolatedTest5125
+				{
+					Id    = x.Id,
+					Expr1 = x.Expr1,
+					Expr2 = x.Expr2
+				});
+			var list = query.ToList();
+
+			Assert.That(list, Has.Count.EqualTo(3));
+		}
+	}
+}


### PR DESCRIPTION
Regression test for the original repro from #5125: non-nullable `string` + `[AllowNull]` + `[ExpressionMethod]` projected via `new T { ... }` after `OrderBy`. Reproduces on v6.0.0-rc.3 with `42P01: missing FROM-clause entry for table "x_1"` on PostgreSQL; passes on master, locking in the fix from #5126.

The v6.2.x regression mentioned in a later comment (`END NULLS FIRST as c1` syntax error 42601) was NOT reproducible — tried 7 query shape variants (`Take` / `Skip` / `Distinct` / `AsSubQuery` / eager-load via inner `Select` / `GroupBy` with inner `OrderBy` / `OrderBy.Select.OrderBy`) on v6.2.1 and v6.0.0-rc.3 against the same model. None triggered that SQL shape. Source-grep confirms `END NULLS FIRST` is only emitted from `Sql.AnalyticFunctions.OrderItemBuilder` (window-function builder), not from regular `ORDER BY`, so the commenter's repro likely involves explicit window/analytic functions or another path my variants don't reach. A separate test is needed once that shape is identified.

Refs #5125.
