### PR TITLE
Fix C# string concatenation null semantics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,9 @@ public class Test: TestBase
 }
 ```
 
+Prefer `AssertQuery` for LINQ tests when the same query can be evaluated against both database and in-memory data.
+Use `AreEqual` when the expected result needs a different expression shape and must be passed explicitly.
+
 ### Configure data providers for tests
 
 `DataSourcesAttribute` generates tests for each enabled data provider. Configuration is taken

--- a/Source/LinqToDB/Internal/DataProvider/Sybase/SybaseSqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Sybase/SybaseSqlExpressionConvertVisitor.cs
@@ -88,6 +88,37 @@ namespace LinqToDB.Internal.DataProvider.Sybase
 			};
 		}
 
+		public override IQueryElement ConvertSqlBinaryExpression(SqlBinaryExpression element)
+		{
+			if (element is { Operation: "+", SystemType: var type } && type.IsStringType)
+			{
+				var expr1 = UnwrapEmptyStringCoalesce(element.Expr1);
+				var expr2 = UnwrapEmptyStringCoalesce(element.Expr2);
+
+				if (!ReferenceEquals(expr1, element.Expr1) || !ReferenceEquals(expr2, element.Expr2))
+					return new SqlBinaryExpression(element.Type, expr1, element.Operation, expr2, element.Precedence);
+			}
+
+			return base.ConvertSqlBinaryExpression(element);
+
+			static ISqlExpression UnwrapEmptyStringCoalesce(ISqlExpression expression)
+			{
+				return expression switch
+				{
+					SqlFunction
+					{
+						Name      : "Coalesce",
+						Parameters: [var value, SqlValue { Value: "" }]
+					} => value,
+					SqlCoalesceExpression
+					{
+						Expressions: [var value, SqlValue { Value: "" }]
+					} => value,
+					_ => expression
+				};
+			}
+		}
+
 		protected override ISqlExpression WrapColumnExpression(ISqlExpression expr)
 		{
 			if (expr is SqlValue

--- a/Source/LinqToDB/Internal/DataProvider/Sybase/SybaseSqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Sybase/SybaseSqlExpressionConvertVisitor.cs
@@ -90,7 +90,8 @@ namespace LinqToDB.Internal.DataProvider.Sybase
 
 		public override IQueryElement ConvertSqlBinaryExpression(SqlBinaryExpression element)
 		{
-			if (element is { Operation: "+", SystemType: var type } && type.IsStringType)
+			// TODO: Revisit this workaround with string concatenation changes in PR #5504.
+			if (DataOptions.LinqOptions.CompareNulls == CompareNulls.LikeClr && element is { Operation: "+", SystemType: var type } && type.IsStringType)
 			{
 				var expr1 = UnwrapEmptyStringCoalesce(element.Expr1);
 				var expr2 = UnwrapEmptyStringCoalesce(element.Expr2);

--- a/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuildVisitor.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuildVisitor.cs
@@ -3215,21 +3215,32 @@ namespace LinqToDB.Internal.Linq.Builder
 			var r = rightPlaceholder.Sql;
 			var t = node.Type;
 
+			if (t == typeof(string) && node.NodeType is ExpressionType.Add or ExpressionType.AddChecked)
+			{
+				var nullability = GetNullabilityContext();
+
+				if (l.SystemType == typeof(string) && l.CanBeNullable(nullability))
+					l = new SqlCoalesceExpression(l, new SqlValue(QueryHelper.GetDbDataType(l, MappingSchema), string.Empty));
+
+				if (r.SystemType == typeof(string) && r.CanBeNullable(nullability))
+					r = new SqlCoalesceExpression(r, new SqlValue(QueryHelper.GetDbDataType(r, MappingSchema), string.Empty));
+			}
+
 			switch (node.NodeType)
 			{
 				case ExpressionType.Add:
-				case ExpressionType.AddChecked: translated = CreatePlaceholder(new SqlBinaryExpression(t, l, "+", r, Precedence.Additive), node); break;
-				case ExpressionType.And:         translated = CreatePlaceholder(new SqlBinaryExpression(t, l, "&", r, Precedence.Bitwise),        node); break;
-				case ExpressionType.Divide:      translated = CreatePlaceholder(new SqlBinaryExpression(t, l, "/", r, Precedence.Multiplicative), node); break;
-				case ExpressionType.ExclusiveOr: translated = CreatePlaceholder(new SqlBinaryExpression(t, l, "^", r, Precedence.Bitwise),        node); break;
-				case ExpressionType.Modulo:      translated = CreatePlaceholder(new SqlBinaryExpression(t, l, "%", r, Precedence.Multiplicative), node); break;
+				case ExpressionType.AddChecked     : translated = CreatePlaceholder(new SqlBinaryExpression(t, l, "+", r, Precedence.Additive),       node); break;
+				case ExpressionType.And            : translated = CreatePlaceholder(new SqlBinaryExpression(t, l, "&", r, Precedence.Bitwise),        node); break;
+				case ExpressionType.Divide         : translated = CreatePlaceholder(new SqlBinaryExpression(t, l, "/", r, Precedence.Multiplicative), node); break;
+				case ExpressionType.ExclusiveOr    : translated = CreatePlaceholder(new SqlBinaryExpression(t, l, "^", r, Precedence.Bitwise),        node); break;
+				case ExpressionType.Modulo         : translated = CreatePlaceholder(new SqlBinaryExpression(t, l, "%", r, Precedence.Multiplicative), node); break;
 				case ExpressionType.Multiply:
 				case ExpressionType.MultiplyChecked: translated = CreatePlaceholder(new SqlBinaryExpression(t, l, "*", r, Precedence.Multiplicative), node); break;
-				case ExpressionType.Or:    translated = CreatePlaceholder(new SqlBinaryExpression(t, l, "|", r, Precedence.Bitwise),      node); break;
-				case ExpressionType.Power: translated = CreatePlaceholder(new SqlFunction(MappingSchema.GetDbDataType(t), "Power", l, r), node); break;
-				case ExpressionType.Subtract:
-				case ExpressionType.SubtractChecked: translated = CreatePlaceholder(new SqlBinaryExpression(t, l, "-", r, Precedence.Subtraction), node); break;
-				case ExpressionType.Coalesce: translated = CreatePlaceholder(new SqlCoalesceExpression(l, r), node); break;
+				case ExpressionType.Or             : translated = CreatePlaceholder(new SqlBinaryExpression(t, l, "|", r, Precedence.Bitwise),        node); break;
+				case ExpressionType.Power          : translated = CreatePlaceholder(new SqlFunction(MappingSchema.GetDbDataType(t), "Power", l, r),   node); break;
+				case ExpressionType.Subtract       :
+				case ExpressionType.SubtractChecked: translated = CreatePlaceholder(new SqlBinaryExpression(t, l, "-", r, Precedence.Subtraction),    node); break;
+				case ExpressionType.Coalesce       : translated = CreatePlaceholder(new SqlCoalesceExpression(l, r), node); break;
 				default:
 					return false;
 			}

--- a/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuildVisitor.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuildVisitor.cs
@@ -3215,7 +3215,8 @@ namespace LinqToDB.Internal.Linq.Builder
 			var r = rightPlaceholder.Sql;
 			var t = node.Type;
 
-			if (t == typeof(string) && node.NodeType is ExpressionType.Add or ExpressionType.AddChecked)
+			// TODO: Revisit string concatenation null semantics handling as part of PR #5504.
+			if (DataOptions.LinqOptions.CompareNulls == CompareNulls.LikeClr && t == typeof(string) && node.NodeType is ExpressionType.Add or ExpressionType.AddChecked)
 			{
 				var nullability = GetNullabilityContext();
 

--- a/Tests/Base/TestBase.AssertQuery.cs
+++ b/Tests/Base/TestBase.AssertQuery.cs
@@ -312,6 +312,10 @@ namespace Tests
 			return mc;
 		}
 
+		/// <summary>
+		/// Executes the same LINQ query against the database and against in-memory data loaded from the query tables,
+		/// then compares both result sets. Prefer this helper when the expected result can be expressed by the same query.
+		/// </summary>
 		protected T[] AssertQuery<T>(IQueryable<T> query, IEqualityComparer<T>? comparer = null)
 		{
 			var expr   = query.Expression;

--- a/Tests/Base/TestBase.Asserts.cs
+++ b/Tests/Base/TestBase.Asserts.cs
@@ -39,9 +39,13 @@ namespace Tests
 		}
 #endif
 
-        protected void AreEqual<T>(IEnumerable<T> expected, IEnumerable<T> result, bool allowEmpty = false, bool printData = false)
+		/// <summary>
+		/// Compares an explicitly constructed expected result set with the query result. Prefer <see cref="AssertQuery{T}"/>
+		/// when the expected result can be expressed by the same LINQ query; use AreEqual when it needs a different shape.
+		/// </summary>
+		protected void AreEqual<T>(IEnumerable<T> expected, IEnumerable<T> result, bool allowEmpty = false, bool printData = false)
 		{
-            AreEqual(t => t, expected, result, EqualityComparer<T>.Default, allowEmpty, printData : printData);
+			AreEqual(t => t, expected, result, EqualityComparer<T>.Default, allowEmpty, printData : printData);
 		}
 
 		protected void AreEqual<T>(IEnumerable<T> expected, IEnumerable<T> result, Func<IEnumerable<T>, IEnumerable<T>> sort)

--- a/Tests/Base/TestUtils.cs
+++ b/Tests/Base/TestUtils.cs
@@ -10,6 +10,7 @@ using LinqToDB;
 using LinqToDB.Data;
 using LinqToDB.DataProvider.Firebird;
 using LinqToDB.Internal.DataProvider.Firebird;
+using LinqToDB.Mapping;
 
 using NUnit.Framework;
 
@@ -184,8 +185,15 @@ namespace Tests
 		sealed class FirebirdTempTable<T> : TestTempTable<T>
 			where T : notnull
 		{
-			public FirebirdTempTable(IDataContext db, string? tableName = null, string? databaseName = null, string? schemaName = null, string? serverName = null, TableOptions tableOptions = TableOptions.NotSet)
-				: base(db, tableName, databaseName, schemaName, serverName, tableOptions : tableOptions)
+			public FirebirdTempTable(
+				IDataContext    db,
+				string?         tableName             = null,
+				string?         databaseName          = null,
+				string?         schemaName            = null,
+				string?         serverName            = null,
+				TableOptions    tableOptions          = TableOptions.NotSet,
+				MappingSchema? previousMappingSchema = null)
+				: base(db, tableName, databaseName, schemaName, serverName, tableOptions : tableOptions, previousMappingSchema : previousMappingSchema)
 			{
 			}
 
@@ -218,29 +226,93 @@ namespace Tests
 		class TestTempTable<T> : TempTable<T>
 			where T : notnull
 		{
-			public TestTempTable(IDataContext db, string? tableName = null, string? databaseName = null, string? schemaName = null, string? serverName = null, TableOptions tableOptions = TableOptions.NotSet)
+			readonly MappingSchema? _previousMappingSchema;
+
+			public TestTempTable(
+				IDataContext    db,
+				string?         tableName             = null,
+				string?         databaseName          = null,
+				string?         schemaName            = null,
+				string?         serverName            = null,
+				TableOptions    tableOptions          = TableOptions.NotSet,
+				MappingSchema? previousMappingSchema = null)
 				: base(db, tableName: tableName, databaseName: databaseName, schemaName: schemaName, serverName: serverName, tableOptions: tableOptions)
 			{
+				_previousMappingSchema = previousMappingSchema;
 			}
 
 			public override void Dispose()
 			{
 				using var _ = new DisableBaseline("Test setup");
-				base.Dispose();
+				try
+				{
+					base.Dispose();
+				}
+				finally
+				{
+					if (_previousMappingSchema != null)
+						DataContext.SetMappingSchema(_previousMappingSchema);
+				}
 			}
 
 			public override async ValueTask DisposeAsync()
 			{
 				using var _ = new DisableBaseline("Test setup");
-				await base.DisposeAsync();
+				try
+				{
+					await base.DisposeAsync();
+				}
+				finally
+				{
+					if (_previousMappingSchema != null)
+						DataContext.SetMappingSchema(_previousMappingSchema);
+				}
 			}
 		}
 
-		static TempTable<T> CreateTable<T>(IDataContext db, string? tableName, string? schemaName = null, string? databaseName = null, string? serverName = null, TableOptions tableOptions = TableOptions.NotSet)
-			where T : notnull =>
-			db.ConfigurationString?.IsAnyOf(TestProvName.AllFirebird) == true ?
-				new FirebirdTempTable<T>(db, tableName, schemaName: schemaName, databaseName: databaseName, serverName: serverName, tableOptions : tableOptions) :
-				new     TestTempTable<T>(db, tableName, schemaName: schemaName, databaseName: databaseName, serverName: serverName, tableOptions : tableOptions);
+		static TempTable<T> CreateTable<T>(
+			IDataContext                    db,
+			string?                         tableName,
+			string?                         schemaName   = null,
+			string?                         databaseName = null,
+			string?                         serverName   = null,
+			TableOptions                    tableOptions = TableOptions.NotSet,
+			Action<EntityMappingBuilder<T>>? setTable     = null)
+			where T : notnull
+		{
+			var previousMappingSchema = ApplyTableMapping(db, setTable);
+
+			try
+			{
+				return db.ConfigurationString?.IsAnyOf(TestProvName.AllFirebird) == true ?
+					new FirebirdTempTable<T>(db, tableName, schemaName: schemaName, databaseName: databaseName, serverName: serverName, tableOptions : tableOptions, previousMappingSchema : previousMappingSchema) :
+					new     TestTempTable<T>(db, tableName, schemaName: schemaName, databaseName: databaseName, serverName: serverName, tableOptions : tableOptions, previousMappingSchema : previousMappingSchema);
+			}
+			catch
+			{
+				if (previousMappingSchema != null)
+					db.SetMappingSchema(previousMappingSchema);
+
+				throw;
+			}
+		}
+
+		static MappingSchema? ApplyTableMapping<T>(IDataContext db, Action<EntityMappingBuilder<T>>? setTable)
+		{
+			if (setTable == null)
+				return null;
+
+			var oldSchema = db.MappingSchema;
+			var newSchema = new MappingSchema("#LocalTable", oldSchema);
+			var builder   = new FluentMappingBuilder(newSchema);
+
+			setTable(builder.Entity<T>());
+			builder.Build();
+
+			db.SetMappingSchema(newSchema);
+
+			return oldSchema;
+		}
 
 		static void ClearDataContext(IDataContext db)
 		{
@@ -257,7 +329,14 @@ namespace Tests
 			return new Version(version);
 		}
 
-		public static TempTable<T> CreateLocalTable<T>(this IDataContext db, string? tableName = null, string? schemaName = null, string? databaseName = null, string? serverName = null, TableOptions tableOptions = TableOptions.CheckExistence)
+		public static TempTable<T> CreateLocalTable<T>(
+			this IDataContext               db,
+			string?                         tableName    = null,
+			string?                         schemaName   = null,
+			string?                         databaseName = null,
+			string?                         serverName   = null,
+			TableOptions                    tableOptions = TableOptions.CheckExistence,
+			Action<EntityMappingBuilder<T>>? setTable     = null)
 			where T : notnull
 		{
 			using var _ = new DisableBaseline("Test setup");
@@ -265,40 +344,60 @@ namespace Tests
 			{
 				if ((tableOptions & TableOptions.CheckExistence) == TableOptions.CheckExistence)
 					db.DropTable<T>(tableName, schemaName: schemaName, databaseName: databaseName, serverName: serverName, tableOptions:tableOptions);
-				return CreateTable<T>(db, tableName, schemaName: schemaName, databaseName: databaseName, serverName: serverName, tableOptions: tableOptions);
+				return CreateTable<T>(db, tableName, schemaName: schemaName, databaseName: databaseName, serverName: serverName, tableOptions: tableOptions, setTable: setTable);
 			}
 			catch
 			{
 				ClearDataContext(db);
 				db.DropTable<T>(tableName, schemaName: schemaName, databaseName: databaseName, serverName: serverName, throwExceptionIfNotExists:false);
-				return CreateTable<T>(db, tableName, schemaName: schemaName, databaseName: databaseName, serverName: serverName, tableOptions: tableOptions);
+				return CreateTable<T>(db, tableName, schemaName: schemaName, databaseName: databaseName, serverName: serverName, tableOptions: tableOptions, setTable: setTable);
 			}
 		}
 
 		public static TempTable<T> CreateLocalTable<T>(this IDataContext db, string? tableName, IEnumerable<T> items, bool insertInTransaction = false)
 			where T : notnull
 		{
+			return CreateLocalTable(db, tableName, items, setTable: null, insertInTransaction: insertInTransaction);
+		}
+
+		public static TempTable<T> CreateLocalTable<T>(
+			this IDataContext               db,
+			string?                         tableName,
+			IEnumerable<T>                  items,
+			Action<EntityMappingBuilder<T>>? setTable,
+			bool                            insertInTransaction = false)
+			where T : notnull
+		{
 			using var _ = new DisableBaseline("Test setup");
 			using (new DisableLogging())
 			{
-				var table = CreateLocalTable<T>(db, tableName, tableOptions: TableOptions.CheckExistence);
+				var table = CreateLocalTable<T>(db, tableName, tableOptions: TableOptions.CheckExistence, setTable: setTable);
 
-				if (db is DataConnection dc)
+				try
 				{
-					// apply transaction only on insert, as not all dbs support DDL within transaction
-					if (insertInTransaction)
-						dc.BeginTransaction();
+					if (db is DataConnection dc)
+					{
+						// apply transaction only on insert, as not all dbs support DDL within transaction
+						if (insertInTransaction)
+							dc.BeginTransaction();
 
-					table.Copy(items, new BulkCopyOptions { BulkCopyType = BulkCopyType.MultipleRows });
+						table.Copy(items, new BulkCopyOptions { BulkCopyType = BulkCopyType.MultipleRows });
 
-					if (insertInTransaction)
-						dc.CommitTransaction();
+						if (insertInTransaction)
+							dc.CommitTransaction();
+					}
+					else
+						foreach (var item in items)
+							db.Insert(item, table.TableName);
+
+					return table;
 				}
-				else
-					foreach (var item in items)
-						db.Insert(item, table.TableName);
+				catch
+				{
+					table.Dispose();
 
-				return table;
+					throw;
+				}
 			}
 		}
 
@@ -307,6 +406,17 @@ namespace Tests
 		{
 			using var _ = new DisableBaseline("Test setup");
 			return CreateLocalTable(db, null, items, insertInTransaction);
+		}
+
+		public static TempTable<T> CreateLocalTable<T>(
+			this IDataContext               db,
+			IEnumerable<T>                  items,
+			Action<EntityMappingBuilder<T>>? setTable,
+			bool                            insertInTransaction = false)
+			where T : notnull
+		{
+			using var _ = new DisableBaseline("Test setup");
+			return CreateLocalTable(db, null, items, setTable, insertInTransaction);
 		}
 
 		public static string GetValidCollationName(string providerName)

--- a/Tests/Linq/Common/ExtensionsTest.cs
+++ b/Tests/Linq/Common/ExtensionsTest.cs
@@ -22,7 +22,7 @@ namespace Tests.Common
 		{
 			public new Guid PropVirtual    { get; set; }
 			public new Guid PropNonVirtual { get; set; }
-		}		
+		}
 
 		[Test]
 		public void VirtualPropDerived()

--- a/Tests/Linq/Linq/StringFunctionsTests.cs
+++ b/Tests/Linq/Linq/StringFunctionsTests.cs
@@ -377,6 +377,88 @@ namespace Tests.Linq
 				Assert.That(actualAllEmpty, Is.EqualTo(expectedAllEmpty));
 			}
 
+		[Test]
+		public void StringPlusNullOperands([DataSources] string context, [Values] bool value1Nullable, [Values] bool value2Nullable)
+		{
+			if (value1Nullable && value2Nullable && context.IsAnyOf(TestProvName.AllSybase))
+				Assert.Ignore("Sybase cannot represent C# empty string result for null + null string concatenation.");
+
+			var data = new []
+				{
+					new { ID = 1, Value1 = (string?)"A1", Value2 = (string?)"A2" },
+					new { ID = 2, Value1 = (string?)null, Value2 = (string?)"B2" },
+					new { ID = 3, Value1 = (string?)"C1", Value2 = (string?)null },
+					new { ID = 4, Value1 = (string?)null, Value2 = (string?)null }
+				}
+				.Where(t => (value1Nullable || t.Value1 != null) && (value2Nullable || t.Value2 != null))
+				.ToArray();
+
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(
+				$"StringPlusNullOperands_{Guid.NewGuid():N}",
+				data,
+				mb => mb
+					.Property(t => t.ID)
+						.IsPrimaryKey()
+					.Property(t => t.Value1)
+						.HasLength(50)
+						.IsNullable(value1Nullable)
+					.Property(t => t.Value2)
+						.HasLength(50)
+						.IsNullable(value2Nullable));
+
+			var query = table
+				.OrderBy(t => t.ID)
+				.Select(t => t.Value1 + t.Value2);
+
+			AssertQuery(query);
+
+			if (context is ProviderName.SQLiteMS or ProviderName.SQLiteClassic)
+			{
+				var expectedCoalesceCount = (value1Nullable ? 1 : 0) + (value2Nullable ? 1 : 0);
+				var sql                   = ((TestDataConnection)db).LastQuery!;
+				var coalesceCount         = sql.Split(["Coalesce("], StringSplitOptions.None).Length - 1;
+
+				Assert.That(coalesceCount, Is.EqualTo(expectedCoalesceCount), sql);
+			}
+		}
+
+		[Test]
+		public void StringPlusIntNullOperands([DataSources] string context, [Values] bool value1Nullable, [Values] bool value2Nullable)
+		{
+			if (value1Nullable && value2Nullable && context.IsAnyOf(TestProvName.AllSybase))
+				Assert.Ignore("Sybase cannot represent C# empty string result for null + null string concatenation.");
+
+			var data = new []
+				{
+					new { ID = 1, Value1 = (string?)"A", Value2 = (int?)1 },
+					new { ID = 2, Value1 = (string?)null, Value2 = (int?)2 },
+					new { ID = 3, Value1 = (string?)"C", Value2 = (int?)null },
+					new { ID = 4, Value1 = (string?)null, Value2 = (int?)null }
+				}
+				.Where(t => (value1Nullable || t.Value1 != null) && (value2Nullable || t.Value2 != null))
+				.ToArray();
+
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(
+				$"StringPlusIntNullOperands_{Guid.NewGuid():N}",
+				data,
+				mb => mb
+					.Property(t => t.ID)
+						.IsPrimaryKey()
+					.Property(t => t.Value1)
+						.HasLength(50)
+						.IsNullable(value1Nullable)
+					.Property(t => t.Value2)
+						.IsNullable(value2Nullable));
+
+			var query = table
+				.OrderBy(t => t.ID)
+				.Select(t => t.Value1 + t.Value2);
+
+			AssertQuery(query);
+		}
+
 		private static SampleClass[] GenerateData()
 		{
 			var data = new[]

--- a/Tests/Linq/Linq/StringFunctionsTests.cs
+++ b/Tests/Linq/Linq/StringFunctionsTests.cs
@@ -459,6 +459,50 @@ namespace Tests.Linq
 			AssertQuery(query);
 		}
 
+		[Test]
+		public void StringPlusNullOperandsCompareNulls(
+			[IncludeDataSources(false, ProviderName.SQLiteMS, ProviderName.SqlServer2025)] string context,
+			[Values] CompareNulls compareNulls)
+		{
+			var data = new []
+			{
+				new { ID = 1, Value1 = (string?)"A1", Value2 = (string?)"A2" },
+				new { ID = 2, Value1 = (string?)null, Value2 = (string?)"B2" },
+				new { ID = 3, Value1 = (string?)"C1", Value2 = (string?)null },
+				new { ID = 4, Value1 = (string?)null, Value2 = (string?)null }
+			};
+
+			using var db    = GetDataContext(context, o => o.UseCompareNulls(compareNulls));
+			using var table = db.CreateLocalTable(
+				$"StringPlusNullOperandsCompareNulls_{Guid.NewGuid():N}",
+				data,
+				mb => mb
+					.Property(t => t.ID)
+						.IsPrimaryKey()
+					.Property(t => t.Value1)
+						.HasLength(50)
+						.IsNullable()
+					.Property(t => t.Value2)
+						.HasLength(50)
+						.IsNullable());
+
+			var actual = table
+				.OrderBy(t => t.ID)
+				.Select(t => t.Value1 + t.Value2);
+
+			var expected = data
+				.OrderBy(t => t.ID)
+				.Select(t => compareNulls == CompareNulls.LikeClr || t.Value1 != null && t.Value2 != null ? t.Value1 + t.Value2 : null);
+
+			AreEqual(expected, actual);
+
+			var expectedCoalesceCount = compareNulls == CompareNulls.LikeClr ? 2 : 0;
+			var sql                   = ((TestDataConnection)db).LastQuery!;
+			var coalesceCount         = sql.Split(["Coalesce("], StringSplitOptions.None).Length - 1;
+
+			Assert.That(coalesceCount, Is.EqualTo(expectedCoalesceCount), sql);
+		}
+
 		private static SampleClass[] GenerateData()
 		{
 			var data = new[]


### PR DESCRIPTION
**Summary**

Fixes C# string concatenation null semantics for translated LINQ expressions.

`string + string` now treats nullable operands like C# does: `null` is concatenated as an empty string instead of letting SQL null-propagation turn the whole result into `NULL`. The translation only adds `COALESCE(..., '')` for operands that can actually be nullable, avoiding unnecessary SQL for non-null operands.

**Changes**

- Added nullable-aware string concatenation handling in `ExpressionBuildVisitor`.
- Added Sybase-specific handling to avoid generating broken empty-string `COALESCE` patterns where Sybase already handles one-null string concatenation cases.
- Extended `CreateLocalTable` to support optional FluentMapping configuration, matching `CreateTempTable` usage.
- Added independent test data for string concatenation null semantics.
- Added parameterized tests for:
  - `string + string`
  - `string + int`
  - nullable/non-null operand combinations
  - local and remote/LinqService providers through `[DataSources]`
- Documented preferred test comparison helpers:
  - use `AssertQuery` when the expected result can be expressed as the same LINQ query;
  - use `AreEqual` when expected and actual need different query shapes.

**Sybase Note**

Sybase cannot represent the C# empty string result for `null + null` string concatenation: `''` materializes as a single space, while zero-length string expressions such as `RTRIM('')`, `Space(0)`, and similar expressions return `NULL`. Because of that, only the impossible `both nullable` Sybase case is skipped; all other Sybase combinations remain covered, including LinqService.
