### PR TITLE
Gate IDE analyzers, ReportAnalyzer, xml-doc to Release builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -111,11 +111,13 @@
 		<RunAnalyzersDuringLiveAnalysis>true</RunAnalyzersDuringLiveAnalysis>
 
 		<AnalysisLevel>preview-All</AnalysisLevel>
-		<!--enable IDExxxx analyzers during build-->
-		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-		<ReportAnalyzer>true</ReportAnalyzer>
-		<!--workaround for https://github.com/dotnet/roslyn/issues/41640, but also required for xml-doc validation -->
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<!--enable IDExxxx analyzers during build (Release only — too slow for dev/test iteration)-->
+		<EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+		<EnforceCodeStyleInBuild Condition="'$(Configuration)' == 'Release'">true</EnforceCodeStyleInBuild>
+		<!--debugging option, set to true temporarily to profile per-analyzer cost-->
+		<ReportAnalyzer>false</ReportAnalyzer>
+		<!--workaround for https://github.com/dotnet/roslyn/issues/41640, but also required for xml-doc validation-->
+		<GenerateDocumentationFile Condition="'$(Configuration)' == 'Release'">true</GenerateDocumentationFile>
 	</PropertyGroup>
 
 	<PropertyGroup Label="Enabled Polyfills">


### PR DESCRIPTION
## Summary

Three analyzer/codegen properties run in Debug/Testing/Azure where they don't pay off:

| Property | Before | After |
|---|---|---|
| `EnforceCodeStyleInBuild` | always on | Release only |
| `ReportAnalyzer` | always on | default off, opt-in via `-p:ReportAnalyzer=true` |
| `GenerateDocumentationFile` | always on | Release only |

`EnforceCodeStyleInBuild` mirrors the existing `RunAnalyzersDuringBuild` pattern (Release-only). `ReportAnalyzer` is a profiling switch the team uses ad-hoc — defaulting it to off removes the per-analyzer instrumentation overhead from every build while keeping the flag one `-p:` away when needed. `GenerateDocumentationFile`'s Roslyn #41640 workaround is moot in non-Release because analyzers don't run there anyway.

## Measured impact

Cold full-solution `dotnet build linq2db.slnx -c Debug` (parallel):

| | Baseline | After | Δ |
|---|---|---|---|
| TOTAL wall-clock | 14:22.757 | 13:20.579 | **−7.2%** |
| SUM CoreCompile | 2,634,117 ms | 2,007,929 ms | **−23.8%** |

## Test plan

- [ ] `/azp run test-all` — verify no regressions across the test matrix
- [ ] CI Release builds still enforce IDE code style and produce xml-doc files in shipped packages
