### PR TITLE
Fix DateTime.Date truncation cast preserving column DbType

### DIFF
--- a/Source/LinqToDB/Internal/DataProvider/Firebird/Translation/FirebirdMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Firebird/Translation/FirebirdMemberTranslator.cs
@@ -236,8 +236,9 @@ namespace LinqToDB.Internal.DataProvider.Firebird.Translation
 
 			protected override ISqlExpression? TranslateDateTimeTruncationToDate(ITranslationContext translationContext, ISqlExpression dateExpression, TranslationFlags translationFlags)
 			{
-				var factory = translationContext.ExpressionFactory;
-				var cast = factory.Cast(dateExpression, factory.GetDbDataType(dateExpression).WithDataType(DataType.Date), true);
+				var factory    = translationContext.ExpressionFactory;
+				var sourceType = factory.GetDbDataType(dateExpression);
+				var cast       = factory.Cast(dateExpression, new DbDataType(sourceType.SystemType, DataType.Date), true);
 
 				return cast;
 			}

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2008MemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/Translation/SqlServer2008MemberTranslator.cs
@@ -30,8 +30,9 @@ namespace LinqToDB.Internal.DataProvider.SqlServer.Translation
 		{
 			protected override ISqlExpression? TranslateDateTimeTruncationToDate(ITranslationContext translationContext, ISqlExpression dateExpression, TranslationFlags translationFlags)
 			{
-				var factory = translationContext.ExpressionFactory;
-				var cast    = factory.Cast(dateExpression, factory.GetDbDataType(dateExpression).WithDataType(DataType.Date), true);
+				var factory    = translationContext.ExpressionFactory;
+				var sourceType = factory.GetDbDataType(dateExpression);
+				var cast       = factory.Cast(dateExpression, new DbDataType(sourceType.SystemType, DataType.Date), true);
 
 				return cast;
 			}

--- a/Tests/Linq/DataProvider/FirebirdTests.cs
+++ b/Tests/Linq/DataProvider/FirebirdTests.cs
@@ -1192,6 +1192,27 @@ namespace Tests.DataProvider
 			record = t.Single();
 			Assert.That(record.CharArrayAccessor, Is.EqualTo(mac2));
 		}
+
+		sealed class TestTimestampDatePartTable
+		{
+			[Column(DbType = "TIMESTAMP")]
+			public DateTime LastModified { get; set; }
+
+			public static readonly TestTimestampDatePartTable[] Data =
+			[
+				new() { LastModified = TestData.DateTime },
+				new() { LastModified = TestData.DateTime.AddDays(10) },
+			];
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5309")]
+		public void TestTimestampDatePart([IncludeDataSources(false, TestProvName.AllFirebird)] string context)
+		{
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable(TestTimestampDatePartTable.Data);
+
+			Assert.That(tb.Where(s => s.LastModified.Date == TestData.DateTime.Date).Count(), Is.EqualTo(1));
+		}
 	}
 
 	#region Extensions

--- a/Tests/Linq/DataProvider/SqlServerTests.cs
+++ b/Tests/Linq/DataProvider/SqlServerTests.cs
@@ -2347,5 +2347,26 @@ DROP TABLE IF EXISTS TemporalTable3History
 			public int     Id    { get; set; }
 			public object? Value { get; set; }
 		}
+
+		sealed class TestDateTime2DatePartTable
+		{
+			[Column(DbType = "DateTime2")]
+			public DateTime LastModified { get; set; }
+
+			public static readonly TestDateTime2DatePartTable[] Data =
+			[
+				new() { LastModified = TestData.DateTime },
+				new() { LastModified = TestData.DateTime.AddDays(10) },
+			];
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5309")]
+		public void TestDateTime2DatePart([IncludeDataSources(false, TestProvName.AllSqlServer2008Plus)] string context)
+		{
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable(TestDateTime2DatePartTable.Data);
+
+			Assert.That(tb.Where(s => s.LastModified.Date == TestData.DateTime.Date).Count(), Is.EqualTo(1));
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- `TranslateDateTimeTruncationToDate` on SQL Server and Firebird built the cast target via `factory.GetDbDataType(dateExpression).WithDataType(DataType.Date)`, which preserves the source expression's DbType string. `BasicSqlBuilder.BuildDataType` emits `DbType` verbatim and ignores `DataType` when both are present, so a column declared `[Column(DbType = "DateTime2")]` cast as `Date` emitted `CAST(... AS DateTime2)` — the LHS of `x.Date == constant.Date` never matched the RHS's `CAST(... AS Date)`.
- Build the cast target from a fresh `DbDataType(SystemType, DataType.Date)` so no `DbType` string is carried over.
- Adds regression tests on `[Column(DbType = "...")]` columns for both providers.

Fixes #5309

## Test plan

- [x] `TestDateTime2DatePart` passes on `SqlServer.2019.MS` post-fix (verified locally)
- [x] `TestTimestampDatePart` passes on `Firebird.5` post-fix (verified locally)
- [ ] CI provider matrix via `/azp run test-all`