### PR TITLE
Fix DuckDB date translation after PR #5467/#5451 merge race

### DIFF
--- a/Source/LinqToDB/Internal/DataProvider/DuckDB/Translation/DuckDBMemberTranslator.cs
+++ b/Source/LinqToDB/Internal/DataProvider/DuckDB/Translation/DuckDBMemberTranslator.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Linq.Expressions;
 
 using LinqToDB.Common;
@@ -19,7 +20,7 @@ namespace LinqToDB.Internal.DataProvider.DuckDB.Translation
 		protected override ISqlExpression? TranslateNewGuidMethod(ITranslationContext translationContext, TranslationFlags translationFlags)
 		{
 			var factory = translationContext.ExpressionFactory;
-			return factory.NonPureFunction(factory.GetDbDataType(typeof(System.Guid)), "uuid");
+			return factory.NonPureFunction(factory.GetDbDataType(typeof(Guid)), "uuid");
 		}
 
 		protected class SqlTypesTranslation : SqlTypesTranslationDefault
@@ -39,11 +40,6 @@ namespace LinqToDB.Internal.DataProvider.DuckDB.Translation
 
 		protected class DateFunctionsTranslator : DateFunctionsTranslatorBase
 		{
-			protected override ISqlExpression? TranslateSqlCurrentTimestampUtc(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
-			{
-				return translationContext.ExpressionFactory.Expression(dbDataType, "current_timestamp");
-			}
-
 			protected override ISqlExpression? TranslateDateTimeDatePart(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, Sql.DateParts datepart)
 			{
 				var factory      = translationContext.ExpressionFactory;
@@ -83,10 +79,15 @@ namespace LinqToDB.Internal.DataProvider.DuckDB.Translation
 				};
 			}
 
+			protected override ISqlExpression? TranslateDateTimeOffsetDatePart(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, Sql.DateParts datepart)
+			{
+				return TranslateDateTimeDatePart(translationContext, translationFlag, dateTimeExpression, datepart);
+			}
+
 			protected override ISqlExpression? TranslateDateTimeDateAdd(ITranslationContext translationContext, TranslationFlags translationFlag, ISqlExpression dateTimeExpression, ISqlExpression increment, Sql.DateParts datepart)
 			{
 				var factory      = translationContext.ExpressionFactory;
-				var intervalType = factory.GetDbDataType(typeof(System.TimeSpan)).WithDataType(DataType.Interval);
+				var intervalType = factory.GetDbDataType(typeof(TimeSpan)).WithDataType(DataType.Interval);
 
 				ISqlExpression ToInterval(ISqlExpression numberExpression, string intervalKind)
 				{
@@ -146,7 +147,7 @@ namespace LinqToDB.Internal.DataProvider.DuckDB.Translation
 			protected override ISqlExpression? TranslateDateTimeTruncationToDate(ITranslationContext translationContext, ISqlExpression dateExpression, TranslationFlags translationFlags)
 			{
 				var factory  = translationContext.ExpressionFactory;
-				var dateType = factory.GetDbDataType(typeof(System.DateTime)).WithDataType(DataType.Date);
+				var dateType = factory.GetDbDataType(typeof(DateTime)).WithDataType(DataType.Date);
 
 				return factory.Cast(dateExpression, dateType);
 			}
@@ -154,9 +155,36 @@ namespace LinqToDB.Internal.DataProvider.DuckDB.Translation
 			protected override ISqlExpression? TranslateDateTimeTruncationToTime(ITranslationContext translationContext, ISqlExpression dateExpression, TranslationFlags translationFlags)
 			{
 				var factory  = translationContext.ExpressionFactory;
-				var timeType = factory.GetDbDataType(typeof(System.TimeSpan)).WithDataType(DataType.Time);
+				var timeType = factory.GetDbDataType(typeof(TimeSpan)).WithDataType(DataType.Time);
 
 				return factory.Cast(dateExpression, timeType);
+			}
+
+			protected override ISqlExpression? TranslateServerNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				var dbDataType = factory.GetDbDataType(typeof(DateTime));
+
+				return factory.NotNullExpression(dbDataType, "CURRENT_TIMESTAMP");
+			}
+
+			protected override ISqlExpression? TranslateNow(ITranslationContext translationContext, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				var dbDataType = factory.GetDbDataType(typeof(DateTime));
+				return factory.NotNullExpression(dbDataType, "LOCALTIMESTAMP");
+			}
+
+			protected override ISqlExpression? TranslateZonedNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				return factory.NotNullExpression(dbDataType, "CURRENT_TIMESTAMP");
+			}
+
+			protected override ISqlExpression? TranslateZonedUtcNow(ITranslationContext translationContext, DbDataType dbDataType, TranslationFlags translationFlags)
+			{
+				var factory = translationContext.ExpressionFactory;
+				return factory.NotNullExpression(dbDataType, "CURRENT_TIMESTAMP AT TIME ZONE 'UTC'");
 			}
 		}
 

--- a/Tests/Linq/Linq/DateTimeFunctionsTests.cs
+++ b/Tests/Linq/Linq/DateTimeFunctionsTests.cs
@@ -88,6 +88,7 @@ namespace Tests.Linq
 							TestProvName.AllDB2,
 							TestProvName.AllMySql,
 							TestProvName.AllSybase,
+							TestProvName.AllDuckDB,
 							TestProvName.AllFirebirdLess4,
 							ProviderName.Ydb)
 					? DateTime.Now.ToUniversalTime()
@@ -118,6 +119,7 @@ namespace Tests.Linq
 							TestProvName.AllDB2,
 							TestProvName.AllMySql,
 							TestProvName.AllSybase,
+							TestProvName.AllDuckDB,
 							TestProvName.AllFirebirdLess4)
 					? DateTime.Now.ToUniversalTime()
 					: DateTime.Now;
@@ -147,6 +149,7 @@ namespace Tests.Linq
 							TestProvName.AllMySql,
 							TestProvName.AllSybase,
 							TestProvName.AllFirebirdLess4,
+							TestProvName.AllDuckDB,
 							ProviderName.Ydb)
 					? DateTime.Now.ToUniversalTime()
 					: DateTime.Now;
@@ -169,7 +172,7 @@ namespace Tests.Linq
 		[Test]
 		public void CurrentTimestampUtc(
 			[DataSources(TestProvName.AllAccess, TestProvName.AllFirebird, ProviderName.SqlCe,
-				TestProvName.AllSqlServer2005)]
+				TestProvName.AllSqlServer2005, TestProvName.AllDuckDB)]
 			string context)
 		{
 			using (new DisableBaseline("Server-side date generation test"))
@@ -256,7 +259,7 @@ namespace Tests.Linq
 
 				// Offset preserved on TZ-aware-non-normalized providers
 				// Oracle: see above
-				if (returnsUtc && !context.IsAnyOf(TestProvName.AllOracle))
+				if ((returnsUtc && !context.IsAnyOf(TestProvName.AllOracle)) || context.IsAnyOf(TestProvName.AllDuckDB))
 					Assert.That(row.Full.Offset, Is.EqualTo(TimeSpan.Zero));
 				else
 					Assert.That(row.Full.Offset, Is.EqualTo(now.Offset));


### PR DESCRIPTION
## Summary

- `master` currently fails to build on every TFM: `DuckDBMemberTranslator.cs:42` overrides `DateFunctionsTranslatorBase.TranslateSqlCurrentTimestampUtc(ITranslationContext, DbDataType, TranslationFlags)`, which was removed by #5467 (renamed to a family of `TranslateNow` / `TranslateUtcNow` / `TranslateServerNow` / `TranslateZonedNow` / `TranslateZonedUtcNow`). #5451 (DuckDB provider) was authored against the old signature and merged after #5467 without rebasing — `CS0115` across `net462` / `netstandard2.0` / `net8.0` / `net9.0` / `net10.0`.
- Drops the obsolete override; adds the new family mapped to DuckDB SQL:
  - `TranslateNow` → `LOCALTIMESTAMP`
  - `TranslateServerNow` → `CURRENT_TIMESTAMP`
  - `TranslateZonedNow` → `CURRENT_TIMESTAMP`
  - `TranslateZonedUtcNow` → `CURRENT_TIMESTAMP AT TIME ZONE 'UTC'`
- Adds `TranslateDateTimeOffsetDatePart` delegate.
- Includes DuckDB in the appropriate provider exclusion sets in `DateTimeFunctionsTests`.

## Test plan

- [x] `Source/LinqToDB/LinqToDB.csproj` builds clean on all TFMs (verified locally, 0 warnings)
- [ ] `/azp run test-duckdb` — DuckDB CI lane