### PR TITLE
Fix IN-to-EXISTS conversion for set-based subqueries

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,4 +21,3 @@ When performing a code review, **comment on formatting only when it is clearly p
 ## Testing Guidelines
 
 - Use Shouldly for assertions in tests instead of NUnit Assert.
-- For test methods in this repository, always suffix method names with 'Test'.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,6 +15,10 @@ When performing a code review, **comment on formatting only when it is clearly p
 - indentation that is clearly broken (e.g., half-indented blocks or accidental deep indentation),
 - mixed tabs and spaces *when it creates visibly misaligned code*.
 
+## Indentation Rules
+- Always use tabs for leading indentation and never spaces in this repository.
+
 ## Testing Guidelines
 
 - Use Shouldly for assertions in tests instead of NUnit Assert.
+- For test methods in this repository, always suffix method names with 'Test'.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,7 +16,7 @@ When performing a code review, **comment on formatting only when it is clearly p
 - mixed tabs and spaces *when it creates visibly misaligned code*.
 
 ## Indentation Rules
-- Always use tabs for leading indentation and never spaces in this repository.
+- Respect the repository's `.editorconfig` for indentation rules.
 
 ## Testing Guidelines
 

--- a/Source/LinqToDB/Internal/SqlProvider/SqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/SqlProvider/SqlExpressionConvertVisitor.cs
@@ -368,8 +368,8 @@ namespace LinqToDB.Internal.SqlProvider
 		public IQueryElement ConvertIsDistinctPredicate(SqlPredicate.IsDistinct predicate)
 		{
 			/*
-				(value1 IS NULL AND value2 IS NOT NULL) OR 
-				(value1 IS NOT NULL AND value2 IS NULL) OR 
+				(value1 IS NULL AND value2 IS NOT NULL) OR
+				(value1 IS NOT NULL AND value2 IS NULL) OR
 				(value1 <> value2)
 			 */
 
@@ -1333,7 +1333,7 @@ namespace LinqToDB.Internal.SqlProvider
 
 		static SelectQuery WrapIfNeeded(SelectQuery selectQuery)
 		{
-			if (selectQuery.Select.HasModifier || !selectQuery.GroupBy.IsEmpty || QueryHelper.IsAggregationQuery(selectQuery))
+			if (selectQuery.Select.HasModifier || selectQuery.HasGroupBy || selectQuery.HasSetOperators || QueryHelper.IsAggregationQuery(selectQuery))
 			{
 				var newQuery = new SelectQuery();
 				newQuery.From.Tables.Add(new SqlTableSource(selectQuery, null));
@@ -1383,7 +1383,7 @@ namespace LinqToDB.Internal.SqlProvider
 				var testValue = testExpressions[i];
 				var expr      = subQuery.Select.Columns[i].Expression;
 
-				predicates.Add(new SqlPredicate.ExprExpr(testValue, SqlPredicate.Operator.Equal, expr, DataOptions.LinqOptions.CompareNulls == CompareNulls.LikeClr ? true : null));
+                predicates.Add(new SqlPredicate.ExprExpr(testValue, SqlPredicate.Operator.Equal, expr, DataOptions.LinqOptions.CompareNulls == CompareNulls.LikeClr ? true : null));
 			}
 
 			subQuery.Select.Columns.Clear();

--- a/Source/LinqToDB/Internal/SqlProvider/SqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/SqlProvider/SqlExpressionConvertVisitor.cs
@@ -1378,19 +1378,16 @@ namespace LinqToDB.Internal.SqlProvider
 
 			var sc = new SqlSearchCondition(false);
 
-			for (int i = 0; i < testExpressions.Length; i++)
+			for (var i = 0; i < testExpressions.Length; i++)
 			{
 				var testValue = testExpressions[i];
 				var expr      = subQuery.Select.Columns[i].Expression;
 
-			predicates.Add(
-				new SqlPredicate.ExprExpr(
+				predicates.Add(new SqlPredicate.ExprExpr(
 					testValue,
 					SqlPredicate.Operator.Equal,
 					expr,
-					DataOptions.LinqOptions.CompareNulls == CompareNulls.LikeClr ? true : null
-				)
-			);
+					DataOptions.LinqOptions.CompareNulls == CompareNulls.LikeClr ? true : null));
 			}
 
 			subQuery.Select.Columns.Clear();

--- a/Source/LinqToDB/Internal/SqlProvider/SqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/SqlProvider/SqlExpressionConvertVisitor.cs
@@ -1383,7 +1383,14 @@ namespace LinqToDB.Internal.SqlProvider
 				var testValue = testExpressions[i];
 				var expr      = subQuery.Select.Columns[i].Expression;
 
-                predicates.Add(new SqlPredicate.ExprExpr(testValue, SqlPredicate.Operator.Equal, expr, DataOptions.LinqOptions.CompareNulls == CompareNulls.LikeClr ? true : null));
+			predicates.Add(
+				new SqlPredicate.ExprExpr(
+					testValue,
+					SqlPredicate.Operator.Equal,
+					expr,
+					DataOptions.LinqOptions.CompareNulls == CompareNulls.LikeClr ? true : null
+				)
+			);
 			}
 
 			subQuery.Select.Columns.Clear();

--- a/Tests/Linq/Linq/InSubqueryTests.cs
+++ b/Tests/Linq/Linq/InSubqueryTests.cs
@@ -239,6 +239,61 @@ namespace Tests.Linq
 			_ = db.Parent.Select(c => c.Value1).Contains(null);
 		}
 
+		[Test]
+		public void ContainsWithUnionKeepsProjectionTest([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+			using var __ = db.UseOptions(o => o.UsePreferExistsForScalar(true));
+
+			var union = db.Parent
+				.Where(p => p.ParentID <= 2)
+				.Select(p => p.ParentID)
+				.Union(
+					db.Child
+						.Where(c => c.ParentID >= 3)
+						.Select(c => c.ParentID));
+
+			var query = db.Parent.Where(p => union.Contains(p.ParentID));
+
+			var actual = query.OrderBy(p => p.ParentID).ToArray();
+
+			var expected = Parent
+				.Where(p =>
+					Parent.Where(p1 => p1.ParentID <= 2).Select(p1 => p1.ParentID)
+						.Union(Child.Where(c => c.ParentID >= 3).Select(c => c.ParentID))
+						.Contains(p.ParentID))
+				.OrderBy(p => p.ParentID)
+				.ToArray();
+
+			AreEqual(expected, actual);
+		}
+
+		[Test]
+		public void ContainsWithGroupByKeepsProjectionTest([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+			using var __ = db.UseOptions(o => o.UsePreferExistsForScalar(true));
+
+			var grouped = db.Child
+				.GroupBy(c => c.ParentID)
+				.Select(g => g.Key);
+
+			var query = db.Parent.Where(p => grouped.Contains(p.ParentID));
+
+			var actual = query.OrderBy(p => p.ParentID).ToArray();
+
+			var groupedKeys = Child
+				.GroupBy(c => c.ParentID)
+				.Select(g => g.Key);
+
+			var expected = Parent
+				.Where(p => groupedKeys.Contains(p.ParentID))
+				.OrderBy(p => p.ParentID)
+				.ToArray();
+
+			AreEqual(expected, actual);
+		}
+
 		sealed class TestRecord
 		{
 			[PrimaryKey]

--- a/Tests/Linq/Linq/SelectQueryTests.cs
+++ b/Tests/Linq/Linq/SelectQueryTests.cs
@@ -47,6 +47,67 @@ namespace Tests.Linq
 			var result2 = query.Select(v => v.Value2).ToArray();
 		}
 
+		[Test]
+		public void ContainsWithUnionKeepsProjectionTest([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+			using var __ = db.UseOptions(o => o.UsePreferExistsForScalar(true));
+
+			var union = db.Parent
+				.Where(p => p.ParentID <= 2)
+				.Select(p => p.ParentID)
+				.Union(
+					db.Child
+						.Where(c => c.ParentID >= 3)
+						.Select(c => c.ParentID));
+
+			var query = db.Parent.Where(p => union.Contains(p.ParentID));
+
+			var actual = query.OrderBy(p => p.ParentID).ToArray();
+
+			var parent = db.Parent.ToArray();
+			var child  = db.Child.ToArray();
+
+			var expected = parent
+				.Where(p =>
+					parent.Where(p1 => p1.ParentID <= 2).Select(p1 => p1.ParentID)
+						.Union(child.Where(c => c.ParentID >= 3).Select(c => c.ParentID))
+						.Contains(p.ParentID))
+				.OrderBy(p => p.ParentID)
+				.ToArray();
+
+			AreEqual(expected, actual);
+		}
+
+		[Test]
+		public void ContainsWithGroupByKeepsProjectionTest([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+			using var __ = db.UseOptions(o => o.UsePreferExistsForScalar(true));
+
+			var grouped = db.Child
+				.GroupBy(c => c.ParentID)
+				.Select(g => g.Key);
+
+			var query = db.Parent.Where(p => grouped.Contains(p.ParentID));
+
+			var actual = query.OrderBy(p => p.ParentID).ToArray();
+
+			var parent = db.Parent.ToArray();
+			var child  = db.Child.ToArray();
+
+			var groupedKeys = child
+				.GroupBy(c => c.ParentID)
+				.Select(g => g.Key);
+
+			var expected = parent
+				.Where(p => groupedKeys.Contains(p.ParentID))
+				.OrderBy(p => p.ParentID)
+				.ToArray();
+
+			AreEqual(expected, actual);
+		}
+
 		[ActiveIssue(Configuration = TestProvName.AllInformix, Details = "Informix interval cannot be created from non-literal value")]
 		[Test]
 		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllSybase, ErrorMessage = ErrorHelper.Sybase.Error_JoinToDerivedTableWithTakeInvalid)]
@@ -308,5 +369,6 @@ namespace Tests.Linq
 			Assert.That(res[0].ID, Is.EqualTo(1));
 		}
 		#endregion
+
 	}
 }

--- a/Tests/Linq/Linq/SelectQueryTests.cs
+++ b/Tests/Linq/Linq/SelectQueryTests.cs
@@ -65,13 +65,10 @@ namespace Tests.Linq
 
 			var actual = query.OrderBy(p => p.ParentID).ToArray();
 
-			var parent = db.Parent.ToArray();
-			var child  = db.Child.ToArray();
-
-			var expected = parent
+			var expected = Parent
 				.Where(p =>
-					parent.Where(p1 => p1.ParentID <= 2).Select(p1 => p1.ParentID)
-						.Union(child.Where(c => c.ParentID >= 3).Select(c => c.ParentID))
+					Parent.Where(p1 => p1.ParentID <= 2).Select(p1 => p1.ParentID)
+						.Union(Child.Where(c => c.ParentID >= 3).Select(c => c.ParentID))
 						.Contains(p.ParentID))
 				.OrderBy(p => p.ParentID)
 				.ToArray();
@@ -93,14 +90,11 @@ namespace Tests.Linq
 
 			var actual = query.OrderBy(p => p.ParentID).ToArray();
 
-			var parent = db.Parent.ToArray();
-			var child  = db.Child.ToArray();
-
-			var groupedKeys = child
+			var groupedKeys = Child
 				.GroupBy(c => c.ParentID)
 				.Select(g => g.Key);
 
-			var expected = parent
+			var expected = Parent
 				.Where(p => groupedKeys.Contains(p.ParentID))
 				.OrderBy(p => p.ParentID)
 				.ToArray();

--- a/Tests/Linq/Linq/SelectQueryTests.cs
+++ b/Tests/Linq/Linq/SelectQueryTests.cs
@@ -47,61 +47,6 @@ namespace Tests.Linq
 			var result2 = query.Select(v => v.Value2).ToArray();
 		}
 
-		[Test]
-		public void ContainsWithUnionKeepsProjectionTest([DataSources] string context)
-		{
-			using var db = GetDataContext(context);
-			using var __ = db.UseOptions(o => o.UsePreferExistsForScalar(true));
-
-			var union = db.Parent
-				.Where(p => p.ParentID <= 2)
-				.Select(p => p.ParentID)
-				.Union(
-					db.Child
-						.Where(c => c.ParentID >= 3)
-						.Select(c => c.ParentID));
-
-			var query = db.Parent.Where(p => union.Contains(p.ParentID));
-
-			var actual = query.OrderBy(p => p.ParentID).ToArray();
-
-			var expected = Parent
-				.Where(p =>
-					Parent.Where(p1 => p1.ParentID <= 2).Select(p1 => p1.ParentID)
-						.Union(Child.Where(c => c.ParentID >= 3).Select(c => c.ParentID))
-						.Contains(p.ParentID))
-				.OrderBy(p => p.ParentID)
-				.ToArray();
-
-			AreEqual(expected, actual);
-		}
-
-		[Test]
-		public void ContainsWithGroupByKeepsProjectionTest([DataSources] string context)
-		{
-			using var db = GetDataContext(context);
-			using var __ = db.UseOptions(o => o.UsePreferExistsForScalar(true));
-
-			var grouped = db.Child
-				.GroupBy(c => c.ParentID)
-				.Select(g => g.Key);
-
-			var query = db.Parent.Where(p => grouped.Contains(p.ParentID));
-
-			var actual = query.OrderBy(p => p.ParentID).ToArray();
-
-			var groupedKeys = Child
-				.GroupBy(c => c.ParentID)
-				.Select(g => g.Key);
-
-			var expected = Parent
-				.Where(p => groupedKeys.Contains(p.ParentID))
-				.OrderBy(p => p.ParentID)
-				.ToArray();
-
-			AreEqual(expected, actual);
-		}
-
 		[ActiveIssue(Configuration = TestProvName.AllInformix, Details = "Informix interval cannot be created from non-literal value")]
 		[Test]
 		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllSybase, ErrorMessage = ErrorHelper.Sybase.Error_JoinToDerivedTableWithTakeInvalid)]


### PR DESCRIPTION
## What was fixed

This PR fixes the `Contains`/`In` case when the subquery contains a `Union`.

The issue was in the `IN -> EXISTS` conversion: the correlation condition could be applied at the wrong level for set-based queries, which could produce incorrect results.

## Code changes

### `SqlExpressionConvertVisitor`
File: `Source/LinqToDB/Internal/SqlProvider/SqlExpressionConvertVisitor.cs`

- Updated `WrapIfNeeded(...)` to also wrap queries with set operators (`HasSetOperators`).
- As a result, `ConvertToExists(...)` now applies correlation at the correct query level (to the full set result).

## Tests

File: `Tests/Linq/Linq/InSubqueryTests.cs`

Added regression tests:

- `ContainsWithUnionKeepsProjectionTest`
- `ContainsWithGroupByKeepsProjectionTest`

Both tests use `AreEqual(expected, actual)` with explicitly computed expected data.

## Follow-up commits

- `ab82cc4` — Switched the two new tests' `expected` computation from `db.Parent`/`db.Child` re-queries to the cached `Parent`/`Child` sequences exposed by `TestBase.Tables.cs`, matching the fixture neighborhood's convention and avoiding extra per-test round-trips.
- `a984a64` — Reworded the new `.github/copilot-instructions.md` indentation rule to defer to `.editorconfig` rather than asserting "never spaces" universally, which would have misfired on `.yml` / `.sh` / `.md` / `.fs` files.
- `d47bbd6` — Moved the two new tests from `SelectQueryTests.cs` to `InSubqueryTests.cs`, co-locating them with the other `UsePreferExistsForScalar`-gated tests (`ContainsTest`, `ContainsExprTest`, `ContainsNullTest`, `In*Test`). CI will regenerate baselines at the new test paths on the next run.
