### PR TITLE
Fix #5154: remove [SqlQueryDependentParams] from Sql.Expr params

### DIFF
--- a/Source/LinqToDB/Internal/Linq/ExpressionQuery.cs
+++ b/Source/LinqToDB/Internal/Linq/ExpressionQuery.cs
@@ -51,10 +51,15 @@ namespace LinqToDB.Internal.Linq
 
 			var expression  = Expression;
 			var expressions = (IQueryExpressions)new RuntimeExpressionsContainer(expression);
-			var info        = GetQuery(ref expressions, true, out _);
+			var info        = GetQuery(ref expressions, true, out var dependsOnParameters);
 
 			if (options?.MultiInsertMode != null && info.Queries[0].Statement is SqlMultiInsertStatement multiInsert)
 				multiInsert.InsertType = options.MultiInsertMode.Value;
+
+			if (!dependsOnParameters)
+			{
+				Expression = expressions.MainExpression;
+			}
 
 			var sqlText    = QueryRunner.GetSqlText(info, DataContext, expressions, Parameters, Preambles);
 

--- a/Source/LinqToDB/Internal/Linq/ExpressionQuery.cs
+++ b/Source/LinqToDB/Internal/Linq/ExpressionQuery.cs
@@ -51,15 +51,10 @@ namespace LinqToDB.Internal.Linq
 
 			var expression  = Expression;
 			var expressions = (IQueryExpressions)new RuntimeExpressionsContainer(expression);
-			var info        = GetQuery(ref expressions, true, out var dependsOnParameters);
+			var info        = GetQuery(ref expressions, true, out _);
 
 			if (options?.MultiInsertMode != null && info.Queries[0].Statement is SqlMultiInsertStatement multiInsert)
 				multiInsert.InsertType = options.MultiInsertMode.Value;
-
-			if (!dependsOnParameters)
-			{
-				Expression = expressions.MainExpression;
-			}
 
 			var sqlText    = QueryRunner.GetSqlText(info, DataContext, expressions, Parameters, Preambles);
 

--- a/Source/LinqToDB/Mapping/SqlQueryDependentParamsAttribute.cs
+++ b/Source/LinqToDB/Mapping/SqlQueryDependentParamsAttribute.cs
@@ -10,7 +10,21 @@ namespace LinqToDB.Mapping
 	/// Used for controlling query caching of custom SQL Functions.
 	/// Parameter with this attribute will be evaluated on client side before generating SQL.
 	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Deprecated; scheduled for removal in v7.
+	/// </para>
+	/// <para>
+	/// The per-parameter expression compile inside <see cref="ExpressionsEqual{TContext}"/> (and the
+	/// base <see cref="SqlQueryDependentAttribute.ExpressionsEqual{TContext}"/>) is unsafe whenever
+	/// the parameter expression captures outer-scope transparent identifiers, e.g. inside multi-level
+	/// eager-loaded projections — see <see href="https://github.com/linq2db/linq2db/issues/5154"/>.
+	/// The default structural cache-compare path is sufficient for the cases this attribute was
+	/// intended to cover.
+	/// </para>
+	/// </remarks>
 	[AttributeUsage(AttributeTargets.Parameter)]
+	[Obsolete("Scheduled for removal in v7. The default structural cache-compare path covers the cases this attribute was intended to handle; see https://github.com/linq2db/linq2db/issues/5154.")]
 	public class SqlQueryDependentParamsAttribute : SqlQueryDependentAttribute
 	{
 		public override bool ExpressionsEqual<TContext>(TContext context, Expression expr1, Expression expr2, Func<TContext, Expression, Expression, bool> comparer)

--- a/Source/LinqToDB/Sql/Sql.Expressions.cs
+++ b/Source/LinqToDB/Sql/Sql.Expressions.cs
@@ -564,8 +564,8 @@ namespace LinqToDB
 		[Extension("", BuilderType = typeof(ExprBuilder), ServerSideOnly = true)]
 		[StringFormatMethod("sql")]
 		public static T Expr<T>(
-			[SqlQueryDependent]              RawSqlString sql,
-			[SqlQueryDependentParams] params object[]     parameters
+			[SqlQueryDependent] RawSqlString sql,
+			params object[]     parameters
 			)
 			=> throw new ServerSideOnlyException(nameof(Expr));
 

--- a/Tests/Linq/UserTests/Issue5154Tests.cs
+++ b/Tests/Linq/UserTests/Issue5154Tests.cs
@@ -1,0 +1,167 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using LinqToDB;
+using LinqToDB.Mapping;
+
+using NUnit.Framework;
+
+namespace Tests.UserTests
+{
+	[TestFixture]
+	public class Issue5154Tests : TestBase
+	{
+		[Table]
+		sealed class MasterClass
+		{
+			[Column] [PrimaryKey] public int     Id1   { get; set; }
+			[Column]              public string? Value { get; set; }
+
+			[Association(ThisKey = nameof(Id1), OtherKey = nameof(DetailClass.MasterId))]
+			public List<DetailClass> Details { get; set; } = null!;
+		}
+
+		[Table]
+		sealed class DetailClass
+		{
+			[Column] [PrimaryKey] public int     DetailId    { get; set; }
+			[Column]              public int?    MasterId    { get; set; }
+			[Column]              public string? DetailValue { get; set; }
+
+			[Association(ThisKey = nameof(DetailId), OtherKey = nameof(SubDetailClass.DetailId))]
+			public SubDetailClass[] SubDetails { get; set; } = null!;
+		}
+
+		[Table]
+		sealed class SubDetailClass
+		{
+			[Column] [PrimaryKey] public int     SubDetailId    { get; set; }
+			[Column]              public int?    DetailId       { get; set; }
+			[Column]              public string? SubDetailValue { get; set; }
+		}
+
+		static (MasterClass[] masters, DetailClass[] details, SubDetailClass[] subDetails) GenerateData()
+		{
+			var masters = Enumerable.Range(1, 5)
+				.Select(i => new MasterClass { Id1 = i, Value = "M" + i })
+				.ToArray();
+
+			var details = masters
+				.SelectMany(m => Enumerable.Range(1, 3).Select(i => new DetailClass
+				{
+					DetailId    = m.Id1 * 100 + i,
+					MasterId    = m.Id1,
+					DetailValue = "D" + (m.Id1 * 100 + i),
+				}))
+				.ToArray();
+
+			var subDetails = details
+				.SelectMany(d => Enumerable.Range(1, 2).Select(i => new SubDetailClass
+				{
+					SubDetailId    = d.DetailId * 10 + i,
+					DetailId       = d.DetailId,
+					SubDetailValue = "S" + (d.DetailId * 10 + i),
+				}))
+				.ToArray();
+
+			return (masters, details, subDetails);
+		}
+
+		// The original bug needs Sql.Expr with SqlQueryDependentParams nested inside multi-level
+		// eager-loaded projections so the cache-compare path
+		// (EqualsToVisitor -> SqlQueryDependentParamsAttribute.ExpressionsEqual)
+		// runs ExpressionEvaluator.EvaluateExpression on a sub-expression after ExpressionQuery
+		// has mutated this.Expression to MainExpression and orphaned its transparent identifiers.
+		[Test]
+		public void ToSqlQuery_Then_ToArray([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			var (masterRecords, detailRecords, subDetailRecords) = GenerateData();
+
+			using var db        = GetDataContext(context);
+			using var master    = db.CreateLocalTable(masterRecords);
+			using var detail    = db.CreateLocalTable(detailRecords);
+			using var subDetail = db.CreateLocalTable(subDetailRecords);
+
+			var query =
+				from m in master
+				let detailsRaw = detail.Where(d => d.MasterId == m.Id1)
+				let mTag       = Sql.Expr<string>("'M' || {0}", m.Id1)
+				select new
+				{
+					m.Id1,
+					mTag,
+					Details = (from d in detailsRaw
+							   let dTag = Sql.Expr<string>("'D' || {0} || '/' || {1}", m.Id1, d.DetailId)
+							   select new
+							   {
+								   d.DetailId,
+								   dTag,
+								   SubDetails = subDetail
+									   .Where(s => s.DetailId == d.DetailId)
+									   .Select(s => new
+									   {
+										   s.SubDetailId,
+										   sTag = Sql.Expr<string>("'S' || {0} || '/' || {1} || '/' || {2}", m.Id1, d.DetailId, s.SubDetailId)
+									   })
+									   .ToArray(),
+								   Another = d.SubDetails
+							   }).ToArray()
+				};
+
+			string? sql    = null;
+			object? result = null;
+
+			Assert.DoesNotThrow(() => sql    = query.ToSqlQuery().Sql);
+			Assert.DoesNotThrow(() => result = query.ToArray());
+
+			Assert.That(sql,    Is.Not.Null.And.Not.Empty);
+			Assert.That(result, Is.Not.Null);
+		}
+
+		[Test]
+		public void ToArray_Then_ToSqlQuery([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			var (masterRecords, detailRecords, subDetailRecords) = GenerateData();
+
+			using var db        = GetDataContext(context);
+			using var master    = db.CreateLocalTable(masterRecords);
+			using var detail    = db.CreateLocalTable(detailRecords);
+			using var subDetail = db.CreateLocalTable(subDetailRecords);
+
+			var query =
+				from m in master
+				let detailsRaw = detail.Where(d => d.MasterId == m.Id1)
+				let mTag       = Sql.Expr<string>("'M' || {0}", m.Id1)
+				select new
+				{
+					m.Id1,
+					mTag,
+					Details = (from d in detailsRaw
+							   let dTag = Sql.Expr<string>("'D' || {0} || '/' || {1}", m.Id1, d.DetailId)
+							   select new
+							   {
+								   d.DetailId,
+								   dTag,
+								   SubDetails = subDetail
+									   .Where(s => s.DetailId == d.DetailId)
+									   .Select(s => new
+									   {
+										   s.SubDetailId,
+										   sTag = Sql.Expr<string>("'S' || {0} || '/' || {1} || '/' || {2}", m.Id1, d.DetailId, s.SubDetailId)
+									   })
+									   .ToArray(),
+								   Another = d.SubDetails
+							   }).ToArray()
+				};
+
+			object? result = null;
+			string? sql    = null;
+
+			Assert.DoesNotThrow(() => result = query.ToArray());
+			Assert.DoesNotThrow(() => sql    = query.ToSqlQuery().Sql);
+
+			Assert.That(result, Is.Not.Null);
+			Assert.That(sql,    Is.Not.Null.And.Not.Empty);
+		}
+	}
+}

--- a/Tests/Linq/UserTests/Issue5154Tests.cs
+++ b/Tests/Linq/UserTests/Issue5154Tests.cs
@@ -67,11 +67,13 @@ namespace Tests.UserTests
 			return (masters, details, subDetails);
 		}
 
-		// The original bug needs Sql.Expr with SqlQueryDependentParams nested inside multi-level
-		// eager-loaded projections so the cache-compare path
-		// (EqualsToVisitor -> SqlQueryDependentParamsAttribute.ExpressionsEqual)
-		// runs ExpressionEvaluator.EvaluateExpression on a sub-expression after ExpressionQuery
-		// has mutated this.Expression to MainExpression and orphaned its transparent identifiers.
+		// Regression test for #5154. Before the fix `Sql.Expr<T>(RawSqlString, params object[])` carried
+		// `[SqlQueryDependentParams]` on its `parameters` arg; the cache-compare path
+		// (EqualsToVisitor -> SqlQueryDependentParamsAttribute.ExpressionsEqual ->
+		// ExpressionEvaluator.EvaluateExpression) compiled each parameter sub-expression on its own.
+		// Multi-level eager-loaded projections capture transparent identifiers from outer scope; after
+		// ExpressionQuery mutates `this.Expression` to `expressions.MainExpression`, those identifiers
+		// are orphaned and the per-parameter compile throws `InvalidOperationException`.
 		[Test]
 		public void ToSqlQuery_Then_ToArray([IncludeDataSources(TestProvName.AllSQLite)] string context)
 		{

--- a/Tests/Linq/UserTests/Issue5154Tests.cs
+++ b/Tests/Linq/UserTests/Issue5154Tests.cs
@@ -75,7 +75,7 @@ namespace Tests.UserTests
 		// ExpressionQuery mutates `this.Expression` to `expressions.MainExpression`, those identifiers
 		// are orphaned and the per-parameter compile throws `InvalidOperationException`.
 		[Test]
-		public void ToSqlQuery_Then_ToArray([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		public void ToSqlQueryAndToArray_InEitherOrder([IncludeDataSources(TestProvName.AllSQLite)] string context)
 		{
 			var (masterRecords, detailRecords, subDetailRecords) = GenerateData();
 
@@ -84,7 +84,7 @@ namespace Tests.UserTests
 			using var detail    = db.CreateLocalTable(detailRecords);
 			using var subDetail = db.CreateLocalTable(subDetailRecords);
 
-			var query =
+			var buildQuery = () =>
 				from m in master
 				let detailsRaw = detail.Where(d => d.MasterId == m.Id1)
 				let mTag       = Sql.Expr<string>("'M' || {0}", m.Id1)
@@ -110,60 +110,30 @@ namespace Tests.UserTests
 							   }).ToArray()
 				};
 
-			string? sql    = null;
-			object? result = null;
+			// Order 1: ToSqlQuery -> ToArray on the same query instance. First call seeds the cache;
+			// second call walks the tree against the cached entry.
+			{
+				var query = buildQuery();
+				string? sql    = null;
+				object? result = null;
+				Assert.DoesNotThrow(() => sql    = query.ToSqlQuery().Sql);
+				Assert.DoesNotThrow(() => result = query.ToArray());
+				Assert.That(sql,    Is.Not.Null.And.Not.Empty);
+				Assert.That(result, Is.Not.Null);
+			}
 
-			Assert.DoesNotThrow(() => sql    = query.ToSqlQuery().Sql);
-			Assert.DoesNotThrow(() => result = query.ToArray());
-
-			Assert.That(sql,    Is.Not.Null.And.Not.Empty);
-			Assert.That(result, Is.Not.Null);
-		}
-
-		[Test]
-		public void ToArray_Then_ToSqlQuery([IncludeDataSources(TestProvName.AllSQLite)] string context)
-		{
-			var (masterRecords, detailRecords, subDetailRecords) = GenerateData();
-
-			using var db        = GetDataContext(context);
-			using var master    = db.CreateLocalTable(masterRecords);
-			using var detail    = db.CreateLocalTable(detailRecords);
-			using var subDetail = db.CreateLocalTable(subDetailRecords);
-
-			var query =
-				from m in master
-				let detailsRaw = detail.Where(d => d.MasterId == m.Id1)
-				let mTag       = Sql.Expr<string>("'M' || {0}", m.Id1)
-				select new
-				{
-					m.Id1,
-					mTag,
-					Details = (from d in detailsRaw
-							   let dTag = Sql.Expr<string>("'D' || {0} || '/' || {1}", m.Id1, d.DetailId)
-							   select new
-							   {
-								   d.DetailId,
-								   dTag,
-								   SubDetails = subDetail
-									   .Where(s => s.DetailId == d.DetailId)
-									   .Select(s => new
-									   {
-										   s.SubDetailId,
-										   sTag = Sql.Expr<string>("'S' || {0} || '/' || {1} || '/' || {2}", m.Id1, d.DetailId, s.SubDetailId)
-									   })
-									   .ToArray(),
-								   Another = d.SubDetails
-							   }).ToArray()
-				};
-
-			object? result = null;
-			string? sql    = null;
-
-			Assert.DoesNotThrow(() => result = query.ToArray());
-			Assert.DoesNotThrow(() => sql    = query.ToSqlQuery().Sql);
-
-			Assert.That(result, Is.Not.Null);
-			Assert.That(sql,    Is.Not.Null.And.Not.Empty);
+			// Order 2: ToArray -> ToSqlQuery on a fresh, structurally identical query. The cache-compare
+			// path runs on the first call here (it finds the entry seeded by the first ordering), which
+			// is the failure mode the original report described.
+			{
+				var query = buildQuery();
+				object? result = null;
+				string? sql    = null;
+				Assert.DoesNotThrow(() => result = query.ToArray());
+				Assert.DoesNotThrow(() => sql    = query.ToSqlQuery().Sql);
+				Assert.That(result, Is.Not.Null);
+				Assert.That(sql,    Is.Not.Null.And.Not.Empty);
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Remove `[SqlQueryDependentParams]` from `Sql.Expr<T>(...).parameters`. Cache compare via `SqlQueryDependentParamsAttribute.ExpressionsEqual` evaluated each param through `Expression.Lambda(expr).Compile()`, which threw `InvalidOperationException("variable '...' referenced from scope '', but it is not defined")` for params capturing outer-scope transparent identifiers from eager-loaded sub-projections. Default structural compare covers this case.
- Regression test `Tests/Linq/UserTests/Issue5154Tests.cs` covers both orderings the reporter described (`ToSqlQuery` → `ToArray` and `ToArray` → `ToSqlQuery`).

Fixes #5154

## Test plan

- [x] `Issue5154Tests` — 4/4 sub-cases (was 4/4 failing before fix)
- [x] `EagerLoadingTests` (SQLite) — 292/292 pass
- [x] `Sql.Expr` users (`SqlExtensionsTests`, `FromSqlTests`, `ExpressionsTests`, `GenerateExpressionTests`, `Issue5371Tests`) — 262/262 pass
- [x] `Issue271Tests.Test1`/`Test2` (SQLServer.2019, SQLServer.2019.MS) — 4/4 pass — Test2 regressed in CI run 20337 when the mutation was also removed; mutation kept in final fix (`ad399e8dcf`).
- [ ] Full provider matrix via `/azp run test-all` after PR opens

## Follow-up commits

Pushed after review by @MaceWindu:

- `91707f4` — Reword `Issue5154Tests` root-cause comment in past tense. Post-PR the wording read as if `Sql.Expr` still carried `[SqlQueryDependentParams]`; rephrase to anchor the test to the pre-fix bug shape.
- `9edd526` — Deprecate `SqlQueryDependentParamsAttribute` and schedule for removal in v7. The attribute is no longer applied anywhere inside the product, and its per-parameter `Expression.Compile()` on the cache-compare path is unsafe whenever the applied parameter captures outer-scope identifiers (same root cause as this PR). `[Obsolete]` so external users applying it on their own extension methods see a warning to migrate.
- `c83aaf5` — Merge the two `Issue5154Tests` methods (`ToSqlQuery_Then_ToArray`, `ToArray_Then_ToSqlQuery`) into one `ToSqlQueryAndToArray_InEitherOrder` that exercises both orderings against the same `db` using a shared query-builder lambda. SQLite baselines drop from 8 files to 4 as a result; the existing baselines PR (`linq2db/linq2db.baselines#1848`) will be regenerated on the next CI run.
