### PR TITLE
Bump versions to 6.4.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,11 +1,11 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<!-- Update to next after release -->
-		<Version>6.3.0</Version>
-		<EF3Version>3.32.0</EF3Version>
-		<EF8Version>8.6.0</EF8Version>
-		<EF9Version>9.5.0</EF9Version>
-		<EF10Version>10.4.0</EF10Version>
+		<Version>6.4.0</Version>
+		<EF3Version>3.33.0</EF3Version>
+		<EF8Version>8.7.0</EF8Version>
+		<EF9Version>9.6.0</EF9Version>
+		<EF10Version>10.5.0</EF10Version>
 		
 		<!-- Baselines update on next major release -->
 		<BaselineVersion>6.0.0</BaselineVersion>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -203,7 +203,7 @@
 	</ItemGroup>
 
 	<ItemGroup Label="Examples">
-		<PackageVersion Include="linq2db.t4models"                                      Version="6.2.1"                        />
+		<PackageVersion Include="linq2db.t4models"                                      Version="6.3.0"                        />
 		<PackageVersion Include="Microsoft.Extensions.ObjectPool"                       Version="$(Net10Latest)"               />
 		<PackageVersion Include="OpenTelemetry"                                         Version="$(OpenTelemetryVersion)"      />
 		<PackageVersion Include="OpenTelemetry.Exporter.Console"                        Version="$(OpenTelemetryVersion)"      />


### PR DESCRIPTION
Bootstrap the 6.4.0 development cycle.

**`Directory.Build.props`** — bump version line:
- `Version`: 6.3.0 → 6.4.0
- `EF3Version`: 3.32.0 → 3.33.0
- `EF8Version`: 8.6.0 → 8.7.0
- `EF9Version`: 9.5.0 → 9.6.0
- `EF10Version`: 10.4.0 → 10.5.0

**`Directory.Packages.props`** — re-pin `linq2db.t4models` from 6.2.1 to **6.3.0** (the just-released version). Lets the next release cycle's T4 scaffold tests / examples consume the freshly-published nuget instead of last-release-but-one's 6.2.1.

Follow-up to 6.3.0 prep (#5533) + 6.3.0 publish (#5534).
