### PR TITLE
Fix SqlTransparentExpression cctor reflecting for wrong ctor signature

### DIFF
--- a/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.cs
@@ -554,7 +554,7 @@ namespace LinqToDB.EntityFrameworkCore
 			}
 
 #if !EF31 && !EF8
-			private static readonly ConstructorInfo _ctor = typeof(SqlTransparentExpression).GetConstructor([typeof(ExceptExpression), typeof(RelationalTypeMapping)])
+			private static readonly ConstructorInfo _ctor = typeof(SqlTransparentExpression).GetConstructor([typeof(ConstantExpression), typeof(RelationalTypeMapping)])
 				?? throw new InvalidOperationException();
 
 			private static readonly MethodInfo _constantExpressionFactoryMethod = typeof(Expression).GetMethod(nameof(Constant), [typeof(object), typeof(Type)])

--- a/Tests/EntityFrameworkCore/Tests/SqlTransparentExpressionTests.cs
+++ b/Tests/EntityFrameworkCore/Tests/SqlTransparentExpressionTests.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+using NUnit.Framework;
+
+namespace LinqToDB.EntityFrameworkCore.Tests
+{
+	[TestFixture]
+	public class SqlTransparentExpressionTests
+	{
+		// Regression for the SqlTransparentExpression static field initializer that reflected for the wrong constructor
+		// signature and threw TypeInitializationException on first touch of the type. Silent on desktop CLR
+		// (beforefieldinit defers cctor execution; _ctor is only consumed by the "not tested" Quote() path),
+		// but fatal on Mono/Android AOT which initializes the type eagerly when any of its code is touched.
+		[Test]
+		public void TypeInitializerDoesNotThrow()
+		{
+			var assembly = typeof(LinqToDBForEFTools).Assembly;
+			var reader   = assembly.GetType("LinqToDB.EntityFrameworkCore.EFCoreMetadataReader");
+			Assert.That(reader, Is.Not.Null, "EFCoreMetadataReader type not found — class layout changed.");
+
+			var nested   = reader!.GetNestedType("SqlTransparentExpression", BindingFlags.NonPublic);
+			Assert.That(nested, Is.Not.Null, "SqlTransparentExpression nested type not found — class layout changed.");
+
+			Assert.DoesNotThrow(() => RuntimeHelpers.RunClassConstructor(nested!.TypeHandle));
+		}
+	}
+}


### PR DESCRIPTION
The static `_ctor` field reflected for a constructor of shape `(ExceptExpression, RelationalTypeMapping)`, but the only instance constructor is `(ConstantExpression, RelationalTypeMapping?)`. `GetConstructor` returned null and the cctor threw `TypeInitializationException` on first touch of the type.

Desktop CLR hides this: `beforefieldinit` defers cctor execution, and `_ctor` is only consumed by `Quote()` (marked `// not tested`), so most workloads never trigger it.

Mono / Android AOT initializes the type eagerly when any of its code is touched, including the instance ctor called from
`GetDbFunctionFromProperty`'s `GetOrAdd` lambda, making the bug fatal during normal metadata reading.

Adds a regression test that forces the cctor via
`RuntimeHelpers.RunClassConstructor` and asserts no throw.