### PR TITLE
Fix #5547: Contains() through Select projection on interface filter

### DIFF
--- a/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuilder.Associations.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuilder.Associations.cs
@@ -70,7 +70,7 @@ namespace LinqToDB.Internal.Linq.Builder
 				}
 			}
 
-			if (expression != null && member.ReflectedType != expression.Type)
+			if (expression != null && (member.ReflectedType != expression.Type || member.DeclaringType != expression.Type))
 			{
 				var newMember = expression.Type.GetMemberEx(member);
 				if (newMember != null)
@@ -78,7 +78,10 @@ namespace LinqToDB.Internal.Linq.Builder
 					// Look up using the realized concrete type rather than newMember.DeclaringType,
 					// which may be an abstract base or interface that the metadata reader doesn't
 					// recognize as an entity (e.g. EFCoreMetadataReader returns nothing for types
-					// not registered in the EF model).
+					// not registered in the EF model). After a projection such as
+					// Select(x => x.Customer) the member's ReflectedType may already match
+					// expression.Type while its DeclaringType still points at the unregistered
+					// base — covered by the second arm of the guard.
 					if (MappingSchema.GetAttribute<AssociationAttribute>(expression.Type, newMember) != null)
 					{
 						associationMember = newMember;

--- a/Tests/EntityFrameworkCore/Models/IssueModel/IssueContextBase.cs
+++ b/Tests/EntityFrameworkCore/Models/IssueModel/IssueContextBase.cs
@@ -69,6 +69,8 @@ namespace LinqToDB.EntityFrameworkCore.Tests.Models.IssueModel
 		public DbSet<Issue5355LicenseProfile> Issue5355LicenseProfiles { get; set; } = null!;
 		public DbSet<Issue5355Customer>       Issue5355Customers       { get; set; } = null!;
 
+		public DbSet<Issue5547CustomerShare>  Issue5547CustomerShares  { get; set; } = null!;
+
 		protected IssueContextBase(DbContextOptions options) : base(options)
 		{
 		}
@@ -376,6 +378,20 @@ namespace LinqToDB.EntityFrameworkCore.Tests.Models.IssueModel
 					new Issue5355Customer { Id = 1, ProfileId = 1, Name = "Alice Smith" },
 					new Issue5355Customer { Id = 2, ProfileId = 1, Name = "Bob Jones"   },
 					new Issue5355Customer { Id = 3, ProfileId = 2, Name = "Carol Davis" });
+			});
+
+			modelBuilder.Entity<Issue5547CustomerShare>(b =>
+			{
+				b.Property(e => e.Id).ValueGeneratedNever();
+
+				b.HasOne(e => e.Customer)
+					.WithMany()
+					.HasForeignKey(e => e.CustomerId);
+
+				b.HasData(
+					new Issue5547CustomerShare { Id = 1, CustomerId = 1 },
+					new Issue5547CustomerShare { Id = 2, CustomerId = 2 },
+					new Issue5547CustomerShare { Id = 3, CustomerId = 3 });
 			});
 		}
 	}

--- a/Tests/EntityFrameworkCore/Models/IssueModel/IssueEntities.cs
+++ b/Tests/EntityFrameworkCore/Models/IssueModel/IssueEntities.cs
@@ -451,6 +451,17 @@ namespace LinqToDB.EntityFrameworkCore.Tests.Models.IssueModel
 
 	#endregion
 
+	#region Issue 5547
+
+	public sealed class Issue5547CustomerShare
+	{
+		public int              Id         { get; set; }
+		public int              CustomerId { get; set; }
+		public Issue5355Customer Customer  { get; set; } = null!;
+	}
+
+	#endregion
+
 	#region Issue 5388
 
 	public class Issue5388Task

--- a/Tests/EntityFrameworkCore/Tests/IssueTests.cs
+++ b/Tests/EntityFrameworkCore/Tests/IssueTests.cs
@@ -1078,6 +1078,44 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 			result[1].Id.ShouldBe(2);
 		}
 
+		public enum Issue5547QueryableShape
+		{
+			Direct,
+			SelectProjection,
+			WhereThenSelectProjection,
+			SelectProjectionThenWhere,
+			SelectProjectionDistinct,
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5547")]
+		public void Issue5547_ContainsThroughQueryableShapes(
+			[EFDataSources] string provider,
+			[Values] Issue5547QueryableShape shape)
+		{
+			using var ctx = CreateContext(provider);
+
+			string[] licenseFilter = ["12345"];
+
+			IQueryable<Issue5355Customer> source = shape switch
+			{
+				Issue5547QueryableShape.Direct                    => ctx.Issue5355Customers,
+				Issue5547QueryableShape.SelectProjection          => ctx.Issue5547CustomerShares.Select(s => s.Customer),
+				Issue5547QueryableShape.WhereThenSelectProjection => ctx.Issue5547CustomerShares.Where(s => s.Id > 0).Select(s => s.Customer),
+				Issue5547QueryableShape.SelectProjectionThenWhere => ctx.Issue5547CustomerShares.Select(s => s.Customer).Where(c => c.Id > 0),
+				Issue5547QueryableShape.SelectProjectionDistinct  => ctx.Issue5547CustomerShares.Select(s => s.Customer).Distinct(),
+				_                                                 => throw new InvalidOperationException($"Unknown shape: {shape}"),
+			};
+
+			var result = source
+				.FilterIssue5355License(licenseFilter)
+				.OrderBy(c => c.Id)
+				.Select(c => c.Id)
+				.ToLinqToDB()
+				.ToList();
+
+			result.ShouldBe(new[] { 1, 2 });
+		}
+
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/5388")]
 		public void ConstantAndValueConversion([EFDataSources] string provider)
 		{

--- a/Tests/Linq/Linq/InterfaceTests.cs
+++ b/Tests/Linq/Linq/InterfaceTests.cs
@@ -728,5 +728,128 @@ namespace Tests.Linq
 
 			_ = query.ToList();
 		}
+
+		#region Generic-interface filter through queryable shapes (#5547)
+
+		// Regression matrix for projection-through-Select interacting with generic-interface
+		// constrained filters. The hierarchy declares the navigation on the abstract base while
+		// the FluentMappingBuilder registers the association on the concrete sealed type — this
+		// produces the DeclaringType != ConcreteType member shape that IsAssociationInRealization
+		// must resolve via the realized type. Mirrors the EF Core fixture
+		// LinqToDB.EntityFrameworkCore.Tests.IssueTests.Issue5547_ContainsThroughQueryableShapes.
+		public interface IHasMembershipProfile
+		{
+			MembershipProfile Profile   { get; set; }
+			int               ProfileId { get; set; }
+		}
+
+		public class MembershipProfile
+		{
+			public int    Id      { get; set; }
+			public string License { get; set; } = null!;
+		}
+
+		public abstract class MemberBase : IHasMembershipProfile
+		{
+			public int               Id        { get; set; }
+			public int               ProfileId { get; set; }
+			public MembershipProfile Profile   { get; set; } = null!;
+		}
+
+		public sealed class Member : MemberBase
+		{
+			public string Name { get; set; } = null!;
+		}
+
+		public sealed class MemberShare
+		{
+			public int    Id       { get; set; }
+			public int    MemberId { get; set; }
+			public Member Member   { get; set; } = null!;
+		}
+
+		public enum MemberQueryableShape
+		{
+			Direct,
+			SelectProjection,
+			WhereThenSelectProjection,
+			SelectProjectionThenWhere,
+			SelectProjectionDistinct,
+		}
+
+		static MappingSchema ConfigureMembershipMapping()
+		{
+			return new FluentMappingBuilder()
+				.Entity<MembershipProfile>()
+					.Property(e => e.Id).IsPrimaryKey()
+					.Property(e => e.License)
+				.Entity<Member>()
+					.Property(e => e.Id).IsPrimaryKey()
+					.Property(e => e.ProfileId)
+					.Property(e => e.Name)
+					.Association(e => e.Profile, e => e.ProfileId, p => p!.Id)
+				.Entity<MemberShare>()
+					.Property(e => e.Id).IsPrimaryKey()
+					.Property(e => e.MemberId)
+					.Association(e => e.Member, e => e.MemberId, m => m!.Id)
+				.Build()
+				.MappingSchema;
+		}
+
+		static IQueryable<T> FilterByLicense<T>(IQueryable<T> source, string[]? licenseFilter)
+			where T : class, IHasMembershipProfile
+		{
+			if (licenseFilter != null)
+				return source.Where(x => licenseFilter.Contains(x.Profile.License));
+
+			return source;
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5547")]
+		public void GenericInterfaceFilterAcrossQueryableShapes(
+			[IncludeDataSources(TestProvName.AllSQLite)] string context,
+			[Values] MemberQueryableShape shape)
+		{
+			using var db = GetDataContext(context, ConfigureMembershipMapping());
+
+			using var profiles = db.CreateLocalTable(new[]
+			{
+				new MembershipProfile { Id = 1, License = "12345" },
+				new MembershipProfile { Id = 2, License = "67890" },
+			});
+			using var members  = db.CreateLocalTable(new Member[]
+			{
+				new() { Id = 1, ProfileId = 1, Name = "Alice Smith" },
+				new() { Id = 2, ProfileId = 1, Name = "Bob Jones"   },
+				new() { Id = 3, ProfileId = 2, Name = "Carol Davis" },
+			});
+			using var shares   = db.CreateLocalTable(new[]
+			{
+				new MemberShare { Id = 1, MemberId = 1 },
+				new MemberShare { Id = 2, MemberId = 2 },
+				new MemberShare { Id = 3, MemberId = 3 },
+			});
+
+			string[] licenseFilter = ["12345"];
+
+			IQueryable<Member> source = shape switch
+			{
+				MemberQueryableShape.Direct                    => members,
+				MemberQueryableShape.SelectProjection          => shares.Select(s => s.Member),
+				MemberQueryableShape.WhereThenSelectProjection => shares.Where(s => s.Id > 0).Select(s => s.Member),
+				MemberQueryableShape.SelectProjectionThenWhere => shares.Select(s => s.Member).Where(m => m.Id > 0),
+				MemberQueryableShape.SelectProjectionDistinct  => shares.Select(s => s.Member).Distinct(),
+				_                                              => throw new InvalidOperationException($"Unknown shape: {shape}"),
+			};
+
+			var result = FilterByLicense(source, licenseFilter)
+				.OrderBy(m => m.Id)
+				.Select(m => m.Id)
+				.ToList();
+
+			result.ShouldBe(new[] { 1, 2 });
+		}
+
+		#endregion
 	}
 }


### PR DESCRIPTION
## Summary

- Widen the V1 guard in `IsAssociationInRealization` (introduced by #5511) to also fire when `member.DeclaringType != expression.Type`, not only `ReflectedType != Type`. After a `Select(x => x.Customer)` projection the member's `ReflectedType` already matches the realized concrete type while `DeclaringType` still points at the unregistered abstract base — that case was skipped and the association went unresolved.
- Add a parameterized regression matrix on both sides covering 5 upstream queryable shapes: `Direct`, `SelectProjection`, `WhereThenSelectProjection`, `SelectProjectionThenWhere`, `SelectProjectionDistinct`.
  - `Tests/EntityFrameworkCore/Tests/IssueTests.Issue5547_ContainsThroughQueryableShapes` — EF Core integration path.
  - `Tests/Linq/Linq/InterfaceTests.GenericInterfaceFilterAcrossQueryableShapes` — provider-agnostic FluentMappingBuilder setup, demonstrates the bug is core-lib, not EF-specific.
- Without the fix, 3 of the 5 shapes (`SelectProjection`, `WhereThenSelectProjection`, `SelectProjectionThenWhere`) fail in both matrices.

Fixes #5547

## Test plan

- [x] CI provider matrix via `/azp run test-all`
- [x] Confirm no regression in adjacent association-resolution tests on the full matrix
