### PR TITLE
Fix MemberInfoEqualityComparer crash on Native AOT synthetic members

### DIFF
--- a/Source/LinqToDB/Internal/Reflection/MemberInfoEqualityComparer.cs
+++ b/Source/LinqToDB/Internal/Reflection/MemberInfoEqualityComparer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 
@@ -9,6 +10,32 @@ namespace LinqToDB.Internal.Reflection
 	public sealed class MemberInfoEqualityComparer : IEqualityComparer<MemberInfo>
 	{
 		public static readonly MemberInfoEqualityComparer Default = new();
+
+		// Native AOT emits synthetic MemberInfo subclasses (e.g. RuntimeSyntheticConstructorInfo
+		// for lambda closures) whose MetadataToken accessor throws InvalidOperationException.
+		// Cache per concrete Type so the exception cost is paid at most once per unsupported type.
+		static readonly ConcurrentDictionary<Type, bool> _supportsMetadataToken = new();
+
+		static bool SupportsMetadataToken(MemberInfo obj)
+		{
+			var type = obj.GetType();
+
+			if (_supportsMetadataToken.TryGetValue(type, out var supported))
+				return supported;
+
+			try
+			{
+				_ = obj.MetadataToken;
+				supported = true;
+			}
+			catch (InvalidOperationException)
+			{
+				supported = false;
+			}
+
+			_supportsMetadataToken.TryAdd(type, supported);
+			return supported;
+		}
 
 		public bool Equals(MemberInfo? x, MemberInfo? y)
 		{
@@ -37,6 +64,9 @@ namespace LinqToDB.Internal.Reflection
 				return xv.Equals(y);
 			}
 
+			if (!SupportsMetadataToken(x))
+				return x.Equals(y);
+
 			return x.MetadataToken == y.MetadataToken && x.Module.Equals(y.Module);
 		}
 
@@ -44,6 +74,9 @@ namespace LinqToDB.Internal.Reflection
 		{
 			// We do not support obj.MetadataToken and obj.Module
 			if (obj is VirtualPropertyInfoBase)
+				return obj.GetHashCode();
+
+			if (!SupportsMetadataToken(obj))
 				return obj.GetHashCode();
 
 			return HashCode.Combine(obj.MetadataToken, obj.Module);

--- a/Source/LinqToDB/Internal/Reflection/MemberInfoEqualityComparer.cs
+++ b/Source/LinqToDB/Internal/Reflection/MemberInfoEqualityComparer.cs
@@ -72,7 +72,7 @@ namespace LinqToDB.Internal.Reflection
 
 		public int GetHashCode(MemberInfo obj)
 		{
-			// We do not support obj.MetadataToken and obj.Module
+			// VirtualPropertyInfoBase has no MetadataToken / Module; use its own GetHashCode.
 			if (obj is VirtualPropertyInfoBase)
 				return obj.GetHashCode();
 

--- a/Tests/Linq/Common/MemberInfoEqualityComparerTests.cs
+++ b/Tests/Linq/Common/MemberInfoEqualityComparerTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Reflection;
+
+using LinqToDB.Internal.Reflection;
+
+using NUnit.Framework;
+
+using Shouldly;
+
+namespace Tests.Common
+{
+	// Regression coverage for https://github.com/linq2db/linq2db/issues/5551.
+	// Native AOT emits RuntimeSyntheticConstructorInfo for lambda closures, whose
+	// MetadataToken accessor throws InvalidOperationException. The equality comparer
+	// must tolerate that and fall back rather than propagate the throw.
+	[TestFixture]
+	public class MemberInfoEqualityComparerTests
+	{
+		[Test]
+		public void GetHashCode_DoesNotThrowWhenMetadataTokenUnavailable()
+		{
+			var member = new SyntheticMemberInfo();
+
+			_ = MemberInfoEqualityComparer.Default.GetHashCode(member);
+		}
+
+		[Test]
+		public void Equals_DoesNotThrowWhenMetadataTokenUnavailable()
+		{
+			var x = new SyntheticMemberInfo();
+			var y = new SyntheticMemberInfo();
+
+			_ = MemberInfoEqualityComparer.Default.Equals(x, y);
+		}
+
+		[Test]
+		public void Equals_SameInstanceReturnsTrueWithoutMetadataTokenAccess()
+		{
+			var member = new SyntheticMemberInfo();
+
+			MemberInfoEqualityComparer.Default.Equals(member, member).ShouldBeTrue();
+		}
+
+		// Mimics RuntimeSyntheticConstructorInfo from Native AOT: every member is
+		// usable except MetadataToken, which throws.
+		private sealed class SyntheticMemberInfo : MemberInfo
+		{
+			public override Type?       DeclaringType => typeof(SyntheticMemberInfo);
+			public override MemberTypes MemberType    => MemberTypes.Constructor;
+			public override string      Name          => "synthetic";
+			public override Type?       ReflectedType => typeof(SyntheticMemberInfo);
+			public override Module      Module        => typeof(SyntheticMemberInfo).Module;
+
+			public override int MetadataToken =>
+				throw new InvalidOperationException("There is no metadata token available for the given member.");
+
+			public override object[] GetCustomAttributes(bool inherit)                     => Array.Empty<object>();
+			public override object[] GetCustomAttributes(Type attributeType, bool inherit) => Array.Empty<object>();
+			public override bool     IsDefined(Type attributeType, bool inherit)           => false;
+		}
+	}
+}

--- a/Tests/Linq/Common/MemberInfoEqualityComparerTests.cs
+++ b/Tests/Linq/Common/MemberInfoEqualityComparerTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 
 using LinqToDB.Internal.Reflection;


### PR DESCRIPTION
## Summary

- `MemberInfoEqualityComparer.GetHashCode` / `Equals` accessed `obj.MetadataToken` directly.
  Native AOT emits `RuntimeSyntheticConstructorInfo` for lambda closures, whose
  `MetadataToken` accessor throws `InvalidOperationException`, crashing any code path that
  hashes or compares such members (e.g. `HashSet<MemberInfo>` in
  `ExpressionBuildVisitor`, `HashCode.Add(member, MemberInfoEqualityComparer.Default)` in
  `ExpressionEqualityComparer`).
- Cache `MetadataToken` support per concrete `Type` via `ConcurrentDictionary<Type, bool>` —
  the exception cost is paid at most once per unsupported type. Fall back to
  `MemberInfo.Equals` / `MemberInfo.GetHashCode` for types that don't support it.

## Test plan

- [x] New unit tests in `Tests/Linq/Common/MemberInfoEqualityComparerTests.cs` reproduce the
      production stack trace via a `MemberInfo` stub whose `MetadataToken` throws. Without
      the fix, 2 of 3 tests fail with `InvalidOperationException`; with the fix all 3 pass.

Fixes #5551
