### PR TITLE
Fix #5125: don't mutate shared AST nodes in column-nesting corrector

### DIFF
--- a/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryColumnNestingCorrector.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryColumnNestingCorrector.cs
@@ -152,20 +152,48 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 
 		// Expression-shaped nodes may be shared across query scopes; visit them in Transform
 		// mode so a changed child produces a fresh instance instead of mutating the shared
-		// Parameters array in place and corrupting sibling scopes (see #5125 / PR #5556).
+		// child slot in place and corrupting sibling scopes (see #5125 / PR #5556).
+		//
+		// Container-shaped nodes (statements, SelectQuery, clauses, table sources, etc.)
+		// stay in Modify so the corrector's own side effects — AddColumn / AddField on
+		// subquery clauses during the walk — remain visible to the eight existing callers
+		// that ignore the visitor's return value. Transform on a clause with a mutable list
+		// (Columns, OrderBy.Items, ...) would copy the list before the side-effect mutation
+		// reaches it and drop the appended entries.
 		public override VisitMode GetVisitMode(IQueryElement element) => element.ElementType switch
 		{
-			QueryElementType.SqlExpression         or
-			QueryElementType.SqlFunction           or
-			QueryElementType.SqlExtendedFunction   or
-			QueryElementType.SqlFragment           or
-			QueryElementType.SearchCondition       or
-			QueryElementType.SqlCase               or
-			QueryElementType.SqlCoalesce           or
-			QueryElementType.CompareTo             or
-			QueryElementType.SqlRow                or
-			QueryElementType.InListPredicate       => VisitMode.Transform,
-			_                                      => base.GetVisitMode(element),
+			// raw templates
+			QueryElementType.SqlExpression            or
+			QueryElementType.SqlFragment              or
+			// functions
+			QueryElementType.SqlFunction              or
+			QueryElementType.SqlExtendedFunction      or
+			// structured expressions
+			QueryElementType.SqlBinaryExpression      or
+			QueryElementType.SqlUnaryExpression       or
+			QueryElementType.SqlNullabilityExpression or
+			QueryElementType.SqlCase                  or
+			QueryElementType.SqlCoalesce              or
+			QueryElementType.SqlCast                  or
+			QueryElementType.SqlCondition             or
+			QueryElementType.SqlConcat                or
+			QueryElementType.CompareTo                or
+			QueryElementType.SqlRow                   or
+			// predicates / search conditions
+			QueryElementType.SearchCondition          or
+			QueryElementType.NotPredicate             or
+			QueryElementType.ExprPredicate            or
+			QueryElementType.ExprExprPredicate        or
+			QueryElementType.LikePredicate            or
+			QueryElementType.SearchStringPredicate    or
+			QueryElementType.BetweenPredicate         or
+			QueryElementType.IsNullPredicate          or
+			QueryElementType.IsDistinctPredicate      or
+			QueryElementType.IsTruePredicate          or
+			QueryElementType.InSubQueryPredicate      or
+			QueryElementType.InListPredicate          or
+			QueryElementType.ExistsPredicate          => VisitMode.Transform,
+			_                                         => base.GetVisitMode(element),
 		};
 
 		public override void Cleanup()

--- a/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryColumnNestingCorrector.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryColumnNestingCorrector.cs
@@ -150,6 +150,24 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 		{
 		}
 
+		// Expression-shaped nodes may be shared across query scopes; visit them in Transform
+		// mode so a changed child produces a fresh instance instead of mutating the shared
+		// Parameters array in place and corrupting sibling scopes (see #5125 / PR #5556).
+		public override VisitMode GetVisitMode(IQueryElement element) => element.ElementType switch
+		{
+			QueryElementType.SqlExpression         or
+			QueryElementType.SqlFunction           or
+			QueryElementType.SqlExtendedFunction   or
+			QueryElementType.SqlFragment           or
+			QueryElementType.SearchCondition       or
+			QueryElementType.SqlCase               or
+			QueryElementType.SqlCoalesce           or
+			QueryElementType.CompareTo             or
+			QueryElementType.SqlRow                or
+			QueryElementType.InListPredicate       => VisitMode.Transform,
+			_                                      => base.GetVisitMode(element),
+		};
+
 		public override void Cleanup()
 		{
 			_parentQueryNesting = null;

--- a/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryOrderByOptimizer.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryOrderByOptimizer.cs
@@ -137,8 +137,12 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 
 							if (canPopulateUpperLevel)
 							{
-								var column = selectQuery.Select.AddColumn(orderByItem.Expression);
-								parentSelectQuery.OrderBy.Items.Add(new SqlOrderByItem(column, orderByItem.IsDescending, orderByItem.IsPositioned));
+								// Push the expression directly to the parent ORDER BY rather than wrapping it as a synthetic
+								// subquery column. Wrapping breaks raw SqlExpression items whose template embeds direction
+								// modifiers (e.g. Sql.Expr<T>($"{0} NULLS FIRST")) — the modifier text would be captured
+								// inside the column expression. Clone() avoids aliasing the same node across two query
+								// scopes so the column nesting corrector can rewrite each independently.
+								parentSelectQuery.OrderBy.Items.Add(new SqlOrderByItem(orderByItem.Expression.Clone(), orderByItem.IsDescending, orderByItem.IsPositioned));
 
 								needsNestingUpdate = true;
 							}

--- a/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryOrderByOptimizer.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryOrderByOptimizer.cs
@@ -137,14 +137,23 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 
 							if (canPopulateUpperLevel)
 							{
-								// Push the expression directly to the parent ORDER BY rather than wrapping it as a
-								// synthetic subquery column. Wrapping captured trailing direction modifiers (e.g.
-								// "NULLS FIRST") inside a raw Sql.Expr template into the column expression and
-								// emitted invalid SQL like `... END NULLS FIRST as c1`. The column nesting corrector
-								// uses Transform-mode visiting for expression nodes (see
-								// SqlQueryColumnNestingCorrector.GetVisitMode), so shared SqlExpression / SqlFunction
-								// instances are not mutated in place and we don't need to clone here.
-								parentSelectQuery.OrderBy.Items.Add(new SqlOrderByItem(orderByItem.Expression, orderByItem.IsDescending, orderByItem.IsPositioned));
+								if (orderByItem.Expression is SqlExpressionBase)
+								{
+									// Raw-template AST nodes (Sql.Expr / Sql.Fragment) may carry trailing
+									// direction modifiers in their template text (e.g. "{0} NULLS FIRST").
+									// Wrapping them as a synthetic subquery column captured the modifier
+									// inside the column expression and emitted invalid SQL like
+									// `... END NULLS FIRST as c1`. Push such expressions directly to the
+									// parent ORDER BY so the modifier stays in the outer clause where it
+									// belongs. Structured node types (SqlFunction, SqlCase, etc.) keep the
+									// existing AddColumn dedup path — their SQL output is a valid scalar.
+									parentSelectQuery.OrderBy.Items.Add(new SqlOrderByItem(orderByItem.Expression, orderByItem.IsDescending, orderByItem.IsPositioned));
+								}
+								else
+								{
+									var column = selectQuery.Select.AddColumn(orderByItem.Expression);
+									parentSelectQuery.OrderBy.Items.Add(new SqlOrderByItem(column, orderByItem.IsDescending, orderByItem.IsPositioned));
+								}
 
 								needsNestingUpdate = true;
 							}

--- a/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryOrderByOptimizer.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryOrderByOptimizer.cs
@@ -137,7 +137,7 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 
 							if (canPopulateUpperLevel)
 							{
-								if (orderByItem.Expression is SqlExpressionBase)
+								if (orderByItem.Expression is SqlExpression or SqlFragment)
 								{
 									// Raw-template AST nodes (Sql.Expr / Sql.Fragment) may carry trailing
 									// direction modifiers in their template text (e.g. "{0} NULLS FIRST").
@@ -145,8 +145,9 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 									// inside the column expression and emitted invalid SQL like
 									// `... END NULLS FIRST as c1`. Push such expressions directly to the
 									// parent ORDER BY so the modifier stays in the outer clause where it
-									// belongs. Structured node types (SqlFunction, SqlCase, etc.) keep the
-									// existing AddColumn dedup path — their SQL output is a valid scalar.
+									// belongs. Every other AST node (structured expressions, columns, fields,
+									// functions, case, etc.) keeps the existing AddColumn dedup path — their
+									// SQL output is always a valid scalar.
 									parentSelectQuery.OrderBy.Items.Add(new SqlOrderByItem(orderByItem.Expression, orderByItem.IsDescending, orderByItem.IsPositioned));
 								}
 								else

--- a/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryOrderByOptimizer.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryOrderByOptimizer.cs
@@ -137,12 +137,14 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 
 							if (canPopulateUpperLevel)
 							{
-								// Push the expression directly to the parent ORDER BY rather than wrapping it as a synthetic
-								// subquery column. Wrapping breaks raw SqlExpression items whose template embeds direction
-								// modifiers (e.g. Sql.Expr<T>($"{0} NULLS FIRST")) — the modifier text would be captured
-								// inside the column expression. Clone() avoids aliasing the same node across two query
-								// scopes so the column nesting corrector can rewrite each independently.
-								parentSelectQuery.OrderBy.Items.Add(new SqlOrderByItem(orderByItem.Expression.Clone(), orderByItem.IsDescending, orderByItem.IsPositioned));
+								// Push the expression directly to the parent ORDER BY rather than wrapping it as a
+								// synthetic subquery column. Wrapping captured trailing direction modifiers (e.g.
+								// "NULLS FIRST") inside a raw Sql.Expr template into the column expression and
+								// emitted invalid SQL like `... END NULLS FIRST as c1`. The column nesting corrector
+								// uses Transform-mode visiting for expression nodes (see
+								// SqlQueryColumnNestingCorrector.GetVisitMode), so shared SqlExpression / SqlFunction
+								// instances are not mutated in place and we don't need to clone here.
+								parentSelectQuery.OrderBy.Items.Add(new SqlOrderByItem(orderByItem.Expression, orderByItem.IsDescending, orderByItem.IsPositioned));
 
 								needsNestingUpdate = true;
 							}

--- a/Tests/Linq/UserTests/Issue5125Tests.cs
+++ b/Tests/Linq/UserTests/Issue5125Tests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+using LinqToDB;
+using LinqToDB.Data;
+using LinqToDB.Internal.Linq;
+using LinqToDB.Mapping;
+
+using NUnit.Framework;
+
+namespace Tests.UserTests
+{
+	[TestFixture]
+	public class Issue5125Tests : TestBase
+	{
+		// Repro of issue #5125 (https://github.com/linq2db/linq2db/issues/5125).
+		// The original repro (non-nullable string + [AllowNull] + [ExpressionMethod] using
+		// `string.IsNullOrEmpty` + interpolated string, projected via `new T { ... }` after
+		// OrderBy on a calculated expression) emitted an invalid SQL where Length(...) inside
+		// the subquery referenced the outer alias `x_1` instead of `x`. That was fixed by #5126.
+		//
+		// The v6.2.0+ follow-up regression reported in the same issue is reproduced here: when
+		// the calling code installs an IExpressionPreprocessor that wraps OrderBy lambdas in
+		// Sql.Expr<T>($"{0} NULLS FIRST"), the optimizer extracts the wrapped expression as a
+		// subquery column but keeps the NULLS FIRST directive inside the column expression,
+		// producing PostgreSQL like:
+		//     CASE WHEN ... THEN ... ELSE ... END NULLS FIRST as c1
+		// which fails with `42601: syntax error at or near "NULLS"`. The NULLS FIRST directive
+		// must stay in the outer ORDER BY clause, not inside the subquery column.
+		[Table("InterpolatedTest5125", IsColumnAttributeRequired = false)]
+		public class InterpolatedTest5125
+		{
+			public int     Id     { get; set; }
+			public string? StrVal { get; set; }
+			public int     IntVal { get; set; }
+
+			[AllowNull]
+			[ExpressionMethod(nameof(Expr1Impl))]
+			public string Expr1 { get; set; } = null!;
+
+			private static Expression<Func<InterpolatedTest5125, IDataContext, string>> Expr1Impl() =>
+				(e, ctx) => !string.IsNullOrEmpty(e.StrVal) ? e.StrVal! : e.IntVal.ToString();
+
+			[AllowNull]
+			[ExpressionMethod(nameof(Expr2Impl))]
+			public string Expr2 { get; set; } = null!;
+
+			private static Expression<Func<InterpolatedTest5125, IDataContext, string>> Expr2Impl() =>
+				(e, ctx) => $"{(!string.IsNullOrEmpty(e.StrVal) ? e.StrVal : e.IntVal.ToString())}";
+		}
+
+		sealed class OrderByNullsFirstVisitor : ExpressionVisitor
+		{
+			static readonly MethodInfo SqlExprMethod =
+				typeof(Sql).GetMethods(BindingFlags.Public | BindingFlags.Static)
+					.First(m => m.Name == nameof(Sql.Expr) && m.IsGenericMethodDefinition
+						&& m.GetParameters().Length == 1
+						&& m.GetParameters()[0].ParameterType == typeof(FormattableString));
+
+			static readonly MethodInfo CreateFormattable =
+				typeof(FormattableStringFactory).GetMethod(
+					nameof(FormattableStringFactory.Create),
+					new[] { typeof(string), typeof(object[]) })!;
+
+			protected override Expression VisitMethodCall(MethodCallExpression node)
+			{
+				if (node.Method.DeclaringType == typeof(Queryable)
+					&& node.Method.Name == nameof(Queryable.OrderBy))
+				{
+					var lambda = (LambdaExpression)((UnaryExpression)node.Arguments[1]).Operand;
+					var body   = lambda.Body;
+
+					var sqlExprCall = Expression.Call(
+						SqlExprMethod.MakeGenericMethod(body.Type),
+						Expression.Call(
+							CreateFormattable,
+							Expression.Constant("{0} NULLS FIRST"),
+							Expression.NewArrayInit(typeof(object), Expression.Convert(body, typeof(object)))
+						)
+					);
+
+					var newLambda = Expression.Lambda(sqlExprCall, lambda.Parameters);
+					return Expression.Call(node.Method, Visit(node.Arguments[0]), newLambda);
+				}
+
+				return base.VisitMethodCall(node);
+			}
+		}
+
+		sealed class InterpolatedDataConnection : DataConnection, IExpressionPreprocessor
+		{
+			public InterpolatedDataConnection(string configurationString) : base(configurationString)
+			{
+			}
+
+			public Expression ProcessExpression(Expression expression)
+				=> new OrderByNullsFirstVisitor().Visit(expression);
+		}
+
+		[Test]
+		public void TestIssue5125_NullsFirst([IncludeDataSources(false, TestProvName.AllPostgreSQL)] string context)
+		{
+			var data = new[]
+			{
+				new InterpolatedTest5125 { Id = 1, StrVal = null,     IntVal = 11 },
+				new InterpolatedTest5125 { Id = 2, StrVal = "",       IntVal = 12 },
+				new InterpolatedTest5125 { Id = 3, StrVal = "Value3", IntVal = 13 },
+			};
+
+			using var db = new InterpolatedDataConnection(context);
+			using var tb = db.CreateLocalTable(data);
+
+			var query = tb
+				.OrderBy(x => x.Expr1)
+				.Select(x => new InterpolatedTest5125
+				{
+					Id    = x.Id,
+					Expr1 = x.Expr1,
+					Expr2 = x.Expr2
+				});
+
+			var list = query.ToList();
+
+			Assert.That(list, Has.Count.EqualTo(3));
+		}
+	}
+}

--- a/Tests/Linq/UserTests/Issue5125Tests.cs
+++ b/Tests/Linq/UserTests/Issue5125Tests.cs
@@ -12,6 +12,8 @@ using LinqToDB.Mapping;
 
 using NUnit.Framework;
 
+using Shouldly;
+
 namespace Tests.UserTests
 {
 	[TestFixture]
@@ -125,7 +127,7 @@ namespace Tests.UserTests
 
 			var list = query.ToList();
 
-			Assert.That(list, Has.Count.EqualTo(3));
+			list.Count.ShouldBe(3);
 		}
 	}
 }


### PR DESCRIPTION
## Summary

When OrderBy items get lifted from a subquery to the parent, the optimizer was wrapping the whole expression as a synthetic subquery column. That's fine for ordinary expressions, but breaks `Sql.Expr<T>($"{0} NULLS FIRST")` — the `NULLS FIRST` text rides inside the column expression and you get `... END NULLS FIRST as c1`, which PostgreSQL rejects with `42601`.

Two parts to the fix:

1. **OrderBy lift** pushes the expression directly into the parent's ORDER BY instead of wrapping it as a subquery column. Matches v6.1.0 behaviour.

2. **Column-nesting corrector** routes expression-shaped AST nodes (`SqlExpression`, `SqlFunction`, `SqlCase`, etc.) through Transform-mode visiting. linq2db de-duplicates these nodes across query scopes — the same `Length(StrVal)` object can sit in both a subquery's column and the parent's ORDER BY — and the corrector running in Modify mode was rewriting the shared `Parameters` array in place, re-exposing the `Length(x_1."StrVal")` form of #5125. Container nodes (statements, clauses, `SelectQuery`) stay in Modify so the 8 existing callers that ignore the return value still observe the in-place side effects on their input tree.

## Test plan

- New regression test `TestIssue5125_NullsFirst` ports the issue reporter's full repro — custom `IExpressionPreprocessor` wrapping OrderBy in `Sql.Expr`. Fails on master, passes here.
- Ran `OrderByTests` / `OrderByDistinctTests` / `CalculatedColumnTests` on PG.16 locally — all non-Oracle providers pass. Oracle container isn't running locally; CI covers that.
- `/azp run test-all` posted on the PR.

Fixes #5125
