### PR TITLE
Enable Issue4783Test now that enum mapping is fixed

### DIFF
--- a/Tests/EntityFrameworkCore/Tests/IssueTests.cs
+++ b/Tests/EntityFrameworkCore/Tests/IssueTests.cs
@@ -982,7 +982,6 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 
 		#region Issue 4783
 
-		[ActiveIssue]
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4783")]
 		public async ValueTask Issue4783Test([EFDataSources] string provider)
 		{


### PR DESCRIPTION
Closes #4783.

Issue #4783 ("Enum mapping issues") was closed by the reporter after verifying the underlying bugs were resolved. The existing regression test (`Issue4783Test` in `Tests/EntityFrameworkCore/Tests/IssueTests.cs`) — added in #4878 — had been kept under `[ActiveIssue]` since 2025-03-16 waiting for the fix to land. This PR drops the `[ActiveIssue]` gate.

## Bisect — which PR made this test pass

Bisected on the EF10 (net10.0) project against SQLite.MS and PostgreSQL.16:

| Commit | PR | Result |
|---|---|---|
| `980d84617` | #5319 (`#5318 fix`, 6.2.0) | ❌ fail |
| `14dad41b1` | #5380 | ❌ fail |
| `4c1f1988a` | #5392 | ❌ fail |
| **`aae685c02`** | **#5393 ([EF Core] Added TypeMapping conversion usage., 6.2.0)** | ✅ **pass** |
| `d08b911a4` | #5400 | ✅ pass |
| `c364e22d9` | #5399 | ✅ pass |
| `2fff70802` | #5420 | ✅ pass |

The load-bearing change is the one-line fallback in [`EFCoreMetadataReader.GetAttributes`](https://github.com/linq2db/linq2db/pull/5393/files):

```diff
- var converter = prop.GetValueConverter();
+ var converter = prop.GetValueConverter() ?? prop.GetTypeMapping()?.Converter;
```

When an EF property has no explicit `ValueConverter` set but its type mapping carries one — exactly what `.HasConversion<string>()` and `EnumToStringConverter<TEnum>()` configure at model-builder time — linq2db now picks up that converter and renders the enum as `'Open'` / `'Closed'` instead of as the underlying integer.

The postgres-enum-type scenario from issue #4783 (Issue 3, mapping the enum to a Postgres-side `CREATE TYPE`-style enum) is covered separately by `Issue4783Test` in `Tests/EntityFrameworkCore/Tests/CustomContextIssueTests.cs` (`NET9_0_OR_GREATER` only). That test was enabled in master earlier — its fix landed across #4945 (6.0.0-rc.1) + #5319 (6.2.0).

## Local verification

```
dotnet test Tests/EntityFrameworkCore/Tests.EntityFrameworkCore.EF10.csproj \
  --filter FullyQualifiedName~Issue4783Test -c Debug
```

| Provider       | Result |
|----------------|--------|
| SQLite.MS      | passed |
| PostgreSQL.16  | passed |

New baselines confirm the three scenarios the original issue called out:
- enum-to-int (`StatusRaw` / `NullableStatusRaw`): integer values
- enum-to-string via `HasConversion<string>()` (`StatusString` / `NullableStatusString`): `'Open'` / `'Closed'`, NULL preserved
- enum-to-string via `EnumToStringConverter` (`StatusConverter` / `NullableStatusConverter`): same
