### PR TITLE
Fix #5535: resolve scaffold-package Redist references without SolutionDir

### DIFF
--- a/NuGet/NuGet.csproj
+++ b/NuGet/NuGet.csproj
@@ -29,21 +29,23 @@
 		</None>
 
 		<Reference Include="System.Data.SqlServerCe">
-			<HintPath>$(SolutionDir)\Redist\SqlCe\System.Data.SqlServerCe.dll</HintPath>
+			<HintPath>$(MSBuildThisFileDirectory)..\Redist\SqlCe\System.Data.SqlServerCe.dll</HintPath>
+			<Private>true</Private>
 		</Reference>
-		<SqlCeNativeLibs64 Include="$(SolutionDir)\Redist\SqlCe\amd64\**" Condition=" $(PlatformTarget) != 'x86' " />
+		<SqlCeNativeLibs64 Include="$(MSBuildThisFileDirectory)..\Redist\SqlCe\amd64\**" Condition=" $(PlatformTarget) != 'x86' " />
 		<None Include="@(SqlCeNativeLibs64)" Condition=" $(PlatformTarget) != 'x86' ">
 			<Link>amd64\%(RecursiveDir)%(FileName)%(Extension)</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
-		<SqlCeNativeLibs86 Include="$(SolutionDir)\Redist\SqlCe\x86\**" Condition=" $(PlatformTarget) == 'x86' " />
+		<SqlCeNativeLibs86 Include="$(MSBuildThisFileDirectory)..\Redist\SqlCe\x86\**" Condition=" $(PlatformTarget) == 'x86' " />
 		<None Include="@(SqlCeNativeLibs86)" Condition=" $(PlatformTarget) == 'x86' ">
 			<Link>x86\%(RecursiveDir)%(FileName)%(Extension)</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
 
 		<Reference Include="Sap.Data.Hana.v4.5">
-			<HintPath>$(SolutionDir)\Redist\SapHana\v4.5\Sap.Data.Hana.v4.5.dll</HintPath>
+			<HintPath>$(MSBuildThisFileDirectory)..\Redist\SapHana\v4.5\Sap.Data.Hana.v4.5.dll</HintPath>
+			<Private>true</Private>
 		</Reference>
 
 		<PackageReference Include="IBM.Data.DB.Provider" GeneratePathProperty="true" />


### PR DESCRIPTION
## Problem

`dotnet pack` of the scaffold packages (`linq2db.SapHana`, `linq2db.SqlCe`,
`linq2db.t4models`) fails with **NU5019 File not found** for
`Sap.Data.Hana.v4.5.dll` / `System.Data.SqlServerCe.dll` when packed as single
projects (e.g. release-test-matrix Track 4.5) rather than through the solution.

## Root cause

> This differs from the hypothesis in #5535. The issue attributed it to a
> non-deterministic CopyLocal heuristic and proposed `<Private>true</Private>`;
> verifying against the build showed that fix is **insufficient** (pack still
> fails NU5019) because the references are *unresolved*, not merely not-copied.

`NuGet/NuGet.csproj` referenced its Redist DLLs and the SqlCe native-lib globs
via `$(SolutionDir)`, a **solution-only** property that is empty when MSBuild
builds a single project. The `HintPath`s collapsed to drive-relative
`\Redist\...`, the references failed to resolve (`MSB3245`), and the DLLs never
reached `$(ToolsPath)` — so Pack errored NU5019. CI builds/packs `linq2db.slnx`
where `$(SolutionDir)` is set, which is why it only surfaced for standalone packs.

## Fix

- Both `<Reference>` `HintPath`s and the `SqlCeNativeLibs64/86` globs:
  `$(SolutionDir)` -> `$(MSBuildThisFileDirectory)..` (matches the existing
  convention on the `SQLite.Runtime.props` import in the same file). This equals
  `$(SolutionDir)` in the CI solution build (both = repo root), so **CI output is
  unchanged**, but it also resolves in a single-project pack.
- Added `<Private>true</Private>` to both references to force CopyLocal on
  machines where these assemblies are GAC-registered (which would otherwise flip
  CopyLocal to false and reintroduce NU5019).

## Verification

Reproduced red -> green locally (`dotnet pack -c Debug`):

| | before | issue's `<Private>` fix | this PR |
|---|---|---|---|
| pack SapHana / SqlCe / t4models | NU5019 | still NU5019 | all succeed |
| SqlCe `tools/amd64/*` native libs | missing | — | 6 DLLs + VC90 CRT present |

Package contents are otherwise unchanged.

Fixes #5535.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
