### PR TITLE
Fix #5530: skip bogus IS NULL guards on non-null Sybase concat operands

### DIFF
--- a/Source/LinqToDB/Internal/DataProvider/Sybase/SybaseSqlBuilder.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Sybase/SybaseSqlBuilder.cs
@@ -43,21 +43,33 @@ namespace LinqToDB.Internal.DataProvider.Sybase
 			// null semantics. Emit `CASE WHEN <any operand IS NULL> THEN NULL ELSE chain
 			// END` at SQL output time so the AST stays a plain `SqlConcatExpression` and
 			// the convert visitor never holds the concat as a child of its own wrap.
+			// Only operands that can actually be NULL need the guard: a string literal,
+			// a non-nullable column or a Coalesce result can never be NULL, so wrapping
+			// it in `IS NULL` is dead weight that bloats the output. Skip those, and when
+			// none of the operands can be NULL drop the CASE entirely and emit the bare
+			// `a + b + c` chain.
 			if (element.PreserveNull && element.Expressions.Length > 1)
 			{
-				StringBuilder.Append("CASE WHEN ");
+				var hasNullableOperand = false;
+
 				for (var i = 0; i < element.Expressions.Length; i++)
 				{
-					if (i > 0)
-						StringBuilder.Append(" OR ");
+					if (!element.Expressions[i].CanBeNullable(NullabilityContext))
+						continue;
+
+					StringBuilder.Append(hasNullableOperand ? " OR " : "CASE WHEN ");
 					BuildExpression(element.Expressions[i]);
 					StringBuilder.Append(" IS NULL");
+					hasNullableOperand = true;
 				}
 
-				StringBuilder.Append(" THEN NULL ELSE ");
-				base.BuildSqlConcatExpression(element);
-				StringBuilder.Append(" END");
-				return;
+				if (hasNullableOperand)
+				{
+					StringBuilder.Append(" THEN NULL ELSE ");
+					base.BuildSqlConcatExpression(element);
+					StringBuilder.Append(" END");
+					return;
+				}
 			}
 
 			base.BuildSqlConcatExpression(element);

--- a/Source/LinqToDB/Internal/DataProvider/Sybase/SybaseSqlBuilder.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Sybase/SybaseSqlBuilder.cs
@@ -43,11 +43,10 @@ namespace LinqToDB.Internal.DataProvider.Sybase
 			// null semantics. Emit `CASE WHEN <any operand IS NULL> THEN NULL ELSE chain
 			// END` at SQL output time so the AST stays a plain `SqlConcatExpression` and
 			// the convert visitor never holds the concat as a child of its own wrap.
-			// Only operands that can actually be NULL need the guard: a string literal,
-			// a non-nullable column or a Coalesce result can never be NULL, so wrapping
-			// it in `IS NULL` is dead weight that bloats the output. Skip those, and when
-			// none of the operands can be NULL drop the CASE entirely and emit the bare
-			// `a + b + c` chain.
+			// Only operands that `CanBeNullable` need the guard: a string literal or a
+			// non-nullable column can never be NULL, so wrapping it in `IS NULL` is dead
+			// weight that bloats the output. Skip those, and when no operand can be NULL
+			// drop the CASE entirely and emit the bare `a + b + c` chain.
 			if (element.PreserveNull && element.Expressions.Length > 1)
 			{
 				var hasNullableOperand = false;

--- a/Tests/Linq/Linq/StringConcatTests.cs
+++ b/Tests/Linq/Linq/StringConcatTests.cs
@@ -110,6 +110,46 @@ namespace Tests.Linq
 			AssertQuery(query);
 		}
 
+		[Table("Concat5530")]
+		sealed class Concat5530Entity
+		{
+			[PrimaryKey]                public int     Id   { get; set; }
+			[Column(CanBeNull = false)] public string  Req  { get; set; } = "";
+			[Column(CanBeNull = true)]  public string? Opt1 { get; set; }
+			[Column(CanBeNull = true)]  public string? Opt2 { get; set; }
+		}
+
+		// Regression for https://github.com/linq2db/linq2db/issues/5530.
+		// Sybase ASE has no null-safe concat operator, so Sql.Concat (PreserveNull) is emitted
+		// as `CASE WHEN <op> IS NULL OR ... THEN NULL ELSE a + b + ... END`. The guard must fire
+		// only for operands that can actually be NULL — a string literal or a non-nullable column
+		// can never be NULL, so wrapping it in `IS NULL` is dead weight that previously bloated
+		// the SQL (#5530). Nullability is taken from the explicit Column(CanBeNull = ...) mapping.
+		[Test]
+		public void Concat_Sybase_NullGuardOnlyForNullableOperands([IncludeDataSources(TestProvName.AllSybase)] string context)
+		{
+			using var db    = GetDataConnection(context);
+			using var table = db.CreateLocalTable(new[] { new Concat5530Entity { Id = 1, Req = "x", Opt1 = "a", Opt2 = "b" } });
+
+			// Both operands provably non-null (non-nullable column + literal): no CASE, no IS NULL guard at all.
+			_ = table.Select(e => Sql.Concat(e.Req, "-x")).ToList();
+			db.LastQuery!.ShouldNotContain("CASE WHEN");
+			db.LastQuery!.ShouldNotContain("IS NULL");
+
+			// Mixed: only the nullable column is guarded; the literal and the non-nullable column are not.
+			_ = table.Select(e => Sql.Concat(e.Req, "-", e.Opt1)).ToList();
+			db.LastQuery!.ShouldContain("CASE WHEN");
+			db.LastQuery!.ShouldContain("[Opt1] IS NULL");
+			db.LastQuery!.ShouldNotContain("[Req] IS NULL");
+			db.LastQuery!.ShouldNotContain("'-' IS NULL");
+
+			// All operands nullable: every column guarded.
+			_ = table.Select(e => Sql.Concat(e.Opt1, e.Opt2)).ToList();
+			db.LastQuery!.ShouldContain("CASE WHEN");
+			db.LastQuery!.ShouldContain("[Opt1] IS NULL");
+			db.LastQuery!.ShouldContain("[Opt2] IS NULL");
+		}
+
 		[Test]
 		public void Concat_FourArgs_Chain([DataSources] string context)
 		{


### PR DESCRIPTION
Fixes #5530.

## Problem

Sybase ASE's `+` operator does not propagate NULL (`'A' + NULL` returns `'A'`), so `Sql.Concat` (PreserveNull) is emitted by `SybaseSqlBuilder.BuildSqlConcatExpression` as a `CASE WHEN <operand> IS NULL OR ... THEN NULL ELSE a + b + ... END` guard. Since #5504 that guard was applied to **every** operand unconditionally — including string literals (`'2010-'`, `'-01'`, `'0'`) and non-nullable columns that can never be NULL — producing heavily bloated SQL.

`DateTimeFunctionsTests.MakeDateTime` on `Sybase.Managed`, before:

```sql
CAST(CASE WHEN '2010-' IS NULL OR RIGHT(CASE WHEN '0' IS NULL OR CAST([t].[ID] AS VarChar(2)) IS NULL THEN NULL ELSE '0' + CAST([t].[ID] AS VarChar(2)) END, 2) IS NULL OR '-01' IS NULL THEN NULL ELSE '2010-' + RIGHT(...) + '-01' END AS DateTime)
```

after:

```sql
CAST('2010-' + RIGHT('0' + CAST([t].[ID] AS VarChar(2)), 2) + '-01' AS DateTime)
```

## Fix

`BuildSqlConcatExpression` now gates each operand's `IS NULL` on `CanBeNullable(NullabilityContext)`:

- non-nullable operands (string literals, `CanBeNull = false` columns, `Coalesce` results, `NotNullable` functions) are omitted from the guard predicate;
- when no operand can be null, the `CASE` is dropped entirely and the raw `a + b + c` chain is emitted.

This restores the pre-#5504 shape. Scope is limited to the one Sybase SQL-builder method.

## Test

`StringConcatTests.Concat_Sybase_NullGuardOnlyForNullableOperands` (Sybase-only) asserts the three shapes from the issue:

- all-non-null (`Sql.Concat(Req, "-x")`) → no `CASE`, no `IS NULL`;
- mixed (`Sql.Concat(Req, "-", Opt1)`) → guard only on the nullable column, **not** on the literal or the non-nullable column;
- all-nullable (`Sql.Concat(Opt1, Opt2)`) → every column guarded.

Verified green against a live SAP ASE 16 instance. The other affected baseline tests (`MakeDateTime` family, `DateOnly*`, `GroupByDate3`, `Issue3250*`, `Issue2434Test`, `Issue1833*`, `SelectScalarTests.Function`) collapse to the master shape through the same code path and regenerate on the CI baselines run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
