### PR TITLE
Fix #5529: restore IS NULL pushdown through SqlConcatExpression

### DIFF
--- a/Source/LinqToDB/Internal/SqlQuery/Visitors/ReduceIsNullExpressionVisitor.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/Visitors/ReduceIsNullExpressionVisitor.cs
@@ -32,10 +32,11 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 			return element?.ElementType switch
 			{
 				QueryElementType.SqlNullabilityExpression or
-				QueryElementType.SqlBinaryExpression or 
-				QueryElementType.SqlCondition or 
-				QueryElementType.SqlCast or 
-				QueryElementType.SqlFunction or 
+				QueryElementType.SqlBinaryExpression or
+				QueryElementType.SqlConcat or
+				QueryElementType.SqlCondition or
+				QueryElementType.SqlCast or
+				QueryElementType.SqlFunction or
 				QueryElementType.SqlExpression =>
 					base.Visit(element),
 
@@ -183,6 +184,22 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 			{
 				ReduceOrAdd(element.Expr1);
 				ReduceOrAdd(element.Expr2);
+			}
+
+			return element;
+		}
+
+		protected internal override IQueryElement VisitSqlConcatExpression(SqlConcatExpression element)
+		{
+			// Null-propagating concat (e.g. SqlServer / Access `+`): the result is NULL iff any operand
+			// is NULL, so `concat IS NULL` reduces to the OR of each operand's IS NULL — mirroring the
+			// `+` case in VisitSqlBinaryExpression. Strict-null=false concats (`||` treating NULL as the
+			// empty string on Oracle / DB2) never yield NULL from a NULL operand, so they are not
+			// nullable and never reach this reducer (folded in VisitIsNullPredicate).
+			if (element.PreserveNull)
+			{
+				foreach (var expr in element.Expressions)
+					ReduceOrAdd(expr);
 			}
 
 			return element;


### PR DESCRIPTION
## Problem

#5504 replaced the string-concat AST node (`SqlBinaryExpression('+')` → `SqlConcatExpression`). `ReduceIsNullExpressionVisitor` only recurses into a type whitelist that excluded `SqlConcat`, so two SqlServer simplifications regressed (surfaced in #5504's baselines review):

1. `(col + literal) IS NULL` no longer pushed down to `col IS NULL`.
2. `LEN(... + '.') - 1 <> 0` no longer folded to `LEN(... + '.') <> 1`.

Regression 2 is **downstream** of regression 1: once the `IS NULL` over the concat reduces to the base column, the comparison's nullability factors out and the existing subtract fold re-fires — so only the reducer needed fixing.

## Fix

`ReduceIsNullExpressionVisitor`: add `SqlConcat` to the visit whitelist + a `VisitSqlConcatExpression` override that reduces each operand's `IS NULL` (mirroring the `+` case), gated on `PreserveNull`. Null-as-empty `||` providers (Oracle/DB2) build `PreserveNull:false` concats and are correctly left untouched.

## Verification

Baselines regenerated regressed → fixed against live DBs:

| Test / provider | After fix |
|---|---|
| `WhereTests.LengthTest1` SqlServer 2022 (`+`) | `LEN([nm].[MiddleName] + N'.') <> 1 OR [nm].[MiddleName] IS NULL` |
| `WhereTests.LengthTest1` SqlServer 2025 (`\|\|`) | `LEN([nm].[MiddleName] \|\| N'.') <> 1 OR [nm].[MiddleName] IS NULL` |
| `StringFunctionsTests.ConcatStringsTest` Access (`+`) | `IIF([t].[Value3] IS NULL, '', ' -> ' + [t].[Value3])` |

Change is global (any null-propagating-concat-under-`IS NULL` query); full cross-provider baselines regenerate via CI.

Fixes #5529.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
