### PR TITLE
Fix #5531: Informix SUM null-guard emits Nvl(x, NULL) instead of the intended default

### DIFF
--- a/Source/LinqToDB/Internal/DataProvider/Access/AccessSqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Access/AccessSqlExpressionConvertVisitor.cs
@@ -134,6 +134,15 @@ namespace LinqToDB.Internal.DataProvider.Access
 			if (element.SystemType == null)
 				return element;
 
+			// Strip NULL-literal operands before folding to IIF, matching base ConvertCoalesce —
+			// otherwise a no-op guard like Coalesce(x, NULL) folds to IIF(x IS NULL, NULL, x)
+			// (issue #5531).
+			var reduced = RemoveNullValues(element);
+			if (reduced is not SqlCoalesceExpression coalesce)
+				return reduced;
+
+			element = coalesce;
+
 			if (element.Expressions.Length == 2)
 			{
 				return new SqlConditionExpression(new SqlPredicate.IsNull(element.Expressions[0], false), element.Expressions[1], element.Expressions[0]);

--- a/Source/LinqToDB/Internal/DataProvider/Informix/InformixSqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Informix/InformixSqlExpressionConvertVisitor.cs
@@ -63,11 +63,16 @@ namespace LinqToDB.Internal.DataProvider.Informix
 
 		public override ISqlExpression ConvertCoalesce(SqlCoalesceExpression element)
 		{
-			return element.SystemType switch
-			{
-				null => element,
-				_ => ConvertCoalesceToBinaryFunc(element, "Nvl", supportsParameters: false),
-			};
+			if (element.SystemType == null)
+				return element;
+
+			// Strip NULL-literal operands before folding to Nvl, matching base ConvertCoalesce —
+			// otherwise a no-op guard like Coalesce(x, NULL) folds to Nvl(x, NULL) (issue #5531).
+			var reduced = RemoveNullValues(element);
+			if (reduced is not SqlCoalesceExpression coalesce)
+				return reduced;
+
+			return ConvertCoalesceToBinaryFunc(coalesce, "Nvl", supportsParameters: false);
 		}
 
 		//TODO: Move everything to SQLBuilder

--- a/Source/LinqToDB/Internal/DataProvider/Translation/AggregateFunctionsMemberTranslatorBase.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Translation/AggregateFunctionsMemberTranslatorBase.cs
@@ -329,7 +329,16 @@ namespace LinqToDB.Internal.DataProvider.Translation
 						// /optimization (so ClickHouse can still reject correlated subqueries) and
 						// DefaultIfEmpty's CASE-injection on the SUM argument is unaffected. The lifted
 						// reference is wrapped with COALESCE(<ref>, default).
-						if (!info.IsGroupBy && argumentValue.SystemType?.IsNullableOrReferenceType == false && functionName is "SUM")
+						// Gate on the method *result* type, not just the argument: a nullable-projected
+						// Sum (e.g. Sum(x => (decimal?)x)) summing a non-nullable column has a non-nullable
+						// argument but a nullable result, so the C# value legitimately allows NULL and needs
+						// no guard. Wrapping it built COALESCE(<ref>, NULL) (DefaultValue of a nullable type is
+						// null) — a no-op everywhere except providers that fold COALESCE without stripping NULL
+						// operands (Informix → Nvl(x, NULL), issue #5531).
+						if (!info.IsGroupBy
+							&& argumentValue.SystemType?.IsNullableOrReferenceType == false
+							&& resultType.SystemType?.IsNullableOrReferenceType    == false
+							&& functionName is "SUM")
 						{
 							var defaultValue = DefaultValue.GetValue(resultType.SystemType);
 							var defaultSql   = factory.Value(resultType, defaultValue!);

--- a/Source/LinqToDB/Internal/SqlProvider/SqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/SqlProvider/SqlExpressionConvertVisitor.cs
@@ -1225,25 +1225,56 @@ namespace LinqToDB.Internal.SqlProvider
 
 		public virtual ISqlExpression ConvertCoalesce(SqlCoalesceExpression element)
 		{
+			var reduced = RemoveNullValues(element);
+			if (reduced is not SqlCoalesceExpression coalesce)
+				return reduced;
+
+			var type = QueryHelper.GetDbDataType(coalesce.Expressions[0], MappingSchema);
+			return new SqlFunction(type, "Coalesce", parametersNullability: ParametersNullabilityType.IfAllParametersNullable, coalesce.Expressions);
+		}
+
+		/// <summary>
+		/// Removes NULL-literal operands from a COALESCE operand list — a literal NULL can never be the
+		/// value COALESCE returns, so it is redundant. Returns the sole surviving operand when only one
+		/// remains, a reduced <see cref="SqlCoalesceExpression"/> over the survivors when several remain,
+		/// or the last operand when every operand is a NULL literal. Returns <paramref name="element"/>
+		/// unchanged when it has no NULL-literal operands.
+		/// Shared so providers that fold COALESCE into a native construct (Informix <c>Nvl</c>, Access
+		/// <c>IIF</c>) apply the same normalization the base <see cref="ConvertCoalesce"/> does before
+		/// folding; otherwise a no-op guard such as <c>Coalesce(x, NULL)</c> folds to <c>Nvl(x, NULL)</c>
+		/// / <c>IIF(x IS NULL, NULL, x)</c> (issue #5531).
+		/// </summary>
+		protected ISqlExpression RemoveNullValues(SqlCoalesceExpression element)
+		{
+			List<ISqlExpression>? kept = null;
+
 			for (var i = 0; i < element.Expressions.Length; i++)
 			{
 				if (element.Expressions[i] is SqlValue { Value: null })
 				{
-					if (element.Expressions.Length == 2)
-						return element.Expressions[i ^ 1];
-					else
+					if (kept == null)
 					{
-						var newElements = new ISqlExpression[element.Expressions.Length - 1];
-						Array.Copy(element.Expressions, newElements, i);
-						Array.Copy(element.Expressions, i + 1, newElements, i, element.Expressions.Length - 1 - i);
-
-						return new SqlCoalesceExpression(newElements);
+						kept = new List<ISqlExpression>(element.Expressions.Length - 1);
+						for (var j = 0; j < i; j++)
+							kept.Add(element.Expressions[j]);
 					}
+				}
+				else
+				{
+					kept?.Add(element.Expressions[i]);
 				}
 			}
 
-			var type = QueryHelper.GetDbDataType(element.Expressions[0], MappingSchema);
-			return new SqlFunction(type, "Coalesce", parametersNullability: ParametersNullabilityType.IfAllParametersNullable, element.Expressions);
+			if (kept == null)
+				return element;
+
+			if (kept.Count == 0)
+				return element.Expressions[^1];
+
+			if (kept.Count == 1)
+				return kept[0];
+
+			return new SqlCoalesceExpression(kept.ToArray());
 		}
 
 		/// <summary>

--- a/Source/LinqToDB/PublicAPI/PublicAPI.Unshipped.txt
+++ b/Source/LinqToDB/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+LinqToDB.Internal.SqlProvider.SqlExpressionConvertVisitor.RemoveNullValues(LinqToDB.Internal.SqlQuery.SqlCoalesceExpression! element) -> LinqToDB.Internal.SqlQuery.ISqlExpression!


### PR DESCRIPTION
## Summary

Follow-up to #5502. Fixes #5531 — on Informix the new non-nullable-`SUM` null-guard emitted `Nvl(x, NULL)` / `Nvl(x, Nvl(NULL, 0))` instead of the intended default.

## Root cause

PR #5502's null-guard (`AggregateFunctionsMemberTranslatorBase`) gated on the aggregate **argument**'s nullability, not the method's **result** type. A `(decimal?)`-cast `.Sum()` over a non-nullable column has a non-nullable argument but a nullable result, so the guard fired — and `DefaultValue.GetValue(decimal?)` returns `null`, so it built `Coalesce(<ref>, NULL)`, a no-op default.

Every provider builds this. All strip the NULL operand in `ConvertCoalesce` **except** Informix (folds straight to `Nvl`) and Access (folds to `IIF`), which leaked the NULL into generated SQL.

> The issue's "expected" for the correlated-subquery case (`Issue4717Test`) assumed `Nvl(SUM, 0)`, but every other provider (DB2 / SQLite / Oracle / SqlServer) actually emits **bare `SUM`** there — the no-op guard vanishes entirely. This fix makes Informix consistent: bare `SUM` for that case, `Nvl(x, 0)` for the lifted-`ORDER BY` case (`Issue3226Test4`).

## Fix

- **A** — `AggregateFunctionsMemberTranslatorBase`: the SUM null-guard now also requires a non-nullable `resultType`, so a nullable `.Sum()` no longer builds the no-op wrap (matches #5502's "non-nullable subquery aggregates" intent).
- **B** — extract `RemoveNullValues` in the base `SqlExpressionConvertVisitor` (base `ConvertCoalesce` refactored to use it — behavior-preserving) and call it from the Informix / Access `ConvertCoalesce` overrides **before** they fold to `Nvl` / `IIF`, so they apply the same NULL-stripping normalization the base does. Closes the structural gap for any future NULL-bearing coalesce, not just #5531's source.

## Generated SQL (verified in-process)

`Issue4717Test` (correlated subquery), Informix:
```diff
- Nvl((SELECT SUM(wp_1.StockOnHand) ...), NULL)
+ (SELECT SUM(wp_1.StockOnHand) ...)            -- bare SUM, matches DB2/SQLite/Oracle
```

`Issue3226Test4` (lifted `ORDER BY`), Informix:
```diff
- ORDER BY Nvl(x_1.Sum_1, Nvl(NULL, 0))
+ ORDER BY Nvl(x_1.Sum_1, 0)
```

SQLite unchanged (bare `SUM` / `Coalesce(SUM, 0)`).

## Test plan

- [x] Core builds clean — Testing + Release (net10.0); analyzers, banned-API, PublicAPI all pass.
- [x] In-process SQL-shape check on Informix + SQLite confirms the shapes above; SQLite output is byte-identical to current baselines (proves the `RemoveNullValues` base refactor is behavior-preserving).
- [ ] CI full provider matrix — regenerates the `Informix.DB2` baselines for `Issue4717Test` / `Issue3226Test4` (which currently show `Nvl(..., NULL)`); the resulting baselines PR should be reviewed.

Fixes #5531

🤖 Generated with [Claude Code](https://claude.com/claude-code)
