### PR TITLE
CI: reset baselines working tree before retried test attempts

### DIFF
--- a/Build/Azure/pipelines/templates/test-workflow-linux.yml
+++ b/Build/Azure/pipelines/templates/test-workflow-linux.yml
@@ -97,7 +97,13 @@ steps:
   condition: and(variables.title, eq(variables.net80, 'true'), succeeded(), ne(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 8): $(title)'
 
-- script: dotnet test ./net8.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net8.0 -l trx $(extra) --blame-hang-timeout 5m
+- script: |
+    if [ -d baselines/.git ]; then
+      echo "Reset baselines working tree so a failed/retried attempt does not leak baselines into the commit"
+      git -C baselines reset --hard
+      git -C baselines clean -fdq
+    fi
+    dotnet test ./net8.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net8.0 -l trx $(extra) --blame-hang-timeout 5m
   condition: and(variables.title, eq(variables.net80, 'true'), succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 8): $(title)'
   retryCountOnTaskFailure: 2
@@ -144,7 +150,13 @@ steps:
   condition: and(variables.title, eq(variables.net90, 'true'), succeeded(), ne(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 9): $(title)'
 
-- script: dotnet test ./net9.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net9.0 -l trx $(extra) --blame-hang-timeout 5m
+- script: |
+    if [ -d baselines/.git ]; then
+      echo "Reset baselines working tree so a failed/retried attempt does not leak baselines into the commit"
+      git -C baselines reset --hard
+      git -C baselines clean -fdq
+    fi
+    dotnet test ./net9.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net9.0 -l trx $(extra) --blame-hang-timeout 5m
   condition: and(variables.title, eq(variables.net90, 'true'), succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 9): $(title)'
   retryCountOnTaskFailure: 2
@@ -191,7 +203,13 @@ steps:
   condition: and(variables.title, eq(variables.net100, 'true'), succeeded(), ne(variables.retry, 'true'))
   displayName: 'Tests (.NET 10): $(title)'
 
-- script: dotnet test ./net10.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net10.0 -l trx $(extra) --blame-hang-timeout 5m
+- script: |
+    if [ -d baselines/.git ]; then
+      echo "Reset baselines working tree so a failed/retried attempt does not leak baselines into the commit"
+      git -C baselines reset --hard
+      git -C baselines clean -fdq
+    fi
+    dotnet test ./net10.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net10.0 -l trx $(extra) --blame-hang-timeout 5m
   condition: and(variables.title, eq(variables.net100, 'true'), succeeded(), eq(variables.retry, 'true'))
   displayName: 'Tests (.NET 10): $(title)'
   retryCountOnTaskFailure: 2

--- a/Build/Azure/pipelines/templates/test-workflow-macos.yml
+++ b/Build/Azure/pipelines/templates/test-workflow-macos.yml
@@ -88,7 +88,13 @@ steps:
   condition: and(variables.title, eq(variables.net80, 'true'), succeeded(), ne(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 8): $(title)'
 
-- script: dotnet test ./net8.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net8.0 -l trx $(extra) --blame-hang-timeout 5m
+- script: |
+    if [ -d baselines/.git ]; then
+      echo "Reset baselines working tree so a failed/retried attempt does not leak baselines into the commit"
+      git -C baselines reset --hard
+      git -C baselines clean -fdq
+    fi
+    dotnet test ./net8.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net8.0 -l trx $(extra) --blame-hang-timeout 5m
   condition: and(variables.title, eq(variables.net80, 'true'), succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 8): $(title)'
   retryCountOnTaskFailure: 2
@@ -135,7 +141,13 @@ steps:
   condition: and(variables.title, eq(variables.net90, 'true'), succeeded(), ne(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 9): $(title)'
 
-- script: dotnet test ./net9.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net9.0 -l trx $(extra) --blame-hang-timeout 5m
+- script: |
+    if [ -d baselines/.git ]; then
+      echo "Reset baselines working tree so a failed/retried attempt does not leak baselines into the commit"
+      git -C baselines reset --hard
+      git -C baselines clean -fdq
+    fi
+    dotnet test ./net9.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net9.0 -l trx $(extra) --blame-hang-timeout 5m
   condition: and(variables.title, eq(variables.net90, 'true'), succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 9): $(title)'
   retryCountOnTaskFailure: 2
@@ -182,7 +194,13 @@ steps:
   condition: and(variables.title, eq(variables.net100, 'true'), succeeded(), ne(variables.retry, 'true'))
   displayName: 'Tests (.NET 10): $(title)'
 
-- script: dotnet test ./net10.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net10.0 -l trx $(extra) --blame-hang-timeout 5m
+- script: |
+    if [ -d baselines/.git ]; then
+      echo "Reset baselines working tree so a failed/retried attempt does not leak baselines into the commit"
+      git -C baselines reset --hard
+      git -C baselines clean -fdq
+    fi
+    dotnet test ./net10.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net10.0 -l trx $(extra) --blame-hang-timeout 5m
   condition: and(variables.title, eq(variables.net100, 'true'), succeeded(), eq(variables.retry, 'true'))
   displayName: 'Tests (.NET 10): $(title)'
   retryCountOnTaskFailure: 2

--- a/Build/Azure/pipelines/templates/test-workflow-windows.yml
+++ b/Build/Azure/pipelines/templates/test-workflow-windows.yml
@@ -125,7 +125,10 @@ steps:
   displayName: 'Tests (NETFX): $(title)'
   condition: and(eq(variables.netfx, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), ne(variables.retry, 'true'))
 
-- script: dotnet test $(netfx_tfm)/main/x86/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f $(netfx_tfm) -l trx $(extra) --blame-hang-timeout 5m
+- script: |
+    if exist baselines\.git\ git -C baselines reset --hard
+    if exist baselines\.git\ git -C baselines clean -fdq
+    dotnet test $(netfx_tfm)/main/x86/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f $(netfx_tfm) -l trx $(extra) --blame-hang-timeout 5m
   displayName: 'Tests (NETFX): $(title)'
   condition: and(eq(variables.netfx, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'))
   retryCountOnTaskFailure: 2
@@ -166,7 +169,10 @@ steps:
   displayName: 'Tests (NETFX x64): $(title)'
   condition: and(eq(variables.netfx, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), ne(variables.retry, 'true'))
 
-- script: dotnet test $(netfx_tfm)/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f $(netfx_tfm) -l trx --arch x64 --blame-hang-timeout 5m
+- script: |
+    if exist baselines\.git\ git -C baselines reset --hard
+    if exist baselines\.git\ git -C baselines clean -fdq
+    dotnet test $(netfx_tfm)/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f $(netfx_tfm) -l trx --arch x64 --blame-hang-timeout 5m
   displayName: 'Tests (NETFX x64): $(title)'
   condition: and(eq(variables.netfx, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'))
   retryCountOnTaskFailure: 2
@@ -240,7 +246,10 @@ steps:
   displayName: 'Tests (.NET 8 x64): $(title)'
   condition: and(eq(variables.net80, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), ne(variables.retry, 'true'), ${{ parameters.full_run }})
 
-- script: dotnet test net8.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net8.0 -l trx --blame-hang-timeout 5m
+- script: |
+    if exist baselines\.git\ git -C baselines reset --hard
+    if exist baselines\.git\ git -C baselines clean -fdq
+    dotnet test net8.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net8.0 -l trx --blame-hang-timeout 5m
   displayName: 'Tests (.NET 8 x64): $(title)'
   condition: and(eq(variables.net80, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   retryCountOnTaskFailure: 2
@@ -249,7 +258,10 @@ steps:
   displayName: 'Tests (.NET 8 x86): $(title)'
   condition: and(eq(variables.net80, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), ne(variables.retry, 'true'), ${{ parameters.full_run }})
 
-- script: dotnet test net8.0/main/x86/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net8.0 -l trx --blame-hang-timeout 5m
+- script: |
+    if exist baselines\.git\ git -C baselines reset --hard
+    if exist baselines\.git\ git -C baselines clean -fdq
+    dotnet test net8.0/main/x86/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net8.0 -l trx --blame-hang-timeout 5m
   displayName: 'Tests (.NET 8 x86): $(title)'
   condition: and(eq(variables.net80, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   retryCountOnTaskFailure: 2
@@ -327,7 +339,10 @@ steps:
   displayName: 'Tests (.NET 9 x64): $(title)'
   condition: and(eq(variables.net90, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), ne(variables.retry, 'true'), ${{ parameters.full_run }})
 
-- script: dotnet test net9.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net9.0 -l trx --blame-hang-timeout 5m
+- script: |
+    if exist baselines\.git\ git -C baselines reset --hard
+    if exist baselines\.git\ git -C baselines clean -fdq
+    dotnet test net9.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net9.0 -l trx --blame-hang-timeout 5m
   displayName: 'Tests (.NET 9 x64): $(title)'
   condition: and(eq(variables.net90, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   retryCountOnTaskFailure: 2
@@ -336,7 +351,10 @@ steps:
   displayName: 'Tests (.NET 9 x86): $(title)'
   condition: and(eq(variables.net90, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), ne(variables.retry, 'true'), ${{ parameters.full_run }})
 
-- script: dotnet test net9.0/main/x86/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net9.0 -l trx --blame-hang-timeout 5m
+- script: |
+    if exist baselines\.git\ git -C baselines reset --hard
+    if exist baselines\.git\ git -C baselines clean -fdq
+    dotnet test net9.0/main/x86/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net9.0 -l trx --blame-hang-timeout 5m
   displayName: 'Tests (.NET 9 x86): $(title)'
   condition: and(eq(variables.net90, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   retryCountOnTaskFailure: 2
@@ -407,7 +425,10 @@ steps:
   displayName: 'Tests (.NET 10 x64): $(title)'
   condition: and(eq(variables.net100, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), ne(variables.retry, 'true'))
 
-- script: dotnet test net10.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net10.0 -l trx --blame-hang-timeout 5m
+- script: |
+    if exist baselines\.git\ git -C baselines reset --hard
+    if exist baselines\.git\ git -C baselines clean -fdq
+    dotnet test net10.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net10.0 -l trx --blame-hang-timeout 5m
   displayName: 'Tests (.NET 10 x64): $(title)'
   condition: and(eq(variables.net100, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'))
   retryCountOnTaskFailure: 2
@@ -416,7 +437,10 @@ steps:
   displayName: 'Tests (.NET 10 x86): $(title)'
   condition: and(eq(variables.net100, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), ne(variables.retry, 'true'))
 
-- script: dotnet test net10.0/main/x86/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net10.0 -l trx --blame-hang-timeout 5m
+- script: |
+    if exist baselines\.git\ git -C baselines reset --hard
+    if exist baselines\.git\ git -C baselines clean -fdq
+    dotnet test net10.0/main/x86/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net10.0 -l trx --blame-hang-timeout 5m
   displayName: 'Tests (.NET 10 x86): $(title)'
   condition: and(eq(variables.net100, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'))
   retryCountOnTaskFailure: 2


### PR DESCRIPTION
## Problem

Spurious baseline files keep getting committed to `linq2db.baselines` from Oracle (and Access) CI jobs and are never pruned — e.g. the long-standing `AnalyticTests.TestMin(Oracle.21.Managed).sql.other`, plus a rotating set of unrelated tests across Oracle 12/18/19/21/23 (`CharTypesTests.StringTrimming`, `CommonTests.ClosureTest`, `ComplexTests2.TestInsertUsingDerivedObjectUsingAttributes`). Full investigation in #5513.

## Root cause

Oracle/Access jobs run with `retry: true` → `retryCountOnTaskFailure: 2` (those providers are unstable / crash mid-test). When an attempt is flaky:

1. the failed attempt writes spurious files into the checked-out baselines working tree — a `.sql.other` direct-vs-remote mismatch marker (which throws in `[TearDown]`), or partial/corrupt `.sql` from a crash — and fails;
2. the retry re-runs, the flake doesn't recur, the task goes **green**;
3. but the failed attempt's files persist on disk, and `Commit test baselines` (condition `succeeded()`) commits them.

Nothing prunes them, so they accumulate across baselines PRs.

## Fix

Reset the baselines working tree (`git reset --hard` + `git clean -fd`) at the start of every retry-enabled test step, so each (re)attempt regenerates baselines from a clean checkout and only the clean, passing run's output is committed. Guarded (`if [ -d baselines/.git ]` / `if exist baselines\.git\`) so it is a no-op when baselines aren't checked out.

Applied to all retry-enabled main-test steps across the Linux, macOS, and Windows workflow templates.

Fix #5513

🤖 Generated with [Claude Code](https://claude.com/claude-code)
