### PR TITLE
Reject unsupported correlated subqueries in expression position (ClickHouse / YDB)

### DIFF
--- a/Source/LinqToDB/Internal/DataProvider/SqlProviderHelper.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlProviderHelper.cs
@@ -9,11 +9,9 @@ namespace LinqToDB.Internal.DataProvider
 	{
 		internal static readonly ObjectPool<SqlQueryValidatorVisitor> ValidationVisitorPool = new(() => new SqlQueryValidatorVisitor(), v => v.Cleanup(), 100);
 
-		public static bool IsValidQuery(IQueryElement element, SelectQuery? parentQuery, SqlJoinedTable? fakeJoin, int? columnSubqueryLevel, SqlProviderFlags providerFlags, out string? errorMessage, bool forErrorReporting = false)
+		public static bool IsValidQuery(IQueryElement element, SelectQuery? parentQuery, SqlJoinedTable? fakeJoin, int? columnSubqueryLevel, SqlProviderFlags providerFlags, out string? errorMessage)
 		{
 			using var visitor = ValidationVisitorPool.Allocate();
-
-			visitor.Value.ForErrorReporting = forErrorReporting;
 
 			return visitor.Value.IsValidQuery(element, parentQuery, fakeJoin, columnSubqueryLevel, providerFlags, out errorMessage);
 		}

--- a/Source/LinqToDB/Internal/DataProvider/SqlProviderHelper.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlProviderHelper.cs
@@ -9,9 +9,11 @@ namespace LinqToDB.Internal.DataProvider
 	{
 		internal static readonly ObjectPool<SqlQueryValidatorVisitor> ValidationVisitorPool = new(() => new SqlQueryValidatorVisitor(), v => v.Cleanup(), 100);
 
-		public static bool IsValidQuery(IQueryElement element, SelectQuery? parentQuery, SqlJoinedTable? fakeJoin, int? columnSubqueryLevel, SqlProviderFlags providerFlags, out string? errorMessage)
+		public static bool IsValidQuery(IQueryElement element, SelectQuery? parentQuery, SqlJoinedTable? fakeJoin, int? columnSubqueryLevel, SqlProviderFlags providerFlags, out string? errorMessage, bool forErrorReporting = false)
 		{
 			using var visitor = ValidationVisitorPool.Allocate();
+
+			visitor.Value.ForErrorReporting = forErrorReporting;
 
 			return visitor.Value.IsValidQuery(element, parentQuery, fakeJoin, columnSubqueryLevel, providerFlags, out errorMessage);
 		}

--- a/Source/LinqToDB/Internal/DataProvider/Ydb/YdbDataProvider.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Ydb/YdbDataProvider.cs
@@ -49,7 +49,7 @@ namespace LinqToDB.Internal.DataProvider.Ydb
 			SqlProviderFlags.IsNestedJoinsSupported           = false;
 			SqlProviderFlags.IsCrossJoinSyntaxRequired        = true;
 
-			SqlProviderFlags.IsSupportedSimpleCorrelatedSubqueries = false;
+			SqlProviderFlags.IsSupportedSimpleCorrelatedSubqueries = true;
 			SqlProviderFlags.SupportedCorrelatedSubqueriesLevel    = 0;
 
 			SetProviderField<byte[]>  (YdbProviderAdapter.GetBytes,        Adapter.DataReaderType);

--- a/Source/LinqToDB/Internal/DataProvider/Ydb/YdbDataProvider.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Ydb/YdbDataProvider.cs
@@ -49,7 +49,7 @@ namespace LinqToDB.Internal.DataProvider.Ydb
 			SqlProviderFlags.IsNestedJoinsSupported           = false;
 			SqlProviderFlags.IsCrossJoinSyntaxRequired        = true;
 
-			SqlProviderFlags.IsSupportedSimpleCorrelatedSubqueries = true;
+			SqlProviderFlags.IsSupportedSimpleCorrelatedSubqueries = false;
 			SqlProviderFlags.SupportedCorrelatedSubqueriesLevel    = 0;
 
 			SetProviderField<byte[]>  (YdbProviderAdapter.GetBytes,        Adapter.DataReaderType);

--- a/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuilder.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuilder.cs
@@ -185,7 +185,7 @@ namespace LinqToDB.Internal.Linq.Builder
 
 					if (queryInfo.Statement.SelectQuery != null)
 					{
-						if (!SqlProviderHelper.IsValidQuery(queryInfo.Statement, parentQuery: null, fakeJoin: null, columnSubqueryLevel: null, DataContext.SqlProviderFlags, out var errorMessage, forErrorReporting: true))
+						if (!SqlProviderHelper.IsValidQuery(queryInfo.Statement, parentQuery: null, fakeJoin: null, columnSubqueryLevel: null, DataContext.SqlProviderFlags, out var errorMessage))
 						{
 							query.ErrorExpression = new SqlErrorExpression(Expression, errorMessage, Expression.Type);
 							return false;

--- a/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuilder.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuilder.cs
@@ -185,7 +185,7 @@ namespace LinqToDB.Internal.Linq.Builder
 
 					if (queryInfo.Statement.SelectQuery != null)
 					{
-						if (!SqlProviderHelper.IsValidQuery(queryInfo.Statement, parentQuery: null, fakeJoin: null, columnSubqueryLevel: null, DataContext.SqlProviderFlags, out var errorMessage))
+						if (!SqlProviderHelper.IsValidQuery(queryInfo.Statement, parentQuery: null, fakeJoin: null, columnSubqueryLevel: null, DataContext.SqlProviderFlags, out var errorMessage, forErrorReporting: true))
 						{
 							query.ErrorExpression = new SqlErrorExpression(Expression, errorMessage, Expression.Type);
 							return false;

--- a/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryValidatorVisitor.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryValidatorVisitor.cs
@@ -106,9 +106,9 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 			// Expression-position correlated subqueries. VisitSqlSearchCondition nulls
 			// _columnSubqueryLevel, so the column-position block below never sees subqueries
 			// embedded in WHERE/HAVING/ON expressions (EXISTS, IN, scalar comparisons). Level-0
-			// providers (e.g. ClickHouse, YDB) can't decorrelate ANY correlated subquery and have
-			// no APPLY fallback, so reject here regardless of slot, while still honoring the same
-			// simple-correlated allowance the column-position path uses.
+			// non-APPLY providers (ClickHouse, YDB) don't support general correlated subqueries
+			// and have no APPLY fallback, so reject here regardless of slot — except the simple
+			// correlated forms the provider explicitly allows (IsSupportedSimpleCorrelatedSubqueries).
 			if (_inExpression
 				&& _providerFlags.SupportedCorrelatedSubqueriesLevel == 0
 				&& !_providerFlags.IsApplyJoinSupported

--- a/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryValidatorVisitor.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryValidatorVisitor.cs
@@ -32,6 +32,11 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 			get => _errorMessage;
 		}
 
+		// When set, validation also rejects unsupported correlated subqueries in predicate position. Used only by
+		// the final ExpressionBuilder gate; the optimizer / eager-load probes leave it false so the validator's
+		// verdict can't alter their rewrites (which would otherwise silently drop e.g. a correlated ORDER BY).
+		internal bool ForErrorReporting { get; set; }
+
 		public SqlQueryValidatorVisitor() : base(VisitMode.ReadOnly)
 		{
 		}
@@ -45,6 +50,7 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 			_columnSubqueryLevel    = default;
 			_columnExpressionDepth  = 0;
 			_columnSubqueryDepth    = 0;
+			ForErrorReporting       = false;
 			_errorMessage           = default!;
 			_ignoredExpressions     = null;
 			_currentSources         = null;
@@ -251,6 +257,7 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 				}
 				else if (_providerFlags.SupportedCorrelatedSubqueriesLevel == 0
 					&& !_providerFlags.IsApplyJoinSupported
+					&& ForErrorReporting
 					&& IsDependsOnOuterSources()
 					&& !(_providerFlags.IsSupportedSimpleCorrelatedSubqueries && IsSimpleCorrelatedSubquery(selectQuery)))
 				{
@@ -260,6 +267,9 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 					// correlated-subquery support) would emit the query and fail at the server. Gated to
 					// SupportedCorrelatedSubqueriesLevel == 0 + non-APPLY, so only ClickHouse/YDB are affected;
 					// simple correlated subqueries stay allowed where the provider supports them (ClickHouse).
+					// Only fires under ForErrorReporting (the final ExpressionBuilder gate) — the optimizer and
+					// eager-load probes leave it false so this verdict can't alter their rewrites (which would
+					// otherwise silently drop e.g. a correlated association ORDER BY).
 					errorMessage = ErrorHelper.Error_Correlated_Subqueries;
 					return false;
 				}

--- a/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryValidatorVisitor.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryValidatorVisitor.cs
@@ -249,6 +249,20 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 						return false;
 					}
 				}
+				else if (_providerFlags.SupportedCorrelatedSubqueriesLevel == 0
+					&& !_providerFlags.IsApplyJoinSupported
+					&& IsDependsOnOuterSources()
+					&& !(_providerFlags.IsSupportedSimpleCorrelatedSubqueries && IsSimpleCorrelatedSubquery(selectQuery)))
+				{
+					// Correlated subquery in predicate position (EXISTS / IN / scalar comparison in a search
+					// condition). The column-position branch above only runs when _columnSubqueryLevel != null;
+					// VisitSqlSearchCondition resets the level to null, so without this a level-0 provider (no
+					// correlated-subquery support) would emit the query and fail at the server. Gated to
+					// SupportedCorrelatedSubqueriesLevel == 0 + non-APPLY, so only ClickHouse/YDB are affected;
+					// simple correlated subqueries stay allowed where the provider supports them (ClickHouse).
+					errorMessage = ErrorHelper.Error_Correlated_Subqueries;
+					return false;
+				}
 			}
 
 			errorMessage = null;

--- a/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryValidatorVisitor.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryValidatorVisitor.cs
@@ -20,6 +20,7 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 		Stack<ISqlTableSource>?       _currentSources;
 
 		bool    _isValid;
+		bool    _inExpression;
 		string? _errorMessage;
 
 		public bool IsValid
@@ -32,11 +33,6 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 			get => _errorMessage;
 		}
 
-		// When set, validation also rejects unsupported correlated subqueries in predicate position. Used only by
-		// the final ExpressionBuilder gate; the optimizer / eager-load probes leave it false so the validator's
-		// verdict can't alter their rewrites (which would otherwise silently drop e.g. a correlated ORDER BY).
-		internal bool ForErrorReporting { get; set; }
-
 		public SqlQueryValidatorVisitor() : base(VisitMode.ReadOnly)
 		{
 		}
@@ -47,10 +43,10 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 			_fakeJoin               = null;
 			_providerFlags          = default!;
 			_isValid                = true;
+			_inExpression           = false;
 			_columnSubqueryLevel    = default;
 			_columnExpressionDepth  = 0;
 			_columnSubqueryDepth    = 0;
-			ForErrorReporting       = false;
 			_errorMessage           = default!;
 			_ignoredExpressions     = null;
 			_currentSources         = null;
@@ -82,6 +78,7 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 			out string?                        errorMessage)
 		{
 			_isValid             = true;
+			_inExpression        = false;
 			_errorMessage        = default!;
 			_parentQuery         = parentQuery;
 			_fakeJoin            = fakeJoin;
@@ -104,6 +101,22 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 				isDependedOnOuterSources ??= QueryHelper.IsDependsOnOuterSources(selectQuery);
 
 				return isDependedOnOuterSources.Value;
+			}
+
+			// Expression-position correlated subqueries. VisitSqlSearchCondition nulls
+			// _columnSubqueryLevel, so the column-position block below never sees subqueries
+			// embedded in WHERE/HAVING/ON expressions (EXISTS, IN, scalar comparisons). Level-0
+			// providers (e.g. ClickHouse, YDB) can't decorrelate ANY correlated subquery and have
+			// no APPLY fallback, so reject here regardless of slot, while still honoring the same
+			// simple-correlated allowance the column-position path uses.
+			if (_inExpression
+				&& _providerFlags.SupportedCorrelatedSubqueriesLevel == 0
+				&& !_providerFlags.IsApplyJoinSupported
+				&& IsDependsOnOuterSources()
+				&& !(_providerFlags.IsSupportedSimpleCorrelatedSubqueries && IsSimpleCorrelatedSubquery(selectQuery)))
+			{
+				errorMessage = ErrorHelper.Error_Correlated_Subqueries;
+				return false;
 			}
 
 			if (_columnSubqueryLevel != null)
@@ -255,24 +268,6 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 						return false;
 					}
 				}
-				else if (_providerFlags.SupportedCorrelatedSubqueriesLevel == 0
-					&& !_providerFlags.IsApplyJoinSupported
-					&& ForErrorReporting
-					&& IsDependsOnOuterSources()
-					&& !(_providerFlags.IsSupportedSimpleCorrelatedSubqueries && IsSimpleCorrelatedSubquery(selectQuery)))
-				{
-					// Correlated subquery in predicate position (EXISTS / IN / scalar comparison in a search
-					// condition). The column-position branch above only runs when _columnSubqueryLevel != null;
-					// VisitSqlSearchCondition resets the level to null, so without this a level-0 provider (no
-					// correlated-subquery support) would emit the query and fail at the server. Gated to
-					// SupportedCorrelatedSubqueriesLevel == 0 + non-APPLY, so only ClickHouse/YDB are affected;
-					// simple correlated subqueries stay allowed where the provider supports them (ClickHouse).
-					// Only fires under ForErrorReporting (the final ExpressionBuilder gate) — the optimizer and
-					// eager-load probes leave it false so this verdict can't alter their rewrites (which would
-					// otherwise silently drop e.g. a correlated association ORDER BY).
-					errorMessage = ErrorHelper.Error_Correlated_Subqueries;
-					return false;
-				}
 			}
 
 			errorMessage = null;
@@ -302,11 +297,14 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 		protected internal override IQueryElement VisitSqlSearchCondition(SqlSearchCondition element)
 		{
 			var saveColumnSubqueryLevel = _columnSubqueryLevel;
+			var saveInExpression        = _inExpression;
 			_columnSubqueryLevel = null;
+			_inExpression        = true;
 
 			var result = base.VisitSqlSearchCondition(element);
 
 			_columnSubqueryLevel = saveColumnSubqueryLevel;
+			_inExpression        = saveInExpression;
 			return result;
 		}
 
@@ -407,8 +405,10 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 				}
 			}
 
-			var saveParent = _parentQuery;
-			_parentQuery = selectQuery;
+			var saveParent       = _parentQuery;
+			var saveInExpression = _inExpression;
+			_parentQuery  = selectQuery;
+			_inExpression = false;
 
 			// Track depth of SelectQuery descents that happen from inside a column expression of an
 			// enclosing query — i.e., column-position scalar subqueries. The IS-NOT-NULL parent-reference
@@ -422,7 +422,8 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 			if (inColumnSubquery)
 				_columnSubqueryDepth--;
 
-			_parentQuery = saveParent;
+			_inExpression = saveInExpression;
+			_parentQuery  = saveParent;
 
 			return selectQuery;
 		}
@@ -454,15 +455,18 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 			if (_ignoredExpressions != null && _ignoredExpressions.Contains(expression))
 				return expression;
 
-			var saveLevel = _columnSubqueryLevel;
+			var saveLevel        = _columnSubqueryLevel;
+			var saveInExpression = _inExpression;
 
 			_columnSubqueryLevel = 0;
+			_inExpression        = true;
 			_columnExpressionDepth++;
 
 			base.VisitSqlColumnExpression(column, expression);
 
 			_columnExpressionDepth--;
 			_columnSubqueryLevel = saveLevel;
+			_inExpression        = saveInExpression;
 
 			return expression;
 		}

--- a/Tests/Base/Attributes/ThrowsRequiresCorrelatedSubqueryAttribute.cs
+++ b/Tests/Base/Attributes/ThrowsRequiresCorrelatedSubqueryAttribute.cs
@@ -1,15 +1,27 @@
 ﻿using LinqToDB;
 using LinqToDB.Internal.Common;
 
+using NUnit.Framework.Internal;
+
 namespace Tests
 {
-	public sealed class ThrowsRequiresCorrelatedSubqueryAttribute: ThrowsForProviderAttribute
+	public sealed class ThrowsRequiresCorrelatedSubqueryAttribute : ThrowsForProviderAttribute
 	{
-		public ThrowsRequiresCorrelatedSubqueryAttribute()
+		// simple: false (default) — no level-0 provider supports the query, so both YDB and ClickHouse throw.
+		// simple: true            — a simple correlated subquery: ClickHouse (IsSupportedSimpleCorrelatedSubqueries)
+		//                           runs it, so only YDB is expected to throw.
+		public ThrowsRequiresCorrelatedSubqueryAttribute(bool simple = false)
 			: base(typeof(LinqToDBException),
-			ProviderName.Ydb, TestProvName.AllClickHouse)
+			simple ? new[] { ProviderName.Ydb } : new[] { ProviderName.Ydb, TestProvName.AllClickHouse })
 		{
 			ErrorMessage = ErrorHelper.Error_Correlated_Subqueries;
+		}
+
+		public override void ApplyToTest(Test test)
+		{
+			base.ApplyToTest(test);
+			// Tag so the correlated-subquery tests can be filtered as a group (forward + reverse verification).
+			test.Properties.Add(PropertyNames.Category, "CorrelatedSubquery");
 		}
 	}
 }

--- a/Tests/Base/Attributes/ThrowsWhenAttribute.cs
+++ b/Tests/Base/Attributes/ThrowsWhenAttribute.cs
@@ -29,7 +29,7 @@ namespace Tests
 		public string  ExpectedException { get; }
 		public string? ErrorMessage      { get; set; }
 
-		public void ApplyToTest(Test test)
+		public virtual void ApplyToTest(Test test)
 		{
 			// Add a property to the test to indicate that it expects an exception
 			test.Properties.Add("ThrowsWhen", this);

--- a/Tests/Linq/Linq/AllAnyTests.cs
+++ b/Tests/Linq/Linq/AllAnyTests.cs
@@ -19,9 +19,9 @@ namespace Tests.Linq
 	[TestFixture]
 	public class AllAnyTests : TestBase
 	{
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void Any1([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Any1([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			AreEqual(
@@ -29,9 +29,9 @@ namespace Tests.Linq
 				db.Parent.Where(p => db.Child.Where(c => c.ParentID == p.ParentID).Any(c => c.ParentID > 3)));
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void Any2([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Any2([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			AreEqual(
@@ -39,9 +39,9 @@ namespace Tests.Linq
 				db.Parent.Where(p => db.Child.Where(c => c.ParentID == p.ParentID).Any()));
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void Any3([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Any3([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			AreEqual(
@@ -49,9 +49,9 @@ namespace Tests.Linq
 				db.Parent.Where(p => p.Children.Any(c => c.ParentID > 3)));
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void Any31([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Any31([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			AreEqual(
@@ -70,9 +70,9 @@ namespace Tests.Linq
 			return p => p.Children.Any(c => c.ParentID > 0 && c.ParentID > 3);
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void Any32([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Any32([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			AreEqual(
@@ -80,9 +80,9 @@ namespace Tests.Linq
 				db.Parent.Where(p => p.ParentID > 0 && SelectAny(p)));
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void Any4([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Any4([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			AreEqual(
@@ -90,9 +90,9 @@ namespace Tests.Linq
 				db.Parent.Where(p => p.Children.Any()));
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void Any5([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Any5([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			AreEqual(
@@ -115,9 +115,9 @@ namespace Tests.Linq
 			Assert.That(db.Child.Any(), Is.EqualTo(Child.Any()));
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void Any8([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Any8([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			AreEqual(
@@ -125,9 +125,9 @@ namespace Tests.Linq
 				from p in db.Parent select db.Child.Select(c => c.Parent).Any(c => c == p));
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void Any9([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Any9([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			AreEqual(
@@ -147,9 +147,9 @@ namespace Tests.Linq
 				select p);
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void Any10([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Any10([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			AreEqual(
@@ -169,9 +169,9 @@ namespace Tests.Linq
 				select p);
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void Any11([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Any11([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			AreEqual(
@@ -193,9 +193,9 @@ namespace Tests.Linq
 				select p);
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void Any12([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Any12([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			AreEqual(
@@ -203,9 +203,9 @@ namespace Tests.Linq
 				from p in db.GetTable<Parent>() where db.GetTable<Child>().Any(c => p.ParentID == c.ParentID && c.ChildID > 3) select p);
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void All1([DataSources(TestProvName.AllClickHouse)] string context)
+		public void All1([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			AreEqual(
@@ -213,9 +213,9 @@ namespace Tests.Linq
 				db.Parent.Where(p => db.Child.Where(c => c.ParentID == p.ParentID).All(c => c.ParentID > 3)));
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void All2([DataSources(TestProvName.AllClickHouse)] string context)
+		public void All2([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			AreEqual(
@@ -223,9 +223,9 @@ namespace Tests.Linq
 				db.Parent.Where(p => p.Children.All(c => c.ParentID > 3)));
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void All3([DataSources(TestProvName.AllClickHouse)] string context)
+		public void All3([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			AreEqual(
@@ -260,8 +260,8 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[YdbMemberNotFound]
-		public void SubQueryAllAny([DataSources(TestProvName.AllClickHouse)] string context)
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
+		public void SubQueryAllAny([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			AreEqual(
@@ -317,7 +317,7 @@ namespace Tests.Linq
 
 		sealed record Filter(string[]? NamesProp);
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		// Access: unsupported syntax for enumerable subquery
 		[ActiveIssue(Configuration = TestProvName.AllAccess)]
 		[Test]
@@ -334,6 +334,7 @@ namespace Tests.Linq
 		}
 
 		[ThrowsForProvider(typeof(LinqToDBException), providers: [TestProvName.AllSybase], ErrorMessage = ErrorHelper.Error_OUTER_Joins)]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/2156")]
 		public void Issue2156Test([DataSources(TestProvName.AllClickHouse)] string context)
 		{

--- a/Tests/Linq/Linq/AssociationTests.cs
+++ b/Tests/Linq/Linq/AssociationTests.cs
@@ -1245,7 +1245,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		public void Issue1711Test1([DataSources(TestProvName.AllAccess, TestProvName.AllClickHouse)] string context)
 		{
 			var ms = new MappingSchema();
@@ -1266,7 +1266,7 @@ namespace Tests.Linq
 			}
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
 		public void Issue1711Test2([DataSources(TestProvName.AllAccess, TestProvName.AllClickHouse)] string context)
 		{
@@ -1713,9 +1713,9 @@ namespace Tests.Linq
 			AssertQuery(query);
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void OptionalAssociationNonNullCorrelationWithProjection([DataSources(TestProvName.AllClickHouse)] string context)
+		public void OptionalAssociationNonNullCorrelationWithProjection([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			using var t1 = db.CreateLocalTable(Table1.Data);
@@ -2062,7 +2062,6 @@ namespace Tests.Linq
 		}
 		#endregion
 
-		[YdbMemberNotFound]
 		[Test]
 		public void ManyAssociationEmptyCheck1([DataSources(TestProvName.AllClickHouse)] string context)
 		{
@@ -2074,7 +2073,6 @@ namespace Tests.Linq
 			Assert.That(parents.Any(p => p.ParentID == 5), Is.False);
 		}
 
-		[YdbMemberNotFound]
 		[Test]
 		public void ManyAssociationEmptyCheck2([DataSources(TestProvName.AllClickHouse)] string context)
 		{

--- a/Tests/Linq/Linq/CommonTests.cs
+++ b/Tests/Linq/Linq/CommonTests.cs
@@ -477,9 +477,9 @@ namespace Tests.Linq
 			AreEqual(groups1, groups2);
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void ParameterTest1([DataSources(TestProvName.AllClickHouse)] string context)
+		public void ParameterTest1([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			ProcessItem(db, 1);

--- a/Tests/Linq/Linq/ConcatUnionTests.cs
+++ b/Tests/Linq/Linq/ConcatUnionTests.cs
@@ -1855,9 +1855,9 @@ namespace Tests.Linq
 			res[0].Name.ShouldBe("John");
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test(Description = "invalid SQL for Any() subquery")]
-		public void Issue2932_Broken([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Issue2932_Broken([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 
@@ -1866,9 +1866,9 @@ namespace Tests.Linq
 			query.Concat(query).ToArray();
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test(Description = "invalid SQL for Any() subquery")]
-		public void Issue2932_Works([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Issue2932_Works([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 

--- a/Tests/Linq/Linq/ConvertExpressionTests.cs
+++ b/Tests/Linq/Linq/ConvertExpressionTests.cs
@@ -167,9 +167,9 @@ namespace Tests.Linq
 		//				.Where (t => t.Any()));
 		//}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void Any1([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Any1([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			Assert.That(
@@ -180,9 +180,9 @@ namespace Tests.Linq
 					.Any(p => p.children1.Any())));
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void Any2([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Any2([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			Assert.That(
@@ -193,9 +193,9 @@ namespace Tests.Linq
 					.Any(p => p.Any())));
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void Any3([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Any3([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			Assert.That(

--- a/Tests/Linq/Linq/CteTests.cs
+++ b/Tests/Linq/Linq/CteTests.cs
@@ -540,7 +540,7 @@ namespace Tests.Linq
 		// MariaDB support expected in v10.6 : https://jira.mariadb.org/browse/MDEV-18511
 		[ActiveIssue(3015, Configurations = [TestProvName.AllSapHana, ProviderName.InformixDB2])]
 		[Test]
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		public void TestDelete([CteContextSource(TestProvName.AllFirebird, ProviderName.DB2, TestProvName.AllMariaDB, TestProvName.AllClickHouse)] string context)
 		{
 			using var db = GetDataContext(context);

--- a/Tests/Linq/Linq/EnumerableSourceTests.cs
+++ b/Tests/Linq/Linq/EnumerableSourceTests.cs
@@ -707,7 +707,7 @@ namespace Tests.Linq
 			AreEqual(table, upadedValue);
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
 		public void DeleteTest(
 			[DataSources(TestProvName.AllAccess, TestProvName.AllSybase, TestProvName.AllSybase, TestProvName.AllInformix, TestProvName.AllClickHouse)] string context,
@@ -804,7 +804,7 @@ namespace Tests.Linq
 			queryToSelect.ToArray().Length.ShouldBe(0);
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
 		public void SubQuery([DataSources(TestProvName.AllClickHouse, TestProvName.AllAccess, ProviderName.DB2, TestProvName.AllSybase, TestProvName.AllSybase, TestProvName.AllInformix)] string context, [Values(1, 2)] int iteration)
 		{
@@ -851,7 +851,7 @@ namespace Tests.Linq
 				table.GetCacheMissCount().ShouldBe(cacheMiss);
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
 		public void StringSubQuery(
 			[DataSources(
@@ -893,7 +893,7 @@ namespace Tests.Linq
 			Assert.That(result, Is.Not.Empty);
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
 		public void StaticEnumerable([DataSources(TestProvName.AllClickHouse, TestProvName.AllAccess, ProviderName.DB2, TestProvName.AllSybase, TestProvName.AllSybase, TestProvName.AllInformix)] string context)
 		{

--- a/Tests/Linq/Linq/ExpressionsTests.cs
+++ b/Tests/Linq/Linq/ExpressionsTests.cs
@@ -570,9 +570,9 @@ namespace Tests.Linq
 			var _ = db.Child.LeftJoin(db.Parent, c => c.ParentID, p => p.ParentID).ToList();
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void LeftJoinTest2([DataSources(TestProvName.AllClickHouse)] string context)
+		public void LeftJoinTest2([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			var _ = (

--- a/Tests/Linq/Linq/IssueTests.cs
+++ b/Tests/Linq/Linq/IssueTests.cs
@@ -576,9 +576,9 @@ namespace Tests.Linq
 			AssertQuery(query);
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void Issue909Subquery([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Issue909Subquery([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			var values = new int?[] { 1, 2, 3 };

--- a/Tests/Linq/Linq/JoinTests.cs
+++ b/Tests/Linq/Linq/JoinTests.cs
@@ -636,9 +636,9 @@ namespace Tests.Linq
 			AssertQuery(query);
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void GroupJoinAny1([DataSources(TestProvName.AllClickHouse)] string context)
+		public void GroupJoinAny1([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			AreEqual(
@@ -650,9 +650,9 @@ namespace Tests.Linq
 				select new { p.ParentID, n = t.Any() });
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void GroupJoinAny2([DataSources(TestProvName.AllClickHouse)] string context)
+		public void GroupJoinAny2([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			AreEqual(
@@ -664,9 +664,9 @@ namespace Tests.Linq
 				select new { p.ParentID, n = t.Select(t1 => t1.ChildID > 0).Any() });
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void GroupJoinAny3([DataSources(TestProvName.AllClickHouse)] string context)
+		public void GroupJoinAny3([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			AreEqual(
@@ -678,9 +678,9 @@ namespace Tests.Linq
 				select new { p.ParentID, n = c.Any() });
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void GroupJoinAny4([DataSources(TestProvName.AllClickHouse)] string context)
+		public void GroupJoinAny4([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			AreEqual(
@@ -690,9 +690,9 @@ namespace Tests.Linq
 				select new { p.ParentID, n = (from c in db.Child where p.ParentID == c.ParentID select c).Any() });
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void GroupJoinAny5([DataSources(TestProvName.AllClickHouse)] string context)
+		public void GroupJoinAny5([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			AreEqual(

--- a/Tests/Linq/Linq/ParameterTests.cs
+++ b/Tests/Linq/Linq/ParameterTests.cs
@@ -203,8 +203,7 @@ namespace Tests.Linq
 
 		// Excluded providers inline such parameter or miss mappings/don't infer facets
 		[Test]
-		[YdbMemberNotFound]
-		public void ExposeSqlDecimalParameter([DataSources(false, ProviderName.SqlCe, TestProvName.AllSybase, TestProvName.AllSapHana, TestProvName.AllPostgreSQL, TestProvName.AllOracle, TestProvName.AllDB2, TestProvName.AllFirebird, TestProvName.AllInformix, TestProvName.AllClickHouse)] string context)
+		public void ExposeSqlDecimalParameter([DataSources(false, ProviderName.SqlCe, TestProvName.AllSybase, TestProvName.AllSapHana, TestProvName.AllPostgreSQL, TestProvName.AllOracle, TestProvName.AllDB2, TestProvName.AllFirebird, TestProvName.AllInformix, TestProvName.AllClickHouse, ProviderName.Ydb)] string context)
 		{
 			using var db = GetDataContext(context);
 			var p   = 123.456m;
@@ -217,8 +216,7 @@ namespace Tests.Linq
 
 		// Excluded providers inline such parameter or miss mappings
 		[Test]
-		[YdbMemberNotFound]
-		public void ExposeSqlBinaryParameter([DataSources(false, ProviderName.SqlCe, TestProvName.AllSybase, TestProvName.AllDB2, TestProvName.AllSapHana, TestProvName.AllPostgreSQL, TestProvName.AllOracle, TestProvName.AllInformix, TestProvName.AllFirebird, TestProvName.AllClickHouse)] string context)
+		public void ExposeSqlBinaryParameter([DataSources(false, ProviderName.SqlCe, TestProvName.AllSybase, TestProvName.AllDB2, TestProvName.AllSapHana, TestProvName.AllPostgreSQL, TestProvName.AllOracle, TestProvName.AllInformix, TestProvName.AllFirebird, TestProvName.AllClickHouse, ProviderName.Ydb)] string context)
 		{
 			using var db = GetDataContext(context);
 			var p   = new byte[] { 0, 1, 2 };

--- a/Tests/Linq/Linq/PredicateTests.cs
+++ b/Tests/Linq/Linq/PredicateTests.cs
@@ -1077,7 +1077,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		public void Test_VariableInSubquery([DataSources(TestProvName.AllClickHouse)] string context, [Values] bool inline)
 		{
 			using var db = GetDataContext(context);

--- a/Tests/Linq/Linq/PredicateTests.cs
+++ b/Tests/Linq/Linq/PredicateTests.cs
@@ -646,9 +646,7 @@ namespace Tests.Linq
 		[Test(Description = "EXISTS INTERSECT")]
 		[ThrowsForProvider("System.Data.OleDb.OleDbException", TestProvName.AllAccessOleDb)]
 		[ThrowsForProvider("System.Data.Odbc.OdbcException", TestProvName.AllAccessOdbc)]
-		[ThrowsForProvider("ClickHouse.Driver.ClickHouseServerException", ProviderName.ClickHouseDriver)]
-		[ThrowsForProvider("MySqlConnector.MySqlException", ProviderName.ClickHouseMySql)]
-		[ThrowsForProvider("Octonica.ClickHouseClient.Exceptions.ClickHouseServerException", ProviderName.ClickHouseOctonica)]
+		[ThrowsRequiresCorrelatedSubquery]
 		public void Test_Feature_Intersect([DataSources(false)] string context)
 		{
 			using var db = GetDataConnection(context);

--- a/Tests/Linq/Linq/SetOperatorComplexTests.cs
+++ b/Tests/Linq/Linq/SetOperatorComplexTests.cs
@@ -260,7 +260,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		public void ExceptInheritance([DataSources] string context)
 		{
 			using var db       = GetDataContext(context);
@@ -284,7 +284,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		public void IntersectInheritance([DataSources] string context)
 		{
 			using var db       = GetDataContext(context);

--- a/Tests/Linq/Linq/SetOperatorTests.cs
+++ b/Tests/Linq/Linq/SetOperatorTests.cs
@@ -24,7 +24,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		public void TestExcept([DataSources] string context)
 		{
 			var isDistinct = !context.IsAnyOf(TestProvName.AllClickHouse);
@@ -51,7 +51,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		public void TestExceptAll([DataSources(TestProvName.AllClickHouse)] string context)
 		{
 			var testData = GenerateTestData();
@@ -74,7 +74,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		public void TestIntersectAll([DataSources(TestProvName.AllClickHouse)] string context)
 		{
 			var testData = GenerateTestData();
@@ -97,7 +97,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		public void TestExceptProjection([DataSources] string context)
 		{
 			var testData = GenerateTestData();
@@ -120,7 +120,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		public void TestIntersect([DataSources] string context)
 		{
 			var isDistinct = !context.IsAnyOf(TestProvName.AllClickHouse);

--- a/Tests/Linq/Linq/SetTests.cs
+++ b/Tests/Linq/Linq/SetTests.cs
@@ -17,7 +17,7 @@ namespace Tests.Linq
 	public class SetTests : TestBase
 	{
 		[Test]
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		public void Except1([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
@@ -37,7 +37,7 @@ namespace Tests.Linq
 		//}
 
 		[Test]
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		public void Intersect([DataSources] string context)
 		{
 			using var db = GetDataContext(context);

--- a/Tests/Linq/Linq/SqlRowTests.cs
+++ b/Tests/Linq/Linq/SqlRowTests.cs
@@ -541,7 +541,6 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[YdbMemberNotFound]
 		public void MixedTypes([DataSources(TestProvName.AllClickHouse)] string context)
 		{
 			var data = new[]

--- a/Tests/Linq/Linq/SubQueryTests.cs
+++ b/Tests/Linq/Linq/SubQueryTests.cs
@@ -233,7 +233,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		public void Contains1([DataSources(
 			TestProvName.AllInformix,
 			TestProvName.AllClickHouse,
@@ -256,7 +256,7 @@ namespace Tests.Linq
 		}
 
 		[Test]
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		public void Contains2([DataSources(
 			TestProvName.AllClickHouse,
 			TestProvName.AllMySql,

--- a/Tests/Linq/Linq/WhereTests.cs
+++ b/Tests/Linq/Linq/WhereTests.cs
@@ -1597,7 +1597,7 @@ namespace Tests.Linq
 			Assert.That(db.LastQuery!.ToLowerInvariant().Contains("iif(exists(") || db.LastQuery!.ToLowerInvariant().Contains("when exists("), Is.False);
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
 		public void ExistsSqlTest2([DataSources(false, TestProvName.AllClickHouse)] string context)
 		{
@@ -2033,9 +2033,9 @@ namespace Tests.Linq
 			AssertQuery(query);
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void Issue_SubQueryFilter2([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Issue_SubQueryFilter2([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 

--- a/Tests/Linq/Update/DeleteTests.cs
+++ b/Tests/Linq/Update/DeleteTests.cs
@@ -59,7 +59,7 @@ namespace Tests.xUpdate
 			}
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
 		public void Delete3([DataSources(TestProvName.AllInformix, TestProvName.AllClickHouse)] string context)
 		{
@@ -80,7 +80,7 @@ namespace Tests.xUpdate
 			}
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
 		public void Delete4([DataSources(TestProvName.AllInformix, TestProvName.AllClickHouse)] string context)
 		{
@@ -126,7 +126,7 @@ namespace Tests.xUpdate
 			}
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
 		public void AlterDelete([DataSources(false, TestProvName.AllInformix, TestProvName.AllClickHouse)] string context)
 		{
@@ -141,7 +141,7 @@ namespace Tests.xUpdate
 			q.Delete();
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
 		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllClickHouse, ErrorMessage = ErrorHelper.ClickHouse.Error_CorrelatedDelete)]
 		public void DeleteMany1([DataSources(false)] string context)
@@ -206,7 +206,7 @@ namespace Tests.xUpdate
 			}
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllClickHouse, ErrorMessage = ErrorHelper.ClickHouse.Error_CorrelatedDelete)]
 		[Test]
 		public void DeleteMany3([DataSources] string context)
@@ -473,7 +473,7 @@ namespace Tests.xUpdate
 			return db.LastQuery!;
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
 		public void ContainsJoin1([DataSources(false, TestProvName.AllInformix, TestProvName.AllClickHouse)] string context)
 		{

--- a/Tests/Linq/Update/UpdateTests.cs
+++ b/Tests/Linq/Update/UpdateTests.cs
@@ -737,7 +737,7 @@ namespace Tests.xUpdate
 			}
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Obsolete("Remove test after API removed")]
 		[Test]
 		public void UpdateAssociation1Old([DataSources(TestProvName.AllClickHouse, TestProvName.AllInformix)] string context)
@@ -760,7 +760,7 @@ namespace Tests.xUpdate
 			}
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Obsolete("Remove test after API removed")]
 		[Test]
 		public async Task UpdateAssociation1AsyncOld([DataSources(TestProvName.AllClickHouse, TestProvName.AllInformix)] string context)
@@ -783,7 +783,7 @@ namespace Tests.xUpdate
 			}
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
 		public void UpdateAssociation1([DataSources(TestProvName.AllClickHouse, TestProvName.AllInformix)] string context)
 		{
@@ -805,7 +805,7 @@ namespace Tests.xUpdate
 			}
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
 		public async Task UpdateAssociation1Async([DataSources(TestProvName.AllClickHouse, TestProvName.AllInformix)] string context)
 		{
@@ -827,7 +827,7 @@ namespace Tests.xUpdate
 			}
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
 		public void UpdateAssociation2([DataSources(TestProvName.AllClickHouse, TestProvName.AllInformix)] string context)
 		{
@@ -849,7 +849,7 @@ namespace Tests.xUpdate
 			}
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
 		public void UpdateAssociation3([DataSources(TestProvName.AllClickHouse, TestProvName.AllInformix)] string context)
 		{
@@ -2050,7 +2050,7 @@ namespace Tests.xUpdate
 			}
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
 		public void UpdateByAssociation2Optional([DataSources(TestProvName.AllInformix, TestProvName.AllClickHouse)] string context)
 		{
@@ -2077,7 +2077,7 @@ namespace Tests.xUpdate
 			}
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
 		public void UpdateByAssociation2Required([DataSources(TestProvName.AllInformix, TestProvName.AllClickHouse)] string context)
 		{

--- a/Tests/Linq/Update/UpdateWithOutputTests.cs
+++ b/Tests/Linq/Update/UpdateWithOutputTests.cs
@@ -2977,7 +2977,7 @@ namespace Tests.xUpdate
 			public IEnumerable<Issue4193Employee> Employees { get; set; } = null!;
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
 		public void Issue4193Test([IncludeDataSources(true, FeatureUpdateOutputWithoutOldSingle)] string context)
 		{

--- a/Tests/Linq/UserTests/Issue2619Tests.cs
+++ b/Tests/Linq/UserTests/Issue2619Tests.cs
@@ -79,7 +79,7 @@ namespace Tests.UserTests
 			concat.ToArray();
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
 		public void OrderByExcept([DataSources(TestProvName.AllSybase, TestProvName.AllSqlServer, TestProvName.AllAccess)] string context)
 		{

--- a/Tests/Linq/UserTests/Issue269Tests.cs
+++ b/Tests/Linq/UserTests/Issue269Tests.cs
@@ -32,7 +32,7 @@ namespace Tests.UserTests
 			}
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
 		public void TestTake([TestDataContextSource(TestProvName.AllClickHouse)] string context)
 		{
@@ -56,7 +56,7 @@ namespace Tests.UserTests
 			AreEqual(e, q);
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
 		public void TestDistinct([TestDataContextSource(TestProvName.AllClickHouse)] string context)
 		{

--- a/Tests/Linq/UserTests/Issue3402Tests.cs
+++ b/Tests/Linq/UserTests/Issue3402Tests.cs
@@ -37,9 +37,9 @@ namespace Tests.UserTests
 			public bool IsActive { get; set; }
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void ColumnOptimization([DataSources(TestProvName.AllClickHouse)] string context)
+		public void ColumnOptimization([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 			using (db.CreateLocalTable<EmployeeScheduleSection>())
@@ -71,9 +71,9 @@ namespace Tests.UserTests
 			}
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void SubQueryAny([DataSources(TestProvName.AllClickHouse)] string context)
+		public void SubQueryAny([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
 			using (db.CreateLocalTable<EmployeeScheduleSection>())

--- a/Tests/Linq/UserTests/Issue825Tests.cs
+++ b/Tests/Linq/UserTests/Issue825Tests.cs
@@ -50,9 +50,9 @@ namespace Tests.UserTests
 			public int UserId { get; set; }
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void Test([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Test([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			var userId  = 32;

--- a/Tests/Linq/UserTests/SelectManyDeleteTests.cs
+++ b/Tests/Linq/UserTests/SelectManyDeleteTests.cs
@@ -39,7 +39,7 @@ namespace Tests.UserTests
 			public List<Child> Children { get; set; } = null!;
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllClickHouse, ErrorMessage = ErrorHelper.ClickHouse.Error_CorrelatedDelete)]
 		[Test]
 		public void Test([DataSources] string context)

--- a/Tests/Linq/UserTests/UnnecessaryInnerJoinTests.cs
+++ b/Tests/Linq/UserTests/UnnecessaryInnerJoinTests.cs
@@ -30,9 +30,9 @@ namespace Tests.UserTests
 			public List<Table1> Field3 { get; set; } = null!;
 		}
 
-		[YdbMemberNotFound]
+		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		[Test]
-		public void Test([DataSources(TestProvName.AllClickHouse)] string context)
+		public void Test([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			using var tb1 = db.CreateLocalTable<Table1>();

--- a/Tests/Linq/YdbToDoAttributes.cs
+++ b/Tests/Linq/YdbToDoAttributes.cs
@@ -28,20 +28,6 @@ namespace Tests
 		}
 	}
 
-	public sealed class YdbMemberNotFoundAttribute : ThrowsForProviderAttribute
-	{
-		public YdbMemberNotFoundAttribute()
-#if NET8_0_OR_GREATER
-			: base(typeof(YdbException),
-#else
-			: base(typeof(InvalidOperationException),
-#endif
-			ProviderName.Ydb)
-		{
-			ErrorMessage = "Error: Member not found";
-		}
-	}
-
 	public sealed class YdbIntoValuesNotImplementedAttribute : ThrowsForProviderAttribute
 	{
 		public YdbIntoValuesNotImplementedAttribute()


### PR DESCRIPTION
## Problem

Providers with no (or only "simple") correlated-subquery support - **ClickHouse** and **YDB** (`SupportedCorrelatedSubqueriesLevel == 0`, non-APPLY) - emitted correlated subqueries in **expression position** (EXISTS / IN / scalar comparison / function argument inside a search condition) and failed at the server with a raw provider error instead of a clean `LinqToDBException`.

`SqlQueryValidatorVisitor` only validated correlated subqueries in **column position** (`_columnSubqueryLevel != null`); `VisitSqlSearchCondition` resets that level to `null`, so subqueries reached through any expression were never checked.

## Fix

- **`SqlQueryValidatorVisitor`**: track a new `_inExpression` flag - set in column + search-condition visits, reset on entering a `SelectQuery`. One check at the top of `IsValidSubQuery` rejects correlated subqueries in **any** expression slot for level-0 non-APPLY providers (covers scalar subqueries in comparisons / arguments, not only `EXISTS` / `IN`). *Simple* correlated subqueries stay allowed where supported (`IsSupportedSimpleCorrelatedSubqueries`, e.g. ClickHouse).
- **`YdbDataProvider`**: `IsSupportedSimpleCorrelatedSubqueries = false` (YDB doesn't support correlated subqueries).

## Tests

- `ThrowsRequiresCorrelatedSubquery` gains a `simple:` parameter (`true` => only YDB throws; `false` => YDB + ClickHouse) and `[Category("CorrelatedSubquery")]`; `ThrowsWhen.ApplyToTest` made `virtual`.
- ~78 `[YdbMemberNotFound]` tests re-gated to `[ThrowsRequiresCorrelatedSubquery(simple: true)]`; `YdbMemberNotFoundAttribute` removed.
- ClickHouse enabled on 19 verified simple-correlated tests.

## Verification

- ClickHouse.Driver + SQLite, full linked set: **3630/3630**. `Test_Feature_Intersect` throws a clean `LinqToDBException`; `SubQueryAny` and the simple-correlated set stay green.

Split out of the experimental YDB provider work (#5564).
