### PR TITLE
LINQPad: fix connection-dialog dropdowns clipped by fixed width

### DIFF
--- a/Source/LinqToDB.LINQPad/UI/Settings/DynamicConnectionTab.xaml
+++ b/Source/LinqToDB.LINQPad/UI/Settings/DynamicConnectionTab.xaml
@@ -18,7 +18,7 @@
 			<StackPanel Margin="5">
 				<DockPanel Margin="0 5 0 0" ToolTip="Select database">
 					<Label>Database Type</Label>
-					<ComboBox Width="380" Margin="10 0 0 0" ItemsSource="{Binding Databases}" SelectedValue="{Binding Database}" HorizontalAlignment="Right">
+					<ComboBox Margin="10 0 0 0" ItemsSource="{Binding Databases}" SelectedValue="{Binding Database}">
 						<ComboBox.ItemTemplate>
 							<DataTemplate>
 								<TextBlock Text="{Binding (main:IDatabaseProvider.Description)}" />
@@ -29,7 +29,7 @@
 
 				<DockPanel Margin="0 5 0 0" ToolTip="Select SQL dialect version or database provider" Visibility="{Binding ProviderVisibility}">
 					<Label>Provider</Label>
-					<ComboBox Width="380" Margin="10 0 0 0" ItemsSource="{Binding Providers}" SelectedValue="{Binding Provider}" DisplayMemberPath="DisplayName" HorizontalAlignment="Right" />
+					<ComboBox Margin="10 0 0 0" ItemsSource="{Binding Providers}" SelectedValue="{Binding Provider}" DisplayMemberPath="DisplayName" />
 				</DockPanel>
 
 				<TextBlock Margin="0 5 0 0" Visibility="{Binding ProviderDownloadUrlVisibility}">You can download provider <Hyperlink NavigateUri="{Binding ProviderDownloadUrl}" RequestNavigate="Url_Click">here</Hyperlink>.</TextBlock>


### PR DESCRIPTION
The Database Type and Provider ComboBoxes in the dynamic-connection tab used a
fixed `Width="380"` with `HorizontalAlignment="Right"` inside a DockPanel. In
LINQPad's connection dialog (narrower than 380 + the label), the right-aligned
fixed-width combo overflowed and its left border was clipped, looking sloppy.

Drop the fixed width and right-alignment so each combo fills the remaining row
width after its label (the standard label-docked-left pattern) — no clipping,
and the two combos size consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
