### PR TITLE
Make non-correlated NOT IN/IN emulation null-safe in the subquery

### DIFF
--- a/Source/LinqToDB/Internal/SqlProvider/SqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/SqlProvider/SqlExpressionConvertVisitor.cs
@@ -1471,13 +1471,25 @@ namespace LinqToDB.Internal.SqlProvider
 			intTestSubQuery.Select.AddNewColumn(new SqlValue(1));
 			intTestSubQuery.Where.SearchCondition.AddIsNull(inSubqueryExpr);
 
+			// The non-null branch tests `testExpr IN (subQuery)`. A NULL row in the subquery makes that IN
+			// return UNKNOWN for a value not otherwise present (SQL three-valued logic), dropping the row —
+			// but LINQ's Contains treats a NULL element as simply non-matching (the null testExpr case is
+			// handled by the branch above). When the subquery column is nullable, filter the NULLs out so the
+			// membership test is a clean TRUE/FALSE. Matters for providers without correlated subqueries,
+			// which can't fall back to NOT EXISTS.
+			var valueSubQuery = inPredicate.SubQuery.CloneQuery();
+			valueSubQuery = WrapIfNeeded(valueSubQuery);
+
+			if (NullabilityContext.CanBeNull(inPredicate.SubQuery.Select.Columns[0].Expression))
+				valueSubQuery.Where.SearchCondition.AddIsNotNull(valueSubQuery.Select.Columns[0].Expression);
+
 			sc.AddAnd(sub => sub
 					.AddIsNull(testExpr)
 					.Add(new SqlPredicate.InSubQuery(new SqlValue(1), false, intTestSubQuery, doNotConvert: true))
 				)
 				.AddAnd(sub => sub
 					.AddIsNotNull(testExpr)
-					.Add(new SqlPredicate.InSubQuery(testExpr, false, inPredicate.SubQuery, doNotConvert: true))
+					.Add(new SqlPredicate.InSubQuery(testExpr, false, valueSubQuery, doNotConvert: true))
 				);
 
 			var result = Optimize(sc.MakeNot(inPredicate.IsNot));


### PR DESCRIPTION
## Problem

`SqlExpressionConvertVisitor.EmulateNullability` builds the `value IN (subquery)` predicate for providers that have **no correlated-subquery support** (`SupportedCorrelatedSubqueriesLevel == 0` — ClickHouse, YDB) and therefore can't fall back to a `NOT EXISTS` form.

Its non-null branch tested `testExpr IN (subQuery)` over the **full** subquery. When the subquery yields a `NULL` row, `value IN (…, NULL)` is **UNKNOWN** for any value not otherwise present (SQL three-valued logic), so the surrounding `NOT IN` drops the row. But LINQ's `Contains` treats a `NULL` element as simply non-matching, so `NOT IN` should keep it.

Example (YDB): `t1 = {1,3,4,5}`, `t2 = {1,2,4,6,NULL}`, `t1.Where(t => t.ID.NotIn(t2.Select(p => p.ID)))` returned **0** rows instead of `{3,5}`.

## Fix

In `EmulateNullability`, the `NULL` *test value* is already handled by the preceding `IS NULL` branch. So in the non-null branch, when the subquery column is nullable, filter the `NULL`s out of the membership subquery (`WHERE <col> IS NOT NULL`) — making the `IN` a clean TRUE/FALSE. Providers with correlated subqueries are unaffected (they use the `NOT EXISTS` path).

## Scope / verification

- Affects only the non-correlated emulation path (ClickHouse, YDB).
- Verified value-correct against YDB (from the experimental YDB provider branch #5564): `Null_NotIn_Null_Test2` and `Null_NotIn_Null_Test1` (direct) now return the LINQ-correct result.
- Core builds clean (net10.0, 0 warnings/errors). Cross-provider behavior to be confirmed by CI (ClickHouse is the level-0 provider present on `master`).

Split out of the experimental YDB provider work (#5564) as a shared-engine fix, to review/CI independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
