### PR TITLE
EF Core: translate many-to-many (skip navigation) associations

### DIFF
--- a/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.ManyToMany.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.ManyToMany.cs
@@ -186,21 +186,32 @@ namespace LinqToDB.EntityFrameworkCore
 		/// Builds an equality predicate matching each principal key member of <paramref name="entityParam"/> against the
 		/// corresponding foreign key column on the join row (accessed via <see cref="Sql.Property{T}"/>). Handles composite keys.
 		/// </summary>
-		private static Expression BuildJoinPredicate(ParameterExpression entityParam, ParameterExpression joinParam, IForeignKey foreignKey)
+		private Expression BuildJoinPredicate(ParameterExpression entityParam, ParameterExpression joinParam, IForeignKey foreignKey)
 		{
 			Expression? predicate = null;
 
 			var principalProperties = foreignKey.PrincipalKey.Properties;
 			var foreignProperties   = foreignKey.Properties;
+			var principalStoreId    = GetStoreObjectIdentifier(foreignKey.PrincipalEntityType);
 
 			for (var i = 0; i < principalProperties.Count; i++)
 			{
 				var principalProperty = principalProperties[i];
 				var foreignProperty   = foreignProperties[i];
 
-				var left = principalProperty.PropertyInfo != null
-					? (Expression)Expression.MakeMemberAccess(entityParam, principalProperty.PropertyInfo)
-					: BuildSqlProperty(entityParam, principalProperty.ClrType, principalProperty.Name);
+				Expression left;
+				if (principalProperty.PropertyInfo != null)
+				{
+					left = Expression.MakeMemberAccess(entityParam, principalProperty.PropertyInfo);
+				}
+				else
+				{
+					// No CLR property (field-mapped key or shadow key): reference the resolved DB column by name.
+					// linq2db can't translate a member access for a private/unmapped backing field, and with no
+					// mapped member Sql.Property uses the supplied name directly as the column.
+					var columnName = principalStoreId != null ? principalProperty.GetColumnName(principalStoreId.Value) : null;
+					left = BuildSqlProperty(entityParam, principalProperty.ClrType, columnName ?? principalProperty.Name);
+				}
 
 				var right = BuildSqlProperty(joinParam, foreignProperty.ClrType, foreignProperty.Name);
 

--- a/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.ManyToMany.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.ManyToMany.cs
@@ -17,7 +17,8 @@ namespace LinqToDB.EntityFrameworkCore
 	// Many-to-many (skip navigation) support: EF Core models many-to-many relationships through a
 	// hidden join entity rather than a regular navigation. This partial builds an association query
 	// expression that joins the target entities through that join table, addressed via the
-	// EfJoinTable<,> marker type (see EfJoinTable.cs).
+	// EfJoinTable<,,> marker type (see EfJoinTable.cs). The third marker type argument is the join
+	// entity's CLR type, which discriminates multiple relationships between the same entity pair.
 	partial class EFCoreMetadataReader
 	{
 		sealed class ManyToManyJoinInfo
@@ -28,7 +29,7 @@ namespace LinqToDB.EntityFrameworkCore
 		}
 
 		/// <summary>
-		/// Resolves EF Core many-to-many join metadata for an <see cref="EfJoinTable{TThis,TOther}"/> marker type.
+		/// Resolves EF Core many-to-many join metadata for an <see cref="EfJoinTable{TThis,TOther,TJoin}"/> marker type.
 		/// Returns <see langword="null"/> when <paramref name="type"/> is not such a marker or no matching skip navigation exists.
 		/// </summary>
 		private ManyToManyJoinInfo? ResolveManyToManyJoin(Type type)
@@ -36,7 +37,7 @@ namespace LinqToDB.EntityFrameworkCore
 			if (_model == null)
 				return null;
 
-			if (!type.IsGenericType || type.GetGenericTypeDefinition() != typeof(EfJoinTable<,>))
+			if (!type.IsGenericType || type.GetGenericTypeDefinition() != typeof(EfJoinTable<,,>))
 				return null;
 
 			return _manyToManyJoins.GetOrAdd(type, static (markerType, model) =>
@@ -44,6 +45,7 @@ namespace LinqToDB.EntityFrameworkCore
 				var args      = markerType.GetGenericArguments();
 				var thisType  = args[0];
 				var otherType = args[1];
+				var joinType  = args[2];
 
 				var entityType = model.FindEntityType(thisType);
 				if (entityType == null)
@@ -52,13 +54,16 @@ namespace LinqToDB.EntityFrameworkCore
 				ISkipNavigation? skipNavigation = null;
 				foreach (var nav in entityType.GetSkipNavigations())
 				{
-					if (nav.TargetEntityType.ClrType == otherType)
-					{
-						if (skipNavigation != null)
-							throw new LinqToDBException($"Multiple many-to-many relationships between '{thisType.Name}' and '{otherType.Name}' are not supported. Use an explicit join entity.");
+					if (nav.TargetEntityType.ClrType != otherType || nav.JoinEntityType.ClrType != joinType)
+						continue;
 
-						skipNavigation = nav;
-					}
+					// Inverse-pair / self-referencing navigations share a single join entity (not ambiguous).
+					// Two *different* join entities with the same CLR type means multiple implicit joins between
+					// the same ordered pair, which the marker cannot disambiguate.
+					if (skipNavigation != null && skipNavigation.JoinEntityType != nav.JoinEntityType)
+						throw new LinqToDBException($"Multiple implicit many-to-many relationships between '{thisType.Name}' and '{otherType.Name}' are not supported. Use an explicit join entity for at least one of them.");
+
+					skipNavigation ??= nav;
 				}
 
 				if (skipNavigation == null)
@@ -139,7 +144,8 @@ namespace LinqToDB.EntityFrameworkCore
 		{
 			var thisType   = entityType.ClrType;
 			var otherType  = skipNavigation.TargetEntityType.ClrType;
-			var markerType = typeof(EfJoinTable<,>).MakeGenericType(thisType, otherType);
+			var joinType   = skipNavigation.JoinEntityType.ClrType;
+			var markerType = typeof(EfJoinTable<,,>).MakeGenericType(thisType, otherType, joinType);
 
 			var thisForeignKey  = skipNavigation.ForeignKey;         // join -> this
 			var otherForeignKey = skipNavigation.Inverse.ForeignKey; // join -> other

--- a/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.ManyToMany.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.ManyToMany.cs
@@ -1,4 +1,4 @@
-#if !EF31
+﻿#if !EF31
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;

--- a/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.ManyToMany.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.ManyToMany.cs
@@ -1,0 +1,220 @@
+#if !EF31
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage;
+
+using LinqToDB.Mapping;
+using LinqToDB.Internal.Mapping;
+using LinqToDB.Internal.Reflection;
+using LinqToDB.EntityFrameworkCore.Internal;
+
+namespace LinqToDB.EntityFrameworkCore
+{
+	// Many-to-many (skip navigation) support: EF Core models many-to-many relationships through a
+	// hidden join entity rather than a regular navigation. This partial builds an association query
+	// expression that joins the target entities through that join table, addressed via the
+	// EfJoinTable<,> marker type (see EfJoinTable.cs).
+	partial class EFCoreMetadataReader
+	{
+		sealed class ManyToManyJoinInfo
+		{
+			public IEntityType JoinEntityType  { get; init; } = null!;
+			public IForeignKey ThisForeignKey  { get; init; } = null!; // join -> this
+			public IForeignKey OtherForeignKey { get; init; } = null!; // join -> other
+		}
+
+		/// <summary>
+		/// Resolves EF Core many-to-many join metadata for an <see cref="EfJoinTable{TThis,TOther}"/> marker type.
+		/// Returns <see langword="null"/> when <paramref name="type"/> is not such a marker or no matching skip navigation exists.
+		/// </summary>
+		private ManyToManyJoinInfo? ResolveManyToManyJoin(Type type)
+		{
+			if (_model == null)
+				return null;
+
+			if (!type.IsGenericType || type.GetGenericTypeDefinition() != typeof(EfJoinTable<,>))
+				return null;
+
+			return _manyToManyJoins.GetOrAdd(type, static (markerType, model) =>
+			{
+				var args      = markerType.GetGenericArguments();
+				var thisType  = args[0];
+				var otherType = args[1];
+
+				var entityType = model.FindEntityType(thisType);
+				if (entityType == null)
+					return null;
+
+				ISkipNavigation? skipNavigation = null;
+				foreach (var nav in entityType.GetSkipNavigations())
+				{
+					if (nav.TargetEntityType.ClrType == otherType)
+					{
+						if (skipNavigation != null)
+							throw new LinqToDBException($"Multiple many-to-many relationships between '{thisType.Name}' and '{otherType.Name}' are not supported. Use an explicit join entity.");
+
+						skipNavigation = nav;
+					}
+				}
+
+				if (skipNavigation == null)
+					return null;
+
+				return new ManyToManyJoinInfo()
+				{
+					JoinEntityType  = skipNavigation.JoinEntityType,
+					ThisForeignKey  = skipNavigation.ForeignKey,
+					OtherForeignKey = skipNavigation.Inverse.ForeignKey,
+				};
+			}, _model);
+		}
+
+		/// <summary>
+		/// Builds a <see cref="ColumnAttribute"/> for a foreign key column of a many-to-many join table,
+		/// exposed on the marker type as a dynamic column.
+		/// </summary>
+		private ColumnAttribute? BuildJoinColumnAttribute(ManyToManyJoinInfo joinInfo, string memberName)
+		{
+			IProperty? prop = null;
+
+			foreach (var p in joinInfo.ThisForeignKey.Properties)
+			{
+				if (string.Equals(p.Name, memberName, StringComparison.Ordinal))
+				{
+					prop = p;
+					break;
+				}
+			}
+
+			if (prop == null)
+			{
+				foreach (var p in joinInfo.OtherForeignKey.Properties)
+				{
+					if (string.Equals(p.Name, memberName, StringComparison.Ordinal))
+					{
+						prop = p;
+						break;
+					}
+				}
+			}
+
+			if (prop == null)
+				return null;
+
+			var storeId  = GetStoreObjectIdentifier(joinInfo.JoinEntityType);
+			var dataType = DataType.Undefined;
+
+			if (prop.GetTypeMapping() is RelationalTypeMapping typeMapping)
+			{
+				if (typeMapping.DbType != null)
+				{
+					dataType = DbTypeToDataType(typeMapping.DbType.Value);
+				}
+				else
+				{
+					var ms = _model != null ? LinqToDBForEFTools.GetMappingSchema(_model, _mappingSource, _valueConverterSelector, null) : MappingSchema.Default;
+					dataType = ms.GetDataType(typeMapping.ClrType).Type.DataType;
+				}
+			}
+
+			return new ColumnAttribute()
+			{
+				Name      = storeId != null ? prop.GetColumnName(storeId.Value) : prop.Name,
+				DataType  = dataType,
+				DbType    = prop.GetColumnType(),
+				CanBeNull = prop.IsNullable,
+			};
+		}
+
+		/// <summary>
+		/// Builds the association query expression for a many-to-many (skip) navigation. The resulting lambda
+		/// <c>(thisRecord, db) =&gt; db.GetTable&lt;join&gt;().Where(j =&gt; j links thisRecord).SelectMany(j =&gt; db.GetTable&lt;TOther&gt;().Where(o =&gt; o linked by j))</c>
+		/// navigates from the source record through the hidden EF join table to the target entities.
+		/// </summary>
+		private LambdaExpression BuildManyToManyQueryExpression(IEntityType entityType, ISkipNavigation skipNavigation)
+		{
+			var thisType   = entityType.ClrType;
+			var otherType  = skipNavigation.TargetEntityType.ClrType;
+			var markerType = typeof(EfJoinTable<,>).MakeGenericType(thisType, otherType);
+
+			var thisForeignKey  = skipNavigation.ForeignKey;         // join -> this
+			var otherForeignKey = skipNavigation.Inverse.ForeignKey; // join -> other
+
+			var thisParam  = Expression.Parameter(thisType,             "t");
+			var dcParam    = Expression.Parameter(typeof(IDataContext), "db");
+			var otherParam = Expression.Parameter(otherType,            "o");
+			var joinParam  = Expression.Parameter(markerType,           "j");
+
+			var joinTable  = Expression.Call(Methods.LinqToDB.GetTable.MakeGenericMethod(markerType), dcParam);
+			var otherTable = Expression.Call(Methods.LinqToDB.GetTable.MakeGenericMethod(otherType),  dcParam);
+
+			// db.GetTable<join>().Where(j => <join row links this record>)
+			var filteredJoin = Expression.Call(
+				Methods.Queryable.Where.MakeGenericMethod(markerType),
+				joinTable,
+				Expression.Quote(Expression.Lambda(BuildJoinPredicate(thisParam, joinParam, thisForeignKey), joinParam)));
+
+			// db.GetTable<TOther>().Where(o => <target record linked by the join row>)
+			var linkedOther = Expression.Call(
+				Methods.Queryable.Where.MakeGenericMethod(otherType),
+				otherTable,
+				Expression.Quote(Expression.Lambda(BuildJoinPredicate(otherParam, joinParam, otherForeignKey), otherParam)));
+
+			// .SelectMany(j => <linked target records>) — flattens the junction join to IQueryable<TOther>
+			var collectionSelectorType = typeof(Func<,>).MakeGenericType(markerType, typeof(IEnumerable<>).MakeGenericType(otherType));
+			var collectionSelector     = Expression.Lambda(collectionSelectorType, linkedOther, joinParam);
+
+			var selectMany = Expression.Call(
+				Methods.Queryable.SelectManySimple.MakeGenericMethod(markerType, otherType),
+				filteredJoin,
+				Expression.Quote(collectionSelector));
+
+			return Expression.Lambda(selectMany, thisParam, dcParam);
+		}
+
+		/// <summary>
+		/// Builds an equality predicate matching each principal key member of <paramref name="entityParam"/> against the
+		/// corresponding foreign key column on the join row (accessed via <see cref="Sql.Property{T}"/>). Handles composite keys.
+		/// </summary>
+		private static Expression BuildJoinPredicate(ParameterExpression entityParam, ParameterExpression joinParam, IForeignKey foreignKey)
+		{
+			Expression? predicate = null;
+
+			var principalProperties = foreignKey.PrincipalKey.Properties;
+			var foreignProperties   = foreignKey.Properties;
+
+			for (var i = 0; i < principalProperties.Count; i++)
+			{
+				var principalProperty = principalProperties[i];
+				var foreignProperty   = foreignProperties[i];
+
+				var left = principalProperty.PropertyInfo != null
+					? (Expression)Expression.MakeMemberAccess(entityParam, principalProperty.PropertyInfo)
+					: BuildSqlProperty(entityParam, principalProperty.ClrType, principalProperty.Name);
+
+				var right = BuildSqlProperty(joinParam, foreignProperty.ClrType, foreignProperty.Name);
+
+				if (left.Type != right.Type)
+					right = Expression.Convert(right, left.Type);
+
+				var equal = Expression.Equal(left, right);
+				predicate = predicate == null ? equal : Expression.AndAlso(predicate, equal);
+			}
+
+			return predicate!;
+		}
+
+		private static Expression BuildSqlProperty(Expression entity, Type columnType, string memberName)
+		{
+			return Expression.Call(
+				Methods.LinqToDB.SqlExt.Property.MakeGenericMethod(columnType),
+				entity,
+				Expression.Constant(memberName));
+		}
+	}
+}
+#endif

--- a/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.cs
@@ -35,6 +35,8 @@ using LinqToDB.SqlQuery;
 using LinqToDB.Expressions;
 using LinqToDB.Internal.Mapping;
 using LinqToDB.Internal.Extensions;
+using LinqToDB.Internal.Reflection;
+using LinqToDB.EntityFrameworkCore.Internal;
 
 using static LinqToDB.DataProvider.SqlServer.SqlFn;
 
@@ -43,7 +45,7 @@ namespace LinqToDB.EntityFrameworkCore
 	/// <summary>
 	/// LINQ To DB metadata reader for EF.Core model.
 	/// </summary>
-	internal sealed class EFCoreMetadataReader : IMetadataReader
+	internal sealed partial class EFCoreMetadataReader : IMetadataReader
 	{
 #if !EF31
 		// renamed in 8.0.0
@@ -61,6 +63,9 @@ namespace LinqToDB.EntityFrameworkCore
 		private readonly IMigrationsAnnotationProvider?                               _annotationProvider;
 #endif
 		private readonly ConcurrentDictionary<MemberInfo, Sql.ExpressionAttribute?>   _calculatedExtensions = new();
+#if !EF31
+		private readonly ConcurrentDictionary<Type, ManyToManyJoinInfo?>             _manyToManyJoins      = new();
+#endif
 #if !EF31
 		private readonly IDiagnosticsLogger<DbLoggerCategory.Query>?                  _logger;
 #endif
@@ -96,6 +101,16 @@ namespace LinqToDB.EntityFrameworkCore
 		public MappingAttribute[] GetAttributes(Type type)
 		{
 			List<MappingAttribute>? result = null;
+
+#if !EF31
+			// Many-to-many join table marker: emit the EF join table mapping.
+			var joinInfo = ResolveManyToManyJoin(type);
+			if (joinInfo != null)
+			{
+				var joinStoreId = GetStoreObjectIdentifier(joinInfo.JoinEntityType);
+				return [new TableAttribute() { Schema = joinStoreId?.Schema, Name = joinStoreId?.Name }];
+			}
+#endif
 
 			var et = _model?.FindEntityType(type);
 			if (et != null)
@@ -260,6 +275,21 @@ namespace LinqToDB.EntityFrameworkCore
 		{
 			if (typeof(Expression).IsSameOrParentOf(type))
 				return [];
+
+#if !EF31
+			// Many-to-many join table marker: expose foreign key columns as dynamic columns.
+			var markerJoinInfo = ResolveManyToManyJoin(type);
+			if (markerJoinInfo != null)
+			{
+				if (memberInfo is DynamicColumnInfo)
+				{
+					var ca = BuildJoinColumnAttribute(markerJoinInfo, memberInfo.Name);
+					return ca != null ? [ca] : [];
+				}
+
+				return [];
+			}
+#endif
 
 			List<MappingAttribute>? result = null;
 			var hasColumn = false;
@@ -456,6 +486,23 @@ namespace LinqToDB.EntityFrameworkCore
 						}
 					}
 				}
+
+#if !EF31
+				// AssociationAttribute for many-to-many (skip) navigations.
+				// EF represents these via a hidden join entity, so we build a query expression
+				// that joins through it (see BuildManyToManyQueryExpression).
+				foreach (var skipNavigation in et.GetSkipNavigations())
+				{
+					if (CompareProperty(skipNavigation.PropertyInfo, memberInfo))
+					{
+						(result ??= new()).Add(new AssociationAttribute()
+						{
+							QueryExpression = BuildManyToManyQueryExpression(et, skipNavigation),
+							CanBeNull       = true,
+						});
+					}
+				}
+#endif
 			}
 
 			if (!hasColumn)
@@ -891,6 +938,22 @@ namespace LinqToDB.EntityFrameworkCore
 
 		public MemberInfo[] GetDynamicColumns(Type type)
 		{
+#if !EF31
+			var joinInfo = ResolveManyToManyJoin(type);
+			if (joinInfo != null)
+			{
+				var columns = new List<MemberInfo>();
+
+				foreach (var p in joinInfo.ThisForeignKey.Properties)
+					columns.Add(new DynamicColumnInfo(type, p.ClrType, p.Name));
+
+				foreach (var p in joinInfo.OtherForeignKey.Properties)
+					columns.Add(new DynamicColumnInfo(type, p.ClrType, p.Name));
+
+				return columns.ToArray();
+			}
+#endif
+
 			return [];
 		}
 

--- a/Source/LinqToDB.EntityFrameworkCore/Internal/EfJoinTable.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/Internal/EfJoinTable.cs
@@ -9,10 +9,10 @@ namespace LinqToDB.EntityFrameworkCore.Internal
 	/// Internal marker entity that represents the hidden join table of an EF Core
 	/// many-to-many (skip navigation) relationship as a queryable LINQ To DB table.
 	/// <para>
-	/// Closing the generic over the two related entity types yields a distinct CLR type
-	/// per relationship. This is required because EF Core's implicit join entity uses a
-	/// single shared CLR type (<see cref="Dictionary{TKey, TValue}"/>) for every
-	/// many-to-many relationship and therefore cannot be addressed by CLR type.
+	/// Closing the generic over the related entity types plus the join entity type yields a
+	/// distinct CLR type per relationship. This is required because EF Core's implicit join
+	/// entity uses a single shared CLR type (<see cref="Dictionary{TKey, TValue}"/>) for every
+	/// implicit many-to-many relationship and therefore cannot be addressed by CLR type alone.
 	/// </para>
 	/// <para>
 	/// Foreign key columns are supplied as dynamic columns by <see cref="EFCoreMetadataReader"/>;
@@ -21,9 +21,16 @@ namespace LinqToDB.EntityFrameworkCore.Internal
 	/// </summary>
 	/// <typeparam name="TThis">Entity type on the declaring side of the navigation.</typeparam>
 	/// <typeparam name="TOther">Entity type on the target side of the navigation.</typeparam>
-	internal sealed class EfJoinTable<TThis, TOther>
+	/// <typeparam name="TJoin">
+	/// CLR type of the EF join entity (<see cref="Dictionary{TKey, TValue}"/> for an implicit join,
+	/// or the join class for an explicit <c>UsingEntity&lt;TJoin&gt;</c>). Acts as a discriminator so
+	/// that multiple distinct relationships between the same <typeparamref name="TThis"/>/<typeparamref name="TOther"/>
+	/// pair (e.g. via different explicit join entities) map to distinct marker types.
+	/// </typeparam>
+	internal sealed class EfJoinTable<TThis, TOther, TJoin>
 		where TThis  : class
 		where TOther : class
+		where TJoin  : class
 	{
 		[DynamicColumnsStore]
 		public IDictionary<string, object> Values { get; set; } = null!;

--- a/Source/LinqToDB.EntityFrameworkCore/Internal/EfJoinTable.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/Internal/EfJoinTable.cs
@@ -1,0 +1,32 @@
+#if !EF31
+using System.Collections.Generic;
+
+using LinqToDB.Mapping;
+
+namespace LinqToDB.EntityFrameworkCore.Internal
+{
+	/// <summary>
+	/// Internal marker entity that represents the hidden join table of an EF Core
+	/// many-to-many (skip navigation) relationship as a queryable LINQ To DB table.
+	/// <para>
+	/// Closing the generic over the two related entity types yields a distinct CLR type
+	/// per relationship. This is required because EF Core's implicit join entity uses a
+	/// single shared CLR type (<see cref="Dictionary{TKey, TValue}"/>) for every
+	/// many-to-many relationship and therefore cannot be addressed by CLR type.
+	/// </para>
+	/// <para>
+	/// Foreign key columns are supplied as dynamic columns by <see cref="EFCoreMetadataReader"/>;
+	/// the type itself declares no mapped members other than the dynamic-columns store.
+	/// </para>
+	/// </summary>
+	/// <typeparam name="TThis">Entity type on the declaring side of the navigation.</typeparam>
+	/// <typeparam name="TOther">Entity type on the target side of the navigation.</typeparam>
+	internal sealed class EfJoinTable<TThis, TOther>
+		where TThis  : class
+		where TOther : class
+	{
+		[DynamicColumnsStore]
+		public IDictionary<string, object> Values { get; set; } = null!;
+	}
+}
+#endif

--- a/Source/LinqToDB.EntityFrameworkCore/Internal/EfJoinTable.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/Internal/EfJoinTable.cs
@@ -1,4 +1,4 @@
-#if !EF31
+﻿#if !EF31
 using System.Collections.Generic;
 
 using LinqToDB.Mapping;

--- a/Tests/EntityFrameworkCore/Models/IssueModel/IssueContextBase.cs
+++ b/Tests/EntityFrameworkCore/Models/IssueModel/IssueContextBase.cs
@@ -71,6 +71,12 @@ namespace LinqToDB.EntityFrameworkCore.Tests.Models.IssueModel
 
 		public DbSet<Issue5547CustomerShare>  Issue5547CustomerShares  { get; set; } = null!;
 
+#if !NETFRAMEWORK
+		public DbSet<Issue5585Customer> Issue5585Customers { get; set; } = null!;
+		public DbSet<Issue5585CustomerShare> Issue5585CustomerShares { get; set; } = null!;
+		public DbSet<Issue5585User> Issue5585Users { get; set; } = null!;
+#endif
+
 		protected IssueContextBase(DbContextOptions options) : base(options)
 		{
 		}
@@ -393,6 +399,47 @@ namespace LinqToDB.EntityFrameworkCore.Tests.Models.IssueModel
 					new Issue5547CustomerShare { Id = 2, CustomerId = 2 },
 					new Issue5547CustomerShare { Id = 3, CustomerId = 3 });
 			});
+
+#if !NETFRAMEWORK
+			modelBuilder.Entity<Issue5585Customer>(b =>
+			{
+				b.Property(e => e.Id).ValueGeneratedNever();
+
+				b.HasMany(e => e.CustomerShares)
+					.WithOne(e => e.Customer)
+					.HasForeignKey(e => e.CustomerId);
+
+				b.HasData(
+					new Issue5585Customer { Id = 1, Name = "Alice Smith" },
+					new Issue5585Customer { Id = 2, Name = "Bob Jones"   });
+			});
+
+			modelBuilder.Entity<Issue5585CustomerShare>(b =>
+			{
+				b.Property(e => e.Id).ValueGeneratedNever();
+
+				b.HasMany(e => e.Users)
+					.WithMany(e => e.CustomerShares)
+					.UsingEntity(j => j.HasData(
+						new { CustomerSharesId = 1, UsersId = 1 },
+						new { CustomerSharesId = 2, UsersId = 1 },
+						new { CustomerSharesId = 3, UsersId = 2 }));
+
+				b.HasData(
+					new Issue5585CustomerShare { Id = 1, CustomerId = 1 },
+					new Issue5585CustomerShare { Id = 2, CustomerId = 1 },
+					new Issue5585CustomerShare { Id = 3, CustomerId = 2 });
+			});
+
+			modelBuilder.Entity<Issue5585User>(b =>
+			{
+				b.Property(e => e.Id).ValueGeneratedNever();
+
+				b.HasData(
+					new Issue5585User { Id = 1, Email = "user@mail.com"  },
+					new Issue5585User { Id = 2, Email = "other@mail.com" });
+			});
+#endif
 		}
 	}
 }

--- a/Tests/EntityFrameworkCore/Models/IssueModel/IssueEntities.cs
+++ b/Tests/EntityFrameworkCore/Models/IssueModel/IssueEntities.cs
@@ -462,6 +462,36 @@ namespace LinqToDB.EntityFrameworkCore.Tests.Models.IssueModel
 
 	#endregion
 
+	#region Issue 5585
+
+	public abstract class Issue5585CustomerBase
+	{
+		public int Id { get; set; }
+		public ICollection<Issue5585CustomerShare> CustomerShares { get; set; } = null!;
+	}
+
+	public sealed class Issue5585Customer : Issue5585CustomerBase
+	{
+		public string Name { get; set; } = null!;
+	}
+
+	public sealed class Issue5585CustomerShare
+	{
+		public int Id { get; set; }
+		public int CustomerId { get; set; }
+		public Issue5585Customer Customer { get; set; } = null!;
+		public ICollection<Issue5585User> Users { get; set; } = null!;
+	}
+
+	public sealed class Issue5585User
+	{
+		public int Id { get; set; }
+		public string Email { get; set; } = null!;
+		public ICollection<Issue5585CustomerShare> CustomerShares { get; set; } = null!;
+	}
+
+	#endregion
+
 	#region Issue 5388
 
 	public class Issue5388Task

--- a/Tests/EntityFrameworkCore/Models/ManyToMany/ManyToManyContextBase.cs
+++ b/Tests/EntityFrameworkCore/Models/ManyToMany/ManyToManyContextBase.cs
@@ -1,0 +1,180 @@
+#if !NETFRAMEWORK
+using Microsoft.EntityFrameworkCore;
+
+namespace LinqToDB.EntityFrameworkCore.Tests.Models.ManyToMany
+{
+	public abstract class ManyToManyContextBase : DbContext
+	{
+		public DbSet<MmStudent> Students { get; set; } = null!;
+		public DbSet<MmCourse>  Courses  { get; set; } = null!;
+
+		public DbSet<MmOrder>   Orders   { get; set; } = null!;
+		public DbSet<MmProduct> Products { get; set; } = null!;
+
+		public DbSet<MmProject> Projects { get; set; } = null!;
+		public DbSet<MmMember>  Members  { get; set; } = null!;
+
+		public DbSet<MmPerson>  People   { get; set; } = null!;
+
+		public DbSet<MmUser>    Users    { get; set; } = null!;
+		public DbSet<MmTeam>    Teams    { get; set; } = null!;
+
+		public DbSet<MmDoc>     Docs     { get; set; } = null!;
+		public DbSet<MmLabel>   Labels   { get; set; } = null!;
+
+		protected ManyToManyContextBase(DbContextOptions options) : base(options)
+		{
+		}
+
+		protected override void OnModelCreating(ModelBuilder modelBuilder)
+		{
+			// 1. Implicit many-to-many, single-column keys.
+			modelBuilder.Entity<MmStudent>(b =>
+			{
+				b.Property(e => e.Id).ValueGeneratedNever();
+
+				b.HasMany(s => s.Courses).WithMany(c => c.Students)
+					.UsingEntity(j => j.HasData(
+						new { CoursesId = 1, StudentsId = 1 },
+						new { CoursesId = 2, StudentsId = 1 },
+						new { CoursesId = 2, StudentsId = 2 }));
+
+				b.HasData(
+					new MmStudent { Id = 1, Name = "Alice" },
+					new MmStudent { Id = 2, Name = "Bob"   },
+					new MmStudent { Id = 3, Name = "Carol" });
+			});
+			modelBuilder.Entity<MmCourse>(b =>
+			{
+				b.Property(e => e.Id).ValueGeneratedNever();
+				b.HasData(
+					new MmCourse { Id = 1, Title = "Math"    },
+					new MmCourse { Id = 2, Title = "Physics" },
+					new MmCourse { Id = 3, Title = "History" });
+			});
+
+			// 2. Explicit join entity with payload.
+			modelBuilder.Entity<MmOrder>(b =>
+			{
+				b.Property(e => e.Id).ValueGeneratedNever();
+
+				b.HasMany(o => o.Products).WithMany(p => p.Orders)
+					.UsingEntity<MmOrderProduct>(
+						r => r.HasOne(op => op.Product).WithMany().HasForeignKey(op => op.ProductId),
+						l => l.HasOne(op => op.Order).WithMany().HasForeignKey(op => op.OrderId),
+						j => j.HasData(
+							new MmOrderProduct { OrderId = 1, ProductId = 1, Qty = 2 },
+							new MmOrderProduct { OrderId = 1, ProductId = 2, Qty = 1 },
+							new MmOrderProduct { OrderId = 2, ProductId = 3, Qty = 5 }));
+
+				b.HasData(
+					new MmOrder { Id = 1, Number = "O-1" },
+					new MmOrder { Id = 2, Number = "O-2" });
+			});
+			modelBuilder.Entity<MmProduct>(b =>
+			{
+				b.Property(e => e.Id).ValueGeneratedNever();
+				b.HasData(
+					new MmProduct { Id = 1, Name = "Apple"  },
+					new MmProduct { Id = 2, Name = "Banana" },
+					new MmProduct { Id = 3, Name = "Cherry" });
+			});
+
+			// 3. Composite-key many-to-many via an explicit join entity.
+			modelBuilder.Entity<MmProject>(b =>
+			{
+				b.HasKey(p => new { p.OrgId, p.Code });
+				b.Property(e => e.OrgId).ValueGeneratedNever();
+				b.Property(e => e.Code).ValueGeneratedNever();
+
+				b.HasMany(p => p.Members).WithMany(m => m.Projects)
+					.UsingEntity<MmProjectMember>(
+						r => r.HasOne(pm => pm.Member).WithMany().HasForeignKey(pm => pm.MemberId),
+						l => l.HasOne(pm => pm.Project).WithMany().HasForeignKey(pm => new { pm.OrgId, pm.Code }),
+						j => j.HasData(
+							new MmProjectMember { OrgId = 1, Code = 10, MemberId = 1 },
+							new MmProjectMember { OrgId = 1, Code = 20, MemberId = 1 },
+							new MmProjectMember { OrgId = 1, Code = 20, MemberId = 2 }));
+
+				b.HasData(
+					new MmProject { OrgId = 1, Code = 10, Name = "Alpha" },
+					new MmProject { OrgId = 1, Code = 20, Name = "Beta"  });
+			});
+			modelBuilder.Entity<MmMember>(b =>
+			{
+				b.Property(e => e.Id).ValueGeneratedNever();
+				b.HasData(
+					new MmMember { Id = 1, Name = "Dan" },
+					new MmMember { Id = 2, Name = "Eve" });
+			});
+
+			// 4. Self-referencing many-to-many via an explicit join entity.
+			modelBuilder.Entity<MmPerson>(b =>
+			{
+				b.Property(e => e.Id).ValueGeneratedNever();
+
+				b.HasMany(p => p.Friends).WithMany(p => p.FriendsOf)
+					.UsingEntity<MmFriendship>(
+						r => r.HasOne(f => f.Friend).WithMany().HasForeignKey(f => f.FriendId),
+						l => l.HasOne(f => f.Person).WithMany().HasForeignKey(f => f.PersonId),
+						j => j.HasData(
+							new MmFriendship { PersonId = 1, FriendId = 2 },
+							new MmFriendship { PersonId = 1, FriendId = 3 },
+							new MmFriendship { PersonId = 2, FriendId = 3 }));
+
+				b.HasData(
+					new MmPerson { Id = 1, Name = "Alice" },
+					new MmPerson { Id = 2, Name = "Bob"   },
+					new MmPerson { Id = 3, Name = "Carol" });
+			});
+
+			// 5. Two distinct many-to-many relationships between the same entity pair (explicit joins).
+			modelBuilder.Entity<MmUser>(b =>
+			{
+				b.Property(e => e.Id).ValueGeneratedNever();
+
+				b.HasMany(u => u.Teams).WithMany(t => t.Members)
+					.UsingEntity<MmMembership>(
+						r  => r.HasOne<MmTeam>().WithMany().HasForeignKey(x => x.TeamId),
+						lb => lb.HasOne<MmUser>().WithMany().HasForeignKey(x => x.UserId),
+						j  => j.HasData(
+							new MmMembership { UserId = 1, TeamId = 1 },
+							new MmMembership { UserId = 2, TeamId = 2 }));
+
+				b.HasMany(u => u.LedTeams).WithMany(t => t.Leaders)
+					.UsingEntity<MmLeadership>(
+						r  => r.HasOne<MmTeam>().WithMany().HasForeignKey(x => x.TeamId),
+						lb => lb.HasOne<MmUser>().WithMany().HasForeignKey(x => x.UserId),
+						j  => j.HasData(
+							new MmLeadership { UserId = 2, TeamId = 1 },
+							new MmLeadership { UserId = 1, TeamId = 2 }));
+
+				b.HasData(
+					new MmUser { Id = 1, Name = "Alice" },
+					new MmUser { Id = 2, Name = "Bob"   });
+			});
+			modelBuilder.Entity<MmTeam>(b =>
+			{
+				b.Property(e => e.Id).ValueGeneratedNever();
+				b.HasData(
+					new MmTeam { Id = 1, Name = "Team1" },
+					new MmTeam { Id = 2, Name = "Team2" });
+			});
+
+			// 6. Two implicit many-to-many relationships between the same entity pair (unsupported -> clear error).
+			modelBuilder.Entity<MmDoc>(b =>
+			{
+				b.Property(e => e.Id).ValueGeneratedNever();
+				b.HasMany(d => d.PrimaryLabels).WithMany(l => l.PrimaryDocs);
+				b.HasMany(d => d.SecondaryLabels).WithMany(l => l.SecondaryDocs);
+				b.HasData(new MmDoc { Id = 1, Title = "Doc1" });
+			});
+			modelBuilder.Entity<MmLabel>(b =>
+			{
+				b.Property(e => e.Id).ValueGeneratedNever();
+				b.HasData(new MmLabel { Id = 1, Name = "L1" });
+			});
+		}
+	}
+}
+#endif

--- a/Tests/EntityFrameworkCore/Models/ManyToMany/ManyToManyContextBase.cs
+++ b/Tests/EntityFrameworkCore/Models/ManyToMany/ManyToManyContextBase.cs
@@ -22,6 +22,12 @@ namespace LinqToDB.EntityFrameworkCore.Tests.Models.ManyToMany
 		public DbSet<MmDoc>     Docs     { get; set; } = null!;
 		public DbSet<MmLabel>   Labels   { get; set; } = null!;
 
+		public DbSet<MmAccount> Accounts { get; set; } = null!;
+		public DbSet<MmRole>    Roles    { get; set; } = null!;
+
+		public DbSet<MmArticle> Articles { get; set; } = null!;
+		public DbSet<MmTag>     Tags     { get; set; } = null!;
+
 		protected ManyToManyContextBase(DbContextOptions options) : base(options)
 		{
 		}
@@ -173,6 +179,52 @@ namespace LinqToDB.EntityFrameworkCore.Tests.Models.ManyToMany
 			{
 				b.Property(e => e.Id).ValueGeneratedNever();
 				b.HasData(new MmLabel { Id = 1, Name = "L1" });
+			});
+
+			// 7. Key mapped to a field (no CLR property), with a renamed column.
+			modelBuilder.Entity<MmAccount>(b =>
+			{
+				b.Property<int>("AccountId").ValueGeneratedNever().HasColumnName("account_id_col");
+				b.HasKey("AccountId");
+
+				b.HasMany(a => a.Roles).WithMany(r => r.Accounts)
+					.UsingEntity(j => j.HasData(
+						new { AccountsAccountId = 1, RolesId = 1 },
+						new { AccountsAccountId = 2, RolesId = 2 }));
+
+				b.HasData(
+					new { AccountId = 1, Name = "Acc1" },
+					new { AccountId = 2, Name = "Acc2" });
+			});
+			modelBuilder.Entity<MmRole>(b =>
+			{
+				b.Property(e => e.Id).ValueGeneratedNever();
+				b.HasData(
+					new MmRole { Id = 1, Name = "Admin" },
+					new MmRole { Id = 2, Name = "User"  });
+			});
+
+			// 8. Shadow primary key (no CLR member), with a renamed column.
+			modelBuilder.Entity<MmArticle>(b =>
+			{
+				b.Property(e => e.Id).ValueGeneratedNever();
+
+				b.HasMany(a => a.Tags).WithMany(t => t.Articles)
+					.UsingEntity(j => j.HasData(
+						new { ArticlesId = 1, TagsTagId = 1 },
+						new { ArticlesId = 2, TagsTagId = 2 }));
+
+				b.HasData(
+					new MmArticle { Id = 1, Title = "Art1" },
+					new MmArticle { Id = 2, Title = "Art2" });
+			});
+			modelBuilder.Entity<MmTag>(b =>
+			{
+				b.Property<int>("TagId").ValueGeneratedNever().HasColumnName("tag_id_col");
+				b.HasKey("TagId");
+				b.HasData(
+					new { TagId = 1, Label = "news" },
+					new { TagId = 2, Label = "tech" });
 			});
 		}
 	}

--- a/Tests/EntityFrameworkCore/Models/ManyToMany/ManyToManyContextBase.cs
+++ b/Tests/EntityFrameworkCore/Models/ManyToMany/ManyToManyContextBase.cs
@@ -1,4 +1,4 @@
-#if !NETFRAMEWORK
+﻿#if !NETFRAMEWORK
 using Microsoft.EntityFrameworkCore;
 
 namespace LinqToDB.EntityFrameworkCore.Tests.Models.ManyToMany

--- a/Tests/EntityFrameworkCore/Models/ManyToMany/ManyToManyEntities.cs
+++ b/Tests/EntityFrameworkCore/Models/ManyToMany/ManyToManyEntities.cs
@@ -1,4 +1,4 @@
-#if !NETFRAMEWORK
+﻿#if !NETFRAMEWORK
 using System.Collections.Generic;
 
 namespace LinqToDB.EntityFrameworkCore.Tests.Models.ManyToMany

--- a/Tests/EntityFrameworkCore/Models/ManyToMany/ManyToManyEntities.cs
+++ b/Tests/EntityFrameworkCore/Models/ManyToMany/ManyToManyEntities.cs
@@ -1,0 +1,133 @@
+#if !NETFRAMEWORK
+using System.Collections.Generic;
+
+namespace LinqToDB.EntityFrameworkCore.Tests.Models.ManyToMany
+{
+	// 1. Implicit many-to-many, single-column keys.
+	public class MmStudent
+	{
+		public int                   Id      { get; set; }
+		public string                Name    { get; set; } = null!;
+		public ICollection<MmCourse> Courses { get; set; } = null!;
+	}
+
+	public class MmCourse
+	{
+		public int                    Id       { get; set; }
+		public string                 Title    { get; set; } = null!;
+		public ICollection<MmStudent> Students { get; set; } = null!;
+	}
+
+	// 2. Explicit join entity with payload.
+	public class MmOrder
+	{
+		public int                    Id       { get; set; }
+		public string                 Number   { get; set; } = null!;
+		public ICollection<MmProduct> Products { get; set; } = null!;
+	}
+
+	public class MmProduct
+	{
+		public int                  Id     { get; set; }
+		public string               Name   { get; set; } = null!;
+		public ICollection<MmOrder> Orders { get; set; } = null!;
+	}
+
+	public class MmOrderProduct
+	{
+		public int       OrderId   { get; set; }
+		public int       ProductId { get; set; }
+		public int       Qty       { get; set; }
+		public MmOrder   Order     { get; set; } = null!;
+		public MmProduct Product   { get; set; } = null!;
+	}
+
+	// 3. Composite-key many-to-many via an explicit join entity.
+	public class MmProject
+	{
+		public int                   OrgId   { get; set; }
+		public int                   Code    { get; set; }
+		public string                Name    { get; set; } = null!;
+		public ICollection<MmMember> Members { get; set; } = null!;
+	}
+
+	public class MmMember
+	{
+		public int                    Id       { get; set; }
+		public string                 Name     { get; set; } = null!;
+		public ICollection<MmProject> Projects { get; set; } = null!;
+	}
+
+	public class MmProjectMember
+	{
+		public int       OrgId    { get; set; }
+		public int       Code     { get; set; }
+		public int       MemberId { get; set; }
+		public MmProject Project  { get; set; } = null!;
+		public MmMember  Member   { get; set; } = null!;
+	}
+
+	// 4. Self-referencing many-to-many via an explicit join entity.
+	public class MmPerson
+	{
+		public int                   Id        { get; set; }
+		public string                Name      { get; set; } = null!;
+		public ICollection<MmPerson> Friends   { get; set; } = null!;
+		public ICollection<MmPerson> FriendsOf { get; set; } = null!;
+	}
+
+	public class MmFriendship
+	{
+		public int      PersonId { get; set; }
+		public int      FriendId { get; set; }
+		public MmPerson Person   { get; set; } = null!;
+		public MmPerson Friend   { get; set; } = null!;
+	}
+
+	// 5. Two distinct many-to-many relationships between the same entity pair (explicit joins).
+	public class MmUser
+	{
+		public int                 Id       { get; set; }
+		public string              Name     { get; set; } = null!;
+		public ICollection<MmTeam> Teams    { get; set; } = null!;
+		public ICollection<MmTeam> LedTeams { get; set; } = null!;
+	}
+
+	public class MmTeam
+	{
+		public int                 Id      { get; set; }
+		public string              Name    { get; set; } = null!;
+		public ICollection<MmUser> Members { get; set; } = null!;
+		public ICollection<MmUser> Leaders { get; set; } = null!;
+	}
+
+	public class MmMembership
+	{
+		public int UserId { get; set; }
+		public int TeamId { get; set; }
+	}
+
+	public class MmLeadership
+	{
+		public int UserId { get; set; }
+		public int TeamId { get; set; }
+	}
+
+	// 6. Two implicit many-to-many relationships between the same entity pair (unsupported -> clear error).
+	public class MmDoc
+	{
+		public int                  Id              { get; set; }
+		public string               Title           { get; set; } = null!;
+		public ICollection<MmLabel> PrimaryLabels   { get; set; } = null!;
+		public ICollection<MmLabel> SecondaryLabels { get; set; } = null!;
+	}
+
+	public class MmLabel
+	{
+		public int                Id            { get; set; }
+		public string             Name          { get; set; } = null!;
+		public ICollection<MmDoc> PrimaryDocs   { get; set; } = null!;
+		public ICollection<MmDoc> SecondaryDocs { get; set; } = null!;
+	}
+}
+#endif

--- a/Tests/EntityFrameworkCore/Models/ManyToMany/ManyToManyEntities.cs
+++ b/Tests/EntityFrameworkCore/Models/ManyToMany/ManyToManyEntities.cs
@@ -129,5 +129,37 @@ namespace LinqToDB.EntityFrameworkCore.Tests.Models.ManyToMany
 		public ICollection<MmDoc> PrimaryDocs   { get; set; } = null!;
 		public ICollection<MmDoc> SecondaryDocs { get; set; } = null!;
 	}
+
+	// 7. Key mapped to a private field with no CLR property (field name must match the EF property name),
+	//    with a renamed column.
+	public class MmAccount
+	{
+#pragma warning disable CS0169, CS0649 // assigned by EF via the field-mapped "AccountId" key
+		private int                AccountId;
+#pragma warning restore CS0169, CS0649
+		public string              Name  { get; set; } = null!;
+		public ICollection<MmRole> Roles { get; set; } = null!;
+	}
+
+	public class MmRole
+	{
+		public int                    Id       { get; set; }
+		public string                 Name     { get; set; } = null!;
+		public ICollection<MmAccount> Accounts { get; set; } = null!;
+	}
+
+	// 8. Shadow primary key (no CLR member), with a renamed column.
+	public class MmArticle
+	{
+		public int                Id    { get; set; }
+		public string             Title { get; set; } = null!;
+		public ICollection<MmTag> Tags  { get; set; } = null!;
+	}
+
+	public class MmTag
+	{
+		public string                 Label    { get; set; } = null!;
+		public ICollection<MmArticle> Articles { get; set; } = null!;
+	}
 }
 #endif

--- a/Tests/EntityFrameworkCore/Models/ManyToMany/Pomelo/ManyToManyContext.cs
+++ b/Tests/EntityFrameworkCore/Models/ManyToMany/Pomelo/ManyToManyContext.cs
@@ -1,4 +1,4 @@
-#if !NETFRAMEWORK
+﻿#if !NETFRAMEWORK
 using LinqToDB.EntityFrameworkCore.Tests.Models.ManyToMany;
 
 using Microsoft.EntityFrameworkCore;

--- a/Tests/EntityFrameworkCore/Models/ManyToMany/Pomelo/ManyToManyContext.cs
+++ b/Tests/EntityFrameworkCore/Models/ManyToMany/Pomelo/ManyToManyContext.cs
@@ -1,0 +1,12 @@
+#if !NETFRAMEWORK
+using LinqToDB.EntityFrameworkCore.Tests.Models.ManyToMany;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace LinqToDB.EntityFrameworkCore.Tests.Pomelo.Models.ManyToMany
+{
+	public class ManyToManyContext(DbContextOptions options) : ManyToManyContextBase(options)
+	{
+	}
+}
+#endif

--- a/Tests/EntityFrameworkCore/Models/ManyToMany/PostgreSQL/ManyToManyContext.cs
+++ b/Tests/EntityFrameworkCore/Models/ManyToMany/PostgreSQL/ManyToManyContext.cs
@@ -1,4 +1,4 @@
-#if !NETFRAMEWORK
+﻿#if !NETFRAMEWORK
 using LinqToDB.EntityFrameworkCore.Tests.Models.ManyToMany;
 
 using Microsoft.EntityFrameworkCore;

--- a/Tests/EntityFrameworkCore/Models/ManyToMany/PostgreSQL/ManyToManyContext.cs
+++ b/Tests/EntityFrameworkCore/Models/ManyToMany/PostgreSQL/ManyToManyContext.cs
@@ -1,0 +1,12 @@
+#if !NETFRAMEWORK
+using LinqToDB.EntityFrameworkCore.Tests.Models.ManyToMany;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace LinqToDB.EntityFrameworkCore.Tests.PostgreSQL.Models.ManyToMany
+{
+	public class ManyToManyContext(DbContextOptions options) : ManyToManyContextBase(options)
+	{
+	}
+}
+#endif

--- a/Tests/EntityFrameworkCore/Models/ManyToMany/SQLServer/ManyToManyContext.cs
+++ b/Tests/EntityFrameworkCore/Models/ManyToMany/SQLServer/ManyToManyContext.cs
@@ -1,4 +1,4 @@
-#if !NETFRAMEWORK
+﻿#if !NETFRAMEWORK
 using LinqToDB.EntityFrameworkCore.Tests.Models.ManyToMany;
 
 using Microsoft.EntityFrameworkCore;

--- a/Tests/EntityFrameworkCore/Models/ManyToMany/SQLServer/ManyToManyContext.cs
+++ b/Tests/EntityFrameworkCore/Models/ManyToMany/SQLServer/ManyToManyContext.cs
@@ -1,0 +1,12 @@
+#if !NETFRAMEWORK
+using LinqToDB.EntityFrameworkCore.Tests.Models.ManyToMany;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace LinqToDB.EntityFrameworkCore.Tests.SqlServer.Models.ManyToMany
+{
+	public class ManyToManyContext(DbContextOptions options) : ManyToManyContextBase(options)
+	{
+	}
+}
+#endif

--- a/Tests/EntityFrameworkCore/Models/ManyToMany/SQLite/ManyToManyContext.cs
+++ b/Tests/EntityFrameworkCore/Models/ManyToMany/SQLite/ManyToManyContext.cs
@@ -1,4 +1,4 @@
-#if !NETFRAMEWORK
+﻿#if !NETFRAMEWORK
 using LinqToDB.EntityFrameworkCore.Tests.Models.ManyToMany;
 
 using Microsoft.EntityFrameworkCore;

--- a/Tests/EntityFrameworkCore/Models/ManyToMany/SQLite/ManyToManyContext.cs
+++ b/Tests/EntityFrameworkCore/Models/ManyToMany/SQLite/ManyToManyContext.cs
@@ -1,0 +1,12 @@
+#if !NETFRAMEWORK
+using LinqToDB.EntityFrameworkCore.Tests.Models.ManyToMany;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace LinqToDB.EntityFrameworkCore.Tests.SQLite.Models.ManyToMany
+{
+	public class ManyToManyContext(DbContextOptions options) : ManyToManyContextBase(options)
+	{
+	}
+}
+#endif

--- a/Tests/EntityFrameworkCore/Tests/IssueTests.cs
+++ b/Tests/EntityFrameworkCore/Tests/IssueTests.cs
@@ -1115,6 +1115,36 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 			result.ShouldBe(new[] { 1, 2 });
 		}
 
+#if !NETFRAMEWORK
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5585")]
+		public void Issue5585_ManyToManyDirectAny([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+
+			var query = ctx.Issue5585CustomerShares
+				.Where(s => s.Users.Any(u => u.Email == "user@mail.com"))
+				.OrderBy(s => s.Id)
+				.Select(s => s.Id);
+
+			query.ToList().ShouldBe(new[] { 1, 2 });
+			query.ToLinqToDB().ToList().ShouldBe(new[] { 1, 2 });
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5585")]
+		public void Issue5585_ManyToManyNestedAny([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+
+			var query = ctx.Issue5585Customers
+				.Where(c => c.CustomerShares.Any(s => s.Users.Any(u => u.Email == "user@mail.com")))
+				.OrderBy(c => c.Id)
+				.Select(c => c.Id);
+
+			query.ToList().ShouldBe(new[] { 1 });
+			query.ToLinqToDB().ToList().ShouldBe(new[] { 1 });
+		}
+#endif
+
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/5388")]
 		public void ConstantAndValueConversion([EFDataSources] string provider)
 		{

--- a/Tests/EntityFrameworkCore/Tests/ManyToManyTests.cs
+++ b/Tests/EntityFrameworkCore/Tests/ManyToManyTests.cs
@@ -240,7 +240,66 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 
 		#endregion
 
-		private void AssertLoaded<T>(List<T> ef, List<T> l2db, Func<T, object> key, Func<T, IEnumerable<int>> collection)
+		#region 7. Field-mapped key (renamed column)
+
+		[Test]
+		public void FieldKey_DirectAny([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+			AssertSame(ctx.Accounts.Where(a => a.Roles.Any(r => r.Name == "Admin")).OrderBy(a => a.Name).Select(a => a.Name));
+		}
+
+		[Test]
+		public void FieldKey_Reverse([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+			AssertSame(ctx.Roles.Where(r => r.Accounts.Any(a => a.Name == "Acc1")).OrderBy(r => r.Id).Select(r => r.Id));
+		}
+
+		[Test]
+		public void FieldKey_Include([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+
+			// Eager-load the field-keyed entity (MmAccount) as the association *target* (MmRole has a normal key).
+			// Including a field/shadow-keyed entity as the query *root* is a known limitation: linq2db can't use
+			// such a key as the root entity identity for LoadWith correlation (the reader doesn't expose it as a column).
+			var query = ctx.Roles.Include(r => r.Accounts).OrderBy(r => r.Id);
+
+			AssertLoaded(query.ToList(), query.ToLinqToDB().ToList(), r => r.Id, r => r.Accounts.Select(a => a.Name));
+		}
+
+		#endregion
+
+		#region 8. Shadow key (renamed column)
+
+		[Test]
+		public void ShadowKey_DirectAny([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+			AssertSame(ctx.Articles.Where(a => a.Tags.Any(t => t.Label == "news")).OrderBy(a => a.Id).Select(a => a.Id));
+		}
+
+		[Test]
+		public void ShadowKey_Reverse([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+			AssertSame(ctx.Tags.Where(t => t.Articles.Any(a => a.Title == "Art2")).OrderBy(t => t.Label).Select(t => t.Label));
+		}
+
+		[Test]
+		public void ShadowKey_Include([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+
+			var query = ctx.Articles.Include(a => a.Tags).OrderBy(a => a.Id);
+
+			AssertLoaded(query.ToList(), query.ToLinqToDB().ToList(), a => a.Id, a => a.Tags.Select(t => t.Label));
+		}
+
+		#endregion
+
+		private void AssertLoaded<T, TItem>(List<T> ef, List<T> l2db, Func<T, object> key, Func<T, IEnumerable<TItem>> collection)
 		{
 			Assert.That(l2db, Has.Count.EqualTo(ef.Count));
 

--- a/Tests/EntityFrameworkCore/Tests/ManyToManyTests.cs
+++ b/Tests/EntityFrameworkCore/Tests/ManyToManyTests.cs
@@ -1,4 +1,4 @@
-#if !NETFRAMEWORK
+﻿#if !NETFRAMEWORK
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Tests/EntityFrameworkCore/Tests/ManyToManyTests.cs
+++ b/Tests/EntityFrameworkCore/Tests/ManyToManyTests.cs
@@ -1,0 +1,258 @@
+#if !NETFRAMEWORK
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using LinqToDB.EntityFrameworkCore.Tests.Models.ManyToMany;
+
+using Microsoft.EntityFrameworkCore;
+
+using NUnit.Framework;
+
+using Tests;
+
+namespace LinqToDB.EntityFrameworkCore.Tests
+{
+	[TestFixture]
+	public class ManyToManyTests : ContextTestBase<ManyToManyContextBase>
+	{
+		protected override ManyToManyContextBase CreateProviderContext(string provider, DbContextOptions<ManyToManyContextBase> options)
+		{
+			return provider switch
+			{
+				_ when provider.IsAnyOf(TestProvName.AllPostgreSQL) => new PostgreSQL.Models.ManyToMany.ManyToManyContext(options),
+				_ when provider.IsAnyOf(TestProvName.AllMySql)       => new Pomelo.Models.ManyToMany.ManyToManyContext(options),
+				_ when provider.IsAnyOf(TestProvName.AllSQLite)      => new SQLite.Models.ManyToMany.ManyToManyContext(options),
+				_ when provider.IsAnyOf(TestProvName.AllSqlServer)   => new SqlServer.Models.ManyToMany.ManyToManyContext(options),
+				_ => throw new InvalidOperationException($"{nameof(CreateProviderContext)} is not implemented for provider {provider}")
+			};
+		}
+
+		// Compares the EF Core result against the same query routed through our translator via ToLinqToDB().
+		private void AssertSame<T>(IQueryable<T> query) => AreEqual(query.ToList(), query.ToLinqToDB().ToList());
+
+		#region 1. Implicit single-key
+
+		[Test]
+		public void Implicit_DirectAny([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+			AssertSame(ctx.Students.Where(s => s.Courses.Any(c => c.Title == "Physics")).OrderBy(s => s.Id).Select(s => s.Id));
+		}
+
+		[Test]
+		public void Implicit_AnyNoPredicate([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+			AssertSame(ctx.Students.Where(s => s.Courses.Any()).OrderBy(s => s.Id).Select(s => s.Id));
+		}
+
+		[Test]
+		public void Implicit_ReverseDirection([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+			AssertSame(ctx.Courses.Where(c => c.Students.Any(s => s.Name == "Alice")).OrderBy(c => c.Id).Select(c => c.Id));
+		}
+
+		[Test]
+		public void Implicit_All([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+			AssertSame(ctx.Students.Where(s => s.Courses.All(c => c.Title != "History")).OrderBy(s => s.Id).Select(s => s.Id));
+		}
+
+		[Test]
+		public void Implicit_Count([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+			AssertSame(ctx.Students.OrderBy(s => s.Id).Select(s => s.Courses.Count()));
+		}
+
+		[Test]
+		public void Implicit_SelectMany([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+			AssertSame(ctx.Students.SelectMany(s => s.Courses).Select(c => c.Id));
+		}
+
+		[Test]
+		public void Implicit_Include([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+
+			var query = ctx.Students.Include(s => s.Courses).OrderBy(s => s.Id);
+
+			var ef   = query.ToList();
+			var l2db = query.ToLinqToDB().ToList();
+
+			AssertLoaded(ef, l2db, s => s.Id, s => s.Courses.Select(c => c.Id));
+		}
+
+		#endregion
+
+		#region 2. Explicit join with payload
+
+		[Test]
+		public void Explicit_DirectAny([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+			AssertSame(ctx.Orders.Where(o => o.Products.Any(p => p.Name == "Apple")).OrderBy(o => o.Id).Select(o => o.Id));
+		}
+
+		[Test]
+		public void Explicit_ReverseDirection([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+			AssertSame(ctx.Products.Where(p => p.Orders.Any(o => o.Number == "O-2")).OrderBy(p => p.Id).Select(p => p.Id));
+		}
+
+		[Test]
+		public void Explicit_SelectMany([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+			AssertSame(ctx.Orders.SelectMany(o => o.Products).Select(p => p.Id));
+		}
+
+		[Test]
+		public void Explicit_Include([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+
+			var query = ctx.Orders.Include(o => o.Products).OrderBy(o => o.Id);
+
+			AssertLoaded(query.ToList(), query.ToLinqToDB().ToList(), o => o.Id, o => o.Products.Select(p => p.Id));
+		}
+
+		#endregion
+
+		#region 3. Composite key (explicit join)
+
+		[Test]
+		public void Composite_DirectAny([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+			AssertSame(ctx.Projects.Where(p => p.Members.Any(m => m.Name == "Eve")).OrderBy(p => p.Code).Select(p => p.Code));
+		}
+
+		[Test]
+		public void Composite_ReverseDirection([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+			AssertSame(ctx.Members.Where(m => m.Projects.Any(p => p.Name == "Alpha")).OrderBy(m => m.Id).Select(m => m.Id));
+		}
+
+		[Test]
+		public void Composite_SelectMany([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+			AssertSame(ctx.Projects.SelectMany(p => p.Members).Select(m => m.Id));
+		}
+
+		[Test]
+		public void Composite_Include([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+
+			var query = ctx.Projects.Include(p => p.Members).OrderBy(p => p.Code);
+
+			AssertLoaded(query.ToList(), query.ToLinqToDB().ToList(), p => p.Code, p => p.Members.Select(m => m.Id));
+		}
+
+		#endregion
+
+		#region 4. Self-referencing (explicit join)
+
+		[Test]
+		public void SelfRef_FriendsAny([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+			AssertSame(ctx.People.Where(p => p.Friends.Any(f => f.Name == "Carol")).OrderBy(p => p.Id).Select(p => p.Id));
+		}
+
+		[Test]
+		public void SelfRef_FriendsOfAny([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+			AssertSame(ctx.People.Where(p => p.FriendsOf.Any(f => f.Name == "Alice")).OrderBy(p => p.Id).Select(p => p.Id));
+		}
+
+		[Test]
+		public void SelfRef_SelectMany([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+			AssertSame(ctx.People.SelectMany(p => p.Friends).Select(f => f.Id));
+		}
+
+		[Test]
+		public void SelfRef_Include([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+
+			var query = ctx.People.Include(p => p.Friends).OrderBy(p => p.Id);
+
+			AssertLoaded(query.ToList(), query.ToLinqToDB().ToList(), p => p.Id, p => p.Friends.Select(f => f.Id));
+		}
+
+		#endregion
+
+		#region 5. Multiple distinct relationships between the same pair
+
+		[Test]
+		public void MultiplePair_Members([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+			AssertSame(ctx.Users.Where(u => u.Teams.Any(t => t.Name == "Team1")).OrderBy(u => u.Id).Select(u => u.Id));
+		}
+
+		[Test]
+		public void MultiplePair_Leaders([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+			AssertSame(ctx.Users.Where(u => u.LedTeams.Any(t => t.Name == "Team1")).OrderBy(u => u.Id).Select(u => u.Id));
+		}
+
+		[Test]
+		public void MultiplePair_DistinctResults([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+
+			var members = ctx.Users.Where(u => u.Teams.Any(t => t.Name == "Team1")).Select(u => u.Id).ToLinqToDB().ToList();
+			var leaders = ctx.Users.Where(u => u.LedTeams.Any(t => t.Name == "Team1")).Select(u => u.Id).ToLinqToDB().ToList();
+
+			// The TJoin discriminator must route each navigation to its own join table.
+			Assert.That(members, Is.EqualTo(new[] { 1 }));
+			Assert.That(leaders, Is.EqualTo(new[] { 2 }));
+		}
+
+		#endregion
+
+		#region 6. Multiple implicit relationships between the same pair (unsupported)
+
+		[Test]
+		public void MultipleImplicitPair_Throws([EFDataSources] string provider)
+		{
+			using var ctx = CreateContext(provider);
+
+			var ex = Assert.Catch(() => ctx.Docs.Where(d => d.PrimaryLabels.Any()).ToLinqToDB().ToList());
+
+			Assert.That(ex!.ToString(), Does.Contain("implicit many-to-many"));
+		}
+
+		#endregion
+
+		private void AssertLoaded<T>(List<T> ef, List<T> l2db, Func<T, object> key, Func<T, IEnumerable<int>> collection)
+		{
+			Assert.That(l2db, Has.Count.EqualTo(ef.Count));
+
+			using (Assert.EnterMultipleScope())
+			{
+				for (var i = 0; i < ef.Count; i++)
+				{
+					Assert.That(key(l2db[i]), Is.EqualTo(key(ef[i])));
+					Assert.That(collection(l2db[i]).OrderBy(x => x), Is.EqualTo(collection(ef[i]).OrderBy(x => x)));
+				}
+			}
+		}
+	}
+}
+#endif


### PR DESCRIPTION
Fixes #5585

EF Core models many-to-many through skip navigations backed by a hidden join entity, which `EFCoreMetadataReader` did not map - `share.Users.Any(...)` (and nested forms) failed with "The LINQ expression could not be converted to SQL."

## Changes
- Each skip navigation is mapped to an association whose `QueryExpression` joins the target entities through the EF join table, addressed by an internal `EfJoinTable<TThis, TOther, TJoin>` marker (the implicit join's shared `Dictionary<string, object>` CLR type can't be addressed directly; `TJoin` is the join entity type and discriminates relationships).
- Composite (multi-column) keys handled by the per-column FK predicate loop.
- Self-referencing m2m and multiple distinct m2m between the same entity pair resolve to distinct join tables; multiple *implicit* joins between the same pair throw a clear exception.
- Principal keys with no CLR property (field-mapped or shadow keys) are referenced in the join predicate by their resolved DB column name via `Sql.Property`, rather than member access - a private backing field can't be referenced by member access since linq2db maps only public members.
- All new types/members are `internal` - no public API change.

## Tests
- New `ManyToMany` EF test suite (dedicated context family): implicit, explicit-join-with-payload, composite-key, self-referencing, and multiple-relationship-per-pair models; covers `Any`/`All`/`Count`/`SelectMany`/reverse-direction and `Include` eager loading, all driven from the EF `DbContext` via `ToLinqToDB()`.
- Regression test for the reported nested-`Any` repro.
- Field-mapped-key and shadow-key models (with renamed key columns). Known limitation: a field/shadow-keyed entity used as the query *root* isn't supported for eager loading (the key isn't exposed to linq2db for LoadWith correlation).
- Green on SQLite + SQL Server 2022; EF Core 8/9/10 share the path, EF Core 3.1 unaffected.
