### PR TITLE
Tests: keyless-table corrections + deterministic Issue5549 baseline (follow-up to #5583)

### DIFF
--- a/Tests/Base/TestProvName.cs
+++ b/Tests/Base/TestProvName.cs
@@ -252,6 +252,10 @@ namespace Tests
 		public const string AllDuckDB = ProviderName.DuckDB;
 		#endregion
 
+		#region YDB
+		public const string AllYdb = ProviderName.Ydb;
+		#endregion
+
 		/// <summary>
 		/// Fake provider, which doesn't execute any real queries. Could be used for tests, that shouldn't be affected
 		/// by real database access.

--- a/Tests/Linq/DataProvider/PostgreSQLTests.cs
+++ b/Tests/Linq/DataProvider/PostgreSQLTests.cs
@@ -3096,7 +3096,9 @@ $function$
 
 		static NodaTime.Instant Issue5549Populate(IDataContext db)
 		{
-			var now = NodaTime.SystemClock.Instance.GetCurrentInstant();
+			// Fixed instant (not SystemClock) so the captured baseline SQL is deterministic; the test
+			// only relies on relative arithmetic (now - 7d / 1h / 2h) and row counts.
+			var now = NodaTime.Instant.FromUtc(2020, 1, 1, 0, 0, 0);
 			db.Insert(new Issue5549Table { ClosedAt = null,                               CreatedAt = now });
 			db.Insert(new Issue5549Table { ClosedAt = now - NodaTime.Duration.FromHours(1), CreatedAt = now - NodaTime.Duration.FromHours(2) });
 			return now;

--- a/Tests/Linq/Linq/CharTypesTests.cs
+++ b/Tests/Linq/Linq/CharTypesTests.cs
@@ -10,49 +10,31 @@ namespace Tests.Linq
 	[TestFixture]
 	public class CharTypesTests : TestBase
 	{
-		[Table("ALLTYPES", Configuration = ProviderName.DB2)]
-		[Table("AllTypes")]
+		[Table]
 		public class StringTestTable
 		{
-			[Column("ID")]
+			[Column, PrimaryKey]
 			public int Id;
 
-			[Column("char20DataType")]
-			[Column(Configuration = ProviderName.SqlCe,			 IsColumn = false)]
-			[Column(Configuration = ProviderName.DB2,			 IsColumn = false)]
-			[Column(Configuration = ProviderName.PostgreSQL,	 IsColumn = false)]
-			[Column(Configuration = ProviderName.MySql,			 IsColumn = false)]
+			[Column(DataType = DataType.Char,  Length = 11)]
 			public string? String;
 
-			[Column("ncharDataType")]
-			[Column("nchar20DataType", Configuration = ProviderName.SapHana)]
-			[Column("CHAR20DATATYPE" , Configuration = ProviderName.DB2)]
-			[Column("char20DataType" , Configuration = ProviderName.PostgreSQL)]
-			[Column("char20DataType" , Configuration = ProviderName.MySql)]
-			[Column(                   Configuration = ProviderName.Firebird, IsColumn = false)]
+			[Column(DataType = DataType.NChar, Length = 11)]
+			[Column(Configuration = ProviderName.Firebird, IsColumn = false)]
 			public string? NString;
 		}
 
-		[Table("ALLTYPES", Configuration = ProviderName.DB2)]
-		[Table("AllTypes")]
+		[Table]
 		public class CharTestTable
 		{
-			[Column("ID"), PrimaryKey, Identity]
+			[Column, PrimaryKey]
 			public int Id;
 
-			[Column("char20DataType")]
-			[Column(Configuration = ProviderName.SqlCe,			 IsColumn = false)]
-			[Column(Configuration = ProviderName.DB2,			 IsColumn = false)]
-			[Column(Configuration = ProviderName.PostgreSQL,	 IsColumn = false)]
-			[Column(Configuration = ProviderName.MySql,			 IsColumn = false)]
+			[Column(DataType = DataType.Char,  Length = 2)]
 			public char? Char;
 
-			[Column("ncharDataType"  , DataType = DataType.NChar)]
-			[Column("nchar20DataType", DataType = DataType.NChar, Configuration = ProviderName.SapHana)]
-			[Column("CHAR20DATATYPE" , DataType = DataType.NChar, Configuration = ProviderName.DB2)]
-			[Column("char20DataType" , DataType = DataType.NChar, Configuration = ProviderName.PostgreSQL)]
-			[Column("char20DataType" , DataType = DataType.NChar, Configuration = ProviderName.MySql)]
-			[Column(                   Configuration = ProviderName.Firebird, IsColumn = false)]
+			[Column(DataType = DataType.NChar, Length = 3)]
+			[Column(Configuration = ProviderName.Firebird, IsColumn = false)]
 			public char? NChar;
 		}
 
@@ -88,61 +70,41 @@ namespace Tests.Linq
 		[Test]
 		public void StringTrimming([DataSources(TestProvName.AllInformix, TestProvName.AllClickHouse, TestProvName.AllDuckDB)] string context)
 		{
-			using var db = GetDataContext(context);
-			var lastId = db.GetTable<StringTestTable>().Select(_ => _.Id).Max();
-			var nextId = lastId + 1;
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable<StringTestTable>();
 
-			try
+			var testData = GetStringData(context);
+
+			for (var i = 0; i < testData.Length; i++)
+				db.Insert(new StringTestTable { Id = i + 1, String = testData[i].String, NString = testData[i].NString });
+
+			var records = table.OrderBy(_ => _.Id).ToArray();
+
+			Assert.That(records, Has.Length.EqualTo(testData.Length));
+
+			for (var i = 0; i < records.Length; i++)
 			{
-				var testData = GetStringData(context);
+				if (context.IsAnyOf(TestProvName.AllSybase, TestProvName.AllOracleDevartOCI))
+					Assert.That(records[i].String, Is.EqualTo(testData[i].String?.TrimEnd(' ')?.TrimEnd('\0')));
+				else if (context.IsAnyOf(TestProvName.AllClickHouse))
+					Assert.That(records[i].String, Is.EqualTo(testData[i].String?.TrimEnd('\0')));
+				else if (context.IsAnyOf(TestProvName.AllYdb))
+					// YDB has no fixed-length CHAR: the value round-trips verbatim (no padding, no trailing trim).
+					Assert.That(records[i].String, Is.EqualTo(testData[i].String));
+				else
+					Assert.That(records[i].String, Is.EqualTo(testData[i].String?.TrimEnd(' ')));
 
-				foreach (var record in testData)
+				if (!context.IsAnyOf(TestProvName.AllFirebird))
 				{
-					var query = db.GetTable<StringTestTable>().Value(_ => _.NString, record.NString);
-
-					if (!SkipChar(context))
-						query = query.Value(_ => _.String, record.String);
-
-					if (context.IsAnyOf(TestProvName.AllFirebird))
-						query = db.GetTable<StringTestTable>().Value(_ => _.String, record.String);
-
-					if (context.IsAnyOf(TestProvName.AllClickHouse))
-						query = query.Value(_ => _.Id, nextId++);
-
-					query.Insert();
+					if (context.IsAnyOf(TestProvName.AllSybase, TestProvName.AllOracleDevartOCI))
+						Assert.That(records[i].NString, Is.EqualTo(testData[i].NString?.TrimEnd(' ')?.TrimEnd('\0')));
+					else if (context.IsAnyOf(TestProvName.AllClickHouse))
+						Assert.That(records[i].NString, Is.EqualTo(testData[i].NString?.TrimEnd('\0')));
+					else if (context.IsAnyOf(TestProvName.AllYdb))
+						Assert.That(records[i].NString, Is.EqualTo(testData[i].NString));
+					else
+						Assert.That(records[i].NString, Is.EqualTo(testData[i].NString?.TrimEnd(' ')));
 				}
-
-				var records = db.GetTable<StringTestTable>().Where(_ => _.Id > lastId).OrderBy(_ => _.Id).ToArray();
-
-				Assert.That(records, Has.Length.EqualTo(testData.Length));
-
-				for (var i = 0; i < records.Length; i++)
-				{
-					if (!SkipChar(context))
-					{
-						if (context.IsAnyOf(TestProvName.AllSybase, TestProvName.AllOracleDevartOCI))
-							Assert.That(records[i].String, Is.EqualTo(testData[i].String?.TrimEnd(' ')?.TrimEnd('\0')));
-						else if (context.IsAnyOf(TestProvName.AllClickHouse))
-							Assert.That(records[i].String, Is.EqualTo(testData[i].String?.TrimEnd('\0')));
-						else
-							Assert.That(records[i].String, Is.EqualTo(testData[i].String?.TrimEnd(' ')));
-					}
-
-					if (!context.IsAnyOf(TestProvName.AllFirebird))
-					{
-						if (context.IsAnyOf(TestProvName.AllSybase, TestProvName.AllOracleDevartOCI))
-							Assert.That(records[i].NString, Is.EqualTo(testData[i].NString?.TrimEnd(' ')?.TrimEnd('\0')));
-						else if (context.IsAnyOf(TestProvName.AllClickHouse))
-							Assert.That(records[i].NString, Is.EqualTo(testData[i].NString?.TrimEnd('\0')));
-						else
-							Assert.That(records[i].NString, Is.EqualTo(testData[i].NString?.TrimEnd(' ')));
-					}
-				}
-
-			}
-			finally
-			{
-				db.GetTable<StringTestTable>().Where(_ => _.Id > lastId).Delete();
 			}
 		}
 
@@ -217,80 +179,56 @@ namespace Tests.Linq
 		[Test]
 		public void CharTrimming([DataSources(TestProvName.AllInformix)] string context)
 		{
-			using var db = GetDataContext(context);
-			var lastId = db.GetTable<CharTestTable>().Select(_ => _.Id).Max();
-			var nextId = lastId + 1;
-			try
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable<CharTestTable>();
+
+			var testData = GetCharData(context);
+
+			for (var i = 0; i < testData.Length; i++)
+				db.Insert(new CharTestTable { Id = i + 1, Char = testData[i].Char, NChar = testData[i].NChar });
+
+			var records = table.OrderBy(_ => _.Id).ToArray();
+
+			Assert.That(records, Has.Length.EqualTo(testData.Length));
+
+			for (var i = 0; i < records.Length; i++)
 			{
-				var testData = GetCharData(context);
-
-				foreach (var record in testData)
+				if (context.IsAnyOf(TestProvName.AllSapHana))
 				{
-					var query = db.GetTable<CharTestTable>().Value(_ => _.NChar, record.NChar);
-					if (!SkipChar(context))
-						query = query.Value(_ => _.Char, record.Char);
+					// SAP or provider trims space and we return default value, which is \0 for char
+					// or we insert it incorrectly?
+					if (testData[i].Char == ' ')
+						Assert.That(records[i].Char, Is.EqualTo('\0'));
+					else
+						Assert.That(records[i].Char, Is.EqualTo(testData[i].Char));
 
-					if (context.IsAnyOf(TestProvName.AllFirebird))
-						query = db.GetTable<CharTestTable>().Value(_ => _.Char, record.Char);
+					if (testData[i].NChar == ' ')
+						Assert.That(records[i].NChar, Is.EqualTo('\0'));
+					else
+						Assert.That(records[i].NChar, Is.EqualTo(testData[i].NChar));
 
-					if (context.IsAnyOf(TestProvName.AllClickHouse))
-						query = query.Value(_ => _.Id, nextId++);
-
-					query.Insert();
+					continue;
 				}
 
-				var records = db.GetTable<CharTestTable>().Where(_ => _.Id > lastId).OrderBy(_ => _.Id).ToArray();
+				if (context.IsAnyOf(TestProvName.AllMySql))
+					// MySQL trims trailing spaces from CHAR on retrieval
+					Assert.That(records[i].Char, Is.EqualTo(testData[i].Char == ' ' ? '\0' : testData[i].Char));
+				else if (context.IsAnyOf(TestProvName.AllSybase))
+					Assert.That(records[i].Char, Is.EqualTo(testData[i].Char == '\0' ? ' ' : testData[i].Char));
+				else
+					Assert.That(records[i].Char, Is.EqualTo(testData[i].Char));
 
-				Assert.That(records, Has.Length.EqualTo(testData.Length));
-
-				for (var i = 0; i < records.Length; i++)
+				if (context.IsAnyOf(TestProvName.AllMySql))
+					// for some reason mysql doesn't insert space
+					Assert.That(records[i].NChar, Is.EqualTo(testData[i].NChar == ' ' ? '\0' : testData[i].NChar));
+				else if (!context.IsAnyOf(TestProvName.AllFirebird))
 				{
-					if (context.IsAnyOf(TestProvName.AllSapHana))
-					{
-						// SAP or provider trims space and we return default value, which is \0 for char
-						// or we insert it incorrectly?
-						if (testData[i].Char == ' ')
-							Assert.That(records[i].Char, Is.EqualTo('\0'));
-						else
-							Assert.That(records[i].Char, Is.EqualTo(testData[i].Char));
-
-						if (testData[i].NChar == ' ')
-							Assert.That(records[i].NChar, Is.EqualTo('\0'));
-						else
-							Assert.That(records[i].NChar, Is.EqualTo(testData[i].NChar));
-
-						continue;
-					}
-
-					if (!SkipChar(context))
-					{
-						if (context.IsAnyOf(TestProvName.AllSybase))
-							Assert.That(records[i].Char, Is.EqualTo(testData[i].Char == '\0' ? ' ' : testData[i].Char));
-						else
-							Assert.That(records[i].Char, Is.EqualTo(testData[i].Char));
-					}
-
-					if (context.IsAnyOf(TestProvName.AllMySql))
-						// for some reason mysql doesn't insert space
-						Assert.That(records[i].NChar, Is.EqualTo(testData[i].NChar == ' ' ? '\0' : testData[i].NChar));
-					else if (!context.IsAnyOf(TestProvName.AllFirebird))
-					{
-						if (context.IsAnyOf(TestProvName.AllSybase))
-							Assert.That(records[i].NChar, Is.EqualTo(testData[i].NChar == '\0' ? ' ' : testData[i].NChar));
-						else
-							Assert.That(records[i].NChar, Is.EqualTo(testData[i].NChar));
-					}
+					if (context.IsAnyOf(TestProvName.AllSybase))
+						Assert.That(records[i].NChar, Is.EqualTo(testData[i].NChar == '\0' ? ' ' : testData[i].NChar));
+					else
+						Assert.That(records[i].NChar, Is.EqualTo(testData[i].NChar));
 				}
 			}
-			finally
-			{
-				db.GetTable<CharTestTable>().Where(_ => _.Id > lastId).Delete();
-			}
-		}
-
-		private static bool SkipChar([DataSources] string context)
-		{
-			return context.IsAnyOf(ProviderName.SqlCe, ProviderName.DB2, TestProvName.AllPostgreSQL, TestProvName.AllMySql);
 		}
 	}
 }

--- a/Tests/Linq/Linq/EnumMappingTests.cs
+++ b/Tests/Linq/Linq/EnumMappingTests.cs
@@ -859,7 +859,7 @@ namespace Tests.Linq
 		public void EnumMapInsertFromSelectWithParam1([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
-			using (new Cleaner(db))
+			using (new Cleaner(db, 2))
 			{
 				db.GetTable<RawTable>().Insert(() => new RawTable
 				{
@@ -869,18 +869,20 @@ namespace Tests.Linq
 
 				var param = TestEnum1.Value1;
 
+				// insert a distinct row (RID + 1) rather than a duplicate of the source PK: YDB enforces
+				// the LinqDataTypes primary key, so re-inserting RID would conflict.
 				var result = db.GetTable<TestTable1>()
 					.Where(r => r.Id == RID && r.TestField == TestEnum1.Value2)
 					.Select(r => new TestTable1
 					{
-						Id = r.Id,
+						Id = r.Id + 1,
 						TestField = param
 					})
 					.Insert(db.GetTable<TestTable1>(), r => r);
 
 				if (context.SupportsRowcount())
 					Assert.That(result, Is.EqualTo(1));
-				Assert.That(db.GetTable<RawTable>().Where(r => r.Id == RID && r.TestField == VAL1).Count(), Is.EqualTo(1));
+				Assert.That(db.GetTable<RawTable>().Where(r => r.Id == RID + 1 && r.TestField == VAL1).Count(), Is.EqualTo(1));
 			}
 		}
 
@@ -888,7 +890,7 @@ namespace Tests.Linq
 		public void EnumMapInsertFromSelectWithParam2([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
-			using (new Cleaner(db))
+			using (new Cleaner(db, 2))
 			{
 				db.GetTable<RawTable>().Insert(() => new RawTable
 				{
@@ -898,18 +900,20 @@ namespace Tests.Linq
 
 				var param = TestEnum21.Value1;
 
+				// insert a distinct row (RID + 1) rather than a duplicate of the source PK: YDB enforces
+				// the LinqDataTypes primary key, so re-inserting RID would conflict.
 				var result = db.GetTable<TestTable2>()
 					.Where(r => r.Id == RID && r.TestField == TestEnum21.Value2)
 					.Select(r => new TestTable2
 					{
-						Id = r.Id,
+						Id = r.Id + 1,
 						TestField = param
 					})
 					.Insert(db.GetTable<TestTable2>(), r => r);
 
 				if (context.SupportsRowcount())
 					Assert.That(result, Is.EqualTo(1));
-				Assert.That(db.GetTable<RawTable>().Where(r => r.Id == RID && r.TestField == VAL1).Count(), Is.EqualTo(1));
+				Assert.That(db.GetTable<RawTable>().Where(r => r.Id == RID + 1 && r.TestField == VAL1).Count(), Is.EqualTo(1));
 			}
 		}
 
@@ -917,7 +921,7 @@ namespace Tests.Linq
 		public void EnumMapInsertFromSelectWithParam3([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
-			using (new Cleaner(db))
+			using (new Cleaner(db, 2))
 			{
 				db.GetTable<RawTable>().Insert(() => new RawTable
 				{
@@ -927,18 +931,20 @@ namespace Tests.Linq
 
 				var param = TestEnum1.Value1;
 
+				// insert a distinct row (RID + 1) rather than a duplicate of the source PK: YDB enforces
+				// the LinqDataTypes primary key, so re-inserting RID would conflict.
 				var result = db.GetTable<NullableTestTable1>()
 					.Where(r => r.Id == RID && r.TestField == TestEnum1.Value2)
 					.Select(r => new NullableTestTable1
 					{
-						Id = r.Id,
+						Id = r.Id + 1,
 						TestField = param
 					})
 					.Insert(db.GetTable<NullableTestTable1>(), r => r);
 
 				if (context.SupportsRowcount())
 					Assert.That(result, Is.EqualTo(1));
-				Assert.That(db.GetTable<RawTable>().Where(r => r.Id == RID && r.TestField == VAL1).Count(), Is.EqualTo(1));
+				Assert.That(db.GetTable<RawTable>().Where(r => r.Id == RID + 1 && r.TestField == VAL1).Count(), Is.EqualTo(1));
 			}
 		}
 
@@ -946,7 +952,7 @@ namespace Tests.Linq
 		public void EnumMapInsertFromSelectWithParam4([DataSources] string context)
 		{
 			using (var db = GetDataContext(context))
-			using (new Cleaner(db))
+			using (new Cleaner(db, 2))
 			{
 				db.GetTable<RawTable>().Insert(() => new RawTable
 				{
@@ -956,18 +962,20 @@ namespace Tests.Linq
 
 				var param = TestEnum21.Value1;
 
+				// insert a distinct row (RID + 1) rather than a duplicate of the source PK: YDB enforces
+				// the LinqDataTypes primary key, so re-inserting RID would conflict.
 				var result = db.GetTable<NullableTestTable2>()
 					.Where(r => r.Id == RID && r.TestField == TestEnum21.Value2)
 					.Select(r => new NullableTestTable2
 					{
-						Id = r.Id,
+						Id = r.Id + 1,
 						TestField = param
 					})
 					.Insert(db.GetTable<NullableTestTable2>(), r => r);
 
 				if (context.SupportsRowcount())
 					Assert.That(result, Is.EqualTo(1));
-				Assert.That(db.GetTable<RawTable>().Where(r => r.Id == RID && r.TestField == VAL1).Count(), Is.EqualTo(1));
+				Assert.That(db.GetTable<RawTable>().Where(r => r.Id == RID + 1 && r.TestField == VAL1).Count(), Is.EqualTo(1));
 			}
 		}
 
@@ -1232,19 +1240,20 @@ namespace Tests.Linq
 			Value2 = 0x2
 		}
 
-		[Table("LinqDataTypes", IsColumnAttributeRequired = false)]
+		[Table]
 		sealed class TestTable5
 		{
-			public int      ID;
-			public TestFlag IntValue;
+			[PrimaryKey] public int      ID;
+			[Column]     public TestFlag IntValue;
 		}
 
 		[Test]
 		public void TestFlagEnum([DataSources(TestProvName.AllAccess)] string context)
 		{
-			using var db = GetDataContext(context);
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable<TestTable5>();
 			var result =
-					from t in db.GetTable<TestTable5>()
+					from t in table
 					where (t.IntValue & TestFlag.Value1) != 0
 					select t;
 

--- a/Tests/Linq/Update/BulkCopyTests.cs
+++ b/Tests/Linq/Update/BulkCopyTests.cs
@@ -324,8 +324,10 @@ namespace Tests.xUpdate
 		[Table]
 		public class DateOnlyTable
 		{
-			[PrimaryKey, Identity] public int Id { get; set; }
-			[Column] public DateOnly Date { get; set; }
+			// Use the DateOnly value as the (natural, supplied) key. The test only checks the DateOnly
+			// round-trip and needs no identity; a supplied key is also required by YDB's BulkUpsert, which
+			// can't auto-generate one (and YDB promotes a sole integer PK to an auto SERIAL).
+			[PrimaryKey] public DateOnly Date { get; set; }
 		}
 #endif
 


### PR DESCRIPTION
Follow-up to #5583. Extracts the provider-agnostic test corrections that are currently bundled into the YDB provider PR (#5564) into a standalone PR, so that #5564's baseline diff stays YDB-only and is easier to review. These changes move every provider's baselines (they are deliberately provider-agnostic), which is exactly what we don't want mixed into the YDB review.

## Test corrections

- **CharTypesTests** — convert `StringTestTable` / `CharTestTable` from the shared keyless `AllTypes` table (with per-provider column maps) to self-contained `[Table]` + `[PrimaryKey]` types created via `CreateLocalTable<>`, and reorganize the per-provider trailing-space/`\0` assertions. Carries YDB-aware assertion branches as dead-but-compiling code (they only execute once the YDB provider lands).
- **EnumMappingTests** — insert a distinct row (`Id + 1`) rather than re-inserting the source PK (so it doesn't collide with an enforced primary key); convert `TestTable5` to a local table with a `[PrimaryKey]`; `Cleaner(db, 2)`.
- **BulkCopyTests** — `DateOnlyTable` uses the `DateOnly` value as a natural `[PrimaryKey]` instead of an identity `int Id`.
- **TestProvName** — add the `AllYdb` constant (referenced by the CharTypes assertions).

## Determinism fix

- **PostgreSQLTests.Issue5549** — `Issue5549Populate` used `NodaTime.SystemClock.Instance.GetCurrentInstant()`, embedding wall-clock time into the captured baseline SQL (non-deterministic — the `.sql` drifts on every regeneration). Replaced with a fixed `NodaTime.Instant`; the test only relies on relative arithmetic and row counts, so behavior is unchanged. Pre-existing on master, surfaced while reviewing #5564's baselines.

## Sequencing

Land this first; it regenerates the affected providers' baselines on master. #5564 then rebases on master and these corrections de-duplicate out of its diff, leaving its baseline movement YDB-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
