### PR TITLE
Fix MA0006/MA0154 analyzer violations introduced in #5570

### DIFF
--- a/Source/LinqToDB/Internal/SqlProvider/SqlExpressionOptimizerVisitor.cs
+++ b/Source/LinqToDB/Internal/SqlProvider/SqlExpressionOptimizerVisitor.cs
@@ -1404,7 +1404,7 @@ string.Equals(be2.Operation, "*", StringComparison.Ordinal) &&
 				// provider's Guid→string translator inserts between the two calls, e.g.
 				//   Lower(Cast(Lower(x) AS VarChar(36))) -> Cast(Lower(x) AS VarChar(36))   (Firebird)
 				//   Lower(«not-null»(Lower(x)))          -> «not-null»(Lower(x))            (Access)
-				if (function.Name == PseudoFunctions.TO_LOWER ? QueryHelper.IsLowerString(argument) : QueryHelper.IsUpperString(argument))
+				if (string.Equals(function.Name, PseudoFunctions.TO_LOWER, StringComparison.Ordinal) ? QueryHelper.IsLowerString(argument) : QueryHelper.IsUpperString(argument))
 				{
 					return argument;
 				}

--- a/Source/LinqToDB/Internal/SqlQuery/QueryHelper.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/QueryHelper.cs
@@ -1671,14 +1671,14 @@ namespace LinqToDB.Internal.SqlQuery
 		}
 
 		/// <summary>
-		/// Returns <c>true</c> when <paramref name="expr"/> is already a lower-cased string, i.e. the result of a
+		/// Returns <see langword="true"/> when <paramref name="expr"/> is already a lower-cased string, i.e. the result of a
 		/// <see cref="PseudoFunctions.TO_LOWER"/> call. Looks through case-preserving wrappers (nullability
 		/// annotations and string casts) that a translator may insert around the conversion.
 		/// </summary>
 		internal static bool IsLowerString(ISqlExpression expr) => IsCaseConversion(expr, PseudoFunctions.TO_LOWER);
 
 		/// <summary>
-		/// Returns <c>true</c> when <paramref name="expr"/> is already an upper-cased string, i.e. the result of a
+		/// Returns <see langword="true"/> when <paramref name="expr"/> is already an upper-cased string, i.e. the result of a
 		/// <see cref="PseudoFunctions.TO_UPPER"/> call. Looks through case-preserving wrappers (nullability
 		/// annotations and string casts) that a translator may insert around the conversion.
 		/// </summary>
@@ -1699,7 +1699,7 @@ namespace LinqToDB.Internal.SqlQuery
 						expr = cast.Expression;
 						break;
 					case SqlFunction { Parameters.Length: 1 } func:
-						return func.Name == caseFunctionName;
+						return string.Equals(func.Name, caseFunctionName, StringComparison.Ordinal);
 					default:
 						return false;
 				}


### PR DESCRIPTION
## Problem

`master` (tip `1ae9418`, from #5570 merged 2026-06-07) does not build in Release.
A plain `dotnet build Source/LinqToDB/LinqToDB.csproj -c Release` fails with four
analyzer errors:

```
Source/LinqToDB/Internal/SqlProvider/SqlExpressionOptimizerVisitor.cs(1407,9): error MA0006
Source/LinqToDB/Internal/SqlQuery/QueryHelper.cs(1674,15): error MA0154
Source/LinqToDB/Internal/SqlQuery/QueryHelper.cs(1681,15): error MA0154
Source/LinqToDB/Internal/SqlQuery/QueryHelper.cs(1702,14): error MA0006
```

#5570's new case-conversion folding code compares strings with `==` and uses
`<c>true</c>` in XML doc comments. Under this repo's analyzer config these are
**errors** for `Source/` code (`dotnet_analyzer_diagnostic.severity = error`, and
`dotnet_diagnostic.MA0154.severity = error`). The `dotnet_diagnostic.MA0006.severity = none`
override only applies under `[Tests/**]`, so it does not cover production code.

## Fix

- `string.Equals(x, y, StringComparison.Ordinal)` for the two function-name
  comparisons — behaviour-identical, since `==` on `string` already does ordinal
  comparison.
- `<see langword="true"/>` instead of `<c>true</c>` in the two XML doc comments.

No functional change. `dotnet build Source/LinqToDB/LinqToDB.csproj -c Release` is
green after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
