### PR TITLE
Use dynamic per-process ports for remote test servers

### DIFF
--- a/Tests/Base/Remote/HttpContext/HttpServerContainer.cs
+++ b/Tests/Base/Remote/HttpContext/HttpServerContainer.cs
@@ -1,4 +1,4 @@
-#if !NETFRAMEWORK
+﻿#if !NETFRAMEWORK
 using System;
 
 using LinqToDB;

--- a/Tests/Base/Remote/HttpContext/HttpServerContainer.cs
+++ b/Tests/Base/Remote/HttpContext/HttpServerContainer.cs
@@ -1,7 +1,5 @@
-﻿#if !NETFRAMEWORK
+#if !NETFRAMEWORK
 using System;
-using System.Collections.Concurrent;
-using System.Threading;
 
 using LinqToDB;
 using LinqToDB.Data;
@@ -18,82 +16,40 @@ using Tests.Model.Remote.HttpContext;
 
 namespace Tests.Remote.ServerContainer
 {
-	public class HttpServerContainer : IServerContainer
+	internal sealed class HttpServerContainer : ServerContainerBase<ITestLinqService>
 	{
-		private const int Port = 22655;
-
-		private readonly Lock _syncRoot = new ();
-
-		//useful for async tests
-		public bool KeepSamePortBetweenThreads { get; set; } = true;
-
-		private ConcurrentDictionary<int, ITestLinqService> _openHosts = new();
-
 		private static string GetServiceUrl(int port) => $"http://localhost:{port}";
 
-		private Func<string?, MappingSchema?, DataConnection> _connectionFactory = null!;
-
-		ITestDataContext IServerContainer.CreateContext(Func<ITestLinqService,DataOptions, DataOptions> optionBuilder, Func<string?, MappingSchema?, DataConnection> connectionFactory)
+		protected override ITestLinqService StartHost(int port, Func<string?, MappingSchema?, DataConnection> connectionFactory)
 		{
-			_connectionFactory = connectionFactory;
-			var service = OpenHost();
-
-			var url = GetServiceUrl(GetPort());
-
-			var dx = new TestHttpContextDataContext(new Uri(url), o => optionBuilder(service, o));
-
-			return dx;
-		}
-
-		private ITestLinqService OpenHost()
-		{
-			var port = GetPort();
-
-			if (_openHosts.TryGetValue(port, out var service))
-				return service;
-
-			lock (_syncRoot)
+			var service = new TestLinqService((c, ms) => connectionFactory(c, ms))
 			{
-				if (_openHosts.TryGetValue(port, out service))
-					return service;
+				AllowUpdates    = true,
+				RemoteClientTag = "HttpClient",
+			};
 
-				service = new TestLinqService((c, ms) => _connectionFactory(c, ms))
+			Startup.Service = service;
+
+			var builder = Host.CreateDefaultBuilder();
+
+			var host = builder.ConfigureWebHostDefaults(
+				webBuilder =>
 				{
-					AllowUpdates     = true,
-					RemoteClientTag = "HttpClient",
-				};
+					webBuilder
+						.UseStartup<Startup>()
+						.UseUrls(GetServiceUrl(port));
+				}).Build();
 
-				Startup.Service = (TestLinqService)service;
-
-				var builder = Host.CreateDefaultBuilder();
-
-				var host = builder.ConfigureWebHostDefaults(
-					webBuilder =>
-					{
-						webBuilder
-							.UseStartup<Startup>()
-							.UseUrls(GetServiceUrl(port));
-					}).Build();
-
-				host.Start();
-
-				_openHosts[port] = service;
-			}
+			host.Start();
 
 			TestExternals.Log("Http host opened");
 
 			return service;
 		}
 
-		//Environment.CurrentManagedThreadId need for a parallel test like DataConnectionTests.MultipleConnectionsTest
-		private int GetPort()
+		protected override ITestDataContext CreateClientContext(ITestLinqService service, int port, Func<ITestLinqService, DataOptions, DataOptions> optionBuilder)
 		{
-			if(KeepSamePortBetweenThreads)
-			{
-				return Port;
-			}
-
-			return Port + (Environment.CurrentManagedThreadId % 1000) + TestExternals.RunID;
+			return new TestHttpContextDataContext(new Uri(GetServiceUrl(port)), o => optionBuilder(service, o));
 		}
 
 		private sealed class Startup
@@ -113,7 +69,7 @@ namespace Tests.Remote.ServerContainer
 			public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 			{
 				app.UsePathBase("/remote/linq2db");
-				
+
 				app.UseRouting();
 
 				app.UseEndpoints(endpoints =>

--- a/Tests/Base/Remote/ServerContainer/ServerContainerBase.cs
+++ b/Tests/Base/Remote/ServerContainer/ServerContainerBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Sockets;
@@ -62,6 +62,12 @@ namespace Tests.Remote.ServerContainer
 			return _connectionFactory(configuration, mappingSchema);
 		}
 
+		// Probe-then-reuse has a TOCTTOU window: another process can claim the probed port
+		// between GetFreePort() and the actual bind inside StartHost. Retry with a freshly
+		// probed port a few times before giving up. 3 attempts is arbitrary: enough to absorb
+		// the rare race without masking a genuine, repeatable start failure.
+		private const int MaxStartAttempts = 3;
+
 		private HostEntry OpenHost()
 		{
 			var slot = GetSlotKey();
@@ -74,12 +80,28 @@ namespace Tests.Remote.ServerContainer
 				if (_openHosts.TryGetValue(slot, out existing))
 					return existing;
 
-				var port  = GetFreePort();
-				var entry = new HostEntry(StartHost(port, InvokeConnectionFactory), port);
+				var entry = StartHostWithRetry();
 
 				_openHosts[slot] = entry;
 
 				return entry;
+			}
+		}
+
+		private HostEntry StartHostWithRetry()
+		{
+			for (var attempt = 1; ; attempt++)
+			{
+				var port = GetFreePort();
+
+				try
+				{
+					return new HostEntry(StartHost(port, InvokeConnectionFactory), port);
+				}
+				catch (Exception) when (attempt < MaxStartAttempts)
+				{
+					// Probed port was taken between probe and bind; retry with a fresh one.
+				}
 			}
 		}
 

--- a/Tests/Base/Remote/ServerContainer/ServerContainerBase.cs
+++ b/Tests/Base/Remote/ServerContainer/ServerContainerBase.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+
+using LinqToDB;
+using LinqToDB.Data;
+using LinqToDB.Mapping;
+
+using Tests.Model;
+
+namespace Tests.Remote.ServerContainer
+{
+	public abstract class ServerContainerBase<TService> : IServerContainer
+	{
+		private readonly Lock _syncRoot = new ();
+
+		private readonly ConcurrentDictionary<int, HostEntry> _openHosts = new();
+
+		//useful for async tests
+		public bool KeepSamePortBetweenThreads { get; set; } = true;
+
+		// Slot key (not a network port): a single shared slot, or one slot per thread.
+		// Raw thread id works as a key - the old "% 1000" only kept the *derived port* in range,
+		// which no longer applies now that the port is probed. Thread ids are never 0, so they
+		// never collide with the shared-slot key.
+		private int GetSlotKey() => KeepSamePortBetweenThreads ? 0 : Environment.CurrentManagedThreadId;
+
+		// Probe-then-reuse: ask the OS for a free port, release it, hand back the number.
+		protected static int GetFreePort()
+		{
+			var listener = new TcpListener(IPAddress.Loopback, 0);
+			listener.Start();
+			try
+			{
+				return ((IPEndPoint)listener.LocalEndpoint).Port;
+			}
+			finally
+			{
+				listener.Stop();
+			}
+		}
+
+		// Refreshed on every CreateContext call and read indirectly by the cached host through
+		// InvokeConnectionFactory. Each call passes a different factory (the per-test factory bakes
+		// in UseConfiguration/UseDataProvider), so a host created once must use the *latest* caller's
+		// factory, not the one captured when it was first started.
+		private Func<string?, MappingSchema?, DataConnection> _connectionFactory = null!;
+
+		ITestDataContext IServerContainer.CreateContext(Func<ITestLinqService,DataOptions, DataOptions> optionBuilder, Func<string?, MappingSchema?, DataConnection> connectionFactory)
+		{
+			_connectionFactory = connectionFactory;
+
+			var entry = OpenHost();
+
+			return CreateClientContext(entry.Service, entry.Port, optionBuilder);
+		}
+
+		private DataConnection InvokeConnectionFactory(string? configuration, MappingSchema? mappingSchema)
+		{
+			return _connectionFactory(configuration, mappingSchema);
+		}
+
+		private HostEntry OpenHost()
+		{
+			var slot = GetSlotKey();
+
+			if (_openHosts.TryGetValue(slot, out var existing))
+				return existing;
+
+			lock (_syncRoot)
+			{
+				if (_openHosts.TryGetValue(slot, out existing))
+					return existing;
+
+				var port  = GetFreePort();
+				var entry = new HostEntry(StartHost(port, InvokeConnectionFactory), port);
+
+				_openHosts[slot] = entry;
+
+				return entry;
+			}
+		}
+
+		// Start the transport host bound to the given port and return the server-side service.
+		// Invoked under the container lock, so the per-transport static-Startup handshake stays serialized.
+		protected abstract TService StartHost(int port, Func<string?, MappingSchema?, DataConnection> connectionFactory);
+
+		// Build the client-side data context against the given port.
+		protected abstract ITestDataContext CreateClientContext(TService service, int port, Func<ITestLinqService,DataOptions, DataOptions> optionBuilder);
+
+		private sealed class HostEntry(TService service, int port)
+		{
+			public TService Service { get; } = service;
+			public int      Port    { get; } = port;
+		}
+	}
+}

--- a/Tests/Base/Remote/SignalR/SignalRServerContainer.cs
+++ b/Tests/Base/Remote/SignalR/SignalRServerContainer.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Concurrent;
-using System.Threading;
+using System;
 
 using LinqToDB;
 using LinqToDB.Data;
@@ -22,89 +20,49 @@ using Microsoft.AspNetCore;
 
 namespace Tests.Remote.ServerContainer
 {
-	public class SignalRServerContainer : IServerContainer
+	internal sealed class SignalRServerContainer : ServerContainerBase<ITestLinqService>
 	{
 		private const string HUB_PATH = "/remote/linq2db";
-		private const int Port = 22656;
-
-		private readonly Lock _syncRoot = new ();
-
-		//useful for async tests
-		public bool KeepSamePortBetweenThreads { get; set; } = true;
-
-		private ConcurrentDictionary<int, ITestLinqService> _openHosts = new();
 
 		private static string GetServiceUrl(int port) => $"http://localhost:{port}";
 
-		private Func<string?, MappingSchema?, DataConnection> _connectionFactory = null!;
-
-		ITestDataContext IServerContainer.CreateContext(Func<ITestLinqService,DataOptions, DataOptions> optionBuilder, Func<string?, MappingSchema?, DataConnection> connectionFactory)
+		protected override ITestLinqService StartHost(int port, Func<string?, MappingSchema?, DataConnection> connectionFactory)
 		{
-			_connectionFactory = connectionFactory;
-			var service = OpenHost();
-
-			var url = GetServiceUrl(GetPort());
-
-			var hubConnection = new HubConnectionBuilder().WithUrl(url + HUB_PATH).Build();
-			hubConnection.StartAsync().GetAwaiter().GetResult();
-			var dx = new TestSignalRDataContext(hubConnection, o => optionBuilder(service, o));
-
-			return dx;
-		}
-
-		private ITestLinqService OpenHost()
-		{
-			var port = GetPort();
-
-			if (_openHosts.TryGetValue(port, out var service))
-				return service;
-
-			lock (_syncRoot)
+			var service = new TestLinqService((c, ms) => connectionFactory(c, ms))
 			{
-				if (_openHosts.TryGetValue(port, out service))
-					return service;
+				AllowUpdates    = true,
+				RemoteClientTag = "SignalR",
+			};
 
-				service = new TestLinqService((c, ms) => _connectionFactory(c, ms))
-				{
-					AllowUpdates    = true,
-					RemoteClientTag = "SignalR",
-				};
-
-				Startup.Service = (TestLinqService)service;
+			Startup.Service = service;
 
 #if NETFRAMEWORK
-				var host = WebHost.CreateDefaultBuilder().UseUrls(GetServiceUrl(port)).UseStartup<Startup>().Build();
+			var host = WebHost.CreateDefaultBuilder().UseUrls(GetServiceUrl(port)).UseStartup<Startup>().Build();
 #else
-				var builder = Host.CreateDefaultBuilder();
+			var builder = Host.CreateDefaultBuilder();
 
-				var host = builder.ConfigureWebHostDefaults(
-					webBuilder =>
-					{
-						webBuilder
-							.UseStartup<Startup>()
-							.UseUrls(GetServiceUrl(port));
-					}).Build();
+			var host = builder.ConfigureWebHostDefaults(
+				webBuilder =>
+				{
+					webBuilder
+						.UseStartup<Startup>()
+						.UseUrls(GetServiceUrl(port));
+				}).Build();
 #endif
 
-				host.Start();
-
-				_openHosts[port] = service;
-			}
+			host.Start();
 
 			TestExternals.Log("SignalR host opened");
 
 			return service;
 		}
 
-		//Environment.CurrentManagedThreadId need for a parallel test like DataConnectionTests.MultipleConnectionsTest
-		private int GetPort()
+		protected override ITestDataContext CreateClientContext(ITestLinqService service, int port, Func<ITestLinqService, DataOptions, DataOptions> optionBuilder)
 		{
-			if(KeepSamePortBetweenThreads)
-			{
-				return Port;
-			}
+			var hubConnection = new HubConnectionBuilder().WithUrl(GetServiceUrl(port) + HUB_PATH).Build();
+			hubConnection.StartAsync().GetAwaiter().GetResult();
 
-			return Port + (Environment.CurrentManagedThreadId % 1000) + TestExternals.RunID;
+			return new TestSignalRDataContext(hubConnection, o => optionBuilder(service, o));
 		}
 
 		private sealed class Startup

--- a/Tests/Base/Remote/SignalR/SignalRServerContainer.cs
+++ b/Tests/Base/Remote/SignalR/SignalRServerContainer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 using LinqToDB;
 using LinqToDB.Data;

--- a/Tests/Base/Remote/WCF/WcfServerContainer.cs
+++ b/Tests/Base/Remote/WCF/WcfServerContainer.cs
@@ -1,4 +1,4 @@
-﻿#if NETFRAMEWORK
+#if NETFRAMEWORK
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
@@ -18,96 +18,56 @@ using Tests.Model.Remote.Wcf;
 
 namespace Tests.Remote.ServerContainer
 {
-	public class WcfServerContainer : IServerContainer
+	internal sealed class WcfServerContainer : ServerContainerBase<TestWcfLinqService>
 	{
-		private const int Port = 22654;
-
-		private readonly Lock _syncRoot = new ();
-
-		//useful for async tests
-		public bool KeepSamePortBetweenThreads { get; set; } = true;
-
-		private ConcurrentDictionary<int, TestWcfLinqService> _openHosts = new();
-
-		private Func<string?, MappingSchema?, DataConnection> _connectionFactory = null!;
-
-		ITestDataContext IServerContainer.CreateContext(Func<ITestLinqService,DataOptions, DataOptions> optionBuilder, Func<string?, MappingSchema?, DataConnection> connectionFactory)
+		protected override TestWcfLinqService StartHost(int port, Func<string?, MappingSchema?, DataConnection> connectionFactory)
 		{
-			_connectionFactory = connectionFactory;
-
-			var service = OpenHost();
-
-			var dx = new TestWcfDataContext(GetPort(), o => optionBuilder(service, o));
-
-			return dx;
-		}
-
-		private TestWcfLinqService OpenHost()
-		{
-			var port = GetPort();
-
-			if (_openHosts.TryGetValue(port, out var service))
-				return service;
-
-			lock (_syncRoot)
-			{
-				if (_openHosts.TryGetValue(port, out service))
-					return service;
-
 #pragma warning disable CA2000 // Dispose objects before losing scope
-				var host = new ServiceHost(
-					service = new TestWcfLinqService(
-						new TestLinqService((c, ms) => _connectionFactory(c, ms))
-						{
-							RemoteClientTag = "Wcf",
-						})
-						{
-							AllowUpdates = true,
-						},
-					new Uri($"net.tcp://localhost:{GetPort()}"));
+			var service = new TestWcfLinqService(
+				new TestLinqService((c, ms) => connectionFactory(c, ms))
+				{
+					RemoteClientTag = "Wcf",
+				})
+				{
+					AllowUpdates = true,
+				};
+
+			var host = new ServiceHost(service, new Uri($"net.tcp://localhost:{port}"));
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
-				host.Description.Behaviors.Add(new ServiceMetadataBehavior());
-				host.Description.Behaviors.Find<ServiceDebugBehavior>().IncludeExceptionDetailInFaults = true;
-				host.AddServiceEndpoint(typeof(IMetadataExchange), MetadataExchangeBindings.CreateMexTcpBinding(), "mex");
-				host.AddServiceEndpoint(
-					typeof(IWcfLinqService),
-					new NetTcpBinding(SecurityMode.None)
-					{
-						MaxReceivedMessageSize = 10000000,
-						MaxBufferPoolSize      = 10000000,
-						MaxBufferSize          = 10000000,
-						CloseTimeout           = new TimeSpan(00, 01, 00),
-						OpenTimeout            = new TimeSpan(00, 01, 00),
-						ReceiveTimeout         = new TimeSpan(00, 10, 00),
-						SendTimeout            = new TimeSpan(00, 10, 00),
-					},
-					"LinqOverWcf");
+			host.Description.Behaviors.Add(new ServiceMetadataBehavior());
+			host.Description.Behaviors.Find<ServiceDebugBehavior>().IncludeExceptionDetailInFaults = true;
+			host.AddServiceEndpoint(typeof(IMetadataExchange), MetadataExchangeBindings.CreateMexTcpBinding(), "mex");
+			host.AddServiceEndpoint(
+				typeof(IWcfLinqService),
+				new NetTcpBinding(SecurityMode.None)
+				{
+					MaxReceivedMessageSize = 10000000,
+					MaxBufferPoolSize      = 10000000,
+					MaxBufferSize          = 10000000,
+					CloseTimeout           = new TimeSpan(00, 01, 00),
+					OpenTimeout            = new TimeSpan(00, 01, 00),
+					ReceiveTimeout         = new TimeSpan(00, 10, 00),
+					SendTimeout            = new TimeSpan(00, 10, 00),
+				},
+				"LinqOverWcf");
 
-				host.Faulted += Host_Faulted;
-				host.Open();
+			host.Faulted += Host_Faulted;
+			host.Open();
 
-				_openHosts[port] = service;
-
-				TestExternals.Log($"WCF host opened, Address : {host.BaseAddresses[0]}");
-			}
+			TestExternals.Log($"WCF host opened, Address : {host.BaseAddresses[0]}");
 
 			return service;
+		}
+
+		protected override ITestDataContext CreateClientContext(TestWcfLinqService service, int port, Func<ITestLinqService, DataOptions, DataOptions> optionBuilder)
+		{
+			return new TestWcfDataContext(port, o => optionBuilder(service, o));
 		}
 
 		private void Host_Faulted(object sender, EventArgs e)
 		{
 			throw new NotImplementedException();
-		}
-
-		public int GetPort()
-		{
-			if (KeepSamePortBetweenThreads)
-			{
-				return Port;
-			}
-
-			return Port + (Environment.CurrentManagedThreadId % 1000) + TestExternals.RunID;
 		}
 	}
 }

--- a/Tests/Base/Remote/WCF/WcfServerContainer.cs
+++ b/Tests/Base/Remote/WCF/WcfServerContainer.cs
@@ -1,10 +1,8 @@
-#if NETFRAMEWORK
+﻿#if NETFRAMEWORK
 using System;
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.ServiceModel;
 using System.ServiceModel.Description;
-using System.Threading;
 
 using LinqToDB;
 using LinqToDB.Data;

--- a/Tests/Base/Remote/gRPC/GrpcServerContainer.cs
+++ b/Tests/Base/Remote/gRPC/GrpcServerContainer.cs
@@ -1,4 +1,4 @@
-#if !NETFRAMEWORK
+﻿#if !NETFRAMEWORK
 using System;
 
 using LinqToDB;

--- a/Tests/Base/Remote/gRPC/GrpcServerContainer.cs
+++ b/Tests/Base/Remote/gRPC/GrpcServerContainer.cs
@@ -1,23 +1,14 @@
-﻿#if !NETFRAMEWORK
+#if !NETFRAMEWORK
 using System;
-using System.Collections.Concurrent;
-using System.Diagnostics;
-using System.Security.Authentication;
-using System.Threading;
 
 using LinqToDB;
 using LinqToDB.Data;
-using LinqToDB.Interceptors;
 using LinqToDB.Mapping;
-using LinqToDB.Remote;
-using LinqToDB.Remote.Grpc;
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-
-using NUnit.Framework;
 
 using ProtoBuf.Grpc.Server;
 
@@ -26,86 +17,38 @@ using Tests.Model.Remote.Grpc;
 
 namespace Tests.Remote.ServerContainer
 {
-	public class GrpcServerContainer : IServerContainer
+	internal sealed class GrpcServerContainer : ServerContainerBase<TestGrpcLinqService>
 	{
-		private const int Port = 22654;
+		private static string GetServiceUrl(int port) => $"https://localhost:{port}";
 
-		private readonly Lock _syncRoot = new ();
-
-		//useful for async tests
-		public bool KeepSamePortBetweenThreads { get; set; } = true;
-
-		private ConcurrentDictionary<int, TestGrpcLinqService> _openHosts = new();
-
-		private static string GetServiceUrl(int port)
+		protected override TestGrpcLinqService StartHost(int port, Func<string?, MappingSchema?, DataConnection> connectionFactory)
 		{
-			return $"https://localhost:{port}";
-		}
+			var service = new TestGrpcLinqService(
+				new TestLinqService((c, ms) => connectionFactory(c, ms))
+				{
+					AllowUpdates    = true,
+					RemoteClientTag = "Grpc",
+				});
 
-		private Func<string?, MappingSchema?, DataConnection> _connectionFactory = null!;
+			Startup.GrpcLinqService = service;
 
-		ITestDataContext IServerContainer.CreateContext(Func<ITestLinqService,DataOptions, DataOptions> optionBuilder, Func<string?, MappingSchema?, DataConnection> connectionFactory)
-		{
-			_connectionFactory = connectionFactory;
-			var service = OpenHost();
-
-			var url = GetServiceUrl(GetPort());
-
-			var dx = new TestGrpcDataContext(url, o => optionBuilder(service, o));
-
-			return dx;
-		}
-
-		private TestGrpcLinqService OpenHost()
-		{
-			var port = GetPort();
-
-			if (_openHosts.TryGetValue(port, out var service))
-				return service;
-
-			lock (_syncRoot)
-			{
-				if (_openHosts.TryGetValue(port, out service))
-					return service;
-
-				service = new TestGrpcLinqService(
-					new TestLinqService((c, ms) => _connectionFactory(c, ms))
-					{
-						AllowUpdates     = true,
-						RemoteClientTag = "Grpc",
-					});
-
-				Startup.GrpcLinqService = service;
-
-				var hb = Host.CreateDefaultBuilder();
-				var host = hb.ConfigureWebHostDefaults(
+			var host = Host.CreateDefaultBuilder().ConfigureWebHostDefaults(
 				webBuilder =>
 				{
 					webBuilder.UseStartup<Startup>();
-
-					var url = GetServiceUrl(port);
-					webBuilder.UseUrls(url);
+					webBuilder.UseUrls(GetServiceUrl(port));
 				}).Build();
 
-				host.Start();
-
-				_openHosts[port] = service;
-			}
+			host.Start();
 
 			TestExternals.Log("gRCP host opened");
 
 			return service;
 		}
 
-		//Environment.CurrentManagedThreadId need for a parallel test like DataConnectionTests.MultipleConnectionsTest
-		public int GetPort()
+		protected override ITestDataContext CreateClientContext(TestGrpcLinqService service, int port, Func<ITestLinqService, DataOptions, DataOptions> optionBuilder)
 		{
-			if(KeepSamePortBetweenThreads)
-			{
-				return Port;
-			}
-
-			return Port + (Environment.CurrentManagedThreadId % 1000) + TestExternals.RunID;
+			return new TestGrpcDataContext(GetServiceUrl(port), o => optionBuilder(service, o));
 		}
 
 		public class Startup


### PR DESCRIPTION
## What

Remote-context test servers (gRPC / HTTP / SignalR / WCF) bound a hardcoded base
port (22654 / 22655 / 22656). The per-process term in the port formula
(`TestExternals.RunID`) is never assigned anywhere in the repo, so it was always
`0` — every test process bound the same port, and concurrent runs on one machine
collided with `address already in use`.

This blocks running the suite from several processes on the same machine at once —
for example multiple AI coding agents, each in its own git worktree/session, running
`dotnet test` concurrently. Probing a free port per process removes the contention.

## Change

- New `ServerContainerBase<TService>` (`Tests/Base/Remote/ServerContainer/`) holding
  the shared slot→(service, port) cache and a probe-then-reuse free-port allocator
  (`TcpListener` on port 0).
- The four containers become thin subclasses overriding `StartHost` (bind + start)
  and `CreateClientContext` (build the client against the bound port).
- The port is probed per slot at runtime instead of computed from a constant; both
  the shared-slot (default) and per-thread (`KeepSamePortBetweenThreads = false`)
  paths use it.
- `IServerContainer`, `KeepSamePortBetweenThreads`, and `PortStatusRestorer` are
  unchanged.

Test-only; no product or public-API changes. `TestExternals.RunID` / `IsParallelRun`
are now unused (left in place).

## Verification

- Build: net10 (Testing) + net462 (Debug), 0 warnings.
- `RemoteContextTests`: net10 63/0 (gRPC/Http/SignalR), net462 42/0 (WCF/SignalR).
- `Issue681Tests` + `Issue278Tests` net10: 1434/0 across SQLite / SqlServer.2019 /
  PostgreSQL.16 / Oracle.23 + their `.LinqService` remote variants.
- `DataConnectionTests.MultipleConnectionsTest` net10: 16/0 (per-thread slot path).
