### PR TITLE
Fix non-deterministic SQLite schema provider table/view ordering

### DIFF
--- a/Source/LinqToDB/Internal/DataProvider/SQLite/SQLiteSchemaProvider.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SQLite/SQLiteSchemaProvider.cs
@@ -107,6 +107,7 @@ namespace LinqToDB.Internal.DataProvider.SQLite
 					t.type = 'view'            AS IsView
 				FROM pragma_table_list() t
 				WHERE t.type IN ('table', 'view'){GenerateTableFilter("t")}
+				ORDER BY t.schema, t.name
 			").ToList();
 		}
 
@@ -183,6 +184,7 @@ namespace LinqToDB.Internal.DataProvider.SQLite
 					t.name   AS TableName
 				FROM pragma_table_list() t
 				WHERE t.type IN ('view'){GenerateTableFilter("t")}
+				ORDER BY t.schema, t.name
 			").ToList();
 
 			if (views.Count > 0)


### PR DESCRIPTION
## Summary

`SQLiteSchemaProvider.GetTables` and the view-enumeration query inside `GetColumns`
read rows from `pragma_table_list()` with no `ORDER BY`. The result order is therefore
whatever the underlying native SQLite library returns, which differs across platforms
and SQLite versions. The per-view `SELECT * FROM [view]` schema probes emitted by
`GetColumns` consequently land in a non-deterministic order, producing spurious
Linux-vs-Windows diffs in the `SchemaProviderTests.NorthwindTest` baselines
(observed in baselines PR linq2db/linq2db.baselines#1918).

## Fix

Add `ORDER BY t.schema, t.name` to both queries. SQLite's default `BINARY` collation
is byte-deterministic and locale-independent, so enumeration is now stable across
platforms. Also makes the user-visible table/view ordering from `GetSchema()`
deterministic.

## Test plan

- [x] `SchemaProviderTests.NorthwindTest` on `Northwind.SQLite` + `Northwind.SQLite.MS` (net10.0) — 3/3 pass; baseline now emits views in stable alphabetical order.
- [ ] Full SQLite suite on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
