### PR TITLE
CI: run PublishSingleFile smoke test in build/default only

### DIFF
--- a/Build/Azure/pipelines/build.yml
+++ b/Build/Azure/pipelines/build.yml
@@ -22,5 +22,6 @@ stages:
       with_nugets: true
       with_examples: true
       with_tests: false
+      with_singlefile_smoke: true
       with_analyzers: false # true disabled till https://github.com/dotnet/roslyn/pull/80621 shipped
       with_release: false

--- a/Build/Azure/pipelines/default.yml
+++ b/Build/Azure/pipelines/default.yml
@@ -24,6 +24,7 @@ stages:
       with_nugets: true
       with_examples: true
       with_tests: eq(variables['System.PullRequest.TargetBranch'], variables['release_branch'])
+      with_singlefile_smoke: true
       ${{ if eq(variables['System.PullRequest.TargetBranch'], variables['release_branch']) }}:
         with_api_analyzers: true
       with_release: eq(variables['Build.SourceBranchName'], variables['release_branch'])

--- a/Build/Azure/pipelines/templates/build-job.yml
+++ b/Build/Azure/pipelines/templates/build-job.yml
@@ -2,6 +2,7 @@ parameters:
   with_nugets: false
   with_examples: false
   with_tests: false
+  with_singlefile_smoke: false
   with_analyzers: false
   with_api_analyzers: false
   with_release: false
@@ -62,7 +63,7 @@ jobs:
         .build\publish\singlefile\linq2db.Tests.SingleFile.exe
         if %errorlevel% neq 0 exit /b %errorlevel%
     displayName: PublishSingleFile Smoke Test
-    condition: and(succeeded(), ${{ parameters.with_tests }})
+    condition: and(succeeded(), ${{ parameters.with_singlefile_smoke }})
 
   - task: DotNetCoreCLI@2
     inputs:


### PR DESCRIPTION
## What

Move the **PublishSingleFile Smoke Test** step so it runs only in the **build** and **default** pipelines, not in the **test** pipelines.

## Why

The step (added in #5489) was gated on `with_tests`, so it ran on every `test-*` PR run (`testing.yml`), adding a self-contained Release publish + execute to each test pipeline. It's a build-side regression guard, not a test-matrix concern, so it belongs with the build pipelines.

## How

- New `with_singlefile_smoke` parameter on `build-job.yml` (default `false`); the step now gates on it instead of `with_tests`.
- Set `with_singlefile_smoke: true` in `build.yml` and `default.yml`.
- `testing.yml` leaves it at the default `false` → step no longer runs there.

The step publishes `Tests.SingleFile` itself, so it never depended on `with_tests` building anything.

Net effect:

| Pipeline | Before | After |
|---|---|---|
| build (`build.yml`) | did not run | runs |
| default (`default.yml`) | ran only on release PRs | runs on all builds |
| test (`testing.yml`) | ran every test PR | does not run |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
