### PR TITLE
Update Octonica.ClickHouseClient to 4.1.4 and re-enable Octonica CI

### DIFF
--- a/Build/Azure/pipelines/templates/test-matrix.yml
+++ b/Build/Azure/pipelines/templates/test-matrix.yml
@@ -909,7 +909,7 @@ jobs:
           enable_fw_net90: true
           enable_fw_net100: true
           ${{ if or(contains(parameters.db_filter, '[all]'), contains(parameters.db_filter, '[clickhouse.all]')) }}:
-            enabled: false
+            enabled: true
           ${{ if not(or(contains(parameters.db_filter, '[all]'), contains(parameters.db_filter, '[clickhouse.all]'))) }}:
             enabled: false
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -118,7 +118,7 @@
 		<PackageVersion Include="Npgsql"                                                Version="10.0.2"                       Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
 		<PackageVersion Include="Npgsql.NodaTime"                                       Version="8.0.9"                        Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
 		<PackageVersion Include="Npgsql.NodaTime"                                       Version="10.0.2"                       Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
-		<PackageVersion Include="Octonica.ClickHouseClient"                             Version="3.1.8"                        />
+		<PackageVersion Include="Octonica.ClickHouseClient"                             Version="4.1.4"                        />
 		<PackageVersion Include="Oracle.ManagedDataAccess"                              Version="21.21.0"                      />
 		<PackageVersion Include="Oracle.ManagedDataAccess.Core"                         Version="23.26.200"                    />
 		<PackageVersion Include="System.Data.Odbc"                                      Version="$(Net10Latest)"               />


### PR DESCRIPTION
## What

- Bump `Octonica.ClickHouseClient` 3.1.8 → 4.1.4.
- Re-enable the `ClickHouse Octonica` CI test-matrix entry (reverts #5460, which disabled it because the 3.1.8 client was broken).

## Package change

4.1.4 ships `net6.0` / `net8.0` / `net10.0`, **drops** `netcoreapp3.1` and the `TimeZoneConverter` dependency, and bumps `K4os.Compression.LZ4` 1.3.6 → 1.3.8. linq2db's test/tooling TFMs (net8/9/10) are all covered. Octonica is centrally versioned and not a shipping dependency of `LinqToDB` (test/tooling only), so no public-API or baseline impact.

## Verification (local, ClickHouse Octonica provider, net10.0)

- Build green on 4.1.4.
- fuget API-surface diff 3.1.8 → 4.1.4: no reflection-wrapped member used by `ClickHouseProviderAdapter` was removed or renamed.
- Connection + DDL + INSERT + data-reader round-trip: pass.
- `ProviderSpecific` column-writer bulk copy: pass.
- Full `CreateData.CreateDatabase` (ClickHouse.Octonica): pass (~6s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
