### PR TITLE
Live test-progress heartbeat for long test runs

### DIFF
--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -72,6 +72,7 @@ dotnet test <project> --filter "<testPattern>" -c <config>
 ```
 
 Notes:
+- **Live progress heartbeat.** When the `LINQ2DB_TEST_PROGRESS` environment variable is set, the test assembly writes a live JSON heartbeat to `.build/.claude/test-progress.<tfm>.<pid>.json` while the run is in flight (see [Tests/Base/TestProgressReporter.cs](../../Tests/Base/TestProgressReporter.cs)). Don't set it inline on the command — it's toggled session-wide via the `/test-progress` skill (which injects it through `.claude/settings.local.json` → `env`), so the plain `dotnet test` form above is correct whether the trace is on or off. When it's on, a watcher can poll `.claude/scripts/test-status.ps1` without waiting for this agent to return.
 - The four EFCore projects each have a single TFM, so `-f <tfm>` is redundant for them. Include `-f <tfm>` only for `Tests/Linq/Tests.csproj` (multi-TFM).
 - `--logger "console;verbosity=detailed"` when `verbosity: "detailed"`.
 - Don't pipe output to `head`/`tail` — read the whole log. Per `testing.md`: NUnit and `dotnet test` interleave relevant info across the log; setup exceptions can come well before the assertion, and stack traces may be truncated if you skim.

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -72,7 +72,7 @@ dotnet test <project> --filter "<testPattern>" -c <config>
 ```
 
 Notes:
-- **Live progress heartbeat.** When the `LINQ2DB_TEST_PROGRESS` environment variable is set, the test assembly writes a live JSON heartbeat to `.build/.claude/test-progress.<tfm>.<pid>.json` while the run is in flight (see [Tests/Base/TestProgressReporter.cs](../../Tests/Base/TestProgressReporter.cs)). Don't set it inline on the command — it's toggled session-wide via the `/test-progress` skill (which injects it through `.claude/settings.local.json` → `env`), so the plain `dotnet test` form above is correct whether the trace is on or off. When it's on, a watcher can poll `.claude/scripts/test-status.ps1` without waiting for this agent to return.
+- **Live progress heartbeat.** When `LINQ2DB_TEST_PROGRESS` is set, the test assembly writes a JSON heartbeat to `.build/.claude/test-progress.<tfm>.<pid>.json` during the run (see [Tests/Base/TestProgressReporter.cs](../../Tests/Base/TestProgressReporter.cs)). Don't set it inline — it's toggled session-wide by the `/test-progress` skill, so the plain `dotnet test` form above is correct whether the trace is on or off.
 - The four EFCore projects each have a single TFM, so `-f <tfm>` is redundant for them. Include `-f <tfm>` only for `Tests/Linq/Tests.csproj` (multi-TFM).
 - `--logger "console;verbosity=detailed"` when `verbosity: "detailed"`.
 - Don't pipe output to `head`/`tail` — read the whole log. Per `testing.md`: NUnit and `dotnet test` interleave relevant info across the log; setup exceptions can come well before the assertion, and stack traces may be truncated if you skim.

--- a/.claude/docs/testing.md
+++ b/.claude/docs/testing.md
@@ -23,6 +23,38 @@ dotnet test Tests/Tests.Playground/Tests.Playground.csproj --filter "FullyQualif
 
 Reach for the full `Tests/Linq/Tests.csproj` only when the test target spans many files that would require a wide playground link, or when running a broad filter (e.g. an entire test class).
 
+## Monitoring a long run
+
+A full suite run takes 1–2 hours. To watch progress without scraping console output, the test assembly can write a small JSON heartbeat (updated ~once/sec, immediately on each failure) that you can `Read` at any time. It's **opt-in** via the `LINQ2DB_TEST_PROGRESS` environment variable; the reporter is a no-op when unset, so default runs are unaffected.
+
+**For test runs Claude launches** (via `/test`, `test-runner`, or ad-hoc Bash), toggle it with the **`/test-progress`** skill — it sets `LINQ2DB_TEST_PROGRESS` session-wide through `.claude/settings.local.json` → `env`, which Claude Code injects into every Bash subprocess. Effect is immediate for the next run, and the `dotnet test` command is unchanged (no permission re-prompt):
+
+```
+/test-progress on        # enable the heartbeat
+/test-progress           # status + latest heartbeat
+/test-progress off       # disable
+```
+
+**For runs in your own terminal**, set the variable yourself before launching:
+
+```bash
+# PowerShell
+$env:LINQ2DB_TEST_PROGRESS = '1'; dotnet test Tests/Linq/Tests.csproj -f net10.0 --filter "..."
+# bash
+LINQ2DB_TEST_PROGRESS=1 dotnet test Tests/Linq/Tests.csproj -f net10.0 --filter "..."
+```
+
+The file lands at `.build/.claude/test-progress.<tfm>.<pid>.json` (one per TFM/process). Set the variable to a directory or a `*.json` path to override the location. Fields: `done`, `total`, `completed`, `passed`, `failed`, `skipped`, `currentTest`, `elapsedSec`, `testsPerSec`, `etaSec`, and `recentFailures[]`.
+
+Read it directly, or run the summary helper:
+
+```bash
+pwsh -NoProfile -File .claude/scripts/test-status.ps1          # newest run, one-line summary
+pwsh -NoProfile -File .claude/scripts/test-status.ps1 -Raw     # dump the raw JSON
+```
+
+**Caveat:** under a `--filter`, `total` reflects the *discovered* (pre-filter) test count, so it over-counts and `etaSec` is unreliable; `total`/`etaSec` are exact only for full, unfiltered runs (the case this is built for). `completed` and `currentTest` are always accurate.
+
 ## Test Database Configuration
 
 Tests run against multiple database providers. Configuration comes from `UserDataProviders.json` (gitignored, user-specific). To get started:

--- a/.claude/scripts/test-status.ps1
+++ b/.claude/scripts/test-status.ps1
@@ -1,0 +1,97 @@
+#!/usr/bin/env pwsh
+# test-status.ps1 — print a one-line summary of an in-progress (or finished) linq2db test run.
+#
+# Reads the JSON heartbeat written by Tests/Base/TestProgressReporter.cs when a run is launched with
+# the LINQ2DB_TEST_PROGRESS environment variable set. By default it picks the most recently updated
+# .build/.claude/test-progress.*.json file (the active run); pass -Path to target a specific file.
+#
+# Usage:
+#   pwsh -NoProfile -File .claude/scripts/test-status.ps1
+#   pwsh -NoProfile -File .claude/scripts/test-status.ps1 -Path .build/.claude/test-progress.net10.0.1234.json
+#   pwsh -NoProfile -File .claude/scripts/test-status.ps1 -Raw      # emit the raw JSON instead of a summary
+
+[CmdletBinding()]
+param(
+	[string] $Path,
+	[switch] $Raw
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..' '..')
+
+if (-not $Path) {
+	$dir = Join-Path $repoRoot '.build/.claude'
+	if (-not (Test-Path $dir)) {
+		Write-Output "No test-progress directory yet ($dir). Start a run with LINQ2DB_TEST_PROGRESS=1."
+		return
+	}
+
+	$latest = Get-ChildItem -Path $dir -Filter 'test-progress.*.json' -File -ErrorAction SilentlyContinue |
+		Sort-Object LastWriteTimeUtc -Descending |
+		Select-Object -First 1
+
+	if (-not $latest) {
+		Write-Output "No test-progress.*.json found in $dir. Start a run with LINQ2DB_TEST_PROGRESS=1."
+		return
+	}
+
+	$Path = $latest.FullName
+}
+
+if (-not (Test-Path $Path)) {
+	Write-Output "File not found: $Path"
+	return
+}
+
+# Reader may catch a write in flight; retry briefly on a parse failure.
+$p = $null
+for ($i = 0; $i -lt 5; $i++) {
+	try { $p = Get-Content -Raw -Path $Path | ConvertFrom-Json; break }
+	catch { Start-Sleep -Milliseconds 100 }
+}
+
+if (-not $p) {
+	Write-Output "Could not parse $Path (still being written?)."
+	return
+}
+
+if ($Raw) {
+	Get-Content -Raw -Path $Path
+	return
+}
+
+function Format-Duration([double] $seconds) {
+	if ($null -eq $seconds) { return 'n/a' }
+	$ts = [TimeSpan]::FromSeconds($seconds)
+	if ($ts.TotalHours -ge 1) { return ('{0}h{1:00}m' -f [int]$ts.TotalHours, $ts.Minutes) }
+	if ($ts.TotalMinutes -ge 1) { return ('{0}m{1:00}s' -f [int]$ts.TotalMinutes, $ts.Seconds) }
+	return ('{0:0}s' -f $ts.TotalSeconds)
+}
+
+$total     = [long]$p.total
+$completed = [long]$p.completed
+$pct       = if ($total -gt 0) { [math]::Round(100.0 * $completed / $total, 1) } else { $null }
+$state     = if ($p.done) { 'DONE' } else { 'RUNNING' }
+$elapsed   = Format-Duration ([double]$p.elapsedSec)
+$eta       = if ($null -ne $p.etaSec) { Format-Duration ([double]$p.etaSec) } else { 'n/a' }
+$rate      = [math]::Round([double]$p.testsPerSec, 1)
+
+$progress  = if ($null -ne $pct) { "$completed/$total ($pct%)" } else { "$completed/?" }
+$current   = if ($p.currentTest) { $p.currentTest } else { '-' }
+
+$line = "[$state $($p.tfm)] $progress " +
+		"| pass $($p.passed) / fail $($p.failed) / skip $($p.skipped) " +
+		"| $rate t/s | elapsed $elapsed | eta $eta " +
+		"| now: $current"
+
+Write-Output $line
+
+if (([long]$p.failed) -gt 0 -and $p.recentFailures) {
+	Write-Output "recent failures:"
+	foreach ($f in $p.recentFailures) {
+		$msg = ($f.message -replace '\s+', ' ')
+		if ($msg.Length -gt 120) { $msg = $msg.Substring(0, 120) + '...' }
+		Write-Output "  - $($f.test): $msg"
+	}
+}

--- a/.claude/scripts/test-status.ps1
+++ b/.claude/scripts/test-status.ps1
@@ -62,7 +62,6 @@ if ($Raw) {
 }
 
 function Format-Duration([double] $seconds) {
-	if ($null -eq $seconds) { return 'n/a' }
 	$ts = [TimeSpan]::FromSeconds($seconds)
 	if ($ts.TotalHours -ge 1) { return ('{0}h{1:00}m' -f [int]$ts.TotalHours, $ts.Minutes) }
 	if ($ts.TotalMinutes -ge 1) { return ('{0}m{1:00}s' -f [int]$ts.TotalMinutes, $ts.Seconds) }

--- a/.claude/skills/test-progress/SKILL.md
+++ b/.claude/skills/test-progress/SKILL.md
@@ -11,7 +11,7 @@ Toggle and inspect the live progress heartbeat written by the test assembly duri
 
 The reporter is **opt-in**: it writes nothing unless `LINQ2DB_TEST_PROGRESS` is set to a truthy value in the process running `dotnet test`. This skill flips that variable in `.claude/settings.local.json` → `env`, which Claude Code injects into every Bash-tool subprocess (and their children, e.g. the NUnit test host). The `dotnet test` command itself is unchanged, so the existing `Bash(dotnet test *)` allowlist still matches (no new permission prompts).
 
-**On = `"1"`, off = `"0"` (not key-removal).** Claude Code applies an added or *changed* env value to the running session immediately (verified), but does **not** un-apply a *removed* key until restart. So `off` sets the value to `"0"` — a present-but-falsy value the reporter treats as disabled — which propagates right away. Removing the key would leave the trace silently on for the rest of the session.
+**On = `"1"`, off = `"0"` (not key-removal).** Claude Code applies an added or *changed* env value to the running session immediately, but does **not** un-apply a *removed* key until restart. So `off` sets `"0"` — a present-but-falsy value the reporter treats as disabled — which takes effect right away; removing the key would leave the trace silently on until restart.
 
 Scope: this affects test runs **Claude** launches via the Bash tool. A run the user starts in their **own** terminal won't inherit it — they set `LINQ2DB_TEST_PROGRESS=1` there themselves (see `testing.md`).
 
@@ -35,7 +35,7 @@ Scope: this affects test runs **Claude** launches via the Bash tool. A run the u
 ### `off` / `disable`
 
 1. `Read` `.claude/settings.local.json`.
-2. Set `env.LINQ2DB_TEST_PROGRESS` to `"0"` (add the `env` object / key if missing). **Do not remove the key** — a removed key isn't un-applied until restart, but a changed value propagates immediately. If it's already `"0"` (or any falsy value), report "already disabled" and stop.
+2. Set `env.LINQ2DB_TEST_PROGRESS` to `"0"` (add the `env` object / key if missing) — **not** key-removal (see *How it works*). If it's already `"0"` or another falsy value, report "already disabled" and stop.
 3. Confirm to the user: trace disabled, effective for the next run. Existing `.build/.claude/test-progress.*.json` files are left as-is (gitignored scratch).
 
 ### `status` (default)

--- a/.claude/skills/test-progress/SKILL.md
+++ b/.claude/skills/test-progress/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: test-progress
+description: Enable, disable, or check the live test-progress heartbeat for linq2db test runs. Toggles the LINQ2DB_TEST_PROGRESS environment variable session-wide via .claude/settings.local.json → env, so dotnet test runs (via /test, test-runner, or ad-hoc) emit a JSON heartbeat (current test, completed/total, pass/fail tally) that can be polled mid-run. Use when the user says "/test-progress", "enable test progress/trace", "watch the test run", "how far along are the tests".
+---
+
+# /test-progress
+
+Toggle and inspect the live progress heartbeat written by the test assembly during a run. Backed by [Tests/Base/TestProgressReporter.cs](../../../Tests/Base/TestProgressReporter.cs); reader docs in [`.claude/docs/testing.md`](../../docs/testing.md) → **Monitoring a long run**.
+
+## How it works
+
+The reporter is **opt-in**: it writes nothing unless `LINQ2DB_TEST_PROGRESS` is set to a truthy value in the process running `dotnet test`. This skill flips that variable in `.claude/settings.local.json` → `env`, which Claude Code injects into every Bash-tool subprocess (and their children, e.g. the NUnit test host). The `dotnet test` command itself is unchanged, so the existing `Bash(dotnet test *)` allowlist still matches (no new permission prompts).
+
+**On = `"1"`, off = `"0"` (not key-removal).** Claude Code applies an added or *changed* env value to the running session immediately (verified), but does **not** un-apply a *removed* key until restart. So `off` sets the value to `"0"` — a present-but-falsy value the reporter treats as disabled — which propagates right away. Removing the key would leave the trace silently on for the rest of the session.
+
+Scope: this affects test runs **Claude** launches via the Bash tool. A run the user starts in their **own** terminal won't inherit it — they set `LINQ2DB_TEST_PROGRESS=1` there themselves (see `testing.md`).
+
+## Arguments
+
+| Arg | Action |
+|---|---|
+| _(none)_ / `status` | Report whether the trace is on, and show the latest heartbeat if a run is active or recent. |
+| `on` / `enable` | Set `env.LINQ2DB_TEST_PROGRESS = "1"` in `settings.local.json`. |
+| `on <path>` | Same, but set the value to `<path>` (a directory or `*.json` file) to redirect the heartbeat location. |
+| `off` / `disable` | Set `env.LINQ2DB_TEST_PROGRESS = "0"` (immediate effect — see below; do **not** remove the key). |
+
+## Steps
+
+### `on` / `enable`
+
+1. `Read` `.claude/settings.local.json` at the repo (worktree) root.
+2. Ensure a top-level `"env"` object exists; set `"LINQ2DB_TEST_PROGRESS"` to `"1"` (or the `<path>` argument if given). Use `Edit` for a minimal change that preserves `permissions` and any other keys. If `env` already has the key with the same value, report "already enabled" and stop.
+3. Confirm to the user: trace enabled, value, and that it applies to the next Claude-run `dotnet test`. Remind that the file lands at `.build/.claude/test-progress.<tfm>.<pid>.json` (or the custom path) and is polled with `/test-progress` or `test-status.ps1`.
+
+### `off` / `disable`
+
+1. `Read` `.claude/settings.local.json`.
+2. Set `env.LINQ2DB_TEST_PROGRESS` to `"0"` (add the `env` object / key if missing). **Do not remove the key** — a removed key isn't un-applied until restart, but a changed value propagates immediately. If it's already `"0"` (or any falsy value), report "already disabled" and stop.
+3. Confirm to the user: trace disabled, effective for the next run. Existing `.build/.claude/test-progress.*.json` files are left as-is (gitignored scratch).
+
+### `status` (default)
+
+1. `Read` `.claude/settings.local.json`; report the trace state from `env.LINQ2DB_TEST_PROGRESS` — **on** for a truthy value (`1`/`true`/`on`/`yes` or a path), **off** when absent or falsy (`0`/`false`/`off`/`no`/empty). Show the raw value when it's a custom path.
+2. Run the summary helper for the most recent run:
+
+   ```
+   pwsh -NoProfile -File .claude/scripts/test-status.ps1
+   ```
+
+   Relay its one-line output. If it reports no heartbeat file, say so. Add `-Raw` only if the user wants the full JSON.
+
+## JSON-editing notes
+
+- `settings.local.json` is small, gitignored, and user-owned. Edit it directly — the user invoking this skill *is* the consent. Do not route through `/update-config` for this single toggle.
+- Make the **minimal** edit: insert or change only the `env.LINQ2DB_TEST_PROGRESS` line. Never reorder or rewrite the `permissions` block.
+- This skill is the one place that toggles this variable. If the user wants other harness env vars managed, point them at `/update-config`.
+
+## Don'ts
+
+- Don't prefix `dotnet test` commands with the variable, and don't ask `test-runner` to — the whole point of the settings-`env` approach is to keep the command (and its allowlist match) unchanged.
+- Don't edit `Tests/Base/TestProgressReporter.cs` or any test source from here — this skill only flips the environment toggle.
+- `/test` auto-enables the trace for **long / full-suite** runs (its step 3.1a) and monitors the heartbeat — that's expected. For **short** single-test runs the trace stays as-is; don't flip it on for those unless the user asks.

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -72,7 +72,7 @@ A run is **long** when any of: project is `Tests/Linq/Tests.csproj` (especially 
 
 For a long run:
 
-1. **Auto-enable the progress heartbeat** — invoke `/test-progress on` (don't merely suggest it), then tell the user it's on and that you'll report progress as it runs. (For short runs, leave the trace as-is.)
+1. **Auto-enable the progress heartbeat** — invoke `/test-progress on` (don't merely suggest it), then tell the user it's on and that you'll report progress as it runs.
 2. **Run it in the background so progress is readable** — invoke `test-runner` with `run_in_background: true`. The test process writes the heartbeat to `.build/.claude/test-progress.<tfm>.<pid>.json` regardless of who launched it; running the agent in the background is what frees you to poll it instead of blocking with nothing to show.
 3. **Poll and surface progress** — between turns, read the heartbeat with `pwsh -NoProfile -File .claude/scripts/test-status.ps1` (or `Read` the JSON) and give the user a one-line update (completed/total, current test, failures so far). You can do this any time the user asks "how's it going?" — you don't have to wait for the run to finish. Don't busy-poll; check when prompted or at natural intervals.
 4. When the background `test-runner` completes, continue with the baselines diff (3.4) and the final report (3.5) as usual.

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -66,6 +66,17 @@ Resolve `{project, tfm}` for each run:
 - **EFCore test** — expand to all four projects (EF3/EF8/EF9/EF10). Use `{efMatrix: true, providers: [...]}` shorthand on the agent.
 - **Explicit filter → specific test** — read the test's attributes to infer `[DataSources]` family and EFCore-vs-main. When the filter matches tests across both main and EFCore projects (rare but possible), ask the user to pick.
 
+#### 3.1a Long runs — auto-trace + background monitor
+
+A run is **long** when any of: project is `Tests/Linq/Tests.csproj` (especially across multiple TFMs); the EF matrix runs against more than one provider; the filter is broad (a whole class, a `CreateDatabase`-only full-init pass, or no narrowing filter); or the user said "full" / "all" / "the whole suite". A single-method or Playground run is **short** — skip this subsection and run it synchronously per 3.3.
+
+For a long run:
+
+1. **Auto-enable the progress heartbeat** — invoke `/test-progress on` (don't merely suggest it), then tell the user it's on and that you'll report progress as it runs. (For short runs, leave the trace as-is.)
+2. **Run it in the background so progress is readable** — invoke `test-runner` with `run_in_background: true`. The test process writes the heartbeat to `.build/.claude/test-progress.<tfm>.<pid>.json` regardless of who launched it; running the agent in the background is what frees you to poll it instead of blocking with nothing to show.
+3. **Poll and surface progress** — between turns, read the heartbeat with `pwsh -NoProfile -File .claude/scripts/test-status.ps1` (or `Read` the JSON) and give the user a one-line update (completed/total, current test, failures so far). You can do this any time the user asks "how's it going?" — you don't have to wait for the run to finish. Don't busy-poll; check when prompted or at natural intervals.
+4. When the background `test-runner` completes, continue with the baselines diff (3.4) and the final report (3.5) as usual.
+
 #### 3.2 Resolve target providers
 
 Provider state is owned by `/test-providers` and read by `test-runner` from `UserDataProviders.json`. `/test` does **not** propose providers, edit the file, or pre-validate that the requested set is enabled — that's the user's job ahead of running `/test`.
@@ -85,6 +96,8 @@ Call `test-runner` with:
 - `config` — `"Debug"` unless the user asked for Release.
 - `verbosity` — `"normal"`; flip to `"detailed"` when the user needs SQL-dump output from `TestContext.Out.WriteLine`.
 
+For a **short** run, invoke `test-runner` synchronously. For a **long** run, invoke it with `run_in_background: true` and monitor the heartbeat per 3.1a.
+
 `test-runner` is read-only on `UserDataProviders.json` — there is no `userProvidersConsent` or `restoreOnCompletion` input, and no provider edits happen as a side effect of the run. If the agent reports `status: "blocked"` with a missing-provider message, relay it to the user with a one-liner: "Run `/test-providers <provider>` to enable it, then re-run `/test`."
 
 #### 3.4 Baselines diff (when baselines are written)
@@ -103,6 +116,8 @@ Relay the agent's per-target summary:
 - One row per target: `<project> (<tfm>) — passed/failed/none_matched · N passed, M failed, K skipped`
 - For `failed` targets, include the first failure's message + top stack frame.
 - For `none_matched` targets, cite the agent's `note` (usually a `#if !NETFRAMEWORK` guard).
+
+For a long run you already enabled the trace and monitored it via the heartbeat (3.1a); the final report still comes from the agent's structured summary, with the heartbeat's failure list as a cross-check.
 
 If any failure looks like an env problem (connection refused, "Provider X not enabled" block, missing schema), point at `/test-providers` for the fix — do not investigate or auto-repair from here. Otherwise just relay the agent's output verbatim.
 

--- a/Tests/Base/TestProgressReporter.cs
+++ b/Tests/Base/TestProgressReporter.cs
@@ -1,0 +1,354 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+
+namespace Tests
+{
+	/// <summary>
+	/// Assembly-level NUnit action that emits a live progress heartbeat (a small JSON file) for long test runs,
+	/// so an external observer can see which test is running, how many remain, and the running pass/fail tally
+	/// without scraping console output.
+	/// <para>
+	/// Opt-in: the reporter is a no-op unless the <c>LINQ2DB_TEST_PROGRESS</c> environment variable is set. When set
+	/// to a flag value (<c>1</c>/<c>true</c>/<c>on</c>/<c>yes</c>) the file is written to
+	/// <c>&lt;repoRoot&gt;/.build/.claude/test-progress.&lt;tfm&gt;.&lt;pid&gt;.json</c>; when set to a directory or
+	/// <c>*.json</c> path that path is used instead.
+	/// </para>
+	/// See <c>.claude/docs/testing.md</c> → "Monitoring a long run".
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Assembly)]
+	public sealed class TestProgressReporterAttribute : NUnitAttribute, ITestAction
+	{
+		ActionTargets ITestAction.Targets => ActionTargets.Test | ActionTargets.Suite;
+
+		void ITestAction.BeforeTest(ITest test) => TestProgressTracker.OnBefore(test);
+		void ITestAction.AfterTest (ITest test) => TestProgressTracker.OnAfter (test);
+	}
+
+	internal static class TestProgressTracker
+	{
+		// Resolved at compile time per target framework so the moniker is always exact (avoids net462 API gaps).
+#if NET462
+		const string Tfm = "net462";
+#elif NET8_0
+		const string Tfm = "net8.0";
+#elif NET9_0
+		const string Tfm = "net9.0";
+#elif NET10_0
+		const string Tfm = "net10.0";
+#else
+		const string Tfm = "unknown";
+#endif
+
+		const int MaxRecentFailures = 20;
+		const int WriteThrottleMs   = 1000;  // at most ~1 file write/sec for the common (passing) case
+
+		static readonly object                              _sync     = new();
+		static readonly Stopwatch                           _clock    = new();
+		static readonly List<(string Test, string Message)> _failures = new();
+
+		static bool    _initialized;
+		static bool    _enabled;
+		static string? _file;
+		static int     _pid;
+
+		static long     _total;
+		static long     _started;
+		static long     _completed;
+		static long     _passed;
+		static long     _failed;
+		static long     _skipped;
+		static string?  _current;
+		static bool     _done;
+		static DateTime _startedUtc;
+		static long     _lastWriteMs = -WriteThrottleMs;
+
+		public static void OnBefore(ITest test)
+		{
+			lock (_sync)
+			{
+				if (!EnsureInit())
+					return;
+
+				if (test.IsSuite)
+				{
+					// The assembly (root) suite has the largest case count → that is the run total.
+					// Note: under a --filter this is the discovered (pre-filter) count, so it over-counts.
+					if (test.TestCaseCount > _total)
+						_total = test.TestCaseCount;
+					return;
+				}
+
+				_started++;
+				_current = test.FullName;
+				Write(force: false);
+			}
+		}
+
+		public static void OnAfter(ITest test)
+		{
+			lock (_sync)
+			{
+				if (!EnsureInit())
+					return;
+
+				if (test.IsSuite)
+				{
+					// Suite teardown fires bottom-up; the root suite (no parent) finishing means the run is done.
+					if (!_done && test.Parent == null)
+					{
+						_done    = true;
+						_current = null;
+						Write(force: true);
+					}
+
+					return;
+				}
+
+				_completed++;
+				// Deliberately do NOT clear _current here: with throttled writes, nulling between every test
+				// makes the on-disk snapshot almost always catch the gap (showing no current test). Keep the
+				// most-recently-started test as "current" until the run completes — during a run that is the
+				// in-flight (or just-finished) test, which is what a watcher wants to see.
+
+				var force = false;
+
+				switch (TestContext.CurrentContext.Result.Outcome.Status)
+				{
+					case TestStatus.Passed : _passed++;  break;
+					case TestStatus.Skipped: _skipped++; break;
+					case TestStatus.Failed :
+						_failed++;
+						force = true;
+						if (_failures.Count < MaxRecentFailures)
+							_failures.Add((test.FullName, Trim(TestContext.CurrentContext.Result.Message)));
+						break;
+					// Inconclusive / Warning — count as completed but neither pass nor fail bucket.
+					default: break;
+				}
+
+				// For unfiltered runs total is exact, so completed reaching it marks the run done even if the
+				// root-suite teardown ordering surprises us.
+				if (!_done && _total > 0 && _completed >= _total)
+				{
+					_done    = true;
+					_current = null;
+					force    = true;
+				}
+
+				Write(force);
+			}
+		}
+
+		static bool EnsureInit()
+		{
+			if (_initialized)
+				return _enabled;
+
+			_initialized = true;
+
+			// Disabled when unset, empty, or an explicit falsy token. The /test-progress skill turns the trace
+			// off by setting the value to "0" (not by removing the key), because Claude Code propagates a changed
+			// env value into the running session but does not un-apply a removed one until restart.
+			var env = Environment.GetEnvironmentVariable("LINQ2DB_TEST_PROGRESS");
+			if (IsDisabledValue(env))
+				return _enabled = false;
+
+			try
+			{
+				_pid        = Process.GetCurrentProcess().Id;
+				_file       = ResolvePath(env!.Trim());
+				_startedUtc = DateTime.UtcNow;
+
+				var dir = Path.GetDirectoryName(_file);
+				if (!string.IsNullOrEmpty(dir))
+					Directory.CreateDirectory(dir!);
+
+				_clock.Start();
+				_enabled = true;
+			}
+			catch
+			{
+				// Never let progress-reporting setup break a test run.
+				_enabled = false;
+			}
+
+			return _enabled;
+		}
+
+		static string ResolvePath(string env)
+		{
+			var fileName = $"test-progress.{Tfm}.{_pid}.json";
+
+			if (!IsFlag(env))
+			{
+				if (Directory.Exists(env))
+					return Path.Combine(env, fileName);
+
+				if (env.EndsWith(".json", StringComparison.OrdinalIgnoreCase)
+					|| env.IndexOf('/') >= 0 || env.IndexOf('\\') >= 0)
+					return env;
+			}
+
+			return Path.Combine(FindRepoRoot(), ".build", ".claude", fileName);
+		}
+
+		static bool IsDisabledValue(string? value)
+		{
+			if (string.IsNullOrWhiteSpace(value))
+				return true;
+
+			var v = value!.Trim();
+
+			return v.Equals("0",        StringComparison.OrdinalIgnoreCase)
+				|| v.Equals("false",    StringComparison.OrdinalIgnoreCase)
+				|| v.Equals("off",      StringComparison.OrdinalIgnoreCase)
+				|| v.Equals("no",       StringComparison.OrdinalIgnoreCase)
+				|| v.Equals("disable",  StringComparison.OrdinalIgnoreCase)
+				|| v.Equals("disabled", StringComparison.OrdinalIgnoreCase);
+		}
+
+		static bool IsFlag(string value) =>
+			   value.Equals("1",       StringComparison.OrdinalIgnoreCase)
+			|| value.Equals("true",    StringComparison.OrdinalIgnoreCase)
+			|| value.Equals("on",      StringComparison.OrdinalIgnoreCase)
+			|| value.Equals("yes",     StringComparison.OrdinalIgnoreCase)
+			|| value.Equals("enable",  StringComparison.OrdinalIgnoreCase)
+			|| value.Equals("enabled", StringComparison.OrdinalIgnoreCase);
+
+		static string FindRepoRoot()
+		{
+			try
+			{
+				for (var dir = new DirectoryInfo(AppContext.BaseDirectory); dir != null; dir = dir.Parent)
+					if (File.Exists(Path.Combine(dir.FullName, "linq2db.slnx")))
+						return dir.FullName;
+			}
+			catch
+			{
+				// fall through to base directory
+			}
+
+			return AppContext.BaseDirectory;
+		}
+
+		static void Write(bool force)
+		{
+			var nowMs = _clock.ElapsedMilliseconds;
+			if (!force && nowMs - _lastWriteMs < WriteThrottleMs)
+				return;
+
+			_lastWriteMs = nowMs;
+
+			var elapsedSec = _clock.Elapsed.TotalSeconds;
+			var rate       = elapsedSec > 0 ? _completed / elapsedSec : 0d;
+			var eta        = rate > 0 && _total > _completed ? (_total - _completed) / rate : (double?)null;
+
+			var sb = new StringBuilder(512);
+
+			sb.Append('{');
+			sb.Append("\"tfm\":")        .Append(JsonString(Tfm))                       .Append(',');
+			sb.Append("\"pid\":")        .Append(Int(_pid))                             .Append(',');
+			sb.Append("\"startedUtc\":") .Append(JsonString(Iso(_startedUtc)))          .Append(',');
+			sb.Append("\"updatedUtc\":") .Append(JsonString(Iso(DateTime.UtcNow)))      .Append(',');
+			sb.Append("\"done\":")       .Append(_done ? "true" : "false")              .Append(',');
+			sb.Append("\"total\":")      .Append(Long(_total))                          .Append(',');
+			sb.Append("\"completed\":")  .Append(Long(_completed))                      .Append(',');
+			sb.Append("\"started\":")    .Append(Long(_started))                        .Append(',');
+			sb.Append("\"passed\":")     .Append(Long(_passed))                         .Append(',');
+			sb.Append("\"failed\":")     .Append(Long(_failed))                         .Append(',');
+			sb.Append("\"skipped\":")    .Append(Long(_skipped))                        .Append(',');
+			sb.Append("\"currentTest\":").Append(JsonString(_current))                  .Append(',');
+			sb.Append("\"elapsedSec\":") .Append(Num(elapsedSec))                       .Append(',');
+			sb.Append("\"testsPerSec\":").Append(Num(rate))                             .Append(',');
+			sb.Append("\"etaSec\":")     .Append(eta.HasValue ? Num(eta.Value) : "null").Append(',');
+			sb.Append("\"recentFailures\":[");
+
+			for (var i = 0; i < _failures.Count; i++)
+			{
+				if (i > 0)
+					sb.Append(',');
+
+				sb.Append("{\"test\":").Append(JsonString(_failures[i].Test))
+				  .Append(",\"message\":").Append(JsonString(_failures[i].Message)).Append('}');
+			}
+
+			sb.Append("]}");
+
+			WriteFile(sb.ToString());
+		}
+
+		static void WriteFile(string content)
+		{
+			try
+			{
+				var tmp = _file + ".tmp";
+
+				File.WriteAllText(tmp, content, new UTF8Encoding(false));
+
+				// Replace atomically so a concurrent reader never sees a half-written file.
+				if (File.Exists(_file))
+					File.Replace(tmp, _file, null);
+				else
+					File.Move(tmp, _file!);
+			}
+			catch
+			{
+				// Best effort — IO contention or a locked file must never fail the test run.
+				try { File.WriteAllText(_file!, content, new UTF8Encoding(false)); }
+				catch { /* give up silently */ }
+			}
+		}
+
+		static string Iso(DateTime value) => value.ToString("o", CultureInfo.InvariantCulture);
+		static string Int(int     value)  => value.ToString(CultureInfo.InvariantCulture);
+		static string Long(long   value)  => value.ToString(CultureInfo.InvariantCulture);
+		static string Num(double  value)  => value.ToString("0.###", CultureInfo.InvariantCulture);
+
+		static string Trim(string? message)
+		{
+			if (string.IsNullOrEmpty(message))
+				return "";
+
+			return message!.Length > 500 ? message.Substring(0, 500) : message;
+		}
+
+		static string JsonString(string? value)
+		{
+			if (value == null)
+				return "null";
+
+			var sb = new StringBuilder(value.Length + 2);
+			sb.Append('"');
+
+			foreach (var c in value)
+			{
+				switch (c)
+				{
+					case '"' : sb.Append("\\\""); break;
+					case '\\': sb.Append("\\\\"); break;
+					case '\b': sb.Append("\\b");  break;
+					case '\f': sb.Append("\\f");  break;
+					case '\n': sb.Append("\\n");  break;
+					case '\r': sb.Append("\\r");  break;
+					case '\t': sb.Append("\\t");  break;
+					default:
+						if (c < ' ')
+							sb.Append("\\u").Append(((int)c).ToString("x4", CultureInfo.InvariantCulture));
+						else
+							sb.Append(c);
+						break;
+				}
+			}
+
+			sb.Append('"');
+			return sb.ToString();
+		}
+	}
+}

--- a/Tests/EntityFrameworkCore/AssemblyInfo.TestProgress.cs
+++ b/Tests/EntityFrameworkCore/AssemblyInfo.TestProgress.cs
@@ -1,0 +1,6 @@
+using Tests;
+
+// Live progress heartbeat for long test runs. Opt-in via the LINQ2DB_TEST_PROGRESS environment variable.
+// Compiled into all EF Core test assemblies (EF3/EF8/EF9/EF10) via the shared source directory.
+// See .claude/docs/testing.md → "Monitoring a long run".
+[assembly: TestProgressReporter]

--- a/Tests/Linq/AssemblyInfo.TestProgress.cs
+++ b/Tests/Linq/AssemblyInfo.TestProgress.cs
@@ -1,0 +1,5 @@
+using Tests;
+
+// Live progress heartbeat for long test runs. Opt-in via the LINQ2DB_TEST_PROGRESS environment variable.
+// See .claude/docs/testing.md → "Monitoring a long run".
+[assembly: TestProgressReporter]

--- a/Tests/Tests.Playground/AssemblyInfo.TestProgress.cs
+++ b/Tests/Tests.Playground/AssemblyInfo.TestProgress.cs
@@ -1,0 +1,5 @@
+using Tests;
+
+// Live progress heartbeat for long test runs. Opt-in via the LINQ2DB_TEST_PROGRESS environment variable.
+// See .claude/docs/testing.md → "Monitoring a long run".
+[assembly: TestProgressReporter]


### PR DESCRIPTION
Adds an opt-in live progress heartbeat for long NUnit runs so progress can be
read mid-run (current test, completed/total, pass/fail tally, recent failures)
without scraping console output.

## Test harness
- `Tests/Base/TestProgressReporter.cs` — assembly-level NUnit `ITestAction` writes
  a JSON heartbeat to `.build/.claude/test-progress.<tfm>.<pid>.json` while a run
  is in flight (throttled ~1/s, immediate on failure). `[assembly: TestProgressReporter]`
  wired into Linq, Playground, and EF Core (EF3/8/9/10).
- Opt-in via the `LINQ2DB_TEST_PROGRESS` env var; a no-op when unset, so default
  runs are byte-identical.

## Agent tooling (.claude)
- `/test-progress` skill toggles the trace via `settings.local.json` → `env`.
- `.claude/scripts/test-status.ps1` prints a one-line summary.
- `/test` auto-enables + background-monitors long runs; documented in `testing.md`.

Caveat: under a `--filter`, `total`/`etaSec` reflect the discovered (pre-filter)
count; `completed`/`currentTest` are always accurate.
