### PR TITLE
Migrate test projects to Microsoft.Testing.Platform

### DIFF
--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -39,7 +39,7 @@ The agent never writes to `UserDataProviders.json` and does not back it up — t
    - **Explicit**: `[{project: "Tests/.../Tests.EntityFrameworkCore.EF10.csproj", tfm: "net10.0", providers: ["SqlServer.2016.MS"]}, ...]`
    - **Shorthand**: `{efMatrix: true, providers: [...]}` — expands to all four EFCore projects (EF3/EF8/EF9/EF10) with the matching TFMs (net462 / net8.0 / net9.0 / net10.0). Or `{mainTests: true, providers: [...]}` — defaults to `Tests/Tests.Playground/Tests.Playground.csproj` at `net10.0`. Add `tfm: "<...>"` and/or `project: "Tests/Linq/Tests.csproj"` explicitly to override the fast-path default.
 3. **`config`** — default `"Debug"`. Testing guidance in `testing.md` warns against `Release` (slow, analyzers); don't override without a specific reason.
-4. **`verbosity`** — default `"normal"`. Set `"detailed"` when the caller needs SQL-dump diagnostics from `TestContext.Out.WriteLine` (translates to `--logger "console;verbosity=detailed"`).
+4. **`verbosity`** — default `"normal"`. Set `"detailed"` when the caller needs SQL-dump diagnostics from `TestContext.Out.WriteLine`. Tests run on Microsoft.Testing.Platform (MTP), which captures the test app's console output by default; surface it with `-p:TestingPlatformCaptureOutput=false` (the VSTest `--logger "console;verbosity=detailed"` no longer applies).
 
 ## TFM / project mapping
 
@@ -68,13 +68,15 @@ Use `Tests/Linq/Tests.csproj` only when the caller explicitly asks (`project: "T
 For each target, issue one `dotnet test` invocation:
 
 ```
-dotnet test <project> --filter "<testPattern>" -c <config>
+dotnet test --project <project> --filter "<testPattern>" -c <config> --settings .runsettings
 ```
 
 Notes:
-- **Live progress heartbeat.** When `LINQ2DB_TEST_PROGRESS` is set, the test assembly writes a JSON heartbeat to `.build/.claude/test-progress.<tfm>.<pid>.json` during the run (see [Tests/Base/TestProgressReporter.cs](../../Tests/Base/TestProgressReporter.cs)). Don't set it inline — it's toggled session-wide by the `/test-progress` skill, so the plain `dotnet test` form above is correct whether the trace is on or off.
+- **`--project` is required.** The repo's `global.json` selects the Microsoft.Testing.Platform runner, where the bare `dotnet test <project>` form is rejected (`Specifying a project for 'dotnet test' should be via '--project'`). The test projects build as MTP executables.
+- **Pass `--settings .runsettings`** (from the repo root). MTP does not auto-discover `.runsettings`; NUnit bridges it via `--settings`, and it carries `AssemblySelectLimit` (without it a filter selecting >~2000 tests can fall back to running the whole assembly).
+- **Live progress heartbeat.** When `LINQ2DB_TEST_PROGRESS` is set, the test assembly writes a JSON heartbeat to `.build/.claude/test-progress.<tfm>.<pid>.json` during the run (see [Tests/Base/TestProgressReporter.cs](../../Tests/Base/TestProgressReporter.cs)). Don't set it inline — it's toggled session-wide by the `/test-progress` skill, so the `dotnet test` form above is correct whether the trace is on or off.
 - The four EFCore projects each have a single TFM, so `-f <tfm>` is redundant for them. Include `-f <tfm>` only for `Tests/Linq/Tests.csproj` (multi-TFM).
-- `--logger "console;verbosity=detailed"` when `verbosity: "detailed"`.
+- `-p:TestingPlatformCaptureOutput=false` when `verbosity: "detailed"` (shows the test app's console / SQL-dump output).
 - Don't pipe output to `head`/`tail` — read the whole log. Per `testing.md`: NUnit and `dotnet test` interleave relevant info across the log; setup exceptions can come well before the assertion, and stack traces may be truncated if you skim.
 
 ## Output format
@@ -104,7 +106,7 @@ Return a single fenced JSON block — nothing else before or after it.
     }
   ],
   "callLog": [
-    { "command": "dotnet test Tests/EntityFrameworkCore/Tests.EntityFrameworkCore.EF10.csproj --filter \"FullyQualifiedName~InsertWithIdentity_Sequence\" -c Debug", "reason": "EF10 run" }
+    { "command": "dotnet test --project Tests/EntityFrameworkCore/Tests.EntityFrameworkCore.EF10.csproj --filter \"FullyQualifiedName~InsertWithIdentity_Sequence\" -c Debug --settings .runsettings", "reason": "EF10 run" }
   ]
 }
 ```
@@ -113,7 +115,7 @@ Target `status` values:
 
 - `"passed"` — non-zero tests ran and all passed.
 - `"failed"` — at least one test failed. Populate `failures[]` with `{test, message, stackTop?}`.
-- `"none_matched"` — `dotnet test` reported `No test matches the given testcase filter`. Common for EF3 when all target tests are `#if !NETFRAMEWORK`; report in `note` and keep going.
+- `"none_matched"` — the run reported zero tests (MTP: `Zero tests ran`, exit code 8; or VSTest's `No test matches the given testcase filter`). Common for EF3 when all target tests are `#if !NETFRAMEWORK`; report in `note` and keep going.
 - `"error"` — the run itself failed (build error, connection error, crash). Populate `error` with a short message.
 
 Top-level `status`:

--- a/.claude/docs/testing.md
+++ b/.claude/docs/testing.md
@@ -1,15 +1,17 @@
 # Running Tests
 
-Tests use **NUnit3** with **Shouldly** assertions (not NUnit Assert). Test targets: `net462`, `net8.0`, `net9.0`, `net10.0`. **Always use Debug configuration and prefer `net10.0`** — Release enables Roslyn analyzers and is much slower to build. The full test suite takes ~1 hour or more; avoid running it unless necessary.
+Tests use **NUnit3** with **Shouldly** assertions (not NUnit Assert), running on **Microsoft.Testing.Platform** (MTP) — selected via `global.json` — not VSTest. Test targets: `net462`, `net8.0`, `net9.0`, `net10.0`. **Always use Debug configuration and prefer `net10.0`** — Release enables Roslyn analyzers and is much slower to build. The full test suite takes ~1 hour or more; avoid running it unless necessary.
 
 **Don't prepend a `dotnet build`.** `dotnet test` builds the project automatically if binaries are stale; a standalone `dotnet build` right before `dotnet test` only adds waiting time. If a test run fails with compile errors, fix them and re-run `dotnet test` directly.
 
+Under MTP, `dotnet test` takes the project via `--project` (a solution/filter via `--solution`) — the bare `dotnet test <project>` form is rejected. Always pass `--settings .runsettings` so NUnit honors `AssemblySelectLimit`; otherwise a broad `--filter` can fall back to running the whole assembly.
+
 ```bash
-# Run a single test class or method via dotnet test
-dotnet test Tests/Linq/Tests.csproj --filter "FullyQualifiedName~ClassName.MethodName" -f net10.0
+# Run a single test class or method
+dotnet test --project Tests/Linq/Tests.csproj --filter "FullyQualifiedName~ClassName.MethodName" -f net10.0 --settings .runsettings
 
 # Run tests with the lightweight playground solution (faster load)
-dotnet test linq2db.playground.slnf
+dotnet test --solution linq2db.playground.slnf --settings .runsettings
 ```
 
 **Default to `Tests.Playground` for any iterative test run** — fresh tests, fix-verification on existing tests, ad-hoc repro. The full `Tests/Linq/Tests.csproj` build is ~3+ minutes; the playground project is ~30s. Two distinct shapes:
@@ -18,7 +20,7 @@ dotnet test linq2db.playground.slnf
 2. **Iterating on a real test in `Tests/Linq/`** — add `<Compile Include="..\Linq\<sub>\<File>.cs" Link="<File>.cs" />` to `Tests/Tests.Playground/Tests.Playground.csproj`. The link is local scratch and must **not** be committed (same rule). Use this shape when iterating on a test that already lives in `Tests/Linq/` (e.g. a regression test you just wrote alongside a fix) without paying the cost of the full `Tests/Linq/Tests.csproj` multi-TFM build.
 
 ```bash
-dotnet test Tests/Tests.Playground/Tests.Playground.csproj --filter "FullyQualifiedName~ClassName.MethodName" -f net10.0
+dotnet test --project Tests/Tests.Playground/Tests.Playground.csproj --filter "FullyQualifiedName~ClassName.MethodName" -f net10.0 --settings .runsettings
 ```
 
 Reach for the full `Tests/Linq/Tests.csproj` only when the test target spans many files that would require a wide playground link, or when running a broad filter (e.g. an entire test class).
@@ -39,9 +41,9 @@ A full suite run takes 1–2 hours. To watch progress without scraping console o
 
 ```bash
 # PowerShell
-$env:LINQ2DB_TEST_PROGRESS = '1'; dotnet test Tests/Linq/Tests.csproj -f net10.0 --filter "..."
+$env:LINQ2DB_TEST_PROGRESS = '1'; dotnet test --project Tests/Linq/Tests.csproj -f net10.0 --filter "..."
 # bash
-LINQ2DB_TEST_PROGRESS=1 dotnet test Tests/Linq/Tests.csproj -f net10.0 --filter "..."
+LINQ2DB_TEST_PROGRESS=1 dotnet test --project Tests/Linq/Tests.csproj -f net10.0 --filter "..."
 ```
 
 The file lands at `.build/.claude/test-progress.<tfm>.<pid>.json` (one per TFM/process). Set the variable to a directory or a `*.json` path to override the location. Fields: `done`, `total`, `completed`, `passed`, `failed`, `skipped`, `currentTest`, `elapsedSec`, `testsPerSec`, `etaSec`, and `recentFailures[]`.
@@ -93,7 +95,7 @@ When the user asks to run tests against a provider family without naming the exa
 **Always include `CreateDatabase` in your `--filter`.** Prepend `FullyQualifiedName~CreateData.CreateDatabase|` to any filter you construct — the test is idempotent, re-running it is cheap, and it removes the "empty database" failure mode entirely.
 
 ```bash
-dotnet test Tests/Linq/Tests.csproj -f net10.0 --filter "FullyQualifiedName~CreateData.CreateDatabase|FullyQualifiedName~FirebirdTests.DropTableTest"
+dotnet test --project Tests/Linq/Tests.csproj -f net10.0 --filter "FullyQualifiedName~CreateData.CreateDatabase|FullyQualifiedName~FirebirdTests.DropTableTest" --settings .runsettings
 ```
 
 If your test modifies data, revert changes to avoid side effects in downstream tests.

--- a/Build/Azure/pipelines/templates/build-job.yml
+++ b/Build/Azure/pipelines/templates/build-job.yml
@@ -131,6 +131,11 @@ jobs:
                 if %errorlevel% neq 0 exit
                 copy DataProviders.json testing\%%f\efcore\%%a
                 if %errorlevel% neq 0 exit
+                REM ship .runsettings next to each test app: MTP does not auto-discover it, NUnit honors it via --settings (AssemblySelectLimit)
+                copy .runsettings testing\%%f\main\%%a
+                if %errorlevel% neq 0 exit
+                copy .runsettings testing\%%f\efcore\%%a
+                if %errorlevel% neq 0 exit
             )
         )
 

--- a/Build/Azure/pipelines/templates/build-job.yml
+++ b/Build/Azure/pipelines/templates/build-job.yml
@@ -84,7 +84,9 @@ jobs:
             if %errorlevel% neq 0 exit
             )
 
-        dotnet publish Tests/EntityFrameworkCore/Tests.EntityFrameworkCore.EF3.csproj -f net462 -c $(test_configuration) -o .build/publish/EFTests/$(test_configuration)/net462_x64
+        REM -a x64: net462 is AnyCPU and runs as x64; without an explicit RID the SQLitePCLRaw net4x
+        REM native target ships only the x86 e_sqlite3, which the x64 EF test process cannot load.
+        dotnet publish Tests/EntityFrameworkCore/Tests.EntityFrameworkCore.EF3.csproj -f net462 -c $(test_configuration) -a x64 -o .build/publish/EFTests/$(test_configuration)/net462_x64
         if %errorlevel% neq 0 exit
 
         dotnet publish Tests/EntityFrameworkCore/Tests.EntityFrameworkCore.EF8.csproj -f net8.0 -c $(test_configuration) -o .build/publish/EFTests/$(test_configuration)/net8.0_x64

--- a/Build/Azure/pipelines/templates/build-job.yml
+++ b/Build/Azure/pipelines/templates/build-job.yml
@@ -103,7 +103,7 @@ jobs:
         if %errorlevel% neq 0 exit
     
         FOR %%f IN (net8.0 net9.0 net10.0) DO (
-            dotnet publish Tests/Linq/Tests.csproj -f %%f -c $(test_configuration) -a x86 /p:DB2STUB=True -o .build/publish/Tests/$(test_configuration)/%%f_x86
+            dotnet publish Tests/Linq/Tests.csproj -f %%f -c $(test_configuration) -a x86 /p:X86STUBS=True -o .build/publish/Tests/$(test_configuration)/%%f_x86
             if %errorlevel% neq 0 exit
         )
 

--- a/Build/Azure/pipelines/templates/test-jobs.yml
+++ b/Build/Azure/pipelines/templates/test-jobs.yml
@@ -153,7 +153,8 @@ jobs:
             script_local: ${{ test_config.script_win_local }}
             psscript_local: ${{ test_config.psscript_win_local }}
             pre_test_win_local: ${{ test_config.pre_test_win_local }}
-            post_test_win_local: ${{ test_config.post_test_win_local }}            netfx: ${{ test_config.enable_fw_netfx }}
+            post_test_win_local: ${{ test_config.post_test_win_local }}
+            netfx: ${{ test_config.enable_fw_netfx }}
             net80: ${{ test_config.enable_fw_net80 }}
             net90: ${{ test_config.enable_fw_net90 }}
             net100: ${{ test_config.enable_fw_net100 }}
@@ -187,7 +188,8 @@ jobs:
             title: ${{ test_config.title }}
             config: ${{ test_config.config_linux }}
             script_global: ${{ test_config.script_linux_global }}
-            script_local: ${{ test_config.script_linux_local }}            net80: ${{ test_config.enable_fw_net80 }}
+            script_local: ${{ test_config.script_linux_local }}
+            net80: ${{ test_config.enable_fw_net80 }}
             net90: ${{ test_config.enable_fw_net90 }}
             net100: ${{ test_config.enable_fw_net100 }}
             retry: ${{ test_config.retry }}
@@ -220,7 +222,8 @@ jobs:
             config: ${{ test_config.config_macos }}
             script_global: ${{ test_config.script_macos_global }}
             script_local: ${{ test_config.script_macos_local }}
-            docker: ${{ test_config.install_docker_macos }}            net80: ${{ test_config.enable_fw_net80 }}
+            docker: ${{ test_config.install_docker_macos }}
+            net80: ${{ test_config.enable_fw_net80 }}
             net90: ${{ test_config.enable_fw_net90 }}
             net100: ${{ test_config.enable_fw_net100 }}
             retry: ${{ test_config.retry }}

--- a/Build/Azure/pipelines/templates/test-jobs.yml
+++ b/Build/Azure/pipelines/templates/test-jobs.yml
@@ -153,9 +153,7 @@ jobs:
             script_local: ${{ test_config.script_win_local }}
             psscript_local: ${{ test_config.psscript_win_local }}
             pre_test_win_local: ${{ test_config.pre_test_win_local }}
-            post_test_win_local: ${{ test_config.post_test_win_local }}
-            extra: ${{ test_config.extra }}
-            netfx: ${{ test_config.enable_fw_netfx }}
+            post_test_win_local: ${{ test_config.post_test_win_local }}            netfx: ${{ test_config.enable_fw_netfx }}
             net80: ${{ test_config.enable_fw_net80 }}
             net90: ${{ test_config.enable_fw_net90 }}
             net100: ${{ test_config.enable_fw_net100 }}
@@ -189,9 +187,7 @@ jobs:
             title: ${{ test_config.title }}
             config: ${{ test_config.config_linux }}
             script_global: ${{ test_config.script_linux_global }}
-            script_local: ${{ test_config.script_linux_local }}
-            extra: ${{ test_config.extra }}
-            net80: ${{ test_config.enable_fw_net80 }}
+            script_local: ${{ test_config.script_linux_local }}            net80: ${{ test_config.enable_fw_net80 }}
             net90: ${{ test_config.enable_fw_net90 }}
             net100: ${{ test_config.enable_fw_net100 }}
             retry: ${{ test_config.retry }}
@@ -224,9 +220,7 @@ jobs:
             config: ${{ test_config.config_macos }}
             script_global: ${{ test_config.script_macos_global }}
             script_local: ${{ test_config.script_macos_local }}
-            docker: ${{ test_config.install_docker_macos }}
-            extra: ${{ test_config.extra }}
-            net80: ${{ test_config.enable_fw_net80 }}
+            docker: ${{ test_config.install_docker_macos }}            net80: ${{ test_config.enable_fw_net80 }}
             net90: ${{ test_config.enable_fw_net90 }}
             net100: ${{ test_config.enable_fw_net100 }}
             retry: ${{ test_config.retry }}

--- a/Build/Azure/pipelines/templates/test-matrix.yml
+++ b/Build/Azure/pipelines/templates/test-matrix.yml
@@ -127,7 +127,8 @@ jobs:
           enable_fw_net80: true
           enable_fw_net90: true
           enable_fw_net100: true
-          x86: true          ${{ if or(contains(parameters.db_filter, '[all]'), contains(parameters.db_filter, '[access.all]')) }}:
+          x86: true
+          ${{ if or(contains(parameters.db_filter, '[all]'), contains(parameters.db_filter, '[access.all]')) }}:
             enabled: true
           ${{ if not(or(contains(parameters.db_filter, '[all]'), contains(parameters.db_filter, '[access.all]'))) }}:
             enabled: false
@@ -144,7 +145,8 @@ jobs:
           enable_fw_net90: true
           enable_fw_net100: true
           x86: true
-          retry: true # x86 provider also could crash with AV as x64, but less often, so we can just restart it          ${{ if or(contains(parameters.db_filter, '[all]'), contains(parameters.db_filter, '[access.all]')) }}:
+          retry: true # x86 provider also could crash with AV as x64, but less often, so we can just restart it
+          ${{ if or(contains(parameters.db_filter, '[all]'), contains(parameters.db_filter, '[access.all]')) }}:
             enabled: true
           ${{ if not(or(contains(parameters.db_filter, '[all]'), contains(parameters.db_filter, '[access.all]'))) }}:
             enabled: false
@@ -159,7 +161,8 @@ jobs:
           enable_fw_netfx: true
           enable_fw_net80: true
           enable_fw_net90: true
-          enable_fw_net100: true          retry: true # x64 provider could crash with AV
+          enable_fw_net100: true
+          retry: true # x64 provider could crash with AV
           ${{ if or(contains(parameters.db_filter, '[all]'), contains(parameters.db_filter, '[access.all]')) }}:
             enabled: true
           ${{ if not(or(contains(parameters.db_filter, '[all]'), contains(parameters.db_filter, '[access.all]'))) }}:

--- a/Build/Azure/pipelines/templates/test-matrix.yml
+++ b/Build/Azure/pipelines/templates/test-matrix.yml
@@ -36,7 +36,6 @@ parameters:
 # GENERAL PROPERTIES
 # - name    (string, required)            : name of test matrix entry (unique, no spaces/dots)
 # - title   (string, required)            : test run name, added to display name for testrun
-# - extra   (string, optional)            : specify additional dotnet test arguments, e.g. "--arch x86"
 # - x86     (true/false string, optional) : windows-only, install dotnet sdk x86
 # - enabled (true/false string, required) : enables/disables test matrix entry completely for current run
 # - retry   (true/false string, optional) : specify that test run should retry on failue, use only for unstable runs like access and oracle
@@ -128,9 +127,7 @@ jobs:
           enable_fw_net80: true
           enable_fw_net90: true
           enable_fw_net100: true
-          x86: true
-          extra: --arch x86
-          ${{ if or(contains(parameters.db_filter, '[all]'), contains(parameters.db_filter, '[access.all]')) }}:
+          x86: true          ${{ if or(contains(parameters.db_filter, '[all]'), contains(parameters.db_filter, '[access.all]')) }}:
             enabled: true
           ${{ if not(or(contains(parameters.db_filter, '[all]'), contains(parameters.db_filter, '[access.all]'))) }}:
             enabled: false
@@ -147,9 +144,7 @@ jobs:
           enable_fw_net90: true
           enable_fw_net100: true
           x86: true
-          retry: true # x86 provider also could crash with AV as x64, but less often, so we can just restart it
-          extra: --arch x86
-          ${{ if or(contains(parameters.db_filter, '[all]'), contains(parameters.db_filter, '[access.all]')) }}:
+          retry: true # x86 provider also could crash with AV as x64, but less often, so we can just restart it          ${{ if or(contains(parameters.db_filter, '[all]'), contains(parameters.db_filter, '[access.all]')) }}:
             enabled: true
           ${{ if not(or(contains(parameters.db_filter, '[all]'), contains(parameters.db_filter, '[access.all]'))) }}:
             enabled: false
@@ -164,9 +159,7 @@ jobs:
           enable_fw_netfx: true
           enable_fw_net80: true
           enable_fw_net90: true
-          enable_fw_net100: true
-          extra: --arch x64
-          retry: true # x64 provider could crash with AV
+          enable_fw_net100: true          retry: true # x64 provider could crash with AV
           ${{ if or(contains(parameters.db_filter, '[all]'), contains(parameters.db_filter, '[access.all]')) }}:
             enabled: true
           ${{ if not(or(contains(parameters.db_filter, '[all]'), contains(parameters.db_filter, '[access.all]'))) }}:

--- a/Build/Azure/pipelines/templates/test-workflow-linux.yml
+++ b/Build/Azure/pipelines/templates/test-workflow-linux.yml
@@ -93,7 +93,7 @@ steps:
   condition: and(variables.title, variables.script_local, eq(variables.net80, 'true'), succeeded())
   displayName: Setup .NET 8 tests
 
-- script: dotnet test ./net8.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net8.0 -l trx $(extra) --blame-hang-timeout 5m
+- script: dotnet ./net8.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net8.0/main/x64/.runsettings --report-trx --report-trx-filename net8.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   condition: and(variables.title, eq(variables.net80, 'true'), succeeded(), ne(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 8): $(title)'
 
@@ -103,12 +103,12 @@ steps:
       git -C baselines reset --hard
       git -C baselines clean -fdq
     fi
-    dotnet test ./net8.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net8.0 -l trx $(extra) --blame-hang-timeout 5m
+    dotnet ./net8.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net8.0/main/x64/.runsettings --report-trx --report-trx-filename net8.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   condition: and(variables.title, eq(variables.net80, 'true'), succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 8): $(title)'
   retryCountOnTaskFailure: 2
 
-- script: dotnet test ./net8.0/efcore/x64/linq2db.EntityFrameworkCore.Tests.dll --filter "TestCategory != SkipCI" -f net8.0 -l trx $(extra) --blame-hang-timeout 5m
+- script: dotnet ./net8.0/efcore/x64/linq2db.EntityFrameworkCore.Tests.dll --filter "TestCategory != SkipCI" --settings ./net8.0/efcore/x64/.runsettings --report-trx --report-trx-filename net8.0-efcore-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   condition: and(variables.title, eq(variables.net80, 'true'), succeeded())
   displayName: 'EF.Core Tests (.NET 8): $(title)'
 
@@ -146,7 +146,7 @@ steps:
   condition: and(variables.title, variables.script_local, eq(variables.net90, 'true'), succeeded())
   displayName: Setup .NET 9 tests
 
-- script: dotnet test ./net9.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net9.0 -l trx $(extra) --blame-hang-timeout 5m
+- script: dotnet ./net9.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net9.0/main/x64/.runsettings --report-trx --report-trx-filename net9.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   condition: and(variables.title, eq(variables.net90, 'true'), succeeded(), ne(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 9): $(title)'
 
@@ -156,12 +156,12 @@ steps:
       git -C baselines reset --hard
       git -C baselines clean -fdq
     fi
-    dotnet test ./net9.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net9.0 -l trx $(extra) --blame-hang-timeout 5m
+    dotnet ./net9.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net9.0/main/x64/.runsettings --report-trx --report-trx-filename net9.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   condition: and(variables.title, eq(variables.net90, 'true'), succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 9): $(title)'
   retryCountOnTaskFailure: 2
 
-- script: dotnet test ./net9.0/efcore/x64/linq2db.EntityFrameworkCore.Tests.dll --filter "TestCategory != SkipCI" -f net9.0 -l trx $(extra) --blame-hang-timeout 5m
+- script: dotnet ./net9.0/efcore/x64/linq2db.EntityFrameworkCore.Tests.dll --filter "TestCategory != SkipCI" --settings ./net9.0/efcore/x64/.runsettings --report-trx --report-trx-filename net9.0-efcore-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   condition: and(variables.title, eq(variables.net90, 'true'), succeeded())
   displayName: 'EF.Core Tests (.NET 9): $(title)'
 
@@ -199,7 +199,7 @@ steps:
   condition: and(variables.title, variables.script_local, eq(variables.net100, 'true'), succeeded())
   displayName: Setup .NET 10 tests
 
-- script: dotnet test ./net10.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net10.0 -l trx $(extra) --blame-hang-timeout 5m
+- script: dotnet ./net10.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net10.0/main/x64/.runsettings --report-trx --report-trx-filename net10.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   condition: and(variables.title, eq(variables.net100, 'true'), succeeded(), ne(variables.retry, 'true'))
   displayName: 'Tests (.NET 10): $(title)'
 
@@ -209,12 +209,12 @@ steps:
       git -C baselines reset --hard
       git -C baselines clean -fdq
     fi
-    dotnet test ./net10.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net10.0 -l trx $(extra) --blame-hang-timeout 5m
+    dotnet ./net10.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net10.0/main/x64/.runsettings --report-trx --report-trx-filename net10.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   condition: and(variables.title, eq(variables.net100, 'true'), succeeded(), eq(variables.retry, 'true'))
   displayName: 'Tests (.NET 10): $(title)'
   retryCountOnTaskFailure: 2
 
-- script: dotnet test ./net10.0/efcore/x64/linq2db.EntityFrameworkCore.Tests.dll --filter "TestCategory != SkipCI" -f net10.0 -l trx $(extra) --blame-hang-timeout 5m
+- script: dotnet ./net10.0/efcore/x64/linq2db.EntityFrameworkCore.Tests.dll --filter "TestCategory != SkipCI" --settings ./net10.0/efcore/x64/.runsettings --report-trx --report-trx-filename net10.0-efcore-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   condition: and(variables.title, eq(variables.net100, 'true'), succeeded())
   displayName: 'EF.Core Tests (.NET 10): $(title)'
 

--- a/Build/Azure/pipelines/templates/test-workflow-macos.yml
+++ b/Build/Azure/pipelines/templates/test-workflow-macos.yml
@@ -84,7 +84,7 @@ steps:
   condition: and(variables.title, variables.script_local, eq(variables.net80, 'true'), succeeded())
   displayName: Setup .NET 8 tests
 
-- script: dotnet test ./net8.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net8.0 -l trx $(extra) --blame-hang-timeout 5m
+- script: dotnet ./net8.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net8.0/main/x64/.runsettings --report-trx --report-trx-filename net8.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   condition: and(variables.title, eq(variables.net80, 'true'), succeeded(), ne(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 8): $(title)'
 
@@ -94,12 +94,12 @@ steps:
       git -C baselines reset --hard
       git -C baselines clean -fdq
     fi
-    dotnet test ./net8.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net8.0 -l trx $(extra) --blame-hang-timeout 5m
+    dotnet ./net8.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net8.0/main/x64/.runsettings --report-trx --report-trx-filename net8.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   condition: and(variables.title, eq(variables.net80, 'true'), succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 8): $(title)'
   retryCountOnTaskFailure: 2
 
-- script: dotnet test ./net8.0/efcore/x64/linq2db.EntityFrameworkCore.Tests.dll --filter "TestCategory != SkipCI" -f net8.0 -l trx $(extra) --blame-hang-timeout 5m
+- script: dotnet ./net8.0/efcore/x64/linq2db.EntityFrameworkCore.Tests.dll --filter "TestCategory != SkipCI" --settings ./net8.0/efcore/x64/.runsettings --report-trx --report-trx-filename net8.0-efcore-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   condition: and(variables.title, eq(variables.net80, 'true'), succeeded())
   displayName: 'EF.Core Tests (.NET 8): $(title)'
 
@@ -137,7 +137,7 @@ steps:
   condition: and(variables.title, variables.script_local, eq(variables.net90, 'true'), succeeded())
   displayName: Setup .NET 9 tests
 
-- script: dotnet test ./net9.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net9.0 -l trx $(extra) --blame-hang-timeout 5m
+- script: dotnet ./net9.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net9.0/main/x64/.runsettings --report-trx --report-trx-filename net9.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   condition: and(variables.title, eq(variables.net90, 'true'), succeeded(), ne(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 9): $(title)'
 
@@ -147,12 +147,12 @@ steps:
       git -C baselines reset --hard
       git -C baselines clean -fdq
     fi
-    dotnet test ./net9.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net9.0 -l trx $(extra) --blame-hang-timeout 5m
+    dotnet ./net9.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net9.0/main/x64/.runsettings --report-trx --report-trx-filename net9.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   condition: and(variables.title, eq(variables.net90, 'true'), succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 9): $(title)'
   retryCountOnTaskFailure: 2
 
-- script: dotnet test ./net9.0/efcore/x64/linq2db.EntityFrameworkCore.Tests.dll --filter "TestCategory != SkipCI" -f net9.0 -l trx $(extra) --blame-hang-timeout 5m
+- script: dotnet ./net9.0/efcore/x64/linq2db.EntityFrameworkCore.Tests.dll --filter "TestCategory != SkipCI" --settings ./net9.0/efcore/x64/.runsettings --report-trx --report-trx-filename net9.0-efcore-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   condition: and(variables.title, eq(variables.net90, 'true'), succeeded())
   displayName: 'EF.Core Tests (.NET 9): $(title)'
 
@@ -190,7 +190,7 @@ steps:
   condition: and(variables.title, variables.script_local, eq(variables.net100, 'true'), succeeded())
   displayName: Setup .NET 10 tests
 
-- script: dotnet test ./net10.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net10.0 -l trx $(extra) --blame-hang-timeout 5m
+- script: dotnet ./net10.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net10.0/main/x64/.runsettings --report-trx --report-trx-filename net10.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   condition: and(variables.title, eq(variables.net100, 'true'), succeeded(), ne(variables.retry, 'true'))
   displayName: 'Tests (.NET 10): $(title)'
 
@@ -200,12 +200,12 @@ steps:
       git -C baselines reset --hard
       git -C baselines clean -fdq
     fi
-    dotnet test ./net10.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net10.0 -l trx $(extra) --blame-hang-timeout 5m
+    dotnet ./net10.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net10.0/main/x64/.runsettings --report-trx --report-trx-filename net10.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   condition: and(variables.title, eq(variables.net100, 'true'), succeeded(), eq(variables.retry, 'true'))
   displayName: 'Tests (.NET 10): $(title)'
   retryCountOnTaskFailure: 2
 
-- script: dotnet test ./net10.0/efcore/x64/linq2db.EntityFrameworkCore.Tests.dll --filter "TestCategory != SkipCI" -f net10.0 -l trx $(extra) --blame-hang-timeout 5m
+- script: dotnet ./net10.0/efcore/x64/linq2db.EntityFrameworkCore.Tests.dll --filter "TestCategory != SkipCI" --settings ./net10.0/efcore/x64/.runsettings --report-trx --report-trx-filename net10.0-efcore-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   condition: and(variables.title, eq(variables.net100, 'true'), succeeded())
   displayName: 'EF.Core Tests (.NET 10): $(title)'
 

--- a/Build/Azure/pipelines/templates/test-workflow-windows.yml
+++ b/Build/Azure/pipelines/templates/test-workflow-windows.yml
@@ -121,19 +121,19 @@ steps:
   condition: and(variables.title, variables.pre_test_win_local, succeeded())
   displayName: Execute Pre-test Script
 
-- script: dotnet test $(netfx_tfm)/main/x86/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f $(netfx_tfm) -l trx $(extra) --blame-hang-timeout 5m
+- script: $(netfx_tfm)\main\x86\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings $(netfx_tfm)\main\x86\.runsettings --report-trx --report-trx-filename netfx-main-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   displayName: 'Tests (NETFX): $(title)'
   condition: and(eq(variables.netfx, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), ne(variables.retry, 'true'))
 
 - script: |
     if exist baselines\.git\ git -C baselines reset --hard
     if exist baselines\.git\ git -C baselines clean -fdq
-    dotnet test $(netfx_tfm)/main/x86/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f $(netfx_tfm) -l trx $(extra) --blame-hang-timeout 5m
+    $(netfx_tfm)\main\x86\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings $(netfx_tfm)\main\x86\.runsettings --report-trx --report-trx-filename netfx-main-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   displayName: 'Tests (NETFX): $(title)'
   condition: and(eq(variables.netfx, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'))
   retryCountOnTaskFailure: 2
 
-- script: dotnet test $(netfx_tfm)/efcore/x86/linq2db.EntityFrameworkCore.Tests.dll --filter "TestCategory != SkipCI" -f $(netfx_tfm) -l trx $(extra) --blame-hang-timeout 5m
+- script: $(netfx_tfm)\efcore\x86\linq2db.EntityFrameworkCore.Tests.exe --filter "TestCategory != SkipCI" --settings $(netfx_tfm)\efcore\x86\.runsettings --report-trx --report-trx-filename netfx-efcore-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   displayName: 'EF.Core Tests (NETFX): $(title)'
   condition: and(eq(variables.netfx, 'true'), eq(variables.x86, 'true'), variables.title, succeeded())
 
@@ -165,19 +165,19 @@ steps:
   condition: and(variables.title, variables.pre_test_win_local, succeeded())
   displayName: Execute Pre-test Script
 
-- script: dotnet test $(netfx_tfm)/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f $(netfx_tfm) -l trx --arch x64 --blame-hang-timeout 5m
+- script: $(netfx_tfm)\main\x64\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings $(netfx_tfm)\main\x64\.runsettings --report-trx --report-trx-filename netfx-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   displayName: 'Tests (NETFX x64): $(title)'
   condition: and(eq(variables.netfx, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), ne(variables.retry, 'true'))
 
 - script: |
     if exist baselines\.git\ git -C baselines reset --hard
     if exist baselines\.git\ git -C baselines clean -fdq
-    dotnet test $(netfx_tfm)/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f $(netfx_tfm) -l trx --arch x64 --blame-hang-timeout 5m
+    $(netfx_tfm)\main\x64\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings $(netfx_tfm)\main\x64\.runsettings --report-trx --report-trx-filename netfx-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   displayName: 'Tests (NETFX x64): $(title)'
   condition: and(eq(variables.netfx, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'))
   retryCountOnTaskFailure: 2
 
-- script: dotnet test $(netfx_tfm)/efcore/x64/linq2db.EntityFrameworkCore.Tests.dll --filter "TestCategory != SkipCI" -f $(netfx_tfm) -l trx --arch x64 --blame-hang-timeout 5m
+- script: $(netfx_tfm)\efcore\x64\linq2db.EntityFrameworkCore.Tests.exe --filter "TestCategory != SkipCI" --settings $(netfx_tfm)\efcore\x64\.runsettings --report-trx --report-trx-filename netfx-efcore-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   displayName: 'EF.Core Tests (NETFX x64): $(title)'
   condition: and(eq(variables.netfx, 'true'), ne(variables.x86, 'true'), variables.title, succeeded())
 
@@ -242,35 +242,35 @@ steps:
   condition: and(variables.title, variables.pre_test_win_local, succeeded())
   displayName: Execute Pre-test Script
 
-- script: dotnet test net8.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net8.0 -l trx --blame-hang-timeout 5m
+- script: net8.0\main\x64\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net8.0\main\x64\.runsettings --report-trx --report-trx-filename net8.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   displayName: 'Tests (.NET 8 x64): $(title)'
   condition: and(eq(variables.net80, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), ne(variables.retry, 'true'), ${{ parameters.full_run }})
 
 - script: |
     if exist baselines\.git\ git -C baselines reset --hard
     if exist baselines\.git\ git -C baselines clean -fdq
-    dotnet test net8.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net8.0 -l trx --blame-hang-timeout 5m
+    net8.0\main\x64\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net8.0\main\x64\.runsettings --report-trx --report-trx-filename net8.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   displayName: 'Tests (.NET 8 x64): $(title)'
   condition: and(eq(variables.net80, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   retryCountOnTaskFailure: 2
 
-- script: dotnet test net8.0/main/x86/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net8.0 -l trx --blame-hang-timeout 5m
+- script: net8.0\main\x86\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net8.0\main\x86\.runsettings --report-trx --report-trx-filename net8.0-main-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   displayName: 'Tests (.NET 8 x86): $(title)'
   condition: and(eq(variables.net80, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), ne(variables.retry, 'true'), ${{ parameters.full_run }})
 
 - script: |
     if exist baselines\.git\ git -C baselines reset --hard
     if exist baselines\.git\ git -C baselines clean -fdq
-    dotnet test net8.0/main/x86/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net8.0 -l trx --blame-hang-timeout 5m
+    net8.0\main\x86\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net8.0\main\x86\.runsettings --report-trx --report-trx-filename net8.0-main-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   displayName: 'Tests (.NET 8 x86): $(title)'
   condition: and(eq(variables.net80, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   retryCountOnTaskFailure: 2
 
-- script: dotnet test net8.0/efcore/x64/linq2db.EntityFrameworkCore.Tests.dll --filter "TestCategory != SkipCI" -f net8.0 -l trx --blame-hang-timeout 5m
+- script: net8.0\efcore\x64\linq2db.EntityFrameworkCore.Tests.exe --filter "TestCategory != SkipCI" --settings net8.0\efcore\x64\.runsettings --report-trx --report-trx-filename net8.0-efcore-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   displayName: 'EF.Core Tests (.NET 8 x64): $(title)'
   condition: and(eq(variables.net80, 'true'), ne(variables.x86, 'true'), variables.title, succeeded())
 
-- script: dotnet test net8.0/efcore/x86/linq2db.EntityFrameworkCore.Tests.dll --filter "TestCategory != SkipCI" -f net8.0 -l trx --blame-hang-timeout 5m
+- script: net8.0\efcore\x86\linq2db.EntityFrameworkCore.Tests.exe --filter "TestCategory != SkipCI" --settings net8.0\efcore\x86\.runsettings --report-trx --report-trx-filename net8.0-efcore-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   displayName: 'EF.Core Tests (.NET 8 x86): $(title)'
   condition: and(eq(variables.net80, 'true'), eq(variables.x86, 'true'), variables.title, succeeded())
 
@@ -335,35 +335,35 @@ steps:
   condition: and(variables.title, variables.pre_test_win_local, succeeded())
   displayName: Execute Pre-test Script
 
-- script: dotnet test net9.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net9.0 -l trx --blame-hang-timeout 5m
+- script: net9.0\main\x64\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net9.0\main\x64\.runsettings --report-trx --report-trx-filename net9.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   displayName: 'Tests (.NET 9 x64): $(title)'
   condition: and(eq(variables.net90, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), ne(variables.retry, 'true'), ${{ parameters.full_run }})
 
 - script: |
     if exist baselines\.git\ git -C baselines reset --hard
     if exist baselines\.git\ git -C baselines clean -fdq
-    dotnet test net9.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net9.0 -l trx --blame-hang-timeout 5m
+    net9.0\main\x64\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net9.0\main\x64\.runsettings --report-trx --report-trx-filename net9.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   displayName: 'Tests (.NET 9 x64): $(title)'
   condition: and(eq(variables.net90, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   retryCountOnTaskFailure: 2
 
-- script: dotnet test net9.0/main/x86/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net9.0 -l trx --blame-hang-timeout 5m
+- script: net9.0\main\x86\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net9.0\main\x86\.runsettings --report-trx --report-trx-filename net9.0-main-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   displayName: 'Tests (.NET 9 x86): $(title)'
   condition: and(eq(variables.net90, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), ne(variables.retry, 'true'), ${{ parameters.full_run }})
 
 - script: |
     if exist baselines\.git\ git -C baselines reset --hard
     if exist baselines\.git\ git -C baselines clean -fdq
-    dotnet test net9.0/main/x86/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net9.0 -l trx --blame-hang-timeout 5m
+    net9.0\main\x86\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net9.0\main\x86\.runsettings --report-trx --report-trx-filename net9.0-main-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   displayName: 'Tests (.NET 9 x86): $(title)'
   condition: and(eq(variables.net90, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   retryCountOnTaskFailure: 2
 
-- script: dotnet test net9.0/efcore/x64/linq2db.EntityFrameworkCore.Tests.dll --filter "TestCategory != SkipCI" -f net9.0 -l trx --blame-hang-timeout 5m
+- script: net9.0\efcore\x64\linq2db.EntityFrameworkCore.Tests.exe --filter "TestCategory != SkipCI" --settings net9.0\efcore\x64\.runsettings --report-trx --report-trx-filename net9.0-efcore-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   displayName: 'EF.Core Tests (.NET 9 x64): $(title)'
   condition: and(eq(variables.net90, 'true'), ne(variables.x86, 'true'), variables.title, succeeded())
 
-- script: dotnet test net9.0/efcore/x86/linq2db.EntityFrameworkCore.Tests.dll --filter "TestCategory != SkipCI" -f net9.0 -l trx --blame-hang-timeout 5m
+- script: net9.0\efcore\x86\linq2db.EntityFrameworkCore.Tests.exe --filter "TestCategory != SkipCI" --settings net9.0\efcore\x86\.runsettings --report-trx --report-trx-filename net9.0-efcore-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   displayName: 'EF.Core Tests (.NET 9 x86): $(title)'
   condition: and(eq(variables.net90, 'true'), eq(variables.x86, 'true'), variables.title, succeeded())
 
@@ -421,35 +421,35 @@ steps:
   condition: and(variables.title, variables.pre_test_win_local, succeeded())
   displayName: Execute Pre-test Script
 
-- script: dotnet test net10.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net10.0 -l trx --blame-hang-timeout 5m
+- script: net10.0\main\x64\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net10.0\main\x64\.runsettings --report-trx --report-trx-filename net10.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   displayName: 'Tests (.NET 10 x64): $(title)'
   condition: and(eq(variables.net100, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), ne(variables.retry, 'true'))
 
 - script: |
     if exist baselines\.git\ git -C baselines reset --hard
     if exist baselines\.git\ git -C baselines clean -fdq
-    dotnet test net10.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net10.0 -l trx --blame-hang-timeout 5m
+    net10.0\main\x64\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net10.0\main\x64\.runsettings --report-trx --report-trx-filename net10.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   displayName: 'Tests (.NET 10 x64): $(title)'
   condition: and(eq(variables.net100, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'))
   retryCountOnTaskFailure: 2
 
-- script: dotnet test net10.0/main/x86/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net10.0 -l trx --blame-hang-timeout 5m
+- script: net10.0\main\x86\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net10.0\main\x86\.runsettings --report-trx --report-trx-filename net10.0-main-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   displayName: 'Tests (.NET 10 x86): $(title)'
   condition: and(eq(variables.net100, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), ne(variables.retry, 'true'))
 
 - script: |
     if exist baselines\.git\ git -C baselines reset --hard
     if exist baselines\.git\ git -C baselines clean -fdq
-    dotnet test net10.0/main/x86/linq2db.Tests.dll --filter "TestCategory != SkipCI" -f net10.0 -l trx --blame-hang-timeout 5m
+    net10.0\main\x86\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net10.0\main\x86\.runsettings --report-trx --report-trx-filename net10.0-main-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   displayName: 'Tests (.NET 10 x86): $(title)'
   condition: and(eq(variables.net100, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'))
   retryCountOnTaskFailure: 2
 
-- script: dotnet test net10.0/efcore/x64/linq2db.EntityFrameworkCore.Tests.dll --filter "TestCategory != SkipCI" -f net10.0 -l trx --blame-hang-timeout 5m
+- script: net10.0\efcore\x64\linq2db.EntityFrameworkCore.Tests.exe --filter "TestCategory != SkipCI" --settings net10.0\efcore\x64\.runsettings --report-trx --report-trx-filename net10.0-efcore-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   displayName: 'EF.Core Tests (.NET 10 x64): $(title)'
   condition: and(eq(variables.net100, 'true'), ne(variables.x86, 'true'), variables.title, succeeded())
 
-- script: dotnet test net10.0/efcore/x86/linq2db.EntityFrameworkCore.Tests.dll --filter "TestCategory != SkipCI" -f net10.0 -l trx --blame-hang-timeout 5m
+- script: net10.0\efcore\x86\linq2db.EntityFrameworkCore.Tests.exe --filter "TestCategory != SkipCI" --settings net10.0\efcore\x86\.runsettings --report-trx --report-trx-filename net10.0-efcore-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
   displayName: 'EF.Core Tests (.NET 10 x86): $(title)'
   condition: and(eq(variables.net100, 'true'), eq(variables.x86, 'true'), variables.title, succeeded())
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,12 +76,12 @@ You can use solution to build and run tests. Also you can build whole solution o
 * `.\Build.cmd` - builds all the projects in the solution for Debug, Release and Azure configurations
 * `.\Compile.cmd` - builds LinqToDB project for Debug and Release configurations
 * `.\Clean.cmd` - cleanups solution projects for Debug, Release and Azure configurations
-* `.\Test.cmd` - builds and runs tests with `Debug` configuration for all supported TFMs and produce HTML report. Parameters supported to change build configuration, logger type and executed TFMs
+* `.\Test.cmd` - builds and runs tests with `Debug` configuration for all supported TFMs and produces a `trx` report. Parameters supported to change build configuration and executed TFMs, plus extra arguments forwarded to the test runner
 
-Example of running `Release` build tests for `net9.0` only with `trx` as output:
+Example of running `Release` build tests for `net9.0` only:
 
 ```cmd
-test.cmd Release 0 0 1 0 trx
+test.cmd Release 0 0 1 0
 ```
 
 ### Different platforms support

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ Because we target different TFMs, we use:
 
 ## Run tests
 
-NUnit3 is used as unit-testing framework. Most of tests are run for all supported databases and written in same pattern:
+NUnit3 is used as the unit-testing framework, running on [Microsoft.Testing.Platform](https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-intro) (MTP) rather than VSTest. The test projects build as executables, so you run them directly (e.g. `linq2db.Tests.exe --filter ...`); `dotnet test` also works. Most of tests are run for all supported databases and written in same pattern:
 
 ```cs
 // TestBase - base class for all our tests

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -162,6 +162,7 @@
 		<PackageVersion Include="Microsoft.AspNetCore.OData"                            Version="9.4.1"                        />
 		<PackageVersion Include="MiniProfiler.Shared"                                   Version="4.5.4"                        />
 		<PackageVersion Include="MiniProfiler.Minimal"                                  Version="4.5.4"                        />
+		<PackageVersion Include="Newtonsoft.Json"                                       Version="13.0.3"                       />
 		<PackageVersion Include="NodaTime"                                              Version="3.3.2"                        />
 		<PackageVersion Include="protobuf-net.Grpc.AspNetCore"                          Version="1.2.2"                        />
 		<PackageVersion Include="System.Linq.Dynamic.Core"                              Version="1.7.2"                        />
@@ -230,7 +231,6 @@
 			https://github.com/advisories/GHSA-x5qj-9vmx-7g6g;
 			https://github.com/advisories/GHSA-xhfc-gr8f-ffwc" />
 
-		<PackageVersion Include="Newtonsoft.Json"                                       Version="13.0.1"                       />
 		<PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core"              Version="$(AspNetCoreLegacyVersion)"   Condition="'$(TargetFramework)'=='net462'" />
 		<PackageVersion Include="Microsoft.Bcl.Memory"                                  Version="$(Net9Latest)"                Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" />
 		<PackageVersion Include="Microsoft.Bcl.Memory"                                  Version="$(Net10Latest)"               Condition="'$(TargetFramework)'=='net10.0'" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -151,7 +151,9 @@
 
 	<ItemGroup Label="Testing">
 		<PackageVersion Include="Shouldly"                                              Version="4.3.0"                        />
-		<PackageVersion Include="Microsoft.NET.Test.Sdk"                                Version="18.5.1"                       />
+		<PackageVersion Include="Microsoft.Testing.Platform.MSBuild"                    Version="2.2.3"                        />
+		<PackageVersion Include="Microsoft.Testing.Extensions.TrxReport"                Version="2.2.3"                        />
+		<PackageVersion Include="Microsoft.Testing.Extensions.HangDump"                 Version="2.2.3"                        />
 		<PackageVersion Include="NUnit"                                                 Version="4.6.0"                        />
 		<PackageVersion Include="NUnit.Analyzers"                                       Version="4.13.0"                       />
 		<PackageVersion Include="NUnit3TestAdapter"                                     Version="6.2.0"                        />

--- a/Test.cmd
+++ b/Test.cmd
@@ -7,24 +7,25 @@ SET NETFX=%2
 SET NET80=%3
 SET NET90=%4
 SET NET100=%5
-SET FORMAT=%6
-SET EXTRA=%7
+SET EXTRA=%6
 
 IF [%1] EQU [] (SET CONFIG=Debug)
 IF [%2] EQU [] (SET NETFX=1)
 IF [%3] EQU [] (SET NET80=1)
 IF [%4] EQU [] (SET NET90=1)
 IF [%5] EQU [] (SET NET100=1)
-IF [%6] EQU [] (SET FORMAT=html)
 
 dotnet build linq2db.slnx -c %CONFIG% -v m
 
-IF %NETFX%  NEQ 0 (dotnet test .build/bin/Tests/%CONFIG%/net462/linq2db.Tests.dll -f net462 -l %FORMAT%;LogFileName=net462.%FORMAT% %EXTRA%)
-IF %NET80%  NEQ 0 (dotnet test .build/bin/Tests/%CONFIG%/net8.0/linq2db.Tests.dll -f net8.0 -l %FORMAT%;LogFileName=net80.%FORMAT% %EXTRA%)
-IF %NET90%  NEQ 0 (dotnet test .build/bin/Tests/%CONFIG%/net9.0/linq2db.Tests.dll -f net9.0 -l %FORMAT%;LogFileName=net90.%FORMAT% %EXTRA%)
-IF %NET100% NEQ 0 (dotnet test .build/bin/Tests/%CONFIG%/net10.0/linq2db.Tests.dll -f net10.0 -l %FORMAT%;LogFileName=net100.%FORMAT% %EXTRA%)
+REM Tests run on Microsoft.Testing.Platform: the test projects are executables, so run them directly
+REM (net462 produces an .exe; net8.0+ produce an apphost .exe). VSTest's "-l <format>" is replaced by
+REM --report-trx; --settings makes NUnit honor .runsettings (AssemblySelectLimit etc.).
+IF %NETFX%  NEQ 0 (.build\bin\Tests\%CONFIG%\net462\linq2db.Tests.exe   --settings .runsettings --report-trx --report-trx-filename net462.trx  --results-directory TestResults %EXTRA%)
+IF %NET80%  NEQ 0 (.build\bin\Tests\%CONFIG%\net8.0\linq2db.Tests.exe   --settings .runsettings --report-trx --report-trx-filename net80.trx   --results-directory TestResults %EXTRA%)
+IF %NET90%  NEQ 0 (.build\bin\Tests\%CONFIG%\net9.0\linq2db.Tests.exe   --settings .runsettings --report-trx --report-trx-filename net90.trx   --results-directory TestResults %EXTRA%)
+IF %NET100% NEQ 0 (.build\bin\Tests\%CONFIG%\net10.0\linq2db.Tests.exe  --settings .runsettings --report-trx --report-trx-filename net100.trx  --results-directory TestResults %EXTRA%)
 
-IF %NETFX%  NEQ 0 (dotnet test .build/bin/Tests.EntityFrameworkCore.EF3/%CONFIG%/net462/linq2db.EntityFrameworkCore.Tests.dll -f net462 -l %FORMAT%;LogFileName=net462.efcore.%FORMAT% %EXTRA%)
-IF %NET80%  NEQ 0 (dotnet test .build/bin/Tests.EntityFrameworkCore.EF8/%CONFIG%/net8.0/linq2db.EntityFrameworkCore.Tests.dll -f net8.0 -l %FORMAT%;LogFileName=net80.efcore.%FORMAT% %EXTRA%)
-IF %NET90%  NEQ 0 (dotnet test .build/bin/Tests.EntityFrameworkCore.EF9/%CONFIG%/net9.0/linq2db.EntityFrameworkCore.Tests.dll -f net9.0 -l %FORMAT%;LogFileName=net90.efcore.%FORMAT% %EXTRA%)
-IF %NET100% NEQ 0 (dotnet test .build/bin/Tests.EntityFrameworkCore.EF10/%CONFIG%/net10.0/linq2db.EntityFrameworkCore.Tests.dll -f net10.0 -l %FORMAT%;LogFileName=net100.efcore.%FORMAT% %EXTRA%)
+IF %NETFX%  NEQ 0 (.build\bin\Tests.EntityFrameworkCore.EF3\%CONFIG%\net462\linq2db.EntityFrameworkCore.Tests.exe    --settings .runsettings --report-trx --report-trx-filename net462.efcore.trx --results-directory TestResults %EXTRA%)
+IF %NET80%  NEQ 0 (.build\bin\Tests.EntityFrameworkCore.EF8\%CONFIG%\net8.0\linq2db.EntityFrameworkCore.Tests.exe   --settings .runsettings --report-trx --report-trx-filename net80.efcore.trx  --results-directory TestResults %EXTRA%)
+IF %NET90%  NEQ 0 (.build\bin\Tests.EntityFrameworkCore.EF9\%CONFIG%\net9.0\linq2db.EntityFrameworkCore.Tests.exe   --settings .runsettings --report-trx --report-trx-filename net90.efcore.trx  --results-directory TestResults %EXTRA%)
+IF %NET100% NEQ 0 (.build\bin\Tests.EntityFrameworkCore.EF10\%CONFIG%\net10.0\linq2db.EntityFrameworkCore.Tests.exe --settings .runsettings --report-trx --report-trx-filename net100.efcore.trx --results-directory TestResults %EXTRA%)

--- a/Tests/Base/Remote/gRPC/GrpcServerContainer.cs
+++ b/Tests/Base/Remote/gRPC/GrpcServerContainer.cs
@@ -1,5 +1,7 @@
 ﻿#if !NETFRAMEWORK
 using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 
 using LinqToDB;
 using LinqToDB.Data;
@@ -7,6 +9,8 @@ using LinqToDB.Mapping;
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -20,6 +24,33 @@ namespace Tests.Remote.ServerContainer
 	internal sealed class GrpcServerContainer : ServerContainerBase<TestGrpcLinqService>
 	{
 		private static string GetServiceUrl(int port) => $"https://localhost:{port}";
+
+		// MTP runs tests as a bare executable, so the ASP.NET Core HTTPS development certificate
+		// that `dotnet test` used to provision is unavailable. Bind Kestrel to a throwaway self-signed
+		// cert instead — the gRPC client accepts any server cert (DangerousAcceptAnyServerCertificateValidator).
+		private static readonly X509Certificate2 _certificate = CreateServerCertificate();
+
+		private static X509Certificate2 CreateServerCertificate()
+		{
+			using var rsa = RSA.Create(2048);
+
+			var request = new CertificateRequest("CN=localhost", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+			request.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension(new OidCollection { new Oid("1.3.6.1.5.5.7.3.1") }, false));
+
+			var san = new SubjectAlternativeNameBuilder();
+			san.AddDnsName("localhost");
+			request.CertificateExtensions.Add(san.Build());
+
+			using var cert = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(10));
+
+			// Round-trip through PKCS#12 so Kestrel's TLS stack can use the private key (required on Windows).
+			var pfx = cert.Export(X509ContentType.Pkcs12);
+#if NET9_0_OR_GREATER
+			return X509CertificateLoader.LoadPkcs12(pfx, null);
+#else
+			return new X509Certificate2(pfx);
+#endif
+		}
 
 		protected override TestGrpcLinqService StartHost(int port, Func<string?, MappingSchema?, DataConnection> connectionFactory)
 		{
@@ -36,6 +67,7 @@ namespace Tests.Remote.ServerContainer
 				webBuilder =>
 				{
 					webBuilder.UseStartup<Startup>();
+					webBuilder.ConfigureKestrel(o => o.ConfigureHttpsDefaults(h => h.ServerCertificate = _certificate));
 					webBuilder.UseUrls(GetServiceUrl(port));
 				}).Build();
 

--- a/Tests/Base/X86Stubs/HanaStubs.cs
+++ b/Tests/Base/X86Stubs/HanaStubs.cs
@@ -1,0 +1,13 @@
+#if HANASTUBS
+namespace Sap.Data.Hana
+{
+	// Sap.Data.Hana.Net.v8.0 is x64-only, so it is not referenced in x86 builds (see Tests.csproj).
+	// These stubs satisfy compilation of the SAP HANA tests on x86; the tests themselves only run
+	// against the SapHanaNative provider, which is never enabled in an x86 test run.
+	public struct HanaDecimal
+	{
+		public HanaDecimal(string _) { }
+		public HanaDecimal(int _)    { }
+	}
+}
+#endif

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -26,20 +26,4 @@
 		<PackageReference Include="Microsoft.Bcl.Memory" />
 	</ItemGroup>
 
-	<!--https://github.com/microsoft/vstest/issues/15297-->
-	<Target Name="Save_PublishDir" BeforeTargets="CopyTraceDataCollectorArtifacts">
-		<CreateProperty Value="$(PublishDir)">
-			<Output TaskParameter="Value" PropertyName="PublishDir_Backup"/>
-		</CreateProperty>
-		<CreateProperty Value="$(PublishDir)\_ignore\">
-			<Output TaskParameter="Value" PropertyName="PublishDir"/>
-		</CreateProperty>
-	</Target>
-	<Target Name="Restore_PublishDir" AfterTargets="CopyTraceDataCollectorArtifacts">
-		<RemoveDir Directories="$(PublishDir)" />
-		<CreateProperty Value="$(PublishDir_Backup)">
-			<Output TaskParameter="Value" PropertyName="PublishDir"/>
-		</CreateProperty>
-	</Target>
-	
 </Project>

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -4,7 +4,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>net462;net8.0;net9.0;net10.0</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Configuration)'=='Testing'">net10.0</TargetFrameworks>
-		<DefineConstants Condition=" $(DB2STUB) == 'True' ">$(DefineConstants);DB2STUBS</DefineConstants>
+		<DefineConstants Condition=" $(DB2STUB) == 'True' ">$(DefineConstants);DB2STUBS;HANASTUBS</DefineConstants>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -4,7 +4,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>net462;net8.0;net9.0;net10.0</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Configuration)'=='Testing'">net10.0</TargetFrameworks>
-		<DefineConstants Condition=" $(DB2STUB) == 'True' ">$(DefineConstants);DB2STUBS;HANASTUBS</DefineConstants>
+		<DefineConstants Condition=" $(X86STUBS) == 'True' ">$(DefineConstants);DB2STUBS;HANASTUBS</DefineConstants>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 

--- a/Tests/Linq/Tests.csproj
+++ b/Tests/Linq/Tests.csproj
@@ -39,8 +39,8 @@
 
 	<!-- Sap.Data.Hana.Net.v8.0 is x64-only; referencing it in an x86 build makes the test
 	     assembly fail to load on x86 (ReflectionTypeLoadException -> NUnit discovers 0 tests).
-	     Skip it on x86 (DB2STUB) and use the HANASTUBS stub types instead, mirroring DB2. -->
-	<ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) and '$(DB2STUB)' != 'True'">
+	     Skip it on x86 (X86STUBS) and use the HANASTUBS stub types instead, mirroring DB2. -->
+	<ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) and '$(X86STUBS)' != 'True'">
 		<Reference Include="Sap.Data.Hana.Net.v8.0">
 			<HintPath>..\..\Redist\SapHana\v8.0\Sap.Data.Hana.Net.v8.0.dll</HintPath>
 		</Reference>

--- a/Tests/Linq/Tests.csproj
+++ b/Tests/Linq/Tests.csproj
@@ -37,7 +37,10 @@
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>
 
-	<ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+	<!-- Sap.Data.Hana.Net.v8.0 is x64-only; referencing it in an x86 build makes the test
+	     assembly fail to load on x86 (ReflectionTypeLoadException -> NUnit discovers 0 tests).
+	     Skip it on x86 (DB2STUB) and use the HANASTUBS stub types instead, mirroring DB2. -->
+	<ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) and '$(DB2STUB)' != 'True'">
 		<Reference Include="Sap.Data.Hana.Net.v8.0">
 			<HintPath>..\..\Redist\SapHana\v8.0\Sap.Data.Hana.Net.v8.0.dll</HintPath>
 		</Reference>

--- a/Tests/Tests.Playground/Tests.Playground.csproj
+++ b/Tests/Tests.Playground/Tests.Playground.csproj
@@ -21,7 +21,7 @@
 		</Reference>
 	</ItemGroup>
 
-	<ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+	<ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) and '$(DB2STUB)' != 'True'">
 		<Reference Include="Sap.Data.Hana.Net.v8.0">
 			<HintPath>..\..\Redist\SapHana\v8.0\Sap.Data.Hana.Net.v8.0.dll</HintPath>
 		</Reference>

--- a/Tests/Tests.Playground/Tests.Playground.csproj
+++ b/Tests/Tests.Playground/Tests.Playground.csproj
@@ -21,7 +21,7 @@
 		</Reference>
 	</ItemGroup>
 
-	<ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) and '$(DB2STUB)' != 'True'">
+	<ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) and '$(X86STUBS)' != 'True'">
 		<Reference Include="Sap.Data.Hana.Net.v8.0">
 			<HintPath>..\..\Redist\SapHana\v8.0\Sap.Data.Hana.Net.v8.0.dll</HintPath>
 		</Reference>

--- a/Tests/linq2db.BasicTestProjects.props
+++ b/Tests/linq2db.BasicTestProjects.props
@@ -1,7 +1,14 @@
 <Project>
+	<PropertyGroup>
+		<!-- Run tests on Microsoft.Testing.Platform via the NUnit MTP runner instead of VSTest. -->
+		<OutputType>Exe</OutputType>
+		<EnableNUnitRunner>true</EnableNUnitRunner>
+	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="NUnit3TestAdapter" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Microsoft.Testing.Platform.MSBuild" />
+		<PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+		<PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
 		<PackageReference Include="Shouldly" />
 	</ItemGroup>
 </Project>

--- a/Tests/linq2db.BasicTestProjects.props
+++ b/Tests/linq2db.BasicTestProjects.props
@@ -10,5 +10,7 @@
 		<PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
 		<PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
 		<PackageReference Include="Shouldly" />
+		<!-- Was a transitive dependency of Microsoft.NET.Test.Sdk; referenced directly now that the SDK is gone. -->
+		<PackageReference Include="Newtonsoft.Json" />
 	</ItemGroup>
 </Project>

--- a/Tests/linq2db.Providers.props
+++ b/Tests/linq2db.Providers.props
@@ -62,7 +62,7 @@
 
 	<!--some magic to not include x64 reference to IBM.Data.DB2.Core in x86 builds, as it fails x86 tests-->
 	<Choose>
-		<When Condition=" $(DB2STUB) != 'True' ">
+		<When Condition=" $(X86STUBS) != 'True' ">
 			<ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
 				<!--PackageReference + Reference beelongs to same nuget-->
 				<PackageReference Include="IBM.Data.DB.Provider" GeneratePathProperty="true" />

--- a/global.json
+++ b/global.json
@@ -3,5 +3,8 @@
 		"version": "10.0.200",
 		"rollForward": "minor",
 		"allowPrerelease": false
+	},
+	"test": {
+		"runner": "Microsoft.Testing.Platform"
 	}
 }


### PR DESCRIPTION
Migrates the NUnit test projects from **Microsoft.NET.Test.Sdk (VSTest)** to the **Microsoft.Testing.Platform (MTP)** NUnit runner. VSTest mode for MTP-capable adapters is deprecated; the repo already ships SDK `10.0.200` and `NUnit3TestAdapter 6.2.0` (MTP-capable).

## Changes

- **`Directory.Packages.props`** — drop `Microsoft.NET.Test.Sdk`; add `Microsoft.Testing.Platform.MSBuild`, `Microsoft.Testing.Extensions.TrxReport`, `Microsoft.Testing.Extensions.HangDump` (`2.2.3`, ≥ the adapter's `2.1.0` floor).
- **`Tests/linq2db.BasicTestProjects.props`** — `OutputType=Exe` + `EnableNUnitRunner=true`; swap the SDK reference for the MTP packages. Applies to all NUnit hosts: `Tests/Linq`, `Tests.Playground`, EF `EF3/8/9/10`, `Tests.T4`, EF F#.
- **`global.json`** — select the MTP runner (`"test": { "runner": "Microsoft.Testing.Platform" }`) so local `dotnet test` uses modern MTP arg syntax.
- **`Tests/Directory.Build.props`** — remove the now-dead VSTest `CopyTraceDataCollectorArtifacts` PublishDir workaround.
- **CI (`Build/Azure/pipelines/templates/*`)** — run the published test executables directly instead of `dotnet test <dll>`:
  - `-l trx` → `--report-trx`/`--report-trx-filename` (lands in `TestResults`, survives the per-TFM cleanup; `PublishTestResults` still parses TRX).
  - `--blame-hang-timeout 5m` → `--hangdump --hangdump-timeout 5m`.
  - `--arch x86/x64` dropped — architecture is baked at publish (`-a x86`); the `x86`/`x64` artifact dir disambiguates. Removed the now-unused matrix `extra` property.
  - Ship `.runsettings` next to each test app and pass it via `--settings` so NUnit's `AssemblySelectLimit` (and the other `<NUnit>` settings) are honored — MTP does not auto-discover `.runsettings`.

## Validation

- Built clean under MTP (Playground + EF F#), 0 warnings; the published app runs as **Microsoft.Testing.Platform v2.2.3**.
- `--help` exposes `--filter` / `--report-trx` / `--hangdump-timeout` / `--settings`; `--list-tests --settings .runsettings` discovers tests and reads the NUnit settings block (only `MaxCpuCount` is ignored by MTP, as expected).
- **First CI run validates:** x86 executable launch on Windows agents, `.trx` publication, and that `AssemblySelectLimit` is honored via `--settings` under MTP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
