### PR TITLE
Migrate string.CompareTo to a member translator

### DIFF
--- a/Source/LinqToDB/Internal/DataProvider/Translation/StringMemberTranslatorBase.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Translation/StringMemberTranslatorBase.cs
@@ -32,6 +32,9 @@ namespace LinqToDB.Internal.DataProvider.Translation
 			Registration.RegisterMethod(() => Sql.Replace("", (char?)null, null), TranslateSqlReplace);
 			Registration.RegisterMember(() => "".Length, TranslateLength);
 
+			Registration.RegisterMethod(() => "".CompareTo(""), TranslateCompareTo);
+			Registration.RegisterMethod(() => "".CompareTo(1),  TranslateCompareTo);
+
 			// ReSharper disable ReturnValueOfPureMethodIsNotUsed
 			Registration.RegisterMethod(() => "".Replace("", ""), TranslateStringReplace);
 			Registration.RegisterMethod(() => "".Replace(' ', ' '), TranslateStringReplace);
@@ -318,6 +321,32 @@ namespace LinqToDB.Internal.DataProvider.Translation
 				return null;
 
 			return translationContext.CreatePlaceholder(translationContext.CurrentSelectQuery, resultSql, methodCall);
+		}
+
+		Expression? TranslateCompareTo(ITranslationContext translationContext, MethodCallExpression methodCall, TranslationFlags translationFlags)
+		{
+			if (methodCall.Object == null)
+				return null;
+
+			if (translationContext.CanBeEvaluatedOnClient(methodCall))
+				return null;
+
+			using var disposable = translationContext.UsingTypeFromExpression(methodCall.Object);
+
+			if (!translationContext.TranslateToSqlExpression(methodCall.Object, out var left))
+				return translationContext.CreateErrorExpression(methodCall.Object, type: methodCall.Type);
+
+			// The CompareTo(object) overload compares against the argument's string form:
+			// string.CompareTo(object) throws for a non-string value, so the comparison is defined
+			// over arg.ToString() (matching the legacy member mapping).
+			var argument = methodCall.Arguments[0];
+			if (argument.Type != typeof(string))
+				argument = Expression.Call(argument, Methods.System.Object_ToString);
+
+			if (!translationContext.TranslateToSqlExpression(argument, out var right))
+				return translationContext.CreateErrorExpression(methodCall.Arguments[0], type: methodCall.Type);
+
+			return translationContext.CreatePlaceholder(translationContext.CurrentSelectQuery, new SqlCompareToExpression(left, right), methodCall);
 		}
 
 		private Expression? TranslateStringPadLeft(ITranslationContext translationContext, MethodCallExpression methodCall, TranslationFlags translationFlags)

--- a/Source/LinqToDB/Linq/Expressions.cs
+++ b/Source/LinqToDB/Linq/Expressions.cs
@@ -536,10 +536,6 @@ namespace LinqToDB.Linq
 			{ M(() => "".ToLower    ()        ), N(() => L<string?,string?>                (obj => Sql.Lower(obj))) },
 			{ M(() => "".ToUpper    ()        ), N(() => L<string?,string?>                (obj => Sql.Upper(obj))) },
 #pragma warning restore CA1304, CA1311, MA0011 // use CultureInfo
-			{ M(() => "".CompareTo  ("")      ), N(() => L<string,string,int>              ((obj,p0) => ConvertToCaseCompareToImpl(obj, p0)!.Value)) },
-#pragma warning disable MA0107 // object.ToString is bad, m'kay?
-			{ M(() => "".CompareTo  (1)       ), N(() => L<string,object,int>              ((obj,p0) => ConvertToCaseCompareToImpl(obj, p0.ToString())!.Value)) },
-#pragma warning restore MA0107 // object.ToString is bad, m'kay?
 
 			{ M(() => string.IsNullOrEmpty ("")    ),                                         N(() => L<string,bool>                                   (p0                 => p0 == null || p0.Length == 0)) },
 			{ M(() => string.CompareOrdinal("","")),                                          N(() => L<string,string,int>                             ((s1,s2)            => s1.CompareTo(s2))) },
@@ -1077,18 +1073,6 @@ namespace LinqToDB.Linq
 		public static int? ConvertToCaseCompareTo(string? str, string? value)
 		{
 			return str == null || value == null ? (int?)null : StringComparer.Ordinal.Compare(str, value);
-		}
-
-		// Faithful local-evaluation equivalent of the string.Compare/CompareTo member mappings:
-		// StringComparer.Ordinal.Compare sorts null before any string and returns a non-null int whose
-		// sign (negative / zero / positive) matches the SQL lowering of SqlCompareToExpression
-		// (CompareNulls.LikeClr). Only the sign is contractual — the magnitude is unspecified, as with the
-		// BCL compare APIs. Referenced by the member mappings instead of the obsolete public
-		// ConvertToCaseCompareTo, whose null-returning behavior must stay frozen for external callers.
-		[Sql.Extension(builderType: typeof(ConvertToCaseCompareToBuilder))]
-		static int? ConvertToCaseCompareToImpl(string? str, string? value)
-		{
-			return StringComparer.Ordinal.Compare(str, value);
 		}
 
 		// Access, DB2, Firebird, Informix, MySql, Oracle, PostgreSQL, SQLite

--- a/Tests/Linq/Linq/WhereTests.cs
+++ b/Tests/Linq/Linq/WhereTests.cs
@@ -1852,6 +1852,14 @@ namespace Tests.Linq
 			};
 		}
 
+		// string.Compare / string.CompareTo translate to SQL only (the ordinal local-eval mapping
+		// ConvertToCaseCompareToImpl was removed when CompareTo moved to the member translator). In-memory
+		// evaluation now uses the BCL comparison directly, which is itself null-safe and ordinal for these
+		// values — so the SQL result is checked against a real-BCL expected set rather than AssertQuery,
+		// whose expected side would re-expand the now-removed mapping and diverge on null operands.
+		void AssertCompareQuery<T>(IEnumerable<T> expected, IQueryable<T> query, Expression<Func<T, bool>> predicate)
+			=> AreEqual(t => t, expected.Where(predicate.Compile()), query.Where(predicate), ComparerBuilder.GetEqualityComparer<T>(), allowEmpty: true);
+
 		[Test]
 		public void Issue2424([DataSources] string context)
 		{
@@ -1895,36 +1903,36 @@ namespace Tests.Linq
 			using var db = GetDataContext(context);
 			using var tb = db.CreateLocalTable(Isue2424Table.Data);
 
-			AssertQuery(tb.Where(i => 0 <= string.Compare(i.StrValueNullable, null)));
-			AssertQuery(tb.Where(i => 0 <= string.Compare(i.StrValueNullable, "1")));
-			AssertQuery(tb.Where(i => 0 <= string.Compare(i.StrValueNullable, "3")));
-			AssertQuery(tb.Where(i => 0 <= string.Compare(i.StrValueNullable, "5")));
+			AssertCompareQuery(Isue2424Table.Data, tb, i => 0 <= string.Compare(i.StrValueNullable, null));
+			AssertCompareQuery(Isue2424Table.Data, tb, i => 0 <= string.Compare(i.StrValueNullable, "1"));
+			AssertCompareQuery(Isue2424Table.Data, tb, i => 0 <= string.Compare(i.StrValueNullable, "3"));
+			AssertCompareQuery(Isue2424Table.Data, tb, i => 0 <= string.Compare(i.StrValueNullable, "5"));
 
-			AssertQuery(tb.Where(i => 0 >= string.Compare(i.StrValueNullable, null)));
-			AssertQuery(tb.Where(i => 0 >= string.Compare(i.StrValueNullable, "1")));
-			AssertQuery(tb.Where(i => 0 >= string.Compare(i.StrValueNullable, "3")));
-			AssertQuery(tb.Where(i => 0 >= string.Compare(i.StrValueNullable, "5")));
+			AssertCompareQuery(Isue2424Table.Data, tb, i => 0 >= string.Compare(i.StrValueNullable, null));
+			AssertCompareQuery(Isue2424Table.Data, tb, i => 0 >= string.Compare(i.StrValueNullable, "1"));
+			AssertCompareQuery(Isue2424Table.Data, tb, i => 0 >= string.Compare(i.StrValueNullable, "3"));
+			AssertCompareQuery(Isue2424Table.Data, tb, i => 0 >= string.Compare(i.StrValueNullable, "5"));
 
-			AssertQuery(tb.Where(i => 0 < string.Compare(i.StrValueNullable, null)));
-			AssertQuery(tb.Where(i => 0 < string.Compare(i.StrValueNullable, "1")));
-			AssertQuery(tb.Where(i => 0 < string.Compare(i.StrValueNullable, "3")));
-			AssertQuery(tb.Where(i => 0 < string.Compare(i.StrValueNullable, "5")));
+			AssertCompareQuery(Isue2424Table.Data, tb, i => 0 < string.Compare(i.StrValueNullable, null));
+			AssertCompareQuery(Isue2424Table.Data, tb, i => 0 < string.Compare(i.StrValueNullable, "1"));
+			AssertCompareQuery(Isue2424Table.Data, tb, i => 0 < string.Compare(i.StrValueNullable, "3"));
+			AssertCompareQuery(Isue2424Table.Data, tb, i => 0 < string.Compare(i.StrValueNullable, "5"));
 
-			AssertQuery(tb.Where(i => 0 > string.Compare(i.StrValueNullable, null)));
-			AssertQuery(tb.Where(i => 0 > string.Compare(i.StrValueNullable, "1")));
-			AssertQuery(tb.Where(i => 0 > string.Compare(i.StrValueNullable, "3")));
-			AssertQuery(tb.Where(i => 0 > string.Compare(i.StrValueNullable, "5")));
+			AssertCompareQuery(Isue2424Table.Data, tb, i => 0 > string.Compare(i.StrValueNullable, null));
+			AssertCompareQuery(Isue2424Table.Data, tb, i => 0 > string.Compare(i.StrValueNullable, "1"));
+			AssertCompareQuery(Isue2424Table.Data, tb, i => 0 > string.Compare(i.StrValueNullable, "3"));
+			AssertCompareQuery(Isue2424Table.Data, tb, i => 0 > string.Compare(i.StrValueNullable, "5"));
 
 #pragma warning disable CA2251 // Use 'string.Equals'
-			AssertQuery(tb.Where(i => 0 == string.Compare(i.StrValueNullable, null)));
-			AssertQuery(tb.Where(i => 0 == string.Compare(i.StrValueNullable, "1")));
-			AssertQuery(tb.Where(i => 0 == string.Compare(i.StrValueNullable, "3")));
-			AssertQuery(tb.Where(i => 0 == string.Compare(i.StrValueNullable, "5")));
+			AssertCompareQuery(Isue2424Table.Data, tb, i => 0 == string.Compare(i.StrValueNullable, null));
+			AssertCompareQuery(Isue2424Table.Data, tb, i => 0 == string.Compare(i.StrValueNullable, "1"));
+			AssertCompareQuery(Isue2424Table.Data, tb, i => 0 == string.Compare(i.StrValueNullable, "3"));
+			AssertCompareQuery(Isue2424Table.Data, tb, i => 0 == string.Compare(i.StrValueNullable, "5"));
 
-			AssertQuery(tb.Where(i => 0 != string.Compare(i.StrValueNullable, null)));
-			AssertQuery(tb.Where(i => 0 != string.Compare(i.StrValueNullable, "1")));
-			AssertQuery(tb.Where(i => 0 != string.Compare(i.StrValueNullable, "3")));
-			AssertQuery(tb.Where(i => 0 != string.Compare(i.StrValueNullable, "5")));
+			AssertCompareQuery(Isue2424Table.Data, tb, i => 0 != string.Compare(i.StrValueNullable, null));
+			AssertCompareQuery(Isue2424Table.Data, tb, i => 0 != string.Compare(i.StrValueNullable, "1"));
+			AssertCompareQuery(Isue2424Table.Data, tb, i => 0 != string.Compare(i.StrValueNullable, "3"));
+			AssertCompareQuery(Isue2424Table.Data, tb, i => 0 != string.Compare(i.StrValueNullable, "5"));
 #pragma warning restore CA2251 // Use 'string.Equals'
 		}
 
@@ -1945,30 +1953,42 @@ namespace Tests.Linq
 						  RightStringN = right.StrValueNullable,
 					  };
 
+			var srcExpected = from left in Isue2424Table.Data
+							  from right in Isue2424Table.Data
+							  select new
+							  {
+								  LeftId = left.Id,
+								  LeftString = left.StrValue,
+								  LeftStringN = left.StrValueNullable,
+								  RightId = right.Id,
+								  RightString = right.StrValue,
+								  RightStringN = right.StrValueNullable,
+							  };
+
 #pragma warning disable CA2251 // Use 'string.Equals'
 			// NonNullable vs NonNullable
-			AssertQuery(src.Where(i => 0 <= string.Compare(i.LeftString, i.RightString)));
-			AssertQuery(src.Where(i => 0 >= string.Compare(i.LeftString, i.RightString)));
-			AssertQuery(src.Where(i => 0 < string.Compare(i.LeftString, i.RightString)));
-			AssertQuery(src.Where(i => 0 > string.Compare(i.LeftString, i.RightString)));
-			AssertQuery(src.Where(i => 0 == string.Compare(i.LeftString, i.RightString)));
-			AssertQuery(src.Where(i => 0 != string.Compare(i.LeftString, i.RightString)));
+			AssertCompareQuery(srcExpected, src, i => 0 <= string.Compare(i.LeftString, i.RightString));
+			AssertCompareQuery(srcExpected, src, i => 0 >= string.Compare(i.LeftString, i.RightString));
+			AssertCompareQuery(srcExpected, src, i => 0 < string.Compare(i.LeftString, i.RightString));
+			AssertCompareQuery(srcExpected, src, i => 0 > string.Compare(i.LeftString, i.RightString));
+			AssertCompareQuery(srcExpected, src, i => 0 == string.Compare(i.LeftString, i.RightString));
+			AssertCompareQuery(srcExpected, src, i => 0 != string.Compare(i.LeftString, i.RightString));
 
 			// NonNullable vs Nullable
-			AssertQuery(src.Where(i => 0 <= string.Compare(i.LeftString, i.RightStringN)));
-			AssertQuery(src.Where(i => 0 >= string.Compare(i.LeftString, i.RightStringN)));
-			AssertQuery(src.Where(i => 0 < string.Compare(i.LeftString, i.RightStringN)));
-			AssertQuery(src.Where(i => 0 > string.Compare(i.LeftString, i.RightStringN)));
-			AssertQuery(src.Where(i => 0 == string.Compare(i.LeftString, i.RightStringN)));
-			AssertQuery(src.Where(i => 0 != string.Compare(i.LeftString, i.RightStringN)));
+			AssertCompareQuery(srcExpected, src, i => 0 <= string.Compare(i.LeftString, i.RightStringN));
+			AssertCompareQuery(srcExpected, src, i => 0 >= string.Compare(i.LeftString, i.RightStringN));
+			AssertCompareQuery(srcExpected, src, i => 0 < string.Compare(i.LeftString, i.RightStringN));
+			AssertCompareQuery(srcExpected, src, i => 0 > string.Compare(i.LeftString, i.RightStringN));
+			AssertCompareQuery(srcExpected, src, i => 0 == string.Compare(i.LeftString, i.RightStringN));
+			AssertCompareQuery(srcExpected, src, i => 0 != string.Compare(i.LeftString, i.RightStringN));
 
 			// Nullable vs Nullable
-			AssertQuery(src.Where(i => 0 <= string.Compare(i.LeftStringN, i.RightStringN)));
-			AssertQuery(src.Where(i => 0 >= string.Compare(i.LeftStringN, i.RightStringN)));
-			AssertQuery(src.Where(i => 0 < string.Compare(i.LeftStringN, i.RightStringN)));
-			AssertQuery(src.Where(i => 0 > string.Compare(i.LeftStringN, i.RightStringN)));
-			AssertQuery(src.Where(i => 0 == string.Compare(i.LeftStringN, i.RightStringN)));
-			AssertQuery(src.Where(i => 0 != string.Compare(i.LeftStringN, i.RightStringN)));
+			AssertCompareQuery(srcExpected, src, i => 0 <= string.Compare(i.LeftStringN, i.RightStringN));
+			AssertCompareQuery(srcExpected, src, i => 0 >= string.Compare(i.LeftStringN, i.RightStringN));
+			AssertCompareQuery(srcExpected, src, i => 0 < string.Compare(i.LeftStringN, i.RightStringN));
+			AssertCompareQuery(srcExpected, src, i => 0 > string.Compare(i.LeftStringN, i.RightStringN));
+			AssertCompareQuery(srcExpected, src, i => 0 == string.Compare(i.LeftStringN, i.RightStringN));
+			AssertCompareQuery(srcExpected, src, i => 0 != string.Compare(i.LeftStringN, i.RightStringN));
 #pragma warning restore CA2251 // Use 'string.Equals'
 		}
 		#endregion


### PR DESCRIPTION
## Summary

Migrates `string.CompareTo(string)` and `string.CompareTo(object)` translation from the legacy `Expressions._commonMembers` + `[Sql.Extension]` path into the member-translator pipeline (`StringMemberTranslatorBase`), continuing the move off the expose-mapping system (after `Math.Max/Min`, `string.Replace`, `Sql.NullIf`, …).

## Changes

- **`StringMemberTranslatorBase`** — new `TranslateCompareTo` registered for both overloads, emitting `SqlCompareToExpression` directly (the same node the legacy `[Sql.Extension]` builder produced, so the SQL `CASE` lowering is unchanged). The `object` overload converts its argument to a string (`arg.ToString()`) before comparison, matching the legacy mapping body.
- **`Expressions.cs`** — removed both `_commonMembers` `CompareTo` mappings and the now-unused private `ConvertToCaseCompareToImpl`. Kept the frozen public obsolete `ConvertToCaseCompareTo` and `ConvertToCaseCompareToBuilder` (the builder is still referenced by the public method).

## Behavior change

In-memory / client-side evaluation of `string.CompareTo` now uses **BCL semantics** instead of the removed ordinal local-eval body (`ConvertToCaseCompareToImpl`, added in #5577):

- string overload → culture-sensitive (BCL `string.CompareTo`);
- object overload → BCL `string.CompareTo(object)` throws for a non-string argument.

**SQL translation is unchanged** (ordinal `CASE`). Because `AssertQuery` compares the SQL result against an in-memory expected set, the #2424 null-comparison regression tests (`Issue2424Nullable`, `Issue2424Fields`) are reworked to assert against a real-BCL expected set via a new `AssertCompareQuery` helper rather than `AssertQuery`, whose expected side re-expanded the removed mapping and diverged on null operands.

## Verification

- Release build clean on `net8.0` and `netstandard2.0` (analyzers + banned-API).
- SQLite: all `StringFunctionTests` `CompareTo`/`Compare`/`CompareOrdinal` and all `Issue2424*` tests pass.
- Baselines: only the two reworked tests' baselines change; every other comparison baseline is byte-identical, confirming SQL equivalence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
