### PR TITLE
Fix Release-mode analyzer build errors in test projects

### DIFF
--- a/Tests/Base/TestProgressReporter.cs
+++ b/Tests/Base/TestProgressReporter.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Text;
+using System.Threading;
 
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
@@ -16,7 +17,7 @@ namespace Tests
 	/// without scraping console output.
 	/// <para>
 	/// Opt-in: the reporter is a no-op unless the <c>LINQ2DB_TEST_PROGRESS</c> environment variable is set. When set
-	/// to a flag value (<c>1</c>/<c>true</c>/<c>on</c>/<c>yes</c>) the file is written to
+	/// to a flag value (<c>1/true/on/yes</c>) the file is written to
 	/// <c>&lt;repoRoot&gt;/.build/.claude/test-progress.&lt;tfm&gt;.&lt;pid&gt;.json</c>; when set to a directory or
 	/// <c>*.json</c> path that path is used instead.
 	/// </para>
@@ -49,7 +50,7 @@ namespace Tests
 		const int MaxRecentFailures = 20;
 		const int WriteThrottleMs   = 1000;  // at most ~1 file write/sec for the common (passing) case
 
-		static readonly object                              _sync     = new();
+		static readonly Lock                                _sync     = new();
 		static readonly Stopwatch                           _clock    = new();
 		static readonly List<(string Test, string Message)> _failures = new();
 
@@ -162,7 +163,11 @@ namespace Tests
 
 			try
 			{
+#if NETFRAMEWORK
 				_pid        = Process.GetCurrentProcess().Id;
+#else
+				_pid        = Environment.ProcessId;
+#endif
 				_file       = ResolvePath(env!.Trim());
 				_startedUtc = DateTime.UtcNow;
 
@@ -192,7 +197,7 @@ namespace Tests
 					return Path.Combine(env, fileName);
 
 				if (env.EndsWith(".json", StringComparison.OrdinalIgnoreCase)
-					|| env.IndexOf('/') >= 0 || env.IndexOf('\\') >= 0)
+					|| env.Contains('/') || env.Contains('\\'))
 					return env;
 			}
 

--- a/Tests/EntityFrameworkCore/Models/ManyToMany/ManyToManyEntities.cs
+++ b/Tests/EntityFrameworkCore/Models/ManyToMany/ManyToManyEntities.cs
@@ -134,9 +134,9 @@ namespace LinqToDB.EntityFrameworkCore.Tests.Models.ManyToMany
 	//    with a renamed column.
 	public class MmAccount
 	{
-#pragma warning disable CS0169, CS0649 // assigned by EF via the field-mapped "AccountId" key
+#pragma warning disable CS0169, CS0649, CA1823 // assigned by EF via the field-mapped "AccountId" key
 		private int                AccountId;
-#pragma warning restore CS0169, CS0649
+#pragma warning restore CS0169, CS0649, CA1823
 		public string              Name  { get; set; } = null!;
 		public ICollection<MmRole> Roles { get; set; } = null!;
 	}


### PR DESCRIPTION
Release builds enable analyzers + `TreatWarningsAsErrors`. Two test files had
only ever compiled in analyzer-free configs (Debug/Testing) and carried latent
analyzer-as-error violations.

## `Tests/Base/TestProgressReporter.cs`
- `MA0154`: collapse `<c>1</c>/<c>true</c>/<c>on</c>/<c>yes</c>` into one
  `<c>1/true/on/yes</c>` span (env-var string values, not C# keywords).
- `MA0158`/`IDE0330`: `object _sync` → `Lock` (`System.Threading.Lock`, polyfilled
  on all TFMs).
- `CA1837`: `Process.GetCurrentProcess().Id` → `Environment.ProcessId`, guarded by
  `#if NETFRAMEWORK` (unavailable on net462).
- `CA2249`: `IndexOf(c) >= 0` → `Contains(c)` (`string.Contains(char)` polyfilled).

## `Tests/EntityFrameworkCore/Models/ManyToMany/ManyToManyEntities.cs`
- `CA1823`: extend the existing `CS0169, CS0649` pragma on EF field-mapped key
  `MmAccount.AccountId` to also suppress the unused-field analyzer rule.

`dotnet build linq2db.slnx -c Release` is green (0 warnings, 0 errors).
