### PR TITLE
Add --provider and --test-progress test CLI options

### DIFF
--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -11,33 +11,33 @@ Read-only subagent that executes tests and reports results. Invoked by `/test` a
 
 Test framework details, patterns, and the "read the full log" rule live in [`.claude/docs/testing.md`](../docs/testing.md). Review it before your first run in a session.
 
-## Pre-condition: providers must already be enabled
+## Pre-condition: providers must have a connection defined
 
-This agent does **not** edit `UserDataProviders.json`. Provider enable/disable, container start/stop, and any other env changes are owned by the `/test-providers` skill (`.claude/skills/test-providers/SKILL.md`); `test-runner` consumes that state read-only.
+This agent does **not** edit `UserDataProviders.json` or `DataProviders.json`. Connection strings, provider enable/disable, container start/stop, and any other env changes are owned by the `/test-providers` skill (`.claude/skills/test-providers/SKILL.md`); `test-runner` consumes that state read-only.
 
-Before the first `dotnet test` invocation:
+The run always passes `--provider <ids>` (see *Running tests*), which **replaces** the providers from `UserDataProviders.json` — so a provider does **not** need to be enabled in any `Providers` array, only to have a connection string defined. Before the first `dotnet test` invocation:
 
-1. `Read` `UserDataProviders.json` at the repo root.
-2. For each target's `(tfm, providers[])` pair, locate the matching TFM bucket (`NETFX` / `NET80` / `NET90` / `NET100` per the table below). Verify each requested provider ID is present in that bucket's `Providers` array **and** is not prefixed with `- ` (i.e. is enabled).
-3. On any miss — provider missing from the bucket, provider disabled, or `UserDataProviders.json` itself absent — abort the entire run with:
+1. `Read` `DataProviders.json` (committed; defines connection strings for every standard provider) and `UserDataProviders.json` (if present) at the repo root.
+2. For each requested provider ID, verify a `Connections` entry with that name exists in either file (case-insensitive).
+3. On any miss, abort the entire run with:
 
    ```json
    {
      "status": "blocked",
-     "reason": "Provider <ID> is not enabled in <BUCKET> of UserDataProviders.json — run /test-providers <ID> [...] to enable it, then re-run /test"
+     "reason": "Provider <ID> has no connection string defined in DataProviders.json / UserDataProviders.json — add one via /test-providers, then re-run /test"
    }
    ```
 
-   List every missing/disabled provider in the message; don't stop at the first. Don't run any partial subset of targets.
+   List every missing provider in the message; don't stop at the first. Don't run any partial subset of targets.
 
-The agent never writes to `UserDataProviders.json` and does not back it up — the file's pre-run state is the user's responsibility (and `/test-providers` already backs it up when it edits).
+Container availability is **not** checked here (that's `/test-providers`' job): a server provider whose container isn't running will fail at connect time — relay that failure and point the caller at `/test-providers`. The agent never writes to either config file.
 
 ## Inputs (provided in the invocation prompt)
 
 1. **`testPattern`** — full or partial `dotnet test --filter` value. Typically `FullyQualifiedName~<fragment>`; `|` for OR is fine, escape as needed for the shell.
 2. **`targets`** — list of one or more run targets. Two accepted shapes:
    - **Explicit**: `[{project: "Tests/.../Tests.EntityFrameworkCore.EF10.csproj", tfm: "net10.0", providers: ["SqlServer.2016.MS"]}, ...]`
-   - **Shorthand**: `{efMatrix: true, providers: [...]}` — expands to all four EFCore projects (EF3/EF8/EF9/EF10) with the matching TFMs (net462 / net8.0 / net9.0 / net10.0). Or `{mainTests: true, providers: [...]}` — defaults to `Tests/Tests.Playground/Tests.Playground.csproj` at `net10.0`. Add `tfm: "<...>"` and/or `project: "Tests/Linq/Tests.csproj"` explicitly to override the fast-path default.
+   - **Shorthand**: `{efMatrix: true, providers: [...]}` — expands to all four EFCore projects (EF3/EF8/EF9/EF10) with the matching TFMs (net462 / net8.0 / net9.0 / net10.0). Or `{mainTests: true, providers: [...]}` — defaults to `Tests/Tests.Playground/Tests.Playground.csproj` at `net10.0`. Add `tfm: "<...>"` and/or `project: "Tests/Linq/Tests.csproj"` explicitly to override the fast-path default. In every shape, `providers` is passed to the run as `--provider` (see *Running tests*) — for main tests it **replaces** the file's provider list, so a provider need not be enabled there, only have a connection string.
 3. **`config`** — default `"Debug"`. Testing guidance in `testing.md` warns against `Release` (slow, analyzers); don't override without a specific reason.
 4. **`verbosity`** — default `"normal"`. Set `"detailed"` when the caller needs SQL-dump diagnostics from `TestContext.Out.WriteLine`. Tests run on Microsoft.Testing.Platform (MTP), which captures the test app's console output by default; surface it with `-p:TestingPlatformCaptureOutput=false` (the VSTest `--logger "console;verbosity=detailed"` no longer applies).
 
@@ -68,13 +68,14 @@ Use `Tests/Linq/Tests.csproj` only when the caller explicitly asks (`project: "T
 For each target, issue one `dotnet test` invocation:
 
 ```
-dotnet test --project <project> --filter "<testPattern>" -c <config> --settings .runsettings
+dotnet test --project <project> --filter "<testPattern>" -c <config> --settings .runsettings --provider <space-separated providers> --test-progress
 ```
 
 Notes:
+- **`--provider <providers>` runs exactly the target's `providers`.** Pass the target's provider IDs space-separated. For main tests this **replaces** the configured set — the providers need not be enabled in `UserDataProviders.json`, only have a connection string (see the pre-condition); EF Core projects intersect their curated supported set. An absent/empty list means no `--provider` (the providers enabled in `UserDataProviders.json` run).
+- **Always pass `--test-progress`.** It enables the live heartbeat at `.build/.claude/test-progress.<tfm>.<pid>.json` (see [Tests/Base/TestProgressReporter.cs](../../Tests/Base/TestProgressReporter.cs)), which `/test` and the user poll via `/test-progress` / `test-status.ps1`. It's a plain CLI option (no env var); a bare `--test-progress` uses the default path.
 - **`--project` is required.** The repo's `global.json` selects the Microsoft.Testing.Platform runner, where the bare `dotnet test <project>` form is rejected (`Specifying a project for 'dotnet test' should be via '--project'`). The test projects build as MTP executables.
 - **Pass `--settings .runsettings`** (from the repo root). MTP does not auto-discover `.runsettings`; NUnit bridges it via `--settings`, and it carries `AssemblySelectLimit` (without it a filter selecting >~2000 tests can fall back to running the whole assembly).
-- **Live progress heartbeat.** When `LINQ2DB_TEST_PROGRESS` is set, the test assembly writes a JSON heartbeat to `.build/.claude/test-progress.<tfm>.<pid>.json` during the run (see [Tests/Base/TestProgressReporter.cs](../../Tests/Base/TestProgressReporter.cs)). Don't set it inline — it's toggled session-wide by the `/test-progress` skill, so the `dotnet test` form above is correct whether the trace is on or off.
 - The four EFCore projects each have a single TFM, so `-f <tfm>` is redundant for them. Include `-f <tfm>` only for `Tests/Linq/Tests.csproj` (multi-TFM).
 - `-p:TestingPlatformCaptureOutput=false` when `verbosity: "detailed"` (shows the test app's console / SQL-dump output).
 - Don't pipe output to `head`/`tail` — read the whole log. Per `testing.md`: NUnit and `dotnet test` interleave relevant info across the log; setup exceptions can come well before the assertion, and stack traces may be truncated if you skim.

--- a/.claude/docs/testing.md
+++ b/.claude/docs/testing.md
@@ -55,6 +55,8 @@ Tests run against multiple database providers. Configuration comes from `UserDat
 
 After the file exists, `/test-providers` is the supported way to enable / disable providers per TFM bucket and to start the docker containers behind them. `/test` reads the resulting state but never edits it — see [`.claude/skills/test-providers/SKILL.md`](../skills/test-providers/SKILL.md).
 
+**For a single run, prefer `--provider` over editing the `Providers` array** — it runs exactly the named providers (any with a connection string defined) without touching the file; see *Scoping a run to specific providers* below. Editing `UserDataProviders.json` is for changing the **default** set (used when no `--provider` is passed), connection strings, and `BaselinesPath`.
+
 **Ask before editing `UserDataProviders.json`.** Before the **first** edit in a session, ask the user whether to stash/back up the current file. The file is gitignored and holds the user's connection strings + enabled-provider flags — an incorrect edit has no git history to recover from. Subsequent edits in the same session don't need to re-prompt.
 
 ### `Providers` is keyed by TFM

--- a/.claude/docs/testing.md
+++ b/.claude/docs/testing.md
@@ -27,28 +27,17 @@ Reach for the full `Tests/Linq/Tests.csproj` only when the test target spans man
 
 ## Monitoring a long run
 
-A full suite run takes 1–2 hours. To watch progress without scraping console output, the test assembly can write a small JSON heartbeat (updated ~once/sec, immediately on each failure) that you can `Read` at any time. It's **opt-in** via the `LINQ2DB_TEST_PROGRESS` environment variable; the reporter is a no-op when unset, so default runs are unaffected.
+A full suite run takes 1–2 hours. To watch progress without scraping console output, the test assembly writes a small JSON heartbeat (updated ~once/sec, immediately on each failure) that you can `Read` at any time. It's **opt-in** via the `--test-progress` command-line option; the reporter is a no-op when the option is absent, so default runs are unaffected.
 
-**For test runs Claude launches** (via `/test`, `test-runner`, or ad-hoc Bash), toggle it with the **`/test-progress`** skill — it sets `LINQ2DB_TEST_PROGRESS` session-wide through `.claude/settings.local.json` → `env`, which Claude Code injects into every Bash subprocess. Effect is immediate for the next run, and the `dotnet test` command is unchanged (no permission re-prompt):
-
-```
-/test-progress on        # enable the heartbeat
-/test-progress           # status + latest heartbeat
-/test-progress off       # disable
-```
-
-**For runs in your own terminal**, set the variable yourself before launching:
+**Always pass `--test-progress` when launching a run** — via `test-runner`, `/test`, or ad-hoc — so progress is observable. It's a normal CLI option (no env var, no session-wide toggle):
 
 ```bash
-# PowerShell
-$env:LINQ2DB_TEST_PROGRESS = '1'; dotnet test --project Tests/Linq/Tests.csproj -f net10.0 --filter "..."
-# bash
-LINQ2DB_TEST_PROGRESS=1 dotnet test --project Tests/Linq/Tests.csproj -f net10.0 --filter "..."
+dotnet test --project Tests/Linq/Tests.csproj -f net10.0 --settings .runsettings --filter "..." --provider SQLite.MS --test-progress
 ```
 
-The file lands at `.build/.claude/test-progress.<tfm>.<pid>.json` (one per TFM/process). Set the variable to a directory or a `*.json` path to override the location. Fields: `done`, `total`, `completed`, `passed`, `failed`, `skipped`, `currentTest`, `elapsedSec`, `testsPerSec`, `etaSec`, and `recentFailures[]`.
+A bare `--test-progress` writes to `.build/.claude/test-progress.<tfm>.<pid>.json` (one per TFM/process); pass `--test-progress <dir|*.json>` to redirect it. Fields: `done`, `total`, `completed`, `passed`, `failed`, `skipped`, `currentTest`, `elapsedSec`, `testsPerSec`, `etaSec`, and `recentFailures[]`.
 
-Read it directly, or run the summary helper:
+Read the heartbeat directly, or with the summary helper (the `/test-progress` skill reports the latest run):
 
 ```bash
 pwsh -NoProfile -File .claude/scripts/test-status.ps1          # newest run, one-line summary
@@ -87,6 +76,35 @@ When the user asks to run tests against a provider family without naming the exa
 - **SAP HANA** → both `SapHana.Native` and `SapHana.Odbc`.
 
 **Access Jet requires x86.** If the user does request `Access.*.Jet.*`, the test process must run under x86 (32-bit). When running x86, **do not** enable any other provider alongside Jet — other providers may be x64-only (native drivers) or architecture-agnostic but untested on x86, so a mixed x86 run risks failures unrelated to the Jet work.
+
+## Scoping a run to specific providers (`--provider`)
+
+The test executables accept a `--provider` command-line option that runs exactly the named provider(s), **replacing** the providers configured in `UserDataProviders.json`. It is repeatable and accepts comma- or space-separated values:
+
+```bash
+dotnet test --project Tests/Linq/Tests.csproj -f net10.0 --settings .runsettings --filter "FullyQualifiedName~CreateData.CreateDatabase|FullyQualifiedName~MyTest" --provider PostgreSQL.18 --test-progress
+```
+
+`--provider` replaces the active main-test provider set (`TestConfiguration.UserProviders`) with exactly the names given, so **any provider with a connection string defined in `DataProviders.json` / `UserDataProviders.json` runs without editing the enabled-providers list** — it need not be enabled. (EF Core test runs instead intersect their curated `EFProviders` list, so `--provider` can only narrow EF runs to supported providers, never add an unsupported one.) Connection strings still come from those files; a `--provider` name with no connection logs a warning and fails to connect. An absent option leaves behavior unchanged (the providers enabled in `UserDataProviders.json` run).
+
+### Running providers in parallel
+
+Each provider config maps to a distinct database, so runs scoped to **distinct** providers don't collide and can run concurrently. Two cautions, both from the standing single-session rule:
+
+- **One distinct provider (= one database) per parallel run.** The same provider on two concurrent runs — including the *same* provider across two TFMs — hits the same database and corrupts state. The parallel unit is the database, not the process.
+- **Build once, and don't let the runs build concurrently.** Two `dotnet test` invocations on the same project race to write and lock the shared `linq2db.Tests.dll` (fails with `MSB3027`). Build once, then launch each run as the **test executable directly** — it never builds, and each process writes its own per-PID heartbeat:
+
+```bash
+dotnet build Tests/Linq/Tests.csproj -c Debug -f net10.0
+```
+```bash
+.build/bin/Tests/Debug/net10.0/linq2db.Tests.exe --provider PostgreSQL.18 --test-progress --filter "FullyQualifiedName~CreateData.CreateDatabase|FullyQualifiedName~MyTest"
+```
+```bash
+.build/bin/Tests/Debug/net10.0/linq2db.Tests.exe --provider MySql.8.0 --test-progress --filter "FullyQualifiedName~CreateData.CreateDatabase|FullyQualifiedName~MyTest"
+```
+
+Each process writes its own `.build/.claude/test-progress.<tfm>.<pid>.json`; poll them with `/test-progress` or `test-status.ps1`. The runner's native filter flag is `--filter` (the same `FullyQualifiedName~` syntax), confirmed via `--help`.
 
 ## Database initialization
 

--- a/.claude/docs/worktree.md
+++ b/.claude/docs/worktree.md
@@ -12,9 +12,9 @@ When working inside an authorized worktree, local / gitignored files in the *mai
 
 ## `UserDataProviders.json` in a worktree
 
-The test harness reads this file from the worktree root, and a fresh worktree starts without one (only `UserDataProviders.json.template` is tracked). Before running tests from a worktree:
+`TestConfiguration` finds this file by walking **up** the directory tree from the test assembly (`GetFilePath` in `Tests/Base/TestConfiguration.cs`), not from a fixed path. A worktree lives under `<main-repo>/.claude/worktrees/<name>` and builds to `<worktree>/.build/bin/…`, so when the worktree has no `UserDataProviders.json` of its own (a fresh worktree only tracks `UserDataProviders.json.template`), the walk-up reaches the **main repo's** copy. Tests run from a worktree therefore work without copying anything.
 
-1. Copy the **main repo's** `UserDataProviders.json` into the worktree root (e.g. `cp C:/GitHub/linq2db/UserDataProviders.json <worktree>/UserDataProviders.json`).
-2. Adjust the `Providers` list under the TFM you're testing against (`NET100` for `net10.0` runs).
+Two consequences:
 
-Editing the main repo's copy for a worktree-scoped run is the wrong place — it affects every future run in the main repo too.
+- **Per-run provider selection: use `--provider`, don't copy/edit the JSON.** `<exe> --provider <name>` (or `/test … on <name>`) replaces the active provider set for that run, so you need neither a worktree-local file nor any `Providers`-array edit. The provider only needs a connection string (already in the tracked `DataProviders.json`) and, for server providers, a running container. See [`testing.md`](testing.md) → *Scoping a run to specific providers*.
+- A **default** run (no `--provider`) from a worktree inherits the **main repo's** enabled set and `BaselinesPath` via the walk-up. Only if you want a *different default set* for the worktree, copy the main repo's `UserDataProviders.json` into the worktree root and adjust the `Providers` list under the TFM you're testing (`NET100` for `net10.0`). Don't edit the main repo's copy for a worktree-scoped run — it affects every future main-repo run too.

--- a/.claude/scripts/test-status.ps1
+++ b/.claude/scripts/test-status.ps1
@@ -2,7 +2,7 @@
 # test-status.ps1 — print a one-line summary of an in-progress (or finished) linq2db test run.
 #
 # Reads the JSON heartbeat written by Tests/Base/TestProgressReporter.cs when a run is launched with
-# the LINQ2DB_TEST_PROGRESS environment variable set. By default it picks the most recently updated
+# the --test-progress command-line option. By default it picks the most recently updated
 # .build/.claude/test-progress.*.json file (the active run); pass -Path to target a specific file.
 #
 # Usage:
@@ -23,7 +23,7 @@ $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..' '..')
 if (-not $Path) {
 	$dir = Join-Path $repoRoot '.build/.claude'
 	if (-not (Test-Path $dir)) {
-		Write-Output "No test-progress directory yet ($dir). Start a run with LINQ2DB_TEST_PROGRESS=1."
+		Write-Output "No test-progress directory yet ($dir). Start a run with --test-progress."
 		return
 	}
 
@@ -32,7 +32,7 @@ if (-not $Path) {
 		Select-Object -First 1
 
 	if (-not $latest) {
-		Write-Output "No test-progress.*.json found in $dir. Start a run with LINQ2DB_TEST_PROGRESS=1."
+		Write-Output "No test-progress.*.json found in $dir. Start a run with --test-progress."
 		return
 	}
 

--- a/.claude/skills/test-progress/SKILL.md
+++ b/.claude/skills/test-progress/SKILL.md
@@ -1,62 +1,32 @@
 ---
 name: test-progress
-description: Enable, disable, or check the live test-progress heartbeat for linq2db test runs. Toggles the LINQ2DB_TEST_PROGRESS environment variable session-wide via .claude/settings.local.json → env, so dotnet test runs (via /test, test-runner, or ad-hoc) emit a JSON heartbeat (current test, completed/total, pass/fail tally) that can be polled mid-run. Use when the user says "/test-progress", "enable test progress/trace", "watch the test run", "how far along are the tests".
+description: Report the live test-progress heartbeat for linq2db test runs (read-only). The heartbeat is always written by Claude-launched runs (test-runner passes --test-progress), so this skill reads the latest .build/.claude/test-progress.*.json and relays a one-line status — current test, completed/total, pass/fail tally. Use when the user says "/test-progress", "how far along are the tests", "watch the test run", "test status".
 ---
 
 # /test-progress
 
-Toggle and inspect the live progress heartbeat written by the test assembly during a run. Backed by [Tests/Base/TestProgressReporter.cs](../../../Tests/Base/TestProgressReporter.cs); reader docs in [`.claude/docs/testing.md`](../../docs/testing.md) → **Monitoring a long run**.
+Report the live progress heartbeat written by the test assembly during a run. Backed by [Tests/Base/TestProgressReporter.cs](../../../Tests/Base/TestProgressReporter.cs); reader docs in [`.claude/docs/testing.md`](../../docs/testing.md) → **Monitoring a long run**.
 
 ## How it works
 
-The reporter is **opt-in**: it writes nothing unless `LINQ2DB_TEST_PROGRESS` is set to a truthy value in the process running `dotnet test`. This skill flips that variable in `.claude/settings.local.json` → `env`, which Claude Code injects into every Bash-tool subprocess (and their children, e.g. the NUnit test host). The `dotnet test` command itself is unchanged, so the existing `Bash(dotnet test *)` allowlist still matches (no new permission prompts).
+The heartbeat is opt-in via the **`--test-progress`** command-line option on the test executable. Claude-launched runs **always** pass it — `test-runner` appends `--test-progress`, and `/test` step 3.1a relies on that for long runs — so a heartbeat file is normally present for the active or most-recent run. There is **no env var and nothing to toggle**; this skill only *reads* the heartbeat.
 
-**On = `"1"`, off = `"0"` (not key-removal).** Claude Code applies an added or *changed* env value to the running session immediately, but does **not** un-apply a *removed* key until restart. So `off` sets `"0"` — a present-but-falsy value the reporter treats as disabled — which takes effect right away; removing the key would leave the trace silently on until restart.
+The file lands at `.build/.claude/test-progress.<tfm>.<pid>.json` (one per TFM / process). For a run the user starts in their own terminal, they pass `--test-progress` themselves (see `testing.md`).
 
-Scope: this affects test runs **Claude** launches via the Bash tool. A run the user starts in their **own** terminal won't inherit it — they set `LINQ2DB_TEST_PROGRESS=1` there themselves (see `testing.md`).
+## Steps (default / `status`)
 
-## Arguments
-
-| Arg | Action |
-|---|---|
-| _(none)_ / `status` | Report whether the trace is on, and show the latest heartbeat if a run is active or recent. |
-| `on` / `enable` | Set `env.LINQ2DB_TEST_PROGRESS = "1"` in `settings.local.json`. |
-| `on <path>` | Same, but set the value to `<path>` (a directory or `*.json` file) to redirect the heartbeat location. |
-| `off` / `disable` | Set `env.LINQ2DB_TEST_PROGRESS = "0"` (immediate effect — see below; do **not** remove the key). |
-
-## Steps
-
-### `on` / `enable`
-
-1. `Read` `.claude/settings.local.json` at the repo (worktree) root.
-2. Ensure a top-level `"env"` object exists; set `"LINQ2DB_TEST_PROGRESS"` to `"1"` (or the `<path>` argument if given). Use `Edit` for a minimal change that preserves `permissions` and any other keys. If `env` already has the key with the same value, report "already enabled" and stop.
-3. Confirm to the user: trace enabled, value, and that it applies to the next Claude-run `dotnet test`. Remind that the file lands at `.build/.claude/test-progress.<tfm>.<pid>.json` (or the custom path) and is polled with `/test-progress` or `test-status.ps1`.
-
-### `off` / `disable`
-
-1. `Read` `.claude/settings.local.json`.
-2. Set `env.LINQ2DB_TEST_PROGRESS` to `"0"` (add the `env` object / key if missing) — **not** key-removal (see *How it works*). If it's already `"0"` or another falsy value, report "already disabled" and stop.
-3. Confirm to the user: trace disabled, effective for the next run. Existing `.build/.claude/test-progress.*.json` files are left as-is (gitignored scratch).
-
-### `status` (default)
-
-1. `Read` `.claude/settings.local.json`; report the trace state from `env.LINQ2DB_TEST_PROGRESS` — **on** for a truthy value (`1`/`true`/`on`/`yes` or a path), **off** when absent or falsy (`0`/`false`/`off`/`no`/empty). Show the raw value when it's a custom path.
-2. Run the summary helper for the most recent run:
+1. Run the summary helper for the most recent run:
 
    ```
    pwsh -NoProfile -File .claude/scripts/test-status.ps1
    ```
 
-   Relay its one-line output. If it reports no heartbeat file, say so. Add `-Raw` only if the user wants the full JSON.
-
-## JSON-editing notes
-
-- `settings.local.json` is small, gitignored, and user-owned. Edit it directly — the user invoking this skill *is* the consent. Do not route through `/update-config` for this single toggle.
-- Make the **minimal** edit: insert or change only the `env.LINQ2DB_TEST_PROGRESS` line. Never reorder or rewrite the `permissions` block.
-- This skill is the one place that toggles this variable. If the user wants other harness env vars managed, point them at `/update-config`.
+   Relay its one-line output (state, completed/total, pass/fail/skip, rate, elapsed, ETA, current test). If it reports no heartbeat file, say so — either no run has started, or the run was launched without `--test-progress` (unusual for a Claude-launched run).
+2. Add `-Raw` if the user wants the full JSON, or `-Path <file>` to target a specific run's heartbeat.
+3. For a parallel per-provider run, each process writes its own `.build/.claude/test-progress.<tfm>.<pid>.json`; point `-Path` at the one you want to watch.
 
 ## Don'ts
 
-- Don't prefix `dotnet test` commands with the variable, and don't ask `test-runner` to — the whole point of the settings-`env` approach is to keep the command (and its allowlist match) unchanged.
-- Don't edit `Tests/Base/TestProgressReporter.cs` or any test source from here — this skill only flips the environment toggle.
-- `/test` auto-enables the trace for **long / full-suite** runs (its step 3.1a) and monitors the heartbeat — that's expected. For **short** single-test runs the trace stays as-is; don't flip it on for those unless the user asks.
+- Don't toggle env vars or edit `settings.local.json` — the heartbeat is controlled by the `--test-progress` option, which `test-runner` always passes. There is no on/off switch to flip.
+- Don't edit `Tests/Base/TestProgressReporter.cs` or any test source from here — this skill only reads the heartbeat.
+- Don't launch test runs from here — that's `/test`. This skill reports the status of a run already in progress or finished.

--- a/.claude/skills/test-providers/SKILL.md
+++ b/.claude/skills/test-providers/SKILL.md
@@ -14,7 +14,9 @@ Shared reference material:
 
 ## When to run
 
-Only when the user explicitly invokes `/test-providers` — typically before a `/test run …` to make sure the right providers are enabled and their containers are up, or after a session to stop containers the user no longer needs. Do not invoke this skill from inside `/test`, from `test-runner`, or from any other skill — the boundary is intentional, and `/test` is allowed to fail when the env doesn't match (the user re-runs `/test-providers` to fix it).
+Only when the user explicitly invokes `/test-providers` — typically before a `/test run …` to make sure the needed connection strings exist and the containers are up, or after a session to stop containers the user no longer needs. Do not invoke this skill from inside `/test`, from `test-runner`, or from any other skill — the boundary is intentional, and `/test` is allowed to fail when the env doesn't match (the user re-runs `/test-providers` to fix it).
+
+**Per-run provider *selection* lives in `--provider`, not this skill.** To run a one-off against specific providers, use `/test … on <provider>` (or `<exe> --provider <name>`) — it replaces the active provider set for that run, so the provider does **not** need to be enabled in a `Providers` array. This skill's enduring jobs are (1) **connection strings** (filling `TODO_ADD_CONNECTION_STRING`, custom overrides), (2) **docker containers** (`--provider X` still needs X's container running), and (3) the **default enabled set** used when a run passes no `--provider`. The `Providers`-array editing below is mainly for (3).
 
 ## Accepted arg shapes
 

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -66,16 +66,15 @@ Resolve `{project, tfm}` for each run:
 - **EFCore test** — expand to all four projects (EF3/EF8/EF9/EF10). Use `{efMatrix: true, providers: [...]}` shorthand on the agent.
 - **Explicit filter → specific test** — read the test's attributes to infer `[DataSources]` family and EFCore-vs-main. When the filter matches tests across both main and EFCore projects (rare but possible), ask the user to pick.
 
-#### 3.1a Long runs — auto-trace + background monitor
+#### 3.1a Long runs — background monitor
 
 A run is **long** when any of: project is `Tests/Linq/Tests.csproj` (especially across multiple TFMs); the EF matrix runs against more than one provider; the filter is broad (a whole class, a `CreateDatabase`-only full-init pass, or no narrowing filter); or the user said "full" / "all" / "the whole suite". A single-method or Playground run is **short** — skip this subsection and run it synchronously per 3.3.
 
 For a long run:
 
-1. **Auto-enable the progress heartbeat** — invoke `/test-progress on` (don't merely suggest it), then tell the user it's on and that you'll report progress as it runs.
-2. **Run it in the background so progress is readable** — invoke `test-runner` with `run_in_background: true`. The test process writes the heartbeat to `.build/.claude/test-progress.<tfm>.<pid>.json` regardless of who launched it; running the agent in the background is what frees you to poll it instead of blocking with nothing to show.
-3. **Poll and surface progress** — between turns, read the heartbeat with `pwsh -NoProfile -File .claude/scripts/test-status.ps1` (or `Read` the JSON) and give the user a one-line update (completed/total, current test, failures so far). You can do this any time the user asks "how's it going?" — you don't have to wait for the run to finish. Don't busy-poll; check when prompted or at natural intervals.
-4. When the background `test-runner` completes, continue with the baselines diff (3.4) and the final report (3.5) as usual.
+1. **Run it in the background so progress is readable** — invoke `test-runner` with `run_in_background: true`. The test process always writes the heartbeat to `.build/.claude/test-progress.<tfm>.<pid>.json` (`test-runner` passes `--test-progress`); running the agent in the background is what frees you to poll it instead of blocking with nothing to show.
+2. **Poll and surface progress** — between turns, read the heartbeat with `pwsh -NoProfile -File .claude/scripts/test-status.ps1` (or `Read` the JSON) and give the user a one-line update (completed/total, current test, failures so far). You can do this any time the user asks "how's it going?" — you don't have to wait for the run to finish. Don't busy-poll; check when prompted or at natural intervals.
+3. When the background `test-runner` completes, continue with the baselines diff (3.4) and the final report (3.5) as usual.
 
 #### 3.2 Resolve target providers
 
@@ -83,7 +82,7 @@ Provider state is owned by `/test-providers` and read by `test-runner` from `Use
 
 Determine the provider list to pass to `test-runner` per target:
 
-- **User named providers in `/test` args** (e.g. `/test run Issue5177Test on PostgreSQL.18, SQLite.MS`) — pass that list through verbatim. If a named provider isn't currently enabled in the matching TFM bucket, `test-runner` will abort with a "Provider X not enabled" message pointing at `/test-providers`; relay that as-is.
+- **User named providers in `/test` args** (e.g. `/test run Issue5177Test on PostgreSQL.18, SQLite.MS`) — pass that list through verbatim; `test-runner` runs exactly those via `--provider` (they need not be enabled in `UserDataProviders.json`, only have a connection string). If a named provider has no connection defined, `test-runner` aborts with a "no connection string defined" message pointing at `/test-providers`; relay that as-is.
 - **No providers in args** — `Read` the relevant TFM bucket of `UserDataProviders.json` once, list the currently enabled providers, and ask the user to confirm or narrow before passing the set through. Do **not** silently default to "every enabled provider" — most users want a small subset for a single-test run.
 
 If the test was just authored by the write flow, the test-writer's `dataSources` output is a hint about scope, not a provider list — still pass the user's explicit choice (or confirmed read-back) to `test-runner`.
@@ -98,7 +97,7 @@ Call `test-runner` with:
 
 For a **short** run, invoke `test-runner` synchronously. For a **long** run, invoke it with `run_in_background: true` and monitor the heartbeat per 3.1a.
 
-`test-runner` is read-only on `UserDataProviders.json` — there is no `userProvidersConsent` or `restoreOnCompletion` input, and no provider edits happen as a side effect of the run. If the agent reports `status: "blocked"` with a missing-provider message, relay it to the user with a one-liner: "Run `/test-providers <provider>` to enable it, then re-run `/test`."
+`test-runner` is read-only on `UserDataProviders.json` — there is no `userProvidersConsent` or `restoreOnCompletion` input, and no provider edits happen as a side effect of the run. If the agent reports `status: "blocked"` (e.g. a provider with no connection string defined), relay it to the user with a one-liner: "Run `/test-providers <provider>` to add its connection, then re-run `/test`."
 
 #### 3.4 Baselines diff (when baselines are written)
 
@@ -139,6 +138,6 @@ If containers were started during the session via `/test-providers`, remind the 
 - Do not edit `UserDataProviders.json` or invoke `docker` commands from `/test`. Env changes route through `/test-providers` exclusively. If the run needs a different provider set or a stopped container started, tell the user — don't fix it.
 - Do not run tests in `Release` config by default — analyzers + banned-API checks are slow and rarely what the user wants for a single-test run.
 - Do not edit source files yourself. Writing is `test-writer`'s job; running is `test-runner`'s job. The skill only orchestrates and relays.
-- Do not run targets in parallel. The agents won't anyway (sequential is built into `test-runner`), but do not try to fan out multiple agent invocations with overlapping target sets either.
+- Do not run targets in parallel from `/test`. The agents won't anyway (sequential is built into `test-runner`), and don't fan out multiple agent invocations with overlapping target sets. Deliberately parallel runs are possible but only **one distinct provider (= one database) per run**, and only as a manual workflow — see `.claude/docs/testing.md` → **Running providers in parallel** (build once, then run the test exe directly with `--provider`).
 - Do not suppress or skim the agent's output. If the agent reports a failure, relay the verbatim error message; don't paraphrase.
 - Do not pre-validate the env state before invoking `test-runner`. Trust the user; let the agent's own provider-check abort surface any mismatch. Auto-fix attempts here defeat the boundary.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -151,6 +151,7 @@
 
 	<ItemGroup Label="Testing">
 		<PackageVersion Include="Shouldly"                                              Version="4.3.0"                        />
+		<PackageVersion Include="Microsoft.Testing.Platform"                            Version="2.2.3"                        />
 		<PackageVersion Include="Microsoft.Testing.Platform.MSBuild"                    Version="2.2.3"                        />
 		<PackageVersion Include="Microsoft.Testing.Extensions.TrxReport"                Version="2.2.3"                        />
 		<PackageVersion Include="Microsoft.Testing.Extensions.HangDump"                 Version="2.2.3"                        />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,6 +39,8 @@
 		<AspNetCoreLegacyVersion>2.3.10</AspNetCoreLegacyVersion>
 		<!--bundled version for OpenTelemetry packages-->
 		<OpenTelemetryVersion>1.15.3</OpenTelemetryVersion>
+		<!--bundled version for Microsoft.Testing.Platform / Extensions packages-->
+		<MicrosoftTestingVersion>2.2.3</MicrosoftTestingVersion>
 	</PropertyGroup>
 
 	<ItemGroup Label="Build: Analyzers and Tools">
@@ -151,10 +153,10 @@
 
 	<ItemGroup Label="Testing">
 		<PackageVersion Include="Shouldly"                                              Version="4.3.0"                        />
-		<PackageVersion Include="Microsoft.Testing.Platform"                            Version="2.2.3"                        />
-		<PackageVersion Include="Microsoft.Testing.Platform.MSBuild"                    Version="2.2.3"                        />
-		<PackageVersion Include="Microsoft.Testing.Extensions.TrxReport"                Version="2.2.3"                        />
-		<PackageVersion Include="Microsoft.Testing.Extensions.HangDump"                 Version="2.2.3"                        />
+		<PackageVersion Include="Microsoft.Testing.Platform"                            Version="$(MicrosoftTestingVersion)"   />
+		<PackageVersion Include="Microsoft.Testing.Platform.MSBuild"                    Version="$(MicrosoftTestingVersion)"   />
+		<PackageVersion Include="Microsoft.Testing.Extensions.TrxReport"                Version="$(MicrosoftTestingVersion)"   />
+		<PackageVersion Include="Microsoft.Testing.Extensions.HangDump"                 Version="$(MicrosoftTestingVersion)"   />
 		<PackageVersion Include="NUnit"                                                 Version="4.6.0"                        />
 		<PackageVersion Include="NUnit.Analyzers"                                       Version="4.13.0"                       />
 		<PackageVersion Include="NUnit3TestAdapter"                                     Version="6.2.0"                        />

--- a/Tests/Base/TestCommandLine.cs
+++ b/Tests/Base/TestCommandLine.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+
+namespace Tests
+{
+	/// <summary>
+	/// Parses linq2db-specific test-run command-line options out of the process arguments.
+	/// <para>
+	/// The options are declared to Microsoft.Testing.Platform via <see cref="TestRunCommandLineProvider"/>
+	/// (so the NUnit MTP runner accepts them and lists them under <c>--help</c>); their values are read here
+	/// directly from <see cref="Environment.GetCommandLineArgs"/> rather than from an MTP service, because the
+	/// values are needed during type initialization / NUnit test discovery — before any MTP service provider
+	/// is resolvable. Reading the raw process arguments is also independent of how the run was launched
+	/// (<c>dotnet test</c> vs the test executable directly) and of the target framework.
+	/// </para>
+	/// </summary>
+	public static class TestCommandLine
+	{
+		/// <summary>Name of the <c>--provider</c> option (without the leading dashes).</summary>
+		public const string ProviderOption = "provider";
+
+		/// <summary>Name of the <c>--test-progress</c> option (without the leading dashes).</summary>
+		public const string TestProgressOption = "test-progress";
+
+		/// <summary>
+		/// Provider configuration names passed via one or more <c>--provider</c> options (each value may be
+		/// space- or comma-separated). Empty when the option was not supplied.
+		/// </summary>
+		public static IReadOnlyList<string> Providers { get; }
+
+		/// <summary>
+		/// Value of the <c>--test-progress</c> option: <see langword="null"/> when the option is absent, an empty
+		/// string when it is present without a value, otherwise the supplied directory or <c>.json</c> path.
+		/// </summary>
+		public static string? TestProgress { get; }
+
+		static TestCommandLine()
+		{
+			string[] args;
+
+			try
+			{
+				args = Environment.GetCommandLineArgs();
+			}
+			catch
+			{
+				// Never let argument parsing break a test run.
+				args = [];
+			}
+
+			Providers    = GetValues(args, ProviderOption);
+			TestProgress = GetSingle(args, TestProgressOption);
+		}
+
+		// All values that follow each "--<option>" token until the next "--" token, split on ','.
+		static IReadOnlyList<string> GetValues(string[] args, string option)
+		{
+			var token  = "--" + option;
+			var result = new List<string>();
+
+			for (var i = 0; i < args.Length; i++)
+			{
+				if (!string.Equals(args[i], token, StringComparison.OrdinalIgnoreCase))
+					continue;
+
+				for (var j = i + 1; j < args.Length && !args[j].StartsWith("--", StringComparison.Ordinal); j++)
+					foreach (var part in args[j].Split(','))
+						if (!string.IsNullOrWhiteSpace(part))
+							result.Add(part.Trim());
+			}
+
+			return result;
+		}
+
+		// The first value following "--<option>", "" if the option is present without a value, null if absent.
+		static string? GetSingle(string[] args, string option)
+		{
+			var token = "--" + option;
+
+			for (var i = 0; i < args.Length; i++)
+			{
+				if (!string.Equals(args[i], token, StringComparison.OrdinalIgnoreCase))
+					continue;
+
+				return i + 1 < args.Length && !args[i + 1].StartsWith("--", StringComparison.Ordinal)
+					? args[i + 1]
+					: "";
+			}
+
+			return null;
+		}
+	}
+}

--- a/Tests/Base/TestCommandLine.cs
+++ b/Tests/Base/TestCommandLine.cs
@@ -52,36 +52,58 @@ namespace Tests
 			TestProgress = GetSingle(args, TestProgressOption);
 		}
 
-		// All values that follow each "--<option>" token until the next "--" token, split on ','.
+		// All values for the option, split on ','. Accepts both the spaced form ("--<option> a b,c", values
+		// run until the next "--" token) and the inline form ("--<option>=a,b", value attached after '=').
 		static IReadOnlyList<string> GetValues(string[] args, string option)
 		{
 			var token  = "--" + option;
+			var prefix = token + "=";
 			var result = new List<string>();
 
 			for (var i = 0; i < args.Length; i++)
 			{
+				// Inline form: --<option>=a,b — the value is attached after '=' and is self-contained.
+				if (args[i].StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+				{
+					AddParts(result, args[i].Substring(prefix.Length));
+					continue;
+				}
+
 				if (!string.Equals(args[i], token, StringComparison.OrdinalIgnoreCase))
 					continue;
 
+				// Spaced form: --<option> a b — consume following tokens until the next "--" token.
 				for (var j = i + 1; j < args.Length && !args[j].StartsWith("--", StringComparison.Ordinal); j++)
-					foreach (var part in args[j].Split(','))
-						if (!string.IsNullOrWhiteSpace(part))
-							result.Add(part.Trim());
+					AddParts(result, args[j]);
 			}
 
 			return result;
+
+			static void AddParts(List<string> target, string value)
+			{
+				foreach (var part in value.Split(','))
+					if (!string.IsNullOrWhiteSpace(part))
+						target.Add(part.Trim());
+			}
 		}
 
-		// The first value following "--<option>", "" if the option is present without a value, null if absent.
+		// The option's value: the token after "--<option>", or the part after '=' in "--<option>=value";
+		// "" when the option is present without a value, null when absent.
 		static string? GetSingle(string[] args, string option)
 		{
-			var token = "--" + option;
+			var token  = "--" + option;
+			var prefix = token + "=";
 
 			for (var i = 0; i < args.Length; i++)
 			{
+				// Inline form: --<option>=value.
+				if (args[i].StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+					return args[i].Substring(prefix.Length);
+
 				if (!string.Equals(args[i], token, StringComparison.OrdinalIgnoreCase))
 					continue;
 
+				// Spaced form: --<option> [value].
 				return i + 1 < args.Length && !args[i + 1].StartsWith("--", StringComparison.Ordinal)
 					? args[i + 1]
 					: "";

--- a/Tests/Base/TestConfiguration.cs
+++ b/Tests/Base/TestConfiguration.cs
@@ -24,6 +24,21 @@ namespace Tests
 		internal static string?         DefaultProvider      { get; }
 		internal static HashSet<string> SkipCategories       { get; }
 
+		// Provider names passed via the --provider command-line option (see TestCommandLine), or null when absent.
+		// For the main test set (UserProviders) they REPLACE the providers configured in UserDataProviders.json, so
+		// any provider with a defined connection string can run without editing the file. For EFProviders they
+		// INTERSECT the curated EF-Core-supported list instead (a provider with no EF context can't run EF tests,
+		// so replacing there would just break). Declared above Providers/EFProviders so its initializer runs before
+		// theirs: static field initializers run in textual order, ahead of the static constructor body.
+		static readonly HashSet<string>? ProviderOverride =
+			TestCommandLine.Providers.Count > 0
+				? new HashSet<string>(TestCommandLine.Providers, StringComparer.OrdinalIgnoreCase)
+				: null;
+
+		// EFProviders keeps the intersection of its curated list and --provider (never an unsupported provider).
+		static IEnumerable<string> ApplyEFProviderOverride(IEnumerable<string> providers) =>
+			ProviderOverride is null ? providers : providers.Where(ProviderOverride.Contains);
+
 		static TestConfiguration()
 		{
 			try
@@ -59,7 +74,21 @@ namespace Tests
 				testSettings.Connections ??= new();
 
 				DisableRemoteContext = testSettings.DisableRemoteContext == true;
-				UserProviders = new HashSet<string>(testSettings.Providers ?? [], StringComparer.OrdinalIgnoreCase);
+				// --provider, when supplied, REPLACES the providers from UserDataProviders.json (see ProviderOverride):
+				// any provider with a defined connection string can be run without editing the file.
+				UserProviders = ProviderOverride is not null
+					? new HashSet<string>(ProviderOverride, StringComparer.OrdinalIgnoreCase)
+					: new HashSet<string>(testSettings.Providers ?? [], StringComparer.OrdinalIgnoreCase);
+
+				if (ProviderOverride is not null)
+				{
+					TestContext.Out.WriteLine($"Provider override (--provider): {string.Join(", ", UserProviders)}");
+
+					foreach (var p in UserProviders)
+						if (!testSettings.Connections.Keys.Contains(p, StringComparer.OrdinalIgnoreCase))
+							TestContext.Out.WriteLine($"WARNING: --provider '{p}' has no connection string defined; it will fail to connect.");
+				}
+
 				SkipCategories = new HashSet<string>(testSettings.Skip ?? [], StringComparer.OrdinalIgnoreCase);
 
 				var logLevel   = testSettings.TraceLevel;
@@ -198,7 +227,7 @@ namespace Tests
 			TestProvName.AllDuckDB,
 		}.SplitAll()).ToList();
 
-		public static readonly IReadOnlyList<string> EFProviders = CustomizationSupport.Interceptor.GetSupportedProviders(new List<string>
+		public static readonly IReadOnlyList<string> EFProviders = ApplyEFProviderOverride(CustomizationSupport.Interceptor.GetSupportedProviders(new List<string>
 		{
 			ProviderName.SQLiteMS,
 			// latest tested ef.core doesn't support older versions, leading to too many failing tests to disable
@@ -228,6 +257,6 @@ namespace Tests
 			//TestProvName.AllMySql,
 			//TestProvName.AllSapHana,
 			//TestProvName.AllClickHouse
-		}.SplitAll()).ToList();
+		}.SplitAll())).ToList();
 	}
 }

--- a/Tests/Base/TestProgressReporter.cs
+++ b/Tests/Base/TestProgressReporter.cs
@@ -16,10 +16,10 @@ namespace Tests
 	/// so an external observer can see which test is running, how many remain, and the running pass/fail tally
 	/// without scraping console output.
 	/// <para>
-	/// Opt-in: the reporter is a no-op unless the <c>LINQ2DB_TEST_PROGRESS</c> environment variable is set. When set
-	/// to a flag value (<c>1/true/on/yes</c>) the file is written to
-	/// <c>&lt;repoRoot&gt;/.build/.claude/test-progress.&lt;tfm&gt;.&lt;pid&gt;.json</c>; when set to a directory or
-	/// <c>*.json</c> path that path is used instead.
+	/// Opt-in: the reporter is a no-op unless the <c>--test-progress</c> command-line option is passed (see
+	/// <see cref="TestCommandLine"/>). A bare <c>--test-progress</c> writes the file to
+	/// <c>&lt;repoRoot&gt;/.build/.claude/test-progress.&lt;tfm&gt;.&lt;pid&gt;.json</c>; <c>--test-progress &lt;dir|*.json&gt;</c>
+	/// uses that path instead.
 	/// </para>
 	/// See <c>.claude/docs/testing.md</c> → "Monitoring a long run".
 	/// </summary>
@@ -154,11 +154,17 @@ namespace Tests
 
 			_initialized = true;
 
-			// Disabled when unset, empty, or an explicit falsy token. The /test-progress skill turns the trace
-			// off by setting the value to "0" (not by removing the key), because Claude Code propagates a changed
-			// env value into the running session but does not un-apply a removed one until restart.
-			var env = Environment.GetEnvironmentVariable("LINQ2DB_TEST_PROGRESS");
-			if (IsDisabledValue(env))
+			// Enabled only by the --test-progress command-line option (see TestCommandLine); absent => no-op.
+			// A bare flag enables the default heartbeat path; a value is a target directory or .json path; a falsy
+			// value (e.g. --test-progress 0) disables it.
+			var cfg = TestCommandLine.TestProgress;
+			if (cfg is null)
+				return _enabled = false;
+
+			if (cfg.Length == 0)
+				cfg = "1";
+
+			if (IsDisabledValue(cfg))
 				return _enabled = false;
 
 			try
@@ -168,7 +174,7 @@ namespace Tests
 #else
 				_pid        = Environment.ProcessId;
 #endif
-				_file       = ResolvePath(env!.Trim());
+				_file       = ResolvePath(cfg.Trim());
 				_startedUtc = DateTime.UtcNow;
 
 				var dir = Path.GetDirectoryName(_file);

--- a/Tests/Base/TestRunCommandLineProvider.cs
+++ b/Tests/Base/TestRunCommandLineProvider.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.CommandLine;
+
+namespace Tests
+{
+	/// <summary>
+	/// Declares linq2db's test-run command-line options to Microsoft.Testing.Platform so the NUnit MTP runner
+	/// accepts them and lists them under <c>--help</c>. The option <em>values</em> are consumed via
+	/// <see cref="TestCommandLine"/> (which reads them early, during discovery). Registered through the
+	/// <c>TestingPlatformBuilderHook</c> MSBuild item declared in <c>linq2db.BasicTestProjects.props</c>.
+	/// </summary>
+	public sealed class TestRunCommandLineProvider : ICommandLineOptionsProvider
+	{
+		/// <inheritdoc/>
+		public string Uid => "linq2db.TestRunOptions";
+
+		/// <inheritdoc/>
+		public string Version => "1.0.0";
+
+		/// <inheritdoc/>
+		public string DisplayName => "linq2db test-run options";
+
+		/// <inheritdoc/>
+		public string Description => "linq2db-specific options for scoping a test run to providers and the progress heartbeat.";
+
+		/// <inheritdoc/>
+		public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+		/// <inheritdoc/>
+		public IReadOnlyCollection<CommandLineOption> GetCommandLineOptions() =>
+		[
+			new CommandLineOption(
+				TestCommandLine.ProviderOption,
+				"Run only the named test provider(s), e.g. --provider SQLite.MS. Repeatable, and space- or comma-separated. REPLACES the providers configured in UserDataProviders.json — any provider with a defined connection string runs, no file edit needed. (EF Core test projects intersect their curated supported set instead.)",
+				ArgumentArity.OneOrMore,
+				isHidden: false),
+			new CommandLineOption(
+				TestCommandLine.TestProgressOption,
+				"Write the live test-progress heartbeat. Optional value: a target directory or a .json file path; omit for the default path under .build/.claude.",
+				ArgumentArity.ZeroOrOne,
+				isHidden: false),
+		];
+
+		/// <inheritdoc/>
+		public Task<ValidationResult> ValidateOptionArgumentsAsync(CommandLineOption commandOption, string[] arguments) =>
+			ValidationResult.ValidTask;
+
+		/// <inheritdoc/>
+		public Task<ValidationResult> ValidateCommandLineOptionsAsync(ICommandLineOptions commandLineOptions) =>
+			ValidationResult.ValidTask;
+	}
+
+	/// <summary>
+	/// Microsoft.Testing.Platform build hook. The generated entry point invokes
+	/// <see cref="AddExtensions"/> for every <c>TestingPlatformBuilderHook</c> MSBuild item; this one adds
+	/// <see cref="TestRunCommandLineProvider"/> so the <c>--provider</c> / <c>--test-progress</c> options are
+	/// recognised by the runner.
+	/// </summary>
+	public static class TestRunBuilderHook
+	{
+		/// <summary>Adds linq2db's command-line option provider to the test application builder.</summary>
+		public static void AddExtensions(ITestApplicationBuilder builder, string[] arguments) =>
+			builder.CommandLine.AddProvider(static () => new TestRunCommandLineProvider());
+	}
+}

--- a/Tests/Base/Tests.Base.csproj
+++ b/Tests/Base/Tests.Base.csproj
@@ -15,6 +15,9 @@
 		<PackageReference Include="NUnit" />
 		<PackageReference Include="NUnit.Analyzers" />
 		<PackageReference Include="Shouldly" />
+
+		<!-- MTP command-line option provider (provider / test-progress options) lives in this assembly. -->
+		<PackageReference Include="Microsoft.Testing.Platform" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' != 'net462' ">

--- a/Tests/EntityFrameworkCore/AssemblyInfo.TestProgress.cs
+++ b/Tests/EntityFrameworkCore/AssemblyInfo.TestProgress.cs
@@ -1,6 +1,6 @@
 using Tests;
 
-// Live progress heartbeat for long test runs. Opt-in via the LINQ2DB_TEST_PROGRESS environment variable.
+// Live progress heartbeat for long test runs. Opt-in via the --test-progress command-line option.
 // Compiled into all EF Core test assemblies (EF3/EF8/EF9/EF10) via the shared source directory.
 // See .claude/docs/testing.md → "Monitoring a long run".
 [assembly: TestProgressReporter]

--- a/Tests/Linq/AssemblyInfo.TestProgress.cs
+++ b/Tests/Linq/AssemblyInfo.TestProgress.cs
@@ -1,5 +1,5 @@
 using Tests;
 
-// Live progress heartbeat for long test runs. Opt-in via the LINQ2DB_TEST_PROGRESS environment variable.
+// Live progress heartbeat for long test runs. Opt-in via the --test-progress command-line option.
 // See .claude/docs/testing.md → "Monitoring a long run".
 [assembly: TestProgressReporter]

--- a/Tests/Linq/DataProvider/YdbTransientExceptionDetectorTests.cs
+++ b/Tests/Linq/DataProvider/YdbTransientExceptionDetectorTests.cs
@@ -109,7 +109,7 @@ namespace Ydb.Sdk.Ado
 {
 	/// <summary>
 	/// Test double mimicking <c>Ydb.Sdk.Ado.YdbException</c>'s shape — the real type's
-	/// constructors are <c>internal</c>, so it can't be instantiated from tests.
+	/// constructors are <see langword="internal"/>, so it can't be instantiated from tests.
 	/// <see cref="LinqToDB.Internal.DataProvider.Ydb.YdbTransientExceptionDetector"/> binds by
 	/// full type name plus the <c>IsTransient</c>/<c>Code</c> members via reflection, so this
 	/// stand-in (same full name) drives it without a live connection.

--- a/Tests/Tests.Playground/AssemblyInfo.TestProgress.cs
+++ b/Tests/Tests.Playground/AssemblyInfo.TestProgress.cs
@@ -1,5 +1,5 @@
 using Tests;
 
-// Live progress heartbeat for long test runs. Opt-in via the LINQ2DB_TEST_PROGRESS environment variable.
+// Live progress heartbeat for long test runs. Opt-in via the --test-progress command-line option.
 // See .claude/docs/testing.md → "Monitoring a long run".
 [assembly: TestProgressReporter]

--- a/Tests/linq2db.BasicTestProjects.props
+++ b/Tests/linq2db.BasicTestProjects.props
@@ -13,4 +13,16 @@
 		<!-- Was a transitive dependency of Microsoft.NET.Test.Sdk; referenced directly now that the SDK is gone. -->
 		<PackageReference Include="Newtonsoft.Json" />
 	</ItemGroup>
+
+	<!-- Register linq2db's test-run command-line options (provider / test-progress) with the NUnit MTP
+	     runner. The generated entry point calls Tests.TestRunBuilderHook.AddExtensions(); the type lives in
+	     Tests.Base. Limited to C# test projects: they all reference Tests.Base, whereas the F# EF test project
+	     (Tests.EntityFrameworkCore.FSharp) imports these props but neither references Tests.Base nor uses
+	     TestConfiguration, so the hook type would not resolve there (and there is nothing to filter). -->
+	<ItemGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
+		<TestingPlatformBuilderHook Include="23DD2B7A-070B-49AF-A837-EE5B967B4B4B">
+			<DisplayName>linq2db</DisplayName>
+			<TypeFullName>Tests.TestRunBuilderHook</TypeFullName>
+		</TestingPlatformBuilderHook>
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Adds two Microsoft.Testing.Platform command-line options to the test executables, via an `ICommandLineOptionsProvider` registered through a `TestingPlatformBuilderHook` (the mechanism NUnit itself uses):

- **`--provider <names>`** — run only the named provider(s). For the main tests it **replaces** `TestConfiguration.UserProviders`, so any provider with a connection string in `DataProviders.json` / `UserDataProviders.json` runs without editing the enabled list. EF Core tests **intersect** their curated `EFProviders` set (an EF-unsupported provider can't be selected). Repeatable; comma- or space-separated.
- **`--test-progress[=<dir|*.json>]`** — write the live progress heartbeat. **Replaces** the `LINQ2DB_TEST_PROGRESS` environment variable, which is removed; this option is now the sole control.

Together these let one fully-populated `UserDataProviders.json` drive many provider-scoped runs — including several in parallel, one distinct provider (= distinct database) each.

## Usage

Scope a run to a single provider (no `UserDataProviders.json` edit needed — the provider only needs a connection string):

```bash
dotnet test --project Tests/Linq/Tests.csproj -f net10.0 --settings .runsettings --filter "FullyQualifiedName~CreateData.CreateDatabase|FullyQualifiedName~MyTest" --provider PostgreSQL.18 --test-progress
```

Run several providers in parallel — build once, then launch the test executable directly with **one distinct provider per run** (each hits its own database):

```bash
dotnet build Tests/Linq/Tests.csproj -c Debug -f net10.0
.build/bin/Tests/Debug/net10.0/linq2db.Tests.exe --provider PostgreSQL.18 --test-progress --filter "FullyQualifiedName~CreateData.CreateDatabase|FullyQualifiedName~MyTest"
.build/bin/Tests/Debug/net10.0/linq2db.Tests.exe --provider MySql.8.0 --test-progress --filter "FullyQualifiedName~CreateData.CreateDatabase|FullyQualifiedName~MyTest"
```

Each process writes its own `.build/.claude/test-progress.<tfm>.<pid>.json`; read any of them with `pwsh -NoProfile -File .claude/scripts/test-status.ps1`.

## Notes

- `test-runner` always passes `--test-progress`; `/test-progress` is now a read-only status reporter; `/test` no longer toggles a session env var.
- Options are read from `Environment.GetCommandLineArgs()`, so they apply during NUnit discovery (where `TestContext.Parameters` isn't available) and are TFM-agnostic. The hook is scoped to C# test projects (the F# EF project doesn't reference `Tests.Base`).
- Separate commit fixes a pre-existing Release-mode analyzer error (MA0154) in `YdbTransientExceptionDetectorTests`, unrelated to the feature — isolated for easy review/drop.

## Test plan

- Full solution builds clean in **Release** (analyzers + banned-API) and across TFMs incl. **net462**.
- `--provider SQLite.MS` → 1 provider; `+ SQLite.Classic` → 2; non-enabled `SqlServer.2022.MS` runs (replace verified).
- `--test-progress` writes a per-PID heartbeat; env var set + no flag → no heartbeat (removal verified). `--help` lists both options.
