### PR TITLE
Fix #5598: F# { record with ... } update sets only changed columns

### DIFF
--- a/Source/LinqToDB.FSharp/DataOptionsExtensions.fs
+++ b/Source/LinqToDB.FSharp/DataOptionsExtensions.fs
@@ -9,4 +9,6 @@ type Methods() =
     /// <remarks>Currently it is limited to record types support, but we plan to add more support in future releases.</remarks>
     [<Extension>]
     static member UseFSharp(options : DataOptions) =
-        options.UseInterceptor FSharpEntityBindingInterceptor.Instance
+        options
+            .UseInterceptor(FSharpEntityBindingInterceptor.Instance)
+            .UseInterceptor(FSharpQueryExpressionInterceptor.Instance)

--- a/Source/LinqToDB.FSharp/FSharpQueryExpressionInterceptor.fs
+++ b/Source/LinqToDB.FSharp/FSharpQueryExpressionInterceptor.fs
@@ -12,8 +12,10 @@ open LinqToDB.Internal.Reflection
 ///       { var x = expr1; new type(x, expr2) }  ->  new type(expr1, expr2)
 ///   * turns an F# record-copy update (`q.Update(p, fun r -> { r with Field = v })`) into the explicit
 ///     partial-update form `q.Where(p).Set(x => x.Field, x => v).Update()`, so only the changed columns
-///     are written. A ctor argument that is a self-copy `r.SameField` is dropped (collateral: a literal
-///     `{ r with Field = r.Field }` no-op is lost, which is acceptable).
+///     are written. A ctor argument that is a self-copy `r.SameField` is dropped; when *every* argument
+///     is a self-copy (a literal no-op such as `{ r with Field = r.Field }`), the change set is empty and
+///     the original full-record construction is left as-is, so that no-op input still emits an all-column
+///     UPDATE (PK included) - acceptable, since such input changes no column anyway.
 /// (Kept out of core so F# quirks live in the F# library.)
 type private FSharpRewriteVisitor() =
     inherit ExpressionVisitor()

--- a/Source/LinqToDB.FSharp/FSharpQueryExpressionInterceptor.fs
+++ b/Source/LinqToDB.FSharp/FSharpQueryExpressionInterceptor.fs
@@ -1,0 +1,125 @@
+namespace LinqToDB.FSharp
+
+open System.Linq.Expressions
+
+open LinqToDB.Expressions
+open LinqToDB.Interceptors
+open LinqToDB.Reflection
+open LinqToDB.Internal.Reflection
+
+/// Rewrites F#-specific expression-tree shapes the core translator does not understand:
+///   * inlines the unnecessary block F# emits for record construction
+///       { var x = expr1; new type(x, expr2) }  ->  new type(expr1, expr2)
+///   * turns an F# record-copy update (`q.Update(p, fun r -> { r with Field = v })`) into the explicit
+///     partial-update form `q.Where(p).Set(x => x.Field, x => v).Update()`, so only the changed columns
+///     are written. A ctor argument that is a self-copy `r.SameField` is dropped (collateral: a literal
+///     `{ r with Field = r.Field }` no-op is lost, which is acceptable).
+/// (Kept out of core so F# quirks live in the F# library.)
+type private FSharpRewriteVisitor() =
+    inherit ExpressionVisitor()
+
+    // Rewrites an F# Update(... , setter) call into a Where(...)?.Set(...).Update() chain that assigns
+    // only the members whose ctor argument is not a self-copy `row.SameMember`.
+    member private _.RewriteUpdate(mc: MethodCallExpression, hasPredicate: bool) : Expression =
+        let entityType = mc.Method.GetGenericArguments().[0]
+        let source     = mc.Arguments.[0]
+        let setterArg  = mc.Arguments.[mc.Arguments.Count - 1]
+        match setterArg with
+        | :? UnaryExpression as q when q.NodeType = ExpressionType.Quote ->
+            match q.Operand with
+            | :? LambdaExpression as setter when
+                    setter.Parameters.Count = 1
+                    && (setter.Body :? NewExpression)
+                    && FSharpEntityBindingInterceptor.isRecord setter.Body.Type ->
+                let ne = setter.Body :?> NewExpression
+                match FSharpEntityBindingInterceptor.TryMapMembersToConstructor(TypeAccessor.GetAccessor ne.Type) with
+                | Some map ->
+                    let rowParam = setter.Parameters.[0]
+                    let changed  = ResizeArray<MemberAccessor * Expression>()
+                    for i in 0 .. ne.Arguments.Count - 1 do
+                        match map.TryGetValue i with
+                        | true, ma ->
+                            let arg = ne.Arguments.[i]
+                            let isSelfCopy =
+                                match arg with
+                                | :? MemberExpression as me -> me.Member = ma.MemberInfo && obj.ReferenceEquals(me.Expression, rowParam)
+                                | _ -> false
+                            if not isSelfCopy then changed.Add((ma, arg))
+                        | _ -> ()
+
+                    if changed.Count = 0 then
+                        mc :> Expression
+                    else
+                        let mutable chain : Expression = source
+                        if hasPredicate then
+                            chain <- Expression.Call(Methods.Queryable.Where.MakeGenericMethod(entityType), source, mc.Arguments.[1])
+
+                        let mutable first = true
+                        for (ma, valueExpr) in changed do
+                            let x       = Expression.Parameter(entityType, "x")
+                            let extract = Expression.Lambda(Expression.MakeMemberAccess(x, ma.MemberInfo), [| x |])
+                            let update  = Expression.Lambda(valueExpr.Replace(rowParam, x), [| x |])
+                            let setM    = if first then Methods.LinqToDB.Update.SetQueryablePrev else Methods.LinqToDB.Update.SetUpdatablePrev
+                            chain <- Expression.Call(setM.MakeGenericMethod(entityType, ma.Type), chain, Expression.Quote extract, Expression.Quote update)
+                            first <- false
+
+                        Expression.Call(Methods.LinqToDB.Update.UpdateUpdatable.MakeGenericMethod(entityType), chain) :> Expression
+                | None -> mc :> Expression
+            | _ -> mc :> Expression
+        | _ -> mc :> Expression
+
+    override this.VisitBlock(node: BlockExpression) =
+        // block items must be: N assignments to block variables + a result expression
+        if node.Variables.Count > 0
+           && node.Variables.Count + 1 = node.Expressions.Count
+           && obj.ReferenceEquals(node.Result, node.Expressions.[node.Expressions.Count - 1]) then
+
+            let mutable result : Expression = node.Result
+            let mutable simplified = true
+            let mutable i = node.Expressions.Count - 2
+
+            while simplified && i >= 0 do
+                match node.Expressions.[i] with
+                | :? BinaryExpression as assign when
+                        assign.NodeType = ExpressionType.Assign
+                        && isNull assign.Method
+                        && (assign.Left :? ParameterExpression) ->
+                    let variable = assign.Left :?> ParameterExpression
+                    let value    = assign.Right
+                    // embed only one of the block's own variables, whose value does not reference itself,
+                    // used at most once in the result (count = 0 accepted: F# can emit unused variables).
+                    if not (node.Variables.Contains variable)
+                       || value.GetCount(variable, (fun v n -> obj.ReferenceEquals(n, v))) <> 0
+                       || result.GetCount(variable, (fun v n -> obj.ReferenceEquals(n, v))) > 1 then
+                        simplified <- false
+                    else
+                        result <- result.Replace(variable, value)
+                | _ -> simplified <- false
+                i <- i - 1
+
+            if simplified then this.Visit result |> nonNull
+            else base.VisitBlock node
+        else
+            base.VisitBlock node
+
+    override this.VisitMethodCall(node: MethodCallExpression) =
+        let visited = base.VisitMethodCall node
+        match visited with
+        | :? MethodCallExpression as mc when mc.Method.IsGenericMethod ->
+            let def = mc.Method.GetGenericMethodDefinition()
+            if   def = Methods.LinqToDB.Update.UpdateSetter          then this.RewriteUpdate(mc, false)
+            elif def = Methods.LinqToDB.Update.UpdatePredicateSetter then this.RewriteUpdate(mc, true)
+            else visited
+        | _ -> visited
+
+/// Handles F#-specific expression-tree shapes that the core translator does not understand.
+type FSharpQueryExpressionInterceptor private () =
+
+    static let _instance = FSharpQueryExpressionInterceptor() :> IQueryExpressionInterceptor
+
+    /// Interceptor instance.
+    static member Instance = _instance
+
+    interface IQueryExpressionInterceptor with
+        member _.ProcessExpression(expression: Expression, _args: QueryExpressionArgs) : Expression =
+            FSharpRewriteVisitor().Visit expression |> nonNull

--- a/Source/LinqToDB.FSharp/FSharpQueryExpressionInterceptor.fs
+++ b/Source/LinqToDB.FSharp/FSharpQueryExpressionInterceptor.fs
@@ -68,6 +68,11 @@ type private FSharpRewriteVisitor() =
             | _ -> mc :> Expression
         | _ -> mc :> Expression
 
+    // Do not descend into non-reducible linq2db custom nodes: the BCL ExpressionVisitor would call
+    // VisitChildren on them and throw "must be reducible node". F# constructs we rewrite live in the raw
+    // standard-node tree, so leaving extension nodes untouched is safe.
+    override _.VisitExtension(node: Expression) : Expression = node
+
     override this.VisitBlock(node: BlockExpression) =
         // block items must be: N assignments to block variables + a result expression
         if node.Variables.Count > 0
@@ -121,5 +126,10 @@ type FSharpQueryExpressionInterceptor private () =
     static member Instance = _instance
 
     interface IQueryExpressionInterceptor with
-        member _.ProcessExpression(expression: Expression, _args: QueryExpressionArgs) : Expression =
-            FSharpRewriteVisitor().Visit expression |> nonNull
+        member _.ProcessExpression(expression: Expression, args: QueryExpressionArgs) : Expression =
+            // Only the raw, pre-expose query tree (standard nodes) - the post-expose tree carries
+            // linq2db custom nodes the F# constructs we handle never appear in.
+            if args.Kind = QueryExpressionArgs.ExpressionKind.Query then
+                FSharpRewriteVisitor().Visit expression |> nonNull
+            else
+                expression

--- a/Source/LinqToDB.FSharp/FSharpQueryExpressionInterceptor.fs
+++ b/Source/LinqToDB.FSharp/FSharpQueryExpressionInterceptor.fs
@@ -4,6 +4,7 @@ open System.Linq.Expressions
 
 open LinqToDB.Expressions
 open LinqToDB.Interceptors
+open LinqToDB.Mapping
 open LinqToDB.Reflection
 open LinqToDB.Internal.Reflection
 
@@ -13,11 +14,11 @@ open LinqToDB.Internal.Reflection
 ///   * turns an F# record-copy update (`q.Update(p, fun r -> { r with Field = v })`) into the explicit
 ///     partial-update form `q.Where(p).Set(x => x.Field, x => v).Update()`, so only the changed columns
 ///     are written. A ctor argument that is a self-copy `r.SameField` is dropped; when *every* argument
-///     is a self-copy (a literal no-op such as `{ r with Field = r.Field }`), the change set is empty and
-///     the original full-record construction is left as-is, so that no-op input still emits an all-column
-///     UPDATE (PK included) - acceptable, since such input changes no column anyway.
+///     is a self-copy (a literal no-op such as `{ r with Field = r.Field }`), the change set is empty, so
+///     every non-PK column is assigned to its own value instead - this keeps the PK out of SET (which YDB
+///     rejects) rather than re-emitting the full all-column UPDATE.
 /// (Kept out of core so F# quirks live in the F# library.)
-type private FSharpRewriteVisitor() =
+type private FSharpRewriteVisitor(mappingSchema: MappingSchema) =
     inherit ExpressionVisitor()
 
     // Rewrites an F# Update(... , setter) call into a Where(...)?.Set(...).Update() chain that assigns
@@ -49,7 +50,25 @@ type private FSharpRewriteVisitor() =
                             if not isSelfCopy then changed.Add((ma, arg))
                         | _ -> ()
 
-                    if changed.Count = 0 then
+                    // when at least one column actually changes, assign just those; for a literal no-op
+                    // `{ r with Field = r.Field }` (empty change set) assign every non-PK column to its own
+                    // value, so the PK is kept out of SET (YDB rejects it) instead of re-emitting the full
+                    // all-column UPDATE.
+                    let assignments =
+                        if changed.Count > 0 then
+                            changed
+                        else
+                            let entityDescriptor = mappingSchema.GetEntityDescriptor entityType
+                            let isPrimaryKey (ma: MemberAccessor) =
+                                entityDescriptor.Columns |> Seq.exists (fun c -> c.IsPrimaryKey && c.MemberInfo = ma.MemberInfo)
+                            let nonPk = ResizeArray<MemberAccessor * Expression>()
+                            for i in 0 .. ne.Arguments.Count - 1 do
+                                match map.TryGetValue i with
+                                | true, ma when not (isPrimaryKey ma) -> nonPk.Add((ma, ne.Arguments.[i]))
+                                | _ -> ()
+                            nonPk
+
+                    if assignments.Count = 0 then
                         mc :> Expression
                     else
                         let mutable chain : Expression = source
@@ -57,7 +76,7 @@ type private FSharpRewriteVisitor() =
                             chain <- Expression.Call(Methods.Queryable.Where.MakeGenericMethod(entityType), source, mc.Arguments.[1])
 
                         let mutable first = true
-                        for (ma, valueExpr) in changed do
+                        for (ma, valueExpr) in assignments do
                             let x       = Expression.Parameter(entityType, "x")
                             let extract = Expression.Lambda(Expression.MakeMemberAccess(x, ma.MemberInfo), [| x |])
                             let update  = Expression.Lambda(valueExpr.Replace(rowParam, x), [| x |])
@@ -132,6 +151,6 @@ type FSharpQueryExpressionInterceptor private () =
             // Only the raw, pre-expose query tree (standard nodes) - the post-expose tree carries
             // linq2db custom nodes the F# constructs we handle never appear in.
             if args.Kind = QueryExpressionArgs.ExpressionKind.Query then
-                FSharpRewriteVisitor().Visit expression |> nonNull
+                FSharpRewriteVisitor(args.DataContext.MappingSchema).Visit expression |> nonNull
             else
                 expression

--- a/Source/LinqToDB.FSharp/LinqToDB.FSharp.fsproj
+++ b/Source/LinqToDB.FSharp/LinqToDB.FSharp.fsproj
@@ -24,6 +24,7 @@
 
 	<ItemGroup>
 		<Compile Include="FSharpEntityBindingInterceptor.fs" />
+		<Compile Include="FSharpQueryExpressionInterceptor.fs" />
 		<Compile Include="DataOptionsExtensions.fs" />
 	</ItemGroup>
 

--- a/Source/LinqToDB/Internal/Linq/Builder/Visitors/ExposeExpressionVisitor.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/Visitors/ExposeExpressionVisitor.cs
@@ -903,57 +903,6 @@ namespace LinqToDB.Internal.Linq.Builder.Visitors
 			return null;
 		}
 
-		protected override Expression VisitBlock(BlockExpression node)
-		{
-			// TODO: in future should be moved to LinqToDB.FSharp if we will introduce pluggable ExposeVisitor to handle F# quirks
-
-			// F# 10.1 could generate unnecessary block like:
-			// { var x = expr1; return new type(x, expr2) }
-			// instead of
-			// new type(expr1, expr2)
-
-			// try to embed variables if:
-			// 1. block items are: N assignments to variables + result expression
-
-			if (node.Variables.Count > 0
-				&& node.Variables.Count + 1 == node.Expressions.Count
-				&& node.Result == node.Expressions[^1])
-			{
-				var result = node.Result;
-				var simplified = true;
-
-				for (var i = node.Expressions.Count - 2; i >= 0; i--)
-				{
-					if (node.Expressions[i] is not BinaryExpression
-						{
-							NodeType: ExpressionType.Assign,
-							Method: null,
-							Left: ParameterExpression variable,
-							Right: { } value,
-						}
-						// external variable/parameter
-						|| !node.Variables.Contains(variable)
-						// self-reference
-						|| value.GetCount(variable, static (variable, n) => n == variable) != 0
-						// 1: replace var only if it used exactly once to avoid unwanted side-effects
-						// 0: because F# defines unused variables, we should also accept count = 0
-						// potentially it could be dangerous, but ppl just shouldn't write code like that
-						|| result.GetCount(variable, static (variable, n) => n == variable) > 1)
-					{
-						simplified = false;
-						break;
-					}
-
-					result = result.Replace(variable, value);
-				}
-
-				if (simplified)
-					return Visit(result);
-			}
-
-			return base.VisitBlock(node);
-		}
-
 		#region Helper methods
 
 		sealed class IsCompilableVisitor : CanBeEvaluatedOnClientCheckVisitorBase

--- a/Tests/FSharp/Issue4132.fs
+++ b/Tests/FSharp/Issue4132.fs
@@ -6,6 +6,7 @@ open LinqToDB
 open LinqToDB.Mapping
 open Tests
 open Tests.Tools
+open NUnit.Framework
 
 [<Table>]
 type Issue4132Table =
@@ -22,4 +23,13 @@ let Issue4132Test1(db : IDataContext) =
 
 let Issue4132Test2(db : IDataContext) =
     use table = db.CreateLocalTable<Issue4132Table>()
+    table.Insert(fun () -> {Issue4132Table.Id = 1; Number = 1; Text = "before"}) |> ignore
+
     table.Update((fun row -> row.Number = 1), (fun row -> {row with Text = "updated recently"})) |> ignore
+
+    let row = query { for r in db.GetTable<Issue4132Table>() do
+                      where (r.Id = 1)
+                      exactlyOne }
+    Assert.That(row.Text,   Is.EqualTo "updated recently")
+    Assert.That(row.Number, Is.EqualTo 1)
+    Assert.That(row.Id,     Is.EqualTo 1)

--- a/Tests/FSharp/Issue5598.fs
+++ b/Tests/FSharp/Issue5598.fs
@@ -1,0 +1,29 @@
+module Tests.FSharp.Issue5598
+
+open Tests.FSharp.Issue4132
+
+open LinqToDB
+open LinqToDB.Data
+open Tests
+open NUnit.Framework
+
+// https://github.com/linq2db/linq2db/issues/5598
+// An F# record-copy update `{ row with X = v }` must set only the changed column, not every column
+// (including the PK). [Number] is neither changed nor in the predicate, so it appears in the SQL only
+// if the update wrongly sets all columns.
+let UpdateSetsOnlyChangedColumn (db : DataConnection) =
+    use table = db.CreateLocalTable<Issue4132Table>()
+    table.Insert(fun () -> { Id = 1; Number = 5; Text = "before" }) |> ignore
+
+    table.Update((fun row -> row.Id = 1), (fun row -> { row with Text = "after" })) |> ignore
+    let updateSql = db.LastQuery
+
+    Assert.That(updateSql, Does.Contain "Text")
+    Assert.That(updateSql, Does.Not.Contain "[Number]")
+
+    let row = query { for r in db.GetTable<Issue4132Table>() do
+                      where (r.Id = 1)
+                      exactlyOne }
+    Assert.That(row.Text,   Is.EqualTo "after")
+    Assert.That(row.Number, Is.EqualTo 5)
+    Assert.That(row.Id,     Is.EqualTo 1)

--- a/Tests/FSharp/Issue5598.fs
+++ b/Tests/FSharp/Issue5598.fs
@@ -20,9 +20,13 @@ let UpdateSetsOnlyChangedColumn (db : DataConnection) (assertSql : bool) =
     table.Update((fun row -> row.Id = 1), (fun row -> { row with Text = "after" })) |> ignore
 
     if assertSql then
-        let updateSql = db.LastQuery
-        Assert.That(updateSql, Does.Contain "[Text]")
-        Assert.That(updateSql, Does.Not.Contain "[Number]")
+        // assert against the SET clause only: [Id] (PK) and [Number] must not be written, while
+        // [Id] legitimately appears in the WHERE clause, so the check is scoped to text before WHERE.
+        let updateSql = nonNull db.LastQuery
+        let setClause = updateSql.Substring(0, updateSql.IndexOf "WHERE")
+        Assert.That(setClause, Does.Contain "[Text]")
+        Assert.That(setClause, Does.Not.Contain "[Number]")
+        Assert.That(setClause, Does.Not.Contain "[Id]")
 
     let row = query { for r in db.GetTable<Issue4132Table>() do
                       where (r.Id = 1)
@@ -30,3 +34,28 @@ let UpdateSetsOnlyChangedColumn (db : DataConnection) (assertSql : bool) =
     Assert.That(row.Text,   Is.EqualTo "after")
     Assert.That(row.Number, Is.EqualTo 5)
     Assert.That(row.Id,     Is.EqualTo 1)
+
+// Async counterpart: UpdateAsync builds its expression from the same synchronous UpdatePredicateSetter
+// method info as Update (async-ness is handled at execution), so the F# record-copy rewrite must fire on
+// this path too. Locks in that the async update emits only the changed column (PK was rejected by YDB).
+let UpdateSetsOnlyChangedColumnAsync (db : DataConnection) (assertSql : bool) : System.Threading.Tasks.Task =
+    task {
+        use table = db.CreateLocalTable<Issue4132Table>()
+        table.Insert(fun () -> { Id = 1; Number = 5; Text = "before" }) |> ignore
+
+        let! _ = table.UpdateAsync((fun row -> row.Id = 1), (fun row -> { row with Text = "after" }))
+
+        if assertSql then
+            let updateSql = nonNull db.LastQuery
+            let setClause = updateSql.Substring(0, updateSql.IndexOf "WHERE")
+            Assert.That(setClause, Does.Contain "[Text]")
+            Assert.That(setClause, Does.Not.Contain "[Number]")
+            Assert.That(setClause, Does.Not.Contain "[Id]")
+
+        let row = query { for r in db.GetTable<Issue4132Table>() do
+                          where (r.Id = 1)
+                          exactlyOne }
+        Assert.That(row.Text,   Is.EqualTo "after")
+        Assert.That(row.Number, Is.EqualTo 5)
+        Assert.That(row.Id,     Is.EqualTo 1)
+    } :> System.Threading.Tasks.Task

--- a/Tests/FSharp/Issue5598.fs
+++ b/Tests/FSharp/Issue5598.fs
@@ -7,6 +7,12 @@ open LinqToDB.Data
 open Tests
 open NUnit.Framework
 
+// The SET clause is the statement text before WHERE; the no-predicate Update overload emits a WHERE-less
+// UPDATE, so fall back to the whole statement instead of throwing on IndexOf returning -1.
+let private setClauseOf (updateSql : string) =
+    let whereIdx = updateSql.IndexOf "WHERE"
+    if whereIdx < 0 then updateSql else updateSql.Substring(0, whereIdx)
+
 // https://github.com/linq2db/linq2db/issues/5598
 // An F# record-copy update `{ row with X = v }` must set only the changed column, not every column
 // (including the PK). The insert -> update-one-column -> read-back round-trip is asserted on every
@@ -23,7 +29,7 @@ let UpdateSetsOnlyChangedColumn (db : DataConnection) (assertSql : bool) =
         // assert against the SET clause only: [Id] (PK) and [Number] must not be written, while
         // [Id] legitimately appears in the WHERE clause, so the check is scoped to text before WHERE.
         let updateSql = nonNull db.LastQuery
-        let setClause = updateSql.Substring(0, updateSql.IndexOf "WHERE")
+        let setClause = setClauseOf updateSql
         Assert.That(setClause, Does.Contain "[Text]")
         Assert.That(setClause, Does.Not.Contain "[Number]")
         Assert.That(setClause, Does.Not.Contain "[Id]")
@@ -47,7 +53,7 @@ let UpdateSetsOnlyChangedColumnAsync (db : DataConnection) (assertSql : bool) : 
 
         if assertSql then
             let updateSql = nonNull db.LastQuery
-            let setClause = updateSql.Substring(0, updateSql.IndexOf "WHERE")
+            let setClause = setClauseOf updateSql
             Assert.That(setClause, Does.Contain "[Text]")
             Assert.That(setClause, Does.Not.Contain "[Number]")
             Assert.That(setClause, Does.Not.Contain "[Id]")
@@ -59,3 +65,49 @@ let UpdateSetsOnlyChangedColumnAsync (db : DataConnection) (assertSql : bool) : 
         Assert.That(row.Number, Is.EqualTo 5)
         Assert.That(row.Id,     Is.EqualTo 1)
     } :> System.Threading.Tasks.Task
+
+// No-predicate overload `table.Update(fun row -> {...})` (UpdateSetter) - a full-table single-column
+// update with no Where. Exercises the RewriteUpdate(mc, false) branch the predicate tests don't reach.
+// The emitted UPDATE has no WHERE, so the SET-clause check relies on setClauseOf tolerating its absence.
+let UpdateSetsOnlyChangedColumnNoPredicate (db : DataConnection) (assertSql : bool) =
+    use table = db.CreateLocalTable<Issue4132Table>()
+    table.Insert(fun () -> { Id = 1; Number = 5; Text = "before" }) |> ignore
+
+    table.Update(fun row -> { row with Text = "after" }) |> ignore
+
+    if assertSql then
+        let updateSql = nonNull db.LastQuery
+        let setClause = setClauseOf updateSql
+        Assert.That(setClause, Does.Contain "[Text]")
+        Assert.That(setClause, Does.Not.Contain "[Number]")
+        Assert.That(setClause, Does.Not.Contain "[Id]")
+
+    let row = query { for r in db.GetTable<Issue4132Table>() do
+                      where (r.Id = 1)
+                      exactlyOne }
+    Assert.That(row.Text,   Is.EqualTo "after")
+    Assert.That(row.Number, Is.EqualTo 5)
+    Assert.That(row.Id,     Is.EqualTo 1)
+
+// No-op record copy `{ r with Id = r.Id }` (every ctor argument a self-copy, empty change set): the PK
+// must still be kept out of SET (YDB rejects assigning a PK column) by assigning only the non-PK columns
+// to their own values, rather than re-emitting the full all-column UPDATE.
+let UpdateNoOpExcludesPrimaryKey (db : DataConnection) (assertSql : bool) =
+    use table = db.CreateLocalTable<Issue4132Table>()
+    table.Insert(fun () -> { Id = 1; Number = 5; Text = "before" }) |> ignore
+
+    table.Update((fun row -> row.Id = 1), (fun row -> { row with Id = row.Id })) |> ignore
+
+    if assertSql then
+        let updateSql = nonNull db.LastQuery
+        let setClause = setClauseOf updateSql
+        Assert.That(setClause, Does.Not.Contain "[Id]")
+        Assert.That(setClause, Does.Contain "[Number]")
+        Assert.That(setClause, Does.Contain "[Text]")
+
+    let row = query { for r in db.GetTable<Issue4132Table>() do
+                      where (r.Id = 1)
+                      exactlyOne }
+    Assert.That(row.Text,   Is.EqualTo "before")
+    Assert.That(row.Number, Is.EqualTo 5)
+    Assert.That(row.Id,     Is.EqualTo 1)

--- a/Tests/FSharp/Issue5598.fs
+++ b/Tests/FSharp/Issue5598.fs
@@ -9,17 +9,20 @@ open NUnit.Framework
 
 // https://github.com/linq2db/linq2db/issues/5598
 // An F# record-copy update `{ row with X = v }` must set only the changed column, not every column
-// (including the PK). [Number] is neither changed nor in the predicate, so it appears in the SQL only
-// if the update wrongly sets all columns.
-let UpdateSetsOnlyChangedColumn (db : DataConnection) =
+// (including the PK). The insert -> update-one-column -> read-back round-trip is asserted on every
+// provider; the SQL-shape check (only [Text] in SET, no [Number]) is gated by `assertSql` because it
+// relies on SQLite's bracket identifier quoting. This lets the same scenario also run on YDB - the
+// provider that originally rejected the all-column UPDATE - as a data-correctness round-trip.
+let UpdateSetsOnlyChangedColumn (db : DataConnection) (assertSql : bool) =
     use table = db.CreateLocalTable<Issue4132Table>()
     table.Insert(fun () -> { Id = 1; Number = 5; Text = "before" }) |> ignore
 
     table.Update((fun row -> row.Id = 1), (fun row -> { row with Text = "after" })) |> ignore
-    let updateSql = db.LastQuery
 
-    Assert.That(updateSql, Does.Contain "Text")
-    Assert.That(updateSql, Does.Not.Contain "[Number]")
+    if assertSql then
+        let updateSql = db.LastQuery
+        Assert.That(updateSql, Does.Contain "[Text]")
+        Assert.That(updateSql, Does.Not.Contain "[Number]")
 
     let row = query { for r in db.GetTable<Issue4132Table>() do
                       where (r.Id = 1)

--- a/Tests/FSharp/Tests.FSharp.fsproj
+++ b/Tests/FSharp/Tests.FSharp.fsproj
@@ -20,6 +20,7 @@
 		<Compile Include="MappingSchema.fs" />
 		<Compile Include="Issue3743.fs" />
 		<Compile Include="Issue4132.fs" />
+		<Compile Include="Issue5598.fs" />
 		<Compile Include="Issue1813.fs" />
 		<Compile Include="Issue5428.fs" />
 	</ItemGroup>

--- a/Tests/Linq/Linq/FSharpTests.cs
+++ b/Tests/Linq/Linq/FSharpTests.cs
@@ -257,7 +257,14 @@ namespace Tests.Linq
 		public void Issue5598_UpdateSetsOnlyChangedColumn([IncludeDataSources(false, TestProvName.AllSQLite)] string context)
 		{
 			using var db = GetDataConnection(context);
-			FSharp.Issue5598.UpdateSetsOnlyChangedColumn(db);
+			FSharp.Issue5598.UpdateSetsOnlyChangedColumn(db, true);
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5598")]
+		public void Issue5598_UpdateSetsOnlyChangedColumnYdb([IncludeDataSources(false, TestProvName.AllYdb)] string context)
+		{
+			using var db = GetDataConnection(context);
+			FSharp.Issue5598.UpdateSetsOnlyChangedColumn(db, false);
 		}
 
 		[ActiveIssue]

--- a/Tests/Linq/Linq/FSharpTests.cs
+++ b/Tests/Linq/Linq/FSharpTests.cs
@@ -246,12 +246,18 @@ namespace Tests.Linq
 			FSharp.Issue4132.Issue4132Test1(db);
 		}
 
-		[ActiveIssue(5598, Configuration = TestProvName.AllYdb, Details = "F# {record with ...} update emits every column (incl. the PK) instead of only the changed one; YDB rejects assigning a PK column in SET")]
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4132")]
 		public void Issue4132Test2([DataSources(TestProvName.AllClickHouse)] string context)
 		{
 			using var db = GetDataContext(context);
 			FSharp.Issue4132.Issue4132Test2(db);
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5598")]
+		public void Issue5598_UpdateSetsOnlyChangedColumn([IncludeDataSources(false, TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataConnection(context);
+			FSharp.Issue5598.UpdateSetsOnlyChangedColumn(db);
 		}
 
 		[ActiveIssue]

--- a/Tests/Linq/Linq/FSharpTests.cs
+++ b/Tests/Linq/Linq/FSharpTests.cs
@@ -283,6 +283,34 @@ namespace Tests.Linq
 			await FSharp.Issue5598.UpdateSetsOnlyChangedColumnAsync(db, false);
 		}
 
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5598")]
+		public void Issue5598_UpdateSetsOnlyChangedColumnNoPredicate([IncludeDataSources(false, TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataConnection(context);
+			FSharp.Issue5598.UpdateSetsOnlyChangedColumnNoPredicate(db, true);
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5598")]
+		public void Issue5598_UpdateSetsOnlyChangedColumnNoPredicateYdb([IncludeDataSources(false, TestProvName.AllYdb)] string context)
+		{
+			using var db = GetDataConnection(context);
+			FSharp.Issue5598.UpdateSetsOnlyChangedColumnNoPredicate(db, false);
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5598")]
+		public void Issue5598_UpdateNoOpExcludesPrimaryKey([IncludeDataSources(false, TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataConnection(context);
+			FSharp.Issue5598.UpdateNoOpExcludesPrimaryKey(db, true);
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5598")]
+		public void Issue5598_UpdateNoOpExcludesPrimaryKeyYdb([IncludeDataSources(false, TestProvName.AllYdb)] string context)
+		{
+			using var db = GetDataConnection(context);
+			FSharp.Issue5598.UpdateNoOpExcludesPrimaryKey(db, false);
+		}
+
 		[ActiveIssue]
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/1813")]
 		public void Issue1813Test1([DataSources] string context)

--- a/Tests/Linq/Linq/FSharpTests.cs
+++ b/Tests/Linq/Linq/FSharpTests.cs
@@ -1,4 +1,6 @@
-﻿using LinqToDB;
+﻿using System.Threading.Tasks;
+
+using LinqToDB;
 using LinqToDB.Data;
 
 using NUnit.Framework;
@@ -265,6 +267,20 @@ namespace Tests.Linq
 		{
 			using var db = GetDataConnection(context);
 			FSharp.Issue5598.UpdateSetsOnlyChangedColumn(db, false);
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5598")]
+		public async Task Issue5598_UpdateSetsOnlyChangedColumnAsync([IncludeDataSources(false, TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataConnection(context);
+			await FSharp.Issue5598.UpdateSetsOnlyChangedColumnAsync(db, true);
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5598")]
+		public async Task Issue5598_UpdateSetsOnlyChangedColumnAsyncYdb([IncludeDataSources(false, TestProvName.AllYdb)] string context)
+		{
+			using var db = GetDataConnection(context);
+			await FSharp.Issue5598.UpdateSetsOnlyChangedColumnAsync(db, false);
 		}
 
 		[ActiveIssue]


### PR DESCRIPTION
## Summary

Fixes the F# record-copy update bug: `query.Update(predicate, fun r -> { r with Field = v })` was
translated to an UPDATE that set **every** column (including the primary key), which YDB rejects.

Now only the changed column(s) are written.

Closes #5598

## How it works

F# `{ r with Field = v }` lowers to a full record reconstruction — `new R(r.Id, r.Number, v)` — so by
the time linq2db sees it there is no marker distinguishing it from an explicit full construction. The
fix introduces an F# `IQueryExpressionInterceptor` (registered by `UseFSharp`) that:

- **moves the F#-specific block-inlining out of core** (`ExposeExpressionVisitor.VisitBlock`) into the
  F# library, where F# quirks belong; and
- rewrites an F# `Update(predicate, setter)` whose setter is a record construction into the explicit
  partial-update form `query.Where(predicate).Set(x => x.Field, x => v)…​.Update()`, keeping only the
  constructor arguments that are **not** a self-copy `Field = r.Field`.

Detection keys off the constructor arguments (`arg == r.SameMember`), **not** F#'s block-variable
codegen, which varies between compiler releases. Explicit field-by-field constructions (including a
deliberate `Field = r.Field`) are left untouched; the only collateral is that a literal no-op
`{ r with Field = r.Field }` is dropped, which is harmless.

The rewrite produces only standard expression nodes (`Where`/`Set`/`Update`), so it flows through the
translator like any C# partial update. No new core API is introduced, and future F# AST quirks can
extend the same interceptor.

## Tests

- New `Issue5598.fs` / `FSharpTests.Issue5598_UpdateSetsOnlyChangedColumn` (SQLite): asserts the
  generated UPDATE contains the changed column and **not** the unchanged one, and that the row
  round-trips correctly.
- `Issue4132Test2`'s `[ActiveIssue(5598, … YDB …)]` gate is removed; verified passing on YDB.
- Full `FSharpTests` fixture green on SQLite (incl. remote/LinqService) — no regression from moving
  `VisitBlock` out of core. Multi-TFM Release build (`net462`, `netstandard2.0`, `net8.0`–`net10.0`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up commits (review)

- Tighten the empty-change-set fallback comment in `FSharpQueryExpressionInterceptor` to state that a literal no-op `{ r with Field = r.Field }` re-emits the full all-column UPDATE (PK included), instead of describing the no-op as "lost".
- Tighten the SQLite assertion in `Issue5598.fs` to the bracket-quoted `[Text]` form (symmetric with the `[Number]` negative check).
- Add `Issue5598_UpdateSetsOnlyChangedColumnYdb`: the same insert/update/read-back round-trip on YDB (the provider that originally rejected the all-column UPDATE), with the SQLite-specific SQL-shape assertion gated behind an `assertSql` flag.
- Add async coverage (`Issue5598_UpdateSetsOnlyChangedColumnAsync`, SQLite + YDB). `UpdateAsync(predicate, setter)` builds its expression from the **synchronous** `UpdateSetter`/`UpdatePredicateSetter` method infos (async-ness is handled at execution), so the F# record-copy rewrite already covers the async path — the new tests lock that in. No interceptor change needed.
- Scope the SQLite SQL-shape assertion to the SET clause (text before `WHERE`) so the PK (`[Id]`) exclusion is asserted directly — `[Id]` legitimately appears in the WHERE clause, so the prior whole-statement check couldn't assert it.

### Review follow-ups (commit b124678)

- **No-op record copy** (`{ r with Id = r.Id }`): the empty-change-set path no longer re-emits the full all-column UPDATE (PK included, rejected by YDB). It now assigns every non-PK column to its own value, keeping the PK out of SET (supersedes the "no-op is dropped / harmless" note above). The `MappingSchema` is threaded into the rewrite visitor to identify PK columns. New `UpdateNoOpExcludesPrimaryKey` test (SQLite SQL-shape + YDB round-trip).
- **No-predicate overload**: new `UpdateSetsOnlyChangedColumnNoPredicate` test exercises `table.Update(fun r -> {...})` (the `UpdateSetter` branch the predicate tests didn't reach).
- **SET-clause extraction**: extracted `setClauseOf`, which tolerates a WHERE-less UPDATE (the no-predicate case) instead of throwing on `IndexOf` returning -1.
- **`Issue4132Test2`**: now inserts a row and reads it back, so the YDB gate removal is backed by a data-correctness assertion rather than smoke-level execution only.

Verified: `FSharpTests` `Issue5598`/`Issue4132` green on SQLite + YDB.

