### PR TITLE
Support PostgreSQL/DuckDB DISTINCT ON via DistinctBy

### DIFF
--- a/Source/LinqToDB/Internal/DataProvider/DuckDB/DuckDBDataProvider.cs
+++ b/Source/LinqToDB/Internal/DataProvider/DuckDB/DuckDBDataProvider.cs
@@ -37,6 +37,7 @@ namespace LinqToDB.Internal.DataProvider.DuckDB
 			SqlProviderFlags.IsCrossApplyJoinSupportsCondition = true;
 			SqlProviderFlags.IsOuterApplyJoinSupportsCondition = true;
 			SqlProviderFlags.IsDistinctFromSupported           = true;
+			SqlProviderFlags.IsDistinctOnSupported             = true;
 			SqlProviderFlags.SupportsPredicatesComparison      = true;
 
 			SqlProviderFlags.DefaultMultiQueryIsolationLevel = System.Data.IsolationLevel.Snapshot;

--- a/Source/LinqToDB/Internal/DataProvider/DuckDB/DuckDBSqlBuilder.cs
+++ b/Source/LinqToDB/Internal/DataProvider/DuckDB/DuckDBSqlBuilder.cs
@@ -37,6 +37,12 @@ namespace LinqToDB.Internal.DataProvider.DuckDB
 		protected override string LimitFormat (SelectQuery selectQuery) => "LIMIT {0}";
 		protected override string OffsetFormat(SelectQuery selectQuery) => "OFFSET {0} ";
 
+		protected override void BuildDistinctModifier(SelectQuery selectQuery)
+		{
+			StringBuilder.Append(" DISTINCT");
+			BuildDistinctOnExpressions(selectQuery);
+		}
+
 		protected override void BuildGetIdentity(SqlInsertClause insertClause)
 		{
 			var identityField = insertClause.Into!.GetIdentityField()

--- a/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
+++ b/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLDataProvider.cs
@@ -52,6 +52,7 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 			SqlProviderFlags.IsUnionAllOrderBySupported        = true;
 			SqlProviderFlags.IsAllSetOperationsSupported       = true;
 			SqlProviderFlags.IsDistinctFromSupported           = true;
+			SqlProviderFlags.IsDistinctOnSupported             = true;
 			SqlProviderFlags.SupportsPredicatesComparison      = true;
 
 			SqlProviderFlags.OutputDeleteUseSpecialTable  = version >= PostgreSQLVersion.v18;

--- a/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLSqlBuilder.cs
+++ b/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLSqlBuilder.cs
@@ -40,6 +40,12 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 
 		protected override ConcatBuildStyle ConcatStyle       => ConcatBuildStyle.Pipes;
 
+		protected override void BuildDistinctModifier(SelectQuery selectQuery)
+		{
+			StringBuilder.Append(" DISTINCT");
+			BuildDistinctOnExpressions(selectQuery);
+		}
+
 		protected override void BuildGetIdentity(SqlInsertClause insertClause)
 		{
 			var identityField = insertClause.Into!.GetIdentityField();

--- a/Source/LinqToDB/Internal/Linq/Builder/DistinctByBuilder.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/DistinctByBuilder.cs
@@ -1,6 +1,7 @@
 ﻿#if NET8_0_OR_GREATER
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -8,6 +9,7 @@ using System.Reflection;
 using LinqToDB.Expressions;
 using LinqToDB.Internal.Common;
 using LinqToDB.Internal.Expressions;
+using LinqToDB.Internal.SqlQuery;
 
 namespace LinqToDB.Internal.Linq.Builder
 {
@@ -97,6 +99,37 @@ namespace LinqToDB.Internal.Linq.Builder
 
 			var selector = methodCall.Arguments[1].UnwrapLambda();
 
+			// On providers that support PostgreSQL-style DISTINCT ON, lower DistinctBy to it directly instead of the
+			// ROW_NUMBER() emulation: the key selector becomes the ON list and the preceding OrderBy is forced to lead
+			// with those keys (the syntax requires it). Falls through to ROW_NUMBER when the key has no usable SQL form.
+			if (builder.DataContext.SqlProviderFlags.IsDistinctOnSupported)
+			{
+				var orderedExpression = WindowFunctionHelpers.ApplyOrderBy(nonOrderedPart, orderByPart);
+
+				var buildResult = builder.TryBuildSequence(new BuildInfo(buildInfo, orderedExpression));
+				if (buildResult.BuildContext == null)
+					return buildResult;
+
+				var sequence      = buildResult.BuildContext;
+				var partitionBody = SequenceHelper.PrepareBody(selector, sequence);
+				var keySql        = builder.BuildSqlExpression(sequence, partitionBody, BuildPurpose.Sql, BuildFlags.ForKeys);
+
+				if (SequenceHelper.IsSqlReady(keySql))
+				{
+					var onExpressions = ExpressionBuilder.CollectDistinctPlaceholders(keySql, false)
+						.Select(static p => p.Sql)
+						.Where(static s => !QueryHelper.IsConstant(s))
+						.ToList();
+
+					// An empty ON list (e.g. DistinctBy(x => 1)) has no valid DISTINCT ON form — fall back to ROW_NUMBER below.
+					if (onExpressions.Count > 0)
+					{
+						ApplyDistinctOn(sequence.SelectQuery, onExpressions);
+						return BuildSequenceResult.FromContext(sequence);
+					}
+				}
+			}
+
 			if (builder.DataContext.SqlProviderFlags.IsWindowFunctionsSupported)
 			{
 				var buildResult = builder.TryBuildSequence(new BuildInfo(buildInfo, nonOrderedPart));
@@ -136,6 +169,30 @@ namespace LinqToDB.Internal.Linq.Builder
 			}
 
 			return BuildSequenceResult.NotSupported();
+		}
+
+		// PostgreSQL/DuckDB require ORDER BY to begin with the DISTINCT ON expressions. Move (or synthesize) the ON
+		// keys to the front of the existing OrderBy, preserving the user's ordering for the remaining keys, then mark
+		// the select clause as DISTINCT ON.
+		static void ApplyDistinctOn(SelectQuery selectQuery, List<ISqlExpression> onExpressions)
+		{
+			var items   = selectQuery.OrderBy.Items;
+			var leading = new List<SqlOrderByItem>(onExpressions.Count);
+
+			foreach (var on in onExpressions)
+			{
+				var existing = items.Find(i => i.Expression.Equals(on));
+				leading.Add(existing ?? new SqlOrderByItem(on, false, false, Sql.NullsPosition.None));
+			}
+
+			var tail = items.FindAll(i => !onExpressions.Exists(on => on.Equals(i.Expression)));
+
+			items.Clear();
+			items.AddRange(leading);
+			items.AddRange(tail);
+
+			selectQuery.Select.IsDistinct = true;
+			selectQuery.Select.DistinctOn = onExpressions;
 		}
 	}
 }

--- a/Source/LinqToDB/Internal/Linq/Builder/DistinctByBuilder.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/DistinctByBuilder.cs
@@ -99,6 +99,12 @@ namespace LinqToDB.Internal.Linq.Builder
 
 			var selector = methodCall.Arguments[1].UnwrapLambda();
 
+			// When the DISTINCT ON branch below builds a sequence but cannot lower to DISTINCT ON (empty ON list or a
+			// key with no usable SQL form), that sequence is reused by the ROW_NUMBER fallback instead of building a
+			// second one — a second TryBuildSequence over the same source leaks an extra table reference into the
+			// query (a cartesian product, e.g. DistinctBy(x => 1)).
+			IBuildContext? sequence = null;
+
 			// On providers that support PostgreSQL-style DISTINCT ON, lower DistinctBy to it directly instead of the
 			// ROW_NUMBER() emulation: the key selector becomes the ON list and the preceding OrderBy is forced to lead
 			// with those keys (the syntax requires it). Falls through to ROW_NUMBER when the key has no usable SQL form.
@@ -110,7 +116,7 @@ namespace LinqToDB.Internal.Linq.Builder
 				if (buildResult.BuildContext == null)
 					return buildResult;
 
-				var sequence      = buildResult.BuildContext;
+				sequence          = buildResult.BuildContext;
 				var partitionBody = SequenceHelper.PrepareBody(selector, sequence);
 				var keySql        = builder.BuildSqlExpression(sequence, partitionBody, BuildPurpose.Sql, BuildFlags.ForKeys);
 
@@ -132,12 +138,15 @@ namespace LinqToDB.Internal.Linq.Builder
 
 			if (builder.DataContext.SqlProviderFlags.IsWindowFunctionsSupported)
 			{
-				var buildResult = builder.TryBuildSequence(new BuildInfo(buildInfo, nonOrderedPart));
+				if (sequence == null)
+				{
+					var buildResult = builder.TryBuildSequence(new BuildInfo(buildInfo, nonOrderedPart));
 
-				if (buildResult.BuildContext == null)
-					return buildResult;
+					if (buildResult.BuildContext == null)
+						return buildResult;
 
-				var sequence      = buildResult.BuildContext;
+					sequence = buildResult.BuildContext;
+				}
 
 				var partitionBody = SequenceHelper.PrepareBody(selector, sequence);
 
@@ -151,8 +160,7 @@ namespace LinqToDB.Internal.Linq.Builder
 
 				expression = WindowFunctionHelpers.ApplyOrderBy(expression, orderByPart);
 
-				buildResult = builder.TryBuildSequence(new BuildInfo(buildInfo, expression));
-				return buildResult;
+				return builder.TryBuildSequence(new BuildInfo(buildInfo, expression));
 			}
 
 			// Rare case when outer apply is supported and window functions are not

--- a/Source/LinqToDB/Internal/Remote/LinqServiceSerializer.cs
+++ b/Source/LinqToDB/Internal/Remote/LinqServiceSerializer.cs
@@ -1352,6 +1352,7 @@ string.Create(CultureInfo.InvariantCulture, $"TypeIndex or TypeArrayIndex ({Type
 							Append(elem.TakeValue);
 							Append((int?)elem.TakeHints);
 							Append(elem.OptimizeDistinct);
+							Append(elem.DistinctOn);
 
 							Append(elem.Columns);
 
@@ -2472,11 +2473,13 @@ string.Create(CultureInfo.InvariantCulture, $"TypeIndex or TypeArrayIndex ({Type
 							var takeValue        = Read<ISqlExpression>()!;
 							var takeHints        = (TakeHints?)ReadNullableInt();
 							var optimizeDistinct = ReadBool();
+							var distinctOn       = ReadArray<ISqlExpression>();
 							var columns          = ReadArray<SqlColumn>()!;
 
 							obj = new SqlSelectClause(isDistinct, takeValue, takeHints, skipValue, columns)
 							{
 								OptimizeDistinct = optimizeDistinct,
+								DistinctOn       = distinctOn == null ? null : new List<ISqlExpression>(distinctOn),
 							};
 
 							break;

--- a/Source/LinqToDB/Internal/Remote/LinqServiceSerializer.cs
+++ b/Source/LinqToDB/Internal/Remote/LinqServiceSerializer.cs
@@ -2479,7 +2479,7 @@ string.Create(CultureInfo.InvariantCulture, $"TypeIndex or TypeArrayIndex ({Type
 							obj = new SqlSelectClause(isDistinct, takeValue, takeHints, skipValue, columns)
 							{
 								OptimizeDistinct = optimizeDistinct,
-								DistinctOn       = distinctOn == null ? null : new List<ISqlExpression>(distinctOn),
+								DistinctOn       = distinctOn == null ? null : [..distinctOn],
 							};
 
 							break;

--- a/Source/LinqToDB/Internal/SqlProvider/BasicSqlBuilder.cs
+++ b/Source/LinqToDB/Internal/SqlProvider/BasicSqlBuilder.cs
@@ -785,12 +785,44 @@ namespace LinqToDB.Internal.SqlProvider
 			StartStatementQueryExtensions(selectQuery);
 
 			if (selectQuery.Select.IsDistinct)
-				StringBuilder.Append(" DISTINCT");
+				BuildDistinctModifier(selectQuery);
 
 			BuildSkipFirst(selectQuery);
 
 			StringBuilder.AppendLine();
 			BuildColumns(selectQuery);
+		}
+
+		/// <summary>
+		/// Emits the <c>DISTINCT</c> modifier. Overridden by providers that support <c>DISTINCT ON (...)</c>
+		/// (see <see cref="SqlProviderFlags.IsDistinctOnSupported"/>); the base emits a plain <c>DISTINCT</c>.
+		/// </summary>
+		protected virtual void BuildDistinctModifier(SelectQuery selectQuery)
+		{
+			StringBuilder.Append(" DISTINCT");
+		}
+
+		/// <summary>
+		/// Renders the <c>ON (expr, ...)</c> part of a <c>DISTINCT ON</c> clause. Called from a
+		/// <see cref="BuildDistinctModifier"/> override on providers that support the syntax, right after the
+		/// <c>DISTINCT</c> keyword. Expressions are rendered exactly as in <c>ORDER BY</c> so the leading-prefix
+		/// match PostgreSQL/DuckDB require holds.
+		/// </summary>
+		protected void BuildDistinctOnExpressions(SelectQuery selectQuery)
+		{
+			var select = ConvertElement(selectQuery.Select);
+			if (select.DistinctOn is not { Count: > 0 } onExpressions)
+				return;
+
+			StringBuilder.Append(" ON (");
+			for (var i = 0; i < onExpressions.Count; i++)
+			{
+				if (i > 0)
+					StringBuilder.Append(InlineComma);
+				BuildExpressionForOrderBy(onExpressions[i]);
+			}
+
+			StringBuilder.Append(')');
 		}
 
 		protected virtual void StartStatementQueryExtensions(SelectQuery? selectQuery)

--- a/Source/LinqToDB/Internal/SqlProvider/BasicSqlOptimizer.cs
+++ b/Source/LinqToDB/Internal/SqlProvider/BasicSqlOptimizer.cs
@@ -2339,7 +2339,7 @@ namespace LinqToDB.Internal.SqlProvider
 			return QueryHelper.WrapQuery(
 				queryFilter,
 				statement,
-				static (queryFilter, q, _) => q.Select.IsDistinct && queryFilter(q),
+				static (queryFilter, q, _) => q.Select.IsDistinct && !q.Select.IsDistinctOn && queryFilter(q),
 				static (_, p, q) =>
 				{
 					p.Select.SkipValue = q.Select.SkipValue;

--- a/Source/LinqToDB/Internal/SqlProvider/SqlProviderFlags.cs
+++ b/Source/LinqToDB/Internal/SqlProvider/SqlProviderFlags.cs
@@ -682,6 +682,15 @@ namespace LinqToDB.Internal.SqlProvider
 		[DataMember(Order = 70), DefaultValue(NullsDefaultOrdering.Unknown)]
 		public NullsDefaultOrdering DefaultNullsOrdering { get; set; }
 
+		/// <summary>
+		/// Provider supports the <c>SELECT DISTINCT ON (expr, ...)</c> syntax (PostgreSQL, DuckDB): one row per
+		/// distinct ON-expression tuple, choosing the row that sorts first under the query <c>ORDER BY</c> (which
+		/// must begin with the ON expressions). When <see langword="false"/> (the default), <c>DistinctBy</c> falls
+		/// back to <c>ROW_NUMBER()</c> / <c>OUTER APPLY</c> emulation.
+		/// </summary>
+		[DataMember(Order = 75)]
+		public bool IsDistinctOnSupported { get; set; }
+
 		public bool GetAcceptsTakeAsParameterFlag(SelectQuery selectQuery)
 		{
 			return AcceptsTakeAsParameter || (AcceptsTakeAsParameterIfSkip && selectQuery.Select.SkipValue != null);
@@ -779,6 +788,7 @@ namespace LinqToDB.Internal.SqlProvider
 				^ IsInsertOrUpdateRequiresAlignedBranches              .GetHashCode()
 				^ IsNullsOrderingSupported                             .GetHashCode()
 				^ DefaultNullsOrdering                                 .GetHashCode()
+				^ IsDistinctOnSupported                                .GetHashCode()
 				^ CustomFlags.Aggregate(0, (hash, flag) => StringComparer.Ordinal.GetHashCode(flag) ^ hash);
 	}
 
@@ -858,6 +868,7 @@ namespace LinqToDB.Internal.SqlProvider
 				&& IsInsertOrUpdateRequiresAlignedBranches               == other.IsInsertOrUpdateRequiresAlignedBranches
 				&& IsNullsOrderingSupported                              == other.IsNullsOrderingSupported
 				&& DefaultNullsOrdering                                  == other.DefaultNullsOrdering
+				&& IsDistinctOnSupported                                 == other.IsDistinctOnSupported
 				&& CustomFlags.SetEquals(other.CustomFlags);
 		}
 		#endregion

--- a/Source/LinqToDB/Internal/SqlQuery/QueryHelper.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/QueryHelper.cs
@@ -1462,7 +1462,9 @@ namespace LinqToDB.Internal.SqlQuery
 					if (selectQuery.HasUniqueKeys)
 						knownKeys.AddRange(selectQuery.UniqueKeys);
 
-					if (includeDistinctAndGrouping && selectQuery.Select.IsDistinct)
+					// DISTINCT ON guarantees uniqueness only on the ON tuple, not on the full projection, so it must
+					// not contribute the projected columns as a unique key.
+					if (includeDistinctAndGrouping && selectQuery.Select.IsDistinct && !selectQuery.Select.IsDistinctOn)
 						knownKeys.Add(selectQuery.Select.Columns.Select(c => c.Expression).ToList());
 
 					if (includeDistinctAndGrouping && !selectQuery.Select.GroupBy.IsEmpty)

--- a/Source/LinqToDB/Internal/SqlQuery/SqlSelectClause.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/SqlSelectClause.cs
@@ -21,9 +21,15 @@ namespace LinqToDB.Internal.SqlQuery
 		}
 
 		internal SqlSelectClause(bool isDistinct, ISqlExpression? takeValue, TakeHints? takeHints, ISqlExpression? skipValue, IEnumerable<SqlColumn> columns)
+			: this(isDistinct, null, takeValue, takeHints, skipValue, columns)
+		{
+		}
+
+		internal SqlSelectClause(bool isDistinct, List<ISqlExpression>? distinctOn, ISqlExpression? takeValue, TakeHints? takeHints, ISqlExpression? skipValue, IEnumerable<SqlColumn> columns)
 			: base(null)
 		{
 			IsDistinct = isDistinct;
+			DistinctOn = distinctOn;
 			TakeValue  = takeValue;
 			TakeHints  = takeHints;
 			SkipValue  = skipValue;
@@ -233,6 +239,19 @@ namespace LinqToDB.Internal.SqlQuery
 		public bool IsDistinct       { get; set; }
 		public bool OptimizeDistinct { get; set; }
 
+		/// <summary>
+		/// When non-empty, marks the clause as a <c>DISTINCT ON (...)</c> query (PostgreSQL, DuckDB): the listed
+		/// expressions form the distinct key and, per key, the row that sorts first under the query's <c>ORDER BY</c>
+		/// (which must begin with these expressions) is kept. Honored only by providers that support <c>DISTINCT ON</c>.
+		/// Callers that populate this must also set <see cref="IsDistinct"/> to <see langword="true"/>.
+		/// </summary>
+		public List<ISqlExpression>? DistinctOn { get; set; }
+
+		/// <summary>
+		/// Returns <see langword="true"/> when <see cref="DistinctOn"/> carries one or more expressions.
+		/// </summary>
+		public bool IsDistinctOn => DistinctOn is { Count: > 0 };
+
 		#endregion
 
 		#region Take
@@ -285,6 +304,10 @@ namespace LinqToDB.Internal.SqlQuery
 			hash.Add(TakeValue?.GetElementHashCode());
 			hash.Add(TakeHints);
 
+			if (DistinctOn != null)
+				foreach (var on in DistinctOn)
+					hash.Add(on.GetElementHashCode());
+
 			foreach (var column in Columns)
 				hash.Add(column.GetElementHashCode());
 
@@ -308,6 +331,19 @@ namespace LinqToDB.Internal.SqlQuery
 			writer.Append("SELECT ");
 
 			if (IsDistinct) writer.Append("DISTINCT ");
+
+			if (IsDistinctOn)
+			{
+				writer.Append("ON (");
+				for (var i = 0; i < DistinctOn!.Count; i++)
+				{
+					if (i > 0)
+						writer.Append(", ");
+					writer.AppendElement(DistinctOn[i]);
+				}
+
+				writer.Append(") ");
+			}
 
 			if (SkipValue != null)
 			{
@@ -399,6 +435,7 @@ namespace LinqToDB.Internal.SqlQuery
 		public void Cleanup()
 		{
 			IsDistinct = false;
+			DistinctOn = null;
 			TakeValue  = null;
 			TakeHints  = null;
 			SkipValue  = null;

--- a/Source/LinqToDB/Internal/SqlQuery/Visitors/QueryElementVisitor.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/Visitors/QueryElementVisitor.cs
@@ -2046,6 +2046,10 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 					Visit(element.TakeValue);
 					Visit(element.SkipValue);
 
+					if (element.DistinctOn != null)
+						foreach (var on in element.DistinctOn)
+							Visit(on);
+
 					foreach (var column in element.Columns)
 					{
 						VisitSqlColumnExpression(column, column.Expression);
@@ -2058,6 +2062,10 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 					element.TakeValue = (ISqlExpression?)Visit(element.TakeValue);
 					element.SkipValue = (ISqlExpression?)Visit(element.SkipValue);
 
+					if (element.DistinctOn != null)
+						for (var i = 0; i < element.DistinctOn.Count; i++)
+							element.DistinctOn[i] = (ISqlExpression)Visit(element.DistinctOn[i]);
+
 					foreach (var column in element.Columns)
 					{
 						column.Expression = VisitSqlColumnExpression(column, column.Expression);
@@ -2069,6 +2077,19 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 				{
 					var take = (ISqlExpression?)Visit(element.TakeValue);
 					var skip = (ISqlExpression?)Visit(element.SkipValue);
+
+					List<ISqlExpression>? newDistinctOn = null;
+					if (element.DistinctOn != null)
+					{
+						for (var i = 0; i < element.DistinctOn.Count; i++)
+						{
+							var on    = element.DistinctOn[i];
+							var newOn = (ISqlExpression)Visit(on);
+
+							if (!ReferenceEquals(on, newOn))
+								(newDistinctOn ??= new List<ISqlExpression>(element.DistinctOn))[i] = newOn;
+						}
+					}
 
 					ISqlExpression?[]? newExpressions = null;
 
@@ -2083,6 +2104,7 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 
 					if (ShouldReplace(element)                    ||
 						newExpressions != null                    ||
+						newDistinctOn  != null                    ||
 						!ReferenceEquals(element.TakeValue, take) ||
 						!ReferenceEquals(element.SkipValue, skip))
 					{
@@ -2095,7 +2117,10 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 							NotifyReplaced(newColumn, oldColumn);
 						}
 
-						return NotifyReplaced(new SqlSelectClause(element.IsDistinct, take, element.TakeHints, skip, newColumns) { OptimizeDistinct = element.OptimizeDistinct }, element);
+						// DistinctOn is a mutable list — give the new clause its own copy so later in-place visits don't alias the original
+						var distinctOn = newDistinctOn ?? (element.DistinctOn != null ? new List<ISqlExpression>(element.DistinctOn) : null);
+
+						return NotifyReplaced(new SqlSelectClause(element.IsDistinct, distinctOn, take, element.TakeHints, skip, newColumns) { OptimizeDistinct = element.OptimizeDistinct }, element);
 					}
 
 					break;
@@ -2167,7 +2192,9 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 
 					if (ReferenceEquals(sc, query.Select))
 					{
-						sc = new SqlSelectClause(query.Select.IsDistinct, query.Select.TakeValue,
+						sc = new SqlSelectClause(query.Select.IsDistinct,
+							query.Select.DistinctOn != null ? new List<ISqlExpression>(query.Select.DistinctOn) : null,
+							query.Select.TakeValue,
 							query.Select.TakeHints, query.Select.SkipValue,
 							query.Select.Columns.Select(c => new SqlColumn(nq, c.Expression, c.RawAlias)));
 

--- a/Source/LinqToDB/Internal/SqlQuery/Visitors/QueryElementVisitor.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/Visitors/QueryElementVisitor.cs
@@ -2087,7 +2087,7 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 							var newOn = (ISqlExpression)Visit(on);
 
 							if (!ReferenceEquals(on, newOn))
-								(newDistinctOn ??= new List<ISqlExpression>(element.DistinctOn))[i] = newOn;
+								(newDistinctOn ??= [..element.DistinctOn])[i] = newOn;
 						}
 					}
 
@@ -2193,7 +2193,7 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 					if (ReferenceEquals(sc, query.Select))
 					{
 						sc = new SqlSelectClause(query.Select.IsDistinct,
-							query.Select.DistinctOn != null ? new List<ISqlExpression>(query.Select.DistinctOn) : null,
+							query.Select.DistinctOn != null ? [..query.Select.DistinctOn] : null,
 							query.Select.TakeValue,
 							query.Select.TakeHints, query.Select.SkipValue,
 							query.Select.Columns.Select(c => new SqlColumn(nq, c.Expression, c.RawAlias)));

--- a/Source/LinqToDB/Internal/SqlQuery/Visitors/SelectQueryOptimizerVisitor.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/Visitors/SelectQueryOptimizerVisitor.cs
@@ -1572,7 +1572,7 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 				parentQuery.Select.OptimizeDistinct = parentQuery.Select.OptimizeDistinct || subQuery.Select.OptimizeDistinct;
 				parentQuery.Select.IsDistinct       = true;
 				// carry DISTINCT ON keys with the modifier so a flattened parent keeps the correct distinct semantics
-				if (subQuery.Select.DistinctOn != null)
+				if (subQuery.Select.IsDistinctOn)
 					parentQuery.Select.DistinctOn = subQuery.Select.DistinctOn;
 			}
 

--- a/Source/LinqToDB/Internal/SqlQuery/Visitors/SelectQueryOptimizerVisitor.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/Visitors/SelectQueryOptimizerVisitor.cs
@@ -1076,6 +1076,10 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 			if (!selectQuery.Select.IsDistinct || !selectQuery.Select.OptimizeDistinct)
 				return false;
 
+			// DISTINCT ON is never "redundant": removing it changes which row survives per ON key. Leave it intact.
+			if (selectQuery.Select.IsDistinctOn)
+				return false;
+
 			if (IsComplexQuery(selectQuery, false))
 				return false;
 
@@ -1386,7 +1390,7 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 						else
 							searchCondition.Add(new SqlPredicate.ExprExpr(rnColumn, SqlPredicate.Operator.LessOrEqual, takeValue, null));
 					}
-					else if (sql.Select.IsDistinct)
+					else if (sql.Select.IsDistinct && !sql.Select.IsDistinctOn)
 					{
 						sql.Select.IsDistinct = false;
 						searchCondition.Add(new SqlPredicate.ExprExpr(rnColumn, SqlPredicate.Operator.Equal, new SqlValue(1), null));
@@ -1567,6 +1571,9 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 			{
 				parentQuery.Select.OptimizeDistinct = parentQuery.Select.OptimizeDistinct || subQuery.Select.OptimizeDistinct;
 				parentQuery.Select.IsDistinct       = true;
+				// carry DISTINCT ON keys with the modifier so a flattened parent keeps the correct distinct semantics
+				if (subQuery.Select.DistinctOn != null)
+					parentQuery.Select.DistinctOn = subQuery.Select.DistinctOn;
 			}
 
 			if (subQuery.Select.TakeValue != null)
@@ -2085,6 +2092,11 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 
 			if (subQuery.IsDistinct)
 			{
+				// A DISTINCT ON subquery must not be flattened into its parent: moving the modifier up would drop the
+				// ON list and break its ORDER BY dependency. Keep it as a nested derived table.
+				if (subQuery.Select.IsDistinctOn)
+					return false;
+
 				if (parentQuery.HasOrderBy && !parentQuery.OrderBy.Items.TrueForAll(oi => oi.Expression is SqlColumn col && subQuery.Select.Columns.Contains(col)))
 				{
 					return false;
@@ -3294,6 +3306,9 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 			{
 				subQuery.Select.IsDistinct = true;
 				query.Select.IsDistinct    = false;
+				// move DISTINCT ON keys down with the modifier and clear them from the source query
+				subQuery.Select.DistinctOn = query.Select.DistinctOn;
+				query.Select.DistinctOn    = null;
 			}
 
 			_columnNestingCorrector.CorrectColumnNesting(query);
@@ -3395,7 +3410,7 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 				}
 			}
 
-			if (joinQuery.Select.Columns.Count > 1 && joinQuery.Select.IsDistinct)
+			if (joinQuery.Select.Columns.Count > 1 && joinQuery.Select.IsDistinct && !joinQuery.Select.IsDistinctOn)
 			{
 				if (!SqlProviderHelper.IsValidQuery(joinQuery, parentQuery: parentQuery, fakeJoin: null, columnSubqueryLevel: 1, _providerFlags, out _))
 					return false;
@@ -3568,8 +3583,9 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 
 			var sq = predicate.SubQuery;
 
-			// We can safely optimize out Distinct
-			if (sq.Select.IsDistinct)
+			// We can safely optimize out Distinct (but not DISTINCT ON — clearing only IsDistinct would leave the ON
+			// list dangling; EXISTS ignores distinctness/ordering anyway, so leaving it intact is harmless).
+			if (sq.Select.IsDistinct && !sq.Select.IsDistinctOn)
 			{
 				sq.Select.IsDistinct = false;
 			}

--- a/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryOrderByOptimizer.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryOrderByOptimizer.cs
@@ -218,6 +218,11 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 			if (selectQuery.OrderBy.IsEmpty)
 				return false;
 
+			// A DISTINCT ON query's ORDER BY is semantically required: it selects the surviving row per ON key and
+			// must begin with the ON expressions. Never strip it or redistribute it to a parent.
+			if (selectQuery.Select.IsDistinctOn)
+				return false;
+
 			if (QueryHelper.IsAggregationQuery(selectQuery, out var needsOrderBy))
 			{
 				if (needsOrderBy)

--- a/Tests/Linq/Linq/DistinctByMethodTests.cs
+++ b/Tests/Linq/Linq/DistinctByMethodTests.cs
@@ -220,6 +220,7 @@ namespace Tests.Linq
 				.Take(2);
 
 			AssertQuery(query);
+			Assert.That(query.ToSqlQuery().Sql, Does.Contain("DISTINCT ON"));
 		}
 
 		[Test]
@@ -236,6 +237,7 @@ namespace Tests.Linq
 				.Where(x => x.Amount > 100m);
 
 			AssertQuery(query);
+			Assert.That(query.ToSqlQuery().Sql, Does.Contain("DISTINCT ON"));
 		}
 
 		[Test]
@@ -254,6 +256,7 @@ namespace Tests.Linq
 				.Where(x => x.Amount > 100m);
 
 			AssertQuery(query);
+			Assert.That(query.ToSqlQuery().Sql, Does.Contain("DISTINCT ON"));
 		}
 
 		[Test]
@@ -270,6 +273,7 @@ namespace Tests.Linq
 				.DistinctBy(x => x.Name);
 
 			AssertQuery(query);
+			Assert.That(query.ToSqlQuery().Sql, Does.Contain("DISTINCT ON"));
 		}
 	}
 }

--- a/Tests/Linq/Linq/DistinctByMethodTests.cs
+++ b/Tests/Linq/Linq/DistinctByMethodTests.cs
@@ -152,6 +152,125 @@ namespace Tests.Linq
 
 			AssertQuery(query);
 		}
+
+		[Test]
+		public void DistinctByEmitsDistinctOn([IncludeDataSources(TestProvName.AllPostgreSQL, TestProvName.AllDuckDB)] string context)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(TestData.Seed());
+
+			var query = table
+				.OrderBy(t => t.Group)
+				.ThenBy(t => t.Date)
+				.DistinctBy(x => x.Group);
+
+			AssertQuery(query);
+
+			var sql = query.ToSqlQuery().Sql;
+			Assert.That(sql, Does.Contain("DISTINCT ON"));
+			Assert.That(sql, Does.Not.Contain("ROW_NUMBER"));
+		}
+
+		[Test]
+		public void DistinctByCompositeKeyEmitsDistinctOn([IncludeDataSources(TestProvName.AllPostgreSQL, TestProvName.AllDuckDB)] string context)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(TestData.Seed());
+
+			var query = table
+				.OrderBy(t => t.Name)
+				.ThenByDescending(t => t.Date)
+				.DistinctBy(x => new { x.Id, x.Name });
+
+			AssertQuery(query);
+
+			Assert.That(query.ToSqlQuery().Sql, Does.Contain("DISTINCT ON"));
+		}
+
+		[Test]
+		public void DistinctByUsesRowNumberWhenDistinctOnUnsupported([IncludeDataSources(TestProvName.AllSqlServer)] string context)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(TestData.Seed());
+
+			var query = table
+				.OrderBy(t => t.Group)
+				.ThenBy(t => t.Date)
+				.DistinctBy(x => x.Group);
+
+			AssertQuery(query);
+
+			var sql = query.ToSqlQuery().Sql;
+			Assert.That(sql, Does.Not.Contain("DISTINCT ON"));
+			Assert.That(sql, Does.Contain("ROW_NUMBER"));
+		}
+
+		[Test]
+		public void DistinctByThenTake([IncludeDataSources(TestProvName.AllPostgreSQL, TestProvName.AllDuckDB)] string context)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(TestData.Seed());
+
+			// DISTINCT ON followed by an outer ORDER BY + LIMIT: the inner ON ordering must survive.
+			var query = table
+				.OrderBy(t => t.Group)
+				.ThenBy(t => t.Date)
+				.DistinctBy(x => x.Group)
+				.OrderBy(x => x.Group)
+				.Take(2);
+
+			AssertQuery(query);
+		}
+
+		[Test]
+		public void DistinctByThenWhere([IncludeDataSources(TestProvName.AllPostgreSQL, TestProvName.AllDuckDB)] string context)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(TestData.Seed());
+
+			// A filter applied after DistinctBy must wrap the DISTINCT ON query as a subquery, not push into it.
+			var query = table
+				.OrderBy(t => t.Group)
+				.ThenBy(t => t.Date)
+				.DistinctBy(x => x.Group)
+				.Where(x => x.Amount > 100m);
+
+			AssertQuery(query);
+		}
+
+		[Test]
+		public void DistinctByInSubQuery([IncludeDataSources(TestProvName.AllPostgreSQL, TestProvName.AllDuckDB)] string context)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(TestData.Seed());
+
+			// Forcing the DISTINCT ON result into a derived table must preserve its ORDER BY (the optimizer
+			// must not strip a DISTINCT ON query's ordering when it becomes a subquery).
+			var query = table
+				.OrderBy(t => t.Group)
+				.ThenBy(t => t.Date)
+				.DistinctBy(x => x.Group)
+				.AsSubQuery()
+				.Where(x => x.Amount > 100m);
+
+			AssertQuery(query);
+		}
+
+		[Test]
+		public void NestedDistinctBy([IncludeDataSources(TestProvName.AllPostgreSQL, TestProvName.AllDuckDB)] string context)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(TestData.Seed());
+
+			// Two stacked DistinctBy stages: the inner DISTINCT ON must remain a nested derived table.
+			var query = table
+				.OrderBy(t => t.Date)
+				.DistinctBy(x => x.Group)
+				.OrderBy(x => x.Id)
+				.DistinctBy(x => x.Name);
+
+			AssertQuery(query);
+		}
 	}
 }
 

--- a/Tests/Linq/Linq/DistinctByMethodTests.cs
+++ b/Tests/Linq/Linq/DistinctByMethodTests.cs
@@ -225,6 +225,9 @@ namespace Tests.Linq
 			var sql = query.ToSqlQuery().Sql;
 			Assert.That(sql, Does.Not.Contain("DISTINCT ON"));
 			Assert.That(sql, Does.Contain("ROW_NUMBER"));
+			// The constant-key fall-through must reuse the single built sequence; a second build would leak an extra
+			// table reference into the ROW_NUMBER subquery (FROM TestData e, TestData e_1 — a cartesian product).
+			Assert.That(sql.Split("TestData").Length - 1, Is.EqualTo(1));
 		}
 
 		[Test]

--- a/Tests/Linq/Linq/DistinctByMethodTests.cs
+++ b/Tests/Linq/Linq/DistinctByMethodTests.cs
@@ -184,7 +184,9 @@ namespace Tests.Linq
 
 			AssertQuery(query);
 
-			Assert.That(query.ToSqlQuery().Sql, Does.Contain("DISTINCT ON"));
+			// Both composite-key columns must reach the ON list: a bare Does.Contain("DISTINCT ON") would still
+			// pass if one key column were dropped (DISTINCT ON (Id) instead of DISTINCT ON (Id, Name)).
+			Assert.That(query.ToSqlQuery().Sql, Does.Match(@"DISTINCT ON \([^)]*\bId\b[^)]*,[^)]*\bName\b[^)]*\)"));
 		}
 
 		[Test]
@@ -197,6 +199,26 @@ namespace Tests.Linq
 				.OrderBy(t => t.Group)
 				.ThenBy(t => t.Date)
 				.DistinctBy(x => x.Group);
+
+			AssertQuery(query);
+
+			var sql = query.ToSqlQuery().Sql;
+			Assert.That(sql, Does.Not.Contain("DISTINCT ON"));
+			Assert.That(sql, Does.Contain("ROW_NUMBER"));
+		}
+
+		[Test]
+		public void DistinctByConstantKeyFallsBackToRowNumber([IncludeDataSources(TestProvName.AllPostgreSQL, TestProvName.AllDuckDB)] string context)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(TestData.Seed());
+
+			// A constant key collects to an empty ON list, which has no valid DISTINCT ON form — even on a
+			// DISTINCT-ON-capable provider it must fall back to the ROW_NUMBER emulation, not emit DISTINCT ON ().
+			var query = table
+				.OrderBy(t => t.Group)
+				.ThenBy(t => t.Date)
+				.DistinctBy(x => 1);
 
 			AssertQuery(query);
 
@@ -273,7 +295,9 @@ namespace Tests.Linq
 				.DistinctBy(x => x.Name);
 
 			AssertQuery(query);
-			Assert.That(query.ToSqlQuery().Sql, Does.Contain("DISTINCT ON"));
+			// Both stages must survive as separate DISTINCT ON queries: a bare Does.Contain would pass even if the
+			// optimizer collapsed the two nested DISTINCT ONs into one.
+			Assert.That(query.ToSqlQuery().Sql.Split("DISTINCT ON").Length - 1, Is.EqualTo(2));
 		}
 	}
 }


### PR DESCRIPTION
Closes #2075

## What

`DistinctBy` now emits native `SELECT DISTINCT ON (...)` on providers that
support it (PostgreSQL, DuckDB) instead of the `ROW_NUMBER()` emulation, which
stays as the fallback everywhere else — no SQL/baseline churn off PG/DuckDB.

The key selector becomes the `ON` expression list; the preceding `OrderBy` is
forced to lead with those keys (the syntax requires it), and the natural
`DISTINCT ON` ordering is kept.

## Changes

- AST: `SqlSelectClause.DistinctOn` + `IsDistinctOn`; threaded through the ctor,
  hash, `ToString`, `Cleanup`, and the query-element visitor (walk + clone).
- New `SqlProviderFlags.IsDistinctOnSupported` (default `false`), set on
  PostgreSQL (all versions) and DuckDB.
- `BasicSqlBuilder.BuildDistinctModifier` hook; PG/DuckDB builders render
  `DISTINCT ON (...)` via a shared helper that reuses the ORDER BY path.
- `DistinctByBuilder`: new branch before the ROW_NUMBER path, gated on the flag.
- Optimizer guards so the ON list and its ORDER BY survive flatten/merge/EXISTS:
  `SqlQueryOrderByOptimizer`, `SelectQueryOptimizerVisitor`,
  `BasicSqlOptimizer.SeparateDistinctFromPagination`, and
  `QueryHelper.CollectUniqueKeys` (ON tuple isn't a full-projection unique key).
- Remote round-trip in `LinqServiceSerializer`.

## Tests

`Tests/Linq/Linq/DistinctByMethodTests.cs`: existing behavioral tests now
exercise DISTINCT ON on PG/DuckDB; added SQL-shape assertions (`DISTINCT ON` on
PG/DuckDB, `ROW_NUMBER` + no `DISTINCT ON` on SQL Server) and edge cases (`Take`,
`Where`, `AsSubQuery`, nested `DistinctBy`, composite key). Green on PostgreSQL 16,
DuckDB, and SQL Server 2019.

## Follow-up

- ClickHouse has a `DISTINCT ON` clause with different ordering guarantees —
  left as a separate task (flag stays `false`).
