### PR TITLE
test infra: scope test Expressions.MapMember registrations to dedicated configurations

### DIFF
--- a/Tests/FSharp/Issue5428.fs
+++ b/Tests/FSharp/Issue5428.fs
@@ -12,6 +12,11 @@ open LinqToDB.DataProvider.PostgreSQL
 open LinqToDB.FSharp
 open Tests
 
+// Scope the DateInterval.Contains mapping to a dedicated configuration rather than the global ""
+// config, so it stays local to this test's MappingSchema and doesn't leak into the process-wide registry.
+[<Literal>]
+let CONFIG = "Issue5428"
+
 type Template =
     {
         [<Column("id")>]
@@ -36,7 +41,7 @@ let createDataOptions (connectionString: string) =
 
     let dataProvider = PostgreSQLTools.GetDataProvider(connectionString = connectionString)
 
-    let mappingSchema = MappingSchema()
+    let mappingSchema = MappingSchema(CONFIG)
     mappingSchema.AddScalarType(typeof<LocalDate>)
     mappingSchema.AddScalarType(typeof<DateInterval>)
 
@@ -49,7 +54,8 @@ let createDataOptions (connectionString: string) =
 let dateIntervalContains (d: DateInterval) (e: LocalDate) = d.Contains(e)
 
 LinqToDB.Linq.Expressions.MapMember<DateInterval, LocalDate, bool>(
-    (fun a b -> a.Contains b),
+    CONFIG,
+    (fun (a: DateInterval) (b: LocalDate) -> a.Contains b),
     dateIntervalContains
 )
 

--- a/Tests/Linq/Linq/ExpressionsTests.cs
+++ b/Tests/Linq/Linq/ExpressionsTests.cs
@@ -192,9 +192,9 @@ namespace Tests.Linq
 		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		public void MapMember1([DataSources(TestProvName.AllClickHouse)] string context)
 		{
-			Expressions.MapMember<Parent,int>(p => Count1(p), p => p.Children.Count(c => c.ChildID > 0));
+			Expressions.MapMember<Parent,int>(nameof(MapMember1), p => Count1(p), p => p.Children.Count(c => c.ChildID > 0));
 
-			using var db = GetDataContext(context);
+			using var db = GetDataContext(context, new MappingSchema(nameof(MapMember1)));
 			AreEqual(Parent.Select(Count1), db.Parent.Select(p => Count1(p)));
 		}
 
@@ -204,9 +204,9 @@ namespace Tests.Linq
 		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		public void MapMember2([DataSources(TestProvName.AllClickHouse)] string context)
 		{
-			Expressions.MapMember<Parent,int,int>((p,id) => Count2(p, id), (p, id) => p.Children.Count(c => c.ChildID > id));
+			Expressions.MapMember<Parent,int,int>(nameof(MapMember2), (p,id) => Count2(p, id), (p, id) => p.Children.Count(c => c.ChildID > id));
 
-			using var db = GetDataContext(context);
+			using var db = GetDataContext(context, new MappingSchema(nameof(MapMember2)));
 			AreEqual(Parent.Select(p => Count2(p, 1)), db.Parent.Select(p => Count2(p, 1)));
 		}
 
@@ -216,11 +216,11 @@ namespace Tests.Linq
 		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		public void MapMember3([DataSources(ProviderName.SqlCe, TestProvName.AllClickHouse)] string context)
 		{
-			Expressions.MapMember<Parent,int,int>((p,id) => Count3(p, id), (p, id) => p.Children.Count(c => c.ChildID > id) + 2);
+			Expressions.MapMember<Parent,int,int>(nameof(MapMember3), (p,id) => Count3(p, id), (p, id) => p.Children.Count(c => c.ChildID > id) + 2);
 
 			var n = 2;
 
-			using var db = GetDataContext(context);
+			using var db = GetDataContext(context, new MappingSchema(nameof(MapMember3)));
 			AreEqual(Parent.Select(p => Count3(p, n)), db.Parent.Select(p => Count3(p, n)));
 		}
 
@@ -588,9 +588,9 @@ namespace Tests.Linq
 		[Test]
 		public void ToLowerInvariantTest([DataSources] string context)
 		{
-			Expressions.MapMember((string s) => s.ToLowerInvariant(), s => s.ToLower());
+			Expressions.MapMember(nameof(ToLowerInvariantTest), (string s) => s.ToLowerInvariant(), s => s.ToLower());
 
-			using var db = GetDataContext(context);
+			using var db = GetDataContext(context, new MappingSchema(nameof(ToLowerInvariantTest)));
 			AreEqual(
 				   Doctor.Where(p => p.Taxonomy.ToLowerInvariant() == "psychiatry").Select(p => p.Taxonomy.ToLower()),
 				db.Doctor.Where(p => p.Taxonomy.ToLowerInvariant() == "psychiatry").Select(p => p.Taxonomy.ToLower()));

--- a/Tests/Linq/Linq/FunctionTests.cs
+++ b/Tests/Linq/Linq/FunctionTests.cs
@@ -469,9 +469,9 @@ namespace Tests.Linq
 		[Test]
 		public void CustomFunc([DataSources] string context)
 		{
-			Expressions.MapMember<Person>(p => p.FullName(), (Expression<Func<Person,string>>)(p => p.LastName + ", " + p.FirstName));
+			Expressions.MapMember<Person>(nameof(CustomFunc), p => p.FullName(), (Expression<Func<Person,string>>)(p => p.LastName + ", " + p.FirstName));
 
-			using var db = GetDataContext(context);
+			using var db = GetDataContext(context, new MappingSchema(nameof(CustomFunc)));
 			AreEqual(
 				from p in Person where p.FullName() == "Pupkin, John" select p.FullName(),
 				from p in db.Person where p.FullName() == "Pupkin, John" select p.FullName());

--- a/Tests/Linq/UserTests/Issue2468Tests.cs
+++ b/Tests/Linq/UserTests/Issue2468Tests.cs
@@ -14,6 +14,11 @@ namespace Tests.UserTests
 	[TestFixture]
 	public class Issue2468Tests : TestBase
 	{
+		// Register the enum ToString mappings under a dedicated configuration (not the global ""
+		// config) so they only apply to this test's MappingSchema and don't leak into the process-wide
+		// registry - which, under parallel execution, would perturb other fixtures' conversions.
+		const string CONFIG = "Issue2468Tests";
+
 		public enum StatusEnum
 		{
 			Unknown = 0,
@@ -92,14 +97,14 @@ namespace Tests.UserTests
 
 			var toStringMethod = type.GetMethods().First(m => m.Name == "ToString" && m.GetParameters().Length == 0);
 
-			Expressions.MapMember(type, toStringMethod, lambda);
+			Expressions.MapMember(CONFIG, type, toStringMethod, lambda);
 		}
 
 		static Issue2468Tests()
 		{
 			MapEnumToString<ColorEnum>();
 			MapEnumToString<CMYKEnum>();
-			Expressions.MapMember((StatusEnum v) => v.ToString(), v => MyExtensions.StatusEnumToString(v));
+			Expressions.MapMember(CONFIG, (StatusEnum v) => v.ToString(), v => MyExtensions.StatusEnumToString(v));
 		}
 
 		[Test]
@@ -108,7 +113,8 @@ namespace Tests.UserTests
 			string context)
 		{
 
-			using var db = (DataConnection)GetDataContext(context);
+			var ms = new MappingSchema(CONFIG);
+			using var db = (DataConnection)GetDataContext(context, ms);
 			using var itb = db.CreateLocalTable<InventoryResourceDTO>();
 			var dto1 = new InventoryResourceDTO
 			{


### PR DESCRIPTION
Pre-flight cleanup for #5614 (parallel test execution).

### Problem

Several tests register member mappings via `Expressions.MapMember(...)` under the **global `""` configuration** — a process-wide, irreversible registration. Serially this is invisible (fixtures run in a fixed, alphabetical order), but it leaks under **parallel test execution**: a global registration from one fixture perturbs conversion resolution in concurrently- or later-running fixtures.

Concretely, `Issue2468Tests`' static-ctor enum→`ToString` registration was breaking `ConvertTests.ToSqlTime`/`ToSqlTimeSql` (client-side string→`Time` resolving a today-dated value instead of min-date) on every real-`TIME` provider once the suite ran in parallel.

### Change

Scope each registration to a **dedicated configuration name** and run the test against a `MappingSchema` carrying that name — the pattern `EvaluationTests.Evaluate_RemappedTimeSpan` already uses — so the mappings stay local to their test:

- `ExpressionsTests`: `MapMember1` / `MapMember2` / `MapMember3` / `ToLowerInvariantTest`
- `FunctionTests.CustomFunc`
- `Issue2468Tests` (enum `ToString` maps)
- `Issue5428` (F#: `DateInterval.Contains`)

No production code touched. All affected fixtures pass (444/444 locally on SQLite + MySQL). `[NonParallelizable]` is **not** a fix for this class — the global registration is irreversible and persists for later tests — so config-scoping is the correct approach.
