### PR TITLE
Fix #5626: ORDER BY dropped for OrderBy().Distinct()/GroupBy().Take()

### DIFF
--- a/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryOrderByOptimizer.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryOrderByOptimizer.cs
@@ -242,12 +242,10 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 		}
 
 		/// <summary>
-		/// Returns <see langword="true"/> when every column/field referenced by <paramref name="orderExpression"/>
-		/// is produced as an output column of the DISTINCT <paramref name="distinctQuery"/>. In that case the
-		/// expression is functionally determined by the DISTINCT projection, so it can be ordered above the
-		/// DISTINCT and exposed as an additional output column without changing which rows are kept.
+		/// Collects the <see cref="QueryElementType.Column"/> / <see cref="QueryElementType.SqlField"/> leaf
+		/// references of <paramref name="orderExpression"/> without descending into their definitions.
 		/// </summary>
-		static bool AllOrderColumnsProducedByDistinct(SelectQuery distinctQuery, ISqlExpression orderExpression)
+		static List<ISqlExpression> CollectReferencedColumns(ISqlExpression orderExpression)
 		{
 			var referenced = new List<ISqlExpression>();
 
@@ -261,6 +259,19 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 
 				return true;
 			});
+
+			return referenced;
+		}
+
+		/// <summary>
+		/// Returns <see langword="true"/> when every column/field referenced by <paramref name="orderExpression"/>
+		/// is produced as an output column of the DISTINCT <paramref name="distinctQuery"/>. In that case the
+		/// expression is functionally determined by the DISTINCT projection, so it can be ordered above the
+		/// DISTINCT and exposed as an additional output column without changing which rows are kept.
+		/// </summary>
+		static bool AllOrderColumnsProducedByDistinct(SelectQuery distinctQuery, ISqlExpression orderExpression)
+		{
+			var referenced = CollectReferencedColumns(orderExpression);
 
 			if (referenced.Count == 0)
 				return false;
@@ -290,18 +301,7 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 			if (groupedQuery.GroupBy.GroupingType != GroupingType.Default)
 				return false;
 
-			var referenced = new List<ISqlExpression>();
-
-			orderExpression.VisitParentFirst(referenced, static (list, e) =>
-			{
-				if (e.ElementType is QueryElementType.Column or QueryElementType.SqlField)
-				{
-					list.Add((ISqlExpression)e);
-					return false; // leaf reference - don't descend into the column/field definition
-				}
-
-				return true;
-			});
+			var referenced = CollectReferencedColumns(orderExpression);
 
 			if (referenced.Count == 0)
 				return false;

--- a/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryOrderByOptimizer.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryOrderByOptimizer.cs
@@ -122,36 +122,47 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 
 							if (canPopulateUpperLevel && parentSelectQuery.Select.IsDistinct)
 							{
-								canPopulateUpperLevel = parentSelectQuery.Select.Columns.Exists(c =>
-								{
-									if (c.Expression is SqlColumn column)
-										return QueryHelper.SameWithoutNullablity(column.Expression, orderByItem.Expression);
-									return false;
-								});
+								// The order can move above a DISTINCT parent only when its expression is built entirely
+								// from columns/fields the DISTINCT projects (#5626). Then it is functionally determined by
+								// the DISTINCT output, so ordering by it above the DISTINCT is well-defined and exposing it
+								// as an extra output column cannot change which rows are distinct. Ordering by anything
+								// outside the projection stays unsupported and the order is dropped.
+								canPopulateUpperLevel = AllOrderColumnsProducedByDistinct(parentSelectQuery, orderByItem.Expression);
 							}
 
 							if (canPopulateUpperLevel && !parentSelectQuery.GroupBy.IsEmpty)
 							{
-								canPopulateUpperLevel = selectQuery.Select.Columns.Exists(c => QueryHelper.SameWithoutNullablity(c.Expression, orderByItem.Expression));
+								// The order can move above a GROUP BY parent only when its expression is built entirely
+								// from the grouping keys (#5626): `GROUP BY a, b ... ORDER BY a * 100 + b` is valid, but
+								// ordering by a non-grouped column is not. The exact-column form is kept for back-compat.
+								canPopulateUpperLevel =
+									selectQuery.Select.Columns.Exists(c => QueryHelper.SameWithoutNullablity(c.Expression, orderByItem.Expression))
+									|| AllOrderColumnsAreGroupingKeys(parentSelectQuery, orderByItem.Expression);
 							}
 
 							if (canPopulateUpperLevel)
 							{
-								if (orderByItem.Expression is SqlExpression or SqlFragment)
+								// Raw-template AST nodes (Sql.Expr / Sql.Fragment) may carry trailing direction
+								// modifiers in their template text (e.g. "{0} NULLS FIRST"). Wrapping them as a synthetic
+								// subquery column captured the modifier inside the column expression and emitted invalid
+								// SQL like `... END NULLS FIRST as c1`. Push such expressions directly to the parent ORDER
+								// BY so the modifier stays in the outer clause.
+								// When a DISTINCT or GROUP BY is involved we also push the expression as-is instead of
+								// materializing it as a column (#5626): the order has been validated to use only columns the
+								// DISTINCT projects / grouping keys, so adding a synthetic column would needlessly widen the
+								// DISTINCT key or the projection. The column-nesting corrector re-levels the references onto
+								// the existing output columns.
+								if (orderByItem.Expression is SqlExpression or SqlFragment
+									|| parentSelectQuery.Select.IsDistinct
+									|| selectQuery.Select.IsDistinct
+									|| !parentSelectQuery.GroupBy.IsEmpty)
 								{
-									// Raw-template AST nodes (Sql.Expr / Sql.Fragment) may carry trailing
-									// direction modifiers in their template text (e.g. "{0} NULLS FIRST").
-									// Wrapping them as a synthetic subquery column captured the modifier
-									// inside the column expression and emitted invalid SQL like
-									// `... END NULLS FIRST as c1`. Push such expressions directly to the
-									// parent ORDER BY so the modifier stays in the outer clause where it
-									// belongs. Every other AST node (structured expressions, columns, fields,
-									// functions, case, etc.) keeps the existing AddColumn dedup path — their
-									// SQL output is always a valid scalar.
 									parentSelectQuery.OrderBy.Items.Add(new SqlOrderByItem(orderByItem.Expression, orderByItem.IsDescending, orderByItem.IsPositioned, orderByItem.NullsPosition));
 								}
 								else
 								{
+									// Every other AST node (structured expressions, columns, fields, functions, case, etc.)
+									// keeps the AddColumn dedup path - their SQL output is always a valid scalar.
 									var column = selectQuery.Select.AddColumn(orderByItem.Expression);
 									parentSelectQuery.OrderBy.Items.Add(new SqlOrderByItem(column, orderByItem.IsDescending, orderByItem.IsPositioned, orderByItem.NullsPosition));
 								}
@@ -227,6 +238,85 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 
 			if (selectQuery.IsLimited)
 				return false;
+			return true;
+		}
+
+		/// <summary>
+		/// Returns <see langword="true"/> when every column/field referenced by <paramref name="orderExpression"/>
+		/// is produced as an output column of the DISTINCT <paramref name="distinctQuery"/>. In that case the
+		/// expression is functionally determined by the DISTINCT projection, so it can be ordered above the
+		/// DISTINCT and exposed as an additional output column without changing which rows are kept.
+		/// </summary>
+		static bool AllOrderColumnsProducedByDistinct(SelectQuery distinctQuery, ISqlExpression orderExpression)
+		{
+			var referenced = new List<ISqlExpression>();
+
+			orderExpression.VisitParentFirst(referenced, static (list, e) =>
+			{
+				if (e.ElementType is QueryElementType.Column or QueryElementType.SqlField)
+				{
+					list.Add((ISqlExpression)e);
+					return false; // leaf reference - don't descend into the column/field definition
+				}
+
+				return true;
+			});
+
+			if (referenced.Count == 0)
+				return false;
+
+			foreach (var reference in referenced)
+			{
+				var produced = distinctQuery.Select.Columns.Exists(c =>
+					c.Expression is SqlColumn column
+						? QueryHelper.SameWithoutNullablity(column.Expression, reference)
+						: QueryHelper.SameWithoutNullablity(c.Expression, reference));
+
+				if (!produced)
+					return false;
+			}
+
+			return true;
+		}
+
+		/// <summary>
+		/// Returns <see langword="true"/> when every column/field referenced by <paramref name="orderExpression"/>
+		/// is one of the grouping keys of <paramref name="groupedQuery"/>. In that case the expression is a function
+		/// of the grouping keys, so it can be ordered above the GROUP BY. Restricted to a plain GROUP BY -
+		/// ROLLUP/CUBE/GROUPING SETS emit super-aggregate rows where ordering by a key is not well-defined.
+		/// </summary>
+		static bool AllOrderColumnsAreGroupingKeys(SelectQuery groupedQuery, ISqlExpression orderExpression)
+		{
+			if (groupedQuery.GroupBy.GroupingType != GroupingType.Default)
+				return false;
+
+			var referenced = new List<ISqlExpression>();
+
+			orderExpression.VisitParentFirst(referenced, static (list, e) =>
+			{
+				if (e.ElementType is QueryElementType.Column or QueryElementType.SqlField)
+				{
+					list.Add((ISqlExpression)e);
+					return false; // leaf reference - don't descend into the column/field definition
+				}
+
+				return true;
+			});
+
+			if (referenced.Count == 0)
+				return false;
+
+			foreach (var reference in referenced)
+			{
+				var isGroupingKey = groupedQuery.GroupBy.Items.Exists(k =>
+					k is SqlColumn column
+						? QueryHelper.SameWithoutNullablity(column.Expression, reference)
+						: QueryHelper.SameWithoutNullablity(k, reference));
+
+				if (!isGroupingKey)
+					return false;
+			}
+
 			return true;
 		}
 

--- a/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryOrderByOptimizer.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryOrderByOptimizer.cs
@@ -142,27 +142,27 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 
 							if (canPopulateUpperLevel)
 							{
-								// Raw-template AST nodes (Sql.Expr / Sql.Fragment) may carry trailing direction
-								// modifiers in their template text (e.g. "{0} NULLS FIRST"). Wrapping them as a synthetic
-								// subquery column captured the modifier inside the column expression and emitted invalid
-								// SQL like `... END NULLS FIRST as c1`. Push such expressions directly to the parent ORDER
-								// BY so the modifier stays in the outer clause.
-								// When a DISTINCT or GROUP BY is involved we also push the expression as-is instead of
-								// materializing it as a column (#5626): the order has been validated to use only columns the
-								// DISTINCT projects / grouping keys, so adding a synthetic column would needlessly widen the
-								// DISTINCT key or the projection. The column-nesting corrector re-levels the references onto
-								// the existing output columns.
+								// Push the order up as-is (instead of materializing it as a synthetic column) when:
+								//  - it is a raw-template node (Sql.Expr / Sql.Fragment): wrapping it as a column would
+								//    capture trailing direction modifiers ("{0} NULLS FIRST") inside the column and emit
+								//    invalid SQL like `... END NULLS FIRST as c1`; or
+								//  - a DISTINCT / GROUP BY is involved and the order is a *computed* expression (not a plain
+								//    column/field) whose referenced columns the projection / grouping keys already produce
+								//    (#5626): materializing it would needlessly widen the DISTINCT key / projection with a
+								//    synthetic column. The nesting corrector re-levels it onto the existing output columns.
+								// A plain column/field stays on the AddColumn dedup path even under DISTINCT/GROUP BY - it
+								// resolves to an existing output column (no new column) and re-levels reliably through deep
+								// nesting, e.g. the master-key correlation order of eager-loading queries which the as-is
+								// path would otherwise drop.
+								var distinctOrGroupBy = parentSelectQuery.Select.IsDistinct || selectQuery.Select.IsDistinct || !parentSelectQuery.GroupBy.IsEmpty;
+
 								if (orderByItem.Expression is SqlExpression or SqlFragment
-									|| parentSelectQuery.Select.IsDistinct
-									|| selectQuery.Select.IsDistinct
-									|| !parentSelectQuery.GroupBy.IsEmpty)
+									|| (distinctOrGroupBy && orderByItem.Expression is not (SqlColumn or SqlField)))
 								{
 									parentSelectQuery.OrderBy.Items.Add(new SqlOrderByItem(orderByItem.Expression, orderByItem.IsDescending, orderByItem.IsPositioned, orderByItem.NullsPosition));
 								}
 								else
 								{
-									// Every other AST node (structured expressions, columns, fields, functions, case, etc.)
-									// keeps the AddColumn dedup path - their SQL output is always a valid scalar.
 									var column = selectQuery.Select.AddColumn(orderByItem.Expression);
 									parentSelectQuery.OrderBy.Items.Add(new SqlOrderByItem(column, orderByItem.IsDescending, orderByItem.IsPositioned, orderByItem.NullsPosition));
 								}

--- a/Tests/Linq/Linq/OrderByDistinctTests.cs
+++ b/Tests/Linq/Linq/OrderByDistinctTests.cs
@@ -483,5 +483,52 @@ namespace Tests.Linq
 
 			AssertQuery(result);
 		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5626")]
+		public void OrderByDistinctTakeOrdering([DataSources] string context)
+		{
+			var testData = GetTestData();
+
+			using var db = GetDataContext(context);
+			using var table = db.CreateLocalTable(testData);
+
+			// OrderBy by an expression (not a literal Distinct output column) followed by Distinct().Take(...):
+			// the ORDER BY must survive because the Take observes which rows it keeps. With OrderData1 * 100 + Id
+			// descending the unique top-3 rows are Ids 600 (1100), 500 (900) and 400 (700) - dropping the ORDER BY
+			// makes the Take return arbitrary rows instead.
+			// Asserted against explicit values rather than AssertQuery: AssertQuery's in-memory baseline is derived
+			// from linq2db's own exposed expression, which drops the same ORDER BY and would mask the bug.
+			var result = table
+				.Concat(table)
+				.OrderByDescending(x => x.OrderData1 * 100 + x.Id)
+				.Distinct()
+				.Take(3)
+				.Select(x => x.Id)
+				.ToArray();
+
+			AreEqual(new[] { 600, 500, 400 }, result);
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5626")]
+		public void OrderByGroupByTakeOrdering([DataSources] string context)
+		{
+			var testData = GetTestData();
+
+			using var db = GetDataContext(context);
+			using var table = db.CreateLocalTable(testData);
+
+			// GROUP BY analog of the Distinct case: OrderBy by an expression built from the grouping keys, then
+			// GroupBy (with an aggregate so the GROUP BY survives) + Take. The ORDER BY must survive above the
+			// GROUP BY because the Take observes it. Distinct (OrderData1, OrderData2) pairs ordered descending by
+			// OrderData1 * 100 + OrderData2 give 505, 404, 303 as the top three.
+			var result = table
+				.OrderByDescending(x => x.OrderData1 * 100 + x.OrderData2)
+				.GroupBy(x => new { x.OrderData1, x.OrderData2 })
+				.Select(g => new { Key = g.Key.OrderData1 * 100 + g.Key.OrderData2, Count = g.Count() })
+				.Take(3)
+				.ToArray();
+
+			AreEqual(new[] { 505, 404, 303 }, result.Select(x => x.Key).ToArray());
+		}
 	}
 }

--- a/Tests/Linq/Linq/OrderByDistinctTests.cs
+++ b/Tests/Linq/Linq/OrderByDistinctTests.cs
@@ -506,7 +506,7 @@ namespace Tests.Linq
 				.Select(x => x.Id)
 				.ToArray();
 
-			AreEqual(new[] { 600, 500, 400 }, result);
+			Assert.That(result, Is.EqualTo(new[] { 600, 500, 400 }));
 		}
 
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/5626")]
@@ -528,7 +528,31 @@ namespace Tests.Linq
 				.Take(3)
 				.ToArray();
 
-			AreEqual(new[] { 505, 404, 303 }, result.Select(x => x.Key).ToArray());
+			Assert.That(result.Select(x => x.Key).ToArray(), Is.EqualTo(new[] { 505, 404, 303 }));
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5626")]
+		public void OrderByGroupByTakeOrderingKeyNotProjected([DataSources] string context)
+		{
+			var testData = GetTestData();
+
+			using var db = GetDataContext(context);
+			using var table = db.CreateLocalTable(testData);
+
+			// Variant of OrderByGroupByTakeOrdering where the ORDER BY expression (OrderData1 * 100 + OrderData2)
+			// is NOT present verbatim in the SELECT projection - only the OrderData1 grouping key is projected.
+			// This exercises the new grouping-key path (AllOrderColumnsAreGroupingKeys) unambiguously, since the
+			// pre-existing exact-column disjunct cannot match an order expression absent from the projection.
+			// Distinct (OrderData1, OrderData2) pairs ordered descending by OrderData1 * 100 + OrderData2 give
+			// (5,5)=505, (4,4)=404, (3,3)=303 as the top three, so the projected OrderData1 values are 5, 4, 3.
+			var result = table
+				.OrderByDescending(x => x.OrderData1 * 100 + x.OrderData2)
+				.GroupBy(x => new { x.OrderData1, x.OrderData2 })
+				.Select(g => g.Key.OrderData1)
+				.Take(3)
+				.ToArray();
+
+			Assert.That(result, Is.EqualTo(new[] { 5, 4, 3 }));
 		}
 	}
 }


### PR DESCRIPTION
Fixes #5626.

`OrderBy(expr).Distinct().Take(n)` dropped the ORDER BY. `SqlQueryOrderByOptimizer`
removed an order feeding a DISTINCT/GROUP BY when its expression wasn't a literal
output column — but a `Take`/`Skip` above the DISTINCT/grouping observes which rows
are kept, so the limit returned arbitrary rows.

## Changes — `SqlQueryOrderByOptimizer`
- **DISTINCT**: keep the order above the DISTINCT when every column it references is
  produced by the DISTINCT projection (so it's functionally determined by the output),
  instead of requiring an exact column match.
- **GROUP BY**: same check against the grouping keys (plain `GROUP BY` only — ROLLUP/
  CUBE/GROUPING SETS excluded); the legacy exact-column form is retained.
- Move the validated order up **as-is** rather than materializing it as a synthetic
  column; the column-nesting corrector re-levels references onto existing columns.

`SelectQueryOptimizerVisitor` was audited — its merge guards already keep these orders
correctly nested; no change needed.

## Tests
`OrderByDistinctTests`: `OrderByDistinctTakeOrdering` (DISTINCT) and
`OrderByGroupByTakeOrdering` (GROUP BY). Asserted against explicit expected rows —
`AssertQuery` can't catch this class of bug (its in-memory baseline drops the same
ORDER BY).

## Validation
- SQLite (direct + remote): 1262/0 across Distinct/OrderBy/GroupBy/Union/TakeSkip/
  EagerLoading/SelectMany.
- SQL Server 2019 (Microsoft.Data.SqlClient, the reported provider): 788/0 — confirms
  valid SQL on a provider that rejects `SELECT DISTINCT … ORDER BY <compound>`.

Generated SQL for affected `…Distinct()/GroupBy().Take()` queries now includes the
ORDER BY, so some SQL baselines will change.


## Follow-up commit

Review follow-up (bb69ae09, 4be07a48):
- Extracted the duplicated order-expression leaf-collection block in `SqlQueryOrderByOptimizer` (`AllOrderColumnsProducedByDistinct` / `AllOrderColumnsAreGroupingKeys`) into a shared `CollectReferencedColumns` helper.
- `OrderByDistinctTests`: switched `OrderByDistinctTakeOrdering` / `OrderByGroupByTakeOrdering` to order-sensitive `Assert.That(..., Is.EqualTo(...))`, and added `OrderByGroupByTakeOrderingKeyNotProjected` whose ORDER BY expression is absent from the SELECT projection, exercising the grouping-key path unambiguously.