### PR TITLE
test infra: isolate + restore tests mutating the global Common.Convert<,> converter

### DIFF
--- a/Tests/Linq/Common/ConvertTests.cs
+++ b/Tests/Linq/Common/ConvertTests.cs
@@ -31,21 +31,28 @@ namespace Tests.Common
 
 		// NonParallelizable: mutates the process-global Common.Convert<TFrom,TTo> converter, which
 		// Sql.Convert / ConvertTo read across all tests - would corrupt concurrent conversion-sensitive
-		// tests under parallel execution. Restored at the end of the test.
+		// tests under parallel execution. Restored in a finally so a failed assertion can't leak it.
 		[Test, NonParallelizable]
 		public void SetExpression()
 		{
-			Convert<int,string>.Lambda = i => (i * 2).ToString();
+			try
+			{
+				Convert<int,string>.Lambda = i => (i * 2).ToString();
 
-			Assert.That(Convert<int,string>.From(2), Is.EqualTo("4"));
+				Assert.That(Convert<int,string>.From(2), Is.EqualTo("4"));
 
-			Convert<int,string>.Expression = i => (i * 3).ToString();
+				Convert<int,string>.Expression = i => (i * 3).ToString();
 
-			Assert.That(Convert<int,string>.From(3), Is.EqualTo("9"));
+				Assert.That(Convert<int,string>.From(3), Is.EqualTo("9"));
 
-			Convert<int,string>.Lambda = null;
+				Convert<int,string>.Lambda = null;
 
-			Assert.That(Convert<int,string>.From(1), Is.EqualTo("1"));
+				Assert.That(Convert<int,string>.From(1), Is.EqualTo("1"));
+			}
+			finally
+			{
+				Convert<int,string>.Lambda = null;
+			}
 		}
 
 		[Test]
@@ -150,18 +157,23 @@ namespace Tests.Common
 
 		// NonParallelizable: mutates the process-global Common.Convert<TFrom,TTo> converter, which
 		// Sql.Convert / ConvertTo read across all tests - would corrupt concurrent conversion-sensitive
-		// tests under parallel execution. Restored at the end of the test.
+		// tests under parallel execution. Restored in a finally so a failed assertion can't leak it.
 		[Test, NonParallelizable]
 		public void ToStringTest()
 		{
-			Convert<DateTime,string>.Expression = d => d.ToString(DateTimeFormatInfo.InvariantInfo);
-			using (Assert.EnterMultipleScope())
+			try
 			{
-				Assert.That(ConvertTo<string>.From(10), Is.EqualTo("10"));
-				Assert.That(ConvertTo<string>.From(new DateTime(2012, 1, 20, 16, 20, 30, 40, DateTimeKind.Utc)), Is.EqualTo("01/20/2012 16:20:30"));
+				Convert<DateTime,string>.Expression = d => d.ToString(DateTimeFormatInfo.InvariantInfo);
+				using (Assert.EnterMultipleScope())
+				{
+					Assert.That(ConvertTo<string>.From(10), Is.EqualTo("10"));
+					Assert.That(ConvertTo<string>.From(new DateTime(2012, 1, 20, 16, 20, 30, 40, DateTimeKind.Utc)), Is.EqualTo("01/20/2012 16:20:30"));
+				}
 			}
-
-			Convert<DateTime,string>.Expression = null;
+			finally
+			{
+				Convert<DateTime,string>.Expression = null;
+			}
 		}
 
 		[Test]

--- a/Tests/Linq/Common/ConvertTests.cs
+++ b/Tests/Linq/Common/ConvertTests.cs
@@ -29,7 +29,10 @@ namespace Tests.Common
 			}
 		}
 
-		[Test]
+		// NonParallelizable: mutates the process-global Common.Convert<TFrom,TTo> converter, which
+		// Sql.Convert / ConvertTo read across all tests - would corrupt concurrent conversion-sensitive
+		// tests under parallel execution. Restored at the end of the test.
+		[Test, NonParallelizable]
 		public void SetExpression()
 		{
 			Convert<int,string>.Lambda = i => (i * 2).ToString();
@@ -145,7 +148,10 @@ namespace Tests.Common
 			}
 		}
 
-		[Test]
+		// NonParallelizable: mutates the process-global Common.Convert<TFrom,TTo> converter, which
+		// Sql.Convert / ConvertTo read across all tests - would corrupt concurrent conversion-sensitive
+		// tests under parallel execution. Restored at the end of the test.
+		[Test, NonParallelizable]
 		public void ToStringTest()
 		{
 			Convert<DateTime,string>.Expression = d => d.ToString(DateTimeFormatInfo.InvariantInfo);

--- a/Tests/Linq/Mapping/MappingSchemaTests.cs
+++ b/Tests/Linq/Mapping/MappingSchemaTests.cs
@@ -90,51 +90,56 @@ namespace Tests.Mapping
 
 		// NonParallelizable: mutates the process-global Common.Convert<TFrom,TTo> converter, which
 		// Sql.Convert / ConvertTo read across all tests - would corrupt concurrent conversion-sensitive
-		// tests under parallel execution. Restored at the end of the test.
+		// tests under parallel execution. Restored in a finally so a failed assertion can't leak it.
 		[Test, NonParallelizable]
 		public void BaseSchema2()
 		{
 			var ms1 = new MappingSchema();
 			var ms2 = new MappingSchema(ms1);
 
-			Convert<DateTime,string>.Lambda = d => d.ToString(DateTimeFormatInfo.InvariantInfo);
-
-			ms1.SetConverter<DateTime,string>(d => d.ToString("M\\/d\\/yyyy h:mm:ss", System.Globalization.CultureInfo.InvariantCulture));
-			ms2.SetConverter<DateTime,string>(d => d.ToString("dd.MM.yyyy HH:mm:ss",  System.Globalization.CultureInfo.InvariantCulture));
-
+			try
 			{
-				var c0 = Convert<DateTime,string>.Lambda;
-				var c1 = ms1.GetConverter<DateTime,string>()!;
-				var c2 = ms2.GetConverter<DateTime,string>()!;
-				using (Assert.EnterMultipleScope())
+				Convert<DateTime,string>.Lambda = d => d.ToString(DateTimeFormatInfo.InvariantInfo);
+
+				ms1.SetConverter<DateTime,string>(d => d.ToString("M\\/d\\/yyyy h:mm:ss", System.Globalization.CultureInfo.InvariantCulture));
+				ms2.SetConverter<DateTime,string>(d => d.ToString("dd.MM.yyyy HH:mm:ss",  System.Globalization.CultureInfo.InvariantCulture));
+
 				{
-					Assert.That(c0(new DateTime(2012, 1, 20, 16, 30, 40, 50, DateTimeKind.Utc)), Is.EqualTo("01/20/2012 16:30:40"));
-					Assert.That(c1(new DateTime(2012, 1, 20, 16, 30, 40, 50, DateTimeKind.Utc)), Is.EqualTo("1/20/2012 4:30:40"));
-					Assert.That(c2(new DateTime(2012, 1, 20, 16, 30, 40, 50, DateTimeKind.Utc)), Is.EqualTo("20.01.2012 16:30:40"));
+					var c0 = Convert<DateTime,string>.Lambda;
+					var c1 = ms1.GetConverter<DateTime,string>()!;
+					var c2 = ms2.GetConverter<DateTime,string>()!;
+					using (Assert.EnterMultipleScope())
+					{
+						Assert.That(c0(new DateTime(2012, 1, 20, 16, 30, 40, 50, DateTimeKind.Utc)), Is.EqualTo("01/20/2012 16:30:40"));
+						Assert.That(c1(new DateTime(2012, 1, 20, 16, 30, 40, 50, DateTimeKind.Utc)), Is.EqualTo("1/20/2012 4:30:40"));
+						Assert.That(c2(new DateTime(2012, 1, 20, 16, 30, 40, 50, DateTimeKind.Utc)), Is.EqualTo("20.01.2012 16:30:40"));
+					}
+				}
+
+				Convert<string,DateTime>.Expression = s => DateTime.Parse(s, DateTimeFormatInfo.InvariantInfo);
+
+				ms1.SetConvertExpression<string,DateTime>(s => DateTime.Parse(s, new CultureInfo("en-US", false).DateTimeFormat));
+				ms2.SetConvertExpression<string,DateTime>(s => DateTime.Parse(s, new CultureInfo("ru-RU", false).DateTimeFormat));
+
+				{
+					var c0 = Convert<string,DateTime>.Lambda;
+					var c1 = ms1.GetConverter<string,DateTime>()!;
+					var c2 = ms2.GetConverter<string,DateTime>()!;
+					using (Assert.EnterMultipleScope())
+					{
+						Assert.That(c0("01/20/2012 16:30:40"), Is.EqualTo(new DateTime(2012, 1, 20, 16, 30, 40)));
+						Assert.That(c1("1/20/2012 4:30:40 PM"), Is.EqualTo(new DateTime(2012, 1, 20, 16, 30, 40)));
+						Assert.That(c2("20.01.2012 16:30:40"), Is.EqualTo(new DateTime(2012, 1, 20, 16, 30, 40)));
+					}
 				}
 			}
-
-			Convert<string,DateTime>.Expression = s => DateTime.Parse(s, DateTimeFormatInfo.InvariantInfo);
-
-			ms1.SetConvertExpression<string,DateTime>(s => DateTime.Parse(s, new CultureInfo("en-US", false).DateTimeFormat));
-			ms2.SetConvertExpression<string,DateTime>(s => DateTime.Parse(s, new CultureInfo("ru-RU", false).DateTimeFormat));
-
+			finally
 			{
-				var c0 = Convert<string,DateTime>.Lambda;
-				var c1 = ms1.GetConverter<string,DateTime>()!;
-				var c2 = ms2.GetConverter<string,DateTime>()!;
-				using (Assert.EnterMultipleScope())
-				{
-					Assert.That(c0("01/20/2012 16:30:40"), Is.EqualTo(new DateTime(2012, 1, 20, 16, 30, 40)));
-					Assert.That(c1("1/20/2012 4:30:40 PM"), Is.EqualTo(new DateTime(2012, 1, 20, 16, 30, 40)));
-					Assert.That(c2("20.01.2012 16:30:40"), Is.EqualTo(new DateTime(2012, 1, 20, 16, 30, 40)));
-				}
+				// Restore the process-global converters this test overrode; otherwise they leak to every
+				// later test (e.g. ConvertTests.ToSqlTime would resolve string->DateTime via DateTime.Parse).
+				Convert<DateTime,string>.Lambda     = null;
+				Convert<string,DateTime>.Expression = null;
 			}
-
-			// Restore the process-global converters this test overrode; otherwise they leak to every
-			// later test (e.g. ConvertTests.ToSqlTime would resolve string->DateTime via DateTime.Parse).
-			Convert<DateTime,string>.Lambda     = null;
-			Convert<string,DateTime>.Expression = null;
 		}
 
 		[Test]

--- a/Tests/Linq/Mapping/MappingSchemaTests.cs
+++ b/Tests/Linq/Mapping/MappingSchemaTests.cs
@@ -88,7 +88,10 @@ namespace Tests.Mapping
 			}
 		}
 
-		[Test]
+		// NonParallelizable: mutates the process-global Common.Convert<TFrom,TTo> converter, which
+		// Sql.Convert / ConvertTo read across all tests - would corrupt concurrent conversion-sensitive
+		// tests under parallel execution. Restored at the end of the test.
+		[Test, NonParallelizable]
 		public void BaseSchema2()
 		{
 			var ms1 = new MappingSchema();
@@ -127,6 +130,11 @@ namespace Tests.Mapping
 					Assert.That(c2("20.01.2012 16:30:40"), Is.EqualTo(new DateTime(2012, 1, 20, 16, 30, 40)));
 				}
 			}
+
+			// Restore the process-global converters this test overrode; otherwise they leak to every
+			// later test (e.g. ConvertTests.ToSqlTime would resolve string->DateTime via DateTime.Parse).
+			Convert<DateTime,string>.Lambda     = null;
+			Convert<string,DateTime>.Expression = null;
 		}
 
 		[Test]


### PR DESCRIPTION
Pre-flight cleanup for #5614 (parallel test execution).

### Problem

Client-side `Sql.Convert(...)` / `ConvertTo<>.From` read the **process-global** `Common.Convert<TFrom,TTo>` static converter. Two tests overwrite it globally:

- **`MappingSchemaTests.BaseSchema2`** sets `Convert<DateTime,string>.Lambda` and `Convert<string,DateTime>.Expression` and **never restores them**. That permanently flips e.g. string→`DateTime` to `DateTime.Parse`, so a time-only string ("9:01:01") resolves to **today's date** instead of min-date.
- **`Common.ConvertTests.SetExpression` / `ToStringTest`** set `Convert<int,string>` / `Convert<DateTime,string>` (these already reset, but weren't isolated).

Serially this is masked by fixture ordering (`Tests.Linq.ConvertTests` runs before `Tests.Mapping.MappingSchemaTests`); under **parallel** execution it corrupts concurrent conversion-sensitive tests — `ConvertTests.ToSqlTime`/`ToSqlTimeSql` resolved a today-dated value against the DB's min-date on every real-`TIME` provider.

### Change

Mark the three tests `[NonParallelizable]` (so they don't run alongside conversion-sensitive tests) **and** restore the global converters after the test — `BaseSchema2` was missing the restore entirely (a latent bug even serially).

Verified red→green locally on MySQL under the parallel harness: `ConvertTests` + `MappingSchemaTests` + `Common.ConvertTests` went from `ToSqlTime` failing → **432/432 passing**. No production code touched.
