### PR TITLE
Fix fluent IsExpression on a nested/complex property

### DIFF
--- a/Source/LinqToDB/Mapping/PropertyMappingBuilder.cs
+++ b/Source/LinqToDB/Mapping/PropertyMappingBuilder.cs
@@ -477,7 +477,21 @@ namespace LinqToDB.Mapping
 		{
 			ArgumentNullException.ThrowIfNull(expression);
 
-			return HasAttribute(new ExpressionMethodAttribute(expression) { IsColumn = isColumn, Alias = alias }).IsNotColumn();
+			LambdaExpression lambda = expression;
+
+			// For a nested/complex property path (e.g. c => c.Address.Postcode) the column lives on the
+			// complex type, not on TEntity. Rebase the expression's parameter from TEntity to that owner
+			// type so the materialization-time substitution binds it to the nested object root; otherwise
+			// ExposeExpressionVisitor.ConvertMemberExpression throws "Can't convert <param> to expression".
+			if (_memberInfo.ReflectedType != null && _memberInfo.ReflectedType != typeof(TEntity))
+			{
+				var oldParameter = expression.Parameters[0];
+				var newParameter = Expression.Parameter(_memberInfo.ReflectedType, oldParameter.Name);
+
+				lambda = Expression.Lambda(expression.Body.Replace(oldParameter, newParameter), newParameter);
+			}
+
+			return HasAttribute(new ExpressionMethodAttribute(lambda) { IsColumn = isColumn, Alias = alias }).IsNotColumn();
 		}
 
 		/// <summary>

--- a/Tests/Linq/Linq/DynamicColumnsTests.cs
+++ b/Tests/Linq/Linq/DynamicColumnsTests.cs
@@ -823,40 +823,6 @@ namespace Tests.Linq
 			}
 		}
 
-		#region Issue 4770
-
-		sealed class Issue4770Person
-		{
-			public int Id { get; set; }
-			public Issue4770Address? Address { get; set; }
-			public string ?TestPostcode { get; set; }
-		}
-
-		sealed class Issue4770Address
-		{
-			public string? Postcode { get; set; }
-		}
-
-		[ActiveIssue]
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/4770")]
-		public void Issue4770([DataSources] string context)
-		{
-			var ms = new MappingSchema();
-			var fb = new FluentMappingBuilder(ms);
-			fb.Entity<Issue4770Person>()
-				.Property(c => c.Id).IsPrimaryKey()
-				.Property(c => c.Address!.Postcode).IsExpression(c => Sql.Upper(Sql.Property<string>(c, "Postcode")), true).IsColumn()
-				.Property(c => c.TestPostcode).IsExpression(c => Sql.Upper(Sql.Property<string>(c, "Postcode")), true);
-
-			fb.Build();
-
-			using var db = GetDataContext(context, ms);
-			using var tb = db.CreateLocalTable<Issue4770Person>();
-
-			tb.ToArray();
-		}
-		#endregion
-
 		sealed class ConvertTable
 		{
 			[PrimaryKey] public int Id { get; set; }

--- a/Tests/Linq/Mapping/FluentMappingExpressionMethodTests.cs
+++ b/Tests/Linq/Mapping/FluentMappingExpressionMethodTests.cs
@@ -195,6 +195,46 @@ namespace Tests.Mapping
 			Assert.That(row.Mid?.Leaf, Is.Not.Null);
 			Assert.That(row.Mid!.Leaf!.Upper, Is.EqualTo("ABC"));
 		}
+
+		sealed class MixedExpr
+		{
+			public int            Id        { get; set; }
+			public string?        TopSource { get; set; }
+			public string?        TopUpper  { get; set; }
+			public MixedExprPart? Part      { get; set; }
+		}
+
+		sealed class MixedExprPart
+		{
+			public string? Source { get; set; }
+			public string? Upper  { get; set; }
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4770")]
+		public void ExpressionMethodOnNestedAndNonNestedProperty([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			var ms = new MappingSchema();
+			var fb = new FluentMappingBuilder(ms);
+
+			fb.Entity<MixedExpr>()
+				.Property(e => e.Id).IsPrimaryKey()
+				.Property(e => e.TopSource)
+				.Property(e => e.TopUpper).IsExpression(e => Sql.Upper(Sql.Property<string>(e, "TopSource")), true).IsColumn()
+				.Property(e => e.Part!.Source)
+				.Property(e => e.Part!.Upper).IsExpression(p => Sql.Upper(Sql.Property<string>(p, "Source")), true).IsColumn()
+				.Build();
+
+			using var db = GetDataContext(context, ms);
+			using var tb = db.CreateLocalTable<MixedExpr>();
+
+			db.Insert(new MixedExpr { Id = 1, TopSource = "abc", Part = new MixedExprPart { Source = "xyz" } });
+
+			var row = tb.Single();
+
+			Assert.That(row.TopUpper,    Is.EqualTo("ABC"));
+			Assert.That(row.Part,        Is.Not.Null);
+			Assert.That(row.Part!.Upper, Is.EqualTo("XYZ"));
+		}
 		#endregion
 	}
 }

--- a/Tests/Linq/Mapping/FluentMappingExpressionMethodTests.cs
+++ b/Tests/Linq/Mapping/FluentMappingExpressionMethodTests.cs
@@ -92,5 +92,109 @@ namespace Tests.Mapping
 
 			AreEqualWithComparer(expected, meterialized);
 		}
+
+		#region IsExpression on a nested/complex property (regression for #4770)
+
+		sealed class NestedExpr
+		{
+			public int             Id   { get; set; }
+			public NestedExprPart? Part { get; set; }
+		}
+
+		sealed class NestedExprPart
+		{
+			public string? Source { get; set; }
+			public string? Upper  { get; set; }
+		}
+
+		// Fluent IsExpression on a nested-property path (Part.Upper): the expression parameter is rebased
+		// from the entity (NestedExpr) to the owner type (NestedExprPart) so Sql.Property(p, "Source")
+		// resolves against the complex type. materialized = expose it as a calculated column.
+		static MappingSchema BuildNestedExprSchema(bool materialized)
+		{
+			var ms = new MappingSchema();
+			var fb = new FluentMappingBuilder(ms);
+
+			var upper = fb.Entity<NestedExpr>()
+				.Property(e => e.Id).IsPrimaryKey()
+				.Property(e => e.Part!.Source)
+				.Property(e => e.Part!.Upper).IsExpression(p => Sql.Upper(Sql.Property<string>(p, "Source")), materialized);
+
+			if (materialized)
+				upper.IsColumn();
+
+			fb.Build();
+
+			return ms;
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4770")]
+		public void ExpressionMethodOnNestedProperty([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataContext(context, BuildNestedExprSchema(materialized: true));
+			using var tb = db.CreateLocalTable<NestedExpr>();
+
+			db.Insert(new NestedExpr { Id = 1, Part = new NestedExprPart { Source = "abc" } });
+
+			var row = tb.Single();
+
+			Assert.That(row.Part, Is.Not.Null);
+			Assert.That(row.Part!.Upper, Is.EqualTo("ABC"));
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4770")]
+		public void ExpressionMethodOnNestedProperty_InFilter([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataContext(context, BuildNestedExprSchema(materialized: false));
+			using var tb = db.CreateLocalTable<NestedExpr>();
+
+			db.Insert(new NestedExpr { Id = 1, Part = new NestedExprPart { Source = "abc" } });
+			db.Insert(new NestedExpr { Id = 2, Part = new NestedExprPart { Source = "xyz" } });
+
+			var ids = tb.Where(e => e.Part!.Upper == "ABC").Select(e => e.Id).ToList();
+
+			Assert.That(ids, Is.EqualTo(new[] { 1 }));
+		}
+
+		sealed class DeepNestedExpr
+		{
+			public int               Id  { get; set; }
+			public DeepNestedExprMid? Mid { get; set; }
+		}
+
+		sealed class DeepNestedExprMid
+		{
+			public DeepNestedExprLeaf? Leaf { get; set; }
+		}
+
+		sealed class DeepNestedExprLeaf
+		{
+			public string? Source { get; set; }
+			public string? Upper  { get; set; }
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4770")]
+		public void ExpressionMethodOnDeeplyNestedProperty([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			var ms = new MappingSchema();
+			var fb = new FluentMappingBuilder(ms);
+
+			fb.Entity<DeepNestedExpr>()
+				.Property(e => e.Id).IsPrimaryKey()
+				.Property(e => e.Mid!.Leaf!.Source)
+				.Property(e => e.Mid!.Leaf!.Upper).IsExpression(l => Sql.Upper(Sql.Property<string>(l, "Source")), true).IsColumn()
+				.Build();
+
+			using var db = GetDataContext(context, ms);
+			using var tb = db.CreateLocalTable<DeepNestedExpr>();
+
+			db.Insert(new DeepNestedExpr { Id = 1, Mid = new DeepNestedExprMid { Leaf = new DeepNestedExprLeaf { Source = "abc" } } });
+
+			var row = tb.Single();
+
+			Assert.That(row.Mid?.Leaf, Is.Not.Null);
+			Assert.That(row.Mid!.Leaf!.Upper, Is.EqualTo("ABC"));
+		}
+		#endregion
 	}
 }


### PR DESCRIPTION
Fixes #4770

Fluent `IsExpression` on a nested property (e.g. `c => c.Address.Postcode`) threw
`LinqToDBException: Can't convert c to expression.` during query build.

## Cause
`IsExpression<TR>(Expression<Func<TEntity, TR>>)` types the lambda parameter as the
entity, but attaches the `ExpressionMethodAttribute` to the leaf member on the complex
type. At materialization `ExposeExpressionVisitor.ConvertMemberExpression` substitutes
the parameter with the nested object root, and its guard
`wpi.Type.IsSameOrParentOf(root.Type)` rejects the entity-typed parameter against the
nested (`Address`) root.

## Fix
In `PropertyMappingBuilder.IsExpression`, when the property path is nested, rebase the
lambda parameter from `TEntity` to the leaf member's owner type, so the stored attribute
is internally consistent and the existing substitution guard binds it correctly.

## Tests
`FluentMappingExpressionMethodTests` (SQLite-only, infrastructure):
- `ExpressionMethodOnNestedProperty` — materialized nested computed column
- `ExpressionMethodOnNestedProperty_InFilter` — query-only nested expression in `WHERE`
- `ExpressionMethodOnDeeplyNestedProperty` — 2-level nesting

Moved the regression out of `DynamicColumnsTests` (its subject is fluent `IsExpression`, not dynamic columns).
