### PR TITLE
Fix Release build (SQLite e_sqlite3 CVE suppression + NUnit1028 regression)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -234,6 +234,13 @@
 			https://github.com/advisories/GHSA-x5qj-9vmx-7g6g;
 			https://github.com/advisories/GHSA-xhfc-gr8f-ffwc" />
 
+		<!--
+		CVE-2025-6965 / GHSA-2m69-gcr7-jv3q: SQLite before 3.50.2. The transitive native package
+		SQLitePCLRaw.lib.e_sqlite3 (<= 2.1.11, via Microsoft.Data.Sqlite / Microsoft.EntityFrameworkCore.Sqlite)
+		has no patched release. Tests and LINQPad reference SourceGear.sqlite3 (>= 3.50.2) for a patched native binary.
+		-->
+		<NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+
 		<PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core"              Version="$(AspNetCoreLegacyVersion)"   Condition="'$(TargetFramework)'=='net462'" />
 		<PackageVersion Include="Microsoft.Bcl.Memory"                                  Version="$(Net9Latest)"                Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" />
 		<PackageVersion Include="Microsoft.Bcl.Memory"                                  Version="$(Net10Latest)"               Condition="'$(TargetFramework)'=='net10.0'" />

--- a/Tests/Linq/UserTests/Issue5616Tests.cs
+++ b/Tests/Linq/UserTests/Issue5616Tests.cs
@@ -40,7 +40,7 @@ namespace Tests.UserTests
 		}
 
 		[Sql.Extension("count_if({predicate})", IsAggregate = true, ServerSideOnly = true)]
-		public static long CountIf<TSource>(IEnumerable<TSource> src, [ExprParameter] Expression<Func<TSource, bool>> predicate)
+		private static long CountIf<TSource>(IEnumerable<TSource> src, [ExprParameter] Expression<Func<TSource, bool>> predicate)
 		{
 			throw new InvalidOperationException();
 		}


### PR DESCRIPTION
## Release build is broken on master

`dotnet build linq2db.slnx -c Release` fails on two unrelated issues; this PR fixes both.

### 1. SQLite native library vulnerability (NU1903)
Transitive `SQLitePCLRaw.lib.e_sqlite3` 2.1.11 (via `Microsoft.Data.Sqlite` / `Microsoft.EntityFrameworkCore.Sqlite`) is flagged by [CVE-2025-6965](https://github.com/advisories/GHSA-2m69-gcr7-jv3q) (SQLite < 3.50.2). The advisory lists **no patched package** — `lib.e_sqlite3` <= 2.1.11 is entirely affected, so there is nothing to upgrade to. Added the advisory to the existing `NuGetAuditSuppress` group in `Directory.Packages.props`. The runtime native binary is already overridden with `SourceGear.sqlite3` 3.50.4.5 (>= 3.50.2) where SQLite is exercised (tests, LINQPad).

### 2. NUnit1028 in Issue5616Tests (regression from #5619)
`CountIf` is a `[Sql.Extension]` helper declared `public` inside a `[TestFixture]`; NUnit1028 errors under Release `TreatWarningsAsErrors`. Analyzers run only in Release, so #5619's Debug/Testing CI did not catch it. Made it `private` (referenced only within the same class).

After both fixes: `Build succeeded. 0 Warning(s), 0 Error(s)`.
