### PR TITLE
Fix Release build: remove duplicate GHSA-2m69-gcr7-jv3q audit suppression

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -233,11 +233,6 @@
 			https://github.com/advisories/GHSA-5f2m-466j-3848;
 			https://github.com/advisories/GHSA-x5qj-9vmx-7g6g;
 			https://github.com/advisories/GHSA-xhfc-gr8f-ffwc" />
-		<!--
-			TODO: paste Genius meme here about MS
-			https://github.com/dotnet/efcore/issues/38257
-			-->
-		<NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
 
 		<!--
 		CVE-2025-6965 / GHSA-2m69-gcr7-jv3q: SQLite before 3.50.2. The transitive native package


### PR DESCRIPTION
## Problem

The `Release` build fails at NuGet restore for all 47 projects:

> NU1508: Duplicate 'NuGetAuditSuppress' items found ... GHSA-2m69-gcr7-jv3q

`TreatWarningsAsErrors` promotes NU1508 to an error, so restore aborts before any compilation runs.

## Cause

A merge race between two recently-merged PRs that each added a suppression for the SQLite `e_sqlite3` CVE (`GHSA-2m69-gcr7-jv3q`) in `Directory.Packages.props`:

- #5636 — documented CVE block
- #5637 — duplicate, placeholder comment

## Fix

Remove the duplicate added in #5637; keep the documented block from #5636. The CVE stays suppressed — only the redundant entry is dropped.

Verified: `dotnet build linq2db.slnx -c Release` now builds clean (0 warnings, 0 errors).
