### PR TITLE
Remove NonParallelizable attribute from tests

### DIFF
--- a/Tests/Linq/Common/ConvertTests.cs
+++ b/Tests/Linq/Common/ConvertTests.cs
@@ -29,10 +29,7 @@ namespace Tests.Common
 			}
 		}
 
-		// NonParallelizable: mutates the process-global Common.Convert<TFrom,TTo> converter, which
-		// Sql.Convert / ConvertTo read across all tests - would corrupt concurrent conversion-sensitive
-		// tests under parallel execution. Restored in a finally so a failed assertion can't leak it.
-		[Test, NonParallelizable]
+		[Test]
 		public void SetExpression()
 		{
 			try
@@ -155,10 +152,7 @@ namespace Tests.Common
 			}
 		}
 
-		// NonParallelizable: mutates the process-global Common.Convert<TFrom,TTo> converter, which
-		// Sql.Convert / ConvertTo read across all tests - would corrupt concurrent conversion-sensitive
-		// tests under parallel execution. Restored in a finally so a failed assertion can't leak it.
-		[Test, NonParallelizable]
+		[Test]
 		public void ToStringTest()
 		{
 			try

--- a/Tests/Linq/Infrastructure/DataOptionsTests.cs
+++ b/Tests/Linq/Infrastructure/DataOptionsTests.cs
@@ -776,7 +776,7 @@ namespace Tests.Infrastructure
 			new DataOptions().UseDefaultNullsPosition(Sql.NullsPosition.First).SqlOptions.DefaultNullsPosition.ShouldBe(Sql.NullsPosition.First);
 		}
 
-		[Test, NonParallelizable]
+		[Test]
 		public void ConfigurationSqlDefaultNullsPositionTest()
 		{
 			// MIN006: the process-global static getter/setter, and its propagation to freshly-built DataOptions.

--- a/Tests/Linq/Linq/AnalyticTests.cs
+++ b/Tests/Linq/Linq/AnalyticTests.cs
@@ -18,7 +18,7 @@ using Tests.Model;
 
 namespace Tests.Linq
 {
-	[TestFixture, NonParallelizable]
+	[TestFixture]
 	public class AnalyticTests : TestBase
 	{
 		[Test]

--- a/Tests/Linq/Linq/DataContextTests.cs
+++ b/Tests/Linq/Linq/DataContextTests.cs
@@ -54,7 +54,7 @@ namespace Tests.Linq
 			}
 		}
 
-		[Test, NonParallelizable]
+		[Test]
 		public void TestNullConfiguration_Unset([Values] bool cleanDefault)
 		{
 			var connectionString = GetConnectionString(ProviderName.SQLiteClassic);
@@ -66,7 +66,7 @@ namespace Tests.Linq
 			_ = db.GetTable<Person>().ToArray();
 		}
 
-		[Test, NonParallelizable]
+		[Test]
 		public void TestNullConfiguration_UnsetRemote([Values] bool cleanDefault)
 		{
 			if (TestConfiguration.DisableRemoteContext) Assert.Ignore("Remote context disabled");
@@ -82,7 +82,7 @@ namespace Tests.Linq
 			_ = db.GetTable<Person>().ToArray();
 		}
 
-		[Test, NonParallelizable]
+		[Test]
 		public void TestNullConfiguration_SetNull([Values] bool cleanDefault)
 		{
 			var connectionString = GetConnectionString(ProviderName.SQLiteClassic);
@@ -94,7 +94,7 @@ namespace Tests.Linq
 			_ = db.GetTable<Person>().ToArray();
 		}
 
-		[Test, NonParallelizable]
+		[Test]
 		public void TestNullConfiguration_SetNullRemote([Values] bool cleanDefault)
 		{
 			if (TestConfiguration.DisableRemoteContext) Assert.Ignore("Remote context disabled");

--- a/Tests/Linq/Mapping/MappingSchemaTests.cs
+++ b/Tests/Linq/Mapping/MappingSchemaTests.cs
@@ -88,10 +88,7 @@ namespace Tests.Mapping
 			}
 		}
 
-		// NonParallelizable: mutates the process-global Common.Convert<TFrom,TTo> converter, which
-		// Sql.Convert / ConvertTo read across all tests - would corrupt concurrent conversion-sensitive
-		// tests under parallel execution. Restored in a finally so a failed assertion can't leak it.
-		[Test, NonParallelizable]
+		[Test]
 		public void BaseSchema2()
 		{
 			var ms1 = new MappingSchema();


### PR DESCRIPTION
## What

Removes the `[NonParallelizable]` / `[TestFixture, NonParallelizable]` markers across the test suite, plus the comment blocks that justified them:

- `Tests/Linq/Common/ConvertTests.cs`
- `Tests/Linq/Mapping/MappingSchemaTests.cs`
- `Tests/Linq/Linq/DataContextTests.cs`
- `Tests/Linq/Linq/AnalyticTests.cs`
- `Tests/Linq/Infrastructure/DataOptionsTests.cs`

## Why

The marks were added on `master` ahead of the parallel-test-execution work (#5614). They're being dropped so parallelism is governed by a single mechanism rather than scattered `[NonParallelizable]` attributes. The global-state save/restore (in a `finally`) those tests already perform stays in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
