### PR TITLE
Resolve value-converter column DB type from the converter provider type

### DIFF
--- a/Source/LinqToDB/Mapping/ColumnDescriptor.cs
+++ b/Source/LinqToDB/Mapping/ColumnDescriptor.cs
@@ -417,7 +417,13 @@ namespace LinqToDB.Mapping
 			DbDataType? dbDataType = null;
 
 			if (completeDataType && dataType == DataType.Undefined)
-				dbDataType = CalculateDbDataType(MappingSchema, systemType);
+				// When a ValueConverter is present, resolve the DB type from the converter's *provider* type
+				// against this descriptor's (active, provider-inclusive) MappingSchema rather than the member
+				// type - so e.g. an F# 'decimal option' (provider type Nullable<decimal>) picks up the
+				// provider's decimal(18,10) and 'string option' the provider's preferred string type. The
+				// member type often has no DB type of its own (the converter is what maps it to a column).
+				// Falls back to the member type when there is no converter.
+				dbDataType = CalculateDbDataType(MappingSchema, ValueConverter?.ToProviderExpression.Body.Type ?? systemType);
 
 			return new DbDataType(systemType, dbDataType?.DataType ?? dataType, DbType ?? dbDataType?.DbType, Length ?? dbDataType?.Length, Precision ?? dbDataType?.Precision, Scale ?? dbDataType?.Scale);
 		}

--- a/Tests/Linq/Mapping/ValueConverterColumnDbTypeTests.cs
+++ b/Tests/Linq/Mapping/ValueConverterColumnDbTypeTests.cs
@@ -1,0 +1,69 @@
+using System.Linq;
+
+using LinqToDB;
+using LinqToDB.Common;
+using LinqToDB.Mapping;
+using LinqToDB.SqlQuery;
+
+using NUnit.Framework;
+
+namespace Tests.Mapping
+{
+	[TestFixture]
+	public class ValueConverterColumnDbTypeTests : TestBase
+	{
+		sealed class Money
+		{
+			public decimal Amount { get; set; }
+		}
+
+		sealed class MoneyToDecimalConverter() : ValueConverter<Money, decimal>(
+			m => m.Amount, d => new Money { Amount = d }, false);
+
+		sealed class PriceEntity
+		{
+			[Column]
+			public int Id { get; set; }
+
+			// No explicit DataType: the column's DB type must be resolved from the value converter's
+			// provider type (decimal) against the active mapping schema, not from the member type (Money,
+			// which has no DB type of its own).
+			[Column, ValueConverter(ConverterType = typeof(MoneyToDecimalConverter))]
+			public Money Price { get; set; } = null!;
+		}
+
+		[Test]
+		public void ConverterColumn_ResolvesDbTypeFromProviderType()
+		{
+			var ms  = new MappingSchema();
+			var ed  = ms.GetEntityDescriptor(typeof(PriceEntity));
+			var col = ed.Columns.Single(c => c.MemberName == nameof(PriceEntity.Price));
+
+			var dbType = col.GetDbDataType(true);
+
+			// Without the fix this is DataType.Undefined: the type is resolved from Money (the member
+			// type), which has no registered DB type, instead of from the converter's provider type.
+			Assert.That(dbType.DataType, Is.EqualTo(DataType.Decimal));
+		}
+
+		[Test]
+		public void ConverterColumn_PropagatesProviderPrecisionAndScale()
+		{
+			var ms = new MappingSchema();
+			// Provider-faithful decimal facets registered on the active schema for the element type.
+			ms.SetDataType(typeof(decimal), new SqlDataType(DataType.Decimal, typeof(decimal), 18, 10));
+
+			var ed  = ms.GetEntityDescriptor(typeof(PriceEntity));
+			var col = ed.Columns.Single(c => c.MemberName == nameof(PriceEntity.Price));
+
+			var dbType = col.GetDbDataType(true);
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(dbType.DataType,  Is.EqualTo(DataType.Decimal));
+				Assert.That(dbType.Precision, Is.EqualTo(18));
+				Assert.That(dbType.Scale,     Is.EqualTo(10));
+			});
+		}
+	}
+}


### PR DESCRIPTION
## Summary

A column with a `ValueConverter` but no explicit `DataType` resolved its DB type from the
**member (model) type**, which usually has no DB type of its own — so the column fell back to
`Undefined` and dropped the element's facets (precision/scale/length).

Most visibly, an F# `decimal option` (provider type `Nullable<decimal>`) collapsed to a bare
`Decimal` and silently truncated scale on strict providers instead of the provider's
`decimal(18,10)`; `string option` likewise ignored the provider's preferred string type.

## Fix

In `ColumnDescriptor.GetDbDataType`, when no explicit `DataType` is set, resolve the DB type from
the converter's **provider type** (`ToProviderExpression` result type) against the descriptor's
active, provider-inclusive `MappingSchema` — falling back to the member type when there is no
converter.

## Impact

- Affects every value-converter column with an undefined `DataType` (enums, custom scalar
  converters, F# option columns). Such columns now pick up the provider-faithful element type and
  its facets. **Baselines will move** accordingly.
- No public-API surface change.

## Context

Surfaced reviewing #5624 (automatic F# `'T option` mapping, fixes #195 / #4646): the metadata
reader can only resolve against `MappingSchema.Default`, so provider precision was lost. This core
change lets the F# reader drop its explicit `DataType` and get provider-faithful option columns;
that follow-up rides on #5624's branch once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
