### PR TITLE
test infra: shrink CI test logs and retry only failed tests on unstable providers

### DIFF
--- a/Build/Azure/pipelines/templates/build-vars.yml
+++ b/Build/Azure/pipelines/templates/build-vars.yml
@@ -19,4 +19,4 @@ variables:
 # Per-test retry for crash/resource-unstable providers (access, oracle). MTP re-runs ONLY the
 # failed tests in-process, so a flaky failure no longer trips retryCountOnTaskFailure into a full
 # ~50-min leg re-run. The max-tests cap skips retry on mass failures (real breakage, not flakiness).
-  test_retry_args: '--retry-failed-tests 2 --retry-failed-tests-max-tests 25'
+  test_retry_args: '--retry-failed-tests 2 --retry-failed-tests-max-tests 5'

--- a/Build/Azure/pipelines/templates/build-vars.yml
+++ b/Build/Azure/pipelines/templates/build-vars.yml
@@ -16,3 +16,7 @@ variables:
   artifact_test_net80_binaries: 'test_net80_binaries'
   artifact_test_net90_binaries: 'test_net90_binaries'
   artifact_test_net100_binaries: 'test_net100_binaries'
+# Per-test retry for crash/resource-unstable providers (access, oracle). MTP re-runs ONLY the
+# failed tests in-process, so a flaky failure no longer trips retryCountOnTaskFailure into a full
+# ~50-min leg re-run. The max-tests cap skips retry on mass failures (real breakage, not flakiness).
+  test_retry_args: '--retry-failed-tests 2 --retry-failed-tests-max-tests 25'

--- a/Build/Azure/pipelines/templates/test-workflow-linux.yml
+++ b/Build/Azure/pipelines/templates/test-workflow-linux.yml
@@ -103,7 +103,7 @@ steps:
       git -C baselines reset --hard
       git -C baselines clean -fdq
     fi
-    dotnet ./net8.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net8.0/main/x64/.runsettings --report-trx --report-trx-filename net8.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
+    dotnet ./net8.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net8.0/main/x64/.runsettings --report-trx --report-trx-filename net8.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   condition: and(variables.title, eq(variables.net80, 'true'), succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 8): $(title)'
   retryCountOnTaskFailure: 2
@@ -156,7 +156,7 @@ steps:
       git -C baselines reset --hard
       git -C baselines clean -fdq
     fi
-    dotnet ./net9.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net9.0/main/x64/.runsettings --report-trx --report-trx-filename net9.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
+    dotnet ./net9.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net9.0/main/x64/.runsettings --report-trx --report-trx-filename net9.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   condition: and(variables.title, eq(variables.net90, 'true'), succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 9): $(title)'
   retryCountOnTaskFailure: 2
@@ -209,7 +209,7 @@ steps:
       git -C baselines reset --hard
       git -C baselines clean -fdq
     fi
-    dotnet ./net10.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net10.0/main/x64/.runsettings --report-trx --report-trx-filename net10.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
+    dotnet ./net10.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net10.0/main/x64/.runsettings --report-trx --report-trx-filename net10.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   condition: and(variables.title, eq(variables.net100, 'true'), succeeded(), eq(variables.retry, 'true'))
   displayName: 'Tests (.NET 10): $(title)'
   retryCountOnTaskFailure: 2

--- a/Build/Azure/pipelines/templates/test-workflow-macos.yml
+++ b/Build/Azure/pipelines/templates/test-workflow-macos.yml
@@ -94,7 +94,7 @@ steps:
       git -C baselines reset --hard
       git -C baselines clean -fdq
     fi
-    dotnet ./net8.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net8.0/main/x64/.runsettings --report-trx --report-trx-filename net8.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
+    dotnet ./net8.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net8.0/main/x64/.runsettings --report-trx --report-trx-filename net8.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   condition: and(variables.title, eq(variables.net80, 'true'), succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 8): $(title)'
   retryCountOnTaskFailure: 2
@@ -147,7 +147,7 @@ steps:
       git -C baselines reset --hard
       git -C baselines clean -fdq
     fi
-    dotnet ./net9.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net9.0/main/x64/.runsettings --report-trx --report-trx-filename net9.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
+    dotnet ./net9.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net9.0/main/x64/.runsettings --report-trx --report-trx-filename net9.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   condition: and(variables.title, eq(variables.net90, 'true'), succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 9): $(title)'
   retryCountOnTaskFailure: 2
@@ -200,7 +200,7 @@ steps:
       git -C baselines reset --hard
       git -C baselines clean -fdq
     fi
-    dotnet ./net10.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net10.0/main/x64/.runsettings --report-trx --report-trx-filename net10.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
+    dotnet ./net10.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net10.0/main/x64/.runsettings --report-trx --report-trx-filename net10.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   condition: and(variables.title, eq(variables.net100, 'true'), succeeded(), eq(variables.retry, 'true'))
   displayName: 'Tests (.NET 10): $(title)'
   retryCountOnTaskFailure: 2

--- a/Build/Azure/pipelines/templates/test-workflow-windows.yml
+++ b/Build/Azure/pipelines/templates/test-workflow-windows.yml
@@ -128,7 +128,7 @@ steps:
 - script: |
     if exist baselines\.git\ git -C baselines reset --hard
     if exist baselines\.git\ git -C baselines clean -fdq
-    $(netfx_tfm)\main\x86\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings $(netfx_tfm)\main\x86\.runsettings --report-trx --report-trx-filename netfx-main-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
+    $(netfx_tfm)\main\x86\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings $(netfx_tfm)\main\x86\.runsettings --report-trx --report-trx-filename netfx-main-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   displayName: 'Tests (NETFX): $(title)'
   condition: and(eq(variables.netfx, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'))
   retryCountOnTaskFailure: 2
@@ -172,7 +172,7 @@ steps:
 - script: |
     if exist baselines\.git\ git -C baselines reset --hard
     if exist baselines\.git\ git -C baselines clean -fdq
-    $(netfx_tfm)\main\x64\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings $(netfx_tfm)\main\x64\.runsettings --report-trx --report-trx-filename netfx-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
+    $(netfx_tfm)\main\x64\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings $(netfx_tfm)\main\x64\.runsettings --report-trx --report-trx-filename netfx-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   displayName: 'Tests (NETFX x64): $(title)'
   condition: and(eq(variables.netfx, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'))
   retryCountOnTaskFailure: 2
@@ -249,7 +249,7 @@ steps:
 - script: |
     if exist baselines\.git\ git -C baselines reset --hard
     if exist baselines\.git\ git -C baselines clean -fdq
-    net8.0\main\x64\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net8.0\main\x64\.runsettings --report-trx --report-trx-filename net8.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
+    net8.0\main\x64\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net8.0\main\x64\.runsettings --report-trx --report-trx-filename net8.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   displayName: 'Tests (.NET 8 x64): $(title)'
   condition: and(eq(variables.net80, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   retryCountOnTaskFailure: 2
@@ -261,7 +261,7 @@ steps:
 - script: |
     if exist baselines\.git\ git -C baselines reset --hard
     if exist baselines\.git\ git -C baselines clean -fdq
-    net8.0\main\x86\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net8.0\main\x86\.runsettings --report-trx --report-trx-filename net8.0-main-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
+    net8.0\main\x86\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net8.0\main\x86\.runsettings --report-trx --report-trx-filename net8.0-main-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   displayName: 'Tests (.NET 8 x86): $(title)'
   condition: and(eq(variables.net80, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   retryCountOnTaskFailure: 2
@@ -342,7 +342,7 @@ steps:
 - script: |
     if exist baselines\.git\ git -C baselines reset --hard
     if exist baselines\.git\ git -C baselines clean -fdq
-    net9.0\main\x64\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net9.0\main\x64\.runsettings --report-trx --report-trx-filename net9.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
+    net9.0\main\x64\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net9.0\main\x64\.runsettings --report-trx --report-trx-filename net9.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   displayName: 'Tests (.NET 9 x64): $(title)'
   condition: and(eq(variables.net90, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   retryCountOnTaskFailure: 2
@@ -354,7 +354,7 @@ steps:
 - script: |
     if exist baselines\.git\ git -C baselines reset --hard
     if exist baselines\.git\ git -C baselines clean -fdq
-    net9.0\main\x86\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net9.0\main\x86\.runsettings --report-trx --report-trx-filename net9.0-main-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
+    net9.0\main\x86\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net9.0\main\x86\.runsettings --report-trx --report-trx-filename net9.0-main-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   displayName: 'Tests (.NET 9 x86): $(title)'
   condition: and(eq(variables.net90, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   retryCountOnTaskFailure: 2
@@ -428,7 +428,7 @@ steps:
 - script: |
     if exist baselines\.git\ git -C baselines reset --hard
     if exist baselines\.git\ git -C baselines clean -fdq
-    net10.0\main\x64\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net10.0\main\x64\.runsettings --report-trx --report-trx-filename net10.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
+    net10.0\main\x64\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net10.0\main\x64\.runsettings --report-trx --report-trx-filename net10.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   displayName: 'Tests (.NET 10 x64): $(title)'
   condition: and(eq(variables.net100, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'))
   retryCountOnTaskFailure: 2
@@ -440,7 +440,7 @@ steps:
 - script: |
     if exist baselines\.git\ git -C baselines reset --hard
     if exist baselines\.git\ git -C baselines clean -fdq
-    net10.0\main\x86\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net10.0\main\x86\.runsettings --report-trx --report-trx-filename net10.0-main-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m
+    net10.0\main\x86\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net10.0\main\x86\.runsettings --report-trx --report-trx-filename net10.0-main-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   displayName: 'Tests (.NET 10 x86): $(title)'
   condition: and(eq(variables.net100, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'))
   retryCountOnTaskFailure: 2

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -157,6 +157,7 @@
 		<PackageVersion Include="Microsoft.Testing.Platform.MSBuild"                    Version="$(MicrosoftTestingVersion)"   />
 		<PackageVersion Include="Microsoft.Testing.Extensions.TrxReport"                Version="$(MicrosoftTestingVersion)"   />
 		<PackageVersion Include="Microsoft.Testing.Extensions.HangDump"                 Version="$(MicrosoftTestingVersion)"   />
+		<PackageVersion Include="Microsoft.Testing.Extensions.Retry"                    Version="$(MicrosoftTestingVersion)"   />
 		<PackageVersion Include="NUnit"                                                 Version="4.6.0"                        />
 		<PackageVersion Include="NUnit.Analyzers"                                       Version="4.13.0"                       />
 		<PackageVersion Include="NUnit3TestAdapter"                                     Version="6.2.0"                        />

--- a/Tests/Base/CustomTestContext.cs
+++ b/Tests/Base/CustomTestContext.cs
@@ -6,7 +6,7 @@ namespace Tests
 	{
 		public static string BASELINE          = "key-baseline";
 		public static string TRACE             = "key-trace";
-		public static string LIMITED           = "key-limited";
+		public static string TRACE_CAPTURED    = "key-trace-captured";
 		public static string BASELINE_DISABLED = "key-baseline-disabled";
 		public static string TRACE_DISABLED    = "key-trace-disabled";
 

--- a/Tests/Base/TestBase.cs
+++ b/Tests/Base/TestBase.cs
@@ -19,6 +19,24 @@ namespace Tests
 	{
 		const int TRACES_LIMIT = 50000;
 
+		// Live per-query trace echo to TestContext.Out. Under the MTP test runner this stream is
+		// captured into the CI build log, so echoing every executed query inflated per-leg logs
+		// ~100x (e.g. the Access leg log grew from 0.13MB to 25MB). Default: on locally, off under
+		// CI; override with LINQ2DB_TESTS_TRACE_CONSOLE=1/0. Failed tests still get the full trace
+		// appended to their failure message in OnAfterTest, and baseline capture is independent.
+		static readonly bool EchoTraceToConsole = GetEchoTraceToConsole();
+
+		static bool GetEchoTraceToConsole()
+		{
+			var setting = Environment.GetEnvironmentVariable("LINQ2DB_TESTS_TRACE_CONSOLE");
+			if (!string.IsNullOrEmpty(setting))
+				return setting is "1" or "true" or "TRUE" or "on";
+
+			// Azure Pipelines sets TF_BUILD; most CI providers set CI.
+			return Environment.GetEnvironmentVariable("TF_BUILD") == null
+				&& Environment.GetEnvironmentVariable("CI")       == null;
+		}
+
 		protected static string? LastQuery { get; set; }
 
 		static TestBase()
@@ -63,12 +81,17 @@ namespace Tests
 						lock (trace)
 							trace.AppendLine(CultureInfo.InvariantCulture, $"{name}: {message}");
 
-						if (traceCount < TRACES_LIMIT || level == TraceLevel.Error)
-						{
-							ctx.Set(CustomTestContext.LIMITED, true);
+						// Record that this test captured trace output so OnAfterTest appends it to the
+						// failure message (Azure surfaces only ErrorInfo). Independent of the console
+						// echo below, so failure diagnostics survive when the echo is suppressed.
+						ctx.Set(CustomTestContext.LIMITED, true);
+
+						// Echoing every query to TestContext.Out floods the MTP-captured CI log (~100x).
+						// Keep it opt-in; Debug.WriteLine stays (debugger only, never hits the build log).
+						if (EchoTraceToConsole && (traceCount < TRACES_LIMIT || level == TraceLevel.Error))
 							TestContext.Out.WriteLine("{0}: {1}", name, message);
-							Debug.WriteLine(message, name);
-						}
+
+						Debug.WriteLine(message, name);
 
 						Interlocked.Increment(ref traceCount);
 					}

--- a/Tests/Base/TestBase.cs
+++ b/Tests/Base/TestBase.cs
@@ -30,7 +30,9 @@ namespace Tests
 		{
 			var setting = Environment.GetEnvironmentVariable("LINQ2DB_TESTS_TRACE_CONSOLE");
 			if (!string.IsNullOrEmpty(setting))
-				return setting is "1" or "true" or "TRUE" or "on";
+				return setting is "1"
+					|| string.Equals(setting, "true", StringComparison.OrdinalIgnoreCase)
+					|| string.Equals(setting, "on",   StringComparison.OrdinalIgnoreCase);
 
 			// Azure Pipelines sets TF_BUILD; most CI providers set CI.
 			return Environment.GetEnvironmentVariable("TF_BUILD") == null
@@ -84,7 +86,7 @@ namespace Tests
 						// Record that this test captured trace output so OnAfterTest appends it to the
 						// failure message (Azure surfaces only ErrorInfo). Independent of the console
 						// echo below, so failure diagnostics survive when the echo is suppressed.
-						ctx.Set(CustomTestContext.LIMITED, true);
+						ctx.Set(CustomTestContext.TRACE_CAPTURED, true);
 
 						// Echoing every query to TestContext.Out floods the MTP-captured CI log (~100x).
 						// Keep it opt-in; Debug.WriteLine stays (debugger only, never hits the build log).
@@ -192,7 +194,7 @@ namespace Tests
 
 				var trace = ctx.Get<StringBuilder>(CustomTestContext.TRACE);
 
-				if (trace != null && TestContext.CurrentContext.Result.FailCount > 0 && ctx.Get<bool>(CustomTestContext.LIMITED))
+				if (trace != null && TestContext.CurrentContext.Result.FailCount > 0 && ctx.Get<bool>(CustomTestContext.TRACE_CAPTURED))
 				{
 					// we need to set ErrorInfo.Message element text
 					// because Azure displays only ErrorInfo node data

--- a/Tests/linq2db.BasicTestProjects.props
+++ b/Tests/linq2db.BasicTestProjects.props
@@ -9,6 +9,7 @@
 		<PackageReference Include="Microsoft.Testing.Platform.MSBuild" />
 		<PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
 		<PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
+		<PackageReference Include="Microsoft.Testing.Extensions.Retry" />
 		<PackageReference Include="Shouldly" />
 		<!-- Was a transitive dependency of Microsoft.NET.Test.Sdk; referenced directly now that the SDK is gone. -->
 		<PackageReference Include="Newtonsoft.Json" />


### PR DESCRIPTION
Two CI optimizations for the unstable-provider legs (access, oracle), where one
flaky failure both floods the logs and re-runs the whole ~14.5k-test assembly.

## 1. Stop echoing per-query SQL traces into CI logs
`TestBase` writes every query (`BeforeExecute` + SQL + timings) to `TestContext.Out`.
Under VSTest that per-test output stayed in test-result detail; under MTP (#5612) it
streams into the build-log task stream, so each leg's log exploded — Access ACE leg
**0.13 MB → 25.6 MB** (0 → 26,089 `BeforeExecute` lines), a full build **~18 MB → ~1.9 GB**.

- Gate the live echo: on locally, off under CI (`TF_BUILD`/`CI`); override with
  `LINQ2DB_TESTS_TRACE_CONSOLE`.
- Failures keep the full trace — `LIMITED` is set unconditionally so `OnAfterTest` still
  appends the captured trace to the failure message. Baseline capture / `LastQuery`
  unaffected; local `dotnet test` is unchanged.

## 2. Retry only failed tests, not the whole leg
`retry: true` legs use `retryCountOnTaskFailure: 2`, which re-runs the entire
`linq2db.Tests.exe` (~50 min) on any non-zero exit — so one flaky graceful failure = a
full re-run (the "+50 min"; compounded across the matrix → hours). Example: build 21310
ran the assembly twice (`Failed!` → `RetryHelper … attempt 1 of 2` → `Passed!`).

- Add `Microsoft.Testing.Extensions.Retry` and pass
  `--retry-failed-tests 2 --retry-failed-tests-max-tests 25` (as `$(test_retry_args)`) on
  the retry-path commands → a flaky test is retried in-process; if it passes the exe exits
  0 and the leg does not re-run.
- Keep `retryCountOnTaskFailure: 2` as the crash backstop — access/oracle can hard-crash
  (AV), where in-process retry can't help and only re-launching the leg recovers.

## Validation
Local: builds clean (net10.0); Access.Ace.Odbc subset 368/368 pass; CI-mode run log
**50 KB**; `--retry-failed-tests` accepted, Retry extension active. The pipeline
`dotnet test` behavior runs only on Azure Pipelines — **needs a CI run to confirm**.
