### PR TITLE
Tests: don't mutate shared test-case schema in MySQL ProceduresSchemaProviderTest

### DIFF
--- a/Tests/Linq/DataProvider/MySqlTests.cs
+++ b/Tests/Linq/DataProvider/MySqlTests.cs
@@ -1219,7 +1219,11 @@ namespace Tests.DataProvider
 			using var db = (DataConnection)GetDataContext(context);
 			var expectedProc = testCase.Schema;
 
-			expectedProc.CatalogName = TestUtils.GetDatabaseName(db, context);
+			// Do not mutate testCase.Schema.CatalogName: NUnit reuses the same test-case instances
+			// across every provider, so under parallel execution two provider lanes (e.g. MySql.Data +
+			// MySqlConnector, which resolve different database names) would race this shared field and
+			// produce spurious CatalogName mismatches. Compare against a local instead.
+			var expectedCatalogName = TestUtils.GetDatabaseName(db, context);
 
 			var schema     = db.DataProvider.GetSchemaProvider().GetSchema(db);
 			var procedures = schema.Procedures.Where(_ => _.ProcedureName == expectedProc.ProcedureName).ToList();
@@ -1229,7 +1233,7 @@ namespace Tests.DataProvider
 			var procedure = procedures[0];
 			using (Assert.EnterMultipleScope())
 			{
-				Assert.That(procedure.CatalogName!.ToLowerInvariant(), Is.EqualTo(expectedProc.CatalogName.ToLowerInvariant()));
+				Assert.That(procedure.CatalogName!.ToLowerInvariant(), Is.EqualTo(expectedCatalogName.ToLowerInvariant()));
 				Assert.That(procedure.SchemaName, Is.EqualTo(expectedProc.SchemaName));
 				Assert.That(procedure.MemberName, Is.EqualTo(expectedProc.MemberName));
 				Assert.That(procedure.IsTableFunction, Is.EqualTo(expectedProc.IsTableFunction));


### PR DESCRIPTION
### Problem

`MySqlTests.ProceduresSchemaProviderTest` mutated the **shared** test-case schema object:

```csharp
var expectedProc = testCase.Schema;
expectedProc.CatalogName = TestUtils.GetDatabaseName(db, context);   // <- shared mutation
...
Assert.That(procedure.CatalogName!.ToLowerInvariant(), Is.EqualTo(expectedProc.CatalogName.ToLowerInvariant()));
```

`testCase` comes from a `[ValueSource]`, and NUnit reuses the same case instances across every provider/TFM run — so `testCase.Schema` is process-global shared state. For MySQL, `GetDatabaseName` returns the connection's actual `DATABASE()`.

The "MySQL 5.7 **both providers**" CI leg runs `MySql.Data` and `MySqlConnector` concurrently on **separate databases**. The two lanes raced `expectedProc.CatalogName`, so one lane's assertion read the database name the other lane had just written → `Assert.That(procedure.CatalogName…, Is.EqualTo(expectedProc.CatalogName…))` mismatch.

Two facts confirm it's a cross-lane race, not a schema bug:
- **only `CatalogName` fails** — the single field the test mutates; the ~20 other assertions against the same shared object pass;
- it appears **only on the concurrent "both providers" leg**, and serial runs are self-consistent.

### Fix

Compare against a **local** `expectedCatalogName` instead of writing it back onto the shared test-case object. Test-only — no behavior change for serial runs.

### Verification

- `Tests/Linq` builds clean in **Testing and Release** (`net10.0`) — analyzers pass.
- The change is serial-equivalent (the local holds the same value previously written to the shared field), so it cannot alter the assertion logic — only remove the cross-lane mutation. Runtime proof is the parallel CI leg (local MySQL was not reachable in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
