### PR TITLE
StackGuard: probe stack every 8 levels to fix flaky StackOverflow

### DIFF
--- a/Source/LinqToDB/Internal/Common/StackGuard.cs
+++ b/Source/LinqToDB/Internal/Common/StackGuard.cs
@@ -9,6 +9,11 @@ namespace LinqToDB.Internal.Common
 {
 	public sealed class StackGuard
 	{
+		// How often (in recursion levels) Enter probes the remaining stack. Small enough that the stack
+		// consumed between two probes stays well inside the margin TryEnsureSufficientExecutionStack
+		// guarantees, so deep recursion always hops gracefully instead of overflowing between probes.
+		const int StackProbeInterval = 8;
+
 		// Use interlocked to be safe when execution switches threads.
 		int _hopCount;
 		int _internalDepth;
@@ -29,11 +34,17 @@ namespace LinqToDB.Internal.Common
 			_internalDepth++;
 			_maxHops ??= LinqToDB.Common.Configuration.TranslationThreadMaxHopCount;
 
-			// test _internalDepth for 1 so we can trigger hop before doing 64 calls and fail
-			// when starting stack is already too small
+			// Probe the stack every StackProbeInterval recursion levels (and on the very first call, so
+			// an already-too-small starting stack is caught). The interval bounds how much stack can be
+			// consumed between two probes: TryEnsureSufficientExecutionStack only guarantees a fixed
+			// margin, so if (interval x per-level-stack) exceeds that margin the stack can overflow
+			// BETWEEN probes - an uncatchable StackOverflowException instead of a graceful hop. At ~220
+			// bytes/level (x64) the old interval of 64 used ~14KB between probes, which overran the
+			// margin on tighter configs (net462 / Linux, larger frames) and produced a flaky hard SO.
+			// 8 keeps it under ~2KB, comfortably inside the margin on every TFM.
 			return _maxHops switch
 			{
-				>= 0 when _internalDepth % 64 == 1 && !TryEnsureSufficientExecutionStack() =>
+				>= 0 when _internalDepth % StackProbeInterval == 1 && !TryEnsureSufficientExecutionStack() =>
 					RunOnEmptyStack(action, arg),
 
 				_ => default,


### PR DESCRIPTION
## Problem

The deep-recursion stack guard used by the expression / SQL visitors intermittently crashes CI with an uncatchable `StackOverflowException` (e.g. `StackUseTests` on the `net462` / Linux legs) instead of recovering via its thread-hop mechanism.

## Root cause

`StackGuard.Enter` probed `RuntimeHelpers.TryEnsureSufficientExecutionStack()` only **every 64 recursion levels**. Between two probes up to ~64 × per-level stack is consumed with no check. Captured at the hop point on x64 there are 3 frames per level (`ExpressionVisitorBase.Visit` → `ExpressionVisitorUtils.VisitArguments` → `ExpressionVisitor.VisitMethodCall`), depth **4737** before the first hop ⇒ **~220 bytes/level**, so 64 levels ≈ **~14 KB**.

`TryEnsureSufficientExecutionStack` only guarantees a fixed margin. On tighter configurations (`net462` / Linux, larger frames) those ~14 KB can exceed the margin, so the stack overflows **between probes** — a hard `StackOverflowException` that crashes the process — rather than the intended graceful hop.

## Fix

Probe **every 8 levels** (named `StackProbeInterval` constant), bounding the between-probe stack to ~2 KB — comfortably inside the guaranteed margin on every TFM. The probe is a cheap JIT intrinsic and only matters for deep recursion (shallow queries probe ~once), so the cost is negligible. Hop semantics are unchanged; it just hops slightly sooner.

## Verification

`StackUseTests` hop tests pass locally on net10.0 — `TestExpressionVisitorHops` / `TestSqlVisitorHops` (0/1/2 → nested `InsufficientExecutionStackException`, 10 → completes) and `TestPreserveExceptionOnHop`. The hard `StackOverflow` only reproduces on the tight-margin legs (net10.0/x64 hops gracefully at depth 4737), so CI on `net462` / Linux is the final confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
