### PR TITLE
Fix InvalidCastException in LoadWith/ThenLoad on non-linq2db IQueryable

### DIFF
--- a/Source/LinqToDB/LinqExtensions/LinqExtensions.LoadWith.cs
+++ b/Source/LinqToDB/LinqExtensions/LinqExtensions.LoadWith.cs
@@ -8,6 +8,7 @@ using System.Threading;
 
 using JetBrains.Annotations;
 
+using LinqToDB.Internal.Async;
 using LinqToDB.Internal.Linq;
 
 namespace LinqToDB
@@ -61,23 +62,29 @@ namespace LinqToDB
 			return newTable;
 		}
 
-		abstract class LoadWithQueryableBase<TEntity>(IExpressionQuery<TEntity> query) : IExpressionQuery
+		abstract class LoadWithQueryableBase<TEntity>(IQueryable<TEntity> query) : IExpressionQuery
 		{
 			[DebuggerBrowsable(DebuggerBrowsableState.Never)]
-			public IExpressionQuery<TEntity> Query { get; } = query;
+			public IQueryable<TEntity> Query { get; } = query;
 
 			[DebuggerBrowsable(DebuggerBrowsableState.Never)]
-			Expression IExpressionQuery.Expression                                   => Query.Expression;
+			Expression IExpressionQuery.Expression => Query.Expression;
 
 			[DebuggerBrowsable(DebuggerBrowsableState.Never)]
-			IDataContext IExpressionQuery.DataContext                                  => ((IExpressionQuery)Query.GetLinqToDBSource()).DataContext;
+			IDataContext IExpressionQuery.DataContext =>
+				Query is IExpressionQuery<TEntity> exprQuery
+					? ((IExpressionQuery)exprQuery.GetLinqToDBSource()).DataContext
+					: throw new LinqToDBException($"LoadWith source '{Query.GetType()}' is not a linq2db query.");
 
 			public abstract QueryDebugView DebugView { get; }
 
-			IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options) => ((IExpressionQuery)Query.GetLinqToDBSource()).GetSqlQueries(options);
+			IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options) =>
+				Query is IExpressionQuery<TEntity> exprQuery
+					? ((IExpressionQuery)exprQuery.GetLinqToDBSource()).GetSqlQueries(options)
+					: throw new LinqToDBException($"LoadWith source '{Query.GetType()}' is not a linq2db query.");
 		}
 
-		sealed class LoadWithQueryable<TEntity, TProperty>(IExpressionQuery<TEntity> query) : LoadWithQueryableBase<TEntity>(query), ILoadWithQueryable<TEntity, TProperty>, IAsyncEnumerable<TEntity>
+		sealed class LoadWithQueryable<TEntity, TProperty>(IQueryable<TEntity> query) : LoadWithQueryableBase<TEntity>(query), ILoadWithQueryable<TEntity, TProperty>, IAsyncEnumerable<TEntity>
 		{
 			[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 			Type IQueryable.ElementType => Query.ElementType;
@@ -90,10 +97,15 @@ namespace LinqToDB
 
 			public Expression Expression => Query.Expression;
 
-			public override QueryDebugView DebugView => Query.DebugView;
+			public override QueryDebugView DebugView =>
+				Query is IExpressionQuery<TEntity> exprQuery
+					? exprQuery.DebugView
+					: throw new LinqToDBException($"LoadWith source '{Query.GetType()}' is not a linq2db query.");
 
 			IAsyncEnumerator<TEntity> IAsyncEnumerable<TEntity>.GetAsyncEnumerator(CancellationToken cancellationToken) =>
-				((IAsyncEnumerable<TEntity>)Query).GetAsyncEnumerator(cancellationToken);
+				Query is IAsyncEnumerable<TEntity> asyncEnum
+					? asyncEnum.GetAsyncEnumerator(cancellationToken)
+					: throw new LinqToDBException($"Async enumeration is not supported for LoadWith source '{Query.GetType()}'.");
 
 			IEnumerator<TEntity> IEnumerable<TEntity>.GetEnumerator() => Query.GetEnumerator();
 
@@ -170,14 +182,14 @@ namespace LinqToDB
 
 			var currentSource = source.ProcessIQueryable();
 
-			var expr = Expression.Call(
-				null,
-				MethodHelper.GetMethodInfo(LoadWith, source, selector),
-				currentSource.Expression,
-				Expression.Quote(selector));
-
-			var result = currentSource.Provider.CreateQuery<TEntity>(expr);
-			return new LoadWithQueryable<TEntity,TProperty>((IExpressionQuery<TEntity>)result);
+			return new LoadWithQueryable<TEntity,TProperty>(
+				currentSource.Provider is IQueryProviderAsync
+					? currentSource.Provider.CreateQuery<TEntity>(Expression.Call(
+						null,
+						MethodHelper.GetMethodInfo(LoadWith, source, selector),
+						currentSource.Expression,
+						Expression.Quote(selector)))
+					: currentSource);
 		}
 
 		/// <summary>
@@ -261,13 +273,13 @@ namespace LinqToDB
 
 			var currentSource = source.ProcessIQueryable();
 
-			var expr = Expression.Call(
-				null,
-				MethodHelper.GetMethodInfo(LoadWith, source, selector, loadFunc),
-				new[] { currentSource.Expression, Expression.Quote(selector), Expression.Quote(loadFunc) });
-
-			var result = currentSource.Provider.CreateQuery<TEntity>(expr);
-			return new LoadWithQueryable<TEntity, TProperty>((IExpressionQuery<TEntity>)result);
+			return new LoadWithQueryable<TEntity, TProperty>(
+				currentSource.Provider is IQueryProviderAsync
+					? currentSource.Provider.CreateQuery<TEntity>(Expression.Call(
+						null,
+						MethodHelper.GetMethodInfo(LoadWith, source, selector, loadFunc),
+						new[] { currentSource.Expression, Expression.Quote(selector), Expression.Quote(loadFunc) }))
+					: currentSource);
 		}
 
 		/// <summary>
@@ -351,15 +363,15 @@ namespace LinqToDB
 
 			var currentSource = source.ProcessIQueryable();
 
-			var expr = Expression.Call(
-				null,
-				MethodHelper.GetMethodInfo(LoadWith, source, selector, loadFunc),
-				currentSource.Expression,
-				Expression.Quote(selector),
-				Expression.Quote(loadFunc));
-
-			var result = currentSource.Provider.CreateQuery<TEntity>(expr);
-			return new LoadWithQueryable<TEntity,TProperty>((IExpressionQuery<TEntity>)result);
+			return new LoadWithQueryable<TEntity,TProperty>(
+				currentSource.Provider is IQueryProviderAsync
+					? currentSource.Provider.CreateQuery<TEntity>(Expression.Call(
+						null,
+						MethodHelper.GetMethodInfo(LoadWith, source, selector, loadFunc),
+						currentSource.Expression,
+						Expression.Quote(selector),
+						Expression.Quote(loadFunc)))
+					: currentSource);
 		}
 
 		/// <summary>
@@ -411,14 +423,14 @@ namespace LinqToDB
 
 			var currentSource = source.ProcessIQueryable();
 
-			var expr = Expression.Call(
-				null,
-				MethodHelper.GetMethodInfo(ThenLoad, source, selector),
-				currentSource.Expression,
-				Expression.Quote(selector));
-
-			var result = currentSource.Provider.CreateQuery<TEntity>(expr);
-			return new LoadWithQueryable<TEntity,TProperty>((IExpressionQuery<TEntity>)result);
+			return new LoadWithQueryable<TEntity,TProperty>(
+				currentSource.Provider is IQueryProviderAsync
+					? currentSource.Provider.CreateQuery<TEntity>(Expression.Call(
+						null,
+						MethodHelper.GetMethodInfo(ThenLoad, source, selector),
+						currentSource.Expression,
+						Expression.Quote(selector)))
+					: currentSource);
 		}
 
 		/// <summary>
@@ -470,13 +482,13 @@ namespace LinqToDB
 
 			var currentSource = source.ProcessIQueryable();
 
-			var expr = Expression.Call(
-				null,
-				MethodHelper.GetMethodInfo(ThenLoad, source, selector),
-				new[] { currentSource.Expression, Expression.Quote(selector) });
-
-			var result = currentSource.Provider.CreateQuery<TEntity>(expr);
-			return new LoadWithQueryable<TEntity,TProperty>((IExpressionQuery<TEntity>)result);
+			return new LoadWithQueryable<TEntity,TProperty>(
+				currentSource.Provider is IQueryProviderAsync
+					? currentSource.Provider.CreateQuery<TEntity>(Expression.Call(
+						null,
+						MethodHelper.GetMethodInfo(ThenLoad, source, selector),
+						new[] { currentSource.Expression, Expression.Quote(selector) }))
+					: currentSource);
 		}
 
 		/// <summary>
@@ -539,13 +551,13 @@ namespace LinqToDB
 
 			var currentSource = source.ProcessIQueryable();
 
-			var expr = Expression.Call(
-				null,
-				MethodHelper.GetMethodInfo(ThenLoad, source, selector, loadFunc),
-				new[] { currentSource.Expression, Expression.Quote(selector), Expression.Quote(loadFunc) });
-
-			var result = currentSource.Provider.CreateQuery<TEntity>(expr);
-			return new LoadWithQueryable<TEntity,TProperty>((IExpressionQuery<TEntity>)result);
+			return new LoadWithQueryable<TEntity,TProperty>(
+				currentSource.Provider is IQueryProviderAsync
+					? currentSource.Provider.CreateQuery<TEntity>(Expression.Call(
+						null,
+						MethodHelper.GetMethodInfo(ThenLoad, source, selector, loadFunc),
+						new[] { currentSource.Expression, Expression.Quote(selector), Expression.Quote(loadFunc) }))
+					: currentSource);
 		}
 
 		/// <summary>
@@ -608,15 +620,15 @@ namespace LinqToDB
 
 			var currentSource = source.ProcessIQueryable();
 
-			var expr = Expression.Call(
-				null,
-				MethodHelper.GetMethodInfo(ThenLoad, source, selector, loadFunc),
-				currentSource.Expression,
-				Expression.Quote(selector),
-				Expression.Quote(loadFunc));
-
-			var result = currentSource.Provider.CreateQuery<TEntity>(expr);
-			return new LoadWithQueryable<TEntity,TProperty>((IExpressionQuery<TEntity>)result);
+			return new LoadWithQueryable<TEntity,TProperty>(
+				currentSource.Provider is IQueryProviderAsync
+					? currentSource.Provider.CreateQuery<TEntity>(Expression.Call(
+						null,
+						MethodHelper.GetMethodInfo(ThenLoad, source, selector, loadFunc),
+						currentSource.Expression,
+						Expression.Quote(selector),
+						Expression.Quote(loadFunc)))
+					: currentSource);
 		}
 
 		/// <summary>
@@ -679,15 +691,15 @@ namespace LinqToDB
 
 			var currentSource = source.ProcessIQueryable();
 
-			var expr = Expression.Call(
-				null,
-				MethodHelper.GetMethodInfo(ThenLoad, source, selector, loadFunc),
-				currentSource.Expression,
-				Expression.Quote(selector),
-				Expression.Quote(loadFunc));
-
-			var result = currentSource.Provider.CreateQuery<TEntity>(expr);
-			return new LoadWithQueryable<TEntity,TProperty>((IExpressionQuery<TEntity>)result);
+			return new LoadWithQueryable<TEntity,TProperty>(
+				currentSource.Provider is IQueryProviderAsync
+					? currentSource.Provider.CreateQuery<TEntity>(Expression.Call(
+						null,
+						MethodHelper.GetMethodInfo(ThenLoad, source, selector, loadFunc),
+						currentSource.Expression,
+						Expression.Quote(selector),
+						Expression.Quote(loadFunc)))
+					: currentSource);
 		}
 
 		/// <summary>
@@ -750,15 +762,15 @@ namespace LinqToDB
 
 			var currentSource = source.ProcessIQueryable();
 
-			var expr = Expression.Call(
-				null,
-				MethodHelper.GetMethodInfo(ThenLoad, source, selector, loadFunc),
-				currentSource.Expression,
-				Expression.Quote(selector),
-				Expression.Quote(loadFunc));
-
-			var result = currentSource.Provider.CreateQuery<TEntity>(expr);
-			return new LoadWithQueryable<TEntity, TProperty>((IExpressionQuery<TEntity>)result);
+			return new LoadWithQueryable<TEntity, TProperty>(
+				currentSource.Provider is IQueryProviderAsync
+					? currentSource.Provider.CreateQuery<TEntity>(Expression.Call(
+						null,
+						MethodHelper.GetMethodInfo(ThenLoad, source, selector, loadFunc),
+						currentSource.Expression,
+						Expression.Quote(selector),
+						Expression.Quote(loadFunc)))
+					: currentSource);
 		}
 		}
 	}

--- a/Source/LinqToDB/LinqExtensions/LinqExtensions.LoadWith.cs
+++ b/Source/LinqToDB/LinqExtensions/LinqExtensions.LoadWith.cs
@@ -74,14 +74,17 @@ namespace LinqToDB
 			IDataContext IExpressionQuery.DataContext =>
 				Query is IExpressionQuery<TEntity> exprQuery
 					? ((IExpressionQuery)exprQuery.GetLinqToDBSource()).DataContext
-					: throw new LinqToDBException($"LoadWith source '{Query.GetType()}' is not a linq2db query.");
+					: throw NotLinqToDbSource();
 
 			public abstract QueryDebugView DebugView { get; }
 
 			IReadOnlyList<QuerySql> IExpressionQuery.GetSqlQueries(SqlGenerationOptions? options) =>
 				Query is IExpressionQuery<TEntity> exprQuery
 					? ((IExpressionQuery)exprQuery.GetLinqToDBSource()).GetSqlQueries(options)
-					: throw new LinqToDBException($"LoadWith source '{Query.GetType()}' is not a linq2db query.");
+					: throw NotLinqToDbSource();
+
+			protected LinqToDBException NotLinqToDbSource() =>
+				new($"LoadWith source '{Query.GetType()}' is not a linq2db query.");
 		}
 
 		sealed class LoadWithQueryable<TEntity, TProperty>(IQueryable<TEntity> query) : LoadWithQueryableBase<TEntity>(query), ILoadWithQueryable<TEntity, TProperty>, IAsyncEnumerable<TEntity>
@@ -100,7 +103,7 @@ namespace LinqToDB
 			public override QueryDebugView DebugView =>
 				Query is IExpressionQuery<TEntity> exprQuery
 					? exprQuery.DebugView
-					: throw new LinqToDBException($"LoadWith source '{Query.GetType()}' is not a linq2db query.");
+					: throw NotLinqToDbSource();
 
 			IAsyncEnumerator<TEntity> IAsyncEnumerable<TEntity>.GetAsyncEnumerator(CancellationToken cancellationToken) =>
 				Query is IAsyncEnumerable<TEntity> asyncEnum

--- a/Source/LinqToDB/LinqExtensions/LinqExtensions.LoadWith.cs
+++ b/Source/LinqToDB/LinqExtensions/LinqExtensions.LoadWith.cs
@@ -173,6 +173,11 @@ namespace LinqToDB
 		/// <param name="source">The source query.</param>
 		/// <param name="selector">A lambda expression representing navigation property to be included (<c>t => t.Property1</c>).</param>
 		/// <returns>Returns new query with related data included.</returns>
+		/// <remarks>
+		/// When the underlying query is not a linq2db query (for example a plain in-memory <see cref="IQueryable{T}"/>
+		/// such as <c>Enumerable.Empty&lt;T&gt;().AsQueryable()</c>), the eager-load directive is ignored and the query
+		/// is returned unchanged as a passthrough — mirroring EF Core <c>Include</c> behavior.
+		/// </remarks>
 		[LinqTunnel]
 		[Pure]
 		public static ILoadWithQueryable<TEntity,TProperty> LoadWith<TEntity,TProperty>(
@@ -263,6 +268,11 @@ namespace LinqToDB
 		/// <param name="selector">A lambda expression representing navigation property to be included (<c>t => t.Property1</c>).</param>
 		/// <param name="loadFunc">Defines additional logic for association load query.</param>
 		/// <returns>Returns new query with related data included.</returns>
+		/// <remarks>
+		/// When the underlying query is not a linq2db query (for example a plain in-memory <see cref="IQueryable{T}"/>
+		/// such as <c>Enumerable.Empty&lt;T&gt;().AsQueryable()</c>), the eager-load directive is ignored and the query
+		/// is returned unchanged as a passthrough — mirroring EF Core <c>Include</c> behavior.
+		/// </remarks>
 		[LinqTunnel]
 		[Pure]
 		public static ILoadWithQueryable<TEntity,TProperty> LoadWith<TEntity,TProperty>(
@@ -353,6 +363,11 @@ namespace LinqToDB
 		/// <param name="selector">A lambda expression representing navigation property to be included (<c>t => t.Property1</c>).</param>
 		/// <param name="loadFunc">Defines additional logic for association load query.</param>
 		/// <returns>Returns new query with related data included.</returns>
+		/// <remarks>
+		/// When the underlying query is not a linq2db query (for example a plain in-memory <see cref="IQueryable{T}"/>
+		/// such as <c>Enumerable.Empty&lt;T&gt;().AsQueryable()</c>), the eager-load directive is ignored and the query
+		/// is returned unchanged as a passthrough — mirroring EF Core <c>Include</c> behavior.
+		/// </remarks>
 		[LinqTunnel]
 		[Pure]
 		public static ILoadWithQueryable<TEntity,TProperty> LoadWith<TEntity,TProperty>(
@@ -414,6 +429,11 @@ namespace LinqToDB
 		/// <param name="source">The source query.</param>
 		/// <param name="selector">A lambda expression representing navigation property to be included (<c>t => t.Property1</c>).</param>
 		/// <returns>Returns new query with related data included.</returns>
+		/// <remarks>
+		/// When the underlying query is not a linq2db query (for example a plain in-memory <see cref="IQueryable{T}"/>
+		/// such as <c>Enumerable.Empty&lt;T&gt;().AsQueryable()</c>), the eager-load directive is ignored and the query
+		/// is returned unchanged as a passthrough — mirroring EF Core <c>Include</c> behavior.
+		/// </remarks>
 		[LinqTunnel]
 		[Pure]
 		public static ILoadWithQueryable<TEntity,TProperty> ThenLoad<TEntity,TPreviousProperty,TProperty>(
@@ -473,6 +493,11 @@ namespace LinqToDB
 		/// <param name="source">The source query.</param>
 		/// <param name="selector">A lambda expression representing navigation property to be included (<c>t => t.Property1</c>).</param>
 		/// <returns>Returns new query with related data included.</returns>
+		/// <remarks>
+		/// When the underlying query is not a linq2db query (for example a plain in-memory <see cref="IQueryable{T}"/>
+		/// such as <c>Enumerable.Empty&lt;T&gt;().AsQueryable()</c>), the eager-load directive is ignored and the query
+		/// is returned unchanged as a passthrough — mirroring EF Core <c>Include</c> behavior.
+		/// </remarks>
 		[LinqTunnel]
 		[Pure]
 		public static ILoadWithQueryable<TEntity,TProperty> ThenLoad<TEntity,TPreviousProperty,TProperty>(
@@ -541,6 +566,11 @@ namespace LinqToDB
 		/// <param name="selector">A lambda expression representing navigation property to be included (<c>t => t.Property1</c>).</param>
 		/// <param name="loadFunc">Defines additional logic for association load query.</param>
 		/// <returns>Returns new query with related data included.</returns>
+		/// <remarks>
+		/// When the underlying query is not a linq2db query (for example a plain in-memory <see cref="IQueryable{T}"/>
+		/// such as <c>Enumerable.Empty&lt;T&gt;().AsQueryable()</c>), the eager-load directive is ignored and the query
+		/// is returned unchanged as a passthrough — mirroring EF Core <c>Include</c> behavior.
+		/// </remarks>
 		[LinqTunnel]
 		[Pure] // ThenLoadFromSingleManyFilter
 		public static ILoadWithQueryable<TEntity,TProperty> ThenLoad<TEntity,TPreviousProperty,TProperty>(
@@ -610,6 +640,11 @@ namespace LinqToDB
 		/// <param name="selector">A lambda expression representing navigation property to be included (<c>t => t.Property1</c>).</param>
 		/// <param name="loadFunc">Defines additional logic for association load query.</param>
 		/// <returns>Returns new query with related data included.</returns>
+		/// <remarks>
+		/// When the underlying query is not a linq2db query (for example a plain in-memory <see cref="IQueryable{T}"/>
+		/// such as <c>Enumerable.Empty&lt;T&gt;().AsQueryable()</c>), the eager-load directive is ignored and the query
+		/// is returned unchanged as a passthrough — mirroring EF Core <c>Include</c> behavior.
+		/// </remarks>
 		[LinqTunnel]
 		[Pure] // Methods.LinqToDB.ThenLoadFromSingleSingleFilter
 		public static ILoadWithQueryable<TEntity,TProperty> ThenLoad<TEntity,TPreviousProperty,TProperty>(
@@ -681,6 +716,11 @@ namespace LinqToDB
 		/// <param name="selector">A lambda expression representing navigation property to be included (<c>t => t.Property1</c>).</param>
 		/// <param name="loadFunc">Defines additional logic for association load query.</param>
 		/// <returns>Returns new query with related data included.</returns>
+		/// <remarks>
+		/// When the underlying query is not a linq2db query (for example a plain in-memory <see cref="IQueryable{T}"/>
+		/// such as <c>Enumerable.Empty&lt;T&gt;().AsQueryable()</c>), the eager-load directive is ignored and the query
+		/// is returned unchanged as a passthrough — mirroring EF Core <c>Include</c> behavior.
+		/// </remarks>
 		[LinqTunnel]
 		[Pure] // // Methods.LinqToDB.ThenLoadFromManySingleFilter
 		public static ILoadWithQueryable<TEntity,TProperty> ThenLoad<TEntity,TPreviousProperty,TProperty>(
@@ -752,6 +792,11 @@ namespace LinqToDB
 		/// <param name="selector">A lambda expression representing navigation property to be included (<c>t => t.Property1</c>).</param>
 		/// <param name="loadFunc">Defines additional logic for association load query.</param>
 		/// <returns>Returns new query with related data included.</returns>
+		/// <remarks>
+		/// When the underlying query is not a linq2db query (for example a plain in-memory <see cref="IQueryable{T}"/>
+		/// such as <c>Enumerable.Empty&lt;T&gt;().AsQueryable()</c>), the eager-load directive is ignored and the query
+		/// is returned unchanged as a passthrough — mirroring EF Core <c>Include</c> behavior.
+		/// </remarks>
 		[LinqTunnel]
 		[Pure] // Methods.LinqToDB.ThenLoadFromManyManyFilter
 		public static ILoadWithQueryable<TEntity, TProperty> ThenLoad<TEntity, TPreviousProperty, TProperty>(

--- a/Tests/Linq/Linq/EagerLoadingTests.cs
+++ b/Tests/Linq/Linq/EagerLoadingTests.cs
@@ -3694,6 +3694,15 @@ namespace Tests.Linq
 			AssertPassthrough(_passthroughQuery.LoadWith(a => a.Children).ThenLoad(b => b.Leaves, q => q));
 		}
 
+		// The passthrough wrapper over a non-linq2db source is not an async source —
+		// async enumeration must throw a clear LinqToDBException, not silently no-op.
+		[Test]
+		public void LoadWith_NonLinqToDBSource_AsyncEnumeration_Throws()
+		{
+			var query = (IAsyncEnumerable<LoadWithPassthroughRoot>)_passthroughQuery.LoadWith(a => a.Child);
+			Assert.That(() => query.GetAsyncEnumerator(), Throws.TypeOf<LinqToDBException>());
+		}
+
 		#endregion
 	}
 }

--- a/Tests/Linq/Linq/EagerLoadingTests.cs
+++ b/Tests/Linq/Linq/EagerLoadingTests.cs
@@ -3601,32 +3601,81 @@ namespace Tests.Linq
 
 		sealed class IssueEntity5649A
 		{
-			public IssueEntity5649B Prop { get; set; } = null!;
+			public IssueEntity5649B  Prop  { get; set; } = null!;
+			public IssueEntity5649B[] Props { get; set; } = null!;
 		}
 
-		sealed class IssueEntity5649B { }
-
-		[Test]
-		public void Issue5649_LoadWith_NonLinqToDBSource()
+		sealed class IssueEntity5649B
 		{
-			// LoadWith on a non-linq2db IQueryable should not throw — mirrors EF Core Include behavior.
-			// No associations are loaded, but enumeration must work.
-			var result = Enumerable.Empty<IssueEntity5649A>().AsQueryable()
-				.LoadWith(a => a.Prop)
-				.ToList();
-
-			Assert.That(result, Is.Empty);
+			public IssueEntity5649C  Child  { get; set; } = null!;
+			public IssueEntity5649C[] Children { get; set; } = null!;
 		}
 
-		[Test]
-		public void Issue5649_LoadWith_ThenLoad_NonLinqToDBSource()
-		{
-			var result = Enumerable.Empty<IssueEntity5649A>().AsQueryable()
-				.LoadWith(a => a.Prop)
-				.ThenLoad(b => b)
-				.ToList();
+		sealed class IssueEntity5649C { }
 
-			Assert.That(result, Is.Empty);
+		static readonly IQueryable<IssueEntity5649A> _emptyA = Enumerable.Empty<IssueEntity5649A>().AsQueryable();
+
+		// LoadWith overload 1: LoadWith(source, selector)
+		[Test]
+		public void Issue5649_LoadWith_Single()
+		{
+			Assert.That(_emptyA.LoadWith(a => a.Prop).ToList(), Is.Empty);
+		}
+
+		// LoadWith overload 2: LoadWith(source, IEnumerable selector, loadFunc)
+		[Test]
+		public void Issue5649_LoadWith_Collection_LoadFunc()
+		{
+			Assert.That(_emptyA.LoadWith(a => a.Props, q => q).ToList(), Is.Empty);
+		}
+
+		// LoadWith overload 3: LoadWith(source, single selector, loadFunc)
+		[Test]
+		public void Issue5649_LoadWith_Single_LoadFunc()
+		{
+			Assert.That(_emptyA.LoadWith(a => a.Prop, q => q).ToList(), Is.Empty);
+		}
+
+		// ThenLoad overload 1: ThenLoad from single, single selector
+		[Test]
+		public void Issue5649_ThenLoad_FromSingle_Single()
+		{
+			Assert.That(_emptyA.LoadWith(a => a.Prop).ThenLoad(b => b.Child).ToList(), Is.Empty);
+		}
+
+		// ThenLoad overload 2: ThenLoad from collection, single selector
+		[Test]
+		public void Issue5649_ThenLoad_FromCollection_Single()
+		{
+			Assert.That(_emptyA.LoadWith(a => a.Props).ThenLoad(b => b.Child).ToList(), Is.Empty);
+		}
+
+		// ThenLoad overload 3: ThenLoad from single, collection selector + loadFunc
+		[Test]
+		public void Issue5649_ThenLoad_FromSingle_Collection_LoadFunc()
+		{
+			Assert.That(_emptyA.LoadWith(a => a.Prop).ThenLoad(b => b.Children, q => q).ToList(), Is.Empty);
+		}
+
+		// ThenLoad overload 4: ThenLoad from single, single selector + loadFunc
+		[Test]
+		public void Issue5649_ThenLoad_FromSingle_Single_LoadFunc()
+		{
+			Assert.That(_emptyA.LoadWith(a => a.Prop).ThenLoad(b => b.Child, q => q).ToList(), Is.Empty);
+		}
+
+		// ThenLoad overload 5: ThenLoad from collection, single selector + loadFunc
+		[Test]
+		public void Issue5649_ThenLoad_FromCollection_Single_LoadFunc()
+		{
+			Assert.That(_emptyA.LoadWith(a => a.Props).ThenLoad(b => b.Child, q => q).ToList(), Is.Empty);
+		}
+
+		// ThenLoad overload 6: ThenLoad from collection, collection selector + loadFunc
+		[Test]
+		public void Issue5649_ThenLoad_FromCollection_Collection_LoadFunc()
+		{
+			Assert.That(_emptyA.LoadWith(a => a.Props).ThenLoad(b => b.Children, q => q).ToList(), Is.Empty);
 		}
 
 		#endregion

--- a/Tests/Linq/Linq/EagerLoadingTests.cs
+++ b/Tests/Linq/Linq/EagerLoadingTests.cs
@@ -3613,70 +3613,85 @@ namespace Tests.Linq
 
 		sealed class LoadWithPassthroughLeaf { }
 
+		static readonly LoadWithPassthroughRoot _passthroughRoot = new()
+		{
+			Child    = new LoadWithPassthroughChild(),
+			Children = [new LoadWithPassthroughChild()],
+		};
+
 		static readonly IQueryable<LoadWithPassthroughRoot> _passthroughQuery =
-			Enumerable.Empty<LoadWithPassthroughRoot>().AsQueryable();
+			new[] { _passthroughRoot }.AsQueryable();
+
+		// The non-linq2db source is enumerated as-is (the LoadWith/ThenLoad directive is a
+		// no-op passthrough), so the original element instance must come through unchanged.
+		static void AssertPassthrough(IQueryable<LoadWithPassthroughRoot> query)
+		{
+			var result = query.ToList();
+			Assert.That(result,    Has.Count.EqualTo(1));
+			Assert.That(result[0], Is.SameAs(_passthroughRoot));
+		}
 
 		// LoadWith overload 1: single selector
 		[Test]
 		public void LoadWith_NonLinqToDBSource_Single()
 		{
-			Assert.That(_passthroughQuery.LoadWith(a => a.Child).ToList(), Is.Empty);
+			AssertPassthrough(_passthroughQuery.LoadWith(a => a.Child));
 		}
 
 		// LoadWith overload 2: collection selector + loadFunc
 		[Test]
 		public void LoadWith_NonLinqToDBSource_Collection_LoadFunc()
 		{
-			Assert.That(_passthroughQuery.LoadWith(a => a.Children, q => q).ToList(), Is.Empty);
+			AssertPassthrough(_passthroughQuery.LoadWith(a => a.Children, q => q));
 		}
 
 		// LoadWith overload 3: single selector + loadFunc
 		[Test]
 		public void LoadWith_NonLinqToDBSource_Single_LoadFunc()
 		{
-			Assert.That(_passthroughQuery.LoadWith(a => a.Child, q => q).ToList(), Is.Empty);
+			AssertPassthrough(_passthroughQuery.LoadWith(a => a.Child, q => q));
 		}
 
 		// ThenLoad overload 1: from single, single selector
 		[Test]
 		public void ThenLoad_NonLinqToDBSource_FromSingle_Single()
 		{
-			Assert.That(_passthroughQuery.LoadWith(a => a.Child).ThenLoad(b => b.Leaf).ToList(), Is.Empty);
+			AssertPassthrough(_passthroughQuery.LoadWith(a => a.Child).ThenLoad(b => b.Leaf));
 		}
 
 		// ThenLoad overload 2: from collection, single selector
 		[Test]
 		public void ThenLoad_NonLinqToDBSource_FromCollection_Single()
 		{
-			Assert.That(_passthroughQuery.LoadWith(a => a.Children).ThenLoad(b => b.Leaf).ToList(), Is.Empty);
+			AssertPassthrough(_passthroughQuery.LoadWith(a => a.Children).ThenLoad(b => b.Leaf));
 		}
 
 		// ThenLoad overload 3: from single, collection selector + loadFunc
 		[Test]
 		public void ThenLoad_NonLinqToDBSource_FromSingle_Collection_LoadFunc()
 		{
-			Assert.That(_passthroughQuery.LoadWith(a => a.Child).ThenLoad(b => b.Leaves, q => q).ToList(), Is.Empty);
+			AssertPassthrough(_passthroughQuery.LoadWith(a => a.Child).ThenLoad(b => b.Leaves, q => q));
 		}
 
 		// ThenLoad overload 4: from single, single selector + loadFunc
 		[Test]
 		public void ThenLoad_NonLinqToDBSource_FromSingle_Single_LoadFunc()
 		{
-			Assert.That(_passthroughQuery.LoadWith(a => a.Child).ThenLoad(b => b.Leaf, q => q).ToList(), Is.Empty);
+			AssertPassthrough(_passthroughQuery.LoadWith(a => a.Child).ThenLoad(b => b.Leaf, q => q));
 		}
 
 		// ThenLoad overload 5: from collection, single selector + loadFunc
 		[Test]
 		public void ThenLoad_NonLinqToDBSource_FromCollection_Single_LoadFunc()
 		{
-			Assert.That(_passthroughQuery.LoadWith(a => a.Children).ThenLoad(b => b.Leaf, q => q).ToList(), Is.Empty);
+			AssertPassthrough(_passthroughQuery.LoadWith(a => a.Children).ThenLoad(b => b.Leaf, q => q));
 		}
 
 		// ThenLoad overload 6: from collection, collection selector + loadFunc
 		[Test]
 		public void ThenLoad_NonLinqToDBSource_FromCollection_Collection_LoadFunc()
 		{
-			Assert.That(_passthroughQuery.LoadWith(a => a.Children).ThenLoad(b => b.Leaves, q => q).ToList(), Is.Empty);
+			AssertPassthrough(_passthroughQuery.LoadWith(a => a.Children).ThenLoad(b => b.Leaves, q => q));
 		}
 
 		#endregion

--- a/Tests/Linq/Linq/EagerLoadingTests.cs
+++ b/Tests/Linq/Linq/EagerLoadingTests.cs
@@ -3597,85 +3597,86 @@ namespace Tests.Linq
 
 		#endregion
 
-		#region Non-linq2db IQueryable source (issue #5649)
+		#region LoadWith/ThenLoad on non-linq2db IQueryable source
 
-		sealed class IssueEntity5649A
+		sealed class LoadWithPassthroughRoot
 		{
-			public IssueEntity5649B  Prop  { get; set; } = null!;
-			public IssueEntity5649B[] Props { get; set; } = null!;
+			public LoadWithPassthroughChild  Child    { get; set; } = null!;
+			public LoadWithPassthroughChild[] Children { get; set; } = null!;
 		}
 
-		sealed class IssueEntity5649B
+		sealed class LoadWithPassthroughChild
 		{
-			public IssueEntity5649C  Child  { get; set; } = null!;
-			public IssueEntity5649C[] Children { get; set; } = null!;
+			public LoadWithPassthroughLeaf  Leaf   { get; set; } = null!;
+			public LoadWithPassthroughLeaf[] Leaves { get; set; } = null!;
 		}
 
-		sealed class IssueEntity5649C { }
+		sealed class LoadWithPassthroughLeaf { }
 
-		static readonly IQueryable<IssueEntity5649A> _emptyA = Enumerable.Empty<IssueEntity5649A>().AsQueryable();
+		static readonly IQueryable<LoadWithPassthroughRoot> _passthroughQuery =
+			Enumerable.Empty<LoadWithPassthroughRoot>().AsQueryable();
 
-		// LoadWith overload 1: LoadWith(source, selector)
+		// LoadWith overload 1: single selector
 		[Test]
-		public void Issue5649_LoadWith_Single()
+		public void LoadWith_NonLinqToDBSource_Single()
 		{
-			Assert.That(_emptyA.LoadWith(a => a.Prop).ToList(), Is.Empty);
+			Assert.That(_passthroughQuery.LoadWith(a => a.Child).ToList(), Is.Empty);
 		}
 
-		// LoadWith overload 2: LoadWith(source, IEnumerable selector, loadFunc)
+		// LoadWith overload 2: collection selector + loadFunc
 		[Test]
-		public void Issue5649_LoadWith_Collection_LoadFunc()
+		public void LoadWith_NonLinqToDBSource_Collection_LoadFunc()
 		{
-			Assert.That(_emptyA.LoadWith(a => a.Props, q => q).ToList(), Is.Empty);
+			Assert.That(_passthroughQuery.LoadWith(a => a.Children, q => q).ToList(), Is.Empty);
 		}
 
-		// LoadWith overload 3: LoadWith(source, single selector, loadFunc)
+		// LoadWith overload 3: single selector + loadFunc
 		[Test]
-		public void Issue5649_LoadWith_Single_LoadFunc()
+		public void LoadWith_NonLinqToDBSource_Single_LoadFunc()
 		{
-			Assert.That(_emptyA.LoadWith(a => a.Prop, q => q).ToList(), Is.Empty);
+			Assert.That(_passthroughQuery.LoadWith(a => a.Child, q => q).ToList(), Is.Empty);
 		}
 
-		// ThenLoad overload 1: ThenLoad from single, single selector
+		// ThenLoad overload 1: from single, single selector
 		[Test]
-		public void Issue5649_ThenLoad_FromSingle_Single()
+		public void ThenLoad_NonLinqToDBSource_FromSingle_Single()
 		{
-			Assert.That(_emptyA.LoadWith(a => a.Prop).ThenLoad(b => b.Child).ToList(), Is.Empty);
+			Assert.That(_passthroughQuery.LoadWith(a => a.Child).ThenLoad(b => b.Leaf).ToList(), Is.Empty);
 		}
 
-		// ThenLoad overload 2: ThenLoad from collection, single selector
+		// ThenLoad overload 2: from collection, single selector
 		[Test]
-		public void Issue5649_ThenLoad_FromCollection_Single()
+		public void ThenLoad_NonLinqToDBSource_FromCollection_Single()
 		{
-			Assert.That(_emptyA.LoadWith(a => a.Props).ThenLoad(b => b.Child).ToList(), Is.Empty);
+			Assert.That(_passthroughQuery.LoadWith(a => a.Children).ThenLoad(b => b.Leaf).ToList(), Is.Empty);
 		}
 
-		// ThenLoad overload 3: ThenLoad from single, collection selector + loadFunc
+		// ThenLoad overload 3: from single, collection selector + loadFunc
 		[Test]
-		public void Issue5649_ThenLoad_FromSingle_Collection_LoadFunc()
+		public void ThenLoad_NonLinqToDBSource_FromSingle_Collection_LoadFunc()
 		{
-			Assert.That(_emptyA.LoadWith(a => a.Prop).ThenLoad(b => b.Children, q => q).ToList(), Is.Empty);
+			Assert.That(_passthroughQuery.LoadWith(a => a.Child).ThenLoad(b => b.Leaves, q => q).ToList(), Is.Empty);
 		}
 
-		// ThenLoad overload 4: ThenLoad from single, single selector + loadFunc
+		// ThenLoad overload 4: from single, single selector + loadFunc
 		[Test]
-		public void Issue5649_ThenLoad_FromSingle_Single_LoadFunc()
+		public void ThenLoad_NonLinqToDBSource_FromSingle_Single_LoadFunc()
 		{
-			Assert.That(_emptyA.LoadWith(a => a.Prop).ThenLoad(b => b.Child, q => q).ToList(), Is.Empty);
+			Assert.That(_passthroughQuery.LoadWith(a => a.Child).ThenLoad(b => b.Leaf, q => q).ToList(), Is.Empty);
 		}
 
-		// ThenLoad overload 5: ThenLoad from collection, single selector + loadFunc
+		// ThenLoad overload 5: from collection, single selector + loadFunc
 		[Test]
-		public void Issue5649_ThenLoad_FromCollection_Single_LoadFunc()
+		public void ThenLoad_NonLinqToDBSource_FromCollection_Single_LoadFunc()
 		{
-			Assert.That(_emptyA.LoadWith(a => a.Props).ThenLoad(b => b.Child, q => q).ToList(), Is.Empty);
+			Assert.That(_passthroughQuery.LoadWith(a => a.Children).ThenLoad(b => b.Leaf, q => q).ToList(), Is.Empty);
 		}
 
-		// ThenLoad overload 6: ThenLoad from collection, collection selector + loadFunc
+		// ThenLoad overload 6: from collection, collection selector + loadFunc
 		[Test]
-		public void Issue5649_ThenLoad_FromCollection_Collection_LoadFunc()
+		public void ThenLoad_NonLinqToDBSource_FromCollection_Collection_LoadFunc()
 		{
-			Assert.That(_emptyA.LoadWith(a => a.Props).ThenLoad(b => b.Children, q => q).ToList(), Is.Empty);
+			Assert.That(_passthroughQuery.LoadWith(a => a.Children).ThenLoad(b => b.Leaves, q => q).ToList(), Is.Empty);
 		}
 
 		#endregion

--- a/Tests/Linq/Linq/EagerLoadingTests.cs
+++ b/Tests/Linq/Linq/EagerLoadingTests.cs
@@ -3596,5 +3596,39 @@ namespace Tests.Linq
 		}
 
 		#endregion
+
+		#region Non-linq2db IQueryable source (issue #5649)
+
+		sealed class IssueEntity5649A
+		{
+			public IssueEntity5649B Prop { get; set; } = null!;
+		}
+
+		sealed class IssueEntity5649B { }
+
+		[Test]
+		public void Issue5649_LoadWith_NonLinqToDBSource()
+		{
+			// LoadWith on a non-linq2db IQueryable should not throw — mirrors EF Core Include behavior.
+			// No associations are loaded, but enumeration must work.
+			var result = Enumerable.Empty<IssueEntity5649A>().AsQueryable()
+				.LoadWith(a => a.Prop)
+				.ToList();
+
+			Assert.That(result, Is.Empty);
+		}
+
+		[Test]
+		public void Issue5649_LoadWith_ThenLoad_NonLinqToDBSource()
+		{
+			var result = Enumerable.Empty<IssueEntity5649A>().AsQueryable()
+				.LoadWith(a => a.Prop)
+				.ThenLoad(b => b)
+				.ToList();
+
+			Assert.That(result, Is.Empty);
+		}
+
+		#endregion
 	}
 }


### PR DESCRIPTION
Fixes #5649

Since #5341 (v6.2.0), `LoadWith` required the source to be a linq2db `IExpressionQuery<T>`, causing an `InvalidCastException` when called on a plain `IQueryable` (e.g. `Enumerable.Empty<A>().AsQueryable()`).

## Changes

- Widened `LoadWithQueryableBase<TEntity>` and `LoadWithQueryable<TEntity,TProperty>` constructor parameters from `IExpressionQuery<TEntity>` to `IQueryable<TEntity>`. linq2db-specific members (`DataContext`, `GetSqlQueries`, `DebugView`) guard with `is IExpressionQuery<TEntity>` and throw a clear `LinqToDBException` if accessed without a linq2db source.
- All 9 `LoadWith`/`ThenLoad` overloads: when the source provider is not a linq2db `IQueryProviderAsync`, skip expression-tree injection and return a passthrough wrapper that delegates enumeration to the original source — mirrors EF Core `Include` behavior.
- Nine tests added, one per `LoadWith`/`ThenLoad` overload.