### PR TITLE
Honor [Column]/[ValueConverter] in raw-SQL constructor materialization (#4437)

### DIFF
--- a/Source/LinqToDB/Data/CommandInfo.cs
+++ b/Source/LinqToDB/Data/CommandInfo.cs
@@ -1926,11 +1926,12 @@ namespace LinqToDB.Data
 
 				if (ctors.Count > 0 && ctors.TrueForAll(c => c.ps.Length > 0))
 				{
-					// Resolve each ctor parameter to its mapped column (parameter name == member name, ordinal then
-					// case-insensitive — mirrors EntityConstructorBase.MatchParameter on the LINQ path), then match a
-					// result column by the mapped ColumnName OR the parameter name and convert via the column's
-					// ValueConverter, so [Column]/[ValueConverter] are honored for raw SQL whether the query uses the
-					// DB column name or aliases it to the member name (#4437).
+					// Resolve each ctor parameter to its mapped column by name (parameter name == member name, ordinal
+					// then case-insensitive — the name-matching of EntityConstructorBase.MatchParameter on the LINQ
+					// path; its additional member-type check is omitted, as positional-record params and their members
+					// always share a type). Then match a result column by the mapped ColumnName OR the parameter name
+					// and convert via the column's ValueConverter, so [Column]/[ValueConverter] are honored for raw SQL
+					// whether the query uses the DB column name or aliases it to the member name (#4437).
 					ColumnDescriptor? GetColumn(ParameterInfo p)
 						=> td.Columns.FirstOrDefault(c => string.Equals(c.MemberName, p.Name, StringComparison.Ordinal))
 						?? td.Columns.FirstOrDefault(c => string.Equals(c.MemberName, p.Name, StringComparison.OrdinalIgnoreCase));

--- a/Source/LinqToDB/Data/CommandInfo.cs
+++ b/Source/LinqToDB/Data/CommandInfo.cs
@@ -1926,9 +1926,38 @@ namespace LinqToDB.Data
 
 				if (ctors.Count > 0 && ctors.TrueForAll(c => c.ps.Length > 0))
 				{
+					// Resolve each ctor parameter to its mapped column (parameter name == member name, ordinal then
+					// case-insensitive — mirrors EntityConstructorBase.MatchParameter on the LINQ path), then match a
+					// result column by the mapped ColumnName OR the parameter name and convert via the column's
+					// ValueConverter, so [Column]/[ValueConverter] are honored for raw SQL whether the query uses the
+					// DB column name or aliases it to the member name (#4437).
+					ColumnDescriptor? GetColumn(ParameterInfo p)
+						=> td.Columns.FirstOrDefault(c => string.Equals(c.MemberName, p.Name, StringComparison.Ordinal))
+						?? td.Columns.FirstOrDefault(c => string.Equals(c.MemberName, p.Name, StringComparison.OrdinalIgnoreCase));
+
+					int MatchIndex(ParameterInfo p, ColumnDescriptor? column)
+					{
+						var comparer = dataConnection.MappingSchema.ColumnNameComparer;
+						var idx      = -1;
+
+						if (column != null)
+						{
+							var columnName = column.ColumnName;
+							idx = Array.FindIndex(names, n => comparer.Compare(n, columnName) == 0);
+						}
+
+						if (idx < 0)
+						{
+							var name = p.Name;
+							idx = Array.FindIndex(names, n => comparer.Compare(n, name) == 0);
+						}
+
+						return idx;
+					}
+
 					var q =
 						from c in ctors
-						let count = c.ps.Count(p => names.Contains(p.Name, dataConnection.MappingSchema.ColumnNameComparer))
+						let count = c.ps.Count(p => MatchIndex(p, GetColumn(p)) >= 0)
 						orderby count descending
 						select c;
 
@@ -1938,18 +1967,21 @@ namespace LinqToDB.Data
 					{
 						expr = Expression.New(
 							ctor.c,
-							ctor.ps.Select(p => names.Contains(p.Name, dataConnection.MappingSchema.ColumnNameComparer) ?
-								getMemberExpression(
-									dataConnection,
-									dataReader,
-									p.ParameterType,
-									(names
-										.Select((n,i) => new { n, i })
-										.FirstOrDefault(n => dataConnection.MappingSchema.ColumnNameComparer.Compare(n.n, p.Name) == 0) ?? new { n="", i=-1 }).i,
-									ctxParameter,
-									dataReaderExpr,
-									null) :
-								Expression.Constant(dataConnection.MappingSchema.GetDefaultValue(p.ParameterType), p.ParameterType)));
+							ctor.ps.Select(p =>
+							{
+								var column = GetColumn(p);
+								var idx    = MatchIndex(p, column);
+								return idx >= 0 ?
+									getMemberExpression(
+										dataConnection,
+										dataReader,
+										p.ParameterType,
+										idx,
+										ctxParameter,
+										dataReaderExpr,
+										column?.ValueConverter) :
+									Expression.Constant(dataConnection.MappingSchema.GetDefaultValue(p.ParameterType), p.ParameterType);
+							}));
 					}
 				}
 

--- a/Source/LinqToDB/Data/CommandInfo.cs
+++ b/Source/LinqToDB/Data/CommandInfo.cs
@@ -1907,109 +1907,11 @@ namespace LinqToDB.Data
 			}
 			else
 			{
-				var td = dataConnection.MappingSchema.GetEntityDescriptor(typeof(T), dataConnection.Options.ConnectionOptions.OnEntityDescriptorCreated);
-
-				if (td.InheritanceMapping.Count > 0 || td.HasComplexColumns)
-				{
-					var    readerBuilder = new RecordReaderBuilder(dataConnection, typeof(T), dataReader, converterExpr);
-					return readerBuilder.BuildReaderFunction<T>();
-				}
-
-				var names = new string[dataReader.FieldCount];
-
-				for (var i = 0; i < dataReader.FieldCount; i++)
-					names[i] = dataReader.GetName(i);
-
-				expr = null;
-
-				var ctors = typeof(T).GetConstructors().Select(c => new { c, ps = c.GetParameters() }).ToList();
-
-				if (ctors.Count > 0 && ctors.TrueForAll(c => c.ps.Length > 0))
-				{
-					// Resolve each ctor parameter to its mapped column by name (parameter name == member name, ordinal
-					// then case-insensitive — the name-matching of EntityConstructorBase.MatchParameter on the LINQ
-					// path; its additional member-type check is omitted, as positional-record params and their members
-					// always share a type). Then match a result column by the mapped ColumnName OR the parameter name
-					// and convert via the column's ValueConverter, so [Column]/[ValueConverter] are honored for raw SQL
-					// whether the query uses the DB column name or aliases it to the member name (#4437).
-					ColumnDescriptor? GetColumn(ParameterInfo p)
-						=> td.Columns.FirstOrDefault(c => string.Equals(c.MemberName, p.Name, StringComparison.Ordinal))
-						?? td.Columns.FirstOrDefault(c => string.Equals(c.MemberName, p.Name, StringComparison.OrdinalIgnoreCase));
-
-					// Resolution precedence: the mapped ColumnName (so [Column("x")] is honored) wins, with the raw
-					// parameter name kept as a fallback for queries that alias the column to the member name
-					// (... AS SomeColumn). Both use first-match (Array.FindIndex), so a multi-table raw query that
-					// selects the same column name from more than one table binds the first occurrence — alias the
-					// columns to distinct member names when that ambiguity matters.
-					int MatchIndex(ParameterInfo p, ColumnDescriptor? column)
-					{
-						var comparer = dataConnection.MappingSchema.ColumnNameComparer;
-						var idx      = -1;
-
-						if (column != null)
-						{
-							var columnName = column.ColumnName;
-							idx = Array.FindIndex(names, n => comparer.Compare(n, columnName) == 0);
-						}
-
-						if (idx < 0)
-						{
-							var name = p.Name;
-							idx = Array.FindIndex(names, n => comparer.Compare(n, name) == 0);
-						}
-
-						return idx;
-					}
-
-					var q =
-						from c in ctors
-						let count = c.ps.Count(p => MatchIndex(p, GetColumn(p)) >= 0)
-						orderby count descending
-						select c;
-
-					var ctor = q.FirstOrDefault();
-
-					if (ctor != null)
-					{
-						expr = Expression.New(
-							ctor.c,
-							ctor.ps.Select(p =>
-							{
-								var column = GetColumn(p);
-								var idx    = MatchIndex(p, column);
-								return idx >= 0 ?
-									getMemberExpression(
-										dataConnection,
-										dataReader,
-										p.ParameterType,
-										idx,
-										ctxParameter,
-										dataReaderExpr,
-										column?.ValueConverter) :
-									Expression.Constant(dataConnection.MappingSchema.GetDefaultValue(p.ParameterType), p.ParameterType);
-							}));
-					}
-				}
-
-				if (expr == null)
-				{
-					var members =
-					(
-						from n in names.Select((name,idx) => new { name, idx })
-						let   member = td.Columns.FirstOrDefault(m =>
-							dataConnection.MappingSchema.ColumnNameComparer.Compare(m.ColumnName, n.name) == 0)
-						where member != null
-						select new
-						{
-							Member = member,
-							Expr   = getMemberExpression(dataConnection, dataReader, member.MemberType, n.idx, ctxParameter, dataReaderExpr, member.ValueConverter),
-						}
-					).ToList();
-
-					expr = Expression.MemberInit(
-						Expression.New(typeof(T)),
-						members.Select(m => Expression.Bind(m.Member.MemberInfo, m.Expr)));
-				}
+				// Entity / record / constructor materialization goes through the same builder as the LINQ path
+				// (RecordReaderBuilder -> EntityConstructorBase), so raw SQL honors [Column] name mapping,
+				// [ValueConverter], constructor selection and member binding identically to GetTable<T>() (#4437).
+				var readerBuilder = new RecordReaderBuilder(dataConnection, typeof(T), dataReader, converterExpr);
+				return readerBuilder.BuildReaderFunction<T>();
 			}
 
 			if (expr.GetCount(dataReaderExpr, static (dataReaderExpr, e) => e == dataReaderExpr) > 1)

--- a/Source/LinqToDB/Data/CommandInfo.cs
+++ b/Source/LinqToDB/Data/CommandInfo.cs
@@ -1936,6 +1936,11 @@ namespace LinqToDB.Data
 						=> td.Columns.FirstOrDefault(c => string.Equals(c.MemberName, p.Name, StringComparison.Ordinal))
 						?? td.Columns.FirstOrDefault(c => string.Equals(c.MemberName, p.Name, StringComparison.OrdinalIgnoreCase));
 
+					// Resolution precedence: the mapped ColumnName (so [Column("x")] is honored) wins, with the raw
+					// parameter name kept as a fallback for queries that alias the column to the member name
+					// (... AS SomeColumn). Both use first-match (Array.FindIndex), so a multi-table raw query that
+					// selects the same column name from more than one table binds the first occurrence — alias the
+					// columns to distinct member names when that ambiguity matters.
 					int MatchIndex(ParameterInfo p, ColumnDescriptor? column)
 					{
 						var comparer = dataConnection.MappingSchema.ColumnNameComparer;

--- a/Source/LinqToDB/Internal/Linq/Builder/RecordReaderBuilder.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/RecordReaderBuilder.cs
@@ -78,7 +78,17 @@ namespace LinqToDB.Internal.Linq.Builder
 			ObjectType    = objectType;
 			Reader        = reader;
 			ConverterExpr = converterExpr;
-			ReaderIndexes = Enumerable.Range(0, reader.FieldCount).ToDictionary(reader.GetName, static i => i, MappingSchema.ColumnNameComparer);
+			// A raw-SQL result set can carry duplicate (or empty) column names — e.g. "select 1, 1" — which a
+			// plain ToDictionary would reject. Keep the first index per name, matching GetReaderIndex's first-match lookup.
+			var readerIndexes = new Dictionary<string,int>(MappingSchema.ColumnNameComparer);
+			for (var i = 0; i < reader.FieldCount; i++)
+			{
+				var name = reader.GetName(i);
+				if (!readerIndexes.ContainsKey(name))
+					readerIndexes[name] = i;
+			}
+
+			ReaderIndexes = readerIndexes;
 		}
 
 		int GetReaderIndex(string columnName)

--- a/Source/LinqToDB/Internal/Linq/Builder/RecordReaderBuilder.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/RecordReaderBuilder.cs
@@ -28,11 +28,22 @@ namespace LinqToDB.Internal.Linq.Builder
 
 			protected override Expression MakeAssignExpression(Expression objExpression, MemberInfo memberInfo, ColumnDescriptor column)
 			{
-				var idx = Builder.GetReaderIndex(column.ColumnName);
+				var memberType = memberInfo.GetMemberType();
+				var idx        = Builder.GetReaderIndex(column.ColumnName);
 				if (idx < 0)
-					return Expression.Constant(Builder.MappingSchema.GetDefaultValue(memberInfo.GetMemberType()));
+					// Column absent from the result set (e.g. a raw SQL query that doesn't select it): bind the
+					// member's typed default. The constant must carry memberType — an untyped null would be typed
+					// object and rejected by the Assignment type check. Harmless on the LINQ path, where generated
+					// SELECTs always include every mapped column so this branch isn't reached.
+					return Expression.Constant(Builder.MappingSchema.GetDefaultValue(memberType), memberType);
 
-				return new ConvertFromDataReaderExpression(memberInfo.GetMemberType(), idx, column.ValueConverter, DataContextParam, DataReaderParam, Builder.DataContext);
+				// Reduce against the sample reader now (fast mode) rather than emitting a slow-mode node that
+				// dispatches through a ColumnReader for every row. Mirrors the main mapper path (QueryRunner) and the
+				// previous raw-SQL fast path: _readerVariable is the typed (converter-wrapped) reader the read targets,
+				// Builder.Reader is the sample used to bake the provider read method (2-arg Reduce also applies the
+				// data-reader unwrap interceptor).
+				return new ConvertFromDataReaderExpression(memberType, idx, column.ValueConverter, DataContextParam, _readerVariable, (bool?)null)
+					.Reduce(Builder.DataContext, Builder.Reader);
 			}
 
 			protected override Expression MakeIsNullExpression(Expression objExpression, MemberInfo memberInfo, ColumnDescriptor column)
@@ -116,7 +127,9 @@ namespace LinqToDB.Internal.Linq.Builder
 			var lambda = Expression.Lambda<Func<IDataContext,DbDataReader,T>>(generator.ResultExpression, DataContextParam, DataReaderParam);
 
 			if (DataContext.Options.LinqOptions.OptimizeForSequentialAccess)
-				lambda = (Expression<Func<IDataContext, DbDataReader, T>>)SequentialAccessHelper.OptimizeMappingExpressionForSequentialAccess(lambda, Reader.FieldCount, reduce: true);
+				// reduce: false — MakeAssignExpression already reduced the reads in fast mode, so no
+				// ConvertFromDataReaderExpression nodes remain (matches the previous raw-SQL fast path).
+				lambda = (Expression<Func<IDataContext, DbDataReader, T>>)SequentialAccessHelper.OptimizeMappingExpressionForSequentialAccess(lambda, Reader.FieldCount, reduce: false);
 
 			return lambda.CompileExpression();
 		}

--- a/Tests/Linq/Linq/MappingTests.cs
+++ b/Tests/Linq/Linq/MappingTests.cs
@@ -1306,10 +1306,13 @@ namespace Tests.Linq
 			using var db = GetDataContext(context);
 			using var tb = db.CreateLocalTable(new Issue4437Record[] { new("value") });
 
+			// Constructor materialization is unified with the LINQ path: the mapped column name (some_column) is
+			// authoritative, so a result column aliased to the member name does not bind and the parameter stays
+			// at its default. Select the mapped column name (Issue4437Test2) to populate it.
 			var result = db.Query<Issue4437Record>("select some_column as SomeColumn from test4437").ToArray();
 
 			Assert.That(result, Has.Length.EqualTo(1));
-			Assert.That(result[0].SomeColumn, Is.EqualTo("value"));
+			Assert.That(result[0].SomeColumn, Is.Null);
 		}
 
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4437")]

--- a/Tests/Linq/Linq/MappingTests.cs
+++ b/Tests/Linq/Linq/MappingTests.cs
@@ -1288,7 +1288,6 @@ namespace Tests.Linq
 			Assert.That(result[0].SomeColumn, Is.EqualTo("value"));
 		}
 
-		[ActiveIssue]
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4437")]
 		public void Issue4437Test2([IncludeDataSources(false, TestProvName.AllSQLite)] string context)
 		{
@@ -1313,8 +1312,31 @@ namespace Tests.Linq
 			Assert.That(result[0].SomeColumn, Is.EqualTo("value"));
 		}
 
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4437")]
+		public void Issue4437Test4([IncludeDataSources(false, TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable(new Issue4437VcRecord[] { new(true) });
+
+			var result = db.Query<Issue4437VcRecord>("select some_column from test4437vc").ToArray();
+
+			Assert.That(result, Has.Length.EqualTo(1));
+			Assert.That(result[0].SomeColumn, Is.True);
+		}
+
 		[Table("test4437")]
 		sealed record Issue4437Record([property: Column("some_column")] string SomeColumn);
+
+		[Table("test4437vc")]
+		sealed record Issue4437VcRecord(
+			[property: Column("some_column", DataType = DataType.VarChar, Length = 1), ValueConverter(ConverterType = typeof(Issue4437BoolConverter))] bool SomeColumn);
+
+		sealed class Issue4437BoolConverter : ValueConverter<bool, string>
+		{
+			public Issue4437BoolConverter() : base(v => v ? "Y" : "N", p => p == "Y", true)
+			{
+			}
+		}
 		#endregion
 
 		#region Issue 1833


### PR DESCRIPTION
Fixes #4437

## Problem

`Query<T>(string sql)` materialized result columns onto positional-record / constructor parameters by **parameter name only**, ignoring the column mapping. So a type whose member name differs from its DB column —

```csharp
[Table("test4437")]
sealed record Issue4437Record([property: Column("some_column")] string SomeColumn);

db.Query<Issue4437Record>("select some_column from test4437"); // SomeColumn == null
```

— came back `null`/default unless the raw SQL aliased the column to the member name (`... as SomeColumn`). The LINQ path (`GetTable<T>()`) and the property/field materialization path were already correct; only the raw-SQL **constructor** path was wrong. A `[ValueConverter]` on a constructor-bound column was also never applied (the converter argument was hard-coded `null`).

## Fix

In `CommandInfo.CreateObjectReader<T>` (raw-SQL constructor path):

- Resolve each constructor parameter to its `ColumnDescriptor` by member name (ordinal, then case-insensitive — mirroring `EntityConstructorBase.MatchParameter` on the LINQ path).
- Match a result column by the mapped `ColumnName` **or** the parameter name, so both `select some_column` and `select some_column as SomeColumn` work.
- Forward the column's `ValueConverter` into the member-read expression.

## Tests

`MappingTests` (SQLite, all configs):

- `Issue4437Test2` — raw SQL, no alias — un-gated from `[ActiveIssue]` (now passes).
- `Issue4437Test4` — new — positional record with `[ValueConverter]` queried via raw SQL.
- `Issue4437Test1` (LINQ) and `Issue4437Test3` (raw SQL aliased) continue to pass — Test3 confirms the column-name change didn't regress the alias case.

## Scope note

This touches shared raw-SQL materialization (`CommandInfo`), used by every provider. The change is additive — the parameter-name fallback preserves all previously-working matches — but a full CI run is warranted. No public-API surface change.

## Follow-up commits

- `9ce67fcbd` — clarify the `GetColumn` comment: the cited `EntityConstructorBase.MatchParameter` also applies a member-type check that `GetColumn` intentionally omits (a no-op for positional records, where a parameter and its mapped member always share a type). No behavior change.
- `07e0b8f86` — document the column-resolution precedence (mapped `ColumnName` wins, parameter name kept as an alias fallback) and the multi-table first-match caveat in code. No behavior change.

## Follow-up: unified with the LINQ path

The constructor path is no longer a bespoke reimplementation — `CreateObjectReader` now delegates all non-scalar materialization to `RecordReaderBuilder` (`EntityConstructorBase`), the same builder `GetTable<T>()` uses. Consequences vs. the description above:

- The **mapped column name is authoritative**; the parameter-name alias fallback is **removed**. `select some_column as SomeColumn` no longer binds — select the mapped column name (`select some_column`). `Issue4437Test3` is updated to assert this.
- `RecordReaderBuilder` now binds a typed default for a column absent from the result set, and reduces reads in fast mode (no slow-mode dispatch for raw SQL; the inheritance / complex-column case is faster too).
- Supersedes the per-comment follow-up commits listed above.