### PR TITLE
Unify raw-SQL entity mapping with the LINQ path (#4437)

### DIFF
--- a/Source/LinqToDB/Data/CommandInfo.cs
+++ b/Source/LinqToDB/Data/CommandInfo.cs
@@ -1907,71 +1907,11 @@ namespace LinqToDB.Data
 			}
 			else
 			{
-				var td = dataConnection.MappingSchema.GetEntityDescriptor(typeof(T), dataConnection.Options.ConnectionOptions.OnEntityDescriptorCreated);
-
-				if (td.InheritanceMapping.Count > 0 || td.HasComplexColumns)
-				{
-					var    readerBuilder = new RecordReaderBuilder(dataConnection, typeof(T), dataReader, converterExpr);
-					return readerBuilder.BuildReaderFunction<T>();
-				}
-
-				var names = new string[dataReader.FieldCount];
-
-				for (var i = 0; i < dataReader.FieldCount; i++)
-					names[i] = dataReader.GetName(i);
-
-				expr = null;
-
-				var ctors = typeof(T).GetConstructors().Select(c => new { c, ps = c.GetParameters() }).ToList();
-
-				if (ctors.Count > 0 && ctors.TrueForAll(c => c.ps.Length > 0))
-				{
-					var q =
-						from c in ctors
-						let count = c.ps.Count(p => names.Contains(p.Name, dataConnection.MappingSchema.ColumnNameComparer))
-						orderby count descending
-						select c;
-
-					var ctor = q.FirstOrDefault();
-
-					if (ctor != null)
-					{
-						expr = Expression.New(
-							ctor.c,
-							ctor.ps.Select(p => names.Contains(p.Name, dataConnection.MappingSchema.ColumnNameComparer) ?
-								getMemberExpression(
-									dataConnection,
-									dataReader,
-									p.ParameterType,
-									(names
-										.Select((n,i) => new { n, i })
-										.FirstOrDefault(n => dataConnection.MappingSchema.ColumnNameComparer.Compare(n.n, p.Name) == 0) ?? new { n="", i=-1 }).i,
-									ctxParameter,
-									dataReaderExpr,
-									null) :
-								Expression.Constant(dataConnection.MappingSchema.GetDefaultValue(p.ParameterType), p.ParameterType)));
-					}
-				}
-
-				if (expr == null)
-				{
-					var members =
-					(
-						from n in names.Select((name,idx) => new { name, idx })
-						let   member = td.Columns.FirstOrDefault(m =>
-							dataConnection.MappingSchema.ColumnNameComparer.Compare(m.ColumnName, n.name) == 0)
-						where member != null
-						select new
-						{
-							Member = member,
-							Expr   = getMemberExpression(dataConnection, dataReader, member.MemberType, n.idx, ctxParameter, dataReaderExpr, member.ValueConverter),
-						}
-					).ToList();
-
-					expr = Expression.MemberInit(
-						Expression.New(typeof(T)),
-						members.Select(m => Expression.Bind(m.Member.MemberInfo, m.Expr)));
-				}
+				// Raw-SQL entity mapping is unified with the LINQ path (issue #4437): map reader fields by
+				// the entity's column metadata (honoring [Column] names) and select/fill the constructor with
+				// the same rules as LINQ queries, instead of matching constructor parameters by reader field name.
+				var readerBuilder = new RecordReaderBuilder(dataConnection, typeof(T), dataReader, converterExpr);
+				return readerBuilder.BuildReaderFunction<T>();
 			}
 
 			if (expr.GetCount(dataReaderExpr, static (dataReaderExpr, e) => e == dataReaderExpr) > 1)

--- a/Source/LinqToDB/Internal/Linq/Builder/RecordReaderBuilder.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/RecordReaderBuilder.cs
@@ -67,7 +67,16 @@ namespace LinqToDB.Internal.Linq.Builder
 			ObjectType    = objectType;
 			Reader        = reader;
 			ConverterExpr = converterExpr;
-			ReaderIndexes = Enumerable.Range(0, reader.FieldCount).ToDictionary(reader.GetName, static i => i, MappingSchema.ColumnNameComparer);
+
+			// Keep the first occurrence of a duplicated field name (e.g. multi-table 'SELECT t1.f, t2.f'),
+			// matching the by-name behavior of raw-SQL mapping; a plain ToDictionary would throw on duplicates.
+			ReaderIndexes = new Dictionary<string,int>(reader.FieldCount, MappingSchema.ColumnNameComparer);
+			for (var i = 0; i < reader.FieldCount; i++)
+			{
+				var name = reader.GetName(i);
+				if (!ReaderIndexes.ContainsKey(name))
+					ReaderIndexes.Add(name, i);
+			}
 		}
 
 		int GetReaderIndex(string columnName)

--- a/Tests/Linq/Data/DataExtensionsTests.cs
+++ b/Tests/Linq/Data/DataExtensionsTests.cs
@@ -72,6 +72,41 @@ namespace Tests.Data
 			Assert.That(list, Has.Count.EqualTo(1));
 		}
 
+		[Table("test")]
+		public record Issue4437Record(
+			[property: Column("some_column")] string SomeColumn);
+
+		[Test]
+		public void Issue4437_RawSqlMapsByColumnName([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			// Raw-SQL mapping is unified with the LINQ path: the [Column] name is honored for records with a
+			// primary constructor, so a 'some_column' field maps onto SomeColumn instead of returning null.
+			using var conn = GetDataContext(context);
+
+			var list = conn.Query<Issue4437Record>("SELECT 'mapped' AS some_column").ToList();
+
+			Assert.That(list, Has.Count.EqualTo(1));
+			Assert.That(list[0].SomeColumn, Is.EqualTo("mapped"));
+		}
+
+		sealed class DuplicateColumnObject
+		{
+			[Column("Column1")] public int Column1 { get; set; }
+		}
+
+		[Test]
+		public void RawSqlDuplicateColumnNameTakesFirst([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			// A multi-table-style result set with a repeated column name must not throw on reader-index build;
+			// the first occurrence wins (matching the legacy by-name behavior).
+			using var conn = GetDataContext(context);
+
+			var list = conn.Query<DuplicateColumnObject>("SELECT 1 AS Column1, 2 AS Column1").ToList();
+
+			Assert.That(list, Has.Count.EqualTo(1));
+			Assert.That(list[0].Column1, Is.EqualTo(1));
+		}
+
 		[Test]
 		public void TestObject3()
 		{


### PR DESCRIPTION
Fixes #4437.

Routes all entity types in raw-SQL queries (`Query<T>` / `QueryToList`) through `RecordReaderBuilder`, so they map reader fields by `[Column]` metadata and select constructors with the same rules as LINQ queries / `GetTable<T>` — instead of the old behavior of matching constructor parameters by reader field name.

- `CommandInfo.CreateObjectReader`: removed the bespoke field-name ctor matcher; all entity types now use `RecordReaderBuilder` (previously only inheritance / complex-column types did).
- `RecordReaderBuilder`: reader-index map now keeps the first occurrence of a duplicated field name (multi-table `SELECT t1.f, t2.f`) instead of throwing.
- Regression tests in `DataExtensionsTests`.

## ⚠️ Breaking change
Raw-SQL result columns must now match the `[Column]` name (the database column name), **not** the C# member name. The previously-recommended workaround `SELECT some_column AS SomeColumn` no longer maps — use `SELECT some_column`. This makes raw-SQL mapping consistent with LINQ.
