### PR TITLE
Self-heal baselines branch so test-job restarts work

### DIFF
--- a/Build/Azure/pipelines/templates/test-jobs.yml
+++ b/Build/Azure/pipelines/templates/test-jobs.yml
@@ -21,102 +21,16 @@ jobs:
 
   steps:
   - checkout: none
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      artifactName: $(artifact_test_scripts)
+      targetPath: '$(System.DefaultWorkingDirectory)/scripts'
+    displayName: Extract test scripts
   - task: PowerShell@2
     inputs:
-      targetType: 'inline'
-      script: |
-        $prId = "$(source_pr_id)"
-        $orgName = "linq2db"
-        $baselinesRepo = "linq2db.baselines"
-        $baselinesRepoUrl = "https://${Env:GITHUB_TOKEN}@github.com/${orgName}/${baselinesRepo}.git"
-        Write-Host "Source PR ID: ${prId}"
-        if ($prId) {
-            $baselinesBranch = "baselines/pr_${prId}"
-        } else {
-            $baselinesBranch = "baselines/default"
-        }
-        Write-Host "Baselines branch name: ${baselinesBranch}"
-        $output = git ls-remote --heads $baselinesRepoUrl $baselinesBranch
-        Write-Host "Baselines HEAD: ${output}"
-        if ($LASTEXITCODE -ne 0) {
-            Write-Host "Baselines HEAD request failed with code ${LASTEXITCODE}"
-            exit 1
-        }
-        $baselinesNewBranch = 0
-        if ($output.Length -lt 40) {
-            Write-Host "Baselines branch not found"
-            Write-Host "Reading baselines repository HEAD hash..."
-            $output = git ls-remote $baselinesRepoUrl $(baselines_master)
-            if ($LASTEXITCODE -ne 0) {
-                Write-Host "Failed to read HEAD hash. Error code ${LASTEXITCODE}"
-                exit 1
-            }
-            if ($output.Length -lt 40) {
-                Write-Host "Baselines repo HEAD not found. Last output: ${output}"
-                exit 1
-            }
-            $baslinesHeadHash = ($output -split '\s+')[0]
-            Write-Host "Creating new baselines branch ${baselinesBranch}..."
-            $output = gh api /repos/$orgName/$baselinesRepo/git/refs -i -F ref=refs/heads/$baselinesBranch -F sha=$baslinesHeadHash
-            Write-Host "Create command output: ${output}"
-            if ($LASTEXITCODE -ne 0) {
-                Write-Host "Failed to create branch. Error code ${LASTEXITCODE}"
-                exit 1
-            }
-            if ($output -match "201 Created") {
-                Write-Host "Baselines branch created"
-                $baselinesNewBranch = 1
-            } else {
-                Write-Host "Baselines branch creation failed"
-                exit 1
-            }
-        } else {
-            Write-Host "Baselines branch already exists, checking if rebase required"
-            $head = git ls-remote $baselinesRepoUrl $(baselines_master)
-            if ($LASTEXITCODE -ne 0) {
-                Write-Host "Failed to read HEAD hash. Error code ${LASTEXITCODE}"
-                exit 1
-            }
-            if ($head.Length -lt 40) {
-                Write-Host "Baselines repo HEAD not found. Last output: ${head}"
-                exit 1
-            }
-            $baslinesHeadHash = ($output -split '\s+')[0]
-            $headHash = ($head -split '\s+')[0]
-            if ($baslinesHeadHash -eq $headHash) {
-                Write-Host "Baselines branch already based on HEAD, no rebase required"
-            } else {
-                Write-Host "Baselines head is ${baslinesHeadHash}, but HEAD is ${head}, trying to rebase on current HEAD"
-                git clone $baselinesRepoUrl baselines
-                if ($LASTEXITCODE -ne 0) {
-                    Write-Host "Failed to clone baselines repository. Error code ${LASTEXITCODE}"
-                    exit 1
-                }
-                cd baselines
-                git checkout origin/$baselinesBranch
-                if ($LASTEXITCODE -ne 0) {
-                    Write-Host "Failed to checkout baselines branch origin/${baselinesBranch}. Error code ${LASTEXITCODE}"
-                    exit 1
-                }
-                git rebase origin/$(baselines_master)
-                if ($LASTEXITCODE -ne 0) {
-                    Write-Host "Failed to rebase baselines PR on origin/$(baselines_master). Delete branch and re-run tests. Error code ${LASTEXITCODE}"
-                    exit 1
-                }
-                git push -f origin HEAD:$baselinesBranch
-                if ($LASTEXITCODE -ne 0) {
-                    Write-Host "Failed to push rebased baselines. Error code ${LASTEXITCODE}"
-                    exit 1
-                }
-                Write-Host "Baselines PR was rebased on HEAD"
-                $baslinesHeadHash = $headHash
-            }
-        }
-        Write-Host "Baselines branch head hash: ${baslinesHeadHash}"
-        # export branch name and hash to pipelines variables
-        echo "##vso[task.setvariable variable=baselines_branch;isOutput=true]${baselinesBranch}"
-        echo "##vso[task.setvariable variable=baselines_head;isOutput=true]${baslinesHeadHash}"
-        echo "##vso[task.setvariable variable=baselines_new_branch;isOutput=true]${baselinesNewBranch}"
+      pwsh: true
+      filePath: '$(System.DefaultWorkingDirectory)/scripts/ensure-baselines-branch.ps1'
+      arguments: -PrId "$(source_pr_id)" -BaselinesMaster "$(baselines_master)" -Rebase -EmitOutputs
       workingDirectory: '$(System.DefaultWorkingDirectory)'
     displayName: Checkout test baselines
     name: baselines_init
@@ -140,6 +54,7 @@ jobs:
   condition: ${{ parameters.enabled }}
   variables:
     baselines_branch: $[ dependencies.create_baselines_branch.outputs['baselines_init.baselines_branch'] ]
+    baselines_head: $[ dependencies.create_baselines_branch.outputs['baselines_init.baselines_head'] ]
 
   strategy:
     matrix:
@@ -179,6 +94,7 @@ jobs:
   condition: ${{ parameters.enabled }}
   variables:
     baselines_branch: $[ dependencies.create_baselines_branch.outputs['baselines_init.baselines_branch'] ]
+    baselines_head: $[ dependencies.create_baselines_branch.outputs['baselines_init.baselines_head'] ]
 
   strategy:
     matrix:
@@ -212,6 +128,7 @@ jobs:
   condition: and(eq(${{ parameters.enabled }}, 'true'), eq(${{ parameters.mac_enabled }}, 'true'))
   variables:
     baselines_branch: $[ dependencies.create_baselines_branch.outputs['baselines_init.baselines_branch'] ]
+    baselines_head: $[ dependencies.create_baselines_branch.outputs['baselines_init.baselines_head'] ]
 
   strategy:
     matrix:

--- a/Build/Azure/pipelines/templates/test-workflow-linux.yml
+++ b/Build/Azure/pipelines/templates/test-workflow-linux.yml
@@ -23,6 +23,27 @@ steps:
       df -h
   displayName: Cleanup Junk
 
+- task: DownloadPipelineArtifact@2
+  inputs:
+    artifactName: $(artifact_test_scripts)
+    targetPath: '$(System.DefaultWorkingDirectory)/scripts'
+  condition: and(variables.title, succeeded())
+  displayName: Extract test scripts
+
+# Re-create the baselines branch if a previous completed run deleted it (empty-branch
+# cleanup). Without this, a "rerun failed jobs" restart fails on the clone below because
+# create_baselines_branch is not re-run on a partial restart. See build 21555.
+- task: PowerShell@2
+  inputs:
+    pwsh: true
+    filePath: '$(System.DefaultWorkingDirectory)/scripts/ensure-baselines-branch.ps1'
+    arguments: -Branch "$(baselines_branch)" -BaselinesMaster "$(baselines_master)" -BaseHash "$(baselines_head)"
+    workingDirectory: '$(System.DefaultWorkingDirectory)'
+  displayName: Ensure test baselines branch
+  condition: and(variables.title, ${{ parameters.with_baselines }}, succeeded())
+  env:
+    GITHUB_TOKEN: $(BASELINES_GH_PAT)
+
 - task: CmdLine@2
   inputs:
     script: 'git clone https://$(BASELINES_GH_PAT)@github.com/linq2db/linq2db.baselines.git baselines && cd baselines && git checkout -b $(baselines_branch) origin/$(baselines_branch) && cd ..'
@@ -36,13 +57,6 @@ steps:
     targetPath: '$(System.DefaultWorkingDirectory)/configs'
   condition: and(variables.title, succeeded())
   displayName: Extract test configs
-
-- task: DownloadPipelineArtifact@2
-  inputs:
-    artifactName: $(artifact_test_scripts)
-    targetPath: '$(System.DefaultWorkingDirectory)/scripts'
-  condition: and(variables.title, succeeded())
-  displayName: Extract test scripts
 
 - task: DownloadPipelineArtifact@2
   inputs:

--- a/Build/Azure/pipelines/templates/test-workflow-macos.yml
+++ b/Build/Azure/pipelines/templates/test-workflow-macos.yml
@@ -7,6 +7,27 @@ steps:
 # .NET 8 SDK already installed https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#language-and-runtime
 # but we still need to install all required versions because only last installed available due to bug
 
+- task: DownloadPipelineArtifact@2
+  inputs:
+    artifactName: $(artifact_test_scripts)
+    targetPath: '$(System.DefaultWorkingDirectory)/scripts'
+  condition: and(variables.title, succeeded())
+  displayName: Extract test scripts
+
+# Re-create the baselines branch if a previous completed run deleted it (empty-branch
+# cleanup). Without this, a "rerun failed jobs" restart fails on the clone below because
+# create_baselines_branch is not re-run on a partial restart. See build 21555.
+- task: PowerShell@2
+  inputs:
+    pwsh: true
+    filePath: '$(System.DefaultWorkingDirectory)/scripts/ensure-baselines-branch.ps1'
+    arguments: -Branch "$(baselines_branch)" -BaselinesMaster "$(baselines_master)" -BaseHash "$(baselines_head)"
+    workingDirectory: '$(System.DefaultWorkingDirectory)'
+  displayName: Ensure test baselines branch
+  condition: and(variables.title, ${{ parameters.with_baselines }}, succeeded())
+  env:
+    GITHUB_TOKEN: $(BASELINES_GH_PAT)
+
 - task: CmdLine@2
   inputs:
     script: 'git clone https://$(BASELINES_GH_PAT)@github.com/linq2db/linq2db.baselines.git baselines && cd baselines && git checkout -b $(baselines_branch) origin/$(baselines_branch) && cd ..'
@@ -20,13 +41,6 @@ steps:
     targetPath: '$(System.DefaultWorkingDirectory)/configs'
   condition: and(variables.title, succeeded())
   displayName: Extract test configs
-
-- task: DownloadPipelineArtifact@2
-  inputs:
-    artifactName: $(artifact_test_scripts)
-    targetPath: '$(System.DefaultWorkingDirectory)/scripts'
-  condition: and(variables.title, succeeded())
-  displayName: Extract test scripts
 
 - task: DownloadPipelineArtifact@2
   inputs:

--- a/Build/Azure/pipelines/templates/test-workflow-windows.yml
+++ b/Build/Azure/pipelines/templates/test-workflow-windows.yml
@@ -52,6 +52,27 @@ steps:
     packageType: sdk
     version: 10.x
 
+- task: DownloadPipelineArtifact@2
+  inputs:
+    artifactName: $(artifact_test_scripts)
+    targetPath: '$(System.DefaultWorkingDirectory)/scripts'
+  condition: and(variables.title, succeeded())
+  displayName: Extract test scripts
+
+# Re-create the baselines branch if a previous completed run deleted it (empty-branch
+# cleanup). Without this, a "rerun failed jobs" restart fails on the clone below because
+# create_baselines_branch is not re-run on a partial restart. See build 21555.
+- task: PowerShell@2
+  inputs:
+    pwsh: true
+    filePath: '$(System.DefaultWorkingDirectory)/scripts/ensure-baselines-branch.ps1'
+    arguments: -Branch "$(baselines_branch)" -BaselinesMaster "$(baselines_master)" -BaseHash "$(baselines_head)"
+    workingDirectory: '$(System.DefaultWorkingDirectory)'
+  displayName: Ensure test baselines branch
+  condition: and(variables.title, ${{ parameters.with_baselines }}, succeeded())
+  env:
+    GITHUB_TOKEN: $(BASELINES_GH_PAT)
+
 - task: CmdLine@2
   inputs:
     script: 'git clone https://$(BASELINES_GH_PAT)@github.com/linq2db/linq2db.baselines.git baselines && cd baselines && git checkout -b $(baselines_branch) origin/$(baselines_branch) && cd ..'
@@ -65,13 +86,6 @@ steps:
     targetPath: '$(System.DefaultWorkingDirectory)/configs'
   condition: and(variables.title, succeeded())
   displayName: Extract test configs
-
-- task: DownloadPipelineArtifact@2
-  inputs:
-    artifactName: $(artifact_test_scripts)
-    targetPath: '$(System.DefaultWorkingDirectory)/scripts'
-  condition: and(variables.title, succeeded())
-  displayName: Extract test scripts
 
 - task: CmdLine@2
   inputs:

--- a/Build/Azure/scripts/ensure-baselines-branch.ps1
+++ b/Build/Azure/scripts/ensure-baselines-branch.ps1
@@ -1,0 +1,163 @@
+<#
+ensure-baselines-branch.ps1 — idempotently ensure the per-run baselines branch
+exists on the linq2db.baselines repository.
+
+Shared by two callers in the test pipeline:
+
+  * create_baselines_branch (central, runs once): -Rebase -EmitOutputs.
+    Creates the branch if missing, rebases it onto baselines master when it
+    already exists but is behind, and exports the branch name / head hash /
+    new-branch flag as task output variables.
+
+  * test_{windows,linux,macos}_job (self-heal, before their clone): ensure-only.
+    Re-creates the branch at the recorded -BaseHash if a previous completed run
+    deleted it (empty branch cleanup) — without this a "rerun failed jobs"
+    restart fails because create_baselines_branch is not re-run, so its branch
+    was already removed by create_baselines_pr (see build 21555).
+
+The branch creation is race-tolerant: when several test jobs self-heal a missing
+branch in parallel, only one wins the ref creation; the losers detect the branch
+now exists (by re-querying) and proceed.
+
+Reads the auth token from the GITHUB_TOKEN environment variable (= BASELINES_GH_PAT).
+The rebase path also needs git identity via EMAIL / GIT_AUTHOR_NAME / GIT_COMMITTER_NAME.
+
+Usage:
+
+  central:   pwsh ... -PrId "$(source_pr_id)" -BaselinesMaster "$(baselines_master)" -Rebase -EmitOutputs
+  self-heal: pwsh ... -Branch "$(baselines_branch)" -BaselinesMaster "$(baselines_master)" -BaseHash "$(baselines_head)"
+
+Parameters:
+  -Branch           resolved branch name (e.g. baselines/pr_1234). When empty it is derived from -PrId.
+  -PrId             source pull request number; empty => baselines/default branch.
+  -BaselinesMaster  baselines repo default branch (master). Required.
+  -BaseHash         hash to create the branch from when it is missing. Empty => baselines master HEAD.
+  -Rebase           rebase an existing branch onto baselines master when it is behind (central job only).
+  -EmitOutputs      export baselines_branch / baselines_head / baselines_new_branch task outputs (central job only).
+#>
+
+param(
+    [string] $Branch = '',
+    [string] $PrId = '',
+    [Parameter(Mandatory = $true)][string] $BaselinesMaster,
+    [string] $BaseHash = '',
+    [switch] $Rebase,
+    [switch] $EmitOutputs
+)
+
+$orgName       = "linq2db"
+$baselinesRepo = "linq2db.baselines"
+$baselinesRepoUrl = "https://${Env:GITHUB_TOKEN}@github.com/${orgName}/${baselinesRepo}.git"
+
+# Resolve branch name (derive from PR id when not passed explicitly)
+if (-not $Branch) {
+    if ($PrId) {
+        $Branch = "baselines/pr_${PrId}"
+    } else {
+        $Branch = "baselines/default"
+    }
+}
+Write-Host "Baselines branch name: ${Branch}"
+
+function Get-RemoteHash([string]$ref, [switch]$Heads) {
+    if ($Heads) {
+        $out = git ls-remote --heads $baselinesRepoUrl $ref
+    } else {
+        $out = git ls-remote $baselinesRepoUrl $ref
+    }
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "ls-remote for '${ref}' failed with code ${LASTEXITCODE}"
+        exit 1
+    }
+    if ($out.Length -lt 40) {
+        return ''
+    }
+    return ($out -split '\s+')[0]
+}
+
+$branchHash  = Get-RemoteHash $Branch -Heads
+$newBranch   = 0
+
+if (-not $branchHash) {
+    Write-Host "Baselines branch not found, creating it"
+
+    # Create from the recorded base hash when supplied (keeps create_baselines_pr's
+    # no-new-commits detection valid across restarts even if master advanced),
+    # otherwise from current baselines master HEAD.
+    if ($BaseHash) {
+        $createHash = $BaseHash
+    } else {
+        $createHash = Get-RemoteHash $BaselinesMaster
+        if (-not $createHash) {
+            Write-Host "Baselines repo HEAD not found for '${BaselinesMaster}'"
+            exit 1
+        }
+    }
+
+    Write-Host "Creating new baselines branch ${Branch} at ${createHash}..."
+    $output = gh api /repos/$orgName/$baselinesRepo/git/refs -i -F ref=refs/heads/$Branch -F sha=$createHash
+    Write-Host "Create command output: ${output}"
+
+    if ($LASTEXITCODE -eq 0 -and ($output -match "201 Created")) {
+        Write-Host "Baselines branch created"
+        $newBranch  = 1
+        $branchHash = $createHash
+    } else {
+        # Creation failed — a sibling job may have created the branch concurrently.
+        Write-Host "Branch creation did not return 201, re-checking whether it now exists"
+        $branchHash = Get-RemoteHash $Branch -Heads
+        if (-not $branchHash) {
+            Write-Host "Failed to create branch and it does not exist. Error code ${LASTEXITCODE}"
+            exit 1
+        }
+        Write-Host "Baselines branch already exists (created by a concurrent job)"
+    }
+} else {
+    Write-Host "Baselines branch already exists"
+
+    if ($Rebase) {
+        Write-Host "Checking if rebase required"
+        $masterHash = Get-RemoteHash $BaselinesMaster
+        if (-not $masterHash) {
+            Write-Host "Baselines repo HEAD not found for '${BaselinesMaster}'"
+            exit 1
+        }
+        if ($branchHash -eq $masterHash) {
+            Write-Host "Baselines branch already based on HEAD, no rebase required"
+        } else {
+            Write-Host "Baselines head is ${branchHash}, but master is ${masterHash}, trying to rebase on current HEAD"
+            git clone $baselinesRepoUrl baselines
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "Failed to clone baselines repository. Error code ${LASTEXITCODE}"
+                exit 1
+            }
+            cd baselines
+            git checkout origin/$Branch
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "Failed to checkout baselines branch origin/${Branch}. Error code ${LASTEXITCODE}"
+                exit 1
+            }
+            git rebase origin/$BaselinesMaster
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "Failed to rebase baselines PR on origin/${BaselinesMaster}. Delete branch and re-run tests. Error code ${LASTEXITCODE}"
+                exit 1
+            }
+            git push -f origin HEAD:$Branch
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "Failed to push rebased baselines. Error code ${LASTEXITCODE}"
+                exit 1
+            }
+            Write-Host "Baselines PR was rebased on HEAD"
+            cd ..
+            $branchHash = $masterHash
+        }
+    }
+}
+
+Write-Host "Baselines branch head hash: ${branchHash}"
+
+if ($EmitOutputs) {
+    echo "##vso[task.setvariable variable=baselines_branch;isOutput=true]${Branch}"
+    echo "##vso[task.setvariable variable=baselines_head;isOutput=true]${branchHash}"
+    echo "##vso[task.setvariable variable=baselines_new_branch;isOutput=true]${newBranch}"
+}


### PR DESCRIPTION
## Problem

When a test run produces no baseline changes, `create_baselines_pr` deletes the
per-PR baselines branch — correct for a completed run, but it breaks **partial
restarts**. On *"rerun failed jobs"* (e.g. a flaky failure, build 21555), Azure does
not re-run the already-succeeded `create_baselines_branch` job, so its output
variables still point at `baselines/pr_<id>` — but that branch was already deleted.
The restarted test job's `git checkout -b … origin/$(baselines_branch)` then fails
and the restart never runs.

## Fix

Extract the "ensure baselines branch exists" logic into a reusable
`Build/Azure/scripts/ensure-baselines-branch.ps1`, shared by both callers:

- **Test jobs** call it (ensure-only) before their existing clone — re-creating the
  branch at the recorded `baselines_head` hash if a previous run deleted it.
- **`create_baselines_branch`** calls it (`-Rebase -EmitOutputs`) in place of its
  inline body — same create + rebase + output-variable behaviour as before.

Branch creation is race-tolerant (parallel test jobs re-query rather than fail on a
concurrent create). No change to `create_baselines_pr`; the happy path is unchanged
(the ensure step is a no-op `ls-remote` when the branch exists).

## Verification

- YAML validated (`yaml.safe_load`) on all four edited templates; script passes the
  PowerShell parser.
- End-to-end is CI-only (`BASELINES_GH_PAT`): a no-baseline run creates+deletes the
  branch as before; rerunning a test job then re-creates the branch and completes.
