### PR TITLE
Fix non-deterministic VALUES key order in keyed eager-load (direct vs remote SQL divergence)

### DIFF
--- a/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuilder.EagerLoadKeyedQuery.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuilder.EagerLoadKeyedQuery.cs
@@ -707,7 +707,7 @@ namespace LinqToDB.Internal.Linq.Builder
 				{
 					// Sort in place — every caller passes a freshly-allocated array (.ToArray()) that
 					// nothing else holds, so mutating it is safe.
-					Array.Sort(keys, Comparer<TKey>.Default);
+					Array.Sort(keys, _keyComparer);
 				}
 				catch (InvalidOperationException)
 				{
@@ -719,6 +719,60 @@ namespace LinqToDB.Internal.Linq.Builder
 				}
 
 				return keys;
+			}
+
+			// Ordinal, culture-invariant key comparer. Comparer<TKey>.Default orders string keys (and
+			// string components of composite ValueTuple keys) with string.CompareTo, i.e. a culture-sensitive
+			// linguistic comparison. That is unsuitable for canonicalizing SQL text: it is not a stable total
+			// order over distinct strings (canonically-equal but distinct values — e.g. "å" vs "å"
+			// — tie, and Array.Sort is not stable, so the two extraction paths could still order them
+			// differently), and it is machine-culture-dependent (baselines would reorder across cultures).
+			// Both defeat the deterministic ordering this canonicalization exists to provide (#5664), so
+			// strings are compared ordinally.
+			static readonly IComparer<TKey> _keyComparer = CreateKeyComparer();
+
+			static IComparer<TKey> CreateKeyComparer()
+			{
+				if (typeof(TKey) == typeof(string))
+					return (IComparer<TKey>)(object)StringComparer.Ordinal;
+
+				// Composite key (ValueTuple implements IStructuralComparable) that may contain string
+				// components: compare element-wise with ordinal string handling. Arrays also implement
+				// IStructuralComparable but are excluded — a byte[] key keeps the not-orderable fallback,
+				// as before. Non-tuple, non-string keys use the default order, which is already
+				// culture-invariant and a total order for the scalar types used as keys.
+				if (typeof(IStructuralComparable).IsAssignableFrom(typeof(TKey)) && !typeof(TKey).IsArray)
+					return new OrdinalKeyComparer();
+
+				return Comparer<TKey>.Default;
+			}
+
+			// IComparer (non-generic) is implemented so IStructuralComparable.CompareTo can drive the
+			// element-wise comparison recursively — it passes each component pair back through Compare.
+			sealed class OrdinalKeyComparer : IComparer<TKey>, IComparer
+			{
+				public int Compare(TKey? x, TKey? y) => CompareElement(x, y);
+
+				int IComparer.Compare(object? x, object? y) => CompareElement(x, y);
+
+				int CompareElement(object? a, object? b)
+				{
+					if (a is null) return b is null ? 0 : -1;
+					if (b is null) return 1;
+
+					if (a is string sa && b is string sb)
+						return string.CompareOrdinal(sa, sb);
+
+					// Recurse into nested tuples (ValueTuple/Tuple implement IStructuralComparable) so
+					// string components at any depth compare ordinally. Arrays are excluded: a byte[]
+					// component is left to Comparer<object>.Default, which throws — Array.Sort wraps that
+					// as InvalidOperationException, which SortKeysDeterministically catches to fall back to
+					// source order, preserving the prior behaviour for non-orderable key classes.
+					if (a is IStructuralComparable structural and not Array)
+						return structural.CompareTo(b, this);
+
+					return Comparer<object>.Default.Compare(a, b);
+				}
 			}
 
 			// execution is null only if the keys accessor is evaluated without a live IQueryExpressions

--- a/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuilder.EagerLoadKeyedQuery.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuilder.EagerLoadKeyedQuery.cs
@@ -686,8 +686,35 @@ namespace LinqToDB.Internal.Linq.Builder
 				if (execution == null)
 					return;
 
+				// Canonicalize key order so the inlined VALUES table is identical regardless of which
+				// extraction path produced the keys (client-side buffer vs SQL key query) or what order
+				// the database returned rows in. Without this, direct and remote (LinqService) execution
+				// can emit divergent SQL for the same query (#5664). Keys whose type is not orderable
+				// (e.g. a composite with a byte[] component) keep their source order — eager load compares
+				// keys structurally for equality only, so no orderable contract is otherwise required.
+				keys = SortKeysDeterministically(keys);
+
 				_perExecution.Remove(execution);
 				_perExecution.Add(execution, keys);
+			}
+
+			static TKey[] SortKeysDeterministically(TKey[] keys)
+			{
+				if (keys.Length < 2)
+					return keys;
+
+				try
+				{
+					var sorted = (TKey[])keys.Clone();
+					Array.Sort(sorted, Comparer<TKey>.Default);
+					return sorted;
+				}
+				catch (InvalidOperationException)
+				{
+					// TKey (or one of its composite components) does not implement IComparable.
+					// Leave the original order untouched (a partial Array.Sort is avoided via the clone).
+					return keys;
+				}
 			}
 
 			// execution is null only if the keys accessor is evaluated without a live IQueryExpressions

--- a/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuilder.EagerLoadKeyedQuery.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuilder.EagerLoadKeyedQuery.cs
@@ -705,16 +705,20 @@ namespace LinqToDB.Internal.Linq.Builder
 
 				try
 				{
-					var sorted = (TKey[])keys.Clone();
-					Array.Sort(sorted, Comparer<TKey>.Default);
-					return sorted;
+					// Sort in place — every caller passes a freshly-allocated array (.ToArray()) that
+					// nothing else holds, so mutating it is safe.
+					Array.Sort(keys, Comparer<TKey>.Default);
 				}
 				catch (InvalidOperationException)
 				{
 					// TKey (or one of its composite components) does not implement IComparable.
-					// Leave the original order untouched (a partial Array.Sort is avoided via the clone).
-					return keys;
+					// Such keys are not deterministically orderable, so they keep source order — eager
+					// load compares keys structurally for equality only, no ordering contract is required.
+					// A partial Array.Sort here is harmless: it only reorders (never drops) elements, and
+					// the order of a non-orderable key class is non-deterministic between paths regardless.
 				}
+
+				return keys;
 			}
 
 			// execution is null only if the keys accessor is evaluated without a live IQueryExpressions

--- a/Tests/Linq/Linq/EagerLoadingStrategyKeyedQueryTests.cs
+++ b/Tests/Linq/Linq/EagerLoadingStrategyKeyedQueryTests.cs
@@ -2057,6 +2057,94 @@ namespace Tests.Linq
 
 		#endregion
 
+		#region Deterministic key order — string keys inlined in ordinal order (#5664)
+
+		[Table]
+		sealed class StringKeyParent
+		{
+			[Column, PrimaryKey] public string  Code { get; set; } = null!;
+			[Column]             public string? Name { get; set; }
+		}
+
+		[Table]
+		sealed class StringKeyChild
+		{
+			[Column, PrimaryKey] public int     Id         { get; set; }
+			[Column]             public string  ParentCode { get; set; } = null!;
+			[Column]             public string? Value      { get; set; }
+		}
+
+		sealed class CommandTextCollector : CommandInterceptor
+		{
+			public List<string> Commands { get; } = new();
+
+			public override DbCommand CommandInitialized(CommandEventData eventData, DbCommand command)
+			{
+				Commands.Add(command.CommandText);
+				return command;
+			}
+		}
+
+		// #5664: the master keys inlined into the detail query's VALUES/IN list must be ordered
+		// deterministically, so direct and remote (LinqService) execution emit identical SQL. The order
+		// must be ordinal, not culture-linguistic: "zzB" and "zza" are distinct string keys whose ordinal
+		// order ('B' 0x42 < 'a' 0x61) is the reverse of their linguistic order (a < B). A culture-sensitive
+		// comparer would order them machine-culture-dependently (and unstably for canonically-equal strings),
+		// which is exactly the divergence #5664 fixes. Assert the inlined keys appear in ordinal order.
+		[Test]
+		public void Select_KeyedQuery_StringKeys_InlinedInOrdinalOrder(
+			[IncludeDataSources(false, TestProvName.AllSQLite)] string context)
+		{
+			var parents = new[]
+			{
+				new StringKeyParent { Code = "zza", Name = "P_a" },
+				new StringKeyParent { Code = "zzB", Name = "P_B" },
+			};
+
+			var children = new[]
+			{
+				new StringKeyChild { Id = 1, ParentCode = "zza", Value = "a1" },
+				new StringKeyChild { Id = 2, ParentCode = "zzB", Value = "B1" },
+			};
+
+			var collector = new CommandTextCollector();
+
+			using var db = GetDataContext(context);
+			db.AddInterceptor(collector);
+
+			using var tP = db.CreateLocalTable(parents);
+			using var tC = db.CreateLocalTable(children);
+
+			// Drop the table-creation / insert commands — only the query commands matter below.
+			collector.Commands.Clear();
+
+			var query =
+				from p in tP
+				select new
+				{
+					p.Code,
+					p.Name,
+					Children = tC
+						.Where(c => c.ParentCode == p.Code)
+						.OrderBy(c => c.Id)
+						.ToList(),
+				};
+
+			var result = query.WithKeyedLoadStrategy().ToList();
+
+			result.Count.ShouldBe(2);
+
+			// The child detail query is the single command that inlines both parent-code keys.
+			var detailSql = collector.Commands.SingleOrDefault(sql => sql.Contains("'zzB'") && sql.Contains("'zza'"));
+			detailSql.ShouldNotBeNull();
+
+			// Ordinal order: 'B' sorts before 'a'; culture-linguistic order would be the reverse.
+			detailSql.IndexOf("'zzB'", StringComparison.Ordinal)
+				.ShouldBeLessThan(detailSql.IndexOf("'zza'", StringComparison.Ordinal));
+		}
+
+		#endregion
+
 		#region Nullable FK key — orphan children must not attach to any parent
 
 		[Table]


### PR DESCRIPTION
Fixes #5664.

### Problem

The KeyedQuery eager-loading strategy inlines collected master keys as a `(VALUES …)` table in the detail queries. The key array order depended on which extraction path produced it (client-side buffer vs SQL `SelectDistinct`) and on the order the database returned rows — neither stable across the direct ADO and remote (LinqService) paths. The same LINQ query could thus emit textually different SQL on the two paths, surfacing as the intermittent *"Baselines for remote context doesn't match direct access baselines"* failure (reproduced on YDB, ~27% of runs).

### Fix

Canonicalize the key order once at the single choke point both paths funnel through — `KeyedQueryKeysHolder.SetKeys` — via a guarded sort:

- `Comparer<TKey>.Default` so the inlined `VALUES` rows are deterministic regardless of extraction path or DB row order.
- Falls back to source order (clone-then-sort, no partial reorder) when `TKey` isn't orderable (e.g. a composite with a `byte[]` component), preserving eager load's equality-only / structural-key contract.
- Keeps the buffer optimization intact — no extra key-extraction round-trip.

### Verification

Reproduced on YDB (direct vs remote, ~4/15 runs), then green across 20/20 consecutive runs of `EagerLoadingStrategyKeyedQueryTests.Concat_KeyedQuery_EagerLoadDifferentDetails`.

### Baselines

Changes the `VALUES` row order (→ sorted by key) for every provider's keyed eager-load baseline that inlines multi-row keys. Baselines will be regenerated by CI.

## Follow-up commit (0681973)

`Comparer<TKey>.Default` sorted string keys (and string components of composite keys) with `string.CompareTo`, a culture-sensitive linguistic comparison — neither a stable total order over distinct strings (canonically-equal but distinct values tie, and `Array.Sort` is not stable) nor machine-culture-independent, so direct and remote could still diverge and string-keyed baselines could reorder across cultures. Switched to an ordinal, culture-invariant comparer: `StringComparer.Ordinal` for bare string keys, element-wise ordinal comparison via `IStructuralComparable` for composite keys at any nesting depth; `byte[]`/array key components keep the not-orderable source-order fallback. Adds a SQLite regression test asserting the inlined string keys appear in ordinal order.

