### PR TITLE
Fix #5666: enum-vs-null comparison emits IS [NOT] NULL instead of <> 0

### DIFF
--- a/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuildVisitor.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuildVisitor.cs
@@ -4655,15 +4655,25 @@ namespace LinqToDB.Internal.Linq.Builder
 				case ExpressionType.Constant:
 				{
 					var origValue = ((ConstantExpression)value).Value;
+
+					// Comparing an enum to null is a null check, not a value comparison. Mapping null to the
+					// enum's underlying default (e.g. 0) would pollute the SQL and turn the check into a value
+					// filter that drops rows whose enum equals that default — see issue #5666. Emit IS [NOT] NULL.
+					if (origValue == null)
+					{
+						var operandSql = (Visit(operand) as SqlPlaceholderExpression)?.Sql;
+						if (operandSql == null)
+							return null;
+
+						return new SqlPredicate.IsNull(operandSql, op == SqlPredicate.Operator.NotEqual);
+					}
+
 					var mapValue  = origValue;
 
-					if (origValue != null)
+					foreach (var enumVal in MappingSchema.GetMapValues(type.UnwrapNullableType())!)
 					{
-						foreach (var enumVal in MappingSchema.GetMapValues(type.UnwrapNullableType())!)
-						{
-							if (origValue.Equals(enumVal.OrigValue) && enumVal.MapValues.Length > 0)
-								mapValue = enumVal.MapValues[0].Value;
-						}
+						if (origValue.Equals(enumVal.OrigValue) && enumVal.MapValues.Length > 0)
+							mapValue = enumVal.MapValues[0].Value;
 					}
 
 					SqlValue sqlvalue;

--- a/Tests/Linq/UserTests/Issue5666Tests.cs
+++ b/Tests/Linq/UserTests/Issue5666Tests.cs
@@ -74,7 +74,7 @@ namespace Tests.UserTests
 			using var db = GetDataContext(context);
 			using var tb = db.CreateLocalTable(new[]
 			{
-				new EnumNullTable { Id = 1, Status = Enum1.Ok }, // Ok = 0, the value the old "<> 0" filter dropped
+				new EnumNullTable { Id = 1, Status = Enum1.Ok }, // nullable-enum vs null goes through the generic null path (IS [NOT] NULL); the "<> 0" regression itself is guarded by Issue5666Test
 				new EnumNullTable { Id = 2, Status = null },
 			});
 

--- a/Tests/Linq/UserTests/Issue5666Tests.cs
+++ b/Tests/Linq/UserTests/Issue5666Tests.cs
@@ -1,0 +1,65 @@
+﻿#nullable disable
+using System.Linq;
+
+using LinqToDB;
+using LinqToDB.Mapping;
+
+using NUnit.Framework;
+
+namespace Tests.UserTests
+{
+	[TestFixture]
+	public class Issue5666Tests : TestBase
+	{
+		enum Enum1
+		{
+			Ok,
+			Fail,
+		}
+
+		class ReceiptBaseTest
+		{
+			[Column("RECEIPT_NO")]  public string ReceiptNo  { get; set; }
+			[Column("SERV_CATG")]   public Enum1  Status     { get; set; }
+			[Column("PROPERTY_ID")] public int?   PropertyId { get; set; }
+
+			[Association(ThisKey = nameof(PropertyId), OtherKey = nameof(EnumTest.Id))]
+			public EnumTest EnumTest { get; }
+		}
+
+		class EnumTest
+		{
+			public int Id { get; set; }
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5666")]
+		public void Issue5666Test([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using var db        = GetDataContext(context);
+			using var receipts  = db.CreateLocalTable(new[]
+			{
+				new ReceiptBaseTest { ReceiptNo = "R1", Status = Enum1.Ok,   PropertyId = 100 },
+				new ReceiptBaseTest { ReceiptNo = "R2", Status = Enum1.Fail, PropertyId = 100 },
+				new ReceiptBaseTest { ReceiptNo = "R3", Status = Enum1.Ok,   PropertyId = 999 },
+			});
+			using var lookup    = db.CreateLocalTable(new[]
+			{
+				new EnumTest { Id = 100 },
+			});
+
+			var query =
+				from i in db.GetTable<ReceiptBaseTest>()
+				where i.EnumTest.Id == 100
+				select new { i.ReceiptNo };
+
+			// R1 (Status = Ok = 0) and R2 (Status = Fail) both reference Property 100, so both must
+			// be returned. The bug injects "SERV_CATG <> 0" into the join, silently dropping R1.
+			var result = query.ToList();
+			Assert.That(result.Select(x => x.ReceiptNo), Is.EquivalentTo(new[] { "R1", "R2" }));
+
+			// The non-nullable enum column is never referenced by the query; it must not leak into the SQL.
+			var sql = query.ToSqlQuery().Sql;
+			Assert.That(sql, Does.Not.Contain("SERV_CATG"));
+		}
+	}
+}

--- a/Tests/Linq/UserTests/Issue5666Tests.cs
+++ b/Tests/Linq/UserTests/Issue5666Tests.cs
@@ -32,6 +32,12 @@ namespace Tests.UserTests
 			public int Id { get; set; }
 		}
 
+		class EnumNullTable
+		{
+			[Column] public int    Id     { get; set; }
+			[Column] public Enum1? Status { get; set; }
+		}
+
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/5666")]
 		public void Issue5666Test([IncludeDataSources(TestProvName.AllSQLite)] string context)
 		{
@@ -60,6 +66,27 @@ namespace Tests.UserTests
 			// The non-nullable enum column is never referenced by the query; it must not leak into the SQL.
 			var sql = query.ToSqlQuery().Sql;
 			Assert.That(sql, Does.Not.Contain("SERV_CATG"));
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5666")]
+		public void Issue5666NullComparison([IncludeDataSources(TestProvName.AllSQLite)] string context, [Values] bool notEqual)
+		{
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable(new[]
+			{
+				new EnumNullTable { Id = 1, Status = Enum1.Ok }, // Ok = 0, the value the old "<> 0" filter dropped
+				new EnumNullTable { Id = 2, Status = null },
+			});
+
+			var query = notEqual
+				? db.GetTable<EnumNullTable>().Where(x => x.Status != null)
+				: db.GetTable<EnumNullTable>().Where(x => x.Status == null);
+
+			var sql = query.ToSqlQuery().Sql;
+			Assert.That(sql, Does.Contain(notEqual ? "IS NOT NULL" : "IS NULL"));
+
+			var result = query.Select(x => x.Id).ToList();
+			Assert.That(result, Is.EquivalentTo(notEqual ? new[] { 1 } : new[] { 2 }));
 		}
 	}
 }


### PR DESCRIPTION
Fixes #5666.

## Problem

For an optional association, the builder adds a row-present guard built from the parent's first non-nullable key column (`ExtractNotNullCheck`), i.e. `column != null`. When that column is an enum, `ConvertEnumConversion` mapped the `null` constant to the enum's underlying default (`0`), emitting `column <> 0` instead of `column IS NOT NULL`. As a value filter, `<> 0` polluted the join ON clause and silently dropped rows whose enum equals its zero-valued member.

Association INNER JOIN ON clause for the repro:

```diff
- ON [i].[SERV_CATG] <> 0 AND [i].[PROPERTY_ID] = [a_EnumTest].[Id]
+ ON [i].[PROPERTY_ID] = [a_EnumTest].[Id]
```

## Fix

`ConvertEnumConversion` now treats a `null` constant as a null check and emits `IS [NOT] NULL`, consistent with non-enum column handling. This also fixes user-written `enumColumn == null` / `enumColumn != null`.

## Tests

- `Tests/Linq/UserTests/Issue5666Tests.cs` — behavioral + SQL-shape; fails before, passes after.
- Regression: 1,149 enum-mapping + association tests pass (SQLite Classic + MS).
