### PR TITLE
fix(DB2): map DECFLOAT special values (Infinity/NaN) per target type

### DIFF
--- a/Source/LinqToDB/Internal/DataProvider/DB2/DB2DataProvider.cs
+++ b/Source/LinqToDB/Internal/DataProvider/DB2/DB2DataProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -82,6 +83,20 @@ namespace LinqToDB.Internal.DataProvider.DB2
 
 			if (Adapter.DB2DateTimeType != null)
 				SetProviderField(Adapter.DB2DateTimeType, typeof(DateTime), Adapter.GetDB2DateTimeReaderMethod!   , dataReaderType: Adapter.DataReaderType);
+
+			// DECFLOAT can hold IEEE special values (Infinity/-Infinity/NaN) that the default decimal reader
+			// (GetDecimal) cannot convert. Read the raw DB2DecimalFloat instead and let the conversions
+			// registered in DB2ProviderAdapter map it per target type. See issue #5663.
+			{
+				var readerParameter = Expression.Parameter(Adapter.DataReaderType, "r");
+				var indexParameter  = Expression.Parameter(typeof(int), "i");
+
+				ReaderExpressions[new ReaderInfo { DataReaderType = Adapter.DataReaderType, FieldType = typeof(decimal), DataTypeName = "DECFLOAT" }] =
+					Expression.Lambda(
+						Expression.Call(readerParameter, Adapter.GetDB2DecimalFloatReaderMethod, null, indexParameter),
+						readerParameter,
+						indexParameter);
+			}
 		}
 
 		public DB2Version Version { get; }

--- a/Source/LinqToDB/Internal/DataProvider/DB2/DB2ProviderAdapter.cs
+++ b/Source/LinqToDB/Internal/DataProvider/DB2/DB2ProviderAdapter.cs
@@ -2,6 +2,7 @@
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq.Expressions;
 
 using LinqToDB.Common;
@@ -91,6 +92,11 @@ namespace LinqToDB.Internal.DataProvider.DB2
 			DB2TimeSpanType     = LoadType("DB2TimeSpan"    , DataType.Timestamp, true, true);
 			// not mapped currently: DB2MonthSpan, DB2SmartLOB, DB2TimeStampOffset, DB2XsrObjectId
 
+			// DECFLOAT special values (Infinity/-Infinity/NaN) can't be converted to decimal. Map the raw
+			// DB2DecimalFloat per target type: the value itself for double/float, null (nullable) / default
+			// (non-nullable) for decimal & integral targets. See issue #5663.
+			RegisterDecimalFloatConverters(MappingSchema, DB2DecimalFloatType);
+
 			var typeMapper = new TypeMapper();
 
 			typeMapper.RegisterTypeWrapper<DB2ServerTypes>(serverTypesType);
@@ -144,6 +150,80 @@ namespace LinqToDB.Internal.DataProvider.DB2
 
 				return type;
 			}
+		}
+
+		static void RegisterDecimalFloatConverters(MappingSchema mappingSchema, Type decimalFloatType)
+		{
+			void Register(Type toType, string method)
+			{
+				var v    = Expression.Parameter(decimalFloatType, "v");
+				var body = Expression.Call(typeof(DecimalFloatConverters), method, null, Expression.Call(v, "ToString", Type.EmptyTypes));
+
+				mappingSchema.SetConvertExpression(decimalFloatType, toType, Expression.Lambda(body, v), addNullCheck: false, ConversionType.FromDatabase);
+			}
+
+			// double/float keep the special value (Infinity/-Infinity/NaN parse natively)
+			Register(typeof(double),   nameof(DecimalFloatConverters.ToDouble));
+			Register(typeof(double?),  nameof(DecimalFloatConverters.ToDoubleNullable));
+			Register(typeof(float),    nameof(DecimalFloatConverters.ToSingle));
+			Register(typeof(float?),   nameof(DecimalFloatConverters.ToSingleNullable));
+
+			// decimal & integral targets can't represent special values: default for non-nullable
+			Register(typeof(decimal),  nameof(DecimalFloatConverters.ToDecimal));
+			Register(typeof(byte),     nameof(DecimalFloatConverters.ToByte));
+			Register(typeof(sbyte),    nameof(DecimalFloatConverters.ToSByte));
+			Register(typeof(short),    nameof(DecimalFloatConverters.ToInt16));
+			Register(typeof(ushort),   nameof(DecimalFloatConverters.ToUInt16));
+			Register(typeof(int),      nameof(DecimalFloatConverters.ToInt32));
+			Register(typeof(uint),     nameof(DecimalFloatConverters.ToUInt32));
+			Register(typeof(long),     nameof(DecimalFloatConverters.ToInt64));
+			Register(typeof(ulong),    nameof(DecimalFloatConverters.ToUInt64));
+
+			// ... and null for nullable
+			Register(typeof(decimal?), nameof(DecimalFloatConverters.ToDecimalNullable));
+			Register(typeof(byte?),    nameof(DecimalFloatConverters.ToByteNullable));
+			Register(typeof(sbyte?),   nameof(DecimalFloatConverters.ToSByteNullable));
+			Register(typeof(short?),   nameof(DecimalFloatConverters.ToInt16Nullable));
+			Register(typeof(ushort?),  nameof(DecimalFloatConverters.ToUInt16Nullable));
+			Register(typeof(int?),     nameof(DecimalFloatConverters.ToInt32Nullable));
+			Register(typeof(uint?),    nameof(DecimalFloatConverters.ToUInt32Nullable));
+			Register(typeof(long?),    nameof(DecimalFloatConverters.ToInt64Nullable));
+			Register(typeof(ulong?),   nameof(DecimalFloatConverters.ToUInt64Nullable));
+		}
+
+		// Converts DB2DecimalFloat.ToString() output to a target CLR type, handling IEEE special values.
+		static class DecimalFloatConverters
+		{
+			// "NaN"/"Infinity"/"-Infinity" parse natively; "sNaN" (signaling NaN) does not, so map it to NaN.
+			public static double  ToDouble        (string s) => s is "sNaN" ? double.NaN : double.Parse(s, CultureInfo.InvariantCulture);
+			public static float   ToSingle        (string s) => s is "sNaN" ? float .NaN : float .Parse(s, CultureInfo.InvariantCulture);
+			public static double? ToDoubleNullable(string s) => s is "sNaN" ? double.NaN : double.Parse(s, CultureInfo.InvariantCulture);
+			public static float?  ToSingleNullable(string s) => s is "sNaN" ? float .NaN : float .Parse(s, CultureInfo.InvariantCulture);
+
+			public static decimal ToDecimal(string s) => IsSpecial(s) ? default : Parse(s);
+			public static byte    ToByte   (string s) => IsSpecial(s) ? default : (byte)  Parse(s);
+			public static sbyte   ToSByte  (string s) => IsSpecial(s) ? default : (sbyte) Parse(s);
+			public static short   ToInt16  (string s) => IsSpecial(s) ? default : (short) Parse(s);
+			public static ushort  ToUInt16 (string s) => IsSpecial(s) ? default : (ushort)Parse(s);
+			public static int     ToInt32  (string s) => IsSpecial(s) ? default : (int)   Parse(s);
+			public static uint    ToUInt32 (string s) => IsSpecial(s) ? default : (uint)  Parse(s);
+			public static long    ToInt64  (string s) => IsSpecial(s) ? default : (long)  Parse(s);
+			public static ulong   ToUInt64 (string s) => IsSpecial(s) ? default : (ulong) Parse(s);
+
+			public static decimal? ToDecimalNullable(string s) => IsSpecial(s) ? null : Parse(s);
+			public static byte?    ToByteNullable   (string s) => IsSpecial(s) ? null : (byte)  Parse(s);
+			public static sbyte?   ToSByteNullable  (string s) => IsSpecial(s) ? null : (sbyte) Parse(s);
+			public static short?   ToInt16Nullable  (string s) => IsSpecial(s) ? null : (short) Parse(s);
+			public static ushort?  ToUInt16Nullable (string s) => IsSpecial(s) ? null : (ushort)Parse(s);
+			public static int?     ToInt32Nullable  (string s) => IsSpecial(s) ? null : (int)   Parse(s);
+			public static uint?    ToUInt32Nullable (string s) => IsSpecial(s) ? null : (uint)  Parse(s);
+			public static long?    ToInt64Nullable  (string s) => IsSpecial(s) ? null : (long)  Parse(s);
+			public static ulong?   ToUInt64Nullable (string s) => IsSpecial(s) ? null : (ulong) Parse(s);
+
+			static decimal Parse(string s) => decimal.Parse(s, NumberStyles.Float, CultureInfo.InvariantCulture);
+
+			// DB2DecimalFloat.ToString() yields these IEEE tokens for special values; any other text is a finite numeric literal.
+			static bool IsSpecial(string s) => s is "NaN" or "Infinity" or "-Infinity" or "sNaN";
 		}
 
 		static readonly Lazy<DB2ProviderAdapter> _lazy = new (() => new ());

--- a/Tests/Linq/DataProvider/DB2Tests.cs
+++ b/Tests/Linq/DataProvider/DB2Tests.cs
@@ -27,6 +27,8 @@ using IBM.Data.DB2Types;
 
 using NUnit.Framework;
 
+using Shouldly;
+
 using Tests.Model;
 
 namespace Tests.DataProvider
@@ -49,6 +51,83 @@ namespace Tests.DataProvider
 				Assert.That(conn.Execute<int>("SELECT Cast(@p1 as int) + Cast(@p2 as int) FROM SYSIBM.SYSDUMMY1", new { p1 = 2, p2 = 3 }), Is.EqualTo(5));
 				Assert.That(conn.Execute<int>("SELECT Cast(@p2 as int) + Cast(@p1 as int) FROM SYSIBM.SYSDUMMY1", new { p2 = 2, p1 = 3 }), Is.EqualTo(5));
 			}
+		}
+
+		public enum DecFloatSpecial
+		{
+			PositiveInfinity,
+			NegativeInfinity,
+			NaN,
+		}
+
+		static string DecFloatSpecialSql(DecFloatSpecial special) => special switch
+		{
+			DecFloatSpecial.PositiveInfinity => "SELECT (CAST(1 AS DECFLOAT)/CAST(0 AS DECFLOAT))  FROM SYSIBM.SYSDUMMY1",
+			DecFloatSpecial.NegativeInfinity => "SELECT (CAST(-1 AS DECFLOAT)/CAST(0 AS DECFLOAT)) FROM SYSIBM.SYSDUMMY1",
+			_                                => "SELECT (CAST(0 AS DECFLOAT)/CAST(0 AS DECFLOAT))  FROM SYSIBM.SYSDUMMY1",
+		};
+
+		// DECFLOAT special values mapped to floating-point targets keep the value. See issue #5663.
+		[Test]
+		public void DecFloatSpecialToFloatingPoint([IncludeDataSources(CurrentProvider)] string context, [Values] DecFloatSpecial special)
+		{
+			using var db = GetDataContext(context);
+			var sql = DecFloatSpecialSql(special);
+
+			var d  = db.Execute<double> (sql);
+			var f  = db.Execute<float>  (sql);
+			var dn = db.Execute<double?>(sql);
+			var fn = db.Execute<float?> (sql);
+
+			switch (special)
+			{
+				case DecFloatSpecial.PositiveInfinity:
+					double.IsPositiveInfinity(d).ShouldBeTrue();
+					float .IsPositiveInfinity(f).ShouldBeTrue();
+					double.IsPositiveInfinity(dn!.Value).ShouldBeTrue();
+					float .IsPositiveInfinity(fn!.Value).ShouldBeTrue();
+					break;
+				case DecFloatSpecial.NegativeInfinity:
+					double.IsNegativeInfinity(d).ShouldBeTrue();
+					float .IsNegativeInfinity(f).ShouldBeTrue();
+					double.IsNegativeInfinity(dn!.Value).ShouldBeTrue();
+					float .IsNegativeInfinity(fn!.Value).ShouldBeTrue();
+					break;
+				default:
+					double.IsNaN(d).ShouldBeTrue();
+					float .IsNaN(f).ShouldBeTrue();
+					double.IsNaN(dn!.Value).ShouldBeTrue();
+					float .IsNaN(fn!.Value).ShouldBeTrue();
+					break;
+			}
+		}
+
+		// DECFLOAT special values can't be represented as decimal/integral: nullable -> null, non-nullable -> default. See issue #5663.
+		[Test]
+		public void DecFloatSpecialToDecimalAndIntegral([IncludeDataSources(CurrentProvider)] string context, [Values] DecFloatSpecial special)
+		{
+			using var db = GetDataContext(context);
+			var sql = DecFloatSpecialSql(special);
+
+			db.Execute<decimal?>(sql).ShouldBeNull();
+			db.Execute<int?>    (sql).ShouldBeNull();
+			db.Execute<long?>   (sql).ShouldBeNull();
+
+			db.Execute<decimal>(sql).ShouldBe(0m);
+			db.Execute<int>    (sql).ShouldBe(0);
+			db.Execute<long>   (sql).ShouldBe(0L);
+		}
+
+		// finite DECFLOAT values still round-trip exactly after the special-value handling. See issue #5663.
+		[Test]
+		public void DecFloatFiniteValue([IncludeDataSources(CurrentProvider)] string context)
+		{
+			using var db = GetDataContext(context);
+			var sql = "SELECT (CAST(123.45 AS DECFLOAT)) FROM SYSIBM.SYSDUMMY1";
+
+			db.Execute<decimal> (sql).ShouldBe(123.45m);
+			db.Execute<double>  (sql).ShouldBe(123.45d);
+			db.Execute<decimal?>(sql).ShouldBe(123.45m);
 		}
 
 		[Test]


### PR DESCRIPTION
Fixes #5663

## Problem

Reading a DB2 `DECFLOAT` column whose value is an IEEE special value (`Infinity`/`-Infinity`/`NaN`) threw `LinqToDBConvertException` → `FormatException`. `DECFLOAT` maps to `decimal` and materializes via `GetDecimal` / `DB2DecimalFloat.Value`, whose explicit→`decimal` conversion can't represent special values. They arise naturally from `expr/0` evaluated in `DECFLOAT` (e.g. `RATIO_TO_REPORT` over a zero-sum partition).

## Fix

- Read `DECFLOAT` columns as the raw `DB2DecimalFloat` (reader keyed on `DataTypeName = "DECFLOAT"`, so plain `DECIMAL` is unaffected), then convert via special-value-aware converters registered `FromDatabase`:
  - `double` / `float` (+ nullable) — keep the special value (`double.PositiveInfinity`, `double.NaN`, …);
  - `decimal` / integral types — `null` for nullable targets, `default` for non-nullable.
- Finite `DECFLOAT` values still round-trip exactly (conversion goes through `DB2DecimalFloat.ToString()`).
- The conversion matrix mirrors the existing ClickHouse special-value handling. Internal-only — no public API change.

## Tests

`Tests/Linq/DataProvider/DB2Tests.cs` — special values originated in-DB via raw SQL (read-only scope), read into `double` / `float` / `decimal` / integral (+ nullables), parametrized over +Infinity / -Infinity / NaN, plus a finite round-trip control. Verified red→green on DB2 (net10.0); Release `net10.0` + `netstandard2.0` builds clean.

## Notes

- Scope is the DB2 `DECFLOAT` reader-conversion only (per the issue) — no write-side / `RATIO_TO_REPORT` translation change.
- Follow-up (separate, on PR #5468): once that merges, remove the `[ActiveIssue(5663, …AllDB2…)]` gate on `RatioToReportZeroPartitionSum`.
