### PR TITLE
Drop unenforced charset=utf-8-bom rule from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,6 @@ indent_style = space
 
 # Code files
 [*.{cs,csx,vb,vbx}]
-charset = utf-8-bom
 
 # XML project files
 [*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]


### PR DESCRIPTION
The `charset = utf-8-bom` rule for C#/VB code files (added in #2350, 2020) has drifted out of relevance:

- **Not enforced.** CI does not check charset — the rule is advisory only.
- **Already inconsistent.** ~27% of sampled `Source` `.cs` files have no BOM, so the rule no longer reflects the actual repo state.
- **No modern need.** Roslyn, the .NET SDK, and git all read BOM-less UTF-8 fine. The BOM's main practical effect today is noisy first-line diffs when an editor flips it on save.

This removes the rule rather than churning dozens of files to satisfy an unenforced convention. The `[*.{cs,csx,vb,vbx}]` section header is kept as an empty placeholder, consistent with the file's other empty section headers.

Surfaced during review of #5468, where 36 new window-function test files were added without a BOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
