### PR TITLE
Fix SQLite datetime rendering losing sub-millisecond ticks

### DIFF
--- a/Source/LinqToDB/Internal/DataProvider/SQLite/SQLiteDataProvider.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SQLite/SQLiteDataProvider.cs
@@ -287,7 +287,7 @@ namespace LinqToDB.Internal.DataProvider.SQLite
 
 			if (value is DateTime dt)
 			{
-				value = dt.ToString("yyyy-MM-dd HH:mm:ss.fff", DateTimeFormatInfo.InvariantInfo);
+				value = SQLiteMappingSchema.FormatDateTime(dt);
 				if (string.Equals(Name, ProviderName.SQLiteClassic, StringComparison.Ordinal))
 					dataType = dataType.WithDataType(DataType.VarChar);
 			}

--- a/Source/LinqToDB/Internal/DataProvider/SQLite/SQLiteMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SQLite/SQLiteMappingSchema.cs
@@ -65,12 +65,14 @@ namespace LinqToDB.Internal.DataProvider.SQLite
 		}
 
 		// Always 3 millisecond digits, plus sub-millisecond digits only when present.
+		// The output is exact: .NET's ".fff" truncates rather than rounds, so the appended
+		// ticks are precisely the digits it dropped.
 		// Not fewer digits (".5"): strftime('%f') emits exactly 3 digits and existing
 		// linq2db-written data stores exactly 3, and raw-text comparisons (e.g. the unwrapped
 		// column side of an IN-list predicate) need those shapes to match.
-		// Not truncated (".123" for ".1236"): comparison operands are normalized via strftime,
-		// which rounds to the nearest millisecond — stored ".1236" normalizes to ".124" while a
-		// truncated ".123" stays ".123", so the same instant compares unequal.
+		// Not plain ".fff" (".123" for ".1236"): SQLite normalizes comparison operands via
+		// strftime, which rounds to the nearest millisecond — stored ".1236" normalizes to
+		// ".124" while a truncated ".123" stays ".123", so the same instant compares unequal.
 		internal static string FormatDateTime(DateTime value)
 		{
 			var result = value.ToString("yyyy-MM-dd HH:mm:ss.fff", DateTimeFormatInfo.InvariantInfo);

--- a/Source/LinqToDB/Internal/DataProvider/SQLite/SQLiteMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SQLite/SQLiteMappingSchema.cs
@@ -11,15 +11,11 @@ namespace LinqToDB.Internal.DataProvider.SQLite
 {
 	public sealed class SQLiteMappingSchema : LockedMappingSchema
 	{
-		internal const string DATE_FORMAT_RAW                   = "yyyy-MM-dd";
+		internal const string DATE_FORMAT_RAW = "yyyy-MM-dd";
 #if SUPPORTS_COMPOSITE_FORMAT
-		private static readonly CompositeFormat DATE_FORMAT           = CompositeFormat.Parse("'{0:yyyy-MM-dd}'");
-		private static readonly CompositeFormat DATETIME_FORMAT       = CompositeFormat.Parse("'{0:yyyy-MM-dd HH:mm:ss.fff}'");
-		private static readonly CompositeFormat DATETIMEOFFSET_FORMAT = CompositeFormat.Parse("'{0:yyyy-MM-dd HH:mm:ss.fffzzz}'");
+		private static readonly CompositeFormat DATE_FORMAT = CompositeFormat.Parse("'{0:yyyy-MM-dd}'");
 #else
-		private  const string DATE_FORMAT           = "'{0:yyyy-MM-dd}'";
-		private  const string DATETIME_FORMAT       = "'{0:yyyy-MM-dd HH:mm:ss.fff}'";
-		private  const string DATETIMEOFFSET_FORMAT = "'{0:yyyy-MM-dd HH:mm:ss.fffzzz}'";
+		private const string DATE_FORMAT = "'{0:yyyy-MM-dd}'";
 #endif
 
 		SQLiteMappingSchema() : base(ProviderName.SQLite)
@@ -68,24 +64,38 @@ namespace LinqToDB.Internal.DataProvider.SQLite
 				.Append('\'');
 		}
 
+		// milliseconds are always rendered as 3 digits: the shape strftime('%f') produces and all
+		// existing linq2db-written data has. Sub-millisecond ticks are appended only when present:
+		// truncating them would lose data on write and break comparisons against values stored at
+		// full precision — comparison operands are normalized via strftime, which rounds to the
+		// nearest millisecond, so a truncated operand can normalize one millisecond below the
+		// same instant stored untruncated
+		internal static string FormatDateTime(DateTime value)
+		{
+			var result = value.ToString("yyyy-MM-dd HH:mm:ss.fff", DateTimeFormatInfo.InvariantInfo);
+
+			var subMillisecondTicks = (int)(value.Ticks % TimeSpan.TicksPerMillisecond);
+			if (subMillisecondTicks != 0)
+				result += subMillisecondTicks.ToString("D4", CultureInfo.InvariantCulture).TrimEnd('0');
+
+			return result;
+		}
+
 		static void ConvertDateTimeToSql(StringBuilder stringBuilder, SqlDataType dataType, DateTime value)
 		{
-#if SUPPORTS_COMPOSITE_FORMAT
-			CompositeFormat format;
-#else
-			string format;
-#endif
 			if (dataType.Type.DataType == DataType.Date)
-				format = DATE_FORMAT;
+				stringBuilder.AppendFormat(CultureInfo.InvariantCulture, DATE_FORMAT, value);
 			else
-				format = DATETIME_FORMAT;
-
-			stringBuilder.AppendFormat(CultureInfo.InvariantCulture, format, value);
+				stringBuilder.Append('\'').Append(FormatDateTime(value)).Append('\'');
 		}
 
 		static void ConvertDateTimeOffsetToSql(StringBuilder stringBuilder, DateTimeOffset value)
 		{
-			stringBuilder.AppendFormat(CultureInfo.InvariantCulture, DATETIMEOFFSET_FORMAT, value);
+			stringBuilder
+				.Append('\'')
+				.Append(FormatDateTime(value.DateTime))
+				.Append(value.ToString("zzz", CultureInfo.InvariantCulture))
+				.Append('\'');
 		}
 
 #if SUPPORTS_DATEONLY

--- a/Source/LinqToDB/Internal/DataProvider/SQLite/SQLiteMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SQLite/SQLiteMappingSchema.cs
@@ -64,12 +64,13 @@ namespace LinqToDB.Internal.DataProvider.SQLite
 				.Append('\'');
 		}
 
-		// milliseconds are always rendered as 3 digits: the shape strftime('%f') produces and all
-		// existing linq2db-written data has. Sub-millisecond ticks are appended only when present:
-		// truncating them would lose data on write and break comparisons against values stored at
-		// full precision — comparison operands are normalized via strftime, which rounds to the
-		// nearest millisecond, so a truncated operand can normalize one millisecond below the
-		// same instant stored untruncated
+		// Always 3 millisecond digits, plus sub-millisecond digits only when present.
+		// Not fewer digits (".5"): strftime('%f') emits exactly 3 digits and existing
+		// linq2db-written data stores exactly 3, and raw-text comparisons (e.g. the unwrapped
+		// column side of an IN-list predicate) need those shapes to match.
+		// Not truncated (".123" for ".1236"): comparison operands are normalized via strftime,
+		// which rounds to the nearest millisecond — stored ".1236" normalizes to ".124" while a
+		// truncated ".123" stays ".123", so the same instant compares unequal.
 		internal static string FormatDateTime(DateTime value)
 		{
 			var result = value.ToString("yyyy-MM-dd HH:mm:ss.fff", DateTimeFormatInfo.InvariantInfo);

--- a/Tests/Linq/DataProvider/SQLiteTests.cs
+++ b/Tests/Linq/DataProvider/SQLiteTests.cs
@@ -19,6 +19,8 @@ using LinqToDB.Tools.Activity;
 
 using NUnit.Framework;
 
+using Shouldly;
+
 using Tests.Model;
 
 using Binary = System.Data.Linq.Binary;
@@ -879,6 +881,83 @@ namespace Tests.DataProvider
 		{
 			[PrimaryKey] public DateTime DateTime { get; set; }
 			[Column] public int Field { get; set; }
+		}
+
+		[Test(Description = "DateTime values must round-trip without losing sub-millisecond ticks")]
+		public void DateTimeRoundTripsSubMillisecondTicks([IncludeDataSources(true, TestProvName.AllSQLite)] string context, [Values] bool inline)
+		{
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<DateTimePrecisionTable>();
+			db.InlineParameters = inline;
+
+			// whole-second and .5s values exercise the no-sub-millisecond path (".000" and ".500");
+			// 50 ticks (".000005") exercises sub-millisecond zero-padding
+			var wholeSecond = new DateTime(2020, 2, 29, 17, 54, 55);
+			var halfSecond  = wholeSecond.AddMilliseconds(500);
+			var fiftyTicks  = wholeSecond.AddTicks(50);
+			db.Insert(new DateTimePrecisionTable() { Id = 1, DateTime = TestData.DateTime });
+			db.Insert(new DateTimePrecisionTable() { Id = 2, DateTime = wholeSecond });
+			db.Insert(new DateTimePrecisionTable() { Id = 3, DateTime = halfSecond });
+			db.Insert(new DateTimePrecisionTable() { Id = 4, DateTime = fiftyTicks });
+
+			tb.Single(r => r.Id == 1).DateTime.ShouldBe(TestData.DateTime);
+			tb.Single(r => r.Id == 2).DateTime.ShouldBe(wholeSecond);
+			tb.Single(r => r.Id == 3).DateTime.ShouldBe(halfSecond);
+			tb.Single(r => r.Id == 4).DateTime.ShouldBe(fiftyTicks);
+		}
+
+		[Test(Description = "DateTimeOffset literals must round-trip without losing sub-millisecond ticks")]
+		public void DateTimeOffsetRoundTripsSubMillisecondTicks([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataContext(context);
+			using var tb = db.CreateLocalTable<DateTimeOffsetPrecisionTable>();
+			// inline only: DateTimeOffset parameters are not rendered by linq2db (SetParameter handles DateTime only)
+			db.InlineParameters = true;
+
+			var wholeSecond    = new DateTimeOffset(2020, 2, 29, 17, 9, 55, TimeSpan.Zero);
+			var nonZeroOffset  = new DateTimeOffset(2020, 2, 29, 17, 9, 55, 123, TimeSpan.FromHours(5)).AddTicks(1234);
+			db.Insert(new DateTimeOffsetPrecisionTable() { Id = 1, DateTimeOffset = TestData.DateTimeOffsetUtc });
+			db.Insert(new DateTimeOffsetPrecisionTable() { Id = 2, DateTimeOffset = wholeSecond });
+			db.Insert(new DateTimeOffsetPrecisionTable() { Id = 3, DateTimeOffset = nonZeroOffset });
+
+			tb.Single(r => r.Id == 1).DateTimeOffset.ShouldBe(TestData.DateTimeOffsetUtc);
+			tb.Single(r => r.Id == 2).DateTimeOffset.ShouldBe(wholeSecond);
+			tb.Single(r => r.Id == 3).DateTimeOffset.ShouldBe(nonZeroOffset);
+		}
+
+		[Test(Description = "Comparisons against values stored at full precision (e.g. by Microsoft.Data.Sqlite) must not misclassify rows: SQLite's date parser rounds to the nearest millisecond, so millisecond-truncated parameter rendering disagrees with full-precision stored text")]
+		public void DateTimeComparisonsAgreeWithProviderWrittenValues([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataConnection(context);
+			using var tb = db.CreateLocalTable<DateTimePrecisionTable>();
+
+			// sub-millisecond part >= 0.5ms: SQLite rounds it up to the next millisecond
+			var subMillisecond = new DateTime(2020, 2, 29, 17, 54, 55).AddTicks(6500);
+			var wholeSecond    = new DateTime(2020, 2, 29, 17, 54, 55);
+			db.Execute("INSERT INTO [DateTimePrecisionTable]([Id], [DateTime]) VALUES(1, '2020-02-29 17:54:55.00065')");
+			db.Execute("INSERT INTO [DateTimePrecisionTable]([Id], [DateTime]) VALUES(2, '2020-02-29 17:54:55')");
+
+			tb.Count(r => r.DateTime == subMillisecond).ShouldBe(1);
+			tb.Count(r => r.DateTime > subMillisecond).ShouldBe(0);
+			tb.Count(r => r.DateTime < subMillisecond).ShouldBe(1);
+
+			tb.Count(r => r.DateTime == wholeSecond).ShouldBe(1);
+			tb.Count(r => r.DateTime > wholeSecond).ShouldBe(1);
+			tb.Count(r => r.DateTime < wholeSecond).ShouldBe(0);
+		}
+
+		[Table]
+		sealed class DateTimePrecisionTable
+		{
+			[PrimaryKey] public int Id { get; set; }
+			[Column] public DateTime DateTime { get; set; }
+		}
+
+		[Table]
+		sealed class DateTimeOffsetPrecisionTable
+		{
+			[PrimaryKey] public int Id { get; set; }
+			[Column] public DateTimeOffset DateTimeOffset { get; set; }
 		}
 
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/2099")]


### PR DESCRIPTION
SQLite `DateTime`/`DateTimeOffset` parameters and inline literals are rendered with `.fff`, truncating sub-millisecond ticks. Two defects:

1. **Round-trip loss.** Values written through linq2db silently lose sub-millisecond ticks. `Microsoft.Data.Sqlite` (and EF Core on top of it) store full tick precision (`yyyy-MM-dd HH:mm:ss.FFFFFFF`).
2. **Comparisons misclassify rows stored at full precision** (e.g. written by `Microsoft.Data.Sqlite`). Comparison operands are normalized via `strftime('%Y-%m-%d %H:%M:%f', ...)`, and SQLite's date parser *rounds* to the nearest millisecond while `.fff` rendering *truncates*. For a stored value with sub-millisecond part ≥ 0.5 ms (e.g. `2020-02-29 17:54:55.00065`), the stored side normalizes to `.001` but a parameter holding the same instant renders as `.000` — equality misses, and the row compares strictly *greater than* its own value.

Fix: keep the existing 3-digit millisecond rendering (byte-identical output for every millisecond-grain value — no shape change for existing data, baselines, or raw-text comparisons such as unwrapped `IN` list columns) and append the sub-millisecond digits only when present: `.500` stays `.500`, `.1231234` no longer collapses to `.123`. One shared helper (`SQLiteMappingSchema.FormatDateTime`) now feeds both `SetParameter` and literal rendering.

Notes:

- Deliberately *not* `FFFFFFF` (Microsoft.Data.Sqlite's exact shape): trimmed text (`.1` vs `.100`) breaks raw-text comparisons against strftime-normalized operands — `Tests.Linq.TypesTests.DateTimeArray1` catches exactly that.
- `DataType.Date` and `DateOnly` rendering (`yyyy-MM-dd`) unchanged.
- Related to #2432 but independent: value rendering only, no change to comparison translation (the strftime wrapping remains).

Tests: round-trip of sub-millisecond ticks for `DateTime` (parameter + inline) and `DateTimeOffset` (inline, incl. non-zero offset), and comparison agreement against full-precision stored text. All red on master (14/14 cases), green here. Full `Tests/Linq` on `SQLite.MS,SQLite.Classic`: 20448 tests, 0 failures.
