### PR TITLE
Firebird: add scoped FirebirdTools.ClearPool(connection)

### DIFF
--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdTools.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdTools.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Data.Common;
 using System.Reflection;
 
@@ -10,28 +10,52 @@ using LinqToDB.Internal.DataProvider.Firebird;
 
 namespace LinqToDB.DataProvider.Firebird
 {
+	/// <summary>
+	/// Firebird ADO.NET provider registration and <see cref="DataConnection"/> factory helpers.
+	/// </summary>
 	[PublicAPI]
 	public static class FirebirdTools
 	{
 		internal static FirebirdProviderDetector ProviderDetector = new();
 
+		/// <summary>
+		/// Gets or sets whether the Firebird dialect is detected automatically by querying the server engine
+		/// version when it is not specified explicitly.
+		/// </summary>
 		public static bool AutoDetectProvider
 		{
 			get => ProviderDetector.AutoDetectProvider;
 			set => ProviderDetector.AutoDetectProvider = value;
 		}
 
+		/// <summary>
+		/// Returns the Firebird <see cref="IDataProvider"/> for the requested (or auto-detected) dialect version.
+		/// </summary>
+		/// <param name="version">Firebird dialect version.</param>
+		/// <param name="connectionString">Optional connection string, used for version auto-detection.</param>
+		/// <param name="connection">Optional connection, used for version auto-detection.</param>
+		/// <param name="transaction">Optional transaction, used for version auto-detection.</param>
+		/// <returns>Firebird data provider instance.</returns>
 		public static IDataProvider GetDataProvider(FirebirdVersion version = FirebirdVersion.AutoDetect, string? connectionString = null, DbConnection? connection = null, DbTransaction? transaction = null)
 		{
 			return ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString, DbConnection: connection, DbTransaction: transaction), default, version);
 		}
 
+		/// <summary>
+		/// Registers an assembly resolver that loads the Firebird ADO.NET client assembly
+		/// (<c>FirebirdSql.Data.FirebirdClient</c>) from the specified path.
+		/// </summary>
+		/// <param name="path">Path to the folder or file containing the Firebird client assembly.</param>
 		public static void ResolveFirebird(string path)
 		{
 			ArgumentNullException.ThrowIfNull(path);
 			_ = new AssemblyResolver(path, FirebirdProviderAdapter.AssemblyName);
 		}
 
+		/// <summary>
+		/// Registers the specified Firebird ADO.NET client assembly (<c>FirebirdSql.Data.FirebirdClient</c>) for resolution.
+		/// </summary>
+		/// <param name="assembly">The Firebird client assembly.</param>
 		public static void ResolveFirebird(Assembly assembly)
 		{
 			ArgumentNullException.ThrowIfNull(assembly);
@@ -40,18 +64,36 @@ namespace LinqToDB.DataProvider.Firebird
 
 		#region CreateDataConnection
 
+		/// <summary>
+		/// Creates <see cref="DataConnection"/> object using provided Firebird connection string.
+		/// </summary>
+		/// <param name="connectionString">Connection string.</param>
+		/// <param name="version">Firebird dialect version.</param>
+		/// <returns><see cref="DataConnection"/> instance.</returns>
 		public static DataConnection CreateDataConnection(string connectionString, FirebirdVersion version = FirebirdVersion.AutoDetect)
 		{
 			return new DataConnection(new DataOptions()
 				.UseConnectionString(ProviderDetector.GetDataProvider(new ConnectionOptions(ConnectionString: connectionString), default, version), connectionString));
 		}
 
+		/// <summary>
+		/// Creates <see cref="DataConnection"/> object using provided connection object.
+		/// </summary>
+		/// <param name="connection">Connection instance.</param>
+		/// <param name="version">Firebird dialect version.</param>
+		/// <returns><see cref="DataConnection"/> instance.</returns>
 		public static DataConnection CreateDataConnection(DbConnection connection, FirebirdVersion version = FirebirdVersion.AutoDetect)
 		{
 			return new DataConnection(new DataOptions()
 				.UseConnection(ProviderDetector.GetDataProvider(new ConnectionOptions(DbConnection: connection), default, version), connection));
 		}
 
+		/// <summary>
+		/// Creates <see cref="DataConnection"/> object using provided transaction object.
+		/// </summary>
+		/// <param name="transaction">Transaction instance.</param>
+		/// <param name="version">Firebird dialect version.</param>
+		/// <returns><see cref="DataConnection"/> instance.</returns>
 		public static DataConnection CreateDataConnection(DbTransaction transaction, FirebirdVersion version = FirebirdVersion.AutoDetect)
 		{
 			return new DataConnection(new DataOptions()
@@ -60,6 +102,11 @@ namespace LinqToDB.DataProvider.Firebird
 
 		#endregion
 
+		/// <summary>
+		/// Clears every Firebird connection pool process-wide (all connection strings).
+		/// See <see cref="ClearPool(DbConnection)"/> / <see cref="ClearPool(string)"/> for a scoped alternative
+		/// that leaves other databases' pools untouched.
+		/// </summary>
 		public static void ClearAllPools() => FirebirdProviderAdapter.Instance.ClearAllPools();
 
 		/// <summary>
@@ -68,6 +115,15 @@ namespace LinqToDB.DataProvider.Firebird
 		/// affects the pool for <paramref name="connection"/>'s connection string, leaving connections for
 		/// other databases/servers untouched.
 		/// </summary>
+		/// <param name="connection">Connection whose connection-string pool should be cleared.</param>
 		public static void ClearPool(DbConnection connection) => FirebirdProviderAdapter.Instance.ClearPool(connection);
+
+		/// <summary>
+		/// Clears the connection pool for the given connection string. Same scoping as
+		/// <see cref="ClearPool(DbConnection)"/>, but keyed by the connection string directly (no live
+		/// connection object required).
+		/// </summary>
+		/// <param name="connectionString">Connection string whose pool should be cleared.</param>
+		public static void ClearPool(string connectionString) => FirebirdProviderAdapter.Instance.ClearPoolByConnectionString(connectionString);
 	}
 }

--- a/Source/LinqToDB/DataProvider/Firebird/FirebirdTools.cs
+++ b/Source/LinqToDB/DataProvider/Firebird/FirebirdTools.cs
@@ -61,5 +61,13 @@ namespace LinqToDB.DataProvider.Firebird
 		#endregion
 
 		public static void ClearAllPools() => FirebirdProviderAdapter.Instance.ClearAllPools();
+
+		/// <summary>
+		/// Clears the connection pool associated with the given connection's connection string.
+		/// Unlike <see cref="ClearAllPools"/> (which evicts every Firebird pool process-wide), this only
+		/// affects the pool for <paramref name="connection"/>'s connection string, leaving connections for
+		/// other databases/servers untouched.
+		/// </summary>
+		public static void ClearPool(DbConnection connection) => FirebirdProviderAdapter.Instance.ClearPool(connection);
 	}
 }

--- a/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdProviderAdapter.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdProviderAdapter.cs
@@ -75,6 +75,7 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 
 			ClearAllPools = typeMapper.BuildAction(typeMapper.MapActionLambda(() => FbConnection.ClearAllPools()));
 			ClearPool     = typeMapper.BuildAction<DbConnection>(typeMapper.MapActionLambda((FbConnection connection) => FbConnection.ClearPool(connection)));
+			ClearPoolByConnectionString = typeMapper.BuildAction<string>(typeMapper.MapActionLambda((string connectionString) => FbConnection.ClearPool(connectionString)));
 
 			IsDateOnlySupported = assembly.GetName().Version >= MinDateOnlyVersion;
 
@@ -118,8 +119,9 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 		public Action<DbParameter, FbDbType> SetDbType { get; }
 		public Func<DbParameter  , FbDbType> GetDbType { get; }
 
-		public Action               ClearAllPools { get; }
-		public Action<DbConnection> ClearPool     { get; }
+		public Action               ClearAllPools               { get; }
+		public Action<DbConnection> ClearPool                   { get; }
+		public Action<string>       ClearPoolByConnectionString { get; }
 
 		public bool IsDateOnlySupported { get; }
 
@@ -147,8 +149,9 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 		{
 			public FbConnection(string connectionString) => throw new NotSupportedException();
 
-			public static void ClearAllPools()                     => throw new NotSupportedException();
-			public static void ClearPool(FbConnection connection)  => throw new NotSupportedException();
+			public static void ClearAllPools()                        => throw new NotSupportedException();
+			public static void ClearPool(FbConnection connection)     => throw new NotSupportedException();
+			public static void ClearPool(string connectionString)     => throw new NotSupportedException();
 		}
 
 		[Wrapper]

--- a/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdProviderAdapter.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Firebird/FirebirdProviderAdapter.cs
@@ -74,6 +74,7 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 			GetDbType = dbTypeBuilder.BuildGetter<IDbDataParameter>();
 
 			ClearAllPools = typeMapper.BuildAction(typeMapper.MapActionLambda(() => FbConnection.ClearAllPools()));
+			ClearPool     = typeMapper.BuildAction<DbConnection>(typeMapper.MapActionLambda((FbConnection connection) => FbConnection.ClearPool(connection)));
 
 			IsDateOnlySupported = assembly.GetName().Version >= MinDateOnlyVersion;
 
@@ -117,7 +118,8 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 		public Action<DbParameter, FbDbType> SetDbType { get; }
 		public Func<DbParameter  , FbDbType> GetDbType { get; }
 
-		public Action ClearAllPools { get; }
+		public Action               ClearAllPools { get; }
+		public Action<DbConnection> ClearPool     { get; }
 
 		public bool IsDateOnlySupported { get; }
 
@@ -145,7 +147,8 @@ namespace LinqToDB.Internal.DataProvider.Firebird
 		{
 			public FbConnection(string connectionString) => throw new NotSupportedException();
 
-			public static void ClearAllPools() => throw new NotSupportedException();
+			public static void ClearAllPools()                     => throw new NotSupportedException();
+			public static void ClearPool(FbConnection connection)  => throw new NotSupportedException();
 		}
 
 		[Wrapper]

--- a/Source/LinqToDB/PublicAPI/PublicAPI.Unshipped.txt
+++ b/Source/LinqToDB/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+LinqToDB.Internal.DataProvider.Firebird.FirebirdProviderAdapter.ClearPool.get -> System.Action<System.Data.Common.DbConnection!>!
+static LinqToDB.DataProvider.Firebird.FirebirdTools.ClearPool(System.Data.Common.DbConnection! connection) -> void
 const LinqToDB.DataProvider.ClickHouse.ClickHouseHints.Join.GlobalAll = "GLOBAL ALL" -> string!
 static LinqToDB.DataProvider.ClickHouse.ClickHouseHints.JoinGlobalAllHint<TSource>(this LinqToDB.DataProvider.ClickHouse.IClickHouseSpecificQueryable<TSource>! query) -> LinqToDB.DataProvider.ClickHouse.IClickHouseSpecificQueryable<TSource>!
 static LinqToDB.DataProvider.ClickHouse.ClickHouseHints.JoinGlobalAllHint<TSource>(this LinqToDB.DataProvider.ClickHouse.IClickHouseSpecificTable<TSource>! table) -> LinqToDB.DataProvider.ClickHouse.IClickHouseSpecificTable<TSource>!

--- a/Source/LinqToDB/PublicAPI/PublicAPI.Unshipped.txt
+++ b/Source/LinqToDB/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 #nullable enable
 LinqToDB.Internal.DataProvider.Firebird.FirebirdProviderAdapter.ClearPool.get -> System.Action<System.Data.Common.DbConnection!>!
+LinqToDB.Internal.DataProvider.Firebird.FirebirdProviderAdapter.ClearPoolByConnectionString.get -> System.Action<string!>!
 static LinqToDB.DataProvider.Firebird.FirebirdTools.ClearPool(System.Data.Common.DbConnection! connection) -> void
+static LinqToDB.DataProvider.Firebird.FirebirdTools.ClearPool(string! connectionString) -> void
 const LinqToDB.DataProvider.ClickHouse.ClickHouseHints.Join.GlobalAll = "GLOBAL ALL" -> string!
 static LinqToDB.DataProvider.ClickHouse.ClickHouseHints.JoinGlobalAllHint<TSource>(this LinqToDB.DataProvider.ClickHouse.IClickHouseSpecificQueryable<TSource>! query) -> LinqToDB.DataProvider.ClickHouse.IClickHouseSpecificQueryable<TSource>!
 static LinqToDB.DataProvider.ClickHouse.ClickHouseHints.JoinGlobalAllHint<TSource>(this LinqToDB.DataProvider.ClickHouse.IClickHouseSpecificTable<TSource>! table) -> LinqToDB.DataProvider.ClickHouse.IClickHouseSpecificTable<TSource>!

--- a/Tests/Base/TestUtils.cs
+++ b/Tests/Base/TestUtils.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -198,16 +199,10 @@ namespace Tests
 
 			public override void Dispose()
 			{
-				// Scoped pool clear (FirebirdTools.ClearPool): after dropping the temp table, evict only THIS
-				// database's pooled connection so its metadata reference is released for the next DDL. Unlike the
-				// former process-wide ClearAllPools, it leaves other Firebird databases' pools alone — which is
-				// what makes running the FB 2.5/3/4/5 suites concurrently safe (each is a distinct connection string).
 				var fbConnection = DataContext is DataConnection dc && dc.DataProvider.Name.Contains(ProviderName.Firebird) ? dc.TryGetDbConnection() : null;
 
 				DataContext.Close();
-
-				if (fbConnection != null)
-					FirebirdTools.ClearPool(fbConnection);
+				ClearFirebirdPool(DataContext, fbConnection);
 
 				base.Dispose();
 			}
@@ -217,9 +212,7 @@ namespace Tests
 				var fbConnection = DataContext is DataConnection dc && dc.DataProvider.Name.Contains(ProviderName.Firebird) ? dc.TryGetDbConnection() : null;
 
 				await DataContext.CloseAsync();
-
-				if (fbConnection != null)
-					FirebirdTools.ClearPool(fbConnection);
+				ClearFirebirdPool(DataContext, fbConnection);
 
 				await base.DisposeAsync();
 			}
@@ -259,12 +252,21 @@ namespace Tests
 				var fbConnection = db is DataConnection dc ? dc.TryGetDbConnection() : null;
 
 				db.Close();
-
-				if (fbConnection != null)
-					FirebirdTools.ClearPool(fbConnection);
-				else
-					FirebirdTools.ClearAllPools();
+				ClearFirebirdPool(db, fbConnection);
 			}
+		}
+
+		// Firebird serializes DDL against object references: after dropping a temp table, the closed-but-pooled
+		// connection keeps a reference that fails the next CREATE/DROP ("object TABLE is in use"). Evict only
+		// THIS database's pool — by the live connection when we have one (direct path), else by its connection
+		// string (remote/LinqService path, where DataContext is not a DataConnection). Never ClearAllPools: it is
+		// process-wide and would tear down the connections other concurrently-running Firebird versions are using.
+		static void ClearFirebirdPool(IDataContext dataContext, DbConnection? connection)
+		{
+			if (connection != null)
+				FirebirdTools.ClearPool(connection);
+			else if (dataContext.ConfigurationString is { } configuration)
+				FirebirdTools.ClearPool(DataConnection.GetConnectionString(configuration.StripRemote()));
 		}
 
 		public static Version GetSqliteVersion(DataConnection db)

--- a/Tests/Base/TestUtils.cs
+++ b/Tests/Base/TestUtils.cs
@@ -198,25 +198,28 @@ namespace Tests
 
 			public override void Dispose()
 			{
-				if (DataContext is DataConnection dc && dc.DataProvider.Name.Contains(ProviderName.Firebird))
-				{
-					FirebirdTools.ClearAllPools();
-				}
+				// Scoped pool clear (FirebirdTools.ClearPool): after dropping the temp table, evict only THIS
+				// database's pooled connection so its metadata reference is released for the next DDL. Unlike the
+				// former process-wide ClearAllPools, it leaves other Firebird databases' pools alone — which is
+				// what makes running the FB 2.5/3/4/5 suites concurrently safe (each is a distinct connection string).
+				var fbConnection = DataContext is DataConnection dc && dc.DataProvider.Name.Contains(ProviderName.Firebird) ? dc.Connection : null;
 
 				DataContext.Close();
-				FirebirdTools.ClearAllPools();
+
+				if (fbConnection != null)
+					FirebirdTools.ClearPool(fbConnection);
+
 				base.Dispose();
 			}
 
 			public override async ValueTask DisposeAsync()
 			{
-				if (DataContext is DataConnection dc && dc.DataProvider.Name.Contains(ProviderName.Firebird))
-				{
-					FirebirdTools.ClearAllPools();
-				}
+				var fbConnection = DataContext is DataConnection dc && dc.DataProvider.Name.Contains(ProviderName.Firebird) ? dc.Connection : null;
 
 				await DataContext.CloseAsync();
-				FirebirdTools.ClearAllPools();
+
+				if (fbConnection != null)
+					FirebirdTools.ClearPool(fbConnection);
 
 				await base.DisposeAsync();
 			}
@@ -253,8 +256,14 @@ namespace Tests
 		{
 			if (db.ConfigurationString?.IsAnyOf(TestProvName.AllFirebird) == true)
 			{
+				var fbConnection = db is DataConnection dc ? dc.Connection : null;
+
 				db.Close();
-				FirebirdTools.ClearAllPools();
+
+				if (fbConnection != null)
+					FirebirdTools.ClearPool(fbConnection);
+				else
+					FirebirdTools.ClearAllPools();
 			}
 		}
 

--- a/Tests/Base/TestUtils.cs
+++ b/Tests/Base/TestUtils.cs
@@ -202,7 +202,7 @@ namespace Tests
 				// database's pooled connection so its metadata reference is released for the next DDL. Unlike the
 				// former process-wide ClearAllPools, it leaves other Firebird databases' pools alone — which is
 				// what makes running the FB 2.5/3/4/5 suites concurrently safe (each is a distinct connection string).
-				var fbConnection = DataContext is DataConnection dc && dc.DataProvider.Name.Contains(ProviderName.Firebird) ? dc.Connection : null;
+				var fbConnection = DataContext is DataConnection dc && dc.DataProvider.Name.Contains(ProviderName.Firebird) ? dc.TryGetDbConnection() : null;
 
 				DataContext.Close();
 
@@ -214,7 +214,7 @@ namespace Tests
 
 			public override async ValueTask DisposeAsync()
 			{
-				var fbConnection = DataContext is DataConnection dc && dc.DataProvider.Name.Contains(ProviderName.Firebird) ? dc.Connection : null;
+				var fbConnection = DataContext is DataConnection dc && dc.DataProvider.Name.Contains(ProviderName.Firebird) ? dc.TryGetDbConnection() : null;
 
 				await DataContext.CloseAsync();
 
@@ -256,7 +256,7 @@ namespace Tests
 		{
 			if (db.ConfigurationString?.IsAnyOf(TestProvName.AllFirebird) == true)
 			{
-				var fbConnection = db is DataConnection dc ? dc.Connection : null;
+				var fbConnection = db is DataConnection dc ? dc.TryGetDbConnection() : null;
 
 				db.Close();
 

--- a/Tests/Linq/Linq/JoinTests.cs
+++ b/Tests/Linq/Linq/JoinTests.cs
@@ -3393,8 +3393,8 @@ namespace Tests.Linq
 
 			AssertQuery(query);
 
-			if (db is DataConnection { DataProvider: FirebirdDataProvider } dc)
-				FirebirdTools.ClearPool(dc.Connection);
+			if (db is DataConnection { DataProvider: FirebirdDataProvider } dc && dc.TryGetDbConnection() is { } cn)
+				FirebirdTools.ClearPool(cn);
 		}
 	}
 }

--- a/Tests/Linq/Linq/JoinTests.cs
+++ b/Tests/Linq/Linq/JoinTests.cs
@@ -3393,8 +3393,8 @@ namespace Tests.Linq
 
 			AssertQuery(query);
 
-			if (db is DataConnection { DataProvider: FirebirdDataProvider })
-				FirebirdTools.ClearAllPools();
+			if (db is DataConnection { DataProvider: FirebirdDataProvider } dc)
+				FirebirdTools.ClearPool(dc.Connection);
 		}
 	}
 }


### PR DESCRIPTION
## What

Adds a **scoped** Firebird pool-clear — `FirebirdTools.ClearPool(DbConnection)` (+ `FirebirdProviderAdapter.ClearPool`) wrapping `FbConnection.ClearPool(FbConnection)`, mirroring the existing YDB `ClearPool`. Switches the test suite's Firebird temp-table teardown to it instead of the process-wide `ClearAllPools()`.

## Background

Firebird serializes DDL against object references: `DROP TABLE` fails with `object TABLE is in use` if any attachment still references it. With `FirebirdSql.Data.FirebirdClient`'s default connection pooling, a closed-but-pooled connection keeps that reference alive, so a subsequent `CREATE`/`DROP` — **even single-threaded and sequential** — hits the lock. The test suite has long worked around this by calling `FirebirdTools.ClearAllPools()` after every Firebird temp-table dispose.

## Problem (parallel execution)

`FbConnection.ClearAllPools()` is process-global across every connection string. Running the Firebird 2.5/3/4/5 suites concurrently (each version is a distinct connection string on its own parallel lane), one version's temp-table teardown calls `ClearAllPools()` and forcibly closes the **other** versions' in-use connections → spurious lock/connection failures. The single-threaded workaround became the parallel failure cause.

## Fix

Scoped `ClearPool(connection)` evicts only the current database's pool — releasing that version's dropped-table reference (keeps the DDL-lock mitigation) while leaving the concurrently-running other-version pools untouched.

- `FirebirdProviderAdapter.ClearPool` + `FirebirdTools.ClearPool(DbConnection)` (public API; `PublicAPI.Unshipped` updated).
- `TestUtils` `FirebirdTempTable.Dispose`/`DisposeAsync` + `ClearDataContext`, and one `JoinTests` cleanup: capture the connection before `Close()`, scoped-clear after.
- `MiniProfilerTests`'s `ClearAllPools()` left as-is — that call deliberately smoke-tests the `ClearAllPools` API resolves.

Real verification is the Firebird CI matrix (all versions run concurrently).

## Follow-up commit

Scoped `ClearPool(connection)` only fired when a live `DataConnection` was available. On the **LinqService (remote)** path `DataContext` isn't a `DataConnection`, so no clear ran and the next DDL hit `lock conflict on no wait transaction` / `object TABLE is in use` — the FB 3/4/5 LinqService failures in build 22015.

All three Firebird teardown sites (`FirebirdTempTable.Dispose`/`DisposeAsync`, `ClearDataContext`) now route through a `ClearFirebirdPool` helper: clear by the live connection when present (direct path), else by connection string — `ClearPool(string)` via `GetConnectionString(config.StripRemote())` — on the remote path. The `ClearAllPools()` fallback is dropped entirely (process-wide; tears down other versions' pools under parallel execution).

Verified red→green locally on `ComplexTests2` + `--provider Firebird.5` (FB5, incl. LinqService): unfixed 3 failed → fixed 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
