### PR TITLE
Fix connection leak in provider version auto-detection (#5296)

### DIFF
--- a/Source/LinqToDB/Internal/DataProvider/ProviderDetectorBase.cs
+++ b/Source/LinqToDB/Internal/DataProvider/ProviderDetectorBase.cs
@@ -100,25 +100,38 @@ namespace LinqToDB.Internal.DataProvider
 
 			TVersion? DetectVersion(ConnectionOptions options, DbConnection cn, DbTransaction? transaction)
 			{
-				if (cn.State != ConnectionState.Open)
+				// When the connection is supplied by the caller (e.g. EF Core's shared connection) we must
+				// leave it in the state we found it - opening it here and not closing it leaks an open
+				// connection back to the caller (issue #5296).
+				var wasClosed = cn.State != ConnectionState.Open;
+
+				try
 				{
-					if (options.ConnectionInterceptor == null)
+					if (wasClosed)
 					{
-						cn.Open();
-					}
-					else
-					{
-						using (ActivityService.Start(ActivityID.ConnectionInterceptorConnectionOpening))
-							options.ConnectionInterceptor.ConnectionOpening(new(null), cn);
+						if (options.ConnectionInterceptor == null)
+						{
+							cn.Open();
+						}
+						else
+						{
+							using (ActivityService.Start(ActivityID.ConnectionInterceptorConnectionOpening))
+								options.ConnectionInterceptor.ConnectionOpening(new(null), cn);
 
-						cn.Open();
+							cn.Open();
 
-						using (ActivityService.Start(ActivityID.ConnectionInterceptorConnectionOpened))
-							options.ConnectionInterceptor.ConnectionOpened(new(null), cn);
+							using (ActivityService.Start(ActivityID.ConnectionInterceptorConnectionOpened))
+								options.ConnectionInterceptor.ConnectionOpened(new(null), cn);
+						}
 					}
+
+					return DetectServerVersion(cn, transaction);
 				}
-
-				return DetectServerVersion(cn, transaction);
+				finally
+				{
+					if (wasClosed && cn.State != ConnectionState.Closed)
+						cn.Close();
+				}
 			}
 		}
 

--- a/Tests/EntityFrameworkCore/Tests/CustomContextIssueTests.cs
+++ b/Tests/EntityFrameworkCore/Tests/CustomContextIssueTests.cs
@@ -231,6 +231,58 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 		}
 		#endregion
 
+		#region Issue 5296
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5296")]
+		public async ValueTask Issue5296Test([EFIncludeDataSources(TestProvName.AllSqlServer, TestProvName.AllPostgreSQL)] string provider)
+		{
+			var connectionString = GetConnectionString(provider);
+
+			var optionsBuilder = new DbContextOptionsBuilder();
+			optionsBuilder.UseLoggerFactory(LoggerFactory);
+
+			optionsBuilder = provider switch
+			{
+				_ when provider.IsAnyOf(TestProvName.AllPostgreSQL) => optionsBuilder.UseNpgsql(connectionString),
+				_ when provider.IsAnyOf(TestProvName.AllSqlServer)  => optionsBuilder.UseSqlServer(connectionString),
+				_                                                   => throw new InvalidOperationException($"ProviderSetup is not implemented for provider {provider}")
+			};
+
+			using var ctx = new Issue5296Context(optionsBuilder.Options);
+
+			using (new DisableBaseline("create db"))
+			{
+				ctx.Database.EnsureDeleted();
+				ctx.Database.EnsureCreated();
+
+				// creating the linq2db connection triggers provider version auto-detection,
+				// which opens EF's shared DbConnection and (before the fix) leaves it open
+				using (var db = ctx.CreateLinqToDBConnection())
+				{
+					await db.GetTable<Issue5296Entity>().ToListAsyncLinqToDB();
+				}
+
+				// must not throw: a leaked-open connection bound to the dropped database
+				// breaks EF's drop/recreate cycle (SocketException / broken-connection recovery)
+				ctx.Database.EnsureDeleted();
+				ctx.Database.EnsureCreated();
+			}
+		}
+
+		public sealed class Issue5296Context(DbContextOptions options) : DbContext(options)
+		{
+			public DbSet<Issue5296Entity> Entities { get; set; } = null!;
+
+			protected override void OnModelCreating(ModelBuilder modelBuilder)
+			{
+				modelBuilder.Entity<Issue5296Entity>();
+			}
+		}
+
+		public record Issue5296Entity(int Id, string Name);
+
+		#endregion
+
 		#region Issue 4783
 
 #if NET9_0_OR_GREATER

--- a/Tests/Linq/Data/DataConnectionTests.cs
+++ b/Tests/Linq/Data/DataConnectionTests.cs
@@ -13,6 +13,7 @@ using LinqToDB.Async;
 using LinqToDB.Data;
 using LinqToDB.DataProvider;
 using LinqToDB.DataProvider.DB2;
+using LinqToDB.DataProvider.PostgreSQL;
 using LinqToDB.DataProvider.SqlServer;
 using LinqToDB.Extensions.DependencyInjection;
 using LinqToDB.Interceptors;
@@ -86,6 +87,24 @@ namespace Tests.Data
 				var sdp = conn.DataProvider;
 				Assert.That(sdp.Name, Is.EqualTo("SqlServer.2008"));
 			}
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5296")]
+		public void ProviderDetectionDoesNotLeakConnection([IncludeDataSources(false, TestProvName.AllSqlServer, TestProvName.AllPostgreSQL)] string context)
+		{
+			var provider         = DataConnection.GetDataProvider(context);
+			var connectionString = DataConnection.GetConnectionString(context);
+
+			using var connection = provider.CreateConnection(connectionString);
+			Assert.That(connection.State, Is.EqualTo(ConnectionState.Closed));
+
+			// AutoDetect version detection on a caller-owned connection must leave it in the state it found it -
+			// opening and not closing it leaks an open connection back to the caller (issue #5296).
+			_ = context.IsAnyOf(TestProvName.AllSqlServer)
+				? SqlServerTools .GetDataProvider(SqlServerVersion .AutoDetect, connection: connection)
+				: PostgreSQLTools.GetDataProvider(PostgreSQLVersion.AutoDetect, connection: connection);
+
+			Assert.That(connection.State, Is.EqualTo(ConnectionState.Closed));
 		}
 
 		[Test]


### PR DESCRIPTION
Fixes #5296

## Problem

`ProviderDetectorBase.DetectVersion` opens a **caller-supplied** `DbConnection` to probe the server version (the `AutoDetect` dialect path) but never closes it. When the connection belongs to someone else — e.g. EF Core's shared `DbConnection` handed to linq2db via `context.CreateLinqToDBConnection()` — it is left open behind the owner's back.

The reported failure sequence (both PostgreSQL and SQL Server):

```cs
await ctx.Database.EnsureCreatedAsync();

using (var db = ctx.CreateLinqToDBConnection())   // AutoDetect opens EF's connection to probe version...
    await db.GetTable<Entity>().ToListAsyncLinqToDB();   // ...and it is never closed

await ctx.Database.EnsureDeletedAsync();          // drops the DB
await ctx.Database.EnsureCreatedAsync();          // throws: SocketException / broken connection
```

The pooled connection stays pinned to the now-dropped database, so EF's next existence check fails during connection recovery.

This surfaced after `linq2db.EntityFrameworkCore` ≥ 9.1.0 because SQL Server / PostgreSQL default to `AutoDetect`, which routes through the borrowed-connection branch of the detector.

## Fix

In `DetectVersion`, record whether the connection was closed on entry and close it again in a `finally` **only when we were the ones who opened it**. A connection the caller already had open is left untouched.

## Testing

Two regression tests — the bug is in core detection, so it is reproduced both through EF Core and pure linq2db:

- `Issue5296Test` (`CustomContextIssueTests`, EF Core, `AllSqlServer` + `AllPostgreSQL`) — mirrors the issue's create → linq2db-query → delete → create cycle.
- `ProviderDetectionDoesNotLeakConnection` (`DataConnectionTests`, pure linq2db, `AllSqlServer` + `AllPostgreSQL`) — hands a caller-owned closed `DbConnection` to `AutoDetect` detection and asserts it is left `Closed`.

Verified red → green:

| Test | Provider | Before fix | After fix |
|---|---|---|---|
| `Issue5296Test` | PostgreSQL 16 (EF10) | ❌ `SocketException (10053)` | ✅ pass |
| `Issue5296Test` | SQL Server 2022 MS (EF10) | ❌ broken connection | ✅ pass |
| `ProviderDetectionDoesNotLeakConnection` | PostgreSQL 16 | ❌ `Expected Closed, was Open` (net462/8/9/10) | ✅ pass |
| `ProviderDetectionDoesNotLeakConnection` | SQL Server 2022 MS | ❌ `Expected Closed, was Open` (net462/8/9/10) | ✅ pass |
