### PR TITLE
CI/tests: SQL Server test DBs use RECOVERY SIMPLE + DELAYED_DURABILITY

### DIFF
--- a/Build/Azure/scripts/sqlserver.2005.cmd
+++ b/Build/Azure/scripts/sqlserver.2005.cmd
@@ -16,6 +16,9 @@ docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "SELECT @@Version"
 
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData;"
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS;"
+REM test-DB perf: SIMPLE recovery cuts transaction-log overhead (DELAYED_DURABILITY needs SQL 2014+, N/A here)
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestData SET RECOVERY SIMPLE;"
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestDataMS SET RECOVERY SIMPLE;"
 
 goto:eof
 

--- a/Build/Azure/scripts/sqlserver.2008.cmd
+++ b/Build/Azure/scripts/sqlserver.2008.cmd
@@ -32,6 +32,9 @@ docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "SELECT @@Version"
 
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData;"
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS;"
+REM test-DB perf: SIMPLE recovery cuts transaction-log overhead (DELAYED_DURABILITY needs SQL 2014+, N/A here)
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestData SET RECOVERY SIMPLE;"
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestDataMS SET RECOVERY SIMPLE;"
 
 goto:eof
 

--- a/Build/Azure/scripts/sqlserver.2012.cmd
+++ b/Build/Azure/scripts/sqlserver.2012.cmd
@@ -16,6 +16,9 @@ docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "SELECT @@Version"
 
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData;"
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS;"
+REM test-DB perf: SIMPLE recovery cuts transaction-log overhead (DELAYED_DURABILITY needs SQL 2014+, N/A here)
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestData SET RECOVERY SIMPLE;"
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestDataMS SET RECOVERY SIMPLE;"
 
 goto:eof
 

--- a/Build/Azure/scripts/sqlserver.2014.cmd
+++ b/Build/Azure/scripts/sqlserver.2014.cmd
@@ -16,6 +16,9 @@ docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "SELECT @@Version"
 
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData;"
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS;"
+REM test-DB perf: SIMPLE recovery + delayed durability cut transaction-log-flush cost on the write-heavy suite
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestData SET RECOVERY SIMPLE; ALTER DATABASE TestData SET DELAYED_DURABILITY = FORCED;"
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestDataMS SET RECOVERY SIMPLE; ALTER DATABASE TestDataMS SET DELAYED_DURABILITY = FORCED;"
 
 goto:eof
 

--- a/Build/Azure/scripts/sqlserver.2016.cmd
+++ b/Build/Azure/scripts/sqlserver.2016.cmd
@@ -16,6 +16,9 @@ docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "SELECT @@Version"
 
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData;"
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS;"
+REM test-DB perf: SIMPLE recovery + delayed durability cut transaction-log-flush cost on the write-heavy suite
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestData SET RECOVERY SIMPLE; ALTER DATABASE TestData SET DELAYED_DURABILITY = FORCED;"
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestDataMS SET RECOVERY SIMPLE; ALTER DATABASE TestDataMS SET DELAYED_DURABILITY = FORCED;"
 
 goto:eof
 

--- a/Build/Azure/scripts/sqlserver.2017.cmd
+++ b/Build/Azure/scripts/sqlserver.2017.cmd
@@ -16,6 +16,9 @@ docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "SELECT @@Version"
 
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData;"
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS;"
+REM test-DB perf: SIMPLE recovery + delayed durability cut transaction-log-flush cost on the write-heavy suite
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestData SET RECOVERY SIMPLE; ALTER DATABASE TestData SET DELAYED_DURABILITY = FORCED;"
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestDataMS SET RECOVERY SIMPLE; ALTER DATABASE TestDataMS SET DELAYED_DURABILITY = FORCED;"
 
 goto:eof
 

--- a/Build/Azure/scripts/sqlserver.2017.sh
+++ b/Build/Azure/scripts/sqlserver.2017.sh
@@ -17,3 +17,6 @@ docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Passwo
 
 docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestData;'
 docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataMS;'
+# test-DB perf: SIMPLE recovery + delayed durability cut transaction-log-flush cost on the write-heavy suite
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'ALTER DATABASE TestData SET RECOVERY SIMPLE; ALTER DATABASE TestData SET DELAYED_DURABILITY = FORCED;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'ALTER DATABASE TestDataMS SET RECOVERY SIMPLE; ALTER DATABASE TestDataMS SET DELAYED_DURABILITY = FORCED;'

--- a/Build/Azure/scripts/sqlserver.2019.cmd
+++ b/Build/Azure/scripts/sqlserver.2019.cmd
@@ -16,6 +16,9 @@ docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "SELECT @@Version"
 
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData COLLATE Latin1_General_CS_AS WITH CATALOG_COLLATION = SQL_Latin1_General_CP1_CI_AS;"
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS COLLATE Latin1_General_CS_AS WITH CATALOG_COLLATION = SQL_Latin1_General_CP1_CI_AS;"
+REM test-DB perf: SIMPLE recovery + delayed durability cut transaction-log-flush cost on the write-heavy suite
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestData SET RECOVERY SIMPLE; ALTER DATABASE TestData SET DELAYED_DURABILITY = FORCED;"
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestDataMS SET RECOVERY SIMPLE; ALTER DATABASE TestDataMS SET DELAYED_DURABILITY = FORCED;"
 
 REM FTS required
 goto:eof

--- a/Build/Azure/scripts/sqlserver.2019.sh
+++ b/Build/Azure/scripts/sqlserver.2019.sh
@@ -26,6 +26,14 @@ docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Passwo
 docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataContained CONTAINMENT = PARTIAL;'
 docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataMSContained CONTAINMENT = PARTIAL;'
 
+# test-DB perf: SIMPLE recovery + delayed durability cut transaction-log-flush cost on the write-heavy suite
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'ALTER DATABASE TestData SET RECOVERY SIMPLE; ALTER DATABASE TestData SET DELAYED_DURABILITY = FORCED;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'ALTER DATABASE TestDataMS SET RECOVERY SIMPLE; ALTER DATABASE TestDataMS SET DELAYED_DURABILITY = FORCED;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'ALTER DATABASE TestDataSA SET RECOVERY SIMPLE; ALTER DATABASE TestDataSA SET DELAYED_DURABILITY = FORCED;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'ALTER DATABASE TestDataMSSA SET RECOVERY SIMPLE; ALTER DATABASE TestDataMSSA SET DELAYED_DURABILITY = FORCED;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'ALTER DATABASE TestDataContained SET RECOVERY SIMPLE; ALTER DATABASE TestDataContained SET DELAYED_DURABILITY = FORCED;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'ALTER DATABASE TestDataMSContained SET RECOVERY SIMPLE; ALTER DATABASE TestDataMSContained SET DELAYED_DURABILITY = FORCED;'
+
 docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE Northwind;'
 docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE NorthwindMS;'
 

--- a/Build/Azure/scripts/sqlserver.2022.cmd
+++ b/Build/Azure/scripts/sqlserver.2022.cmd
@@ -32,6 +32,9 @@ docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "SELECT @@Version"
 
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData;"
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS;"
+REM test-DB perf: SIMPLE recovery + delayed durability cut transaction-log-flush cost on the write-heavy suite
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestData SET RECOVERY SIMPLE; ALTER DATABASE TestData SET DELAYED_DURABILITY = FORCED;"
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestDataMS SET RECOVERY SIMPLE; ALTER DATABASE TestDataMS SET DELAYED_DURABILITY = FORCED;"
 
 REM FTS required
 goto:eof

--- a/Build/Azure/scripts/sqlserver.2022.sh
+++ b/Build/Azure/scripts/sqlserver.2022.sh
@@ -17,3 +17,6 @@ docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Passwo
 
 docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestData;'
 docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataMS;'
+# test-DB perf: SIMPLE recovery + delayed durability cut transaction-log-flush cost on the write-heavy suite
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'ALTER DATABASE TestData SET RECOVERY SIMPLE; ALTER DATABASE TestData SET DELAYED_DURABILITY = FORCED;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'ALTER DATABASE TestDataMS SET RECOVERY SIMPLE; ALTER DATABASE TestDataMS SET DELAYED_DURABILITY = FORCED;'

--- a/Build/Azure/scripts/sqlserver.2025.cmd
+++ b/Build/Azure/scripts/sqlserver.2025.cmd
@@ -32,6 +32,9 @@ docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "SELECT @@Version"
 
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData;" -C
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS;" -C
+REM test-DB perf: SIMPLE recovery + delayed durability cut transaction-log-flush cost on the write-heavy suite
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestData SET RECOVERY SIMPLE; ALTER DATABASE TestData SET DELAYED_DURABILITY = FORCED;" -C
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestDataMS SET RECOVERY SIMPLE; ALTER DATABASE TestDataMS SET DELAYED_DURABILITY = FORCED;" -C
 
 goto:eof
 

--- a/Build/Azure/scripts/sqlserver.2025.sh
+++ b/Build/Azure/scripts/sqlserver.2025.sh
@@ -17,3 +17,6 @@ docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Passwo
 
 docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestData;'
 docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataMS;'
+# test-DB perf: SIMPLE recovery + delayed durability cut transaction-log-flush cost on the write-heavy suite
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'ALTER DATABASE TestData SET RECOVERY SIMPLE; ALTER DATABASE TestData SET DELAYED_DURABILITY = FORCED;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'ALTER DATABASE TestDataMS SET RECOVERY SIMPLE; ALTER DATABASE TestDataMS SET DELAYED_DURABILITY = FORCED;'

--- a/Build/Azure/scripts/sqlserver.extras.cmd
+++ b/Build/Azure/scripts/sqlserver.extras.cmd
@@ -22,6 +22,12 @@ docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "RECONFIGURE;"
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataContained CONTAINMENT = PARTIAL;"
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMSContained CONTAINMENT = PARTIAL;"
 
+REM test-DB perf: SIMPLE recovery + delayed durability cut transaction-log-flush cost on the write-heavy suite (SQL 2019 image)
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestDataSA SET RECOVERY SIMPLE; ALTER DATABASE TestDataSA SET DELAYED_DURABILITY = FORCED;"
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestDataMSSA SET RECOVERY SIMPLE; ALTER DATABASE TestDataMSSA SET DELAYED_DURABILITY = FORCED;"
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestDataContained SET RECOVERY SIMPLE; ALTER DATABASE TestDataContained SET DELAYED_DURABILITY = FORCED;"
+docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestDataMSContained SET RECOVERY SIMPLE; ALTER DATABASE TestDataMSContained SET DELAYED_DURABILITY = FORCED;"
+
 goto:eof
 
 :fail

--- a/Build/Azure/scripts/sqlserver.extras.sh
+++ b/Build/Azure/scripts/sqlserver.extras.sh
@@ -22,3 +22,9 @@ docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Passwo
 docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'RECONFIGURE;'
 docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataContained CONTAINMENT = PARTIAL;'
 docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'CREATE DATABASE TestDataMSContained CONTAINMENT = PARTIAL;'
+
+# test-DB perf: SIMPLE recovery + delayed durability cut transaction-log-flush cost on the write-heavy suite (SQL 2019 image)
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'ALTER DATABASE TestDataSA SET RECOVERY SIMPLE; ALTER DATABASE TestDataSA SET DELAYED_DURABILITY = FORCED;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'ALTER DATABASE TestDataMSSA SET RECOVERY SIMPLE; ALTER DATABASE TestDataMSSA SET DELAYED_DURABILITY = FORCED;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'ALTER DATABASE TestDataContained SET RECOVERY SIMPLE; ALTER DATABASE TestDataContained SET DELAYED_DURABILITY = FORCED;'
+docker exec mssql /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P Password12! -Q 'ALTER DATABASE TestDataMSContained SET RECOVERY SIMPLE; ALTER DATABASE TestDataMSContained SET DELAYED_DURABILITY = FORCED;'


### PR DESCRIPTION
Splits the SQL Server test-DB log-flush tuning out of the parallel-test-execution work (#5614) into a focused, independently-mergeable PR — so master's SQL Server CI benefits now.

The baseline test DBs run FULL recovery + synchronous commit, so the write-heavy suite (CreateData seeding + BulkCopy + Merge) pays a per-commit transaction-log-flush cost. Two settings cut that:

- **`RECOVERY SIMPLE`** — auto-truncates the log; applied on **all** versions (2005+).
- **`DELAYED_DURABILITY = FORCED`** — async commit; applied on **2014+** only (the feature doesn't exist on 2005/2008/2012).

Measured on SQL Server 2022 (bounded `CreateData|BulkCopy|Merge`, 695 tests, net10): **~40% faster** (152.5s → ~92s), no failures. Both are safe for tests — the DBs are ephemeral (rebuilt each run), so relaxed durability / no point-in-time recovery is fine.

Applied to `TestData`/`TestDataMS` and the SA/Contained extras DBs at setup, in the shared `sqlserver.*` container scripts (local + Azure CI). Read-only Northwind is left untouched.

Measured but **not** adopted: `MEMORY_OPTIMIZED TEMPDB_METADATA` (no benefit) and `OPTIMIZE_FOR_AD_HOC_WORKLOADS` (no perf benefit; memory-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
