### PR TITLE
test: gate TakeSkipJoin for YDB (26.1.1.20 optimizer regression)

### DIFF
--- a/Tests/Linq/Linq/TakeSkipTests.cs
+++ b/Tests/Linq/Linq/TakeSkipTests.cs
@@ -731,7 +731,7 @@ namespace Tests.Linq
 			Assert.Throws<LinqToDBException>(() => db.Parent.Take(10, TakeHints.Percent).ToList());
 		}
 
-		[ActiveIssue("YDB 26.1.1.20: server optimizer assertion (dq_opt_phy_finalizing.cpp:540 'requirement false failed') on a LEFT JOIN of two LIMIT-ed UNION ALL subqueries; regression from the release's Shuffle Elimination. TODO: replace with the filed https://github.com/ydb-platform/ydb/issues/<n> link.", Configuration = TestProvName.AllYdb)]
+		[ActiveIssue("https://github.com/ydb-platform/ydb/issues/46197", Configuration = TestProvName.AllYdb, Details = "YDB 26.1.1.20 server optimizer assertion (dq_opt_phy_finalizing.cpp:540 'requirement false failed') on a LEFT JOIN of two LIMIT-ed UNION ALL subqueries; regression from the release's Shuffle Elimination.")]
 		[Test]
 		public void TakeSkipJoin([DataSources(TestProvName.AllSybase)] string context, [Values] bool withParameters)
 		{

--- a/Tests/Linq/Linq/TakeSkipTests.cs
+++ b/Tests/Linq/Linq/TakeSkipTests.cs
@@ -731,6 +731,7 @@ namespace Tests.Linq
 			Assert.Throws<LinqToDBException>(() => db.Parent.Take(10, TakeHints.Percent).ToList());
 		}
 
+		[ActiveIssue("YDB 26.1.1.20: server optimizer assertion (dq_opt_phy_finalizing.cpp:540 'requirement false failed') on a LEFT JOIN of two LIMIT-ed UNION ALL subqueries; regression from the release's Shuffle Elimination. TODO: replace with the filed https://github.com/ydb-platform/ydb/issues/<n> link.", Configuration = TestProvName.AllYdb)]
 		[Test]
 		public void TakeSkipJoin([DataSources(TestProvName.AllSybase)] string context, [Values] bool withParameters)
 		{


### PR DESCRIPTION
Gates `TakeSkipTests.TakeSkipJoin` for YDB.

YDB **26.1.1.20** crashes with a server-side optimizer assertion (`dq_opt_phy_finalizing.cpp:540 'requirement false failed'`) on the query this test generates — a `LEFT JOIN` of two `LIMIT`-ed `UNION ALL` subqueries. It passed on the prior YDB version, so this is a regression, most likely introduced by 26.1.1.20 enabling **Shuffle Elimination** in production.

The generated YQL + a minimal self-contained repro were filed upstream as ydb-platform/ydb#46197; the `[ActiveIssue]` links it.

Scope: test-only, YDB-only gate — no product code changed.
