### PR TITLE
tests: DuckDB in-memory preload, SqlServer READPAST fix, and fixture hygiene

### DIFF
--- a/Build/Azure/net100/duckdb.json
+++ b/Build/Azure/net100/duckdb.json
@@ -2,11 +2,6 @@
 	"NET100.Azure": {
 		"Providers": [
 			"DuckDB"
-		],
-		"Connections": {
-			// CI runs DuckDB against a shared-cache in-memory DB (no per-commit fsync); one keep-alive
-			// connection is held open in TestsInitialization for the run.
-			"DuckDB": { "Provider": "DuckDB", "ConnectionString": "Data Source=:memory:?cache=shared" }
-		}
+		]
 	}
 }

--- a/Build/Azure/net80/duckdb.json
+++ b/Build/Azure/net80/duckdb.json
@@ -2,11 +2,6 @@
 	"NET80.Azure": {
 		"Providers": [
 			"DuckDB"
-		],
-		"Connections": {
-			// CI runs DuckDB against a shared-cache in-memory DB (no per-commit fsync); one keep-alive
-			// connection is held open in TestsInitialization for the run.
-			"DuckDB": { "Provider": "DuckDB", "ConnectionString": "Data Source=:memory:?cache=shared" }
-		}
+		]
 	}
 }

--- a/Build/Azure/net90/duckdb.json
+++ b/Build/Azure/net90/duckdb.json
@@ -2,11 +2,6 @@
 	"NET90.Azure": {
 		"Providers": [
 			"DuckDB"
-		],
-		"Connections": {
-			// CI runs DuckDB against a shared-cache in-memory DB (no per-commit fsync); one keep-alive
-			// connection is held open in TestsInitialization for the run.
-			"DuckDB": { "Provider": "DuckDB", "ConnectionString": "Data Source=:memory:?cache=shared" }
-		}
+		]
 	}
 }

--- a/Data/Create Scripts/DuckDB.sql
+++ b/Data/Create Scripts/DuckDB.sql
@@ -120,12 +120,6 @@ CREATE TABLE "LinqDataTypes"
 )
 GO
 
-DROP SEQUENCE IF EXISTS SequenceTestSeq
-GO
-
-CREATE SEQUENCE SequenceTestSeq INCREMENT BY 1 START 1
-GO
-
 DROP TABLE IF EXISTS "SequenceTest1"
 GO
 
@@ -133,6 +127,14 @@ DROP TABLE IF EXISTS "SequenceTest2"
 GO
 
 DROP TABLE IF EXISTS "SequenceTest3"
+GO
+
+-- drop the sequence after its dependent tables: on a preloaded in-memory catalog SequenceTest3
+-- still defaults off SequenceTestSeq, so dropping the sequence first is blocked and CREATE collides
+DROP SEQUENCE IF EXISTS SequenceTestSeq
+GO
+
+CREATE SEQUENCE SequenceTestSeq INCREMENT BY 1 START 1
 GO
 
 DROP SEQUENCE IF EXISTS "SequenceTest2_ID_seq"

--- a/DataProviders.json
+++ b/DataProviders.json
@@ -86,7 +86,7 @@
 			"Northwind.SQLite"      : { "Provider": "System.Data.SQLite",    "ConnectionString": "FullUri=file:northwind_cl?mode=memory&cache=shared"                                                                                                  },
 			"Northwind.SQLite.MS"   : { "Provider": "SQLite.Microsoft",      "ConnectionString": "Data Source=northwind_ms;Mode=Memory;Cache=Shared"                                                                                                   },
 			"TestNoopProvider"      : { "Provider": "TestNoopProvider",      "ConnectionString": "TestNoopProvider"                                                                                                                                    },
-			"DuckDB"                : { "Provider": "DuckDB",                "ConnectionString": "Data Source=Database/TestData.duckdb"                                                                                                                }
+			"DuckDB"                : { "Provider": "DuckDB",                "ConnectionString": "Data Source=:memory:?cache=shared"                                                                                                             }
 		}
 	},
 

--- a/Tests/Linq/Extensions/SqlServerTests.cs
+++ b/Tests/Linq/Extensions/SqlServerTests.cs
@@ -35,7 +35,9 @@ namespace Tests.Extensions
 				SqlServerHints.Table.PagLock,
 				SqlServerHints.Table.ReadCommitted,
 				SqlServerHints.Table.ReadCommittedLock,
-				SqlServerHints.Table.ReadPast,
+				// ReadPast is covered by WithReadPastTableTest, which pins an explicit READ COMMITTED
+				// transaction (READPAST is invalid under SNAPSHOT/SERIALIZABLE, which a pooled connection
+				// may carry over under parallel execution).
 				SqlServerHints.Table.ReadUncommitted,
 				SqlServerHints.Table.RepeatableRead,
 				SqlServerHints.Table.RowLock,

--- a/Tests/Linq/Extensions/SqlServerTests.generated.cs
+++ b/Tests/Linq/Extensions/SqlServerTests.generated.cs
@@ -4,6 +4,7 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 
+using LinqToDB.Data;
 using LinqToDB.DataProvider.SqlServer;
 
 using NUnit.Framework;
@@ -265,9 +266,10 @@ namespace Tests.Extensions
 		}
 
 		[Test]
-		public void WithReadPastTableTest([IncludeDataSources(true, TestProvName.AllSqlServer)] string context)
+		public void WithReadPastTableTest([IncludeDataSources(false, TestProvName.AllSqlServer)] string context)
 		{
 			using var db = GetDataContext(context);
+			using var tx = ((DataConnection)db).BeginTransaction(System.Data.IsolationLevel.ReadCommitted);
 
 			var q =
 				from p in db.Parent
@@ -281,9 +283,10 @@ namespace Tests.Extensions
 		}
 
 		[Test]
-		public void WithReadPastInScopeTest([IncludeDataSources(true, TestProvName.AllSqlServer)] string context)
+		public void WithReadPastInScopeTest([IncludeDataSources(false, TestProvName.AllSqlServer)] string context)
 		{
 			using var db = GetDataContext(context);
+			using var tx = ((DataConnection)db).BeginTransaction(System.Data.IsolationLevel.ReadCommitted);
 
 			var q =
 			(

--- a/Tests/Linq/Extensions/SqlServerTests.tt
+++ b/Tests/Linq/Extensions/SqlServerTests.tt
@@ -10,6 +10,7 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 
+using LinqToDB.Data;
 using LinqToDB.DataProvider.SqlServer;
 
 using NUnit.Framework;
@@ -26,7 +27,7 @@ namespace Tests.Extensions
 	GenerateTableTest("PagLock");
 	GenerateTableTest("ReadCommitted");
 	GenerateTableTest("ReadCommittedLock");
-	GenerateTableTest("ReadPast");
+	GenerateTableTest("ReadPast", isolationLevel: "ReadCommitted");
 	GenerateTableTest("ReadUncommitted");
 	GenerateTableTest("RepeatableRead");
 	GenerateTableTest("RowLock");
@@ -60,13 +61,21 @@ namespace Tests.Extensions
 	}
 }
 <#+
-void GenerateTableTest(string test, string version = "")
+void GenerateTableTest(string test, string version = "", string isolationLevel = null)
 {
+	// When an isolation level is required (e.g. READPAST is only valid under READ COMMITTED /
+	// REPEATABLE READ), pin it with an explicit transaction so the test doesn't inherit a pooled
+	// connection's leftover isolation level, and disable remote/LinqService (the client-side
+	// transaction can't set the remote server connection's isolation level).
+	var remote = isolationLevel == null ? "true" : "false";
 #>
 		[Test]
-		public void With<#= test #>TableTest([IncludeDataSources(true, TestProvName.AllSqlServer<#= version #>)] string context)
+		public void With<#= test #>TableTest([IncludeDataSources(<#= remote #>, TestProvName.AllSqlServer<#= version #>)] string context)
 		{
 			using var db = GetDataContext(context);
+<#+ if (isolationLevel != null) { #>
+			using var tx = ((DataConnection)db).BeginTransaction(System.Data.IsolationLevel.<#= isolationLevel #>);
+<#+ } #>
 
 			var q =
 				from p in db.Parent
@@ -80,9 +89,12 @@ void GenerateTableTest(string test, string version = "")
 		}
 
 		[Test]
-		public void With<#= test #>InScopeTest([IncludeDataSources(true, TestProvName.AllSqlServer<#= version #>)] string context)
+		public void With<#= test #>InScopeTest([IncludeDataSources(<#= remote #>, TestProvName.AllSqlServer<#= version #>)] string context)
 		{
 			using var db = GetDataContext(context);
+<#+ if (isolationLevel != null) { #>
+			using var tx = ((DataConnection)db).BeginTransaction(System.Data.IsolationLevel.<#= isolationLevel #>);
+<#+ } #>
 
 			var q =
 			(

--- a/Tests/Linq/Mapping/MappingSchemaTests.cs
+++ b/Tests/Linq/Mapping/MappingSchemaTests.cs
@@ -374,7 +374,8 @@ namespace Tests.Mapping
 		[Test]
 		public void DoNotUseComplexAttributes()
 		{
-			var ed = MappingSchema.Default.GetEntityDescriptor(typeof(FkTable));
+			// local schema (not MappingSchema.Default) so a concurrent Default mutation can't perturb the read
+			var ed = new MappingSchema().GetEntityDescriptor(typeof(FkTable));
 			var c  = ed.Columns.Single(_ => _.ColumnName == "ParentId");
 			using (Assert.EnterMultipleScope())
 			{

--- a/Tests/Linq/TestsInitialization.cs
+++ b/Tests/Linq/TestsInitialization.cs
@@ -271,7 +271,18 @@ public class TestsInitialization
 		// connection using the same string — exactly like SQLite — so we only need to hold one master
 		// connection open; the database is destroyed once its last connection closes.
 		var master = new DuckDB.NET.Data.DuckDBConnection(cs);
-		master.Open();
+		try
+		{
+			master.Open();
+		}
+		catch (DllNotFoundException)
+		{
+			// no native duckdb on this leg (e.g. the x86 Access runs, where DuckDB isn't a tested
+			// provider) — skip the in-memory keep-alive rather than failing global OneTimeSetUp.
+			master.Dispose();
+			return;
+		}
+
 		TestInMemoryDatabases.AddKeepAlive(master);
 
 		// Preload from the committed on-disk file so a filtered run (which skips a_CreateData) still has

--- a/Tests/Linq/TestsInitialization.cs
+++ b/Tests/Linq/TestsInitialization.cs
@@ -267,18 +267,45 @@ public class TestsInitialization
 		if (cs == null || cs.IndexOf(":memory:", StringComparison.OrdinalIgnoreCase) < 0)
 			return; // file-based -> nothing to do
 
-		// DuckDB in-memory is CI-only (the tracked DataProviders.json default stays file-based). Unlike
-		// SQLite, DuckDB can't preload the in-memory DB from its committed on-disk file (COPY FROM DATABASE
-		// fails on FK ordering), so the shared in-memory catalog is only ever seeded by a_CreateData. CI
-		// always runs the full suite, so a_CreateData seeds it first; a filtered run against an in-memory
-		// DuckDB would see an empty DB — which is why the default is left file-based for local/filtered runs.
-
 		// A DuckDB shared-cache in-memory database (Data Source=:memory:?cache=shared) is shared by every
 		// connection using the same string — exactly like SQLite — so we only need to hold one master
 		// connection open; the database is destroyed once its last connection closes.
 		var master = new DuckDB.NET.Data.DuckDBConnection(cs);
 		master.Open();
 		TestInMemoryDatabases.AddKeepAlive(master);
+
+		// Preload from the committed on-disk file so a filtered run (which skips a_CreateData) still has
+		// tables and data. DuckDB can't COPY FROM DATABASE (it inserts child rows before parents, hitting
+		// an FK violation), so round-trip via EXPORT/IMPORT DATABASE, which loads schema -> data ->
+		// constraints in phases and preserves sequence values. Full runs re-seed on top (create drops first).
+		var srcFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Database", "TestData.duckdb");
+		if (File.Exists(srcFile))
+		{
+			var work = Path.Combine(Path.GetTempPath(), $"l2db-duckdb-{Guid.NewGuid():N}.duckdb");
+			var dump = Path.Combine(Path.GetTempPath(), $"l2db-duckdb-{Guid.NewGuid():N}");
+			try
+			{
+				// export off a copy so the committed file is never opened writable
+				File.Copy(srcFile, work, true);
+				using (var fileDb = new DuckDB.NET.Data.DuckDBConnection($"Data Source={work.Replace('\\', '/')}"))
+				{
+					fileDb.Open();
+					using var ec = fileDb.CreateCommand();
+					ec.CommandText = $"EXPORT DATABASE '{dump.Replace('\\', '/')}' (FORMAT PARQUET)";
+					ec.ExecuteNonQuery();
+				}
+
+				using var ic = master.CreateCommand();
+				ic.CommandText = $"IMPORT DATABASE '{dump.Replace('\\', '/')}'";
+				ic.ExecuteNonQuery();
+				TestContext.Progress.WriteLine($"[duckdb-inmemory] preloaded from {srcFile}");
+			}
+			finally
+			{
+				try { File.Delete(work); } catch { /* best effort */ }
+				try { if (Directory.Exists(dump)) Directory.Delete(dump, true); } catch { /* best effort */ }
+			}
+		}
 
 		TestContext.Progress.WriteLine($"[duckdb-inmemory] keep-alive open ({cs})");
 	}

--- a/Tests/Linq/UserTests/Issue1373Tests.cs
+++ b/Tests/Linq/UserTests/Issue1373Tests.cs
@@ -2,7 +2,6 @@
 
 using LinqToDB;
 using LinqToDB.Data;
-using LinqToDB.Internal.Linq;
 using LinqToDB.Mapping;
 
 using NUnit.Framework;
@@ -62,8 +61,6 @@ namespace Tests.UserTests
 		[Test]
 		public void Test1([DataSources] string context)
 		{
-			Query.ClearCaches();
-
 			var ms = new MappingSchema();
 			ms.SetConvertExpression<string?, CustomFieldType?>(s => CustomFieldType.FromString(s));
 			ms.SetConvertExpression<CustomFieldType, DataParameter>(
@@ -94,8 +91,6 @@ namespace Tests.UserTests
 		[Test]
 		public void Test2([DataSources] string context)
 		{
-			Query.ClearCaches();
-
 			var ms = new MappingSchema();
 
 			ms.SetConvertExpression<string?, CustomFieldType?>(s => CustomFieldType.FromString(s));
@@ -129,8 +124,6 @@ namespace Tests.UserTests
 		[Test]
 		public void Test3([DataSources] string context)
 		{
-			Query.ClearCaches();
-
 			var ms = new MappingSchema();
 
 			ms.SetConvertExpression<string?, CustomFieldType?>(s => CustomFieldType.FromString(s));
@@ -162,8 +155,6 @@ namespace Tests.UserTests
 		[Test]
 		public void TestExpr1([DataSources] string context)
 		{
-			Query.ClearCaches();
-
 			var ms = new MappingSchema();
 			ms.SetConvertExpression<string?, CustomFieldType?>(s => CustomFieldType.FromString(s));
 			ms.SetConvertExpression<CustomFieldType, DataParameter>(
@@ -195,8 +186,6 @@ namespace Tests.UserTests
 		[Test]
 		public void TestExpr2([DataSources] string context)
 		{
-			Query.ClearCaches();
-
 			var ms = new MappingSchema();
 
 			ms.SetConvertExpression<string?, CustomFieldType?>(s => CustomFieldType.FromString(s));
@@ -231,8 +220,6 @@ namespace Tests.UserTests
 		[Test]
 		public void TestExpr3([DataSources] string context)
 		{
-			Query.ClearCaches();
-
 			var ms = new MappingSchema();
 
 			ms.SetConvertExpression<string?, CustomFieldType?>(s => CustomFieldType.FromString(s));

--- a/Tests/Linq/UserTests/Issue822Tests.cs
+++ b/Tests/Linq/UserTests/Issue822Tests.cs
@@ -12,13 +12,14 @@ namespace Tests.UserTests
 	[TestFixture]
 	public class Issue822Tests : TestBase
 	{
-		int? ID1;
-
-		int? ID2;
-
 		[Test]
 		public void TestWrongValue([DataSources(TestProvName.AllClickHouse)] string context, [Values(1, 2)] int _)
 		{
+			// ID1/ID2 are locals (not fixture fields) so parallel cases don't share state; the query closures
+			// still capture them and linq2db re-reads the value at execution, so mutating before ToList() is #822's point.
+			int? ID1 = null;
+			int? ID2 = null;
+
 			using var db = GetDataContext(context);
 			var query = db.GetTable<LinqDataTypes2>()
 					.Where(_ => GetSource(db, ID1!.Value).Select(r => r.ID).Contains(_.ID));
@@ -41,6 +42,9 @@ namespace Tests.UserTests
 		[Test]
 		public void TestNullValue([DataSources(TestProvName.AllClickHouse)] string context, [Values(1, 2)] int _)
 		{
+			int? ID1 = null;
+			int? ID2 = null;
+
 			using var db = GetDataContext(context);
 			var query = db.GetTable<LinqDataTypes2>()
 					.Where(_ => GetSource(db, ID1!.Value).Select(r => r.ID).Contains(_.ID));


### PR DESCRIPTION
Directly-unrelated test fixes/refactors split out of the parallel-test-execution work (#5614) so they can merge to master independently.

## DuckDB in-memory testing for local / filtered runs

Make DuckDB's default in-memory (matching SQLite) rather than file-based with a CI-only in-memory override. DuckDB can't preload an in-memory database via `COPY FROM DATABASE` — it inserts child rows before parents and fails the FK constraint — so `TestsInitialization.SetupDuckDBInMemory` seeds the shared in-memory DB by round-tripping the committed on-disk file through `EXPORT`/`IMPORT DATABASE`, which loads schema → data → constraints in phases and preserves sequence values. Filtered / local runs (which skip `a_CreateData`) then still have tables and data; full runs re-seed on top (the create script drops first).

- `DataProviders.json`: `CommonConnectionStrings` DuckDB → in-memory shared cache.
- `Build/Azure/*/duckdb.json`: Providers-only (inherit the Common in-memory string).

Verified on net10: a no-seed filtered run reads back the preloaded data correctly (incl. decimal / blob / hugeint via PARQUET); a full seeded run passes.

## SqlServer READPAST hint isolation fix

`WithReadPastTableTest` / `WithReadPastInScopeTest` (and the `ReadPast` value of `TableHint2005PlusTest`) failed sporadically with *"You can only specify the READPAST lock in the READ COMMITTED or REPEATABLE READ isolation levels"*: with no explicit transaction they inherit the pooled connection's leftover isolation level (SqlClient doesn't reset it on pool return). Pin it with an explicit `READ COMMITTED` transaction, and disable remote/LinqService for that case (the client-side transaction can't set the remote server connection's isolation).

## Test-fixture hygiene refactors

Drop shared / vestigial state from three fixtures:

- **Issue822Tests** — `ID1`/`ID2` were shared fixture instance fields mutated mid-test and captured by the query closures; now method locals, so the `[Values]` cases don't share mutable state (closures still capture + re-read them at execution, the point of #822).
- **Issue1373Tests** — drop the vestigial `Query.ClearCaches()` from all six tests: each uses a distinct local `MappingSchema` (part of the compiled-query cache key), so there's no stale-cache collision to clear.
- **MappingSchemaTests.DoNotUseComplexAttributes** — read the entity descriptor from a local `MappingSchema` instead of the process-global `MappingSchema.Default`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
