### PR TITLE
CI: expand and instrument Linux disk-cleanup step

### DIFF
--- a/Build/Azure/pipelines/templates/test-workflow-linux.yml
+++ b/Build/Azure/pipelines/templates/test-workflow-linux.yml
@@ -12,15 +12,29 @@ steps:
 - task: CmdLine@2
   inputs:
     script: |
-      # 1Gb
-      sudo apt-get remove -y '^llvm-.*'
-      # 10Gb
-      sudo rm -rf /usr/local/lib/android
-      df -h
-      # frees ~7Gb
-      echo remove .ghcup
-      sudo rm -rf /usr/local/.ghcup/
-      df -h
+      # Free disk space so large-DB jobs (Oracle 21/23) fit. Each step logs the space it
+      # actually freed (avail before -> after); the ~sizes below are measured on build 22224.
+      #
+      # Enabled (each frees >= 1 GB): ~23.6 GB total, takes avail from ~15 GB to ~39 GB.
+      # Disabled (freed < 1 GB, or unsafe) - uncomment if a job needs more headroom:
+      #   apt clean      ~0.1 GB
+      #   remove dotnet  ~2-3 GB  (breaks all legs - system dotnet is used before UseDotNet@2)
+      avail() { df --output=avail -m / | tail -1 | tr -d ' '; }
+      report() { local a=$(avail); echo ">>> $2: freed $(( a - $1 )) MB (avail now $a MB)"; }
+
+      b=$(avail); sudo apt-get remove -y '^llvm-.*';        report $b "remove llvm (~1.4Gb)"
+      b=$(avail); sudo rm -rf /usr/local/lib/android;       report $b "remove android (~10Gb)"
+      b=$(avail); sudo rm -rf /usr/local/.ghcup/;           report $b "remove ghcup (~3.7Gb)"
+      b=$(avail); sudo rm -rf /opt/hostedtoolcache/CodeQL;  report $b "remove CodeQL (~1.7Gb, unused)"
+      b=$(avail); sudo rm -rf /usr/share/swift;             report $b "remove swift (~3.4Gb, unused)"
+      b=$(avail); sudo rm -rf /usr/lib/jvm;                 report $b "remove jvm (~1.4Gb, unused)"
+      # docker image prune runs before any DB container exists (safe); it also prints its own
+      # "Total reclaimed space" line in addition to the avail delta below.
+      b=$(avail); sudo docker image prune -af;              report $b "docker image prune (~1.9Gb)"
+      df -h /
+      # Disabled - freed < 1 GB or breaks legs; uncomment if a job needs more space:
+      # b=$(avail); sudo apt-get clean;                     report $b "apt clean (~0.1Gb)"
+      # b=$(avail); sudo rm -rf /usr/share/dotnet;          report $b "remove dotnet (~2-3Gb est)"
   displayName: Cleanup Junk
 
 - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
Offload from #5614 (parallel test execution): the Linux CI legs need more free disk for large-DB providers (Oracle 21/23) running in parallel. This expands the `Cleanup Junk` step in `test-workflow-linux.yml` and instruments each removal so the freed space is logged per-step.

## What changed
- Adds removals beyond the original llvm/android/ghcup: CodeQL, swift, jvm, `docker image prune`.
- Each step logs `>>> <name>: freed <N> MB (avail now <M> MB)` so runner-image drift stays visible in the log.
- Keeps only removals that free **>= 1 GB** (measured on build 22224). `apt clean` (~0.1 GB) and `remove dotnet` (~2-3 GB, breaks legs) are left commented for future enable.
- `docker image prune -af` runs before any DB container exists, so it only reclaims preinstalled runner images.

## Measured (build 22224, one Linux leg)
| Step | Freed |
|---|---|
| remove llvm | 1.4 GB |
| remove android | 10.3 GB |
| remove ghcup | 3.7 GB |
| remove CodeQL | 1.7 GB |
| remove swift | 3.4 GB |
| remove jvm | 1.4 GB |
| docker image prune | 1.9 GB |

Total ~23.6 GB freed; available disk ~15 GB -> ~39 GB.
