### PR TITLE
Tests/CI: stop committing partial baselines from failed tests

### DIFF
--- a/Build/Azure/pipelines/templates/test-workflow-linux.yml
+++ b/Build/Azure/pipelines/templates/test-workflow-linux.yml
@@ -125,13 +125,7 @@ steps:
   condition: and(variables.title, eq(variables.net80, 'true'), succeeded(), ne(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 8): $(title)'
 
-- script: |
-    if [ -d baselines/.git ]; then
-      echo "Reset baselines working tree so a failed/retried attempt does not leak baselines into the commit"
-      git -C baselines reset --hard
-      git -C baselines clean -fdq
-    fi
-    dotnet ./net8.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net8.0/main/x64/.runsettings --report-trx --report-trx-filename net8.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
+- script: dotnet ./net8.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net8.0/main/x64/.runsettings --report-trx --report-trx-filename net8.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   condition: and(variables.title, eq(variables.net80, 'true'), succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 8): $(title)'
   retryCountOnTaskFailure: 2
@@ -178,13 +172,7 @@ steps:
   condition: and(variables.title, eq(variables.net90, 'true'), succeeded(), ne(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 9): $(title)'
 
-- script: |
-    if [ -d baselines/.git ]; then
-      echo "Reset baselines working tree so a failed/retried attempt does not leak baselines into the commit"
-      git -C baselines reset --hard
-      git -C baselines clean -fdq
-    fi
-    dotnet ./net9.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net9.0/main/x64/.runsettings --report-trx --report-trx-filename net9.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
+- script: dotnet ./net9.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net9.0/main/x64/.runsettings --report-trx --report-trx-filename net9.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   condition: and(variables.title, eq(variables.net90, 'true'), succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 9): $(title)'
   retryCountOnTaskFailure: 2
@@ -231,13 +219,7 @@ steps:
   condition: and(variables.title, eq(variables.net100, 'true'), succeeded(), ne(variables.retry, 'true'))
   displayName: 'Tests (.NET 10): $(title)'
 
-- script: |
-    if [ -d baselines/.git ]; then
-      echo "Reset baselines working tree so a failed/retried attempt does not leak baselines into the commit"
-      git -C baselines reset --hard
-      git -C baselines clean -fdq
-    fi
-    dotnet ./net10.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net10.0/main/x64/.runsettings --report-trx --report-trx-filename net10.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
+- script: dotnet ./net10.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net10.0/main/x64/.runsettings --report-trx --report-trx-filename net10.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   condition: and(variables.title, eq(variables.net100, 'true'), succeeded(), eq(variables.retry, 'true'))
   displayName: 'Tests (.NET 10): $(title)'
   retryCountOnTaskFailure: 2

--- a/Build/Azure/pipelines/templates/test-workflow-macos.yml
+++ b/Build/Azure/pipelines/templates/test-workflow-macos.yml
@@ -102,13 +102,7 @@ steps:
   condition: and(variables.title, eq(variables.net80, 'true'), succeeded(), ne(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 8): $(title)'
 
-- script: |
-    if [ -d baselines/.git ]; then
-      echo "Reset baselines working tree so a failed/retried attempt does not leak baselines into the commit"
-      git -C baselines reset --hard
-      git -C baselines clean -fdq
-    fi
-    dotnet ./net8.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net8.0/main/x64/.runsettings --report-trx --report-trx-filename net8.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
+- script: dotnet ./net8.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net8.0/main/x64/.runsettings --report-trx --report-trx-filename net8.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   condition: and(variables.title, eq(variables.net80, 'true'), succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 8): $(title)'
   retryCountOnTaskFailure: 2
@@ -155,13 +149,7 @@ steps:
   condition: and(variables.title, eq(variables.net90, 'true'), succeeded(), ne(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 9): $(title)'
 
-- script: |
-    if [ -d baselines/.git ]; then
-      echo "Reset baselines working tree so a failed/retried attempt does not leak baselines into the commit"
-      git -C baselines reset --hard
-      git -C baselines clean -fdq
-    fi
-    dotnet ./net9.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net9.0/main/x64/.runsettings --report-trx --report-trx-filename net9.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
+- script: dotnet ./net9.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net9.0/main/x64/.runsettings --report-trx --report-trx-filename net9.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   condition: and(variables.title, eq(variables.net90, 'true'), succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   displayName: 'Tests (.NET 9): $(title)'
   retryCountOnTaskFailure: 2
@@ -208,13 +196,7 @@ steps:
   condition: and(variables.title, eq(variables.net100, 'true'), succeeded(), ne(variables.retry, 'true'))
   displayName: 'Tests (.NET 10): $(title)'
 
-- script: |
-    if [ -d baselines/.git ]; then
-      echo "Reset baselines working tree so a failed/retried attempt does not leak baselines into the commit"
-      git -C baselines reset --hard
-      git -C baselines clean -fdq
-    fi
-    dotnet ./net10.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net10.0/main/x64/.runsettings --report-trx --report-trx-filename net10.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
+- script: dotnet ./net10.0/main/x64/linq2db.Tests.dll --filter "TestCategory != SkipCI" --settings ./net10.0/main/x64/.runsettings --report-trx --report-trx-filename net10.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   condition: and(variables.title, eq(variables.net100, 'true'), succeeded(), eq(variables.retry, 'true'))
   displayName: 'Tests (.NET 10): $(title)'
   retryCountOnTaskFailure: 2

--- a/Build/Azure/pipelines/templates/test-workflow-windows.yml
+++ b/Build/Azure/pipelines/templates/test-workflow-windows.yml
@@ -151,10 +151,7 @@ steps:
   displayName: 'Tests (NETFX): $(title)'
   condition: and(eq(variables.netfx, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), ne(variables.retry, 'true'))
 
-- script: |
-    if exist baselines\.git\ git -C baselines reset --hard
-    if exist baselines\.git\ git -C baselines clean -fdq
-    $(netfx_tfm)\main\x86\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings $(netfx_tfm)\main\x86\.runsettings --report-trx --report-trx-filename netfx-main-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
+- script: $(netfx_tfm)\main\x86\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings $(netfx_tfm)\main\x86\.runsettings --report-trx --report-trx-filename netfx-main-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   displayName: 'Tests (NETFX): $(title)'
   condition: and(eq(variables.netfx, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'))
   retryCountOnTaskFailure: 2
@@ -195,10 +192,7 @@ steps:
   displayName: 'Tests (NETFX x64): $(title)'
   condition: and(eq(variables.netfx, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), ne(variables.retry, 'true'))
 
-- script: |
-    if exist baselines\.git\ git -C baselines reset --hard
-    if exist baselines\.git\ git -C baselines clean -fdq
-    $(netfx_tfm)\main\x64\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings $(netfx_tfm)\main\x64\.runsettings --report-trx --report-trx-filename netfx-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
+- script: $(netfx_tfm)\main\x64\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings $(netfx_tfm)\main\x64\.runsettings --report-trx --report-trx-filename netfx-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   displayName: 'Tests (NETFX x64): $(title)'
   condition: and(eq(variables.netfx, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'))
   retryCountOnTaskFailure: 2
@@ -272,10 +266,7 @@ steps:
   displayName: 'Tests (.NET 8 x64): $(title)'
   condition: and(eq(variables.net80, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), ne(variables.retry, 'true'), ${{ parameters.full_run }})
 
-- script: |
-    if exist baselines\.git\ git -C baselines reset --hard
-    if exist baselines\.git\ git -C baselines clean -fdq
-    net8.0\main\x64\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net8.0\main\x64\.runsettings --report-trx --report-trx-filename net8.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
+- script: net8.0\main\x64\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net8.0\main\x64\.runsettings --report-trx --report-trx-filename net8.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   displayName: 'Tests (.NET 8 x64): $(title)'
   condition: and(eq(variables.net80, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   retryCountOnTaskFailure: 2
@@ -284,10 +275,7 @@ steps:
   displayName: 'Tests (.NET 8 x86): $(title)'
   condition: and(eq(variables.net80, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), ne(variables.retry, 'true'), ${{ parameters.full_run }})
 
-- script: |
-    if exist baselines\.git\ git -C baselines reset --hard
-    if exist baselines\.git\ git -C baselines clean -fdq
-    net8.0\main\x86\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net8.0\main\x86\.runsettings --report-trx --report-trx-filename net8.0-main-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
+- script: net8.0\main\x86\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net8.0\main\x86\.runsettings --report-trx --report-trx-filename net8.0-main-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   displayName: 'Tests (.NET 8 x86): $(title)'
   condition: and(eq(variables.net80, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   retryCountOnTaskFailure: 2
@@ -365,10 +353,7 @@ steps:
   displayName: 'Tests (.NET 9 x64): $(title)'
   condition: and(eq(variables.net90, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), ne(variables.retry, 'true'), ${{ parameters.full_run }})
 
-- script: |
-    if exist baselines\.git\ git -C baselines reset --hard
-    if exist baselines\.git\ git -C baselines clean -fdq
-    net9.0\main\x64\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net9.0\main\x64\.runsettings --report-trx --report-trx-filename net9.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
+- script: net9.0\main\x64\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net9.0\main\x64\.runsettings --report-trx --report-trx-filename net9.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   displayName: 'Tests (.NET 9 x64): $(title)'
   condition: and(eq(variables.net90, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   retryCountOnTaskFailure: 2
@@ -377,10 +362,7 @@ steps:
   displayName: 'Tests (.NET 9 x86): $(title)'
   condition: and(eq(variables.net90, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), ne(variables.retry, 'true'), ${{ parameters.full_run }})
 
-- script: |
-    if exist baselines\.git\ git -C baselines reset --hard
-    if exist baselines\.git\ git -C baselines clean -fdq
-    net9.0\main\x86\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net9.0\main\x86\.runsettings --report-trx --report-trx-filename net9.0-main-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
+- script: net9.0\main\x86\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net9.0\main\x86\.runsettings --report-trx --report-trx-filename net9.0-main-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   displayName: 'Tests (.NET 9 x86): $(title)'
   condition: and(eq(variables.net90, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'), ${{ parameters.full_run }})
   retryCountOnTaskFailure: 2
@@ -451,10 +433,7 @@ steps:
   displayName: 'Tests (.NET 10 x64): $(title)'
   condition: and(eq(variables.net100, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), ne(variables.retry, 'true'))
 
-- script: |
-    if exist baselines\.git\ git -C baselines reset --hard
-    if exist baselines\.git\ git -C baselines clean -fdq
-    net10.0\main\x64\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net10.0\main\x64\.runsettings --report-trx --report-trx-filename net10.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
+- script: net10.0\main\x64\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net10.0\main\x64\.runsettings --report-trx --report-trx-filename net10.0-main-x64.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   displayName: 'Tests (.NET 10 x64): $(title)'
   condition: and(eq(variables.net100, 'true'), ne(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'))
   retryCountOnTaskFailure: 2
@@ -463,10 +442,7 @@ steps:
   displayName: 'Tests (.NET 10 x86): $(title)'
   condition: and(eq(variables.net100, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), ne(variables.retry, 'true'))
 
-- script: |
-    if exist baselines\.git\ git -C baselines reset --hard
-    if exist baselines\.git\ git -C baselines clean -fdq
-    net10.0\main\x86\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net10.0\main\x86\.runsettings --report-trx --report-trx-filename net10.0-main-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
+- script: net10.0\main\x86\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings net10.0\main\x86\.runsettings --report-trx --report-trx-filename net10.0-main-x86.trx --results-directory TestResults --hangdump --hangdump-timeout 5m $(test_retry_args)
   displayName: 'Tests (.NET 10 x86): $(title)'
   condition: and(eq(variables.net100, 'true'), eq(variables.x86, 'true'), variables.title, succeeded(), eq(variables.retry, 'true'))
   retryCountOnTaskFailure: 2

--- a/Tests/Base/BaselinesManager.cs
+++ b/Tests/Base/BaselinesManager.cs
@@ -1,5 +1,7 @@
 ﻿using System.Text;
 
+using NUnit.Framework;
+
 namespace Tests
 {
 	public static class BaselinesManager
@@ -23,6 +25,12 @@ namespace Tests
 
 		public static void Dump(bool isRemote, string? providerSuffix = null)
 		{
+			// A failed test can leave a truncated/partial baseline: SQL captured only up to the point it
+			// threw, or only one of the direct/remote contexts ran. Skip the dump for failed tests so CI
+			// never commits a partial file; a passing (re-)run regenerates the baseline in full.
+			if (TestContext.CurrentContext.Result.FailCount > 0)
+				return;
+
 			if (TestConfiguration.BaselinesPath != null)
 			{
 				var baseline = CustomTestContext.Get().Get<StringBuilder>(CustomTestContext.BASELINE);


### PR DESCRIPTION
## Problem

CI regenerates SQL baselines into `linq2db.baselines` and opens a baselines PR. On providers with test-task restarts enabled (`retry: true` — Oracle 12–23, Access ACE), a test that dies **between its direct and remote (`.LinqService`) contexts** left a truncated / one-context `.sql` baseline, because the harness flushed the captured SQL unconditionally on teardown regardless of pass/fail. Those partials got committed.

A prior mitigation added `git -C baselines reset --hard` + `clean -fdq` at the head of every retry-enabled test task. It ran at the wrong time: because the test tasks in one job share the same `baselines/` working tree, a later task's `reset --hard` wiped valid baselines earlier tasks had already produced (including per-EF-version `.EF8/.EF9/.EF10` files no other task regenerates).

## Fix

- **Root cause** (`Tests/Base/BaselinesManager.cs`): `Dump` now returns early when the test failed (`TestContext.CurrentContext.Result.FailCount > 0`), so a failed / partially-run test never writes a baseline; a passing (re-)run regenerates it in full. Since direct and remote produce identical SQL, skipping the failing context leaves the passing context's normal file — which matches the existing baseline, so no spurious diff. The intentional direct≠remote divergence check in `BaselinesWriter` (throws *inside* `Dump`, while `FailCount` is still 0) is untouched.
- **CI** (`Build/Azure/pipelines/templates/test-workflow-{windows,linux,macos}.yml`): removed the now-unnecessary retry-task `reset --hard` / `clean` cleanup (14 sites). `retryCountOnTaskFailure` and `$(test_retry_args)` are kept; the final "Commit test baselines" step (gated on `succeeded()`) is unchanged, so a hard job failure still commits nothing.

## Verification

- `dotnet build Tests/Linq/Tests.csproj -c Testing` — clean (0 warnings / 0 errors).
- The three edited pipeline templates validated as YAML.
- End-to-end proof requires a baselines-enabled CI run on an affected provider; Oracle flakiness is non-deterministic, so confirmation is the absence of partial baselines in subsequent baseline PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
