### PR TITLE
Tests: composite property projection coverage (#4568)

### DIFF
--- a/Tests/Linq/Linq/ComplexTests.cs
+++ b/Tests/Linq/Linq/ComplexTests.cs
@@ -704,7 +704,7 @@ namespace Tests.Linq
 		}
 
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4568")]
-		public void SelectCompositePropertyMapped_Class_OnlyRequiredColumns([DataSources] string context)
+		public void SelectCompositePropertyMapped_Class_OnlyRequiredColumns([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
 			using var db    = GetDataContext(context);
 
@@ -714,7 +714,7 @@ namespace Tests.Linq
 		}
 
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4568")]
-		public void SelectCompositePropertyMapped_Struct_OnlyRequiredColumns([DataSources] string context)
+		public void SelectCompositePropertyMapped_Struct_OnlyRequiredColumns([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
 			var ms = new MappingSchema();
 			ms.SetScalarType(typeof(AddressStruct), false);
@@ -727,7 +727,7 @@ namespace Tests.Linq
 		}
 
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4568")]
-		public void SelectCompositePropertyMapped_Class_Distinct_OnlyRequiredColumns([DataSources] string context)
+		public void SelectCompositePropertyMapped_Class_Distinct_OnlyRequiredColumns([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
 			using var db = GetDataContext(context);
 
@@ -737,7 +737,7 @@ namespace Tests.Linq
 		}
 
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4568")]
-		public void SelectCompositePropertyMapped_Class_Projected_OnlyRequiredColumns([DataSources] string context)
+		public void SelectCompositePropertyMapped_Class_Projected_OnlyRequiredColumns([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
 			using var db = GetDataContext(context);
 
@@ -785,7 +785,7 @@ namespace Tests.Linq
 		}
 
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4568")]
-		public void SelectNestedCompositeProperty_OnlyRequiredColumns([DataSources] string context)
+		public void SelectNestedCompositeProperty_OnlyRequiredColumns([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
 			using var db = GetDataContext(context);
 
@@ -797,7 +797,7 @@ namespace Tests.Linq
 		}
 
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4568")]
-		public void SelectNestedCompositeProperty([DataSources] string context)
+		public void SelectNestedCompositeProperty([IncludeDataSources(true, TestProvName.AllSQLite)] string context)
 		{
 			using var db    = GetDataContext(context);
 			using var table = db.CreateLocalTable(NestedCoordEntity.TestData);

--- a/Tests/Linq/Linq/ComplexTests.cs
+++ b/Tests/Linq/Linq/ComplexTests.cs
@@ -12,6 +12,8 @@ using LinqToDB.Mapping;
 
 using NUnit.Framework;
 
+using Shouldly;
+
 using Tests.Model;
 
 namespace Tests.Linq
@@ -722,6 +724,98 @@ namespace Tests.Linq
 			var query = db.GetTable<UserStruct>().Select(u => u.Residence);
 
 			Assert.That(query.GetSelectQuery().Select.Columns, Has.Count.EqualTo(3));
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4568")]
+		public void SelectCompositePropertyMapped_Class_Distinct_OnlyRequiredColumns([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var query = db.GetTable<User>().Select(u => u.Residence).Distinct();
+
+			query.GetSelectQuery().Select.Columns.Count.ShouldBe(3);
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4568")]
+		public void SelectCompositePropertyMapped_Class_Projected_OnlyRequiredColumns([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var query = db.GetTable<User>().Select(u => new { Residence = u.Residence });
+
+			query.GetSelectQuery().Select.Columns.Count.ShouldBe(3);
+		}
+
+		public class CoordinateDepth
+		{
+			public int Z1 { get; set; }
+			public int Z2 { get; set; }
+		}
+
+		public class Coordinate
+		{
+			public int               X { get; set; }
+			public int               Y { get; set; }
+			public CoordinateDepth?  Z { get; set; }
+		}
+
+		[Column("x",  "Coord.X")]
+		[Column("y",  "Coord.Y")]
+		[Column("z1", "Coord.Z.Z1")]
+		[Column("z2", "Coord.Z.Z2")]
+		public class NestedCoordEntity
+		{
+			[PrimaryKey] public long Id { get; set; }
+
+			public Coordinate? Coord { get; set; }
+
+			public static readonly NestedCoordEntity[] TestData = new []
+			{
+				new NestedCoordEntity()
+				{
+					Id    = 1,
+					Coord = new Coordinate()
+					{
+						X = 11,
+						Y = 22,
+						Z = new CoordinateDepth() { Z1 = 33, Z2 = 44 }
+					}
+				}
+			};
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4568")]
+		public void SelectNestedCompositeProperty_OnlyRequiredColumns([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var root = db.GetTable<NestedCoordEntity>().Select(t => t.Coord);
+			root.GetSelectQuery().Select.Columns.Count.ShouldBe(4);
+
+			var nested = db.GetTable<NestedCoordEntity>().Select(t => t.Coord!.Z);
+			nested.GetSelectQuery().Select.Columns.Count.ShouldBe(2);
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4568")]
+		public void SelectNestedCompositeProperty([DataSources] string context)
+		{
+			using var db    = GetDataContext(context);
+			using var table = db.CreateLocalTable(NestedCoordEntity.TestData);
+
+			var coord = table.Select(t => t.Coord).Single();
+
+			coord.ShouldNotBeNull();
+			coord.X.ShouldBe(11);
+			coord.Y.ShouldBe(22);
+			coord.Z.ShouldNotBeNull();
+			coord.Z.Z1.ShouldBe(33);
+			coord.Z.Z2.ShouldBe(44);
+
+			var depth = table.Select(t => t.Coord!.Z).Single();
+
+			depth.ShouldNotBeNull();
+			depth.Z1.ShouldBe(33);
+			depth.Z2.ShouldBe(44);
 		}
 
 		#region Issue 4139


### PR DESCRIPTION
Tests only, no product code changes.

## Why

#4568 reports that selecting a composite (complex-mapped) property in a final projection emits all entity columns. It does not reproduce.

The behaviour was fixed by b7de32bf46 (#4676, "Refactored SQL generation"), which also added `SelectCompositePropertyMapped_Class_OnlyRequiredColumns` / `_Struct_OnlyRequiredColumns` - ungated, and green. First release containing the fix is `v6.0.0-preview.2`; re-verified on the released `v6.3.0` tag, where the same variants also produce minimal column lists. So the issue is stale rather than open.

Confirmed by bisect across that commit - same worktree, same toolchain, same provider. At these commits `User` has no `Id`, so its full column set is exactly 4 (`user_name`, `city`, `street`, `building_number`):

| Commit | `Select(u => u.Residence)` | `+ .Distinct()` | `new { u.Residence }` |
|---|---|---|---|
| `b7de32bf46^` (f9000ca39d, 2024-12-13) | 4 (all columns) | 4 | 4 |
| `b7de32bf46` (2024-12-20) | 3 | 3 | 3 |

Both sides were run with sentinel expected values, so each figure is a reported actual rather than an inferred pass.

## What

The two existing tests only cover the bare `Select(u => u.Residence)` shape. This adds the untested variants:

| Test | Query | Expected columns |
|---|---|---|
| `SelectCompositePropertyMapped_Class_Distinct_OnlyRequiredColumns` | `Select(u => u.Residence).Distinct()` | 3 |
| `SelectCompositePropertyMapped_Class_Projected_OnlyRequiredColumns` | `Select(u => new { u.Residence })` | 3 |
| `SelectNestedCompositeProperty_OnlyRequiredColumns` | `Select(t => t.Coord)` / `Select(t => t.Coord!.Z)` | 4 / 2 |
| `SelectNestedCompositeProperty` | materialization round-trip | n/a |

The nested cases add a `NestedCoordEntity` model mirroring the two-level `Coord.X` / `Coord.Y` / `Coord.Z.Z1` / `Coord.Z.Z2` mapping from #2874's original example, which had no coverage at all. `SelectNestedCompositeProperty` round-trips values through `CreateLocalTable`, since a column-count assertion alone can pass while returning wrong data.

`Distinct()` is the variant worth pinning: extra columns there change result semantics, not just payload size.

All six #4568 tests - the four added here plus the two pre-existing `_OnlyRequiredColumns` ones - are pinned to `[IncludeDataSources(true, TestProvName.AllSQLite)]`. The assertions are provider-agnostic (SQL AST column counts, plus one materialization round-trip), so running them across the full matrix cost CI time without adding signal. Switching the two pre-existing tests off `[DataSources]` is the only change here to code the PR didn't introduce.

## Verification

Assertions confirmed non-vacuous by re-running them with sentinel expected counts and reading back the actual values - 3 / 3 / 4 / 2 on both `master` and `v6.3.0`.

Run green on SQLite.Classic and SQLite.MS, including the LinqService remote variant of each. The SQLite pin was verified to actually bind rather than merely pass: adding `SqlServer.2019.MS` to the provider set takes the run from 32 tests to 20, i.e. the six restricted tests decline it while the two unrestricted #2874 tests pick it up.

Before the tests were pinned to SQLite they also ran green on SqlServer.2019.MS, Oracle.11.Managed, Firebird.2.5, DB2 and Informix.DB2, so the expected column counts are not SQLite-specific.

Closes #4568


