### PR TITLE
Tests: fix progress heartbeat over-counting expected-throw cases

### DIFF
--- a/Tests/Base/Attributes/ThrowsWhenAttribute.cs
+++ b/Tests/Base/Attributes/ThrowsWhenAttribute.cs
@@ -116,6 +116,10 @@ namespace Tests
 				// Check if the parameter value matches the expected value
 				if (expectsException)
 				{
+					// The TestProgressReporter heartbeat action runs *inside* this IWrapSetUpTearDown wrapper, so it
+					// already sampled this (pre-rewrite) status. Remember it, then reconcile the tally after we rewrite.
+					var countedStatus = testResult.ResultState.Status;
+
 					if (testResult.Message == null)
 					{
 						testResult.SetResult(ResultState.Failure, $"Expected a <{_attribute.ExpectedException}> to be thrown, but no exception was thrown");
@@ -137,6 +141,9 @@ namespace Tests
 						else
 							testResult.SetResult(ResultState.Success, "Required exception was thrown:\n\n" + testResult.Message);
 					}
+
+					// Move the heartbeat's tally from the status it sampled to the verdict we just finalized (no-op if unchanged).
+					TestProgressTracker.Reclassify(countedStatus, testResult.ResultState.Status, context.CurrentTest.FullName, testResult.Message);
 				}
 
 				return testResult;

--- a/Tests/Base/Attributes/ThrowsWhenAttribute.cs
+++ b/Tests/Base/Attributes/ThrowsWhenAttribute.cs
@@ -88,6 +88,30 @@ namespace Tests
 
 			public override TestResult Execute(TestExecutionContext context)
 			{
+				// The TestProgressReporter heartbeat action runs *inside* this IWrapSetUpTearDown wrapper, so the
+				// outcome it samples is the pre-rewrite one. Hold the unit back for the duration of this wrapper and
+				// hand the tracker our final verdict instead, so no provisional result is ever counted or published.
+				// Deferrals nest: with several ThrowsWhen attributes on one test only the outermost wrapper — the one
+				// that sees the final result — books the unit.
+				var fullName = context.CurrentTest.FullName;
+
+				TestProgressTracker.BeginDeferred(fullName);
+
+				TestResult? testResult = null;
+
+				try
+				{
+					testResult = ExecuteInner(context);
+					return testResult;
+				}
+				finally
+				{
+					TestProgressTracker.CommitDeferred(fullName, testResult);
+				}
+			}
+
+			TestResult ExecuteInner(TestExecutionContext context)
+			{
 				var expectsException = false;
 				var expectsFirst     = true;
 
@@ -116,10 +140,6 @@ namespace Tests
 				// Check if the parameter value matches the expected value
 				if (expectsException)
 				{
-					// The TestProgressReporter heartbeat action runs *inside* this IWrapSetUpTearDown wrapper, so it
-					// already sampled this (pre-rewrite) status. Remember it, then reconcile the tally after we rewrite.
-					var countedStatus = testResult.ResultState.Status;
-
 					if (testResult.Message == null)
 					{
 						testResult.SetResult(ResultState.Failure, $"Expected a <{_attribute.ExpectedException}> to be thrown, but no exception was thrown");
@@ -141,9 +161,6 @@ namespace Tests
 						else
 							testResult.SetResult(ResultState.Success, "Required exception was thrown:\n\n" + testResult.Message);
 					}
-
-					// Move the heartbeat's tally from the status it sampled to the verdict we just finalized (no-op if unchanged).
-					TestProgressTracker.Reclassify(countedStatus, testResult.ResultState.Status, context.CurrentTest.FullName, testResult.Message);
 				}
 
 				return testResult;

--- a/Tests/Base/TestProgressReporter.cs
+++ b/Tests/Base/TestProgressReporter.cs
@@ -147,6 +147,55 @@ namespace Tests
 			}
 		}
 
+		/// <summary>
+		/// Corrects the running tally when a result the heartbeat already sampled is subsequently rewritten by an
+		/// outer command. The <see cref="TestProgressReporterAttribute"/> action runs <em>inside</em> the
+		/// <c>IWrapSetUpTearDown</c> layer, so for an expected-throw case (<see cref="ThrowsWhenAttribute"/>) it
+		/// counts the pre-rewrite (Failed) status; <c>ThrowsWhenCommand</c> then rewrites the result to Success and
+		/// calls this to move the unit between buckets (and prune the now-stale <c>recentFailures</c> entry). Handles
+		/// the symmetric case too — an expected throw that never fired is counted Passed here, then reclassified Failed.
+		/// A no-op when the status is unchanged or the heartbeat is disabled.
+		/// </summary>
+		internal static void Reclassify(TestStatus before, TestStatus after, string? test, string? message)
+		{
+			if (before == after)
+				return;
+
+			lock (_sync)
+			{
+				if (!_enabled)
+					return;
+
+				switch (before)
+				{
+					case TestStatus.Passed : if (_passed  > 0) _passed--;  break;
+					case TestStatus.Skipped: if (_skipped > 0) _skipped--; break;
+					case TestStatus.Failed :
+						if (_failed > 0)
+							_failed--;
+						if (test != null)
+							_failures.RemoveAll(f => f.Test == test);
+						break;
+					// Inconclusive / Warning were never counted into a pass/fail bucket — nothing to undo.
+					default: break;
+				}
+
+				switch (after)
+				{
+					case TestStatus.Passed : _passed++;  break;
+					case TestStatus.Skipped: _skipped++; break;
+					case TestStatus.Failed :
+						_failed++;
+						if (test != null && _failures.Count < MaxRecentFailures)
+							_failures.Add((test, Trim(message)));
+						break;
+					default: break;
+				}
+
+				Write(force: true);
+			}
+		}
+
 		static bool EnsureInit()
 		{
 			if (_initialized)

--- a/Tests/Base/TestProgressReporter.cs
+++ b/Tests/Base/TestProgressReporter.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -47,26 +46,17 @@ namespace Tests
 		const string Tfm = "unknown";
 #endif
 
-		const int MaxRecentFailures = 20;
-		const int WriteThrottleMs   = 1000;  // at most ~1 file write/sec for the common (passing) case
+		const int WriteThrottleMs = 1000;  // at most ~1 file write/sec for the common (passing) case
 
-		static readonly Lock                                _sync     = new();
-		static readonly Stopwatch                           _clock    = new();
-		static readonly List<(string Test, string Message)> _failures = new();
+		static readonly Lock              _sync  = new();
+		static readonly Stopwatch         _clock = new();
+		static readonly TestProgressState _state = new(Write);
 
 		static bool    _initialized;
 		static bool    _enabled;
 		static string? _file;
 		static int     _pid;
 
-		static long     _total;
-		static long     _started;
-		static long     _completed;
-		static long     _passed;
-		static long     _failed;
-		static long     _skipped;
-		static string?  _current;
-		static bool     _done;
 		static DateTime _startedUtc;
 		static long     _lastWriteMs = -WriteThrottleMs;
 
@@ -81,14 +71,11 @@ namespace Tests
 				{
 					// The assembly (root) suite has the largest case count → that is the run total.
 					// Note: under a --filter this is the discovered (pre-filter) count, so it over-counts.
-					if (test.TestCaseCount > _total)
-						_total = test.TestCaseCount;
+					_state.SetTotal(test.TestCaseCount);
 					return;
 				}
 
-				_started++;
-				_current = test.FullName;
-				Write(force: false);
+				_state.StartTest(test.FullName);
 			}
 		}
 
@@ -102,97 +89,48 @@ namespace Tests
 				if (test.IsSuite)
 				{
 					// Suite teardown fires bottom-up; the root suite (no parent) finishing means the run is done.
-					if (!_done && test.Parent == null)
-					{
-						_done    = true;
-						_current = null;
-						Write(force: true);
-					}
+					if (test.Parent == null)
+						_state.MarkDone();
 
 					return;
 				}
 
-				_completed++;
-				// Deliberately do NOT clear _current here: with throttled writes, nulling between every test
-				// makes the on-disk snapshot almost always catch the gap (showing no current test). Keep the
-				// most-recently-started test as "current" until the run completes — during a run that is the
-				// in-flight (or just-finished) test, which is what a watcher wants to see.
+				var result = TestContext.CurrentContext.Result;
 
-				var force = false;
-
-				switch (TestContext.CurrentContext.Result.Outcome.Status)
-				{
-					case TestStatus.Passed : _passed++;  break;
-					case TestStatus.Skipped: _skipped++; break;
-					case TestStatus.Failed :
-						_failed++;
-						force = true;
-						if (_failures.Count < MaxRecentFailures)
-							_failures.Add((test.FullName, Trim(TestContext.CurrentContext.Result.Message)));
-						break;
-					// Inconclusive / Warning — count as completed but neither pass nor fail bucket.
-					default: break;
-				}
-
-				// For unfiltered runs total is exact, so completed reaching it marks the run done even if the
-				// root-suite teardown ordering surprises us.
-				if (!_done && _total > 0 && _completed >= _total)
-				{
-					_done    = true;
-					_current = null;
-					force    = true;
-				}
-
-				Write(force);
+				_state.CompleteTest(test.FullName, result.Outcome.Status, result.Message);
 			}
 		}
 
 		/// <summary>
-		/// Corrects the running tally when a result the heartbeat already sampled is subsequently rewritten by an
-		/// outer command. The <see cref="TestProgressReporterAttribute"/> action runs <em>inside</em> the
-		/// <c>IWrapSetUpTearDown</c> layer, so for an expected-throw case (<see cref="ThrowsWhenAttribute"/>) it
-		/// counts the pre-rewrite (Failed) status; <c>ThrowsWhenCommand</c> then rewrites the result to Success and
-		/// calls this to move the unit between buckets (and prune the now-stale <c>recentFailures</c> entry). Handles
-		/// the symmetric case too — an expected throw that never fired is counted Passed here, then reclassified Failed.
-		/// A no-op when the status is unchanged or the heartbeat is disabled.
+		/// Opens a deferral for a test whose result an outer <c>IWrapSetUpTearDown</c> wrapper is going to rewrite
+		/// (<see cref="ThrowsWhenAttribute"/>). NUnit nests this reporter's action <em>inside</em> such a wrapper, so
+		/// the outcome it samples is the pre-rewrite one; deferring holds the unit back until
+		/// <see cref="CommitDeferred"/> supplies the final verdict, so no provisional outcome is ever counted, added
+		/// to <c>recentFailures</c>, or published. Protocol details: <see cref="TestProgressState"/>.
 		/// </summary>
-		internal static void Reclassify(TestStatus before, TestStatus after, string? test, string? message)
+		public static void BeginDeferred(string fullName)
 		{
-			if (before == after)
-				return;
-
 			lock (_sync)
 			{
-				if (!_enabled)
+				if (!EnsureInit())
 					return;
 
-				switch (before)
-				{
-					case TestStatus.Passed : if (_passed  > 0) _passed--;  break;
-					case TestStatus.Skipped: if (_skipped > 0) _skipped--; break;
-					case TestStatus.Failed :
-						if (_failed > 0)
-							_failed--;
-						if (test != null)
-							_failures.RemoveAll(f => f.Test == test);
-						break;
-					// Inconclusive / Warning were never counted into a pass/fail bucket — nothing to undo.
-					default: break;
-				}
+				_state.BeginDeferred(fullName);
+			}
+		}
 
-				switch (after)
-				{
-					case TestStatus.Passed : _passed++;  break;
-					case TestStatus.Skipped: _skipped++; break;
-					case TestStatus.Failed :
-						_failed++;
-						if (test != null && _failures.Count < MaxRecentFailures)
-							_failures.Add((test, Trim(message)));
-						break;
-					default: break;
-				}
+		/// <summary>
+		/// Closes a deferral opened by <see cref="BeginDeferred"/>, booking the unit with the wrapper's final verdict.
+		/// <paramref name="result"/> is <see langword="null"/> when the wrapper failed before producing one.
+		/// </summary>
+		public static void CommitDeferred(string fullName, ITestResult? result)
+		{
+			lock (_sync)
+			{
+				if (!EnsureInit())
+					return;
 
-				Write(force: true);
+				_state.CommitDeferred(fullName, result?.ResultState.Status ?? TestStatus.Failed, result?.Message);
 			}
 		}
 
@@ -306,9 +244,14 @@ namespace Tests
 
 			_lastWriteMs = nowMs;
 
+			// Read under the state's lock (Write is invoked from inside it), so the snapshot is coherent.
+			var total      = _state.Total;
+			var completed  = _state.Completed;
+			var failures   = _state.RecentFailures;
+
 			var elapsedSec = _clock.Elapsed.TotalSeconds;
-			var rate       = elapsedSec > 0 ? _completed / elapsedSec : 0d;
-			var eta        = rate > 0 && _total > _completed ? (_total - _completed) / rate : (double?)null;
+			var rate       = elapsedSec > 0 ? completed / elapsedSec : 0d;
+			var eta        = rate > 0 && total > completed ? (total - completed) / rate : (double?)null;
 
 			var sb = new StringBuilder(512);
 
@@ -317,26 +260,26 @@ namespace Tests
 			sb.Append("\"pid\":")        .Append(Int(_pid))                             .Append(',');
 			sb.Append("\"startedUtc\":") .Append(JsonString(Iso(_startedUtc)))          .Append(',');
 			sb.Append("\"updatedUtc\":") .Append(JsonString(Iso(DateTime.UtcNow)))      .Append(',');
-			sb.Append("\"done\":")       .Append(_done ? "true" : "false")              .Append(',');
-			sb.Append("\"total\":")      .Append(Long(_total))                          .Append(',');
-			sb.Append("\"completed\":")  .Append(Long(_completed))                      .Append(',');
-			sb.Append("\"started\":")    .Append(Long(_started))                        .Append(',');
-			sb.Append("\"passed\":")     .Append(Long(_passed))                         .Append(',');
-			sb.Append("\"failed\":")     .Append(Long(_failed))                         .Append(',');
-			sb.Append("\"skipped\":")    .Append(Long(_skipped))                        .Append(',');
-			sb.Append("\"currentTest\":").Append(JsonString(_current))                  .Append(',');
+			sb.Append("\"done\":")       .Append(_state.Done ? "true" : "false")        .Append(',');
+			sb.Append("\"total\":")      .Append(Long(total))                           .Append(',');
+			sb.Append("\"completed\":")  .Append(Long(completed))                       .Append(',');
+			sb.Append("\"started\":")    .Append(Long(_state.Started))                  .Append(',');
+			sb.Append("\"passed\":")     .Append(Long(_state.Passed))                   .Append(',');
+			sb.Append("\"failed\":")     .Append(Long(_state.Failed))                   .Append(',');
+			sb.Append("\"skipped\":")    .Append(Long(_state.Skipped))                  .Append(',');
+			sb.Append("\"currentTest\":").Append(JsonString(_state.Current))            .Append(',');
 			sb.Append("\"elapsedSec\":") .Append(Num(elapsedSec))                       .Append(',');
 			sb.Append("\"testsPerSec\":").Append(Num(rate))                             .Append(',');
 			sb.Append("\"etaSec\":")     .Append(eta.HasValue ? Num(eta.Value) : "null").Append(',');
 			sb.Append("\"recentFailures\":[");
 
-			for (var i = 0; i < _failures.Count; i++)
+			for (var i = 0; i < failures.Count; i++)
 			{
 				if (i > 0)
 					sb.Append(',');
 
-				sb.Append("{\"test\":").Append(JsonString(_failures[i].Test))
-				  .Append(",\"message\":").Append(JsonString(_failures[i].Message)).Append('}');
+				sb.Append("{\"test\":").Append(JsonString(failures[i].Test))
+				  .Append(",\"message\":").Append(JsonString(failures[i].Message)).Append('}');
 			}
 
 			sb.Append("]}");
@@ -370,14 +313,6 @@ namespace Tests
 		static string Int(int     value)  => value.ToString(CultureInfo.InvariantCulture);
 		static string Long(long   value)  => value.ToString(CultureInfo.InvariantCulture);
 		static string Num(double  value)  => value.ToString("0.###", CultureInfo.InvariantCulture);
-
-		static string Trim(string? message)
-		{
-			if (string.IsNullOrEmpty(message))
-				return "";
-
-			return message!.Length > 500 ? message.Substring(0, 500) : message;
-		}
 
 		static string JsonString(string? value)
 		{

--- a/Tests/Base/TestProgressState.cs
+++ b/Tests/Base/TestProgressState.cs
@@ -38,6 +38,9 @@ namespace Tests
 		// Keyed by test full name — unique per case by project convention (the baseline files are keyed by the same
 		// fully-qualified name), so a duplicate is a test-authoring bug to fix, not a case this protocol handles.
 		readonly Dictionary<string, DeferredUnit>    _deferred = new(StringComparer.Ordinal);
+		// Verdict already booked per test case, so a repeat/retry wrapper - which sits *outside* the reporter action
+		// and re-enters it once per iteration - books one unit rather than one per iteration. See Book.
+		readonly Dictionary<string, TestStatus>      _booked   = new(StringComparer.Ordinal);
 		readonly Action<bool>?                       _publish;
 
 		long    _total;
@@ -99,7 +102,10 @@ namespace Tests
 		{
 			lock (_sync)
 			{
-				_started++;
+				// A repeat/retry iteration re-enters this for an already-booked case; it is not a new unit.
+				if (!_booked.ContainsKey(fullName))
+					_started++;
+
 				_current = fullName;
 
 				Publish(force: false);
@@ -196,7 +202,16 @@ namespace Tests
 
 		void Book(string fullName, TestStatus status, string? message)
 		{
-			_completed++;
+			// [Repeat] / [Retry] wrappers sit outside the reporter action, so it runs once per iteration for the same
+			// test case while the run total counts the case once. Book the unit on first sight and afterwards only
+			// move it between buckets, keeping the latest verdict - which is what the platform summary reports.
+			if (_booked.TryGetValue(fullName, out var booked))
+				Unbook(fullName, booked);
+			else
+				_completed++;
+
+			_booked[fullName] = status;
+
 			// Deliberately do NOT clear _current here: with throttled writes, nulling between every test
 			// makes the on-disk snapshot almost always catch the gap (showing no current test). Keep the
 			// most-recently-started test as "current" until the run completes — during a run that is the
@@ -228,6 +243,27 @@ namespace Tests
 			}
 
 			Publish(force);
+		}
+
+		// Withdraws a previously booked verdict, so a re-booked case does not double-count.
+		void Unbook(string fullName, TestStatus booked)
+		{
+			switch (booked)
+			{
+				case TestStatus.Passed : _passed--;  break;
+				case TestStatus.Skipped: _skipped--; break;
+				case TestStatus.Failed :
+					_failed--;
+
+					// Only the entry this case added, not every entry sharing its name.
+					var idx = _failures.FindLastIndex(f => f.Test == fullName);
+
+					if (idx >= 0)
+						_failures.RemoveAt(idx);
+
+					break;
+				default: break;
+			}
 		}
 
 		void Publish(bool force)

--- a/Tests/Base/TestProgressState.cs
+++ b/Tests/Base/TestProgressState.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+using NUnit.Framework.Interfaces;
+
+namespace Tests
+{
+	/// <summary>
+	/// The accounting behind the <c>--test-progress</c> heartbeat: run counters, the bounded recent-failure list and
+	/// the deferred-commit protocol used by result-rewriting command wrappers. Deliberately free of file IO, static
+	/// state and command-line dependencies so it can be exercised directly by tests;
+	/// <see cref="TestProgressTracker"/> owns a single instance and adds the publishing side.
+	/// <para>
+	/// <b>Deferred commit.</b> An <c>IWrapSetUpTearDown</c> wrapper such as <see cref="ThrowsWhenAttribute"/> rewrites
+	/// the test result <em>after</em> the reporter action — which NUnit nests inside it — has already sampled the
+	/// outcome. Such a wrapper calls <see cref="BeginDeferred"/> before running the inner command, which makes
+	/// <see cref="CompleteTest"/> hold the sampled outcome back instead of booking it; <see cref="CommitDeferred"/>
+	/// then books the unit exactly once, with the final verdict. No provisional outcome is ever counted, added to the
+	/// recent-failure list, or published — so there is a single write per unit and the bounded list only ever holds
+	/// real failures.
+	/// </para>
+	/// <para>
+	/// The protocol is self-correcting if NUnit's command ordering ever changes: when <see cref="CompleteTest"/> finds
+	/// no deferral in flight (the reporter ran <em>outside</em> the wrapper, so it already sampled the final verdict)
+	/// it books the unit immediately, and the wrapper's <see cref="CommitDeferred"/> becomes a no-op.
+	/// </para>
+	/// </summary>
+	public sealed class TestProgressState
+	{
+		/// <summary>Upper bound on the failures retained for the heartbeat's <c>recentFailures</c> list.</summary>
+		public const int MaxRecentFailures = 20;
+
+		const int MaxMessageLength = 500;
+
+		readonly Lock                                _sync     = new();
+		readonly List<(string Test, string Message)> _failures = new();
+		readonly Dictionary<string, DeferredUnit>    _deferred = new(StringComparer.Ordinal);
+		readonly Action<bool>?                       _publish;
+
+		long    _total;
+		long    _started;
+		long    _completed;
+		long    _passed;
+		long    _failed;
+		long    _skipped;
+		string? _current;
+		bool    _done;
+
+		/// <param name="publish">
+		/// Invoked on every state change, while the state lock is held — so a reader that pulls the counters from
+		/// inside the callback sees a consistent snapshot. The argument is <see langword="true"/> when the change
+		/// should bypass write throttling. Pass <see langword="null"/> (the default) for a state that only accumulates.
+		/// </param>
+		public TestProgressState(Action<bool>? publish = null)
+		{
+			_publish = publish;
+		}
+
+		/// <summary>Discovered test-case count of the run (the largest suite count wins).</summary>
+		public long Total     { get { lock (_sync) return _total;     } }
+		/// <summary>Tests that have entered execution.</summary>
+		public long Started   { get { lock (_sync) return _started;   } }
+		/// <summary>Tests booked with a final verdict.</summary>
+		public long Completed { get { lock (_sync) return _completed; } }
+		/// <summary>Tests booked as passed.</summary>
+		public long Passed    { get { lock (_sync) return _passed;    } }
+		/// <summary>Tests booked as failed.</summary>
+		public long Failed    { get { lock (_sync) return _failed;    } }
+		/// <summary>Tests booked as skipped.</summary>
+		public long Skipped   { get { lock (_sync) return _skipped;   } }
+		/// <summary>Most recently started test, or <see langword="null"/> once the run is done.</summary>
+		public string? Current { get { lock (_sync) return _current;  } }
+		/// <summary>Whether the run has finished.</summary>
+		public bool Done      { get { lock (_sync) return _done;      } }
+		/// <summary>Number of units held back awaiting a deferred commit.</summary>
+		public int  Pending   { get { lock (_sync) return _deferred.Count; } }
+
+		/// <summary>Snapshot of the bounded recent-failure list, oldest first.</summary>
+		public IReadOnlyList<(string Test, string Message)> RecentFailures
+		{
+			get { lock (_sync) return _failures.ToArray(); }
+		}
+
+		/// <summary>Raises the run total to <paramref name="testCaseCount"/> if it is larger than the current one.</summary>
+		public void SetTotal(long testCaseCount)
+		{
+			lock (_sync)
+			{
+				if (testCaseCount > _total)
+					_total = testCaseCount;
+			}
+		}
+
+		/// <summary>Records that <paramref name="fullName"/> has started executing.</summary>
+		public void StartTest(string fullName)
+		{
+			lock (_sync)
+			{
+				_started++;
+				_current = fullName;
+
+				Publish(force: false);
+			}
+		}
+
+		/// <summary>
+		/// Opens a deferral for <paramref name="fullName"/>: until the matching <see cref="CommitDeferred"/> arrives,
+		/// <see cref="CompleteTest"/> only samples the outcome instead of booking it. Nests — several wrappers on one
+		/// test each open (and close) their own level, and only the outermost one, which sees the final verdict, books.
+		/// </summary>
+		public void BeginDeferred(string fullName)
+		{
+			lock (_sync)
+			{
+				if (!_deferred.TryGetValue(fullName, out var unit))
+					_deferred[fullName] = unit = new DeferredUnit();
+
+				unit.Depth++;
+			}
+		}
+
+		/// <summary>
+		/// Books the final outcome of <paramref name="fullName"/> — unless a deferral is in flight, in which case the
+		/// outcome is only sampled and <see cref="CommitDeferred"/> books it.
+		/// </summary>
+		public void CompleteTest(string fullName, TestStatus status, string? message)
+		{
+			lock (_sync)
+			{
+				if (_deferred.TryGetValue(fullName, out var unit))
+				{
+					unit.Sampled = true;
+					unit.Status  = status;
+					unit.Message = message;
+
+					return;
+				}
+
+				Book(fullName, status, message);
+			}
+		}
+
+		/// <summary>
+		/// Closes one deferral level for <paramref name="fullName"/>. The outermost level books the unit with the
+		/// verdict passed here — the wrapper's final one, after any rewrite. A no-op when no deferral is in flight, or
+		/// when the reporter never sampled the test (an exception escaping around it), so nothing is booked twice.
+		/// </summary>
+		public void CommitDeferred(string fullName, TestStatus status, string? message)
+		{
+			lock (_sync)
+			{
+				if (!_deferred.TryGetValue(fullName, out var unit))
+					return;
+
+				if (--unit.Depth > 0)
+					return;
+
+				_deferred.Remove(fullName);
+
+				if (unit.Sampled)
+					Book(fullName, status, message);
+			}
+		}
+
+		/// <summary>
+		/// Marks the run finished, first booking any unit still held back — a wrapper that never committed (an
+		/// exception escaping between the sample and the commit) must not silently drop its unit from the tally.
+		/// </summary>
+		public void MarkDone()
+		{
+			lock (_sync)
+			{
+				if (_deferred.Count > 0)
+				{
+					foreach (var pair in _deferred)
+					{
+						if (pair.Value.Sampled)
+							Book(pair.Key, pair.Value.Status, pair.Value.Message);
+					}
+
+					_deferred.Clear();
+				}
+
+				if (_done)
+					return;
+
+				_done    = true;
+				_current = null;
+
+				Publish(force: true);
+			}
+		}
+
+		void Book(string fullName, TestStatus status, string? message)
+		{
+			_completed++;
+			// Deliberately do NOT clear _current here: with throttled writes, nulling between every test
+			// makes the on-disk snapshot almost always catch the gap (showing no current test). Keep the
+			// most-recently-started test as "current" until the run completes — during a run that is the
+			// in-flight (or just-finished) test, which is what a watcher wants to see.
+
+			var force = false;
+
+			switch (status)
+			{
+				case TestStatus.Passed : _passed++;  break;
+				case TestStatus.Skipped: _skipped++; break;
+				case TestStatus.Failed :
+					_failed++;
+					force = true;
+					if (_failures.Count < MaxRecentFailures)
+						_failures.Add((fullName, Trim(message)));
+					break;
+				// Inconclusive / Warning — count as completed but neither pass nor fail bucket.
+				default: break;
+			}
+
+			// For unfiltered runs total is exact, so completed reaching it marks the run done even if the
+			// root-suite teardown ordering surprises us.
+			if (!_done && _total > 0 && _completed >= _total)
+			{
+				_done    = true;
+				_current = null;
+				force    = true;
+			}
+
+			Publish(force);
+		}
+
+		void Publish(bool force)
+		{
+			_publish?.Invoke(force);
+		}
+
+		static string Trim(string? message)
+		{
+			if (string.IsNullOrEmpty(message))
+				return "";
+
+			return message!.Length > MaxMessageLength ? message.Substring(0, MaxMessageLength) : message;
+		}
+
+		sealed class DeferredUnit
+		{
+			public int        Depth   { get; set; }
+			public bool       Sampled { get; set; }
+			public TestStatus Status  { get; set; }
+			public string?    Message { get; set; }
+		}
+	}
+}

--- a/Tests/Base/TestProgressState.cs
+++ b/Tests/Base/TestProgressState.cs
@@ -17,7 +17,7 @@ namespace Tests
 	/// outcome. Such a wrapper calls <see cref="BeginDeferred"/> before running the inner command, which makes
 	/// <see cref="CompleteTest"/> hold the sampled outcome back instead of booking it; <see cref="CommitDeferred"/>
 	/// then books the unit exactly once, with the final verdict. No provisional outcome is ever counted, added to the
-	/// recent-failure list, or published — so there is a single write per unit and the bounded list only ever holds
+	/// recent-failure list, or published — so each unit is booked exactly once and the bounded list only ever holds
 	/// real failures.
 	/// </para>
 	/// <para>

--- a/Tests/Base/TestProgressState.cs
+++ b/Tests/Base/TestProgressState.cs
@@ -35,6 +35,8 @@ namespace Tests
 
 		readonly Lock                                _sync     = new();
 		readonly List<(string Test, string Message)> _failures = new();
+		// Keyed by test full name — unique per case by project convention (the baseline files are keyed by the same
+		// fully-qualified name), so a duplicate is a test-authoring bug to fix, not a case this protocol handles.
 		readonly Dictionary<string, DeferredUnit>    _deferred = new(StringComparer.Ordinal);
 		readonly Action<bool>?                       _publish;
 

--- a/Tests/Linq/Infrastructure/TestProgressStateTests.cs
+++ b/Tests/Linq/Infrastructure/TestProgressStateTests.cs
@@ -1,0 +1,270 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+
+using Shouldly;
+
+namespace Tests.Infrastructure
+{
+	/// <summary>
+	/// Accounting behind the <c>--test-progress</c> heartbeat (<see cref="TestProgressState"/>). The interesting
+	/// cases come from result-rewriting wrappers such as <see cref="ThrowsWhenAttribute"/>, whose verdict is only
+	/// known <em>after</em> the reporter action — which NUnit nests inside them — has sampled the outcome.
+	/// </summary>
+	[TestFixture]
+	public class TestProgressStateTests : TestBase
+	{
+		const string Unit  = "Tests.Sample.Query(SQLite)";
+		const string Other = "Tests.Sample.Other(SQLite)";
+
+		const string RawMessage   = "LinqToDB.LinqToDBException : Correlated subqueries are not supported.";
+		const string FinalMessage = "Expected a <LinqToDB.LinqToDBException> to be thrown, but found: 'System.InvalidOperationException : nope'";
+
+		[Test]
+		public void ExpectedThrowIsNeverPublishedAsFailure()
+		{
+			var rec = Recorder.Create();
+
+			// The wrapper defers, the inner test throws (sampled Failed), the wrapper rewrites the verdict to Success.
+			rec.State.BeginDeferred (Unit);
+			rec.State.StartTest     (Unit);
+			rec.State.CompleteTest  (Unit, TestStatus.Failed, RawMessage);
+			rec.State.CommitDeferred(Unit, TestStatus.Passed, "Required exception was thrown:\n\n" + RawMessage);
+
+			rec.State.Completed.ShouldBe(1);
+			rec.State.Passed   .ShouldBe(1);
+			rec.State.Failed   .ShouldBe(0);
+			rec.State.Pending  .ShouldBe(0);
+			rec.State.RecentFailures.ShouldBeEmpty();
+
+			// No snapshot the heartbeat could have written ever showed the provisional failure, and the whole unit
+			// cost no forced (throttle-bypassing) write at all.
+			rec.Writes.ShouldAllBe(w => w.Failed == 0 && w.Failures == 0);
+			rec.Writes.Count(w => w.Force).ShouldBe(0);
+		}
+
+		[Test]
+		public void ExpectedThrowThatDidNotFireIsCountedAsFailure()
+		{
+			var rec = Recorder.Create();
+
+			const string message = "Expected a <LinqToDB.LinqToDBException> to be thrown, but no exception was thrown";
+
+			rec.State.BeginDeferred (Unit);
+			rec.State.StartTest     (Unit);
+			rec.State.CompleteTest  (Unit, TestStatus.Passed, null);
+			rec.State.CommitDeferred(Unit, TestStatus.Failed, message);
+
+			rec.State.Completed.ShouldBe(1);
+			rec.State.Passed   .ShouldBe(0);
+			rec.State.Failed   .ShouldBe(1);
+			rec.State.RecentFailures.Count     .ShouldBe(1);
+			rec.State.RecentFailures[0].Test   .ShouldBe(Unit);
+			rec.State.RecentFailures[0].Message.ShouldBe(message);
+
+			// The provisional pass was never published either, and the real failure forces exactly one write.
+			rec.Writes.ShouldAllBe(w => w.Passed == 0);
+			rec.Writes.Count(w => w.Force).ShouldBe(1);
+		}
+
+		[Test]
+		public void WrongExceptionKeepsTheFinalizedMessage()
+		{
+			var rec = Recorder.Create();
+
+			// Failed -> Failed: the wrapper keeps the failure but replaces the raw exception text with the one that
+			// says *which* expectation was not met. The heartbeat has to carry the finalized message, not the raw one.
+			rec.State.BeginDeferred (Unit);
+			rec.State.StartTest     (Unit);
+			rec.State.CompleteTest  (Unit, TestStatus.Failed, "System.InvalidOperationException : nope");
+			rec.State.CommitDeferred(Unit, TestStatus.Failed, FinalMessage);
+
+			rec.State.Completed.ShouldBe(1);
+			rec.State.Failed   .ShouldBe(1);
+			rec.State.RecentFailures.Count     .ShouldBe(1);
+			rec.State.RecentFailures[0].Message.ShouldBe(FinalMessage);
+
+			rec.Writes.Count(w => w.Force).ShouldBe(1);
+		}
+
+		[Test]
+		public void ProvisionalFailureDoesNotConsumeARecentFailureSlot()
+		{
+			var state = new TestProgressState();
+
+			for (var i = 0; i < TestProgressState.MaxRecentFailures - 1; i++)
+			{
+				Complete(state, $"Tests.Sample.Bulk{i}", TestStatus.Failed, "boom");
+			}
+
+			// An expected-throw unit is in flight (its provisional Failed would have taken the last free slot) while a
+			// real failure completes. The real one must get the slot, and keep it after the expected throw resolves.
+			state.BeginDeferred(Unit);
+			state.StartTest    (Unit);
+			state.CompleteTest (Unit, TestStatus.Failed, RawMessage);
+
+			Complete(state, Other, TestStatus.Failed, "real failure");
+
+			state.CommitDeferred(Unit, TestStatus.Passed, null);
+
+			var failures = state.RecentFailures;
+
+			failures.Count                   .ShouldBe(TestProgressState.MaxRecentFailures);
+			failures[failures.Count - 1].Test.ShouldBe(Other);
+			failures.ShouldNotContain(f => f.Test == Unit);
+		}
+
+		[Test]
+		public void NestedWrappersBookOnceWithTheOutermostVerdict()
+		{
+			var rec = Recorder.Create();
+
+			// Several ThrowsWhen-family attributes on one test nest their wrappers; only the outermost one sees the
+			// final result, so only it may book the unit.
+			rec.State.BeginDeferred (Unit);
+			rec.State.BeginDeferred (Unit);
+			rec.State.StartTest     (Unit);
+			rec.State.CompleteTest  (Unit, TestStatus.Failed, RawMessage);
+			rec.State.CommitDeferred(Unit, TestStatus.Failed, RawMessage);   // inner wrapper: did not rewrite
+			rec.State.CommitDeferred(Unit, TestStatus.Passed, null);         // outer wrapper: rewrote to Success
+
+			rec.State.Completed.ShouldBe(1);
+			rec.State.Passed   .ShouldBe(1);
+			rec.State.Failed   .ShouldBe(0);
+			rec.State.Pending  .ShouldBe(0);
+			rec.State.RecentFailures.ShouldBeEmpty();
+
+			rec.Writes.ShouldAllBe(w => w.Failed == 0);
+		}
+
+		[Test]
+		public void ReporterOutsideTheWrapperBooksImmediately()
+		{
+			var state = new TestProgressState();
+
+			// Defensive against a change in NUnit's command ordering: if the reporter action ever ends up *outside*
+			// the wrapper it already samples the final verdict, so the commit must not book a second unit.
+			state.BeginDeferred (Unit);
+			state.CommitDeferred(Unit, TestStatus.Passed, null);
+			state.CompleteTest  (Unit, TestStatus.Passed, null);
+
+			state.Completed.ShouldBe(1);
+			state.Passed   .ShouldBe(1);
+			state.Pending  .ShouldBe(0);
+		}
+
+		[Test]
+		public void UncommittedDeferralIsFlushedWhenTheRunEnds()
+		{
+			var state = new TestProgressState();
+
+			// An exception escaping between the sample and the commit must not drop the unit from the tally.
+			state.BeginDeferred(Unit);
+			state.StartTest    (Unit);
+			state.CompleteTest (Unit, TestStatus.Failed, RawMessage);
+
+			state.MarkDone();
+
+			state.Completed.ShouldBe(1);
+			state.Failed   .ShouldBe(1);
+			state.Pending  .ShouldBe(0);
+			state.Done     .ShouldBeTrue();
+			state.Current  .ShouldBeNull();
+			state.RecentFailures.Count     .ShouldBe(1);
+			state.RecentFailures[0].Test   .ShouldBe(Unit);
+			state.RecentFailures[0].Message.ShouldBe(RawMessage);
+		}
+
+		[Test]
+		public void DoneLatchesWhenCompletedReachesTotal()
+		{
+			var state = new TestProgressState();
+
+			state.SetTotal(2);
+
+			Complete(state, Unit,  TestStatus.Passed, null);
+			state.Done.ShouldBeFalse();
+
+			Complete(state, Other, TestStatus.Passed, null);
+			state.Done   .ShouldBeTrue();
+			state.Current.ShouldBeNull();
+		}
+
+		[Test]
+		public void ConcurrentUnitsKeepTheTallyConsistent()
+		{
+			const int units = 500;
+
+			var state = new TestProgressState();
+
+			Parallel.For(0, units, i =>
+			{
+				var name = $"Tests.Sample.Concurrent{i}";
+
+				// Every third unit goes through the deferred (expected-throw) path.
+				if (i % 3 == 0)
+				{
+					state.BeginDeferred (name);
+					state.StartTest     (name);
+					state.CompleteTest  (name, TestStatus.Failed, RawMessage);
+					state.CommitDeferred(name, TestStatus.Passed, null);
+				}
+				else
+				{
+					Complete(state, name, i % 3 == 1 ? TestStatus.Passed : TestStatus.Failed, "boom");
+				}
+			});
+
+			var failed = Enumerable.Range(0, units).Count(i => i % 3 == 2);
+
+			state.Started  .ShouldBe(units);
+			state.Completed.ShouldBe(units);
+			state.Pending  .ShouldBe(0);
+			(state.Passed + state.Failed + state.Skipped).ShouldBe(units);
+
+			state.Failed.ShouldBe(failed);
+			state.RecentFailures.Count.ShouldBe(TestProgressState.MaxRecentFailures);
+			state.RecentFailures.ShouldAllBe(f => f.Test != null && f.Message == "boom");
+		}
+
+		[Test]
+		public void LongFailureMessagesAreTruncated()
+		{
+			var state = new TestProgressState();
+
+			Complete(state, Unit, TestStatus.Failed, new string('x', 900));
+
+			state.RecentFailures[0].Message.Length.ShouldBe(500);
+		}
+
+		static void Complete(TestProgressState state, string test, TestStatus status, string? message)
+		{
+			state.StartTest   (test);
+			state.CompleteTest(test, status, message);
+		}
+
+		/// <summary>
+		/// A state plus every snapshot the heartbeat would have written from it — the publish callback fires under the
+		/// state lock, so what it reads is exactly what a watcher could have observed on disk.
+		/// </summary>
+		sealed class Recorder
+		{
+			public TestProgressState State { get; private set; } = null!;
+
+			public List<(long Passed, long Failed, long Skipped, long Completed, int Failures, bool Force)> Writes { get; } = new();
+
+			public static Recorder Create()
+			{
+				var rec = new Recorder();
+
+				rec.State = new TestProgressState(force => rec.Writes.Add(
+					(rec.State.Passed, rec.State.Failed, rec.State.Skipped, rec.State.Completed, rec.State.RecentFailures.Count, force)));
+
+				return rec;
+			}
+		}
+	}
+}

--- a/Tests/Linq/Infrastructure/TestProgressStateTests.cs
+++ b/Tests/Linq/Infrastructure/TestProgressStateTests.cs
@@ -231,6 +231,26 @@ namespace Tests.Infrastructure
 		}
 
 		[Test]
+		public void RepeatIterationsBookOneUnitWithTheLatestVerdict()
+		{
+			var rec = Recorder.Create();
+
+			// [Repeat] / [Retry] wrappers sit *outside* the reporter action, so it runs once per iteration for a
+			// single test case while the run total counts that case once. The unit must be booked once, with the
+			// last verdict, and a withdrawn failure must not leave its recentFailures entry behind.
+			rec.State.StartTest   (Unit);
+			rec.State.CompleteTest(Unit, TestStatus.Failed, "first attempt");
+			rec.State.StartTest   (Unit);
+			rec.State.CompleteTest(Unit, TestStatus.Passed, null);
+
+			rec.State.Started  .ShouldBe(1);
+			rec.State.Completed.ShouldBe(1);
+			rec.State.Passed   .ShouldBe(1);
+			rec.State.Failed   .ShouldBe(0);
+			rec.State.RecentFailures.ShouldBeEmpty();
+		}
+
+		[Test]
 		public void LongFailureMessagesAreTruncated()
 		{
 			var state = new TestProgressState();


### PR DESCRIPTION
## Problem

The `--test-progress` heartbeat over-reports failures: every `[ThrowsForProvider]` (and other `ThrowsWhen`-family) case where the provider-capability exception fires is counted as a failure, even though the run's verdict is a pass. On a 5-provider sweep this showed as `failed 466` in the heartbeat vs `failed 0` in the MTP summary.

## Cause

`ThrowsWhenCommand` (an `IWrapSetUpTearDown` wrapper) runs the inner test, then rewrites the expected throw `Failed -> Success`. The `TestProgressReporter` heartbeat is an `ITestAction` that fires *inside* that wrapper, so its `AfterTest` samples the result before the rewrite and counts it `Failed` (with the raw exception in `recentFailures`).

## Fix

The unit is **deferred** rather than counted-then-corrected. `ThrowsWhenCommand.Execute` brackets the inner command with `TestProgressTracker.BeginDeferred(fullName)` / `CommitDeferred(fullName, result)`; while a deferral is in flight the reporter action only *samples* the outcome, and the wrapper books the unit once, with its final verdict.

No provisional result is ever counted, added to `recentFailures`, or published. The bounded failure list therefore only ever holds real failures — a provisional entry can no longer occupy the last slot and cause a concurrent real failure to be dropped — and there is exactly one publish per unit. An expected throw that fires books `Passed`, which is not a forced write at all, so the common case costs *fewer* writes than before.

Details worth knowing:

- **Deferrals nest by depth, and only the outermost wrapper books.** Several `ThrowsWhen`-family attributes on one method are common — `[ThrowsRequiresCorrelatedSubquery]` + `[ThrowsForProvider(…)]` pairs across `Tests/Linq/Update/` and `Tests/Linq/Linq/` — and their wrappers nest. The inner one typically has `expectsException == false` for the running provider and returns the result untouched while the outer one rewrites it, so the outermost level is the one that sees the final verdict.
- **No dependence on NUnit's command ordering.** If the reporter action ever ends up *outside* the wrapper, `CompleteTest` finds no deferral in flight, books immediately, and `CommitDeferred` no-ops.
- **Nothing drops out of the tally.** A unit still held back at run end (an exception escaping between the sample and the commit) is flushed by the root-suite teardown.

The accounting itself moves out of the static holder into `TestProgressState` (`Tests/Base/TestProgressState.cs`): the counters, the bounded recent-failure list and the deferral protocol, with no file IO, no statics and no command-line dependency, so it can be exercised directly. `TestProgressTracker` holds one instance and keeps `Write` / `EnsureInit`.

## Verification

`Tests/Linq/Infrastructure/TestProgressStateTests.cs` — 10 tests covering both expected-throw directions, the wrong-exception (`Failed -> Failed`) message rewrite, the `MaxRecentFailures` boundary with a provisional in flight, nested wrappers, the reporter-outside-wrapper ordering, the run-end straggler flush, message truncation, the done-latch, and a 500-unit `Parallel.For` consistency check.

End-to-end, same slice (`DistinctTests` against `SQLite.Classic`, `--test-progress`); MTP reports `failed: 0` in both runs:

- pre-fix build — heartbeat `"passed":136,"failed":2` plus two phantom `recentFailures` entries
- with the fix — `"passed":176,"failed":0,"recentFailures":[]` (176-case run, `DistinctTests` + `ElementOperationTests`)

Test-infra only: `TestProgressState` lives in the `linq2db.Tests.Base` test-support assembly, which is not packed — no public-API or baseline impact.
