### PR TITLE
Fix IgnoreSystemHistoryTables dropping all views (SQL Server)

### DIFF
--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/SqlServerSchemaProvider.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/SqlServerSchemaProvider.cs
@@ -37,7 +37,7 @@ namespace LinqToDB.Internal.DataProvider.SqlServer
 			var withTemporal        = CompatibilityLevel >= 130;
 			var temporalFilterStart = !withTemporal || !options.IgnoreSystemHistoryTables ? string.Empty : "(";
 			var temporalFilterEnd   = !withTemporal || !options.IgnoreSystemHistoryTables ? string.Empty : @"
-					) AND t.temporal_type <> 1
+					) AND (t.temporal_type IS NULL OR t.temporal_type <> 1)
 ";
 
 			return dataConnection.Query<TableInfo>(

--- a/Tests/Linq/DataProvider/SqlServerTests.cs
+++ b/Tests/Linq/DataProvider/SqlServerTests.cs
@@ -2354,6 +2354,21 @@ DROP TABLE IF EXISTS TemporalTable3History
 		}
 
 		[Test]
+		public void TestIgnoreSystemHistoryTablesKeepsViews([IncludeDataSources(false, TestProvName.AllSqlServer2016Plus)] string context)
+		{
+			using var db = new TestDataConnection(context);
+
+			var options = new GetSchemaOptions()
+			{
+				IgnoreSystemHistoryTables = true
+			};
+			var schema = db.DataProvider.GetSchemaProvider().GetSchema(db, options);
+
+			// views are not present in sys.tables, so the temporal history filter must not discard them
+			schema.Tables.Where(t => t.IsView).Select(t => t.TableName).ShouldContain("ParentView");
+		}
+
+		[Test]
 		public void GetDataConnectionTest([IncludeDataSources(false, TestProvName.AllSqlServer)] string context)
 		{
 			var cs = DataConnection.GetConnectionString(context);


### PR DESCRIPTION
## Problem

`GetSchemaOptions.IgnoreSystemHistoryTables = true` silently removes **every view** from the schema returned by the SQL Server provider.

When the flag is set, `SqlServerSchemaProvider.GetTables` appends to the `WHERE` clause:

```sql
(t.object_id IS NULL OR t.is_ms_shipped <> 1 AND (...) IS NULL) AND t.temporal_type <> 1
```

Views are absent from `sys.tables`, so the `LEFT JOIN` yields NULL — which is precisely how they satisfy the first group via `t.object_id IS NULL`. The appended `NULL <> 1` then evaluates to NULL, and the row is discarded.

## Fix

```sql
) AND (t.temporal_type IS NULL OR t.temporal_type <> 1)
```

`temporalFilterEnd` is shared by the Azure and on-prem query branches, so one change covers both.

## Evidence

Same `WHERE` shape run directly against the SQL Server 2019 test database:

| WHERE | BASE TABLE | VIEW |
|---|---:|---:|
| without the appended condition | 102 | 2 |
| `AND t.temporal_type <> 1` (before) | 101 | 0 |
| `AND (t.temporal_type IS NULL OR ...)` (after) | 101 | 2 |

The one dropped base table is the genuine history table (`temporal_type = 1`), filtered correctly both before and after. Reproduced identically on SQL Server 2022.

## Tests

`TestIgnoreSystemHistoryTablesKeepsViews` added — red before the fix (`should contain "ParentView" but was actually []`), green after.

12/12 green: the new test plus the two existing `TestTemporalTableSchema*` tests, across `SqlServer.2019`, `SqlServer.2019.MS`, `SqlServer.2022`, `SqlServer.2022.MS`. The existing history-hiding assertions still pass, so the filter itself is unweakened.

## Note

The filter only activates at `CompatibilityLevel >= 130`; below that the option is a silent no-op. Unchanged here, but undocumented in `GetSchemaOptions`.
