### PR TITLE
Restore analyzer delivery through the linq2db.FSharp package

### DIFF
--- a/Source/LinqToDB.FSharp/LinqToDB.FSharp.fsproj
+++ b/Source/LinqToDB.FSharp/LinqToDB.FSharp.fsproj
@@ -30,7 +30,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\LinqToDB\LinqToDB.csproj" />
+		<!-- `analyzers` stays out of PrivateAssets so the linq2db.Analyzers subtree reaches this
+		     package's consumers; the default (contentfiles;analyzers;build) makes pack write
+		     exclude="Build,Analyzers", which suppresses it. See Source/LinqToDB/LinqToDB.csproj. -->
+		<ProjectReference Include="..\LinqToDB\LinqToDB.csproj" PrivateAssets="contentfiles;build" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">

--- a/Source/LinqToDB/LinqToDB.csproj
+++ b/Source/LinqToDB/LinqToDB.csproj
@@ -44,7 +44,7 @@
 		     untouched - so neither happens. See the comment there.
 		     Deliberately NO OutputItemType="Analyzer" (unlike CodeGenerators) so the user-facing rules don't run
 		     against linq2db's own source.
-		     Every satellite package (Tools, Remote.*, Extensions, Compat, Scaffold, EntityFrameworkCore) keeps
+		     Every satellite package (Tools, Remote.*, Extensions, Compat, Scaffold, FSharp, EntityFrameworkCore) keeps
 		     `analyzers` out of PrivateAssets on its own linq2db / Tools reference for the same reason: an
 		     intermediate hop that excludes them is documented to suppress the linq2db.Analyzers subtree for that
 		     package's consumers. EF Core keeps the same chain unbroken - EFCore.SqlServer -> EFCore.Relational ->


### PR DESCRIPTION
Release blocker for 6.4.0 — `default (Nugets Generation)` fails fail-fast on release PR #5742 ([build 22629](https://dev.azure.com/linq2db/0dcc414b-ea54-451e-a54f-d63f05367c4b/_build/results?buildId=22629)).

## What breaks

`Source/LinqToDB.FSharp/LinqToDB.FSharp.fsproj` referenced `LinqToDB.csproj` with no `PrivateAssets`, so it inherited the SDK default `contentfiles;analyzers;build` and packed `exclude="Build,Analyzers"` in all five dependency groups. Per NuGet's documented semantics that suppresses the whole `linq2db.Analyzers` subtree for anyone consuming `linq2db.FSharp`.

`verify-analyzer-delivery.ps1` check 2 exists for exactly this — the invariant lives across a dozen separate `ProjectReference` lines, and a new or reverted-to-default one cuts delivery silently.

## Fix

`PrivateAssets="contentfiles;build"` on that reference, matching the ten sibling satellites byte for byte, plus a short comment pointing at the rationale in `Source/LinqToDB/LinqToDB.csproj`.

That rationale comment enumerated the satellites that must keep `analyzers` public — Tools, Remote.\*, Extensions, Compat, Scaffold, EntityFrameworkCore — and **omitted FSharp**, which is why the `.fsproj` was never updated with the other ten. Added.

## Why it wasn't caught sooner

The guard arrived in #5720, merged two commits ahead of the release prep merge, and runs only in the CI `Nugets Generation` job. No local prep step packs and validates, and the prep PR's `test-all` doesn't include that job — so the release PR was the first run in a position to fail.

## Verification

By CI (the guard re-runs here). Checked against the guard's actual logic rather than NuGet semantics alone: check 2 splits the packed `exclude` attribute and looks for an `Analyzers` token, and `PrivateAssets="contentfiles;build"` packs `exclude="ContentFiles,Build"`, which carries none. `linq2db.FSharp` is not in the script's `$noFlowRequired` exemption list, so it is expected to be checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
