### PR TITLE
Fix the DuckDB x86 native guard catching the wrong exception type

### DIFF
--- a/Tests/Linq/TestsInitialization.cs
+++ b/Tests/Linq/TestsInitialization.cs
@@ -275,10 +275,13 @@ public class TestsInitialization
 		{
 			master.Open();
 		}
-		catch (DllNotFoundException)
+		catch (Exception ex) when (ex is DllNotFoundException || ex.InnerException is DllNotFoundException)
 		{
 			// no native duckdb on this leg (e.g. the x86 Access runs, where DuckDB isn't a tested
 			// provider) — skip the in-memory keep-alive rather than failing global OneTimeSetUp.
+			// The native load happens in DuckDBConnectionStringBuilder's static ctor, so the CLR hands
+			// us TypeInitializationException wrapping the DllNotFoundException; catching only the latter
+			// missed it and took down TestAssemblySetup, failing every test in the assembly.
 			master.Dispose();
 			return;
 		}


### PR DESCRIPTION
Release blocker for 6.4.0 — both x86 Access jobs fail on release PR #5742 ([build 22636](https://dev.azure.com/linq2db/0dcc414b-ea54-451e-a54f-d63f05367c4b/_build/results?buildId=22636)): **43 725** failures on Access ACE, **14 564** on Access MDB, every one the same assembly-level `OneTimeSetUp`.

```
OneTimeSetUp: SetUp : System.TypeInitializationException : The type initializer for
'DuckDB.NET.Data.DuckDBConnectionStringBuilder' threw an exception.
  ----> System.DllNotFoundException : Unable to load DLL 'duckdb' or one of its
        dependencies: The specified module could not be found. (0x8007007E)
  at DuckDB.NET.Data.DuckDBConnectionStringBuilder..cctor()
  at TestsInitialization.SetupDuckDBInMemory()
  at TestsInitialization.SetupInMemoryDatabases()
  at TestsInitialization.TestAssemblySetup()
```

## What breaks

`SetupDuckDBInMemory` already guards for legs without a native duckdb — its comment names *"the x86 Access runs"* explicitly. It caught `DllNotFoundException`, but the native load happens inside `DuckDBConnectionStringBuilder`'s **static constructor**, so the CLR wraps it in `TypeInitializationException`. The filter never matched, the exception escaped `TestAssemblySetup`, and the whole assembly went down with it.

So the intent was right and only the exception type was wrong.

## Fix

An exception filter matching either the bare `DllNotFoundException` or anything wrapping one. No coverage is lost — DuckDB isn't a tested provider on x86. (`CA1031` is `severity = none` in `.editorconfig`, so the filtered broad catch is in line with the repo's config.)

## Scope, and why it went unnoticed

Every job reaches this code: `DataProviders.json` declares DuckDB as `Data Source=:memory:?cache=shared` in `CommonConnectionStrings`, so the file-based early-out never fires anywhere, x86 included. Only non-netfx TFMs are affected — the NETFX task of the *same job* passed, because `SetupDuckDBInMemory` sits behind `#if !NETFRAMEWORK`.

Introduced by #5698 in this release cycle. No CI run had exercised it: the Access jobs run only for a release-targeting PR or a full `test-all`, and the 6.4.0 prep `test-all` ([22627](https://dev.azure.com/linq2db/0dcc414b-ea54-451e-a54f-d63f05367c4b/_build/results?buildId=22627)) was cancelled by later pushes before reaching them. Its timeline contains **no Access records at all**, so the `SUCCESS` state still displayed against that job on prep PR #5741 is a queued-but-never-run check, not a pass.

## Verification

Not verifiable from this PR's own CI — a `master`-targeting PR runs `build.yml` only, and the Access jobs live in the release-targeting matrix. The real gate is the Access ACE / MDB jobs on #5742 once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
