### PR TITLE
Bump versions for 6.5.0

### DIFF
--- a/Build/Azure/pipelines/templates/build-job.yml
+++ b/Build/Azure/pipelines/templates/build-job.yml
@@ -268,7 +268,7 @@ jobs:
         $version = dotnet msbuild Source\LinqToDB\LinqToDB.csproj -getProperty:Version
         $relnotesVersion = $version -replace '\.',''
         Write-Host "Create release v$version draft"
-        $output = gh release create v$version "$(Build.SourcesDirectory)/.build/lpx/linq2db.LINQPad.lpx" "$(Build.SourcesDirectory)/.build/lpx/linq2db.LINQPad.lpx6" --draft --fail-on-no-commits --generate-notes --latest --notes "[Release notes](https://github.com/linq2db/linq2db/wiki/Releases-and-Roadmap#release-$relnotesVersion) [Nugets](https://www.nuget.org/profiles/LinqToDB)" --title "Release $version"
+        $output = gh release create v$version "$(Build.SourcesDirectory)/.build/lpx/linq2db.LINQPad.lpx" --draft --fail-on-no-commits --generate-notes --latest --notes "[Release notes](https://github.com/linq2db/linq2db/wiki/Releases-and-Roadmap#release-$relnotesVersion) [Nugets](https://www.nuget.org/profiles/LinqToDB)" --title "Release $version"
         if ($LASTEXITCODE -ne 0) {
             Write-Host "Command failed. Error code ${LASTEXITCODE}, output: ${output}"
             exit 1

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,11 +1,11 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<!-- Update to next after release -->
-		<Version>6.4.0</Version>
-		<EF3Version>3.33.0</EF3Version>
-		<EF8Version>8.7.0</EF8Version>
-		<EF9Version>9.6.0</EF9Version>
-		<EF10Version>10.5.0</EF10Version>
+		<Version>6.5.0</Version>
+		<EF3Version>3.34.0</EF3Version>
+		<EF8Version>8.8.0</EF8Version>
+		<EF9Version>9.7.0</EF9Version>
+		<EF10Version>10.6.0</EF10Version>
 		
 		<!-- Baselines update on next major release -->
 		<BaselineVersion>6.0.0</BaselineVersion>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -218,7 +218,7 @@
 	</ItemGroup>
 
 	<ItemGroup Label="Examples">
-		<PackageVersion Include="linq2db.t4models"                                      Version="6.3.0"                        />
+		<PackageVersion Include="linq2db.t4models"                                      Version="6.4.0"                        />
 		<PackageVersion Include="Microsoft.Extensions.ObjectPool"                       Version="$(Net10Latest)"               />
 		<PackageVersion Include="OpenTelemetry"                                         Version="$(OpenTelemetryVersion)"      />
 		<PackageVersion Include="OpenTelemetry.Exporter.Console"                        Version="$(OpenTelemetryVersion)"      />


### PR DESCRIPTION
Bootstraps the 6.5.0 development cycle now that 6.4.0 has shipped.

- `Directory.Build.props` — `Version` to `6.5.0`, and each `EFxVersion` minor incremented (`3.33.0` → `3.34.0`, `8.7.0` → `8.8.0`, `9.6.0` → `9.7.0`, `10.5.0` → `10.6.0`). `BaselineVersion` is untouched — it only moves on a major.
- `Directory.Packages.props` — `linq2db.t4models` re-pinned to the just-released `6.4.0` (verified live on nuget.org, so restore resolves).

Also on this branch, since it is a one-line release-pipeline change with no code impact:

- `Build/Azure/pipelines/templates/build-job.yml` — the *Create Release Draft* step no longer attaches `linq2db.LINQPad.lpx6`; only the `.lpx` goes on the GitHub release. `--generate-notes` is deliberately kept, because the *New Contributors* section it produces is wanted and GitHub emits it in the same call as *What's Changed* — that section is instead removed by hand when the release body is written.

`linq2db4iSeries` stays at `6.3.0`: it is published by the iSeries provider's maintainer rather than this org, so it moves only once a matching build exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
