### PR TITLE
Hold one Access ODBC connection open for the test run

### DIFF
--- a/Build/Azure/pipelines/templates/test-jobs.yml
+++ b/Build/Azure/pipelines/templates/test-jobs.yml
@@ -198,17 +198,20 @@ jobs:
             Write-Host "Baselines branch hash missing"
             exit 1
         }
-        $output = git ls-remote --heads $baselinesRepoUrl $baselinesBranch
+        # @(...) keeps a single-line answer an array, so the emptiness test below counts refs rather
+        # than characters - a bare string would make a legitimate multi-ref answer read as "no result".
+        $output = @(git ls-remote --heads $baselinesRepoUrl $baselinesBranch)
         Write-Host "Baselines current HEAD: ${output}"
         if ($LASTEXITCODE -ne 0) {
             Write-Host "Baselines HEAD request failed with code ${LASTEXITCODE}"
             exit 1
         }
-        if ($output.Length -lt 40) {
+        $baselinesHeadLine = $output | Where-Object { $_ -match '^[0-9a-f]{40}\s' } | Select-Object -First 1
+        if (-not $baselinesHeadLine) {
             Write-Host "Baselines HEAD request returned no result"
             exit 1
         }
-        $baslinesCurrentHash = ($output -split '\s+')[0]
+        $baslinesCurrentHash = ($baselinesHeadLine -split '\s+')[0]
         Write-Host "Baselines branch current head hash: ${baslinesCurrentHash}"
         if ($baselinesHash -eq $baslinesCurrentHash) {
             Write-Host "Baselines branch has no new commits"

--- a/Build/Azure/pipelines/templates/test-jobs.yml
+++ b/Build/Azure/pipelines/templates/test-jobs.yml
@@ -172,6 +172,11 @@ jobs:
     baselines_head: $[ dependencies.create_baselines_branch.outputs['baselines_init.baselines_head'] ]
     baselines_new_branch: $[ dependencies.create_baselines_branch.outputs['baselines_init.baselines_new_branch'] ]
     source_pr_id: $[coalesce(variables['system.pullRequest.pullRequestNumber'], '')]
+    # Read by the empty-branch cleanup below: this job's condition replaces the implicit succeeded(),
+    # so it also runs when a test leg failed and a retry is still to come.
+    tests_windows_result: $[ dependencies.test_windows_job.result ]
+    tests_ubuntu_result: $[ dependencies.test_ubuntu_job.result ]
+    tests_macos_result: $[ dependencies.test_macos_job.result ]
 
   steps:
   - checkout: none
@@ -216,6 +221,17 @@ jobs:
         if ($baselinesHash -eq $baslinesCurrentHash) {
             Write-Host "Baselines branch has no new commits"
             if ($newBranch -eq 1) {
+                $testResults = @("$(tests_windows_result)", "$(tests_ubuntu_result)", "$(tests_macos_result)")
+                $resultsText = $testResults -join ', '
+                Write-Host "Test job results: ${resultsText}"
+                # A failed leg can still be retried, and the retry re-creates this branch through the
+                # self-heal in ensure-baselines-branch.ps1. Deleting it now races that retry, which is
+                # how the branch ends up vanishing and reappearing mid-run.
+                $blocked = $testResults | Where-Object { $_ -in @('Failed', 'Canceled') }
+                if ($blocked) {
+                    Write-Host "A test job did not pass - keeping the baselines branch for a possible retry"
+                    exit 0
+                }
                 Write-Host "Remove empty baselines branch"
                 $output = gh api -XDELETE /repos/$orgName/$baselinesRepo/git/refs/heads/$baselinesBranch
                 Write-Host "Delete branch command output: ${output}"

--- a/Build/Azure/pipelines/templates/test-workflow-windows.yml
+++ b/Build/Azure/pipelines/templates/test-workflow-windows.yml
@@ -210,7 +210,7 @@ steps:
 
 - task: CmdLine@2
   inputs:
-    script: 'RMDIR $(System.DefaultWorkingDirectory)\$(netfx_tfm) /S /Q'
+    script: 'if exist $(System.DefaultWorkingDirectory)\$(netfx_tfm) rmdir $(System.DefaultWorkingDirectory)\$(netfx_tfm) /S /Q'
   displayName: Remove NETFX test binaries
   condition: and(variables.title, eq(variables.netfx, 'true'))
 
@@ -297,7 +297,7 @@ steps:
 
 - task: CmdLine@2
   inputs:
-    script: 'RMDIR $(System.DefaultWorkingDirectory)\net8.0 /S /Q'
+    script: 'if exist $(System.DefaultWorkingDirectory)\net8.0 rmdir $(System.DefaultWorkingDirectory)\net8.0 /S /Q'
   displayName: Remove NET 8 test binaries
   condition: and(variables.title, eq(variables.net80, 'true'))
 
@@ -384,7 +384,7 @@ steps:
 
 - task: CmdLine@2
   inputs:
-    script: 'RMDIR $(System.DefaultWorkingDirectory)\net9.0 /S /Q'
+    script: 'if exist $(System.DefaultWorkingDirectory)\net9.0 rmdir $(System.DefaultWorkingDirectory)\net9.0 /S /Q'
   displayName: Remove NET 9 test binaries
   condition: and(variables.title, eq(variables.net90, 'true'))
 
@@ -464,7 +464,7 @@ steps:
 
 - task: CmdLine@2
   inputs:
-    script: 'RMDIR $(System.DefaultWorkingDirectory)\net10.0 /S /Q'
+    script: 'if exist $(System.DefaultWorkingDirectory)\net10.0 rmdir $(System.DefaultWorkingDirectory)\net10.0 /S /Q'
   displayName: Remove NET 10 test binaries
   condition: and(variables.title, eq(variables.net100, 'true'))
 

--- a/Build/Azure/scripts/ensure-baselines-branch.ps1
+++ b/Build/Azure/scripts/ensure-baselines-branch.ps1
@@ -60,19 +60,23 @@ if (-not $Branch) {
 Write-Host "Baselines branch name: ${Branch}"
 
 function Get-RemoteHash([string]$ref, [switch]$Heads) {
+    # @(...) keeps a single-line answer an array. Without it PowerShell hands back a bare string for
+    # one match and a string[] for several, so a length test means "characters" in the first case and
+    # "lines" in the second — and a legitimate multi-ref answer reads as "not found".
     if ($Heads) {
-        $out = git ls-remote --heads $baselinesRepoUrl $ref
+        $out = @(git ls-remote --heads $baselinesRepoUrl $ref)
     } else {
-        $out = git ls-remote $baselinesRepoUrl $ref
+        $out = @(git ls-remote $baselinesRepoUrl $ref)
     }
     if ($LASTEXITCODE -ne 0) {
         Write-Host "ls-remote for '${ref}' failed with code ${LASTEXITCODE}"
         exit 1
     }
-    if ($out.Length -lt 40) {
+    $line = $out | Where-Object { $_ -match '^[0-9a-f]{40}\s' } | Select-Object -First 1
+    if (-not $line) {
         return ''
     }
-    return ($out -split '\s+')[0]
+    return ($line -split '\s+')[0]
 }
 
 $branchHash  = Get-RemoteHash $Branch -Heads

--- a/Tests/Base/TestInMemoryDatabases.cs
+++ b/Tests/Base/TestInMemoryDatabases.cs
@@ -5,11 +5,17 @@ namespace Tests
 {
 	/// <summary>
 	/// Holds keep-alive resources (typically a master <c>DbConnection</c>) open for the whole test run
-	/// and disposes them at assembly teardown. Provider-agnostic: any provider whose CI configuration
-	/// uses a shared in-memory database that is destroyed once its last connection closes — SQLite
-	/// (<c>...cache=shared</c>) or DuckDB (<c>:memory:?cache=shared</c>) — registers one anchor
-	/// connection here so the database survives linq2db's open/close-per-query lifecycle. No-op unless
-	/// something is registered (i.e. the normal file-based dev setup).
+	/// and disposes them at assembly teardown. Provider-agnostic, and despite the name not limited to
+	/// in-memory databases — two different reasons to outlive a single test register here:
+	/// <list type="bullet">
+	/// <item>a shared in-memory database that is destroyed once its last connection closes — SQLite
+	/// (<c>...cache=shared</c>) or DuckDB (<c>:memory:?cache=shared</c>) — anchored by one connection so
+	/// it survives linq2db's open/close-per-query lifecycle;</item>
+	/// <item>a file-based connection whose first open is disproportionately expensive, held so the run
+	/// pays that cost once instead of per test — Access over ODBC, where the ACE driver has no pooling
+	/// and leaks OS handles on every connect.</item>
+	/// </list>
+	/// No-op unless something is registered (i.e. the normal file-based dev setup).
 	/// </summary>
 	public static class TestInMemoryDatabases
 	{

--- a/Tests/Linq/TestsInitialization.cs
+++ b/Tests/Linq/TestsInitialization.cs
@@ -219,6 +219,14 @@ public class TestsInitialization
 	{
 		foreach (var name in new[] { "Access.Ace.Odbc", "Access.Jet.Odbc" })
 		{
+			// Only what this run actually tests. Both configs point at the same TestData.ODBC.mdb but through
+			// different engines - {Microsoft Access Driver (*.mdb, *.accdb)} is ACE, the {...(*.mdb)} one is
+			// Jet - and a connection string exists for both no matter which are enabled. Opening the one that
+			// is not under test pinned that single file open through two Access engines for the whole run,
+			// which is not a supported combination.
+			if (!TestConfiguration.UserProviders.Contains(name))
+				continue;
+
 			string cs;
 			try { cs = LinqToDB.Data.DataConnection.GetConnectionString(name); }
 			catch { continue; }

--- a/Tests/Linq/TestsInitialization.cs
+++ b/Tests/Linq/TestsInitialization.cs
@@ -171,6 +171,9 @@ public class TestsInitialization
 		// Set up in-memory databases (SQLite/DuckDB) for any provider configured with an in-memory
 		// connection string (CI), before a_CreateData seeds them. No-op for the normal file-based setup.
 		SetupInMemoryDatabases();
+
+		// Hold one Access connection open for the run - see the method for why. No-op where Access isn't tested.
+		SetupAccessKeepAlive();
 	}
 
 	private void RegisterSqlCEFactory()
@@ -196,6 +199,53 @@ public class TestsInitialization
 	// the run (the DB is destroyed once its last connection closes) — registered in TestInMemoryDatabases.
 	// Auto-activates per config only when its connection string is in-memory; a complete no-op for the
 	// normal file-based (dev) setup.
+	// Access over ODBC pays for every connection twice over, and both charges fall on opening the first one.
+	// The ACE driver has no pooling - it is the one driver with no CPTimeout under its ODBCINST.INI key, so
+	// the driver manager closes each connection for real - and ACEODBC.DLL leaks three OS handles per connect
+	// that it never releases: the Office 16.0 "common" registry key, the same key again through the
+	// Click-to-Run virtualization layer, and an ETW registration. Neither is ours to fix; both were measured
+	// against a raw OdbcConnection with no linq2db on the path, and against the same driver with no database
+	// at all, while a different ODBC driver over the identical stack showed neither.
+	//
+	// What that costs is the 0->1 transition. While any connection to the file is open the driver keeps its
+	// state, and every further connect is cheap and leaks nothing - so one connection held for the run pays
+	// the price once instead of once per test. Measured over the full Access suite: it did not finish at all
+	// before (a run stopped at 36 minutes had reached 2096 of 7861 tests, holding 13891 handles and slowing
+	// from 112 to 2-6 tests a minute), and completes in 13 minutes with this, handle count flat.
+	//
+	// Registered with the same keep-alive list the in-memory databases use: not an in-memory database, but the
+	// same lifetime - opened before the first test, disposed at assembly teardown.
+	static void SetupAccessKeepAlive()
+	{
+		foreach (var name in new[] { "Access.Ace.Odbc", "Access.Jet.Odbc" })
+		{
+			string cs;
+			try { cs = LinqToDB.Data.DataConnection.GetConnectionString(name); }
+			catch { continue; }
+
+			if (cs == null)
+				continue;
+
+			var keep = new System.Data.Odbc.OdbcConnection(cs);
+
+			try
+			{
+				keep.Open();
+			}
+			catch (Exception ex)
+			{
+				// No ACE driver on this leg, or no database file: Access simply is not tested here, and a
+				// keep-alive that cannot open must not take down the whole assembly's setup.
+				TestContext.Progress.WriteLine($"[access-keepalive] skipped {name}: {ex.Message}");
+				keep.Dispose();
+				continue;
+			}
+
+			TestInMemoryDatabases.AddKeepAlive(keep);
+			TestContext.Progress.WriteLine($"[access-keepalive] holding a connection open for {name}");
+		}
+	}
+
 	static void SetupInMemoryDatabases()
 	{
 		SetupSqliteInMemory();

--- a/Tests/Linq/TestsInitialization.cs
+++ b/Tests/Linq/TestsInitialization.cs
@@ -231,7 +231,9 @@ public class TestsInitialization
 			try { cs = LinqToDB.Data.DataConnection.GetConnectionString(name); }
 			catch { continue; }
 
-			if (cs == null)
+			// Whitespace, not just null: a provider can be enabled with an empty connection string, and
+			// handing that to Open() only to land in the catch below is noise for a known non-starter.
+			if (string.IsNullOrWhiteSpace(cs))
 				continue;
 
 			var keep = new System.Data.Odbc.OdbcConnection(cs);
@@ -243,8 +245,12 @@ public class TestsInitialization
 			catch (Exception ex)
 			{
 				// No ACE driver on this leg, or no database file: Access simply is not tested here, and a
-				// keep-alive that cannot open must not take down the whole assembly's setup.
-				TestContext.Progress.WriteLine($"[access-keepalive] skipped {name}: {ex.Message}");
+				// keep-alive that cannot open must not take down the whole assembly's setup. The catch is
+				// deliberately broad - see SetupDuckDBInMemory below, where catching only the expected
+				// exception type missed a TypeInitializationException wrapping it and failed every test in
+				// the assembly. Log the whole exception, not just Message, so that if something other than
+				// "not installed here" ever lands in this path it is still diagnosable from the log.
+				TestContext.Progress.WriteLine($"[access-keepalive] skipped {name}: {ex}");
 				keep.Dispose();
 				continue;
 			}


### PR DESCRIPTION
## What

Opens one ODBC connection to the Access test database at assembly setup and holds it for the whole run, registered with the existing `TestInMemoryDatabases` keep-alive list that SQLite and DuckDB already use.

Test harness only — nothing under `Source/` changes.

## Why

The full Access suite does not finish today. A run stopped after 36 minutes had reached 2096 of 7861 tests, was holding 13891 OS handles, and had slowed from 112 to 2-6 tests a minute. With this change the same suite completes in **13 minutes** and the handle count stays flat.

Two separate costs, both paid on opening the *first* connection:

**There is no pooling.** `Microsoft Access Driver (*.mdb, *.accdb)` is the one driver with no `CPTimeout` under its `ODBCINST.INI` key, so the ODBC driver manager really does close each connection. `System.Data.Odbc` performs no managed pooling for any provider either — on a live connection, `PoolGroup.PoolGroupOptions` and `InnerConnection.Pool` are null for ACE and for SQL Server alike. So every connect pays ~300 ms.

**`ACEODBC.DLL` leaks handles.** Every `SQLDriverConnect` leaks three OS handles it never releases: the `Software\Microsoft\Office\16.0\common` registry key, the same key again through the Click-to-Run virtualization layer, and an ETW registration.

Neither is ours to fix. Both were measured against a raw `OdbcConnection`, with no linq2db anywhere on the path:

| driver | ms/open | handles/open |
|---|---|---|
| ACE ODBC → `.mdb` | 335 | +3.15 |
| ACE ODBC → Text driver, no database at all | 346 | +3.02 |
| HANA ODBC, same `System.Data.Odbc` stack | 18 | 0.00 |
| ACE OLE DB, same file | 10 | +0.05 |

The leak follows `ACEODBC.DLL`: it happens with no Jet database present at all, and does not happen for a different ODBC driver over the identical stack.

Our own code is clean, and that was measured rather than assumed. 1000 queries on one open connection cost 242 ms with no handle growth; 500 failing `DROP TABLE` statements — the existence guard `CreateLocalTable` issues before every table, and the obvious suspect given how many local tables the suite creates — cost 86 ms, also with no growth. In an Access run, connection open and dispose account for 98% of all ADO.NET time; every statement in the run together is 7.7 s out of 5 m 50 s.

## Why holding one connection fixes it

The expensive, leaky work is the 0 → 1 connection transition. While any connection to the file is open the driver keeps its state, so every further connect is cheap and leaks nothing. One connection held for the run pays that price once instead of once per test.

## Notes

- No-op wherever Access is not tested: if the configuration has no connection string, or the ACE driver is not installed, the attempt is logged and skipped rather than failing the assembly setup for everyone.
- Covers `Access.Ace.Odbc` and `Access.Jet.Odbc`. The OLE DB configurations do not need it — 10 ms per connect and no leak.
- Turning on driver-manager pooling for ACE would mean writing `CPTimeout` under `HKLM\SOFTWARE\ODBC\ODBCINST.INI\Microsoft Access Driver (*.mdb, *.accdb)`, a machine-wide registry change, so it is not an option here.
