### PR TITLE
Replace per-file .github/.claude solution listing with NoTargets glue projects

### DIFF
--- a/.github/.github.csproj
+++ b/.github/.github.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.Build.NoTargets/3.7.0">
+	<!--
+	Solution-visibility project only: no code, nothing to compile or pack.
+	Globs .github/ so its content shows up in Solution Explorer without a
+	per-file list here - replaces the old hand-maintained <File Path> entries
+	that used to live directly in linq2db.slnx.
+	-->
+	<PropertyGroup>
+		<TargetFrameworks />
+		<TargetFramework>net10.0</TargetFramework>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<!--drop everything Directory.Build.props injects (analyzers, polyfills, SourceLink, the Source/Shared Compatibility linkbase) - none of it applies to a docs-only glue project-->
+		<PackageReference Remove="@(PackageReference)" />
+		<Compile Remove="@(Compile)" />
+	</ItemGroup>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 		<EF8Version>8.8.0</EF8Version>
 		<EF9Version>9.7.0</EF9Version>
 		<EF10Version>10.6.0</EF10Version>
-		
+
 		<!-- Baselines update on next major release -->
 		<BaselineVersion>6.0.0</BaselineVersion>
 		<EF3BaselineVersion>3.28.0</EF3BaselineVersion>
@@ -18,7 +18,7 @@
 		<AssemblyVersion>$(Version).0</AssemblyVersion>
 		<VersionSuffix Condition=" '$(VersionSuffix)' == '' ">-local.1</VersionSuffix>
 		<ApplyVersionSuffix Condition=" '$(ApplyVersionSuffix)' == '' ">true</ApplyVersionSuffix>
-		
+
 		<Configurations>Testing;Debug;Release;Azure</Configurations>
 
 		<AppDesignerFolder>Properties</AppDesignerFolder>

--- a/linq2db.slnx
+++ b/linq2db.slnx
@@ -5,35 +5,31 @@
     <BuildType Name="Release" />
     <BuildType Name="Testing" />
   </Configurations>
-  <Folder Name="/.github/">
-    <File Path=".github/CODEOWNERS" />
-    <File Path=".github/copilot-instructions.md" />
-  </Folder>
-  <Folder Name="/.github/ISSUE_TEMPLATE/">
-    <File Path=".github/ISSUE_TEMPLATE/01_bug_report_linq2db.yml" />
-    <File Path=".github/ISSUE_TEMPLATE/02_bug_report_linq2db.efcore.yml" />
-    <File Path=".github/ISSUE_TEMPLATE/03_bug_report_linq2db.cli.yml" />
-    <File Path=".github/ISSUE_TEMPLATE/04_bug_report_linq2db.t4.yml" />
-    <File Path=".github/ISSUE_TEMPLATE/05_bug_report_linq2db.linqpad.yml" />
-    <File Path=".github/ISSUE_TEMPLATE/09_bug_report_linq2db.other.yml" />
-    <File Path=".github/ISSUE_TEMPLATE/11_feture_request_linq2db.yml" />
-    <File Path=".github/ISSUE_TEMPLATE/12_feture_request_linq2db.efcore.yml" />
-    <File Path=".github/ISSUE_TEMPLATE/13_feture_request_linq2db.cli.yml" />
-    <File Path=".github/ISSUE_TEMPLATE/14_feture_request_linq2db.t4.yml" />
-    <File Path=".github/ISSUE_TEMPLATE/15_feture_request_linq2db.linqpad.yml" />
-    <File Path=".github/ISSUE_TEMPLATE/19_feture_request_linq2db.other.yml" />
-    <File Path=".github/ISSUE_TEMPLATE/config.yml" />
+  <Folder Name="/.agents/">
+    <Project Path=".github/.github.csproj">
+      <Build Solution="*|*" Project="false" />
+    </Project>
+    <File Path="AGENTS.md" />
+    <File Path="CLAUDE.md" />
+    <Project Path=".claude/.claude.csproj">
+      <Build Solution="*|*" Project="false" />
+    </Project>
   </Folder>
   <Folder Name="/.root/">
     <File Path=".editorconfig" />
     <File Path=".gitattributes" />
     <File Path=".gitignore" />
+    <File Path=".gitmodules" />
     <File Path=".runsettings" />
+    <File Path="AGENTS.md" />
     <File Path="Build.cmd" />
+    <File Path="CLAUDE.md" />
     <File Path="Clean.cmd" />
     <File Path="Compile.cmd" />
     <File Path="CONTRIBUTING.md" />
     <File Path="DataProviders.json" />
+    <File Path="Directory.Build.props" />
+    <File Path="Directory.Packages.props" />
     <File Path="global.json" />
     <File Path="linq2db.Benchmarks.slnf" />
     <File Path="linq2db.playground.slnf" />
@@ -42,6 +38,7 @@
     <File Path="README.md" />
     <File Path="SQLite.Runtime.props" />
     <File Path="Test.cmd" />
+    <File Path="UpdateBaselines.cmd" />
   </Folder>
   <Folder Name="/Build/">
     <File Path="Build/linq2db.snk" />


### PR DESCRIPTION
## Summary
- Replace the hand-maintained per-file `<File Path>` listing for `.github/` in `linq2db.slnx` (~13 entries, needed a manual edit for every new file) with a single NoTargets glue project, `.github/.github.csproj`, that globs the directory automatically.
- Surface the `.claude/` submodule ([linq2db/agents](https://github.com/linq2db/agents)) in Solution Explorer for the first time via `.claude/.claude.csproj`, same pattern.
- Group both, plus the root `AGENTS.md`/`CLAUDE.md` trampolines, under a new `/.agents/` solution folder.
- Both glue projects are docs-only: no `Compile` items, no `PackageReference` (the analyzer/signing/`Compatibility`-linkbase injections `Directory.Build.props` applies repo-wide are explicitly stripped), single `net10.0` `TargetFramework` (avoids picking up the root's 5-way cross-targeting for a project with zero code), and excluded from `Build` in every solution configuration (`Build Solution="*|*" Project="false"`) since there's nothing to actually build.
- `.claude/.claude.csproj` is tracked in the `linq2db/agents` submodule itself (already pushed there, commit `ded20a5`), not in this repo — consistent with the existing design where the `.claude` gitlink is a bootstrap pointer, not a version pin (`.gitmodules` `ignore=all`, `.githooks/pre-commit` refuses a gitlink bump).

## Why
Individually listing every file under `.github/`/`.claude/` in `linq2db.slnx` doesn't scale — every new file needs a manual solution-file edit or it's invisible in the IDE. A NoTargets project scoped to the directory picks up new files automatically via default item globbing.

## Test plan
- [x] `dotnet build .github/.github.csproj` / `.claude/.claude.csproj` standalone — succeed under `Testing` and `Release`
- [x] `dotnet sln linq2db.slnx list` — both projects parse and list correctly
- [x] `dotnet restore linq2db.slnx` — full solution restore (56 projects) succeeds
- [x] `dotnet build linq2db.slnx -t:ValidateProjects -c Release` — confirms both projects are excluded from build in every solution configuration
- [x] Verified `.claude.csproj`'s default item glob resolves all ~1223 files under the submodule