### PR TITLE
Split the Access ACE x86 test leg per provider and keep its OLE DB connection open

### DIFF
--- a/Build/Azure/net100/access.ace.json
+++ b/Build/Azure/net100/access.ace.json
@@ -1,8 +1,0 @@
-﻿{
-	"NET100.Azure": {
-		"Providers": [
-			"Access.Ace.OleDb",
-			"Access.Ace.Odbc"
-		]
-	}
-}

--- a/Build/Azure/net100/access.ace.odbc.json
+++ b/Build/Azure/net100/access.ace.odbc.json
@@ -1,0 +1,8 @@
+{
+	"NET100.Azure": {
+		// One ACE provider per run - see the Access_ACE_* entries in test-matrix.yml for why they are split.
+		"Providers": [
+			"Access.Ace.Odbc"
+		]
+	}
+}

--- a/Build/Azure/net100/access.ace.oledb.json
+++ b/Build/Azure/net100/access.ace.oledb.json
@@ -1,0 +1,8 @@
+{
+	"NET100.Azure": {
+		// One ACE provider per run - see the Access_ACE_* entries in test-matrix.yml for why they are split.
+		"Providers": [
+			"Access.Ace.OleDb"
+		]
+	}
+}

--- a/Build/Azure/net80/access.ace.json
+++ b/Build/Azure/net80/access.ace.json
@@ -1,8 +1,0 @@
-﻿{
-	"NET80.Azure": {
-		"Providers": [
-			"Access.Ace.OleDb",
-			"Access.Ace.Odbc"
-		]
-	}
-}

--- a/Build/Azure/net80/access.ace.odbc.json
+++ b/Build/Azure/net80/access.ace.odbc.json
@@ -1,0 +1,8 @@
+{
+	"NET80.Azure": {
+		// One ACE provider per run - see the Access_ACE_* entries in test-matrix.yml for why they are split.
+		"Providers": [
+			"Access.Ace.Odbc"
+		]
+	}
+}

--- a/Build/Azure/net80/access.ace.oledb.json
+++ b/Build/Azure/net80/access.ace.oledb.json
@@ -1,0 +1,8 @@
+{
+	"NET80.Azure": {
+		// One ACE provider per run - see the Access_ACE_* entries in test-matrix.yml for why they are split.
+		"Providers": [
+			"Access.Ace.OleDb"
+		]
+	}
+}

--- a/Build/Azure/net90/access.ace.json
+++ b/Build/Azure/net90/access.ace.json
@@ -1,8 +1,0 @@
-﻿{
-	"NET90.Azure": {
-		"Providers": [
-			"Access.Ace.OleDb",
-			"Access.Ace.Odbc"
-		]
-	}
-}

--- a/Build/Azure/net90/access.ace.odbc.json
+++ b/Build/Azure/net90/access.ace.odbc.json
@@ -1,0 +1,8 @@
+{
+	"NET90.Azure": {
+		// One ACE provider per run - see the Access_ACE_* entries in test-matrix.yml for why they are split.
+		"Providers": [
+			"Access.Ace.Odbc"
+		]
+	}
+}

--- a/Build/Azure/net90/access.ace.oledb.json
+++ b/Build/Azure/net90/access.ace.oledb.json
@@ -1,0 +1,8 @@
+{
+	"NET90.Azure": {
+		// One ACE provider per run - see the Access_ACE_* entries in test-matrix.yml for why they are split.
+		"Providers": [
+			"Access.Ace.OleDb"
+		]
+	}
+}

--- a/Build/Azure/netfx/access.ace.json
+++ b/Build/Azure/netfx/access.ace.json
@@ -1,8 +1,0 @@
-﻿{
-	"NETFX.Azure": {
-		"Providers": [
-			"Access.Ace.OleDb",
-			"Access.Ace.Odbc"
-		]
-	}
-}

--- a/Build/Azure/netfx/access.ace.odbc.json
+++ b/Build/Azure/netfx/access.ace.odbc.json
@@ -1,0 +1,8 @@
+{
+	"NETFX.Azure": {
+		// One ACE provider per run - see the Access_ACE_* entries in test-matrix.yml for why they are split.
+		"Providers": [
+			"Access.Ace.Odbc"
+		]
+	}
+}

--- a/Build/Azure/netfx/access.ace.oledb.json
+++ b/Build/Azure/netfx/access.ace.oledb.json
@@ -1,0 +1,8 @@
+{
+	"NETFX.Azure": {
+		// One ACE provider per run - see the Access_ACE_* entries in test-matrix.yml for why they are split.
+		"Providers": [
+			"Access.Ace.OleDb"
+		]
+	}
+}

--- a/Build/Azure/pipelines/templates/test-matrix.yml
+++ b/Build/Azure/pipelines/templates/test-matrix.yml
@@ -134,9 +134,36 @@ jobs:
           ${{ if not(or(contains(parameters.db_filter, '[all]'), contains(parameters.db_filter, '[access.all]'))) }}:
             enabled: false
 
-        - name: Access_ACE
-          title: Access ACE (OLEDB/ODBC) x86
-          config_win: access.ace
+# The two ACE providers run as separate entries, one provider each. Together they put ~14.9k tests through a
+# single x86 process, which reaches ~1.7GB of reserved address space by the end - and NUnit's last act is to
+# serialize the whole result document into one contiguous string, which then fails with OutOfMemoryException.
+# That failure is deterministic, so unlike the random AV below it survives every retry and the leg stays red.
+# Halving the run removes it: measured locally against the CI ACE build (2010 redist, x86), 7731 and 7715
+# tests, both exit 0, no OOM. It costs no wall-clock either - the halves take 360s + 332s against 741s for the
+# combined run - but only because TestsInitialization now holds one connection open per transport: splitting
+# also takes away the ODBC anchor that used to keep the shared ACE engine warm for both, and without an OLE DB
+# anchor of its own that half alone takes 1866s. The EF.Core step is not provider-scoped, so it runs in both.
+        - name: Access_ACE_Odbc
+          title: Access ACE (ODBC) x86
+          config_win: access.ace.odbc
+          psscript_win_global: access.ace.ps1
+          enable_os_windows: true
+          enable_os_ubuntu: false
+          enable_os_macos: false
+          enable_fw_netfx: true
+          enable_fw_net80: true
+          enable_fw_net90: true
+          enable_fw_net100: true
+          x86: true
+          retry: true # x86 provider also could crash with AV as x64, but less often, so we can just restart it
+          ${{ if or(contains(parameters.db_filter, '[all]'), contains(parameters.db_filter, '[access.all]')) }}:
+            enabled: true
+          ${{ if not(or(contains(parameters.db_filter, '[all]'), contains(parameters.db_filter, '[access.all]'))) }}:
+            enabled: false
+
+        - name: Access_ACE_OleDb
+          title: Access ACE (OLEDB) x86
+          config_win: access.ace.oledb
           psscript_win_global: access.ace.ps1
           enable_os_windows: true
           enable_os_ubuntu: false

--- a/Build/Azure/pipelines/templates/test-matrix.yml
+++ b/Build/Azure/pipelines/templates/test-matrix.yml
@@ -142,7 +142,7 @@ jobs:
 # tests, both exit 0, no OOM. It costs no wall-clock either - the halves take 360s + 332s against 741s for the
 # combined run - but only because TestsInitialization now holds one connection open per transport: splitting
 # also takes away the ODBC anchor that used to keep the shared ACE engine warm for both, and without an OLE DB
-# anchor of its own that half alone takes 1866s. The EF.Core step is not provider-scoped, so it runs in both.
+# anchor of its own that half alone takes 1866s.
         - name: Access_ACE_Odbc
           title: Access ACE (ODBC) x86
           config_win: access.ace.odbc

--- a/Tests/Base/TestInMemoryDatabases.cs
+++ b/Tests/Base/TestInMemoryDatabases.cs
@@ -6,14 +6,16 @@ namespace Tests
 	/// <summary>
 	/// Holds keep-alive resources (typically a master <c>DbConnection</c>) open for the whole test run
 	/// and disposes them at assembly teardown. Provider-agnostic, and despite the name not limited to
-	/// in-memory databases — two different reasons to outlive a single test register here:
+	/// in-memory databases — three different reasons to outlive a single test register here:
 	/// <list type="bullet">
 	/// <item>a shared in-memory database that is destroyed once its last connection closes — SQLite
 	/// (<c>...cache=shared</c>) or DuckDB (<c>:memory:?cache=shared</c>) — anchored by one connection so
 	/// it survives linq2db's open/close-per-query lifecycle;</item>
 	/// <item>a file-based connection whose first open is disproportionately expensive, held so the run
 	/// pays that cost once instead of per test — Access over ODBC, where the ACE driver has no pooling
-	/// and leaks OS handles on every connect.</item>
+	/// and leaks OS handles on every connect;</item>
+	/// <item>a file-based connection whose engine is unsafe to tear down and re-create — Access over
+	/// OLE DB, where an open racing the teardown of the last connection access-violates the process.</item>
 	/// </list>
 	/// No-op unless something is registered (i.e. the normal file-based dev setup).
 	/// </summary>

--- a/Tests/Linq/TestsInitialization.cs
+++ b/Tests/Linq/TestsInitialization.cs
@@ -213,25 +213,21 @@ public class TestsInitialization
 	// before (a run stopped at 36 minutes had reached 2096 of 7861 tests, holding 13891 handles and slowing
 	// from 112 to 2-6 tests a minute), and completes in 13 minutes with this, handle count flat.
 	//
-	// Access over OLE DB has the same 0->1 transition with a worse symptom. The ACE OLE DB provider tears its
-	// engine down when the last connection to the file closes, and an open racing that teardown takes the whole
-	// process out with an access violation (0xC0000005) - a hard crash, not an exception, so nothing in the run
-	// can catch it and the leg loses every test it had already passed. The CI x86 ACE leg has been hitting it
-	// since well before the ODBC keep-alive existed, always with the fault inside ACE (ICommandText::Execute
-	// there, IDataInitialize::GetDataSource when reproduced here). Measured against a raw OleDbConnection with
-	// no linq2db on the path: 8 threads x 100 open/query/close crashed on 3 runs out of 3, the same loop on a
-	// single thread survived 9000 iterations, and with one connection held open it survived 4800 concurrent
-	// cycles over 6 runs. The query shape is irrelevant - a plain column crashes exactly like the GUID-literal
-	// one the CI stack happened to name - and OLE DB Services pooling does not help.
+	// Access over OLE DB pays that same 0->1 transition, and one held connection pays it once the same way.
+	// Measured over the full Access suite against the ACE build CI installs (2010 redistributable, x86): the
+	// OLE-DB-only leg takes 332s with a connection held open against 1866s without one. It shows nothing in a
+	// leg that runs both transports, because they drive one shared ACE engine core - the ODBC anchor above
+	// already keeps it warm for both - so this anchor only earns its place once the leg is split per provider,
+	// which it now is (see the Access_ACE_* entries in Build/Azure/pipelines/templates/test-matrix.yml).
 	//
-	// The same churn is also why that leg runs out of memory at the very end, in NUnit's own
-	// StringBuilder.ToString() over the whole run's result XML. It is not that the XML is large: the Jet leg
-	// runs the same ~14.9k tests through the same runner - Jet OLE DB included - and never hits it, so what
-	// differs is how much contiguous 32-bit address space is left by then. Each ACE OLE DB connect/disconnect
-	// cycle reserves address space it never returns: 2000 cycles cost 1122 MB and 1130 MB of reserved virtual
-	// memory across two runs, against 106 MB and 107 MB with one connection held open, while committed bytes
-	// were the same (~38 MB) either way. So the anchor is a ~10x cut in address-space growth, not only a
-	// crash guard.
+	// It is not a crash guard, despite what the leg's history suggests. That leg also takes a hard 0xC0000005
+	// inside ACE from time to time; that is dotnet/runtime#46187, it long pre-dates either keep-alive, it still
+	// happens with both anchors held, and the pipeline absorbs it with retry: true. Ruled out as causes while
+	// chasing it, so they are not re-attempted: connection churn (the anchored build crashed just the same),
+	// the query shape (SELECT TOP 1 CVar(?) over a DBTYPE_GUID parameter - what BuildSqlParameterCastExpression
+	// emits, since Access has no CAST - survives isolated hammering, as do a bare parameter and a literal), and
+	// pooling (ACE registers OLEDB_SERVICES = 0xFFFFFFFE, every service except resource pooling, so there is
+	// nothing for OleDbConnection.ReleaseObjectPool to release).
 	//
 	// Registered with the same keep-alive list the in-memory databases use: not an in-memory database, but the
 	// same lifetime - opened before the first test, disposed at assembly teardown.
@@ -242,8 +238,8 @@ public class TestsInitialization
 		// {...(*.mdb)} one is Jet, for OLE DB Microsoft.ACE.OLEDB.12.0 and Microsoft.Jet.OLEDB.4.0 likewise -
 		// and a connection string exists for both no matter which are enabled. Pinning that single file open
 		// through two Access engines for the whole run is not a supported combination, so the first config that
-		// opens wins and the rest of its group is left alone. The two transports are independent engines, so
-		// each needs its own anchor: the ODBC one does nothing for the OLE DB crash above.
+		// opens wins and the rest of its group is left alone. Each transport still gets an anchor of its own:
+		// they share an engine core, so either one would warm both, but a split leg enables only one of them.
 		KeepOneAccessConnectionAlive("ODBC",   new[] { "Access.Ace.Odbc",  "Access.Jet.Odbc"  }, static cs => new System.Data.Odbc.OdbcConnection(cs));
 		KeepOneAccessConnectionAlive("OLE DB", new[] { "Access.Ace.OleDb", "Access.Jet.OleDb" }, static cs => new System.Data.OleDb.OleDbConnection(cs));
 	}

--- a/Tests/Linq/TestsInitialization.cs
+++ b/Tests/Linq/TestsInitialization.cs
@@ -213,17 +213,46 @@ public class TestsInitialization
 	// before (a run stopped at 36 minutes had reached 2096 of 7861 tests, holding 13891 handles and slowing
 	// from 112 to 2-6 tests a minute), and completes in 13 minutes with this, handle count flat.
 	//
+	// Access over OLE DB has the same 0->1 transition with a worse symptom. The ACE OLE DB provider tears its
+	// engine down when the last connection to the file closes, and an open racing that teardown takes the whole
+	// process out with an access violation (0xC0000005) - a hard crash, not an exception, so nothing in the run
+	// can catch it and the leg loses every test it had already passed. The CI x86 ACE leg has been hitting it
+	// since well before the ODBC keep-alive existed, always with the fault inside ACE (ICommandText::Execute
+	// there, IDataInitialize::GetDataSource when reproduced here). Measured against a raw OleDbConnection with
+	// no linq2db on the path: 8 threads x 100 open/query/close crashed on 3 runs out of 3, the same loop on a
+	// single thread survived 9000 iterations, and with one connection held open it survived 4800 concurrent
+	// cycles over 6 runs. The query shape is irrelevant - a plain column crashes exactly like the GUID-literal
+	// one the CI stack happened to name - and OLE DB Services pooling does not help.
+	//
+	// The same churn is also why that leg runs out of memory at the very end, in NUnit's own
+	// StringBuilder.ToString() over the whole run's result XML. It is not that the XML is large: the Jet leg
+	// runs the same ~14.9k tests through the same runner - Jet OLE DB included - and never hits it, so what
+	// differs is how much contiguous 32-bit address space is left by then. Each ACE OLE DB connect/disconnect
+	// cycle reserves address space it never returns: 2000 cycles cost 1122 MB and 1130 MB of reserved virtual
+	// memory across two runs, against 106 MB and 107 MB with one connection held open, while committed bytes
+	// were the same (~38 MB) either way. So the anchor is a ~10x cut in address-space growth, not only a
+	// crash guard.
+	//
 	// Registered with the same keep-alive list the in-memory databases use: not an in-memory database, but the
 	// same lifetime - opened before the first test, disposed at assembly teardown.
 	static void SetupAccessKeepAlive()
 	{
-		foreach (var name in new[] { "Access.Ace.Odbc", "Access.Jet.Odbc" })
+		// One anchor per transport, not per config. Within a transport both configs point at the same file
+		// through different engines - for ODBC {Microsoft Access Driver (*.mdb, *.accdb)} is ACE and the
+		// {...(*.mdb)} one is Jet, for OLE DB Microsoft.ACE.OLEDB.12.0 and Microsoft.Jet.OLEDB.4.0 likewise -
+		// and a connection string exists for both no matter which are enabled. Pinning that single file open
+		// through two Access engines for the whole run is not a supported combination, so the first config that
+		// opens wins and the rest of its group is left alone. The two transports are independent engines, so
+		// each needs its own anchor: the ODBC one does nothing for the OLE DB crash above.
+		KeepOneAccessConnectionAlive("ODBC",   new[] { "Access.Ace.Odbc",  "Access.Jet.Odbc"  }, static cs => new System.Data.Odbc.OdbcConnection(cs));
+		KeepOneAccessConnectionAlive("OLE DB", new[] { "Access.Ace.OleDb", "Access.Jet.OleDb" }, static cs => new System.Data.OleDb.OleDbConnection(cs));
+	}
+
+	static void KeepOneAccessConnectionAlive(string transport, string[] names, Func<string, DbConnection> create)
+	{
+		foreach (var name in names)
 		{
-			// Only what this run actually tests. Both configs point at the same TestData.ODBC.mdb but through
-			// different engines - {Microsoft Access Driver (*.mdb, *.accdb)} is ACE, the {...(*.mdb)} one is
-			// Jet - and a connection string exists for both no matter which are enabled. Opening the one that
-			// is not under test pinned that single file open through two Access engines for the whole run,
-			// which is not a supported combination.
+			// Only what this run actually tests.
 			if (!TestConfiguration.UserProviders.Contains(name))
 				continue;
 
@@ -236,7 +265,7 @@ public class TestsInitialization
 			if (string.IsNullOrWhiteSpace(cs))
 				continue;
 
-			var keep = new System.Data.Odbc.OdbcConnection(cs);
+			var keep = create(cs);
 
 			try
 			{
@@ -256,7 +285,9 @@ public class TestsInitialization
 			}
 
 			TestInMemoryDatabases.AddKeepAlive(keep);
-			TestContext.Progress.WriteLine($"[access-keepalive] holding a connection open for {name}");
+			TestContext.Progress.WriteLine($"[access-keepalive] holding an open {transport} connection for {name}");
+
+			return;
 		}
 	}
 

--- a/linq2db.slnx
+++ b/linq2db.slnx
@@ -53,7 +53,8 @@
     <File Path="Build/Azure/README.md" />
   </Folder>
   <Folder Name="/Build/Azure/net100/">
-    <File Path="Build/Azure/net100/access.ace.json" />
+    <File Path="Build/Azure/net100/access.ace.odbc.json" />
+    <File Path="Build/Azure/net100/access.ace.oledb.json" />
     <File Path="Build/Azure/net100/access.ace.x64.json" />
     <File Path="Build/Azure/net100/access.mdb.json" />
     <File Path="Build/Azure/net100/clickhouse.driver.json" />
@@ -99,7 +100,8 @@
     <File Path="Build/Azure/net100/sybase.json" />
   </Folder>
   <Folder Name="/Build/Azure/net80/">
-    <File Path="Build/Azure/net80/access.ace.json" />
+    <File Path="Build/Azure/net80/access.ace.odbc.json" />
+    <File Path="Build/Azure/net80/access.ace.oledb.json" />
     <File Path="Build/Azure/net80/access.ace.x64.json" />
     <File Path="Build/Azure/net80/access.mdb.json" />
     <File Path="Build/Azure/net80/clickhouse.driver.json" />
@@ -145,7 +147,8 @@
     <File Path="Build/Azure/net80/sybase.json" />
   </Folder>
   <Folder Name="/Build/Azure/net90/">
-    <File Path="Build/Azure/net90/access.ace.json" />
+    <File Path="Build/Azure/net90/access.ace.odbc.json" />
+    <File Path="Build/Azure/net90/access.ace.oledb.json" />
     <File Path="Build/Azure/net90/access.ace.x64.json" />
     <File Path="Build/Azure/net90/access.mdb.json" />
     <File Path="Build/Azure/net90/clickhouse.driver.json" />
@@ -191,7 +194,8 @@
     <File Path="Build/Azure/net90/sybase.json" />
   </Folder>
   <Folder Name="/Build/Azure/netfx/">
-    <File Path="Build/Azure/netfx/access.ace.json" />
+    <File Path="Build/Azure/netfx/access.ace.odbc.json" />
+    <File Path="Build/Azure/netfx/access.ace.oledb.json" />
     <File Path="Build/Azure/netfx/access.ace.x64.json" />
     <File Path="Build/Azure/netfx/access.mdb.json" />
     <File Path="Build/Azure/netfx/sqlce.json" />


### PR DESCRIPTION
Restores the `Tests (.NET 10 x86): Access ACE (OLEDB/ODBC) x86` leg, red on every attempt since the start of August.

## What was failing

The leg fails with two different symptoms, sometimes both in one build:

- `System.OutOfMemoryException` while NUnit serializes the run's result document — `TNode.get_OuterXml()` → `StringWriter.ToString()` → `StringBuilder.ToString()`.
- `0xC0000005` inside `System.Data.Common.UnsafeNativeMethods+ICommandText.Execute`, the stack always naming `FunctionTests.NewGuid7_Emulated` on `Access.Ace.OleDb`.

Neither is new and neither was caused by #5747. Scanning the last 15 `test-all` runs of this leg: the AV appears in builds 22529 and 22532 (2026-07-30), the OOM in 22519 and 22622 — all before that PR merged.

What #5747 changed is the leg's runtime, ~52 min → ~12 min. It now reliably *reaches* the end-of-run serialization, and the OOM there is deterministic, so it fails all three retry attempts identically. Previously attempts often died earlier and a retry could still come back green.

The AV is dotnet/runtime#46187 — already documented in `test-matrix.yml`, which is why the x64 ACE leg is disabled and why the x86 one carries `retry: true`. This PR does not address it and does not need to: removing the deterministic OOM is what gives `retry` something to absorb it with again.

## Root cause of the OOM

Not the size of the result document. The full leg's TRX is ~22 MB, and 97% of that is plain per-test metadata — captured output is 3.0%, result messages 0.1%, no stack traces (measured on a TRX from half the leg). So trimming `ThrowsWhen` messages or `OnAfterTest` traces would buy ~3%; there is no lever inside the test harness.

The problem is the process: 14 648 tests in one 32-bit run reach ~1.7 GB of reserved address space, leaving no contiguous block for the final string. Only the ACE leg hits it — the Jet leg runs ~14.9k tests through the same runner, its own OLE DB provider included, and never does.

## Changes

**1. Split the leg per provider.** `access.ace.json` → `access.ace.odbc.json` + `access.ace.oledb.json` for each TFM; the `Access_ACE` matrix entry becomes `Access_ACE_Odbc` and `Access_ACE_OleDb`. No workflow-template change — the run step takes its provider list from the copied config. The job's EF.Core step is untouched and costs nothing extra: `TestConfiguration.EFProviders` has no Access entry, so it intersects to an empty provider set either way.

**2. Hold one ACE OLE DB connection open for the run,** alongside the ODBC one #5747 added. `SetupAccessKeepAlive` now anchors one connection per transport, and at most one per transport — the two configs in each group point at the same file through different engines (ACE vs Jet), and pinning one file open through two Access engines is not a supported combination.

The two changes are not independent: the split is what makes the anchor necessary. Both ACE transports share one engine core, so *any* open ACE connection keeps it warm for both — in the combined leg the ODBC anchor already did that, which is why an OLE DB anchor shows no effect there. Splitting takes that away from the OLE DB half, and without an anchor of its own that half costs 1866 s instead of 332 s.

## Verification

Reproduced and measured locally against the same ACE build CI installs (2010 redistributable, x86, `OFFICE14\ACEOLEDB.DLL` 14.0.7011.1000), with `LINQ2DB_TESTS_TRACE_CONSOLE=0` so captured output matches CI.

| check | result |
|---|---|
| full leg, both providers (baseline) | 14 648 tests, 12m 15s, **OOM, exit 2** — same failure as CI |
| `--provider Access.Ace.Odbc` alone | 7 731 tests, 360 s, exit 0, no OOM |
| `--provider Access.Ace.OleDb` alone | 7 715 tests, exit 0, no OOM |
| OLE DB half, with anchor / without | **332 s / 1866 s** (5.6×, reproduced twice) |
| peak reserved address space, with anchor / without | 1678 MB / 1692 MB — the anchor costs no memory |
| wall-clock, combined vs split | 741 s (red) vs 360 + 332 = **692 s**, both green |
| build | net10.0 `Testing` and net462 `Release`: 0 warnings, 0 errors |
| matrix vs configs | every `config_win` resolves for every enabled TFM; `linq2db.slnx` parses |

Not verified: the leg itself on CI. That needs a `test-all` run on this branch.

## Ruled out along the way

Recorded so they are not re-attempted:

- **The anchor does not fix either symptom.** The anchored build still took the AV, and both builds OOM identically. Its payoff is speed, not stability.
- **x64 measurements do not transfer.** On a machine with 64-bit M365, `Microsoft.ACE.OLEDB.12.0` resolves to Office 16's `ACEOLEDB.DLL`, not the ACE 2010 CI uses. An AV under concurrent connection opens, and ~1.1 GB of address space reserved per 2000 connect/disconnect cycles, both reproduce on ACE 16 and on neither on ACE 2010 x86.
- **Not the query shape.** `SELECT TOP 1 CVar(?) FROM LinqDataTypes` with a `DBTYPE_GUID` parameter — what `AccessSqlBuilderBase.BuildSqlParameterCastExpression` emits, since Access has no `CAST` — survives 400 iterations, as do a bare parameter, a `{guid {…}}` literal and a plain column. `NewGuid7_Emulated` passes in isolation (2/2); it only falls in a loaded process.
- **Not connection pooling.** ACE ships `OLEDB_SERVICES = 0xFFFFFFFE` in both registry hives — every service *except* resource pooling — so `OleDbConnection.ReleaseObjectPool()` has nothing to release. Same for ODBC, per the `CPTimeout` note in #5747.

## Reproducing locally

Needs the 32-bit Access Database Engine 2010 redistributable (`Build/Azure/scripts/access.ace.ps1` installs the same binary CI uses; note it conflicts with 64-bit Office and needs `/Passive`).

```
dotnet publish Tests/Linq/Tests.csproj -f net10.0 -c Testing -a x86 -p:X86STUBS=True -o <dir>
set LINQ2DB_TESTS_TRACE_CONSOLE=0
<dir>\linq2db.Tests.exe --filter "TestCategory != SkipCI" --settings <abs>\.runsettings --provider Access.Ace.OleDb Access.Ace.Odbc
```

Without `LINQ2DB_TESTS_TRACE_CONSOLE=0` the run is not comparable — the trace echo is on by default off-CI, and it moves the OOM to a different frame.
