### PR TITLE
DB2 setup: disable AUTO_STMT_STATS (real-time statistics) — 3.7x faster tests

### DIFF
--- a/Build/Azure/scripts/db2.sh
+++ b/Build/Azure/scripts/db2.sh
@@ -17,3 +17,9 @@ until docker logs db2 | grep -q 'Setup has completed'; do
 done
 
 docker logs db2
+
+# AUTO_STMT_STATS (real-time statistics) makes the optimizer synchronously profile a table's stats
+# during query compilation whenever they're missing/stale - our tests constantly create/drop small
+# tables and immediately query them, so this fires on nearly every fresh table. Measured 3.7x slower
+# with it on (confirmed via a controlled run: identical test counts, only this setting differed).
+docker exec -u db2inst1 db2 bash -lc "db2 connect to testdb && db2 UPDATE DB CFG FOR testdb USING AUTO_STMT_STATS OFF"

--- a/Build/Azure/scripts/mac.db2.sh
+++ b/Build/Azure/scripts/mac.db2.sh
@@ -17,3 +17,9 @@ until docker logs db2 | grep -q 'Setup has completed'; do
 done
 
 docker logs db2
+
+# AUTO_STMT_STATS (real-time statistics) makes the optimizer synchronously profile a table's stats
+# during query compilation whenever they're missing/stale - our tests constantly create/drop small
+# tables and immediately query them, so this fires on nearly every fresh table. Measured 3.7x slower
+# with it on (confirmed via a controlled run: identical test counts, only this setting differed).
+docker exec -u db2inst1 db2 bash -lc "db2 connect to testdb && db2 UPDATE DB CFG FOR testdb USING AUTO_STMT_STATS OFF"

--- a/Data/Setup Scripts/db2.cmd
+++ b/Data/Setup Scripts/db2.cmd
@@ -30,3 +30,9 @@ REM   https://community.ibm.com/community/user/discussion/121-container-communit
 REM ---------------------------------------------------------------------------
 
 docker exec db2 sed -i "/^if ! create_instance; then$/i [ -f /database/config/db2inst1/sqllib/adm/fencedid ] && chown root:db2iadm1 /database/config/db2inst1/sqllib/adm/fencedid" /var/db2_setup/lib/setup_db2_instance.sh
+
+REM AUTO_STMT_STATS (real-time statistics) makes the optimizer synchronously profile a table's stats
+REM during query compilation whenever they're missing/stale - our tests constantly create/drop small
+REM tables and immediately query them, so this fires on nearly every fresh table. Measured 3.7x slower
+REM with it on (confirmed via a controlled run: identical test counts, only this setting differed).
+docker exec -u db2inst1 db2 bash -lc "db2 connect to testdb && db2 UPDATE DB CFG FOR testdb USING AUTO_STMT_STATS OFF"

--- a/Tests/Base/DataProvider/DataProviderTestBase.cs
+++ b/Tests/Base/DataProvider/DataProviderTestBase.cs
@@ -19,9 +19,14 @@ namespace Tests.DataProvider
 		{
 			// number of parameters to create for providers with unnamed parameters
 			paramCount = 1;
-			return "SELECT ID FROM {1} WHERE @p IS NULL AND {0} IS NULL OR @p IS NOT NULL AND {0} = @p";
+			// ORDER BY ID: AllTypes is a shared fixture other tests also insert into (deliberately never
+			// cleaned up here - see TestBase.Identity.cs's ResetAllTypesIdentity - so a leftover row with a
+			// duplicate value is a real, if rare, possibility). Only the lookup's chosen row matters (Execute
+			// reads a single scalar), so ordering by ID makes it deterministically the lowest-ID (canonical)
+			// match instead of whichever row the engine happens to return first.
+			return "SELECT ID FROM {1} WHERE @p IS NULL AND {0} IS NULL OR @p IS NOT NULL AND {0} = @p ORDER BY ID";
 		}
-		protected virtual string  PassValueSql(DataConnection dc) => "SELECT ID FROM {1} WHERE {0} = @p";
+		protected virtual string  PassValueSql(DataConnection dc) => "SELECT ID FROM {1} WHERE {0} = @p ORDER BY ID";
 
 		protected T TestType<T>(DataConnection conn, string fieldName,
 			DataType dataType          = DataType.Undefined,

--- a/Tests/Linq/DataProvider/AccessTests.cs
+++ b/Tests/Linq/DataProvider/AccessTests.cs
@@ -46,12 +46,12 @@ namespace Tests.DataProvider
 		{
 			paramCount = dc.DataProvider.Name.IsAnyOf(TestProvName.AllAccessOdbc) ? 3 : 1;
 			return dc.DataProvider.Name.IsAnyOf(TestProvName.AllAccessOdbc)
-				? "SELECT ID FROM {1} WHERE ? IS NULL AND {0} IS NULL OR ? IS NOT NULL AND {0} = ?"
+				? "SELECT ID FROM {1} WHERE ? IS NULL AND {0} IS NULL OR ? IS NOT NULL AND {0} = ? ORDER BY ID"
 				: base.PassNullSql(dc, out paramCount);
 		}
 		protected override string PassValueSql(DataConnection dc) =>
 			dc.DataProvider.Name.IsAnyOf(TestProvName.AllAccessOdbc)
-				? "SELECT ID FROM {1} WHERE {0} = ?"
+				? "SELECT ID FROM {1} WHERE {0} = ? ORDER BY ID"
 				: base.PassValueSql(dc);
 
 		[Test]

--- a/Tests/Linq/DataProvider/InformixTests.cs
+++ b/Tests/Linq/DataProvider/InformixTests.cs
@@ -30,7 +30,7 @@ namespace Tests.DataProvider
 			paramCount = 1;
 			return null;
 		}
-		protected override string  PassValueSql(DataConnection dc) => "SELECT ID FROM {1} WHERE {0} = ?";
+		protected override string  PassValueSql(DataConnection dc) => "SELECT ID FROM {1} WHERE {0} = ? ORDER BY ID";
 
 		[Test]
 		public void TestDataTypes([IncludeDataSources(CurrentProvider)] string context)

--- a/Tests/Linq/DataProvider/PostgreSQLTests.cs
+++ b/Tests/Linq/DataProvider/PostgreSQLTests.cs
@@ -51,10 +51,10 @@ namespace Tests.DataProvider
 		protected override string? PassNullSql(DataConnection dc, out int paramCount)
 		{
 			paramCount = 1;
-			return "SELECT \"ID\" FROM \"AllTypes\" WHERE :p IS NULL AND \"{0}\" IS NULL OR :p IS NOT NULL AND \"{0}\" = :p";
+			return "SELECT \"ID\" FROM \"AllTypes\" WHERE :p IS NULL AND \"{0}\" IS NULL OR :p IS NOT NULL AND \"{0}\" = :p ORDER BY \"ID\"";
 		}
 		protected override string  GetNullSql  (DataConnection dc) => "SELECT \"{0}\" FROM {1} WHERE \"ID\" = 1";
-		protected override string  PassValueSql(DataConnection dc) => "SELECT \"ID\" FROM \"AllTypes\" WHERE \"{0}\" = :p";
+		protected override string  PassValueSql(DataConnection dc) => "SELECT \"ID\" FROM \"AllTypes\" WHERE \"{0}\" = :p ORDER BY \"ID\"";
 		protected override string  GetValueSql (DataConnection dc) => "SELECT \"{0}\" FROM {1} WHERE \"ID\" = 2";
 
 		[Test]

--- a/Tests/Linq/DataProvider/SapHanaTests.cs
+++ b/Tests/Linq/DataProvider/SapHanaTests.cs
@@ -55,13 +55,13 @@ namespace Tests.DataProvider
 		{
 			paramCount = 1;
 			return dc.DataProvider.Name == ProviderName.SapHanaOdbc
-				? "SELECT \"ID\" FROM {1} WHERE \"{0}\" IS NULL AND ? IS NULL"
-				: "SELECT \"ID\" FROM {1} WHERE \"{0}\" IS NULL AND :p IS NULL";
+				? "SELECT \"ID\" FROM {1} WHERE \"{0}\" IS NULL AND ? IS NULL ORDER BY \"ID\""
+				: "SELECT \"ID\" FROM {1} WHERE \"{0}\" IS NULL AND :p IS NULL ORDER BY \"ID\"";
 		}
 		protected override string  PassValueSql(DataConnection dc) =>
 			dc.DataProvider.Name == ProviderName.SapHanaOdbc
-				? "SELECT \"ID\" FROM {1} WHERE \"{0}\" = ?"
-				: "SELECT \"ID\" FROM {1} WHERE \"{0}\" = :p";
+				? "SELECT \"ID\" FROM {1} WHERE \"{0}\" = ? ORDER BY \"ID\""
+				: "SELECT \"ID\" FROM {1} WHERE \"{0}\" = :p ORDER BY \"ID\"";
 
 		[Test]
 		public void TestParameters([IncludeDataSources(CurrentProvider)] string context)


### PR DESCRIPTION
## Problem

`DB2` is by far the slowest provider in our local/CI test matrix, despite the DB2 container itself being nearly idle (~3% CPU) while tests run — a classic "client and server both idle, but slow" symptom.

Root cause: `testdb`'s `AUTO_STMT_STATS` (real-time statistics) is on by default. Our test suite constantly creates/drops small tables and immediately runs a query against them (schema setup, `WindowFunctionsTests`, etc.), so almost every query compiles against a table with missing/stale statistics. With `AUTO_STMT_STATS` on, the optimizer synchronously profiles the table right there during query compilation — adding latency to nearly every statement, without showing up as CPU load.

Confirmed this is DB2-side, not the client or the network: `Informix.DB2` goes through the exact same DB2 CLI driver client, with a near-identical test volume, and runs **14.6x faster**. Same client code, wildly different behavior depending on which server it talks to.

## Before / after

Controlled A/B on the same test matrix (`--provider DB2`, `--no-linq-service` to keep the comparison to the direct-connection variant only) — identical test counts and pass/fail either way, only `AUTO_STMT_STATS` differed:

| | `AUTO_STMT_STATS=ON` (before) | `AUTO_STMT_STATS=OFF` (after) |
|---|---|---|
| Total / passed / failed | 5235 / 5120 / 0 | 5235 / 5120 / 0 |
| Duration | 42:52.8 | **11:35** |
| Throughput | 2.00 tests/s | **7.42 tests/s** |

**3.71x faster**, with no change in test outcomes.

## Change

Adds one `db2 UPDATE DB CFG FOR testdb USING AUTO_STMT_STATS OFF` call, run against the `db2inst1` OS user's local (password-less, OS-trusted) connection right after the container finishes its own setup:

- `Build/Azure/scripts/db2.sh` (CI, Linux runner)
- `Build/Azure/scripts/mac.db2.sh` (CI, macOS runner)
- `Data/Setup Scripts/db2.cmd` (local dev image)

`db2.provider.sh`/`mac.db2.provider.sh` are untouched — those only swap in the client driver binaries and are shared with the `Informix.DB2` job, which doesn't need this (different server, no `AUTO_STMT_STATS` mechanism).

## Also included: deterministic AllTypes lookup

Investigating this PR's own CI run surfaced a second, unrelated bug: `DataProviderTestBase.TestType`'s `PassNullSql`/`PassValueSql` look up a just-inserted row by value with no `ORDER BY`, assuming the result is always the well-known canonical ID (1/2). `AllTypes` is a shared fixture other tests also insert into without deleting afterward (by design - see `ResetAllTypesIdentity`'s own comment), so a leftover row whose value collides with another test's magic number can make that lookup return a different, wrong ID. This DB2 config change did not create such a row - it just changed which query plan the optimizer picked for the ambiguous lookup, which is what made an existing leftover row visible as a failure.

Fixed by adding `ORDER BY ID` (or the provider's quoted equivalent) to the base implementation and every override that does not already delegate to it (SapHana, PostgreSQL, Informix's `PassValueSql`, Access's ODBC branch) - deterministically picks the lowest-ID (canonical) row. Verified locally against DB2: deliberately duplicated the canonical `AllTypes` row without recreating the schema, reproduced the failure, confirmed it is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
