### PR TITLE
YDB setup: use in-memory PDisks — ~42% faster tests

### DIFF
--- a/Build/Azure/scripts/ydb.sh
+++ b/Build/Azure/scripts/ydb.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-docker run -d --name ydb -p 2136:2136 -e YDB_FEATURE_FLAGS=enable_temp_tables ydbplatform/local-ydb:latest
+# YDB_USE_IN_MEMORY_PDISKS: RAM-backed storage instead of file-backed disks, so commits skip real
+# fsync/disk I/O - YDB's own recommended setting for test environments; CI containers are destroyed
+# after every run anyway, so there's no data to lose by skipping durability.
+docker run -d --name ydb -p 2136:2136 -e YDB_FEATURE_FLAGS=enable_temp_tables -e YDB_USE_IN_MEMORY_PDISKS=1 ydbplatform/local-ydb:latest
 
 retries=0
 until docker logs ydb 2>&1 | grep -q 'Table profiles were not loaded'; do

--- a/Data/Setup Scripts/ydb.cmd
+++ b/Data/Setup Scripts/ydb.cmd
@@ -6,7 +6,10 @@ docker rm -f ydb
 
 REM use pull to get latest layers (run will use cached layers)
 docker pull ydbplatform/local-ydb:latest
-docker run -d --name ydb -p 2136:2136 -p 8765:8765 -e YDB_FEATURE_FLAGS=enable_temp_tables ydbplatform/local-ydb:latest
+REM YDB_USE_IN_MEMORY_PDISKS: RAM-backed storage instead of file-backed disks, so commits skip real
+REM fsync/disk I/O - YDB's own recommended setting for test environments, where durability across
+REM container restarts doesn't matter (test data gets recreated on every run anyway).
+docker run -d --name ydb -p 2136:2136 -p 8765:8765 -e YDB_FEATURE_FLAGS=enable_temp_tables -e YDB_USE_IN_MEMORY_PDISKS=1 ydbplatform/local-ydb:latest
 
 ECHO pause to wait for YDB startup completion
 call wait-err ydb "Table profiles were not loaded"


### PR DESCRIPTION
## Problem

YDB is by far the slowest provider in our local/CI test matrix - disproportionately slower per-DDL than other providers even though it runs single-node. YDB is a distributed-consensus database (scheme-shard + tablets); by default it persists every commit to file-backed disks with real fsync, adding real disk-I/O latency to every write and DDL statement even in this single-node local/CI setup.

## Fix

`YDB_USE_IN_MEMORY_PDISKS=1` - YDB's own recommended environment variable for test environments, switching storage to RAM-backed PDisks so commits skip fsync/real disk I/O entirely. Neither environment needs durability across restarts: local test data gets recreated every run (`a_CreateData`), and CI containers are destroyed after every run anyway.

Applied to both setup scripts:

- `Build/Azure/scripts/ydb.sh` (CI)
- `Data/Setup Scripts/ydb.cmd` (local dev image)

## Verification

Full isolated run, same provider/test volume, only this env var differed:

| | Before | After |
|---|---|---|
| Duration | 44:46 | **26:07** |
| Passed / Failed / Skipped | 8615 / 0 / 203 (8818 total) | 8615 / 0 / 203 (8818 total) |

**~42% faster**, identical test outcomes - no correctness change, only wall-clock.

Note this doesn't eliminate YDB's remaining network/consensus latency (confirmed separately: bumping the container's available CPU and YDB's own actor-system thread pools moved throughput by ~4%, within noise - the remaining cost is the distributed-consensus protocol itself, not a resource/thread-starvation misconfiguration). This fix addresses the disk-I/O portion specifically, which is real and free to remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
