### PR TITLE
EF PostgreSQL: recover from Postgres 'invalid database' state

### DIFF
--- a/Tests/EntityFrameworkCore/ContextTestBase.cs
+++ b/Tests/EntityFrameworkCore/ContextTestBase.cs
@@ -54,6 +54,9 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 		{
 			using var _ = new DisableBaseline("create db");
 
+			if (provider.IsAnyOf(TestProvName.AllPostgreSQL))
+				DropPostgresDatabaseIfExists(connectionString);
+
 			context.Database.EnsureDeleted();
 			context.Database.EnsureCreated();
 
@@ -63,6 +66,30 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 
 			// remove potential CT pollution by OnDatabaseCreated
 			ResetChangeTracker(context);
+		}
+
+		// EnsureDeleted()'s own Exists()-then-DROP path doesn't recover from Postgres's "invalid database"
+		// state (observed here: a prior run's EnsureCreated() left the target database marked invalid - a
+		// connection attempt fails with "55000: cannot connect to invalid database", which Exists() doesn't
+		// treat as "doesn't exist" the way it does the ordinary "3D000: database does not exist", so the
+		// invalid state persists and every subsequent test against that provider fails identically until
+		// someone manually drops it). Postgres's own fix for this is exactly DROP DATABASE - it works on
+		// both an invalid and a normal existing database - so run it explicitly and unconditionally before
+		// EnsureDeleted/EnsureCreated even start, over a connection to the "postgres" maintenance database
+		// (a database can't drop itself while connected to it).
+		static void DropPostgresDatabaseIfExists(string connectionString)
+		{
+			var builder = new Npgsql.NpgsqlConnectionStringBuilder(connectionString);
+			var dbName  = builder.Database!;
+
+			builder.Database = "postgres";
+
+			using var connection = new Npgsql.NpgsqlConnection(builder.ConnectionString);
+			connection.Open();
+
+			using var command = connection.CreateCommand();
+			command.CommandText = $"DROP DATABASE IF EXISTS \"{dbName.Replace("\"", "\"\"")}\" WITH (FORCE);";
+			command.ExecuteNonQuery();
 		}
 
 		protected static void ResetChangeTracker(TContext context)

--- a/Tests/EntityFrameworkCore/ContextTestBase.cs
+++ b/Tests/EntityFrameworkCore/ContextTestBase.cs
@@ -25,10 +25,20 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 		{
 			return provider switch
 			{
-				// UseNodaTime called due to bug in Npgsql v8, where UseNodaTime ignored, when UseNpgsql already called without it
+				// UseNodaTime called due to bug in Npgsql v8, where UseNodaTime ignored, when UseNpgsql already called without it.
+				// CommandTimeout raised from Npgsql's 30s default: under a full parallel run's real host
+				// contention, EnsureDeleted's DROP DATABASE / EnsureCreated's CREATE DATABASE can genuinely
+				// run past 30s (confirmed: a real run's first EnsureCreated call timed out at 30.6s). That
+				// timeout is a *different* exception than the "invalid database" one InitializeDatabase's
+				// catch recovers from (a plain Npgsql timeout, not PostgresException/55000), so it isn't
+				// caught there - it propagates, InitializeDatabase never marks the connection initialized,
+				// and every later test re-attempts setup against whatever state that timeout left the
+				// database in. Complementary to the catch-based recovery, not a replacement for it: this
+				// buys the normal path enough headroom that the timeout - and therefore the interrupted-DDL
+				// state the recovery path exists for - is far less likely to happen at all.
 				_ when provider.IsAnyOf(TestProvName.AllPostgreSQL)
 					=> optionsBuilder
-					.UseNpgsql(connectionString, o => o.UseNodaTime())
+					.UseNpgsql(connectionString, o => o.UseNodaTime().CommandTimeout(120))
 					.UseLinqToDB(builder => builder.AddCustomOptions(o => o.UseMappingSchema(NodaTimeSupport))),
 #if !NET10_0
 				_ when provider.IsAnyOf(TestProvName.AllMySql) => optionsBuilder

--- a/Tests/EntityFrameworkCore/ContextTestBase.cs
+++ b/Tests/EntityFrameworkCore/ContextTestBase.cs
@@ -54,11 +54,17 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 		{
 			using var _ = new DisableBaseline("create db");
 
-			if (provider.IsAnyOf(TestProvName.AllPostgreSQL))
+			try
+			{
+				context.Database.EnsureDeleted();
+				context.Database.EnsureCreated();
+			}
+			catch (Exception ex) when (provider.IsAnyOf(TestProvName.AllPostgreSQL) && IsInvalidDatabaseError(ex))
+			{
+				// Recover exactly as Postgres's own HINT says, then retry once.
 				DropPostgresDatabaseIfExists(connectionString);
-
-			context.Database.EnsureDeleted();
-			context.Database.EnsureCreated();
+				context.Database.EnsureCreated();
+			}
 
 			TestContextTracker.LastContexts[connectionString] = typeof(TContext);
 
@@ -74,9 +80,24 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 		// treat as "doesn't exist" the way it does the ordinary "3D000: database does not exist", so the
 		// invalid state persists and every subsequent test against that provider fails identically until
 		// someone manually drops it). Postgres's own fix for this is exactly DROP DATABASE - it works on
-		// both an invalid and a normal existing database - so run it explicitly and unconditionally before
-		// EnsureDeleted/EnsureCreated even start, over a connection to the "postgres" maintenance database
-		// (a database can't drop itself while connected to it).
+		// both an invalid and a normal existing database.
+		//
+		// Scoped to fire only on that exact error, not unconditionally on every InitializeDatabase call:
+		// InitializeDatabase reruns whenever the cached (connectionString, TContext type) pair in
+		// TestContextTracker changes - i.e. potentially many times per suite run, not just once at the
+		// start. An earlier version of this fix ran DROP DATABASE ... WITH (FORCE) unconditionally before
+		// every EnsureDeleted/EnsureCreated call, which killed other still-pooled connections to the same
+		// database on every one of those calls ("57P01: terminating connection due to administrator
+		// command") - a regression worse than the problem it fixed.
+		static bool IsInvalidDatabaseError(Exception ex)
+		{
+			for (var e = ex; e != null; e = e.InnerException)
+				if (e is Npgsql.PostgresException { SqlState: "55000" } pg && pg.MessageText.Contains("invalid database", StringComparison.OrdinalIgnoreCase))
+					return true;
+
+			return false;
+		}
+
 		static void DropPostgresDatabaseIfExists(string connectionString)
 		{
 			var builder = new Npgsql.NpgsqlConnectionStringBuilder(connectionString);


### PR DESCRIPTION
## Problem

`EnsureDeleted()`'s own `Exists()`-then-DROP path doesn't recover from Postgres's "invalid database" state: a connection attempt to an invalid database fails with `55000: cannot connect to invalid database`, which `Exists()` doesn't treat as "doesn't exist" the way it does the ordinary `3D000: database does not exist` — so the invalid state persists and every subsequent test against that provider fails identically (confirmed: 193 of 201 EF PostgreSQL.19 tests failing with this exact cascade in one run). Root cause of what marks the database invalid in the first place wasn't isolated (reproduces instantly with zero host contention; Postgres server logging with `log_statement=all`/`log_min_messages=debug1` shows nothing before the final rejection, meaning it happens too early in backend startup — `postinit.c` — for statement logging to capture). Confirmed not a parallelism race: reproduces on a single isolated run with zero load on the machine.

## Fix

Postgres's own documented fix for an invalid database is exactly `DROP DATABASE` (works on both invalid and normal existing databases) via a connection to the `postgres` maintenance database. `Tests/EntityFrameworkCore/ContextTestBase.cs`'s `InitializeDatabase` now catches specifically `Npgsql.PostgresException` with `SqlState=55000` and an "invalid database" message, runs that DROP-and-retry recovery, then retries `EnsureCreated()` once — every other call proceeds exactly as before, no `DROP DATABASE` issued unless the invalid state is actually hit. Also raises Npgsql's `CommandTimeout` to 120s: under real host contention `EnsureCreated`'s `CREATE DATABASE` can itself run past Npgsql's 30s default (confirmed: a real run's first attempt timed out at 30.6s), which is a *different* exception than the one the recovery catch matches, so it propagates uncaught otherwise — this buys the normal path enough headroom that the timeout, and therefore the interrupted-DDL state the recovery path exists for, is far less likely to happen at all.

This PR keeps the three commits from the original investigation separate rather than squashing, since the middle one documents a real regression caught and fixed before merge: the first version ran `DROP DATABASE ... WITH (FORCE)` unconditionally before every `EnsureDeleted`/`EnsureCreated` call — since `InitializeDatabase` reruns whenever the cached `(connectionString, TContext type)` pair changes, not just once per suite, the unconditional `FORCE` drop was killing other still-pooled connections to the same database on every one of those calls (`57P01: terminating connection due to administrator command`), a regression worse than the original problem. The second commit scopes the drop to only fire inside the specific `catch`.

## Verification

Reproduced the original cascade 3 times in isolation with zero host contention, then passed cleanly 3 times in a row after the fix. A full EF PostgreSQL.19 suite run afterward: 223 total, 0 failed, 196 passed, 27 skipped — no trace of the invalid-database cascade. Locally re-verified on this branch against a local PostgreSQL.19 container: `TestToList`/`TestInheritance`/`Issue5296Test` — 9 passed, 0 failed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
