### PR TITLE
Clear the visited set when returning a parent-first visitor to the pool

### DIFF
--- a/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryParentFirstVisitor{TContext}.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/Visitors/SqlQueryParentFirstVisitor{TContext}.cs
@@ -29,6 +29,7 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 		{
 			_action  = null!;
 			_context = default!;
+			_visited = null;
 
 			base.Cleanup();
 		}


### PR DESCRIPTION
## What

`SqlQueryParentFirstVisitor<TContext>.Cleanup()` resets `_action` and `_context` but not `_visited`. The non-generic `SqlQueryParentFirstVisitor` clears all three.

## Why it matters

`ObjectPool<T>.Free` runs the cleanup delegate *before* storing the instance, so an idle pooled visitor keeps a `HashSet<IQueryElement>` referencing every element of its last traversal — pinning whole query ASTs for as long as the instance sits in the pool.

The pools are `static` and sized 100 per `TContext`, so the retained set scales with the number of distinct visitor context types the process uses, not with any single query.

## Risk

None behaviourally: `_visited` is reassigned at the top of every `Visit(context, root, visitAll, action)` call, so the stale set was never read — only held.

## Context

Found while investigating out-of-memory failures on long-running CI test legs. It is not claimed to be the sole cause of those; it is a clear retention bug worth fixing on its own, and small enough to ship ahead of that investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
