### PR TITLE
Add analyzer projects to solution filters

### DIFF
--- a/linq2db.Benchmarks.slnf
+++ b/linq2db.Benchmarks.slnf
@@ -3,6 +3,8 @@
     "path": "linq2db.slnx",
     "projects": [
       "Source\\CodeGenerators\\CodeGenerators.csproj",
+      "Source\\LinqToDB.Analyzers\\LinqToDB.Analyzers.csproj",
+      "Source\\LinqToDB.Analyzers.CodeFixes\\LinqToDB.Analyzers.CodeFixes.csproj",
       "Source\\LinqToDB\\LinqToDB.csproj",
       "Tests\\Tests.Benchmarks\\linq2db.Benchmarks.csproj"
     ]

--- a/linq2db.Testing.slnf
+++ b/linq2db.Testing.slnf
@@ -3,6 +3,8 @@
     "path": "linq2db.slnx",
     "projects": [
       "Source\\CodeGenerators\\CodeGenerators.csproj",
+      "Source\\LinqToDB.Analyzers\\LinqToDB.Analyzers.csproj",
+      "Source\\LinqToDB.Analyzers.CodeFixes\\LinqToDB.Analyzers.CodeFixes.csproj",
       "Source\\LinqToDB.Extensions\\LinqToDB.Extensions.csproj",
       "Source\\LinqToDB.FSharp\\LinqToDB.FSharp.fsproj",
       "Source\\LinqToDB.Remote.HttpClient.Client\\LinqToDB.Remote.HttpClient.Client.csproj",

--- a/linq2db.playground.slnf
+++ b/linq2db.playground.slnf
@@ -3,6 +3,8 @@
     "path": "linq2db.slnx",
     "projects": [
       "Source\\CodeGenerators\\CodeGenerators.csproj",
+      "Source\\LinqToDB.Analyzers\\LinqToDB.Analyzers.csproj",
+      "Source\\LinqToDB.Analyzers.CodeFixes\\LinqToDB.Analyzers.CodeFixes.csproj",
       "Source\\LinqToDB.Extensions\\LinqToDB.Extensions.csproj",
       "Source\\LinqToDB.FSharp\\LinqToDB.FSharp.fsproj",
       "Source\\LinqToDB.Remote.HttpClient.Client\\LinqToDB.Remote.HttpClient.Client.csproj",


### PR DESCRIPTION
`Source/LinqToDB/LinqToDB.csproj` carries a `ProjectReference` to `LinqToDB.Analyzers.CodeFixes`, which in turn references `LinqToDB.Analyzers`. Neither project was listed in any of the three solution filters.

Visual Studio loads only the projects a filter lists, so opening one of them and building fails:

```
CSC : error CS0006: Metadata file '...\.build\obj\LinqToDB.Analyzers.CodeFixes\Debug\ref\LinqToDB.Analyzers.CodeFixes.dll' could not be found
```

Command-line builds were unaffected — MSBuild resolves each project's `ProjectReference` regardless of the filter — which is why this went unnoticed.

## Change

Added both projects to `linq2db.playground.slnf`, `linq2db.Testing.slnf` and `linq2db.Benchmarks.slnf` (2 lines each).

## Verification

Walked the full transitive `ProjectReference` closure of every project in each filter: those two were the only ones missing, and all three filters are now complete.

| Filter | Config | Result |
|---|---|---|
| `linq2db.playground.slnf` | Debug | 0 errors |
| `linq2db.Testing.slnf` | Testing | 0 errors |
| `linq2db.Benchmarks.slnf` | Release | 0 errors |

The CLI builds confirm no regression; they do not reproduce the defect, since it only manifests in an IDE that honours the filter's project list.
