### PR TITLE
Different types on predicate can break PostgreSql

### DIFF
--- a/Tests/Linq/Linq/SelectTests.cs
+++ b/Tests/Linq/Linq/SelectTests.cs
@@ -2188,5 +2188,22 @@ namespace Tests.Linq
 
 			AreEqual(parentsQry, parents);
 		}
+
+		[Test]
+		public void DifferentTypesOnPredicateTest([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+			var parentValue1 = 1;
+
+			// do not change names (!)
+			// SQLite fails between aliases [child] and [Child]
+			var parentsQry = db.Parent
+				.Where(_ => _.Value1 == parentValue1 * 1.0);
+
+			var parents = Parent
+				.Where(_ => _.Value1 == parentValue1 * 1.0);
+
+			AreEqual(parentsQry, parents);
+		}
 	}
 }

--- a/Tests/Linq/Linq/SelectTests.cs
+++ b/Tests/Linq/Linq/SelectTests.cs
@@ -2195,8 +2195,6 @@ namespace Tests.Linq
 			using var db = GetDataContext(context);
 			var parentValue1 = 1;
 
-			// do not change names (!)
-			// SQLite fails between aliases [child] and [Child]
 			var parentsQry = db.Parent
 				.Where(_ => _.Value1 == parentValue1 * 1.0);
 


### PR DESCRIPTION
One more v5-v6 regression fails with PostgreSql, there are easy workaround to cast value outer of linq expression, but in anyway this used  to work :)