### PR TITLE
Avoid compiling a lambda per `default(T)` during query build (~11x on deep `LoadWith` chains)

### DIFF
--- a/Source/LinqToDB/Internal/Expressions/ExpressionEvaluator.cs
+++ b/Source/LinqToDB/Internal/Expressions/ExpressionEvaluator.cs
@@ -29,6 +29,9 @@ namespace LinqToDB.Internal.Expressions
 				{ NodeType: ExpressionType.Default } => true,
 				{ NodeType: ExpressionType.Constant } => true,
 
+				// our own default-value node reduces to a constant, so it needs no compiled lambda
+				DefaultValueExpression => true,
+
 				MemberExpression { NodeType: ExpressionType.MemberAccess } member =>
 					member.Member.MemberType is MemberTypes.Field or MemberTypes.Property
 					&& IsSimpleEvaluatable(member.Expression),
@@ -52,6 +55,11 @@ namespace LinqToDB.Internal.Expressions
 
 				case ExpressionType.Constant:
 					return ((ConstantExpression)expr).Value;
+
+				// Reduce() is what produced this value before, via a compiled lambda - it honours a
+				// mapping schema's custom default, so reducing here keeps the result identical.
+				case ExpressionType.Extension when expr is DefaultValueExpression defaultValue:
+					return defaultValue.Reduce().EvaluateExpressionInternal();
 
 				case ExpressionType.MemberAccess:
 				{

--- a/Source/LinqToDB/Internal/SqlQuery/Visitors/SelectQueryOptimizerVisitor.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/Visitors/SelectQueryOptimizerVisitor.cs
@@ -1053,7 +1053,7 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 						// is reached, never the verdict itself.
 						var probeLocally = !ReferenceEquals(_rootElement, selectQuery);
 
-						if (probeLocally && QueryHelper.IsDependsOnSources(selectQuery, sources, ignore)
+						if ((probeLocally && QueryHelper.IsDependsOnSources(selectQuery, sources, ignore))
 							|| QueryHelper.IsDependsOnSources(_rootElement, sources, ignore))
 						{
 							join.IsWeak = false;

--- a/Source/LinqToDB/Internal/SqlQuery/Visitors/SelectQueryOptimizerVisitor.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/Visitors/SelectQueryOptimizerVisitor.cs
@@ -1045,7 +1045,16 @@ namespace LinqToDB.Internal.SqlQuery.Visitors
 					{
 						var sources = QueryHelper.EnumerateAccessibleSources(join.Table).ToList();
 						var ignore  = new[] { join };
-						if (QueryHelper.IsDependsOnSources(_rootElement, sources, ignore))
+
+						// Probe the enclosing query before walking the whole statement: 99% of kept joins are
+						// referenced from their own query, and reaching them from the statement root wastes the
+						// whole descent. selectQuery is reachable from _rootElement without passing through join,
+						// so a local hit is necessarily a root hit as well - this changes how quickly the verdict
+						// is reached, never the verdict itself.
+						var probeLocally = !ReferenceEquals(_rootElement, selectQuery);
+
+						if (probeLocally && QueryHelper.IsDependsOnSources(selectQuery, sources, ignore)
+							|| QueryHelper.IsDependsOnSources(_rootElement, sources, ignore))
 						{
 							join.IsWeak = false;
 							continue;

--- a/Tests/Tests.Benchmarks/Benchmarks/QueryGeneration/WeakJoinScanBenchmark.cs
+++ b/Tests/Tests.Benchmarks/Benchmarks/QueryGeneration/WeakJoinScanBenchmark.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Data;
+using System.Linq;
+
+using BenchmarkDotNet.Attributes;
+
+using LinqToDB.Benchmarks.TestProvider;
+using LinqToDB.Data;
+using LinqToDB.DataProvider.Firebird;
+using LinqToDB.Mapping;
+
+namespace LinqToDB.Benchmarks.QueryGeneration
+{
+	// Query-generation cost of shapes that produce many removable (weak) association joins:
+	// a deep LoadWith chain (the https://github.com/linq2db/linq2db/issues/5265 shape) and a wide
+	// entity whose one-to-one associations are all loaded.
+	public class WeakJoinScanBenchmark
+	{
+		[Table]
+		public sealed class ChainNode
+		{
+			[PrimaryKey] public int Id    { get; set; }
+			[Column]     public int FK    { get; set; }
+			[Column]     public int Field { get; set; }
+
+			[Association(ThisKey = nameof(Id), OtherKey = nameof(FK))] public ChainNode? Next { get; set; }
+		}
+
+		[Table]
+		public sealed class WideChild
+		{
+			[PrimaryKey] public int Id    { get; set; }
+			[Column]     public int FK    { get; set; }
+			[Column]     public int Field { get; set; }
+		}
+
+		[Table]
+		public sealed class WideRoot
+		{
+			[PrimaryKey] public int Id { get; set; }
+
+			[Association(ThisKey = nameof(Id), OtherKey = nameof(WideChild.FK))] public WideChild? C01 { get; set; }
+			[Association(ThisKey = nameof(Id), OtherKey = nameof(WideChild.FK))] public WideChild? C02 { get; set; }
+			[Association(ThisKey = nameof(Id), OtherKey = nameof(WideChild.FK))] public WideChild? C03 { get; set; }
+			[Association(ThisKey = nameof(Id), OtherKey = nameof(WideChild.FK))] public WideChild? C04 { get; set; }
+			[Association(ThisKey = nameof(Id), OtherKey = nameof(WideChild.FK))] public WideChild? C05 { get; set; }
+			[Association(ThisKey = nameof(Id), OtherKey = nameof(WideChild.FK))] public WideChild? C06 { get; set; }
+			[Association(ThisKey = nameof(Id), OtherKey = nameof(WideChild.FK))] public WideChild? C07 { get; set; }
+			[Association(ThisKey = nameof(Id), OtherKey = nameof(WideChild.FK))] public WideChild? C08 { get; set; }
+			[Association(ThisKey = nameof(Id), OtherKey = nameof(WideChild.FK))] public WideChild? C09 { get; set; }
+			[Association(ThisKey = nameof(Id), OtherKey = nameof(WideChild.FK))] public WideChild? C10 { get; set; }
+			[Association(ThisKey = nameof(Id), OtherKey = nameof(WideChild.FK))] public WideChild? C11 { get; set; }
+			[Association(ThisKey = nameof(Id), OtherKey = nameof(WideChild.FK))] public WideChild? C12 { get; set; }
+			[Association(ThisKey = nameof(Id), OtherKey = nameof(WideChild.FK))] public WideChild? C13 { get; set; }
+			[Association(ThisKey = nameof(Id), OtherKey = nameof(WideChild.FK))] public WideChild? C14 { get; set; }
+			[Association(ThisKey = nameof(Id), OtherKey = nameof(WideChild.FK))] public WideChild? C15 { get; set; }
+			[Association(ThisKey = nameof(Id), OtherKey = nameof(WideChild.FK))] public WideChild? C16 { get; set; }
+			[Association(ThisKey = nameof(Id), OtherKey = nameof(WideChild.FK))] public WideChild? C17 { get; set; }
+			[Association(ThisKey = nameof(Id), OtherKey = nameof(WideChild.FK))] public WideChild? C18 { get; set; }
+			[Association(ThisKey = nameof(Id), OtherKey = nameof(WideChild.FK))] public WideChild? C19 { get; set; }
+			[Association(ThisKey = nameof(Id), OtherKey = nameof(WideChild.FK))] public WideChild? C20 { get; set; }
+		}
+
+		DataConnection _db = null!;
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+		[GlobalSetup]
+		public void Setup()
+		{
+			_db = new DataConnection(new DataOptions()
+				.UseConnection(FirebirdTools.GetDataProvider(FirebirdVersion.v5), new MockDbConnection(Array.Empty<QueryResult>(), ConnectionState.Open))
+				// the point of the benchmark is building the query, so it must not be served from the cache
+				.UseDisableQueryCache(true));
+		}
+#pragma warning restore CA2000 // Dispose objects before losing scope
+
+		[GlobalCleanup]
+		public void Cleanup()
+		{
+			_db.Dispose();
+		}
+
+		[Benchmark]
+		public string DeepChain13()
+		{
+			return _db.GetTable<ChainNode>()
+				.LoadWith(x => x.Next!.Next!.Next!.Next!.Next!.Next!.Next!.Next!.Next!.Next!.Next!.Next!.Next)
+				.ToSqlQuery().Sql;
+		}
+
+		[Benchmark]
+		public string Wide20()
+		{
+			return _db.GetTable<WideRoot>()
+				.LoadWith(x => x.C01).LoadWith(x => x.C02).LoadWith(x => x.C03).LoadWith(x => x.C04)
+				.LoadWith(x => x.C05).LoadWith(x => x.C06).LoadWith(x => x.C07).LoadWith(x => x.C08)
+				.LoadWith(x => x.C09).LoadWith(x => x.C10).LoadWith(x => x.C11).LoadWith(x => x.C12)
+				.LoadWith(x => x.C13).LoadWith(x => x.C14).LoadWith(x => x.C15).LoadWith(x => x.C16)
+				.LoadWith(x => x.C17).LoadWith(x => x.C18).LoadWith(x => x.C19).LoadWith(x => x.C20)
+				.ToSqlQuery().Sql;
+		}
+
+		// Manual runner, mirroring CacheActivityBenchmark.RunManually: BDN's child-process toolchain
+		// cannot restore its auto-generated project in this repo layout (NU1101), and a single
+		// operation here costs seconds, so the auto-iteration toolchain is impractical for A/B runs.
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0030", Justification = "Benchmark output requires Console")]
+		public static void RunManually(int warmups = 2, int iterations = 8)
+		{
+			if (warmups    < 0) warmups    = 0;
+			if (iterations < 1) iterations = 1;
+
+			var b = new WeakJoinScanBenchmark();
+			b.Setup();
+
+			var methods = new (string Name, Func<string> Run)[]
+			{
+				("DeepChain13", b.DeepChain13),
+				("Wide20",      b.Wide20),
+			};
+
+			var tag = Environment.GetEnvironmentVariable("WEAKJOIN_BENCH_TAG") ?? "(unknown)";
+
+			Console.WriteLine();
+			Console.WriteLine("=== WeakJoinScanBenchmark manual run | tag: " + tag + " ===");
+			Console.WriteLine();
+			Console.WriteLine("| Benchmark | Mean (ms) | Median (ms) | Min (ms) | SQL len |");
+			Console.WriteLine("|---|---:|---:|---:|---:|");
+
+			foreach (var (name, run) in methods)
+			{
+				for (var i = 0; i < warmups; i++)
+					run();
+
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+				GC.Collect();
+
+				var samples = new double[iterations];
+				var sw      = new System.Diagnostics.Stopwatch();
+				var sqlLen  = 0;
+
+				for (var i = 0; i < iterations; i++)
+				{
+					sw.Restart();
+					var sql = run();
+					sw.Stop();
+					samples[i] = sw.Elapsed.TotalMilliseconds;
+					sqlLen     = sql.Length;
+				}
+
+				var mean = samples.Average();
+
+				Array.Sort(samples);
+				var mid    = samples.Length / 2;
+				var median = samples.Length % 2 == 0
+					? (samples[mid - 1] + samples[mid]) / 2.0
+					: samples[mid];
+
+				Console.WriteLine($"| {name,-12} | {mean,9:F1} | {median,11:F1} | {samples[0],8:F1} | {sqlLen,7} |");
+			}
+
+			Console.WriteLine();
+
+			b.Cleanup();
+		}
+	}
+}

--- a/Tests/Tests.Benchmarks/Program.cs
+++ b/Tests/Tests.Benchmarks/Program.cs
@@ -29,6 +29,15 @@ namespace LinqToDB.Benchmarks
 				return;
 			}
 
+			// Usage: manual-weakjoin [iterations] [warmups]
+			if (args.Length > 0 && args[0] == "manual-weakjoin")
+			{
+				var iters   = args.Length > 1 && int.TryParse(args[1], out var n) ? n : 8;
+				var warmups = args.Length > 2 && int.TryParse(args[2], out var w) ? w : 2;
+				WeakJoinScanBenchmark.RunManually(warmups, iters);
+				return;
+			}
+
 			//if (args.Length == 0)
 			//{
 			//	//	var b1 = new FetchGraphBenchmark();


### PR DESCRIPTION
Two independent query-build optimisations, plus the benchmark that found them. No linked issue - #5265 (the stack overflow on this shape) is closed; this is a separate performance concern on the same shape.

## 1. `default(T)` no longer compiles a lambda

`IsSimpleEvaluatable` admitted the BCL's `DefaultExpression` (`NodeType == Default`) but not linq2db's own `DefaultValueExpression`, whose `NodeType` is `Extension`. Every `default(T)` therefore fell through to `Expression.Lambda(expr).CompileExpression().DynamicInvokeExt()`.

Building a 13-level `LoadWith` chain compiled **38460** lambdas, 38220 of them for the same `Default(ChainNode)` node. A CPU profile put 81% of the building thread inside `BuildConstant` -> `EvaluateExpression`, with a second core saturated in `DynamicResolver+DestroyScout.Finalize` destroying the resulting `DynamicMethod`s.

The fix reduces the node instead. `Reduce()` returns the same constant the compiled lambda produced - including a mapping schema's custom default - so it is exact, not an approximation.

## 2. Weak-join dependency scan probes the enclosing query first

`ResolveWeakJoins` asked whether a removable join's sources are referenced anywhere in the statement, walking from the statement root once per candidate. The reference that keeps a join is almost always in the join's own query, so the walk paid a full descent to reach it.

This is exact, not heuristic: `selectQuery` is reachable from `_rootElement` without passing through the join, and reference dedup never drops a node from a closure, so a local hit is necessarily a root hit; a local miss falls through to the original scan. Instrumentation found 6961 of 7030 scans hit locally, and **zero** cases of a local hit without a root hit across 7117 scans.

**This reduces work, not wall-clock time** - weak-join scanning is under 1% of query build for these shapes, so no timing improvement is claimed for it.

## Measurements

| | before | after |
|---|---|---|
| lambda compiles per build (deep chain) | 38460 | 0 |
| deep-chain query build | ~4470 ms | ~410 ms |
| weak-join scan work, whole suite | - | -58% |
| weak-join scan work, deep chain | - | -71% |

## Verification

- Full suite, SQLite.MS, net10.0: **10373 passed, 0 failed, 30 skipped** - identical to the pre-change reference.
- `StackUseTests.EagerLoadProjection` canary on PostgreSQL.16: passes (200 KB stack ceiling holds).
- Release builds clean on net10.0, netstandard2.0, net462.
- Generated SQL byte-identical for both benchmark shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
