### PR TITLE
Fix linq2db.cli pack on .NET SDK 10.0.400 (NU5118)

### DIFF
--- a/Source/LinqToDB.CLI/LinqToDB.CLI.csproj
+++ b/Source/LinqToDB.CLI/LinqToDB.CLI.csproj
@@ -43,6 +43,18 @@
 		<PackageProjectUrl>https://linq2db.github.io/</PackageProjectUrl>
 
 		<EnablePackageValidation>false</EnablePackageValidation>
+
+		<!--
+		NU5118: SDK 10.0.400 (dotnet/sdk#55107) packs the RID pointer package's DotnetToolSettings.xml
+		at a TFM-agnostic tools/any/any/ path, but PackTool runs once per TFM - so all three of our
+		TFMs emit that same package path and NuGet reports a collision (fatal under
+		TreatWarningsAsErrors). The three generated files are byte-identical: the pointer settings
+		carry only ToolCommandName plus the per-RID sub-package ids, nothing TFM-specific. So NuGet
+		keeping the first and skipping the rest is lossless, and the emitted package is exactly the
+		single-settings-file layout the new SDK intends. Scoped to the pointer package so the per-RID
+		packs keep NU5118 enforcement. Remove once the SDK stops emitting one copy per TFM.
+		-->
+		<NoWarn Condition="'$(RuntimeIdentifier)' == ''">$(NoWarn);NU5118</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup Label="Nuget">


### PR DESCRIPTION
## Problem

The `build` CI job has failed on **every** PR since 2026-08-11 — 10 consecutive runs across unrelated PRs (last green [22735](https://dev.azure.com/linq2db/linq2db/_build/results?buildId=22735), first red [22738](https://dev.azure.com/linq2db/linq2db/_build/results?buildId=22738)). `dotnet pack linq2db.slnx` fails with two `NU5118` errors on `LinqToDB.CLI`, with no compile errors:

```
NuGet.Build.Tasks.Pack.targets(226,5): error NU5118: Warning As Error: File
'.build\obj\LinqToDB.CLI\Release\net8.0\DotnetToolSettings.xml' is not added because
the package already contains file 'tools\any\any\DotnetToolSettings.xml'
```

No repo change caused it — the hosted agent's SDK rolled forward from **10.0.302** to **10.0.400**. `Build/Azure/pipelines/templates/build-job.yml` requests bare `10.x` and `global.json` pins `10.0.200` with `rollForward: minor`, which accepts the new feature band.

## Cause

[dotnet/sdk#55107](https://github.com/dotnet/sdk/pull/55107), first shipped in 10.0.400 (not present in 10.0.303), moves the RID pointer package's `DotnetToolSettings.xml` to a TFM-agnostic `tools/any/any/` path. But `PackTool` runs once per TFM, so our three TFMs all emit that same package path and NuGet reports a collision — fatal under `TreatWarningsAsErrors`. The upstream test asserts the pointer package holds *exactly one* settings file, which only holds for single-TFM tools.

## Fix

`NoWarn` on `NU5118`, scoped to the pointer package. The three generated files are byte-identical (matching SHA-256) — the pointer settings carry only `ToolCommandName` plus the per-RID sub-package ids, nothing TFM-specific. So NuGet keeping the first and skipping the duplicates is lossless, and the result is exactly the single-settings-file layout the new SDK intends. The `RuntimeIdentifier == ''` condition keeps `NU5118` enforced for the seven per-RID packs.

Alternatives rejected: collapsing to one TFM breaks the documented .NET 8/9/10 runtime support (`Source/LinqToDB.CLI/readme.md`), and forcing `_ToolPackageShouldIncludeImplementation=true` would inflate the thin pointer into a full framework-dependent tool x3 TFMs, risking the 200 MB size gate.

## Verification

Local `dotnet pack` on SDK 10.0.400 — reproduced red, then green:

- Full pack exits 0, zero warnings
- Pointer package: exactly one `tools/any/any/DotnetToolSettings.xml`, all 7 RIDs listed, `packageType="DotnetTool"`, 0.1 MB
- All 7 RID sub-packages retain their per-TFM `tools/net8.0/<rid>/`, `tools/net9.0/<rid>/`, `tools/net10.0/<rid>/` layout
- `Build/Azure/scripts/verify-nuget-sizes.ps1` passes 8/8

## Follow-ups (not in this PR)

- Upstream issue on dotnet/sdk: multi-TFM `PackAsTool` + `ToolPackageRuntimeIdentifiers` cannot pack at all on 10.0.400.
- Consider pinning the SDK feature band in CI — requesting bare `10.x` is what let a feature-band bump red-line ten unrelated PRs with no repo change.
