### PR TITLE
Fix wrong MappingSchema when one DbContext type is used with several providers

### DIFF
--- a/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.cs
@@ -720,14 +720,15 @@ namespace LinqToDB.EntityFrameworkCore
 
 #if !EF31
 						// https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1801
-						if (string.Equals(ctx.this_._dependencies!.MethodCallTranslatorProvider.GetType().Name, "MySqlMethodCallTranslatorProvider", StringComparison.Ordinal))
+						// The field is non-null exactly when the constructor identified Pomelo's provider.
+						if (ctx.this_._databaseDependencies != null)
 						{
 							var contextProperty = ctx.this_._dependencies!.MethodCallTranslatorProvider.GetType().GetProperty("QueryCompilationContext")
 							?? throw new InvalidOperationException("MySqlMethodCallTranslatorProvider.QueryCompilationContext property not found");
 
 							if (contextProperty.GetValue(ctx.this_._dependencies!.MethodCallTranslatorProvider) == null)
 							{
-								contextProperty.SetValue(ctx.this_._dependencies!.MethodCallTranslatorProvider, ctx.this_._databaseDependencies!.QueryCompilationContextFactory.Create(false));
+								contextProperty.SetValue(ctx.this_._dependencies!.MethodCallTranslatorProvider, ctx.this_._databaseDependencies.QueryCompilationContextFactory.Create(false));
 							}
 						}
 #endif

--- a/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.cs
@@ -12,6 +12,7 @@ using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore;
 #if !EF31
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 #endif
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -86,8 +87,21 @@ namespace LinqToDB.EntityFrameworkCore
 				_annotationProvider     = accessor.GetService<IMigrationsAnnotationProvider>();
 #else
 				_annotationProvider     = accessor.GetService<IRelationalAnnotationProvider>();
-				_logger                 = accessor.GetService<IDiagnosticsLogger<DbLoggerCategory.Query>>();
-				_databaseDependencies   = accessor.GetService<DatabaseDependencies>();
+
+				// Built from its parts rather than resolved: the context's own logger carries IInterceptors,
+				// which holds the CoreOptionsExtension and so the application service provider, and this
+				// reader is cached for the process lifetime. EF builds its loggers the same way.
+				_logger                 = new DiagnosticsLogger<DbLoggerCategory.Query>(
+					accessor.GetService<Microsoft.Extensions.Logging.ILoggerFactory>()!,
+					accessor.GetService<ILoggingOptions>()!,
+					accessor.GetService<System.Diagnostics.DiagnosticSource>()!,
+					accessor.GetService<LoggingDefinitions>()!,
+					new NullDbContextLogger());
+
+				// Only Pomelo's translator provider reads it (see GetDbFunctionFromMethodCall), and it reaches
+				// this context's IDbContextOptions through QueryCompilationContextDependencies.
+				if (string.Equals(_dependencies?.MethodCallTranslatorProvider.GetType().Name, "MySqlMethodCallTranslatorProvider", StringComparison.Ordinal))
+					_databaseDependencies = accessor.GetService<DatabaseDependencies>();
 #endif
 			}
 

--- a/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/EFCoreMetadataReader.cs
@@ -92,10 +92,10 @@ namespace LinqToDB.EntityFrameworkCore
 				// which holds the CoreOptionsExtension and so the application service provider, and this
 				// reader is cached for the process lifetime. EF builds its loggers the same way.
 				_logger                 = new DiagnosticsLogger<DbLoggerCategory.Query>(
-					accessor.GetService<Microsoft.Extensions.Logging.ILoggerFactory>()!,
-					accessor.GetService<ILoggingOptions>()!,
-					accessor.GetService<System.Diagnostics.DiagnosticSource>()!,
-					accessor.GetService<LoggingDefinitions>()!,
+					accessor.GetService<Microsoft.Extensions.Logging.ILoggerFactory>(),
+					accessor.GetService<ILoggingOptions>(),
+					accessor.GetService<System.Diagnostics.DiagnosticSource>(),
+					accessor.GetService<LoggingDefinitions>(),
 					new NullDbContextLogger());
 
 				// Only Pomelo's translator provider reads it (see GetDbFunctionFromMethodCall), and it reaches

--- a/Source/LinqToDB.EntityFrameworkCore/Internal/LinqToDBOptionsExtension.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/Internal/LinqToDBOptionsExtension.cs
@@ -103,7 +103,11 @@ namespace LinqToDB.EntityFrameworkCore.Internal
 				=> debugInfo["LinqToDB"] = "1";
 
 #if !EF31
-			public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other) => true;
+			// none of our options affect the service provider, but the answer is still only "yes"
+			// for another instance of this extension: EF compares extensions pairwise by position,
+			// so answering true for a foreign extension makes two different configurations look
+			// like one — both to EF's service provider cache and to our mapping schema cache.
+			public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other) => other is LinqToDBExtensionInfo;
 #endif
 		}
 	}

--- a/Source/LinqToDB.EntityFrameworkCore/Internal/LinqToDBOptionsExtension.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/Internal/LinqToDBOptionsExtension.cs
@@ -103,10 +103,10 @@ namespace LinqToDB.EntityFrameworkCore.Internal
 				=> debugInfo["LinqToDB"] = "1";
 
 #if !EF31
-			// none of our options affect the service provider, but the answer is still only "yes"
-			// for another instance of this extension: EF compares extensions pairwise by position,
-			// so answering true for a foreign extension makes two different configurations look
-			// like one — both to EF's service provider cache and to our mapping schema cache.
+			// none of our options affect the service provider, so "yes" only for another instance of
+			// this extension — the shape EF's own RelationalExtensionInfo uses. Hardening rather than
+			// part of the #5778 fix: both service-provider caches fold the extension types into their
+			// hash, so configurations with different extension sets never reach this pairwise compare.
 			public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other) => other is LinqToDBExtensionInfo;
 #endif
 		}

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.cs
@@ -100,10 +100,11 @@ namespace LinqToDB.EntityFrameworkCore
 			}
 		}
 
-		// Weak-keyed: a cached reader must not keep its model alive. Contexts that build a fresh model
-		// each time (EnableServiceProviderCaching(false), pooled contexts, several providers) would
-		// otherwise add one never-evicted entry per DbContext instance. Reassigned rather than cleared
-		// because ConditionalWeakTable.Clear() is not available on the netstandard2.0 / net462 builds.
+		// Weak-keyed: a cached reader must not keep its model alive. A configuration that defeats EF's
+		// model caching — EnableServiceProviderCaching(false), or a freshly built model passed to
+		// UseModel per context — would otherwise add one never-evicted entry per DbContext instance.
+		// Reassigned rather than cleared because ConditionalWeakTable.Clear() is not available on the
+		// netstandard2.0 / net462 builds.
 		static ConditionalWeakTable<IModel, IMetadataReader> _metadataReaders = new();
 
 		static Lazy<IMetadataReader?> _defaultMetadataReader;
@@ -244,9 +245,9 @@ namespace LinqToDB.EntityFrameworkCore
 		{
 			// Share one mapping schema — and therefore one ConfigurationID — across DbContext
 			// instances of the same model, keyed on EF's own model-cache key. A fresh IModel per
-			// context (pooled contexts, EnableServiceProviderCaching(false), multiple internal
-			// service providers) would otherwise yield a fresh schema identity and the linq2db
-			// query cache would miss on every context.
+			// context (EnableServiceProviderCaching(false), or any configuration that defeats EF's
+			// model caching) would otherwise yield a fresh schema identity and the linq2db query
+			// cache would miss on every context.
 			if (accessor is DbContext context)
 			{
 				var factory = context.GetService<IModelCacheKeyFactory>();

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.cs
@@ -103,7 +103,7 @@ namespace LinqToDB.EntityFrameworkCore
 
 		static Lazy<IMetadataReader?> _defaultMetadataReader;
 
-		static readonly ConcurrentDictionary<(object ModelKey, DataOptions? DataOptions, bool Tracking), MappingSchema> _mappingSchemas = new();
+		static readonly ConcurrentDictionary<(object ModelKey, object ServiceKey, DataOptions? DataOptions, bool Tracking), MappingSchema> _mappingSchemas = new();
 
 		/// <summary>
 		/// Clears internal caches
@@ -243,12 +243,47 @@ namespace LinqToDB.EntityFrameworkCore
 #endif
 
 				return _mappingSchemas.GetOrAdd(
-					(modelKey, dataOptions, EnableChangeTracker),
+					(modelKey, GetServiceKey(context), dataOptions, EnableChangeTracker),
 					static (_, state) => BuildMappingSchema(state.model, state.accessor, state.dataOptions),
 					(model, accessor, dataOptions));
 			}
 
 			return BuildMappingSchema(model, accessor, dataOptions);
+		}
+
+		/// <summary>
+		/// Identifies the set of EF services the model and its type mappings were built from. The
+		/// model-cache key alone is not enough: it is unique only within one EF internal service
+		/// provider (EF's default key is the context type), while our schema cache is process-wide.
+		/// Without this component one context type used with two providers — or with two
+		/// service-affecting configurations — would share a single schema, and the first model
+		/// discovered would win for all of them.
+		/// </summary>
+		static object GetServiceKey(DbContext context)
+		{
+			var options = GetContextOptions(context);
+
+			if (options == null)
+				return context.GetType();
+
+#if EF31
+			// EF 3.1 has no DbContextOptions equality, so reproduce the key its own
+			// ServiceProviderCache uses (extension types + per-extension service-provider hash).
+			// The ordered type-name list is added so different providers can never collide on the
+			// aggregated hash alone.
+			return (
+				string.Join(",", options.Extensions.Select(static e => e.GetType().FullName).OrderBy(static n => n, StringComparer.Ordinal)),
+				options.Extensions
+					.OrderBy(static e => e.GetType().Name, StringComparer.Ordinal)
+					.Aggregate(0L, static (hash, e) => (hash * 397) ^ ((long)e.GetType().GetHashCode() * 397) ^ e.Info.GetServiceProviderHashCode()));
+#else
+			// DbContextOptions implements Equals/GetHashCode over exactly those options that
+			// require a distinct EF internal service provider (DbContextOptionsExtensionInfo's
+			// ShouldUseSameServiceProvider / GetServiceProviderHashCode) — the same key EF's own
+			// ServiceProviderCache uses. Being content-based, equivalent-but-distinct options
+			// objects still map to one schema, which is what the sharing above relies on.
+			return options;
+#endif
 		}
 
 		static MappingSchema BuildMappingSchema(IModel model, IInfrastructure<IServiceProvider>? accessor, DataOptions? dataOptions)

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.cs
@@ -282,7 +282,12 @@ namespace LinqToDB.EntityFrameworkCore
 			// ShouldUseSameServiceProvider / GetServiceProviderHashCode) — the same key EF's own
 			// ServiceProviderCache uses. Being content-based, equivalent-but-distinct options
 			// objects still map to one schema, which is what the sharing above relies on.
-			return options;
+			// The application service provider takes no part in that equality, and this key lives for
+			// the process lifetime, so drop it first — as EF's own ServiceProviderCache does.
+			return options.FindExtension<CoreOptionsExtension>() is { ApplicationServiceProvider: not null } coreExtension
+				&& options is DbContextOptions contextOptions
+					? contextOptions.WithExtension(coreExtension.WithApplicationServiceProvider(null))
+					: options;
 #endif
 		}
 

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFTools.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 
 using JetBrains.Annotations;
 
@@ -93,13 +94,17 @@ namespace LinqToDB.EntityFrameworkCore
 			{
 				ArgumentNullException.ThrowIfNull(value);
 				_implementation = value;
-				_metadataReaders.Clear();
+				_metadataReaders = new();
 				_mappingSchemas .Clear();
 				_defaultMetadataReader = new Lazy<IMetadataReader?>(() => Implementation.CreateMetadataReader(null, null));
 			}
 		}
 
-		static readonly ConcurrentDictionary<IModel, IMetadataReader?> _metadataReaders = new();
+		// Weak-keyed: a cached reader must not keep its model alive. Contexts that build a fresh model
+		// each time (EnableServiceProviderCaching(false), pooled contexts, several providers) would
+		// otherwise add one never-evicted entry per DbContext instance. Reassigned rather than cleared
+		// because ConditionalWeakTable.Clear() is not available on the netstandard2.0 / net462 builds.
+		static ConditionalWeakTable<IModel, IMetadataReader> _metadataReaders = new();
 
 		static Lazy<IMetadataReader?> _defaultMetadataReader;
 
@@ -110,7 +115,7 @@ namespace LinqToDB.EntityFrameworkCore
 		/// </summary>
 		public static void ClearCaches()
 		{
-			_metadataReaders.Clear();
+			_metadataReaders = new();
 			_mappingSchemas .Clear();
 			Implementation.ClearCaches();
 			Query.ClearCaches();
@@ -136,7 +141,16 @@ namespace LinqToDB.EntityFrameworkCore
 			if (model == null)
 				return _defaultMetadataReader.Value;
 
-			return _metadataReaders.GetOrAdd(model, static (m, a) => Implementation.CreateMetadataReader(m, a), accessor);
+			var readers = _metadataReaders;
+
+			if (readers.TryGetValue(model, out var reader))
+				return reader;
+
+			// A null reader is not cached: ConditionalWeakTable cannot store one, and the shipped
+			// implementation never returns null.
+			var created = Implementation.CreateMetadataReader(model, accessor);
+
+			return created == null ? null : readers.GetValue(model, _ => created);
 		}
 
 		/// <summary>

--- a/Tests/EntityFrameworkCore/Tests/MappingSchemaCacheTests.cs
+++ b/Tests/EntityFrameworkCore/Tests/MappingSchemaCacheTests.cs
@@ -206,9 +206,9 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 
 		/// <summary>
 		/// The metadata-reader cache is keyed on the <c>IModel</c> instance, so it must not keep that
-		/// model alive. Contexts that build a fresh model each time — <c>EnableServiceProviderCaching(false)</c>,
-		/// pooled contexts, several providers — would otherwise add one never-evicted entry per
-		/// <see cref="DbContext"/> instance.
+		/// model alive. A configuration that defeats EF's model caching — <c>EnableServiceProviderCaching(false)</c>,
+		/// or a freshly built model passed to <c>UseModel</c> per context — would otherwise add one
+		/// never-evicted entry per <see cref="DbContext"/> instance.
 		/// </summary>
 		[Test]
 		public void MetadataReaderCacheDoesNotRetainModel()

--- a/Tests/EntityFrameworkCore/Tests/MappingSchemaCacheTests.cs
+++ b/Tests/EntityFrameworkCore/Tests/MappingSchemaCacheTests.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 using LinqToDB.Internal.Common;
 using LinqToDB.Mapping;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 using Microsoft.Extensions.DependencyInjection;
 
@@ -177,13 +179,7 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 		[Test]
 		public void CachesDoNotRetainApplicationServiceProvider()
 		{
-			var applicationServices = BuildSchemaAndDiscardContext();
-
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-			GC.Collect();
-
-			applicationServices.IsAlive.ShouldBeFalse();
+			ShouldBeCollected(BuildSchemaAndDiscardContext());
 
 			[MethodImpl(MethodImplOptions.NoInlining)]
 			static WeakReference BuildSchemaAndDiscardContext()
@@ -208,32 +204,49 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 		/// The metadata-reader cache is keyed on the <c>IModel</c> instance, so it must not keep that
 		/// model alive. A configuration that defeats EF's model caching — <c>EnableServiceProviderCaching(false)</c>,
 		/// or a freshly built model passed to <c>UseModel</c> per context — would otherwise add one
-		/// never-evicted entry per <see cref="DbContext"/> instance.
+		/// never-evicted entry per <see cref="DbContext"/> instance. The cached reader references the
+		/// model it was built from, so only a weakly-keyed cache releases it.
 		/// </summary>
+		/// <remarks>
+		/// The model is built directly rather than taken from a <see cref="DbContext"/>: a context drags
+		/// in EF's internal service provider and the DI engine, whose background call-site compilation
+		/// keeps parts of that graph transiently rooted, and no amount of collecting releases them until
+		/// that work has run. Keying the assertion on the cache alone keeps it deterministic.
+		/// </remarks>
 		[Test]
 		public void MetadataReaderCacheDoesNotRetainModel()
 		{
-			var model = BuildReaderAndDiscardContext();
-
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-			GC.Collect();
-
-			model.IsAlive.ShouldBeFalse();
+			ShouldBeCollected(BuildReaderAndDiscardModel());
 
 			[MethodImpl(MethodImplOptions.NoInlining)]
-			static WeakReference BuildReaderAndDiscardContext()
+			static WeakReference BuildReaderAndDiscardModel()
 			{
-				using var ctx = new RetentionContext(
-					new DbContextOptionsBuilder<RetentionContext>()
-						.EnableServiceProviderCaching(false)
-						.UseSqlite("Data Source=:memory:")
-						.Options);
+				var model = new Model();
 
-				LinqToDBForEFTools.GetMetadataReader(ctx.Model, ctx);
+				LinqToDBForEFTools.GetMetadataReader(model, null);
 
-				return new WeakReference(ctx.Model);
+				return new WeakReference(model);
 			}
+		}
+
+		/// <summary>
+		/// Collects until <paramref name="reference"/> dies, giving up after a bounded number of rounds.
+		/// The pause matters as much as the collection: an EF object graph stays transiently rooted by
+		/// thread-pool work items queued while it was alive, which further collections cannot clear.
+		/// </summary>
+		static void ShouldBeCollected(WeakReference reference)
+		{
+			for (var i = 0; i < 20 && reference.IsAlive; i++)
+			{
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+				GC.Collect();
+
+				if (reference.IsAlive)
+					Thread.Sleep(50);
+			}
+
+			reference.IsAlive.ShouldBeFalse();
 		}
 	}
 }

--- a/Tests/EntityFrameworkCore/Tests/MappingSchemaCacheTests.cs
+++ b/Tests/EntityFrameworkCore/Tests/MappingSchemaCacheTests.cs
@@ -1,10 +1,14 @@
+using System;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 using LinqToDB.Internal.Common;
 using LinqToDB.Mapping;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+
+using Microsoft.Extensions.DependencyInjection;
 
 using NUnit.Framework;
 
@@ -156,5 +160,48 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 				.Columns
 				.Single(c => c.MemberName == nameof(ProviderSplitItem.Name))
 				.ColumnName;
+
+		public class RetentionContext(DbContextOptions options) : DbContext(options)
+		{
+			public DbSet<Item> Items { get; set; } = null!;
+		}
+
+		/// <summary>
+		/// The process-wide caches must not outlive the application service provider of the context
+		/// that populated them. With <c>EnableServiceProviderCaching(false)</c> EF builds a fresh
+		/// <c>IModel</c> per context, so a strongly-keyed cache entry per model pins one application
+		/// scope per <see cref="DbContext"/> instance. EF avoids this in its own long-lived key:
+		/// <c>ServiceProviderCache.GetOrAdd</c> replaces the options' core extension with
+		/// <c>WithApplicationServiceProvider(null)</c> before storing it.
+		/// </summary>
+		[Test]
+		public void CachesDoNotRetainApplicationServiceProvider()
+		{
+			var applicationServices = BuildSchemaAndDiscardContext();
+
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			GC.Collect();
+
+			applicationServices.IsAlive.ShouldBeFalse();
+
+			[MethodImpl(MethodImplOptions.NoInlining)]
+			static WeakReference BuildSchemaAndDiscardContext()
+			{
+				var services = new ServiceCollection().BuildServiceProvider();
+
+				using (var ctx = new RetentionContext(
+					new DbContextOptionsBuilder<RetentionContext>()
+						.EnableServiceProviderCaching(false)
+						.UseApplicationServiceProvider(services)
+						.UseSqlite("Data Source=:memory:")
+						.Options))
+				{
+					LinqToDBForEFTools.GetMappingSchema(ctx.Model, ctx, null);
+				}
+
+				return new WeakReference(services);
+			}
+		}
 	}
 }

--- a/Tests/EntityFrameworkCore/Tests/MappingSchemaCacheTests.cs
+++ b/Tests/EntityFrameworkCore/Tests/MappingSchemaCacheTests.cs
@@ -1,6 +1,10 @@
+using System.Linq;
+
 using LinqToDB.Internal.Common;
+using LinqToDB.Mapping;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 
 using NUnit.Framework;
 
@@ -57,5 +61,100 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 
 			id2.ShouldBe(id1);
 		}
+
+		const string SqliteNameColumn    = "name_sqlite";
+		const string SqlServerNameColumn = "name_mssql";
+
+		public class ProviderSplitItem
+		{
+			public int     Id   { get; set; }
+			public string? Name { get; set; }
+		}
+
+		/// <summary>
+		/// One context type mapping a property differently per provider — the shape reported in
+		/// <a href="https://github.com/linq2db/linq2db/issues/5778">#5778</a>. EF's default model
+		/// cache key is the context type alone, so it cannot tell the two models apart.
+		/// </summary>
+		public class ProviderSplitContext(DbContextOptions options) : DbContext(options)
+		{
+			public DbSet<ProviderSplitItem> Items { get; set; } = null!;
+
+			protected override void OnModelCreating(ModelBuilder modelBuilder)
+			{
+				modelBuilder.Entity<ProviderSplitItem>()
+					.Property(e => e.Name)
+					.HasColumnName(Database.IsSqlite() ? SqliteNameColumn : SqlServerNameColumn);
+			}
+		}
+
+		/// <summary>
+		/// The schema cache must not share a schema between contexts of the same type running on
+		/// different providers: the model, and therefore the schema, differs per provider. Neither
+		/// context connects — only the model and the mapping schema are built.
+		/// </summary>
+		[Test]
+		public void MappingSchemaNotSharedBetweenProviders()
+		{
+			using var sqlite = new ProviderSplitContext(
+				new DbContextOptionsBuilder<ProviderSplitContext>()
+					.UseSqlite("Data Source=:memory:")
+					.Options);
+
+			using var sqlServer = new ProviderSplitContext(
+				new DbContextOptionsBuilder<ProviderSplitContext>()
+					.UseSqlServer("Server=.;Database=MappingSchemaCacheTests;Integrated Security=SSPI;TrustServerCertificate=true")
+					.Options);
+
+			var sqliteSchema    = LinqToDBForEFTools.GetMappingSchema(sqlite   .Model, sqlite   , null);
+			var sqlServerSchema = LinqToDBForEFTools.GetMappingSchema(sqlServer.Model, sqlServer, null);
+
+			GetNameColumn(sqliteSchema   ).ShouldBe(SqliteNameColumn);
+			GetNameColumn(sqlServerSchema).ShouldBe(SqlServerNameColumn);
+		}
+
+		const string CustomizedNameColumn = "name_customized";
+
+		sealed class RenamingModelCustomizer(ModelCustomizerDependencies dependencies) : ModelCustomizer(dependencies)
+		{
+			public override void Customize(ModelBuilder modelBuilder, DbContext context)
+			{
+				base.Customize(modelBuilder, context);
+
+				modelBuilder.Entity<ProviderSplitItem>()
+					.Property(e => e.Name)
+					.HasColumnName(CustomizedNameColumn);
+			}
+		}
+
+		/// <summary>
+		/// Same context type, same provider, but a replaced service that changes the model. EF treats
+		/// a replaced service as requiring its own internal service provider (and therefore its own
+		/// model), so the schema cache must keep the two apart as well — which the provider name
+		/// alone could not express.
+		/// </summary>
+		[Test]
+		public void MappingSchemaNotSharedBetweenReplacedServices()
+		{
+			using var plain = new ProviderSplitContext(
+				new DbContextOptionsBuilder<ProviderSplitContext>()
+					.UseSqlite("Data Source=:memory:")
+					.Options);
+
+			using var customized = new ProviderSplitContext(
+				new DbContextOptionsBuilder<ProviderSplitContext>()
+					.UseSqlite("Data Source=:memory:")
+					.ReplaceService<IModelCustomizer, RenamingModelCustomizer>()
+					.Options);
+
+			GetNameColumn(LinqToDBForEFTools.GetMappingSchema(plain     .Model, plain     , null)).ShouldBe(SqliteNameColumn);
+			GetNameColumn(LinqToDBForEFTools.GetMappingSchema(customized.Model, customized, null)).ShouldBe(CustomizedNameColumn);
+		}
+
+		static string? GetNameColumn(MappingSchema schema)
+			=> schema.GetEntityDescriptor(typeof(ProviderSplitItem))
+				.Columns
+				.Single(c => c.MemberName == nameof(ProviderSplitItem.Name))
+				.ColumnName;
 	}
 }

--- a/Tests/EntityFrameworkCore/Tests/MappingSchemaCacheTests.cs
+++ b/Tests/EntityFrameworkCore/Tests/MappingSchemaCacheTests.cs
@@ -203,5 +203,37 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 				return new WeakReference(services);
 			}
 		}
+
+		/// <summary>
+		/// The metadata-reader cache is keyed on the <c>IModel</c> instance, so it must not keep that
+		/// model alive. Contexts that build a fresh model each time — <c>EnableServiceProviderCaching(false)</c>,
+		/// pooled contexts, several providers — would otherwise add one never-evicted entry per
+		/// <see cref="DbContext"/> instance.
+		/// </summary>
+		[Test]
+		public void MetadataReaderCacheDoesNotRetainModel()
+		{
+			var model = BuildReaderAndDiscardContext();
+
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			GC.Collect();
+
+			model.IsAlive.ShouldBeFalse();
+
+			[MethodImpl(MethodImplOptions.NoInlining)]
+			static WeakReference BuildReaderAndDiscardContext()
+			{
+				using var ctx = new RetentionContext(
+					new DbContextOptionsBuilder<RetentionContext>()
+						.EnableServiceProviderCaching(false)
+						.UseSqlite("Data Source=:memory:")
+						.Options);
+
+				LinqToDBForEFTools.GetMetadataReader(ctx.Model, ctx);
+
+				return new WeakReference(ctx.Model);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Fixes #5778 — regression introduced in 6.4.0 by #5695.

## Cause

`LinqToDBForEFTools._mappingSchemas` keyed on `(modelKey, DataOptions, tracking)`, where `modelKey` comes from `IModelCacheKeyFactory`. EF's default `ModelCacheKey` is `(context type, designTime)`, which is unique only *within one EF internal service provider* — EF's own model cache lives there, and it differs per provider. Our cache is process-global, and `new DataOptions()` compares equal by value, so one `DbContext` type used with two providers in one process collapsed to a single key: the first model discovered won for both, producing wrong column names/types in generated SQL and the reported `BulkCopy` failure on a column the other provider does not map.

## Change

- The key gains a service-provider identity component (`GetServiceKey`): on EF 8/9/10 the `IDbContextOptions` instance itself — its `Equals`/`GetHashCode` are defined over exactly the options that require a distinct EF internal service provider (`DbContextOptionsExtensionInfo.ShouldUseSameServiceProvider` / `GetServiceProviderHashCode`), i.e. the same key EF's own `ServiceProviderCache` uses. Being content-based, equivalent-but-distinct options objects (pooled contexts, `EnableServiceProviderCaching(false)`) still map to one schema and therefore one `ConfigurationID`, which is what #5695 needed. EF 3.1 has no such equality, so that build reproduces the key EF 3.1's own `ServiceProviderCache` used (extension type list + aggregated hash).
- `LinqToDBOptionsExtension`'s `ShouldUseSameServiceProvider` now answers `true` only for another instance of itself instead of unconditionally. EF compares extensions pairwise by position, so the old answer could make two different configurations look like one — to EF's service provider cache as well as to the key above.

Provider name alone would fix the reported case but would still over-share when two same-provider contexts differ in something EF treats as service-affecting (`ReplaceService<IModelCustomizer, …>`, `UseNetTopologySuite()`, Npgsql `MapEnum<T>()` / `UseNodaTime()`) — those change the model or the type mappings the schema is built from. The second test below pins that case.

No public API change.

## Tests

`Tests/EntityFrameworkCore/Tests/MappingSchemaCacheTests.cs`, both red before the change (verified by running against the pre-fix build, standalone and inside the full fixture) and green after:

- `MappingSchemaNotSharedBetweenProviders` — one context type mapping a column differently per provider (the reported shape); pre-fix the SQL Server context received the SQLite schema.
- `MappingSchemaNotSharedBetweenReplacedServices` — same context type and provider, one side with a replaced `IModelCustomizer` that renames a column; pre-fix the second context received the first schema.

Neither test opens a connection — only the model and the mapping schema are built. #5695's `MappingSchemaIdentityStableAcrossContexts` stays green, which is what proves the new component is content-based rather than instance-based.

## Verification

- All three fixture tests green on EF10, EF9, EF8. On EF3 (net462) both new tests are green.
- Full EF10 suite, `--provider SQLite.MS`: 184 total, 0 failed, 166 passed, 18 skipped.
- Release build (Roslyn analyzers + banned APIs) of the EF3 and EF10 source projects: clean.

Unrelated pre-existing observation: on EF3/net462 `MappingSchemaIdentityStableAcrossContexts` fails locally inside EF's `SqliteRelationalConnection.CreateDbConnection()` because that output directory carries an x86 `e_sqlite3.dll` ("%1 is not a valid Win32 application"). It is an environment/packaging issue in the net462 publish layout, independent of this change.

## Follow-up commits

Three commits added after review (`9160c07b2`, `651e89303`, `b67c1cd26`).

**The process-wide caches pinned EF objects for the lifetime of the process.** Proven by `CachesDoNotRetainApplicationServiceProvider` and `MetadataReaderCacheDoesNotRetainModel`, both red before the change and green after:

- `EFCoreMetadataReader` captured the context's `IDiagnosticsLogger<Query>`, whose `Interceptors` holds the `CoreOptionsExtension` and so the application service provider — a per-request DI scope under the default `AddDbContext` registration, which defaults `optionsLifetime` to `Scoped`. The logger is now built from its parts without interceptors, the way EF's own `ServiceProviderCache` builds one.
- `EFCoreMetadataReader` captured `DatabaseDependencies` unconditionally, which reaches `IDbContextOptions` through `QueryCompilationContextDependencies`. Only Pomelo's translator provider ever reads it, so it is captured only for Pomelo.
- The mapping-schema cache key added here is the `IDbContextOptions` instance. The application service provider takes no part in its equality, so it is dropped before the options become a key — as EF does for its own long-lived key.
- `_metadataReaders` is keyed on the `IModel` instance and never evicted, so a fresh model per context (`EnableServiceProviderCaching(false)`, pooled contexts, several providers) added one permanent entry per `DbContext` instance. It is now a `ConditionalWeakTable`, whose ephemeron semantics handle the cached reader's back-reference to the model that keys it.

**Correction to the Change section above.** The claim that answering `ShouldUseSameServiceProvider` unconditionally "could make two different configurations look like one" does not hold in practice: both service-provider caches are hash-keyed and `DbContextOptions.GetHashCode` folds each extension `Type`, so configurations with different extension sets never reach the pairwise `Equals` walk — only a hash collision would expose the old answer. The narrowing is hardening, not part of the #5778 fix, and the inline comment has been corrected to say so.

**Updated verification.** Full EF10 suite, `--provider SQLite.MS`: 186 total, 0 failed, 168 passed, 18 skipped. EF9 and EF8: 182 total, 0 failed, 164 passed, 18 skipped each. Release build of the EF3 (`netstandard2.0`/`net462`) and EF10 source projects: clean. Still no public API change.

Two further commits from a second review pass (`97aae5fa2`, `e7b422a91`): the Pomelo path now tests the captured `DatabaseDependencies` field instead of repeating the translator-provider name test, and the cache comments' model-churn examples are corrected — pooled contexts share one `IModel` (`AddDbContextPool` takes no options lifetime, and EF documents that the configuration cannot change between uses), and several providers give one model per provider configuration, not one per `DbContext`.

Two behaviour notes for release notes: diagnostics raised while the metadata reader probes translators no longer reach the creating context's `LogTo(...)` sink or its diagnostics interceptors, since the cached reader now builds its own logger; and on Pomelo/MySQL the reader still pins the context that built the model, because the [#1801](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1801) workaround needs that context's `DatabaseDependencies` — this change confines that pin from every provider to Pomelo alone.

One further commit (`41c328512`): `MetadataReaderCacheDoesNotRetainModel` failed on all 18 net462 (EF Core 3.1) legs and on two .NET 9 legs. Not a leak. The test collected EF's whole object graph (context, internal service provider, DI engine), parts of which stay transiently rooted by thread-pool work items queued while it was alive: a control probe making no linq2db call at all failed the same way, further collections never released the model while a pause between them did, and a bare `ConditionalWeakTable` value-to-key cycle collects normally on net462. The test now builds the model directly, so the graph under test is only the cache key and the reader referencing it, and both retention tests poll with a pause instead of collecting a fixed number of times. Green on net462/EF3 across three consecutive runs and on net10/EF10.
