### PR TITLE
Fix DB2 tests leaving ~90k rows in AllTypes, revert the ORDER BY workaround

### DIFF
--- a/Tests/Base/DataProvider/DataProviderTestBase.cs
+++ b/Tests/Base/DataProvider/DataProviderTestBase.cs
@@ -19,14 +19,9 @@ namespace Tests.DataProvider
 		{
 			// number of parameters to create for providers with unnamed parameters
 			paramCount = 1;
-			// ORDER BY ID: AllTypes is a shared fixture other tests also insert into (deliberately never
-			// cleaned up here - see TestBase.Identity.cs's ResetAllTypesIdentity - so a leftover row with a
-			// duplicate value is a real, if rare, possibility). Only the lookup's chosen row matters (Execute
-			// reads a single scalar), so ordering by ID makes it deterministically the lowest-ID (canonical)
-			// match instead of whichever row the engine happens to return first.
-			return "SELECT ID FROM {1} WHERE @p IS NULL AND {0} IS NULL OR @p IS NOT NULL AND {0} = @p ORDER BY ID";
+			return "SELECT ID FROM {1} WHERE @p IS NULL AND {0} IS NULL OR @p IS NOT NULL AND {0} = @p";
 		}
-		protected virtual string  PassValueSql(DataConnection dc) => "SELECT ID FROM {1} WHERE {0} = @p ORDER BY ID";
+		protected virtual string  PassValueSql(DataConnection dc) => "SELECT ID FROM {1} WHERE {0} = @p";
 
 		protected T TestType<T>(DataConnection conn, string fieldName,
 			DataType dataType          = DataType.Undefined,

--- a/Tests/Linq/Data/MiniProfilerTests.cs
+++ b/Tests/Linq/Data/MiniProfilerTests.cs
@@ -646,6 +646,10 @@ namespace Tests.Data
 			}
 
 			// bulk copy
+			// AllTypes.ID is GENERATED ALWAYS, so the IDs set below are discarded and the server assigns
+			// its own - clean up by the high-water mark rather than by a value we think we inserted.
+			var maxId = db.GetTable<ALLTYPE>().Select(_ => _.ID).Max();
+
 			try
 			{
 				db.BulkCopy(
@@ -656,7 +660,7 @@ namespace Tests.Data
 			}
 			finally
 			{
-				db.GetTable<ALLTYPE>().Delete(p => p.ID >= 2000);
+				db.GetTable<ALLTYPE>().Delete(p => p.ID > maxId);
 			}
 
 			// just check schema (no api used)

--- a/Tests/Linq/DataProvider/AccessTests.cs
+++ b/Tests/Linq/DataProvider/AccessTests.cs
@@ -46,12 +46,12 @@ namespace Tests.DataProvider
 		{
 			paramCount = dc.DataProvider.Name.IsAnyOf(TestProvName.AllAccessOdbc) ? 3 : 1;
 			return dc.DataProvider.Name.IsAnyOf(TestProvName.AllAccessOdbc)
-				? "SELECT ID FROM {1} WHERE ? IS NULL AND {0} IS NULL OR ? IS NOT NULL AND {0} = ? ORDER BY ID"
+				? "SELECT ID FROM {1} WHERE ? IS NULL AND {0} IS NULL OR ? IS NOT NULL AND {0} = ?"
 				: base.PassNullSql(dc, out paramCount);
 		}
 		protected override string PassValueSql(DataConnection dc) =>
 			dc.DataProvider.Name.IsAnyOf(TestProvName.AllAccessOdbc)
-				? "SELECT ID FROM {1} WHERE {0} = ? ORDER BY ID"
+				? "SELECT ID FROM {1} WHERE {0} = ?"
 				: base.PassValueSql(dc);
 
 		[Test]

--- a/Tests/Linq/DataProvider/DB2Tests.cs
+++ b/Tests/Linq/DataProvider/DB2Tests.cs
@@ -484,6 +484,11 @@ namespace Tests.DataProvider
 		void BulkCopyTest(string context, BulkCopyType bulkCopyType, int maxSize, int batchSize)
 		{
 			using var conn = GetDataContext(context);
+
+			// AllTypes.ID is GENERATED ALWAYS, so the IDs set below are discarded and the server assigns
+			// its own - clean up by the high-water mark rather than by a value we think we inserted.
+			var maxId = conn.GetTable<ALLTYPE>().Select(_ => _.ID).Max();
+
 			try
 			{
 				conn.BulkCopy(
@@ -521,13 +526,17 @@ namespace Tests.DataProvider
 			}
 			finally
 			{
-				conn.GetTable<ALLTYPE>().Delete(p => p.SMALLINTDATATYPE >= 5000);
+				conn.GetTable<ALLTYPE>().Delete(p => p.ID > maxId);
 			}
 		}
 
 		async Task BulkCopyTestAsync(string context, BulkCopyType bulkCopyType, int maxSize, int batchSize)
 		{
 			using var conn = GetDataContext(context);
+
+			// see BulkCopyTest: the supplied IDs are discarded, so clean up by the high-water mark.
+			var maxId = conn.GetTable<ALLTYPE>().Select(_ => _.ID).Max();
+
 			try
 			{
 				await conn.BulkCopyAsync(
@@ -564,7 +573,7 @@ namespace Tests.DataProvider
 			}
 			finally
 			{
-				await conn.GetTable<ALLTYPE>().DeleteAsync(p => p.SMALLINTDATATYPE >= 5000);
+				await conn.GetTable<ALLTYPE>().DeleteAsync(p => p.ID > maxId);
 			}
 		}
 

--- a/Tests/Linq/DataProvider/InformixTests.cs
+++ b/Tests/Linq/DataProvider/InformixTests.cs
@@ -30,7 +30,7 @@ namespace Tests.DataProvider
 			paramCount = 1;
 			return null;
 		}
-		protected override string  PassValueSql(DataConnection dc) => "SELECT ID FROM {1} WHERE {0} = ? ORDER BY ID";
+		protected override string  PassValueSql(DataConnection dc) => "SELECT ID FROM {1} WHERE {0} = ?";
 
 		[Test]
 		public void TestDataTypes([IncludeDataSources(CurrentProvider)] string context)

--- a/Tests/Linq/DataProvider/PostgreSQLTests.cs
+++ b/Tests/Linq/DataProvider/PostgreSQLTests.cs
@@ -51,10 +51,10 @@ namespace Tests.DataProvider
 		protected override string? PassNullSql(DataConnection dc, out int paramCount)
 		{
 			paramCount = 1;
-			return "SELECT \"ID\" FROM \"AllTypes\" WHERE :p IS NULL AND \"{0}\" IS NULL OR :p IS NOT NULL AND \"{0}\" = :p ORDER BY \"ID\"";
+			return "SELECT \"ID\" FROM \"AllTypes\" WHERE :p IS NULL AND \"{0}\" IS NULL OR :p IS NOT NULL AND \"{0}\" = :p";
 		}
 		protected override string  GetNullSql  (DataConnection dc) => "SELECT \"{0}\" FROM {1} WHERE \"ID\" = 1";
-		protected override string  PassValueSql(DataConnection dc) => "SELECT \"ID\" FROM \"AllTypes\" WHERE \"{0}\" = :p ORDER BY \"ID\"";
+		protected override string  PassValueSql(DataConnection dc) => "SELECT \"ID\" FROM \"AllTypes\" WHERE \"{0}\" = :p";
 		protected override string  GetValueSql (DataConnection dc) => "SELECT \"{0}\" FROM {1} WHERE \"ID\" = 2";
 
 		[Test]

--- a/Tests/Linq/DataProvider/SapHanaTests.cs
+++ b/Tests/Linq/DataProvider/SapHanaTests.cs
@@ -55,13 +55,13 @@ namespace Tests.DataProvider
 		{
 			paramCount = 1;
 			return dc.DataProvider.Name == ProviderName.SapHanaOdbc
-				? "SELECT \"ID\" FROM {1} WHERE \"{0}\" IS NULL AND ? IS NULL ORDER BY \"ID\""
-				: "SELECT \"ID\" FROM {1} WHERE \"{0}\" IS NULL AND :p IS NULL ORDER BY \"ID\"";
+				? "SELECT \"ID\" FROM {1} WHERE \"{0}\" IS NULL AND ? IS NULL"
+				: "SELECT \"ID\" FROM {1} WHERE \"{0}\" IS NULL AND :p IS NULL";
 		}
 		protected override string  PassValueSql(DataConnection dc) =>
 			dc.DataProvider.Name == ProviderName.SapHanaOdbc
-				? "SELECT \"ID\" FROM {1} WHERE \"{0}\" = ? ORDER BY \"ID\""
-				: "SELECT \"ID\" FROM {1} WHERE \"{0}\" = :p ORDER BY \"ID\"";
+				? "SELECT \"ID\" FROM {1} WHERE \"{0}\" = ?"
+				: "SELECT \"ID\" FROM {1} WHERE \"{0}\" = :p";
 
 		[Test]
 		public void TestParameters([IncludeDataSources(CurrentProvider)] string context)


### PR DESCRIPTION
Fixes #5765.

`DataProviderTestBase.TestType` resolves `SELECT ID FROM AllTypes WHERE <field> IS NULL / = @p` and takes the first row, so any leftover row displaces the seeded rows 1/2 and `DB2Tests.TestDataTypes` fails with ids like 50773 / 182126 / 216310 in place of 1 / 2.

## Who leaves the rows

A local DB2 run instrumented to report every change in the leftover row count named the writers exactly:

```
grew   0->1000      MiniProfilerTests.TestDB2("DB2",Raw)
grew   1000->1997   MiniProfilerTests.TestDB2("DB2",MiniProfiler)
grew   1997->46462  DB2Tests.BulkCopyProviderSpecific("DB2")
grew   46462->90927 DB2Tests.BulkCopyProviderSpecificAsync("DB2")
shrank 90927->0     TransactionTests.AutoRollbackTransaction("DB2")
```

~90 900 rows per DB2 run, which is what drives the identity burn behind the ids seen in CI.

Both cleanups look correct and delete nothing:

- `TestDB2` bulk-copies rows as `new ALLTYPE { ID = 2000 + n }` and deletes `ID >= 2000`, but `AllTypes.ID` is `GENERATED ALWAYS AS IDENTITY` — DB2 discards the supplied ids and assigns its own low values, so the predicate matches no row.
- `BulkCopyTest` inserts 100 001 rows and deletes `SMALLINTDATATYPE >= 5000`, where the column is set to `(short)(5000 + n)`. That cast wraps negative once `n` passes 27 767, so every row beyond the wrap escapes the filter.

Both now capture the id high-water mark before the copy and delete `ID > maxId` in the `finally`, which is immune to either trap.

The rows were invisible after the fact because `RestoreBaseTables.Dispose` deletes `ID > 2`, so whichever test uses it next wipes them — which is why a post-run check finds a clean table and this looked like it did not reproduce locally.

## Reverts the ORDER BY workaround

Also reverts the `DataProviderTestBase` `ORDER BY ID` changes from #5754 (test half only; the DB2 `AUTO_STMT_STATS` setting it shipped alongside is kept). That change made the lookup pick the lowest-id match so a leftover row could not win, which treated the symptom — with the writers fixed there is nothing to disambiguate, and the test SQL goes back to expressing what it actually asserts.

## Scope

Only the DB2 sites are changed. `MiniProfilerTests` uses the same `delete ID >= 2000` cleanup for several other providers, but those allow identity insert, so the supplied ids land and the cleanup works; no leftovers were measured for them.

## Testing

Test-only change, verified by build. The measurement above came from a full local DB2 leg (9141 tests); the acceptance check on CI is `DB2Tests.TestDataTypes` staying green with no leftover rows reported.
