### PR TITLE
Add [QueryCacheTest] and mark the query-cache-dependent tests

### DIFF
--- a/Tests/Base/Attributes/QueryCacheTestAttribute.cs
+++ b/Tests/Base/Attributes/QueryCacheTestAttribute.cs
@@ -1,0 +1,69 @@
+using System;
+
+using LinqToDB.Internal.Linq;
+
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+
+namespace Tests
+{
+	/// <summary>
+	/// Marks a test that depends on process-global query-cache state - typically asserting exact
+	/// <c>GetCacheMissCount()</c> deltas, query-object identity across two executions, or clearing the
+	/// cache itself. Such a test needs two things that ordinary tests do not:
+	/// <list type="number">
+	/// <item>no other test may run concurrently, because <c>Query&lt;T&gt;</c> reads the process-wide
+	/// <see cref="QueryCache.Default"/> and a concurrent test's compilation perturbs the counters;</item>
+	/// <item>nothing may be evicted from the cache while it runs, because netfx / 32-bit runs cap the
+	/// cache at 100 entries (see TestsInitialization) and a suite that has already filled it evicts the
+	/// entry the test expects to hit - which reads as one extra compilation.</item>
+	/// </list>
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Derives from <see cref="ParallelizableAttribute"/> with <see cref="ParallelScope.None"/> so the
+	/// scope is published through the same <c>ParallelScope</c> property NUnit's own
+	/// <c>[NonParallelizable]</c> uses - which is what the test run's dispatcher reads to route work to
+	/// the globally-exclusive lane.
+	/// </para>
+	/// <para>
+	/// The second guarantee is met by lifting the cap for the duration of the test (restoring the
+	/// configured value afterwards), not by clearing the cache. Clearing would break the many tests
+	/// parameterised by iteration (<c>[Values(1, 2)] int iteration</c>), where the first case warms the
+	/// cache and the second asserts it was hit: NUnit fires <see cref="ITestAction"/> per test *case*, so
+	/// a clear lands between them. Lifting the cap keeps those entries and still rules out eviction.
+	/// Memory stays bounded - only this one exclusive test adds entries while the cap is lifted, and the
+	/// first <c>Add</c> after it is restored trims back to the configured size.
+	/// </para>
+	/// </remarks>
+	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
+	public sealed class QueryCacheTestAttribute : ParallelizableAttribute, ITestAction
+	{
+		// Captured once, before the first test lifts it, so a mispaired Before/After can never leave the
+		// run uncapped - restoring always targets the value TestsInitialization configured.
+		static int? _configuredCap;
+		static bool _capCaptured;
+
+		public QueryCacheTestAttribute() : base(ParallelScope.None)
+		{
+		}
+
+		public ActionTargets Targets => ActionTargets.Test;
+
+		public void BeforeTest(ITest test)
+		{
+			if (!_capCaptured)
+			{
+				_configuredCap = QueryCache.Default.MaxEntriesOverride;
+				_capCaptured   = true;
+			}
+
+			QueryCache.Default.MaxEntriesOverride = null;
+		}
+
+		public void AfterTest(ITest test)
+		{
+			QueryCache.Default.MaxEntriesOverride = _configuredCap;
+		}
+	}
+}

--- a/Tests/Linq/DataProvider/PostgreSQLArrayTests.cs
+++ b/Tests/Linq/DataProvider/PostgreSQLArrayTests.cs
@@ -40,7 +40,7 @@ namespace Tests.DataProvider
 			}
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void ArrayParameterCacheTest_Int([IncludeDataSources(TestProvName.AllPostgreSQL)] string context, [Values(1, 2)] int iteration)
 		{
 			using var db    = GetDataContext(context);
@@ -61,7 +61,7 @@ namespace Tests.DataProvider
 			}
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void ArrayParameterCacheTest_Long([IncludeDataSources(TestProvName.AllPostgreSQL)] string context, [Values(1, 2)] int iteration)
 		{
 			using var db    = GetDataContext(context);
@@ -82,7 +82,7 @@ namespace Tests.DataProvider
 			}
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void ArrayParameterCacheTest_Short([IncludeDataSources(TestProvName.AllPostgreSQL)] string context, [Values(1, 2)] int iteration)
 		{
 			using var db    = GetDataContext(context);
@@ -103,7 +103,7 @@ namespace Tests.DataProvider
 			}
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void ArrayParameterCacheTest_String([IncludeDataSources(TestProvName.AllPostgreSQL)] string context, [Values(1, 2)] int iteration)
 		{
 			using var db    = GetDataContext(context);
@@ -124,7 +124,7 @@ namespace Tests.DataProvider
 			}
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void ArrayParameterCacheTest_Double([IncludeDataSources(TestProvName.AllPostgreSQL)] string context, [Values(1, 2)] int iteration)
 		{
 			using var db    = GetDataContext(context);
@@ -145,7 +145,7 @@ namespace Tests.DataProvider
 			}
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void ArrayParameterCacheTest_Decimal([IncludeDataSources(TestProvName.AllPostgreSQL)] string context, [Values(1, 2)] int iteration)
 		{
 			using var db    = GetDataContext(context);
@@ -166,7 +166,7 @@ namespace Tests.DataProvider
 			}
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void ArrayParameterCacheTest_Float([IncludeDataSources(TestProvName.AllPostgreSQL)] string context, [Values(1, 2)] int iteration)
 		{
 			using var db    = GetDataContext(context);
@@ -187,7 +187,7 @@ namespace Tests.DataProvider
 			}
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void ArrayParameterCacheTest_Guid([IncludeDataSources(TestProvName.AllPostgreSQL)] string context, [Values(1, 2)] int iteration)
 		{
 			using var db    = GetDataContext(context);
@@ -210,7 +210,7 @@ namespace Tests.DataProvider
 			}
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void ArrayParameterCacheTest_DateTime([IncludeDataSources(TestProvName.AllPostgreSQL)] string context, [Values(1, 2)] int iteration)
 		{
 			using var db    = GetDataContext(context);
@@ -233,7 +233,7 @@ namespace Tests.DataProvider
 			}
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void ArrayParameterCacheTest_Bool([IncludeDataSources(TestProvName.AllPostgreSQL)] string context, [Values(1, 2)] int iteration)
 		{
 			using var db    = GetDataContext(context);

--- a/Tests/Linq/DataProvider/PostgreSQLExtensionsTests.cs
+++ b/Tests/Linq/DataProvider/PostgreSQLExtensionsTests.cs
@@ -52,7 +52,7 @@ namespace Tests.DataProvider
 			}
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void Unnest([IncludeDataSources(TestProvName.AllPostgreSQL95Plus)] string context, [Values(1, 2)] int iteration)
 		{
 			var testData = SampleClass.Seed();
@@ -445,7 +445,7 @@ namespace Tests.DataProvider
 			_ = query.ToArray();
 		}
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/5480")]
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5480"), QueryCacheTest]
 		public void FromSqlScalarCache([IncludeDataSources(TestProvName.AllPostgreSQL95Plus)] string context, [Values(1, 2)] int iteration)
 		{
 			var testData = SampleClass.Seed();
@@ -466,7 +466,7 @@ namespace Tests.DataProvider
 			}
 		}
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/5480")]
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5480"), QueryCacheTest]
 		public void UnnestCache([IncludeDataSources(TestProvName.AllPostgreSQL95Plus)] string context, [Values(1, 2)] int iteration)
 		{
 			var       testData = SampleClass.Seed();
@@ -487,7 +487,7 @@ namespace Tests.DataProvider
 			}
 		}
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/5480")]
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5480"), QueryCacheTest]
 		public void UnnestWithOrdinalityCache([IncludeDataSources(TestProvName.AllPostgreSQL95Plus)] string context, [Values(1, 2)] int iteration)
 		{
 			var       testData = SampleClass.Seed();
@@ -508,7 +508,7 @@ namespace Tests.DataProvider
 			}
 		}
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/5480")]
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5480"), QueryCacheTest]
 		public void GenerateSubscriptsCache([IncludeDataSources(TestProvName.AllPostgreSQL95Plus)] string context, [Values(1, 2)] int iteration)
 		{
 			var       testData = SampleClass.Seed();
@@ -529,7 +529,7 @@ namespace Tests.DataProvider
 			}
 		}
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/5480")]
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5480"), QueryCacheTest]
 		public void GenerateSubscriptsReverseCache([IncludeDataSources(TestProvName.AllPostgreSQL95Plus)] string context, [Values(1, 2)] int iteration)
 		{
 			var       testData = SampleClass.Seed();
@@ -550,7 +550,7 @@ namespace Tests.DataProvider
 			}
 		}
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/5480")]
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5480"), QueryCacheTest]
 		public void GenerateSeriesIntCache([IncludeDataSources(TestProvName.AllPostgreSQL95Plus)] string context, [Values(1, 2)] int iteration)
 		{
 			var       testData = SampleClass.Seed();
@@ -572,7 +572,7 @@ namespace Tests.DataProvider
 			}
 		}
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/5480")]
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5480"), QueryCacheTest]
 		public void GenerateSeriesIntStepCache([IncludeDataSources(TestProvName.AllPostgreSQL95Plus)] string context, [Values(1, 2)] int iteration)
 		{
 			var       testData = SampleClass.Seed();
@@ -595,7 +595,7 @@ namespace Tests.DataProvider
 			}
 		}
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/5480")]
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5480"), QueryCacheTest]
 		public void GenerateSeriesDateCache([IncludeDataSources(TestProvName.AllPostgreSQL95Plus)] string context, [Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);

--- a/Tests/Linq/Linq/AnalyticTests.cs
+++ b/Tests/Linq/Linq/AnalyticTests.cs
@@ -496,7 +496,7 @@ namespace Tests.Linq
 				Assert.Fail("Missing assertion");
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestFirstValueOracle([IncludeDataSources(true, TestProvName.AllOracle, TestProvName.AllDuckDB, TestProvName.AllPostgreSQL19Plus)] string context, [Values(Sql.Nulls.Ignore, Sql.Nulls.None)] Sql.Nulls nulls, [Values(1, 2)]int iteration)
 		{
 			using var db = GetDataContext(context);

--- a/Tests/Linq/Linq/CachingTests.cs
+++ b/Tests/Linq/Linq/CachingTests.cs
@@ -234,7 +234,7 @@ namespace Tests.Linq
 		}
 
 		[ActiveIssue]
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/4266")]
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4266"), QueryCacheTest]
 		public void TestExtensionCollectionParameterSameQuery([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
 		{
 			using var db = GetDataContext(context);
@@ -271,7 +271,7 @@ namespace Tests.Linq
 		}
 
 		[ActiveIssue]
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/4266")]
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4266"), QueryCacheTest]
 		public void TestExtensionCollectionParameterEqualQuery([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
 		{
 			using var db = GetDataContext(context);
@@ -357,7 +357,7 @@ namespace Tests.Linq
 		[Sql.Extension("{field} IN (select * from {values})", IsPredicate = true, ServerSideOnly = true)]
 		private static bool InExtStruct<T>([ExprParameter] T field, [ExprParameter] IntArrayStruct values) where T : struct, IEquatable<int> => throw new NotImplementedException();
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/4266")]
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4266"), QueryCacheTest]
 		public void Issue4266Test_Class([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
 		{
 			var ms = new MappingSchema();
@@ -396,7 +396,7 @@ namespace Tests.Linq
 			}
 		}
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/4266")]
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4266"), QueryCacheTest]
 		public void Issue4266Test_Struct([IncludeDataSources(TestProvName.AllSqlServer2008Plus)] string context)
 		{
 			var ms = new MappingSchema();

--- a/Tests/Linq/Linq/ConstantTests.cs
+++ b/Tests/Linq/Linq/ConstantTests.cs
@@ -140,7 +140,7 @@ namespace Tests.Linq
 			AssertQuery(query);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void static_readonly_access_readonly_members ([DataSources] string context)
 		{
 			using var db    = GetDataContext(context);
@@ -166,7 +166,7 @@ namespace Tests.Linq
 		}
 
 #if SUPPORTS_READONLY
-		[Test]
+		[Test, QueryCacheTest]
 		public void static_readonly_field_readonly_struct([DataSources] string context)
 		{
 			using var db    = GetDataContext(context);
@@ -191,7 +191,7 @@ namespace Tests.Linq
 			query2.GetCacheMissCount().ShouldBe(cacheMissCount);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void static_field_readonly_struct([DataSources] string context)
 		{
 			using var db    = GetDataContext(context);
@@ -217,7 +217,7 @@ namespace Tests.Linq
 		}
 #endif
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void static_field_readonly_members([DataSources] string context)
 		{
 			using var db    = GetDataContext(context);
@@ -242,7 +242,7 @@ namespace Tests.Linq
 			query2.GetCacheMissCount().ShouldBe(cacheMissCount);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void instance_readonly_members([DataSources] string context)
 		{
 			using var db    = GetDataContext(context);

--- a/Tests/Linq/Linq/DistinctTests.cs
+++ b/Tests/Linq/Linq/DistinctTests.cs
@@ -51,7 +51,7 @@ namespace Tests.Linq
 				(from p in db.Parent select new Parent { ParentID = p.Value1 ?? p.ParentID % 2, Value1 = p.Value1 }).Distinct());
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void Distinct5([DataSources] string context, [Values(2, 3)] int id, [Values(0, 1)] int iteration)
 		{
 			using var db = GetDataContext(context);
@@ -69,7 +69,7 @@ namespace Tests.Linq
 			query2.GetCacheMissCount().ShouldBe(cacheMissCount);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void Distinct6([DataSources] string context, [Values(2, 3)] int id, [Values(0, 1)] int iteration)
 		{
 			using var db = GetDataContext(context);

--- a/Tests/Linq/Linq/EagerLoadingStrategyUnionTests.cs
+++ b/Tests/Linq/Linq/EagerLoadingStrategyUnionTests.cs
@@ -1742,7 +1742,7 @@ namespace Tests.Linq
 
 		#region Query cache validation — iteration 2 must hit cache with correct values
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void Cache_Union_ParentFilterChanged(
 			[DataSources(true, TestProvName.AllAccess, TestProvName.AllFirebirdLess3)] string context,
 			[Values(1, 2)] int iteration)
@@ -1799,7 +1799,7 @@ namespace Tests.Linq
 			}
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void Cache_Union_ChildFilterChanged(
 			[DataSources(true, TestProvName.AllFirebirdLess3)] string context,
 			[Values(1, 2)] int iteration)
@@ -1874,7 +1874,7 @@ namespace Tests.Linq
 
 		// TODO: Handle Clickhouse correlated subquery in join expression
 		[ThrowsRequiresCorrelatedSubquery(simple: true)]
-		[Test]
+		[Test, QueryCacheTest]
 		public void Cache_Union_MultipleAssociationsFilterChanged(
 			[DataSources(true, TestProvName.AllAccess, TestProvName.AllClickHouse, TestProvName.AllFirebirdLess3)] string context,
 			[Values(1, 2)] int iteration)

--- a/Tests/Linq/Linq/EnumerableSourceTests.AsQueryable.cs
+++ b/Tests/Linq/Linq/EnumerableSourceTests.AsQueryable.cs
@@ -116,7 +116,7 @@ namespace Tests.Linq
 			sql.ShouldNotContain("'Data 7778'");
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void AsQueryable_Parameterize_CacheStable_AcrossDataChanges(
 			[DataSources(TestProvName.AllAccess, TestProvName.AllClickHouse)] string context)
 		{
@@ -141,7 +141,7 @@ namespace Tests.Linq
 			secondList[1].Id.ShouldBe(101);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void AsQueryable_Parameterize_CacheHit_AcrossIterations(
 			[DataSources(TestProvName.AllAccess, TestProvName.AllClickHouse)] string context,
 			[Values(1, 2)] int iteration)
@@ -161,7 +161,7 @@ namespace Tests.Linq
 				query.GetCacheMissCount().ShouldBe(cacheMiss);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void AsQueryable_Inline_CacheHit_AcrossIterations(
 			[DataSources(TestProvName.AllAccess)] string context,
 			[Values(1, 2)] int iteration)
@@ -182,7 +182,7 @@ namespace Tests.Linq
 				query.GetCacheMissCount().ShouldBe(cacheMiss);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void AsQueryable_Parameterize_ExceptId_CacheHit_AcrossIterations(
 			[DataSources(TestProvName.AllAccess, TestProvName.AllClickHouse)] string context,
 			[Values(1, 2)] int iteration)
@@ -265,7 +265,7 @@ namespace Tests.Linq
 			act.ShouldThrow<LinqToDBException>().Message.ShouldContain("AsQueryable configure");
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void AsQueryable_JoinPerson_CacheHit_AcrossIterations(
 			[DataSources(TestProvName.AllAccess, TestProvName.AllClickHouse)] string context,
 			[Values(1, 2)] int iteration)
@@ -288,7 +288,7 @@ namespace Tests.Linq
 				query.GetCacheMissCount().ShouldBe(cacheMiss);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void AsQueryable_CrossApply_CacheHit_AcrossIterations(
 			[IncludeDataSources(
 				TestProvName.AllSqlServer2008Plus,

--- a/Tests/Linq/Linq/EnumerableSourceTests.cs
+++ b/Tests/Linq/Linq/EnumerableSourceTests.cs
@@ -16,7 +16,7 @@ namespace Tests.Linq
 	[TestFixture]
 	public partial class EnumerableSourceTests : TestBase
 	{
-		[Test]
+		[Test, QueryCacheTest]
 		public void ApplyJoinArray(
 			[IncludeDataSources(
 				TestProvName.AllSqlServer2008Plus,
@@ -53,7 +53,7 @@ namespace Tests.Linq
 			}
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void InnerJoinArray(
 			[DataSources(TestProvName.AllAccess, ProviderName.DB2, TestProvName.AllInformix)] string context, [Values(1, 2)] int iteration)
 		{
@@ -79,7 +79,7 @@ namespace Tests.Linq
 			AreEqual(expected, result);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void InnerJoinArray2(
 			[DataSources(TestProvName.AllAccess, ProviderName.DB2, TestProvName.AllInformix)] string context, [Values(1, 2)] int iteration)
 		{
@@ -105,7 +105,7 @@ namespace Tests.Linq
 			AreEqual(expected, result);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void InnerJoinArray3(
 			[DataSources(TestProvName.AllAccess, ProviderName.DB2, TestProvName.AllInformix)] string context, [Values(1, 2)] int iteration)
 		{
@@ -138,7 +138,7 @@ namespace Tests.Linq
 			}
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void InnerJoinArray4(
 			[DataSources(TestProvName.AllAccess, ProviderName.DB2, TestProvName.AllInformix)] string context, [Values(1, 2)] int iteration)
 		{
@@ -172,7 +172,7 @@ namespace Tests.Linq
 			}
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void InnerJoinArray5(
 			[DataSources(TestProvName.AllAccess, ProviderName.DB2, TestProvName.AllInformix)] string context, [Values(1, 2)] int iteration)
 		{
@@ -202,7 +202,7 @@ namespace Tests.Linq
 			AreEqual(expected, result);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void InnerJoinArray6(
 			[DataSources(TestProvName.AllAccess, TestProvName.AllPostgreSQL9)] string context, [Values(1, 2)] int iteration)
 		{
@@ -227,7 +227,7 @@ namespace Tests.Linq
 			AreEqual(expected, result);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void InnerJoinArray6Postgres([IncludeDataSources(TestProvName.AllPostgreSQL9, TestProvName.AllClickHouse)] string context, [Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);
@@ -251,7 +251,7 @@ namespace Tests.Linq
 			AreEqual(expected, result);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void ApplyJoinAnonymousClassArray(
 			[IncludeDataSources(
 				TestProvName.AllSqlServer2008Plus,
@@ -288,7 +288,7 @@ namespace Tests.Linq
 			AreEqual(expected, result);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void ApplyJoinAnonymousClassArray2(
 			[IncludeDataSources(
 				TestProvName.AllSqlServer2008Plus,
@@ -325,7 +325,7 @@ namespace Tests.Linq
 			AreEqual(expected, result);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void ApplyJoinClassArray(
 			[IncludeDataSources(
 				TestProvName.AllSqlServer2008Plus,
@@ -362,7 +362,7 @@ namespace Tests.Linq
 			AreEqual(expected, result);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void OuterApplyJoinClassArray(
 			[IncludeDataSources(
 				TestProvName.AllSqlServer2008Plus,
@@ -400,7 +400,7 @@ namespace Tests.Linq
 			AreEqual(expected, result);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void InnerJoinClassArray(
 			[DataSources(TestProvName.AllAccess, ProviderName.DB2, TestProvName.AllInformix)] string context, [Values(1, 2)] int iteration)
 		{
@@ -427,7 +427,7 @@ namespace Tests.Linq
 			AreEqual(expected, result);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void InnerJoinAnonymousClassRecords(
 			[DataSources(TestProvName.AllAccess, ProviderName.DB2, TestProvName.AllInformix)] string context, [Values(1, 2)] int iteration)
 		{
@@ -454,7 +454,7 @@ namespace Tests.Linq
 			AreEqual(expected, result);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void InnerJoinClassRecords(
 			[DataSources(TestProvName.AllAccess, ProviderName.DB2, TestProvName.AllInformix)] string context, [Values(1, 2)] int iteration)
 		{
@@ -484,7 +484,7 @@ namespace Tests.Linq
 			AreEqual(expected, result);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void InnerJoinClassRecordsCache(
 			[DataSources(TestProvName.AllAccess, ProviderName.DB2, TestProvName.AllInformix)] string context,
 			[Values(1, 2)] int iteration)
@@ -528,7 +528,7 @@ namespace Tests.Linq
 			result2.Count.ShouldNotBe(result1.Count);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void Projection(
 			[DataSources(TestProvName.AllAccess, ProviderName.DB2, TestProvName.AllInformix)] string context,
 			[Values(1, 2)] int iteration)
@@ -548,7 +548,7 @@ namespace Tests.Linq
 				db.Person.GetCacheMissCount().ShouldBe(cacheMiss);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void NestingProperties(
 			[DataSources(TestProvName.AllAccess, ProviderName.DB2, TestProvName.AllInformix)] string context,
 			[Values(1, 2)]                                                                    int    iteration)
@@ -636,7 +636,7 @@ namespace Tests.Linq
 			}
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void InsertTest([DataSources(TestProvName.AllAccess, ProviderName.DB2, TestProvName.AllInformix)] string context, [Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);
@@ -666,7 +666,7 @@ namespace Tests.Linq
 				table.GetCacheMissCount().ShouldBe(cacheMiss);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		public void UpdateTest(
 			[DataSources(
@@ -709,7 +709,7 @@ namespace Tests.Linq
 		}
 
 		[ThrowsRequiresCorrelatedSubquery(simple: true)]
-		[Test]
+		[Test, QueryCacheTest]
 		public void DeleteTest(
 			[DataSources(TestProvName.AllAccess, TestProvName.AllSybase, TestProvName.AllSybase, TestProvName.AllInformix, TestProvName.AllClickHouse)] string context,
 			[Values(1, 2)] int iteration)
@@ -741,7 +741,7 @@ namespace Tests.Linq
 				table.GetCacheMissCount().ShouldBe(cacheMiss);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void CTETest([IncludeDataSources(TestProvName.AllSQLite)] string context, [Values(1, 2)] int iteration)
 		{
 			var records = new TableToInsert[]
@@ -767,7 +767,7 @@ namespace Tests.Linq
 				table.GetCacheMissCount().ShouldBe(cacheMiss);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void EmptyValues([DataSources(TestProvName.AllClickHouse, TestProvName.AllAccess, ProviderName.DB2, TestProvName.AllSybase, TestProvName.AllSybase, TestProvName.AllInformix)] string context, [Values(1, 2)] int iteration)
 		{
 			var records = Array.Empty<TableToInsert>();
@@ -806,7 +806,7 @@ namespace Tests.Linq
 		}
 
 		[ThrowsRequiresCorrelatedSubquery(simple: true)]
-		[Test]
+		[Test, QueryCacheTest]
 		public void SubQuery([DataSources(TestProvName.AllClickHouse, TestProvName.AllAccess, ProviderName.DB2, TestProvName.AllSybase, TestProvName.AllSybase, TestProvName.AllInformix)] string context, [Values(1, 2)] int iteration)
 		{
 			var records = new TableToInsert[]
@@ -832,7 +832,7 @@ namespace Tests.Linq
 				table.GetCacheMissCount().ShouldBe(cacheMiss);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		[ThrowsRequiresCorrelatedSubquery(simple: true)]
 		public void EmptySubQuery([DataSources(TestProvName.AllClickHouse, TestProvName.AllAccess, ProviderName.DB2, TestProvName.AllSybase, TestProvName.AllSybase, TestProvName.AllInformix)] string context, [Values(1, 2)] int iteration)
 		{
@@ -854,7 +854,7 @@ namespace Tests.Linq
 		}
 
 		[ThrowsRequiresCorrelatedSubquery(simple: true)]
-		[Test]
+		[Test, QueryCacheTest]
 		public void StringSubQuery(
 			[DataSources(
 				TestProvName.AllAccess,

--- a/Tests/Linq/Linq/ExpressionsTests.cs
+++ b/Tests/Linq/Linq/ExpressionsTests.cs
@@ -1118,7 +1118,7 @@ namespace Tests.Linq
 		#endregion
 
 		#region Regression: query comparison
-		[Test(Description = "Tests regression introduced in 3.5.2")]
+		[Test(Description = "Tests regression introduced in 3.5.2"), QueryCacheTest]
 		public void ComparisonTest1([DataSources(ProviderName.SqlCe, TestProvName.AllClickHouse)] string context, [Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);

--- a/Tests/Linq/Linq/FromSqlTests.cs
+++ b/Tests/Linq/Linq/FromSqlTests.cs
@@ -227,7 +227,7 @@ namespace Tests.Linq
 			Assert.That(projection, Is.EqualTo(expected));
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestParameters([DataSources(ProviderName.DB2, TestProvName.AllSapHana)] string context, [Values(1, 2)] int iteration, [Values(14, 15)] int endId)
 		{
 			using var db = GetDataContext(context);
@@ -490,7 +490,7 @@ namespace Tests.Linq
 			public string Value { get; set; } = default!;
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestSplitStringParametrized(
 			[IncludeDataSources(true, TestProvName.AllSqlServer2016Plus)]
 			string context, [Values(1, 2)] int iteration)
@@ -518,7 +518,7 @@ namespace Tests.Linq
 			query.GetSelectQuery().HasQueryParameter().ShouldBeTrue();
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestSplitStringParametrizedExplicitParameter(
 			[IncludeDataSources(true, TestProvName.AllSqlServer2016Plus)]
 			string context, [Values(1, 2)] int iteration)
@@ -562,7 +562,7 @@ namespace Tests.Linq
 			Shouldly.Should.Throw<Npgsql.PostgresException>(() => query.ToArray());
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestQueryCaching_Interpolated_DataParameter([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
 		{
 			using var db = GetDataContext(context);
@@ -585,7 +585,7 @@ namespace Tests.Linq
 			}
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestQueryCaching_Interpolated_ValueParameter([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
 		{
 			using var db = GetDataContext(context);
@@ -608,7 +608,7 @@ namespace Tests.Linq
 			}
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestQueryCaching_InterpolatedCache_BySqlExpressionParameter([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
 		{
 			using var db = GetDataContext(context);
@@ -633,7 +633,7 @@ namespace Tests.Linq
 			}
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestQueryCaching_Format_DataParameter([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
 		{
 			using var db = GetDataContext(context);
@@ -659,7 +659,7 @@ namespace Tests.Linq
 			}
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestQueryCaching_Format_ValueParameter([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
 		{
 			using var db = GetDataContext(context);
@@ -685,7 +685,7 @@ namespace Tests.Linq
 			}
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestQueryCaching_Format_BySqlExpressionParameter([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
 		{
 			using var db = GetDataContext(context);
@@ -785,7 +785,7 @@ namespace Tests.Linq
 			}
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestQueryCaching_ByParameter_Formatted2([IncludeDataSources(true, TestProvName.AllSqlServer, TestProvName.AllClickHouse)] string context)
 		{
 			// important: comment added to avoid use of cached query from other test

--- a/Tests/Linq/Linq/FullTextTests.SqlServer.cs
+++ b/Tests/Linq/Linq/FullTextTests.SqlServer.cs
@@ -856,7 +856,7 @@ namespace Tests.Linq
 			db.LastQuery!.ShouldContain("CONTAINSTABLE([Categories], ([Description]), @search, @top)");
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void ContainsTableByAll([IncludeDataSources(TestProvName.AllNorthwind)] string context, [Values(1, 2)] int iteration)
 		{
 			using var db = new NorthwindDB(context);
@@ -1046,7 +1046,7 @@ namespace Tests.Linq
 			db.LastQuery!.ShouldContain("CONTAINSTABLE([Categories], ([CategoryName], [Description]), @search, LANGUAGE @language, @top)");
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void ContainsTableByColumnsTop([IncludeDataSources(TestProvName.AllNorthwind)] string context, [Values(1, 2, 3)] int top)
 		{
 			using var db = new NorthwindDB(context);

--- a/Tests/Linq/Linq/MappingTests.cs
+++ b/Tests/Linq/Linq/MappingTests.cs
@@ -1492,7 +1492,7 @@ namespace Tests.Linq
 		record MappingTypingByConstant<T>(int Id, T Value);
 
 		[ActiveIssue("CAST to BIGINT doesn't work in MariaDB and MySQL 5.7", Configurations = [TestProvName.AllMariaDB, TestProvName.AllMySql57], SkipForLinqService = true)]
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955")]
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955"), QueryCacheTest]
 		public void MappingTypingByConstant_FromEnumerable_Int64([DataSources(TestProvName.AllAccess)] string context, [Values(null, 1L)] long? first)
 		{
 			using var db = GetDataContext(context);
@@ -1537,7 +1537,7 @@ namespace Tests.Linq
 			Assert.That(res[0].Value, Is.EqualTo(value));
 		}
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955")]
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955"), QueryCacheTest]
 		public void MappingTypingByConstant_FromEnumerable_UInt64([DataSources(TestProvName.AllAccess)] string context, [Values(null, 1ul)] ulong? first)
 		{
 			using var db = GetDataContext(context);
@@ -1581,7 +1581,7 @@ namespace Tests.Linq
 			Assert.That(res[0].Value, Is.EqualTo(value));
 		}
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955")]
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955"), QueryCacheTest]
 		public void MappingTypingByConstant_FromEnumerable_UInt32([DataSources(TestProvName.AllAccess)] string context, [Values(null, 1u)] uint? first)
 		{
 			using var db = GetDataContext(context);
@@ -1625,7 +1625,7 @@ namespace Tests.Linq
 			Assert.That(res[0].Value, Is.EqualTo(value));
 		}
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955")]
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955"), QueryCacheTest]
 		public void MappingTypingByConstant_FromEnumerable_Decimal([DataSources(TestProvName.AllAccess)] string context, [Values] bool isNull)
 		{
 			using var db = GetDataContext(context);
@@ -1669,7 +1669,7 @@ namespace Tests.Linq
 			Assert.That(res[0].Value, Is.EqualTo(value));
 		}
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955")]
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955"), QueryCacheTest]
 		public void MappingTypingByConstant_FromEnumerable_Double([DataSources(TestProvName.AllAccess)] string context, [Values(null, 0D)] double? first)
 		{
 			using var db = GetDataContext(context);
@@ -1713,7 +1713,7 @@ namespace Tests.Linq
 			Assert.That(res[0].Value, Is.EqualTo(value));
 		}
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955")]
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/4955"), QueryCacheTest]
 		public void MappingTypingByConstant_FromEnumerable_Float([DataSources(TestProvName.AllAccess)] string context, [Values(null, 0F)] float? first)
 		{
 			using var db = GetDataContext(context);

--- a/Tests/Linq/Linq/MathFunctionTests.cs
+++ b/Tests/Linq/Linq/MathFunctionTests.cs
@@ -340,7 +340,7 @@ namespace Tests.Linq
 		}
 
 		// TODO: implement other MidpointRounding values (and remove NUnit4001 suppress)
-		[Test]
+		[Test, QueryCacheTest]
 #pragma warning disable NUnit4001
 		public void Round12([DataSources(TestProvName.AllSQLite)] string context, [Values(MidpointRounding.AwayFromZero, MidpointRounding.ToEven)] MidpointRounding mp, [Values(1, 2)] int iteration)
 #pragma warning restore NUnit4001

--- a/Tests/Linq/Linq/ParameterTests.cs
+++ b/Tests/Linq/Linq/ParameterTests.cs
@@ -530,7 +530,7 @@ namespace Tests.Linq
 			return db.Person.Where(p => p.ID == personId!.Value);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestParametersByEquality([DataSources(TestProvName.AllSQLite)] string context, [Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);
@@ -602,7 +602,7 @@ namespace Tests.Linq
 			};
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void ParameterDeduplication_Insert([IncludeDataSources(TestProvName.AllSqlServer)] string context)
 		{
 			using var db = (DataConnection)GetDataContext(context);
@@ -696,7 +696,7 @@ namespace Tests.Linq
 			res[1].String3.ShouldBe("str3");
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void ParameterDeduplication_InsertObject([IncludeDataSources(TestProvName.AllSqlServer)] string context)
 		{
 			using var db = (DataConnection)GetDataContext(context);
@@ -772,7 +772,7 @@ namespace Tests.Linq
 			res[1].String3.ShouldBe("str3");
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void ParameterDeduplication_ValueValue([IncludeDataSources(TestProvName.AllSqlServer)] string context)
 		{
 			using var db = (DataConnection)GetDataContext(context);
@@ -846,7 +846,7 @@ namespace Tests.Linq
 			res[1].String3.ShouldBe("str3");
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void ParameterDeduplication_ValueExpr([IncludeDataSources(TestProvName.AllSqlServer)] string context)
 		{
 			using var db = (DataConnection)GetDataContext(context);
@@ -939,7 +939,7 @@ namespace Tests.Linq
 			res[1].String3.ShouldBe("str3");
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void ParameterDeduplication_Update([IncludeDataSources(TestProvName.AllSqlServer)] string context)
 		{
 			using var db = (DataConnection)GetDataContext(context);
@@ -1033,7 +1033,7 @@ namespace Tests.Linq
 			res[1].String3.ShouldBe("str3");
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void ParameterDeduplication_UpdateObject([IncludeDataSources(TestProvName.AllSqlServer)] string context)
 		{
 			using var db = (DataConnection)GetDataContext(context);
@@ -1109,7 +1109,7 @@ namespace Tests.Linq
 			res[1].String3.ShouldBe("str3");
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void ParameterDeduplication_SetValue([IncludeDataSources(TestProvName.AllSqlServer)] string context)
 		{
 			using var db = (DataConnection)GetDataContext(context);
@@ -1183,7 +1183,7 @@ namespace Tests.Linq
 			res[1].String3.ShouldBe("str3");
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void ParameterDeduplication_SetExpr([IncludeDataSources(TestProvName.AllSqlServer)] string context)
 		{
 			using var db = (DataConnection)GetDataContext(context);
@@ -1280,7 +1280,7 @@ namespace Tests.Linq
 		private int _cnt3;
 		private int _param;
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/3450")]
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/3450"), QueryCacheTest]
 		public void TestIQueryableParameterEvaluation([DataSources(TestProvName.AllClickHouse)] string context)
 		{
 			// cached queries affect cnt values due to extra comparisons in cache
@@ -1876,7 +1876,7 @@ namespace Tests.Linq
 			public bool? Value5 { get; set; }
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void DedupOfParameters([IncludeDataSources(true, TestProvName.AllSQLite)] string context, [Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);

--- a/Tests/Linq/Linq/QueryFilterTests.cs
+++ b/Tests/Linq/Linq/QueryFilterTests.cs
@@ -193,7 +193,7 @@ namespace Tests.Linq
 			Assert.That(currentMissCount, Is.EqualTo(query.GetCacheMissCount()), () => "Caching is wrong.");
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void EntityFilterTestsCache([IncludeDataSources(false, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context, [Values(1, 2, 3)] int iteration, [Values] bool filtered)
 		{
 			var testData = GenerateTestData();

--- a/Tests/Linq/Linq/SelectTests.cs
+++ b/Tests/Linq/Linq/SelectTests.cs
@@ -1086,7 +1086,7 @@ namespace Tests.Linq
 			public Child? Child    { get; set; }
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestConditionalProjectionOptimization(
 			[IncludeDataSources(false, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context,
 			[Values] bool includeChild,
@@ -1835,7 +1835,7 @@ namespace Tests.Linq
 
 		#region Caching Tests
 
-		[Test(Description = "https://github.com/linq2db/linq2db/issues/2116")]
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/2116"), QueryCacheTest]
 		public void CachedObjectRefence([DataSources] string context)
 		{
 			using var db = GetDataContext(context);

--- a/Tests/Linq/Linq/SpecialFunctionsTest.cs
+++ b/Tests/Linq/Linq/SpecialFunctionsTest.cs
@@ -26,7 +26,7 @@ namespace Tests.Linq
 			Assert.That(orderBy.Items[0].IsPositioned, Is.True);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void Parameter([IncludeDataSources(TestProvName.AllSQLite)] string context)
 		{
 			using var db = GetDataContext(context);
@@ -53,7 +53,7 @@ namespace Tests.Linq
 			Assert.That(parameters[0].IsQueryParameter, Is.True);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void Constant([IncludeDataSources(TestProvName.AllSQLite)] string context, [Values(1, 2)] int iteration)
 		{
 			using var db = GetDataContext(context);

--- a/Tests/Linq/Linq/StringTrimTests.cs
+++ b/Tests/Linq/Linq/StringTrimTests.cs
@@ -369,7 +369,7 @@ namespace Tests.Linq
 		// different chars value is safe — asserting a miss there would lock in
 		// avoidable cache churn.
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TrimStartCharsCacheTest([DataSources] string context, [Values(1, 2)] int iteration)
 		{
 			using var db    = GetDataContext(context);
@@ -391,7 +391,7 @@ namespace Tests.Linq
 			}
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TrimEndCharsCacheTest([DataSources] string context, [Values(1, 2)] int iteration)
 		{
 			using var db    = GetDataContext(context);
@@ -416,7 +416,7 @@ namespace Tests.Linq
 		// stored type and accessor type must agree, otherwise the cache compare always
 		// returns false and trim-with-chars queries miss cache on every execution.
 		// Re-executing the same query must hit the cache.
-		[Test]
+		[Test, QueryCacheTest]
 		public void TrimEndCharsCache_HitsOnSameContent([DataSources] string context)
 		{
 			using var db    = GetDataContext(context);
@@ -436,7 +436,7 @@ namespace Tests.Linq
 		// display-class type and same field layout, so structural compare matches.
 		// Sorted-string cache key gives set semantics, so a reordered chars argument
 		// must still hit the cache.
-		[Test]
+		[Test, QueryCacheTest]
 		public void TrimEndCharsCache_LocalFunctionWithReorderedCharsHits([DataSources] string context)
 		{
 			using var db    = GetDataContext(context);
@@ -461,7 +461,7 @@ namespace Tests.Linq
 		// providers the translator returns null and the trim runs client-side, where
 		// the closure-captured chars is parameter-bound and the cache reuses the same
 		// plan across mutations (no stale SQL to worry about).
-		[Test]
+		[Test, QueryCacheTest]
 		public void TrimEndCharsCache_MutationMissesCache([DataSources] string context)
 		{
 			using var db    = GetDataContext(context);

--- a/Tests/Linq/Linq/TakeSkipTests.cs
+++ b/Tests/Linq/Linq/TakeSkipTests.cs
@@ -44,7 +44,7 @@ namespace Tests.Linq
 			CheckTakeSkipParams(dc, false, additional);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void Take1([DataSources] string context, [Values] bool withParameters)
 		{
 			using var db = GetDataContext(context, o => o.UseParameterizeTakeSkip(withParameters));
@@ -65,7 +65,7 @@ namespace Tests.Linq
 			Assert.That(db.Child.GetCacheMissCount(), Is.EqualTo(currentCacheMissCount));
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public async Task Take1Async([DataSources] string context, [Values] bool withParameters)
 		{
 			using var db = GetDataContext(context, o => o.UseParameterizeTakeSkip(withParameters));
@@ -220,7 +220,7 @@ namespace Tests.Linq
 			CheckTakeGlobalParams(db);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void Skip1([DataSources] string context, [Values] bool withParameters)
 		{
 			using var db = GetDataContext(context, o => o.UseParameterizeTakeSkip(withParameters));
@@ -646,7 +646,7 @@ namespace Tests.Linq
 			CheckTakeSkipParameterized(db);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void ElementAtDefault5([DataSources] string context, [Values(2,3)] int idx, [Values] bool withParameters)
 		{
 			using var db = GetDataContext(context, o => o.UseParameterizeTakeSkip(withParameters));
@@ -1113,7 +1113,7 @@ namespace Tests.Linq
 			}
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void MultipleSkip2([DataSources] string context, [Values] bool withParameters)
 		{
 			using var db = GetDataContext(context, o => o.UseParameterizeTakeSkip(withParameters));
@@ -1346,7 +1346,7 @@ namespace Tests.Linq
 			CheckTakeGlobalParams(db);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void SkipTakeCaching([DataSources] string context, [Values(1, 2)] int skip, [Values(1, 2)] int take)
 		{
 			using var db = GetDataContext(context);

--- a/Tests/Linq/Linq/TestQueryCache.cs
+++ b/Tests/Linq/Linq/TestQueryCache.cs
@@ -164,7 +164,7 @@ namespace Tests.Linq
 			return ms;
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestSqlQueryDepended([IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context)
 		{
 			using var db = GetDataContext(context);

--- a/Tests/Linq/Mapping/FluentMappingBuildTests.cs
+++ b/Tests/Linq/Mapping/FluentMappingBuildTests.cs
@@ -111,7 +111,7 @@ namespace Tests.Mapping
 				.MergeAsync();
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void CacheTest([DataSources] string context)
 		{
 			var count = Test("Value");

--- a/Tests/Linq/Update/EntityInsertTests.cs
+++ b/Tests/Linq/Update/EntityInsertTests.cs
@@ -171,7 +171,7 @@ namespace Tests.xUpdate
 		/// call does NOT trigger a cache miss. If the entity's columns were inlined as SQL
 		/// constants instead of parameters, the second call would generate different SQL and miss.
 		/// </summary>
-		[Test]
+		[Test, QueryCacheTest]
 		public void QueryCache_ParameterisesItemValues([DataSources] string context)
 		{
 			using var db = GetDataContext(context);

--- a/Tests/Linq/Update/EntityUpdateTests.cs
+++ b/Tests/Linq/Update/EntityUpdateTests.cs
@@ -190,7 +190,7 @@ namespace Tests.xUpdate
 		/// the WHERE predicate) were inlined as SQL constants instead of parameters, the second
 		/// call would generate different SQL and miss.
 		/// </summary>
-		[Test]
+		[Test, QueryCacheTest]
 		public void QueryCache_ParameterisesItemValues([DataSources] string context)
 		{
 			using var db    = GetDataContext(context);

--- a/Tests/Linq/Update/MergeTests.Caching.cs
+++ b/Tests/Linq/Update/MergeTests.Caching.cs
@@ -11,7 +11,7 @@ namespace Tests.xUpdate
 	// tests for empty enumerable source
 	public partial class MergeTests
 	{
-		[Test]
+		[Test, QueryCacheTest]
 		public void EnumerableSourceQueryCaching([MergeDataContextSource] string context)
 		{
 			using (var db = GetDataContext(context))

--- a/Tests/Linq/Update/MergeTests.Issues.cs
+++ b/Tests/Linq/Update/MergeTests.Issues.cs
@@ -1008,7 +1008,7 @@ namespace Tests.xUpdate
 			Assert.That(db.LastQuery!.Count(_ => _ == GetParameterToken(context)), Is.EqualTo(6));
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void MergeSubquery([MergeDataContextSource(false, TestProvName.AllOracle, TestProvName.AllFirebird, TestProvName.AllSybase)] string context, [Values(1, 2)] int iteration)
 		{
 			using var db  = GetDataContext(context);

--- a/Tests/Linq/Update/UpsertTests.Single.cs
+++ b/Tests/Linq/Update/UpsertTests.Single.cs
@@ -460,7 +460,7 @@ namespace Tests.xUpdate
 
 		#region Query-cache parameterisation smoke tests
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void Single_QueryCache_Parameterises_ItemValues_NativePath([InsertOrUpdateDataSources] string context)
 		{
 			using var db    = GetDataContext(context);
@@ -485,7 +485,7 @@ namespace Tests.xUpdate
 			rows[1].Version.ShouldBe(20);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		[ThrowsForProvider(typeof(LinqToDBException),
 			TestProvName.AllSapHana, TestProvName.AllSqlServer2005, TestProvName.AllSQLite, TestProvName.AllPostgreSQL14Minus,
 			TestProvName.AllMySql, TestProvName.AllSqlCe, TestProvName.AllAccess,

--- a/Tests/Linq/UserTests/Issue3148Tests.cs
+++ b/Tests/Linq/UserTests/Issue3148Tests.cs
@@ -18,7 +18,7 @@ namespace Tests.UserTests
 	[TestFixture]
 	public class Issue3148Tests : TestBase
 	{
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestDefaultExpression([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context, [Values] bool withDefault)
 		{
 			using var db = GetDataContext(context);
@@ -45,7 +45,7 @@ namespace Tests.UserTests
 			Assert.That(db.Person.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestDefaultExpression_01([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context, [Values] bool withDefault)
 		{
 			using var db = GetDataContext(context);
@@ -66,7 +66,7 @@ namespace Tests.UserTests
 			Assert.That(db.Person.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestDefaultExpression_02([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context, [Values] bool withDefault)
 		{
 			using var db = GetDataContext(context);
@@ -87,7 +87,7 @@ namespace Tests.UserTests
 			Assert.That(db.Person.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestDefaultExpression_05([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context, [Values] bool withDefault)
 		{
 			using var db = GetDataContext(context);
@@ -118,7 +118,7 @@ namespace Tests.UserTests
 			Assert.That(db.Parent.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestDefaultExpression_06([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context, [Values] bool withDefault)
 		{
 			using var db = GetDataContext(context);
@@ -149,7 +149,7 @@ namespace Tests.UserTests
 			Assert.That(db.Parent.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestDefaultExpression_07([IncludeDataSources(true, TestProvName.AllSQLite)] string context, [Values] bool withDefault)
 		{
 			using var db = GetDataContext(context);
@@ -181,7 +181,7 @@ namespace Tests.UserTests
 		}
 
 		// Test requires OUTER/LATERAL APPLY support from Provider
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestDefaultExpression_08([IncludeDataSources(true, TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL)] string context, [Values] bool withDefault)
 		{
 			using var db = GetDataContext(context);
@@ -223,7 +223,7 @@ namespace Tests.UserTests
 		}
 
 		// Test requires OUTER/LATERAL APPLY support from Provider
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestDefaultExpression_09([IncludeDataSources(true, TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL)] string context, [Values] bool withDefault)
 		{
 			using var db = GetDataContext(context);
@@ -263,7 +263,7 @@ namespace Tests.UserTests
 		}
 
 		// Test requires OUTER/LATERAL APPLY or ROW_NUMBER Window function support from Provider
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestDefaultExpression_10([IncludeDataSources(true, ProviderName.SQLiteClassic, TestProvName.AllSqlServer2008Plus, TestProvName.AllPostgreSQL)] string context)
 		{
 			using var db = GetDataContext(context);
@@ -336,7 +336,7 @@ namespace Tests.UserTests
 			}
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestDefaultExpression_12([IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context, [Values] bool withDefault)
 		{
 			using var db = new TestDataConnection(context);
@@ -363,7 +363,7 @@ namespace Tests.UserTests
 			Assert.That(db.GetTable<TestTable>().GetCacheMissCount(), Is.EqualTo(cacheMiss));
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestDefaultExpression_13([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context, [Values] bool withDefault)
 		{
 			using var db = GetDataContext(context);
@@ -384,7 +384,7 @@ namespace Tests.UserTests
 			Assert.That(db.Person.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestDefaultExpression_14([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context, [Values] bool withDefault)
 		{
 			using var db = GetDataContext(context);
@@ -405,7 +405,7 @@ namespace Tests.UserTests
 			Assert.That(db.Person.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestDefaultExpression_15([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context, [Values] bool withDefault)
 		{
 			using var db = GetDataContext(context);
@@ -426,7 +426,7 @@ namespace Tests.UserTests
 			Assert.That(db.Person.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestDefaultExpression_16([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context, [Values] bool withDefault)
 		{
 			using var db = GetDataContext(context);
@@ -461,7 +461,7 @@ namespace Tests.UserTests
 			Assert.That(db.Person.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestDefaultExpression_17([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context, [Values] bool withDefault)
 		{
 			using var db = GetDataContext(context);
@@ -480,7 +480,7 @@ namespace Tests.UserTests
 			Assert.That(query2.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestDefaultExpression_18([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context, [Values] bool withDefault)
 		{
 			using var db = GetDataContext(context);
@@ -499,7 +499,7 @@ namespace Tests.UserTests
 			Assert.That(query2.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestDefaultExpression_19([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context, [Values] bool withDefault)
 		{
 			using var db = GetDataContext(context);
@@ -519,7 +519,7 @@ namespace Tests.UserTests
 			Assert.That(query2.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestDefaultExpression_20([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllSqlServer, TestProvName.AllClickHouse)] string context, [Values] bool withDefault)
 		{
 			using var db = GetDataContext(context);
@@ -540,7 +540,7 @@ namespace Tests.UserTests
 			Assert.That(db.Person.GetCacheMissCount(), Is.EqualTo(cacheMiss));
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestDefaultExpression_21([IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context, [Values] bool withDefault)
 		{
 			using var db = new TestDataConnection(context);
@@ -567,7 +567,7 @@ namespace Tests.UserTests
 			Assert.That(db.GetTable<TestTable>().GetCacheMissCount(), Is.EqualTo(cacheMiss));
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestDefaultExpression_22([IncludeDataSources(true, TestProvName.AllSQLite, TestProvName.AllClickHouse)] string context, [Values] bool withDefault)
 		{
 			using var db = GetDataContext(context);

--- a/Tests/Linq/UserTests/Issue447Tests.cs
+++ b/Tests/Linq/UserTests/Issue447Tests.cs
@@ -44,7 +44,7 @@ namespace Tests.UserTests
 			_ = result.ToSqlQuery().Sql;
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestLinqToDBComplexQueryCache([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
@@ -85,7 +85,7 @@ namespace Tests.UserTests
 			result1.GetCacheMissCount().ShouldBe(cacheMiss);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestLinqToDBComplexQueryCacheWithExposing([DataSources] string context)
 		{
 			using var db = GetDataContext(context);

--- a/Tests/Linq/UserTests/Issue5302Tests.cs
+++ b/Tests/Linq/UserTests/Issue5302Tests.cs
@@ -28,7 +28,7 @@ namespace Tests.UserTests
 		/// <summary>
 		/// Reproduces the issue: query using ValueIsEqualToAny with array causes cache miss on every execution.
 		/// </summary>
-		[Test]
+		[Test, QueryCacheTest]
 		public void ValueIsEqualToAnyCacheTest([IncludeDataSources(TestProvName.AllPostgreSQL)] string context, [Values(1, 2)] int iteration)
 		{
 			var testData = new[]

--- a/Tests/Linq/UserTests/Issue973Tests.cs
+++ b/Tests/Linq/UserTests/Issue973Tests.cs
@@ -112,7 +112,7 @@ namespace Tests.UserTests
 				GetParents(db, values2));
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void TestCache([DataSources] string context)
 		{
 			using var db = GetDataContext(context);


### PR DESCRIPTION
Split out of #5614 so it can be reviewed and CI'd on its own, and so that PR's diff stops carrying 31 test files.

145 tests across 31 files depend on process-global query-cache state — they assert exact `GetCacheMissCount` deltas, compare query-object identity across two executions, or clear the cache themselves. Nothing said so at the call site, so the dependency was invisible until one of them failed.

## The attribute

`[QueryCacheTest]` declares it, and carries the two guarantees such a test needs:

- derives from `ParallelizableAttribute(ParallelScope.None)`, so the test never runs concurrently with another — `Query<T>` reaches `QueryCache.Default` statically, and a concurrent test's compilation perturbs the counters;
- lifts `QueryCache.MaxEntriesOverride` for the duration of the test and restores the configured value afterwards, so nothing can be evicted from under it while it runs.

It deliberately does **not** clear the cache. NUnit fires `ITestAction` per test *case*, and many of these tests are parameterised by iteration (`[Values(1, 2)]`) where the first case warms the cache and the second asserts it was hit — a clear lands between them and fails them by construction. The configured cap is captured once, before the first test lifts it, so a mispaired `Before`/`After` can never leave a whole run uncapped.

## Behaviour on master

Both effects are inert here: nothing configures `MaxEntriesOverride` on master, and these tests do not currently run in parallel. The value today is that the dependency is declared where the tests live. It becomes load-bearing in #5614, which runs the suite in parallel and caps the cache at 100 entries on netfx / 32-bit legs — the configuration under which these tests fail without it.

## Selection

Scripted, not hand-picked: a test qualifies when its body reads `GetCacheMissCount`, `CacheMissCount`, `Query.ClearCaches` or `Query<T>.GetQuery`. Heaviest files: `EnumerableSourceTests` (26), `Issue3148Tests` (20), `ParameterTests` (11), `PostgreSQLArrayTests` (10), `FromSqlTests` (10).

Two groups are worth calling out because they don't read as cache tests at a glance:

- `FromSqlTests.TestQueryCaching_*` assert query-object identity across two executions rather than a miss count, so they depend on the entry surviving between them;
- `MappingTests.MappingTypingByConstant_FromEnumerable_*` call `Query.ClearCaches` themselves, which perturbs any concurrently running cache-counter test.

## Testing

Build-verified. In #5614, where the attribute is load-bearing, the equivalent state runs the full SQLite suite (4 providers, cache capped at 100) at 40135 tests / 0 failures, against 279 failures with plain `[NonParallelizable]` and 256 with a clearing variant.
