### PR TITLE
Do not write the provider's parameter name back onto the cached statement

### DIFF
--- a/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
+++ b/Source/LinqToDB/Data/DataConnection.QueryRunner.cs
@@ -342,16 +342,18 @@ namespace LinqToDB.Data
 			static DbParameter CreateParameter(DataConnection dataConnection, DbCommand command, SqlParameter parameter, SqlParameterValue parmValue)
 			{
 				var paramValue = parameter.CorrectParameterValue(parmValue.ProviderValue);
-				var p          = dataConnection.DataProvider.CreateParameter(
+
+				// Some providers (managed Sybase, YDB's '$' prefix) rewrite the name of the DbParameter we hand them.
+				// That name must NOT be written back onto `parameter`: this is the very instance whose Name was
+				// rendered into this command's SQL, and for a non-parameter-dependent query it belongs to the CACHED
+				// statement - shared by every later execution and by concurrent threads, so the write is a data race.
+				// It also buys nothing: nothing here rebinds a parameter by name (GetSqlTextImpl and PrintParameterName
+				// both read DbParameter.ParameterName directly), and the rewritten name is stripped back out by the
+				// parameters normalizer on the next render anyway.
+				return dataConnection.DataProvider.CreateParameter(
 					dataConnection,
 					command,
 					new DataProviderParameterContext(parameter.Name!, parmValue.DbDataType, paramValue, isDbDataTypeExplicit: parmValue.IsDbDataTypeExplicit));
-
-				// some providers (e.g. managed sybase provider) could change parameter name
-				// which breaks parameters rebind logic
-				parameter.Name = p.ParameterName;
-
-				return p;
 			}
 
 			protected override void SetQuery(IReadOnlyParameterValues parameterValues, bool forGetSqlText)

--- a/Tests/Linq/Linq/ParameterTests.cs
+++ b/Tests/Linq/Linq/ParameterTests.cs
@@ -35,6 +35,27 @@ namespace Tests.Linq
 			Assert.That(parent1.ParentID, Is.Not.EqualTo(parent2.ParentID));
 		}
 
+		// A provider may rewrite the name of the DbParameter it is handed (managed Sybase; YDB prefixes it with '$').
+		// That name must never be written back onto the SqlParameter of the CACHED statement, which every later
+		// execution and every concurrent thread shares - the Transform-mode mutation guard reports such a write as
+		// "convert mutated the element it was given". The name the query builder assigned must survive execution.
+		[Test]
+		public void ExecutionDoesNotRenameCachedParameters([DataSources(false)] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var id    = 1;
+			var query = db.GetTable<Parent>().Where(p => p.ParentID == id);
+
+			query.ToArray();
+
+			var parameters = new List<SqlParameter>();
+
+			QueryHelper.CollectParametersAndValues(query.GetStatement(), parameters, new List<SqlValue>());
+
+			parameters.Select(p => p.Name).ShouldBe(new[] { "id" });
+		}
+
 		[Test]
 		public void TestQueryCacheWithNullParameters([DataSources] string context)
 		{


### PR DESCRIPTION
## Problem

`DataConnection.QueryRunner.CreateParameter` copied the name of the `DbParameter` the provider had just created back onto the `SqlParameter` it was handed:

```csharp
// some providers (e.g. managed sybase provider) could change parameter name
// which breaks parameters rebind logic
parameter.Name = p.ParameterName;
```

That instance is the one whose `Name` was rendered into this command's SQL — `commands[i].SqlParameters` is `optimizationContext.GetParameters()` — and for a non-parameter-dependent query it belongs to the **cached** statement, shared by every later execution and by concurrent threads. Providers that rewrite the name (managed Sybase, YDB with its `$` prefix) therefore rename a cached AST node mid-render.

On `origin/master` this makes `MultiThreadingTests.ParamOptimization("YDB")` fail in 1–2 runs out of 10:

```
System.InvalidOperationException : Transform-mode convert mutated the element it was given.
BEFORE: ((t16.Id = @$p(A:1) OR t16.Id = @p(A:3)))
AFTER:  ((t16.Id = @$p(A:1) OR t16.Id = @$p(A:3)))
```

## Why the write-back is not needed

- Nothing in this path rebinds a parameter by name. The only readers of `DbParameter.ParameterName` are `GetSqlTextImpl` and `PrintParameterName`, and both take it from the `DbParameter` directly.
- The SQL text and the `DbParameter` are already consistent without it — both are built from the same `SqlParameter.Name`.
- `UniqueParametersNormalizer.MakeValidName` strips the injected characters back out on the next render, so the rewritten name never survived anyway. It only cost an extra `SqlParameter` clone per render, because `AddParameter` then saw a changed name.

## Test

`ParameterTests.ExecutionDoesNotRenameCachedParameters` pins the invariant **deterministically**, not through the race: after executing a parameterized query the cached statement must still carry the name the query builder assigned.

| check | before | after |
|---|---|---|
| pin, YDB | `["$id"]` — red | `["id"]` — green |
| pin, SQLite / MySQL 8 / MariaDB 11 / Sybase | green | green |
| `ParamOptimization("YDB")`, 10 runs | 1–2 failures | 0 failures |

The same change applied on top of #5673 runs the full YDB suite green (8741 passed, 0 failed).
