### PR TITLE
CI: do not fail the build when the Azure Artifacts feed is over quota

### DIFF
--- a/Build/Azure/pipelines/templates/nuget-job.yml
+++ b/Build/Azure/pipelines/templates/nuget-job.yml
@@ -28,13 +28,18 @@ jobs:
       filePath: '$(Build.SourcesDirectory)/Build/Azure/scripts/verify-analyzer-delivery.ps1'
       arguments: '-PackagesDir "$(Build.SourcesDirectory)/.build/nugets"'
 
-  - task: NuGetCommand@2
-    inputs:
-      command: 'push'
-      packagesToPush: '$(Build.SourcesDirectory)/.build/nugets/*.nupkg'
-      nuGetFeedType: 'internal'
-      publishVstsFeed: '0dcc414b-ea54-451e-a54f-d63f05367c4b/967a4107-9788-41a4-9f6d-a2318aab1410'
+  # Pushed through a script rather than NuGetCommand@2 so that the feed being over its storage
+  # quota (HTTP 402) warns instead of failing the build, while any other push failure still fails.
+  - task: NuGetAuthenticate@1
+    displayName: Authenticate to Azure Artifacts feed
+    condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['master_branch']))
+
+  - task: PowerShell@2
     displayName: Publish to Azure Artifacts feed
+    inputs:
+      pwsh: true
+      filePath: '$(Build.SourcesDirectory)/Build/Azure/scripts/publish-azure-artifacts.ps1'
+      arguments: '-PackagesDir "$(Build.SourcesDirectory)/.build/nugets" -Source "https://pkgs.dev.azure.com/linq2db/0dcc414b-ea54-451e-a54f-d63f05367c4b/_packaging/967a4107-9788-41a4-9f6d-a2318aab1410/nuget/v3/index.json"'
     condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['master_branch']))
 
   - task: NuGetCommand@2

--- a/Build/Azure/scripts/publish-azure-artifacts.ps1
+++ b/Build/Azure/scripts/publish-azure-artifacts.ps1
@@ -1,0 +1,106 @@
+<#
+publish-azure-artifacts.ps1 — push .nupkg files to the Azure Artifacts feed, tolerating the feed's
+storage-quota rejection.
+
+The feed has a fixed storage allowance. Once it is full, Azure Artifacts answers a push with
+HTTP 402 (Payment Required — "Artifact cannot be uploaded because max quantity has been exceeded
+or the payment instrument is invalid"). That is a feed capacity condition, not a defect in the
+commit being built, but the NuGetCommand@2 task it replaces treats any non-zero push exit as a
+build failure — so a full feed turned every master build red (e.g. build 22947 on af5eda3d8).
+
+The CI feed is a convenience mirror, not a release channel (releases go to nuget.org via a separate
+step), so an over-quota feed must not fail the build. Every *other* push failure still does — a
+blanket `continueOnError: true` on the task would have hidden genuine publish breakage too, which
+is the reason this is a script rather than one line of YAML.
+
+Usage:
+
+  pwsh -NoProfile -File Build/Azure/scripts/publish-azure-artifacts.ps1 -PackagesDir <dir> -Source <url>
+
+  -PackagesDir   directory to scan recursively for *.nupkg (required)
+  -Source        NuGet v3 index URL of the target feed (required)
+  -NoAzdoLogs    suppress the Azure DevOps `##vso[...]` lines, which are on by default. Use it for
+                 local invocation. A switch rather than a [bool], because `pwsh -File` passes every
+                 argument as a string and a [bool] parameter rejects strings outright.
+
+Exit codes:
+  0  every package pushed, or the only failures were the feed being over quota (HTTP 402)
+  1  any package failed to push for any other reason
+  2  invalid args / no nupkgs found
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $PackagesDir,
+    [Parameter(Mandatory = $true)]
+    [string] $Source,
+    [switch] $NoAzdoLogs
+)
+
+$ErrorActionPreference = 'Continue'
+
+if (-not (Test-Path $PackagesDir)) {
+    [Console]::Error.WriteLine("PackagesDir not found: $PackagesDir")
+    exit 2
+}
+
+$pkgs = Get-ChildItem -Path $PackagesDir -Recurse -Filter '*.nupkg' -File
+if (-not $pkgs -or $pkgs.Count -eq 0) {
+    [Console]::Error.WriteLine("No .nupkg files found under: $PackagesDir")
+    exit 2
+}
+
+$pushed      = @()
+$overQuota   = @()
+$failed      = @()
+
+foreach ($p in $pkgs) {
+    Write-Output "Pushing $($p.Name)"
+
+    # 2>&1 so the 402 body, which NuGet writes to stderr, is matchable below.
+    $output   = & dotnet nuget push $p.FullName --source $Source --api-key AzureArtifacts --skip-duplicate 2>&1
+    $exitCode = $LASTEXITCODE
+    $text     = ($output | Out-String)
+
+    Write-Output $text
+
+    if ($exitCode -eq 0) {
+        $pushed += $p.Name
+        continue
+    }
+
+    # Match the phrase and the status code independently, so a reword of either still lands. The
+    # numeric form is anchored to a status-code context on purpose: a bare 402 also occurs inside
+    # the DevOps activity GUID the same message carries, and matching that would silently swallow
+    # an unrelated push failure.
+    if ($text -match 'Payment Required' -or $text -match 'status code[^\r\n]{0,60}\b402\b') {
+        $overQuota += $p.Name
+    }
+    else {
+        $failed += $p.Name
+    }
+}
+
+Write-Output ""
+Write-Output ("Scanned {0} nupkg(s). Pushed: {1}  Over quota: {2}  Failed: {3}" -f $pkgs.Count, $pushed.Count, $overQuota.Count, $failed.Count)
+
+foreach ($name in $failed) {
+    $msg = "$name failed to publish to the Azure Artifacts feed"
+    Write-Output "  [FAIL]  $msg"
+    if (-not $NoAzdoLogs) {
+        Write-Output "##vso[task.logissue type=error]$msg"
+    }
+}
+
+if ($failed.Count -gt 0) { exit 1 }
+
+if ($overQuota.Count -gt 0) {
+    $msg = "Azure Artifacts feed is over its storage quota (HTTP 402); {0} package(s) were not published: {1}. Release publishing to nuget.org is unaffected. See https://aka.ms/artbilling" -f $overQuota.Count, ($overQuota -join ', ')
+    Write-Output "  [WARN]  $msg"
+    if (-not $NoAzdoLogs) {
+        Write-Output "##vso[task.logissue type=warning]$msg"
+        Write-Output "##vso[task.complete result=SucceededWithIssues;]$msg"
+    }
+}
+
+exit 0


### PR DESCRIPTION
## Problem

`default (Nugets Generation)` fails on every `master` build once the Azure Artifacts feed fills up. The feed answers a push with `HTTP 402 Payment Required` ("Artifact cannot be uploaded because max quantity has been exceeded or the payment instrument is invalid"), and `NuGetCommand@2` treats any non-zero push exit as a build failure — so the build goes red with every other step green.

Most recent occurrence: [build 22947](https://dev.azure.com/linq2db/0dcc414b-ea54-451e-a54f-d63f05367c4b/_build/results?buildId=22947) on af5eda3d8, where the only failing step was `Publish to Azure Artifacts feed`.

## Change

The Azure Artifacts push moves from `NuGetCommand@2` to `NuGetAuthenticate@1` + `Build/Azure/scripts/publish-azure-artifacts.ps1`.

- Feed over quota (`402`) → warning + `SucceededWithIssues`; the build is not failed.
- Any other push failure → the step fails, as before.

The Azure Artifacts feed is a convenience mirror. Releases publish to nuget.org through a separate step, which this PR does not touch.

## Why a script rather than `continueOnError: true`

`continueOnError` on the task would tolerate *every* push failure, including genuine publish breakage. The script distinguishes the quota case from the rest.

The numeric match is deliberately anchored to a status-code context rather than matching a bare `402`: the same message carries a DevOps activity GUID that can itself contain `402`, and matching that would silently swallow an unrelated push failure.

## Verification

- Pipeline YAML parses; step order unchanged apart from the inserted auth task.
- Script parses clean.
- Matcher checked against the verbatim 402 body from build 22947, plus negatives: `401 Unauthorized`, `500 Internal Server Error`, and a GUID containing `402`.

## Reviewer note

Two things this PR's own CI cannot validate, because the publish step is `condition: eq(variables['Build.SourceBranchName'], variables['master_branch'])` and is skipped on any PR branch:

1. The feed URL `https://pkgs.dev.azure.com/linq2db/0dcc414b-.../_packaging/967a4107-.../nuget/v3/index.json` is derived from the GUIDs in the previous `publishVstsFeed` value.
2. Authentication now comes from `NuGetAuthenticate@1` + `dotnet nuget push` instead of the task's built-in internal-feed handling.

Both only execute after merge to `master`, so they are worth an explicit look.
