### PR TITLE
Fix EF provider cache collapsing all servers of one family

### DIFF
--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFToolsImplDefault.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFToolsImplDefault.cs
@@ -118,7 +118,16 @@ namespace LinqToDB.EntityFrameworkCore
 			else
 				info = GetLinqToDBProviderInfo(providerInfo);
 
-			return _knownProviders.GetOrAdd(new ProviderKey(info.ProviderName, connectionInfo.ConnectionString), k =>
+			// A context configured with a DbDataSource (or an externally-supplied DbConnection) carries no
+			// connection string on its EF options extension, so the key has to fall back to the connection the
+			// provider is detected from - otherwise every server of one family shares a single entry and all
+			// but the first are served the dialect detected from someone else's server.
+			// Precedence mirrors ProviderDetectorBase.DetectServerVersion.
+			var connectionString = connectionInfo.ConnectionString
+				?? connectionInfo.Connection?.ConnectionString
+				?? connectionInfo.Transaction?.Connection?.ConnectionString;
+
+			return _knownProviders.GetOrAdd(new ProviderKey(info.ProviderName, connectionString), k =>
 			{
 				return CreateLinqToDBDataProvider(providerInfo, info, connectionInfo);
 			});

--- a/Tests/EntityFrameworkCore/Tests/CustomContextIssueTests.cs
+++ b/Tests/EntityFrameworkCore/Tests/CustomContextIssueTests.cs
@@ -13,6 +13,8 @@ using Npgsql;
 
 using NUnit.Framework;
 
+using Shouldly;
+
 using Tests;
 
 namespace LinqToDB.EntityFrameworkCore.Tests
@@ -377,7 +379,12 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 			}
 
 			using var db  = ctx.CreateLinqToDBConnection(); //should not throw an exception
-			await db.GetTable<Issue4917RecordDb>().ToListAsyncLinqToDB(); 
+
+			// the data source carries the connection string, so EF exposes none: the dialect still has to come
+			// from this server and not from whichever PostgreSQL instance the process resolved first
+			db.DataProvider.Name.ShouldBe(DataConnection.GetDataProvider(provider).Name);
+
+			await db.GetTable<Issue4917RecordDb>().ToListAsyncLinqToDB();
 		}
 
 		public sealed class Issue4917Context(DbContextOptions options) : DbContext(options)

--- a/Tests/EntityFrameworkCore/Tests/DataProviderCacheTests.cs
+++ b/Tests/EntityFrameworkCore/Tests/DataProviderCacheTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Data.Common;
+
+using LinqToDB.Data;
+using LinqToDB.DataProvider;
+
+using Npgsql;
+
+using NUnit.Framework;
+
+using Shouldly;
+
+using Tests;
+
+namespace LinqToDB.EntityFrameworkCore.Tests
+{
+	/// <summary>
+	/// The linq2db data provider resolved for an EF Core context must reflect the server that context
+	/// connects to. The provider carries the SQL dialect, so one resolved from a different server
+	/// silently generates SQL for the wrong version.
+	/// </summary>
+	[TestFixture]
+	public class DataProviderCacheTests : TestBase
+	{
+		// RFC 2606 reserves .invalid, so this host cannot resolve. Resolving a provider for it has to fail
+		// rather than quietly hand back the dialect detected from another connection.
+		const string UnreachableConnectionString = "Host=linq2db-nonexistent.invalid;Database=x;Username=x;Password=x;Timeout=1;Pooling=false";
+
+		/// <summary>
+		/// A context configured with a <c>DbDataSource</c> (or an externally-supplied
+		/// <see cref="DbConnection"/>) carries no connection string on its EF options extension, so
+		/// <see cref="EFConnectionInfo.ConnectionString"/> is <see langword="null"/> and the connection is
+		/// the only thing identifying the server. The provider cache has to key on it — otherwise every
+		/// server of one family shares a single entry and all but the first are served the dialect detected
+		/// from someone else's server.
+		/// </summary>
+		[Test]
+		public void ProviderNotSharedBetweenConnectionsWithoutConnectionString([EFIncludeDataSources(TestProvName.AllPostgreSQL)] string provider)
+		{
+			using var configured  = new NpgsqlConnection(DataConnection.GetConnectionString(provider));
+			using var unreachable = new NpgsqlConnection(UnreachableConnectionString);
+
+			Resolve(configured).Name.ShouldBe(DataConnection.GetDataProvider(provider).Name);
+
+			Shouldly.Should.Throw<Exception>(() => Resolve(unreachable));
+
+			static IDataProvider Resolve(DbConnection connection)
+				=> LinqToDBForEFTools.GetDataProvider(
+					new DataOptions(),
+					new EFProviderInfo   { Connection = connection },
+					new EFConnectionInfo { Connection = connection });
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`LinqToDBForEFToolsImplDefault.GetDataProvider` keys its provider cache on `ProviderKey(providerName, connectionInfo.ConnectionString)`, and that connection string comes from `RelationalOptionsExtension.ConnectionString`. A context configured with a `DbDataSource` (`UseNpgsql(NpgsqlDataSource)`) or with an externally supplied `DbConnection` carries no connection string there, so the key degenerates to `(family, null)`.

Every server of that family then shares one cache entry, and the dialect detected from whichever server resolved first is handed to all the others. Order-dependent, first-wins, silent. Both `PostgreSqlDefaultVersion` and `SqlServerDefaultVersion` are `AutoDetect`, so this is not PostgreSQL-specific.

The dialect is load-bearing: `IsUpsertWithMergeLoweringSupported` (v15+), the four `Output*UseSpecialTable(s)` flags (v18+), `PostgreSQL18/19MemberTranslator` selection and the per-version mapping schemas all key off it. A v15 dialect aimed at a PostgreSQL 13 server emits `MERGE`, which that server does not have.

## Repro

`Issue4917Test` run from the EF8 test binary against two PostgreSQL instances in one process, on `master`:

| `--provider` | trace header(s) emitted |
|---|---|
| `PostgreSQL.15` | `-- PostgreSQL.15 PostgreSQL12` |
| `PostgreSQL.13` | `-- PostgreSQL.13 PostgreSQL12` |
| `PostgreSQL.13,PostgreSQL.15` | `-- PostgreSQL.13` twice |
| `PostgreSQL.15,PostgreSQL.13` | `-- PostgreSQL.15` twice |

The header's first token is `DataConnection.ConfigurationString`, which for an EF-created connection falls back to `DataProvider.Name` — the detected dialect. `ProviderName.PostgreSQL15` is literally `"PostgreSQL.15"`, which is what makes it read like a configuration name.

## Fix

Fall back to the connection the provider is actually detected from when the options extension carries no connection string, using the same precedence as `ProviderDetectorBase.DetectServerVersion`.

If a connection exposes no connection string either, the key stays `null` and the old behaviour remains — deliberately the least-invasive change rather than bypassing the cache for that case.

## Tests

- `DataProviderCacheTests.ProviderNotSharedBetweenConnectionsWithoutConnectionString` resolves a provider twice through the public `LinqToDBForEFTools.GetDataProvider`, with `ConnectionString = null` and two different connections, the second unreachable. Pre-fix the second call is served from cache and never connects; post-fix it attempts detection and fails. One server, deterministic, independent of prior cache state.
- `Issue4917Test` now asserts the resolved dialect matches the one linq2db resolves for the same server, so a recurrence names its cause instead of surfacing as baseline drift.

Verified locally: both red pre-fix, green post-fix. Full EF8 suite against PostgreSQL.13 — 191 passed, 26 skipped, 0 failed. Release builds of EF3/EF8/EF9/EF10 report no diagnostics in the changed files (net462/net8.0/net9.0/net10.0). Only EF8/net8.0 was executed locally.

## Note

This also explains the 15 `Issue4917Test` baselines that drift on [#5614](https://github.com/linq2db/linq2db/pull/5614) — not a regression from that PR, but this bug becoming visible once its merged PostgreSQL CI jobs put different dialect buckets in one process. The old split jobs co-located same-bucket instances (13+14, 15+16+17), so the collapsed cache was accidentally right. Those baselines revert to master's values once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
