### PR TITLE
Fix async materialization for LoadWith and other query wrappers

### DIFF
--- a/Source/LinqToDB/Async/AsyncExtensions.cs
+++ b/Source/LinqToDB/Async/AsyncExtensions.cs
@@ -168,6 +168,9 @@ namespace LinqToDB.Async
 			if (source is IAsyncEnumerable<TSource> asyncQuery)
 				return asyncQuery;
 
+			if (source.AsLinqToDBQuery() is { } query)
+				return query;
+
 			if (LinqExtensions.ExtensionsAdapter != null)
 				return LinqExtensions.ExtensionsAdapter.AsAsyncEnumerable(source);
 
@@ -212,7 +215,7 @@ namespace LinqToDB.Async
 			this IQueryable<TSource> source, Action<TSource> action,
 			CancellationToken token = default)
 		{
-			if (source is ExpressionQuery<TSource> query)
+			if (source.AsLinqToDBQuery() is { } query)
 				return query.GetForEachAsync(action, token);
 
 			if (LinqExtensions.ExtensionsAdapter != null)
@@ -245,7 +248,7 @@ namespace LinqToDB.Async
 			this IQueryable<TSource> source, Func<TSource,bool> func,
 			CancellationToken token = default)
 		{
-			if (source is ExpressionQuery<TSource> query)
+			if (source.AsLinqToDBQuery() is { } query)
 				return query.GetForEachUntilAsync(func, token);
 
 			return Task.Run(
@@ -278,7 +281,7 @@ namespace LinqToDB.Async
 			this IQueryable<TSource> source,
 			CancellationToken token = default)
 		{
-			if (source is ExpressionQuery<TSource> query)
+			if (source.AsLinqToDBQuery() is { } query)
 			{
 				var list = new List<TSource>();
 				await query.GetForEachAsync(list.Add, token).ConfigureAwait(false);
@@ -306,7 +309,7 @@ namespace LinqToDB.Async
 			this IQueryable<TSource> source,
 			CancellationToken token = default)
 		{
-			if (source is ExpressionQuery<TSource> query)
+			if (source.AsLinqToDBQuery() is { } query)
 			{
 				var list = new List<TSource>();
 				await query.GetForEachAsync(list.Add, token).ConfigureAwait(false);
@@ -338,7 +341,7 @@ namespace LinqToDB.Async
 			CancellationToken        token   = default)
 			where TKey : notnull
 		{
-			if (source is ExpressionQuery<TSource> query)
+			if (source.AsLinqToDBQuery() is { } query)
 			{
 				var dic = new Dictionary<TKey,TSource>();
 				await query.GetForEachAsync(item => dic.Add(keySelector(item), item), token).ConfigureAwait(false);
@@ -368,7 +371,7 @@ namespace LinqToDB.Async
 			CancellationToken        token = default)
 			where TKey : notnull
 		{
-			if (source is ExpressionQuery<TSource> query)
+			if (source.AsLinqToDBQuery() is { } query)
 			{
 				var dic = new Dictionary<TKey,TSource>(comparer);
 				await query.GetForEachAsync(item => dic.Add(keySelector(item), item), token).ConfigureAwait(false);
@@ -399,7 +402,7 @@ namespace LinqToDB.Async
 			CancellationToken        token = default)
 			where TKey : notnull
 		{
-			if (source is ExpressionQuery<TSource> query)
+			if (source.AsLinqToDBQuery() is { } query)
 			{
 				var dic = new Dictionary<TKey,TElement>();
 				await query.GetForEachAsync(item => dic.Add(keySelector(item), elementSelector(item)), token).ConfigureAwait(false);
@@ -432,7 +435,7 @@ namespace LinqToDB.Async
 			CancellationToken        token = default)
 			where TKey : notnull
 		{
-			if (source is ExpressionQuery<TSource> query)
+			if (source.AsLinqToDBQuery() is { } query)
 			{
 				var dic = new Dictionary<TKey,TElement>(comparer);
 				await query.GetForEachAsync(item => dic.Add(keySelector(item), elementSelector(item)), token).ConfigureAwait(false);
@@ -492,7 +495,7 @@ namespace LinqToDB.Async
 			CancellationToken        token = default)
 			where TKey : notnull
 		{
-			if (source is ExpressionQuery<TSource> query)
+			if (source.AsLinqToDBQuery() is { } query)
 			{
 				var lookup = new Lookup<TKey,TSource>(comparer);
 				await query.GetForEachAsync(item => lookup.AddItem(keySelector(item), item), token).ConfigureAwait(false);
@@ -551,7 +554,7 @@ namespace LinqToDB.Async
 			CancellationToken        token = default)
 			where TKey : notnull
 		{
-			if (source is ExpressionQuery<TSource> query)
+			if (source.AsLinqToDBQuery() is { } query)
 			{
 				var lookup = new Lookup<TKey,TElement>(comparer);
 				await query.GetForEachAsync(item => lookup.AddItem(keySelector(item), elementSelector(item)), token).ConfigureAwait(false);

--- a/Source/LinqToDB/Internal/DataProvider/DatabaseSpecificQueryable.cs
+++ b/Source/LinqToDB/Internal/DataProvider/DatabaseSpecificQueryable.cs
@@ -11,8 +11,10 @@ using LinqToDB.Internal.Linq;
 
 namespace LinqToDB.Internal.DataProvider
 {
-	public abstract class DatabaseSpecificQueryable<TSource>(IExpressionQuery<TSource> query) : IExpressionQuery<TSource>
+	public abstract class DatabaseSpecificQueryable<TSource>(IExpressionQuery<TSource> query) : IExpressionQuery<TSource>, IQueryableWrapper<TSource>
 	{
+		IQueryable<TSource> IQueryableWrapper<TSource>.WrappedQuery => query;
+
 		public IEnumerator<TSource> GetEnumerator() 
 			=> query.GetEnumerator();
 

--- a/Source/LinqToDB/Internal/DataProvider/DatabaseSpecificTable.cs
+++ b/Source/LinqToDB/Internal/DataProvider/DatabaseSpecificTable.cs
@@ -11,7 +11,7 @@ using LinqToDB.Internal.Linq;
 
 namespace LinqToDB.Internal.DataProvider
 {
-	public abstract class DatabaseSpecificTable<TSource> : ITable<TSource>
+	public abstract class DatabaseSpecificTable<TSource> : ITable<TSource>, IQueryableWrapper<TSource>
 		where TSource : notnull
 	{
 		protected DatabaseSpecificTable(ITable<TSource> table)
@@ -20,6 +20,8 @@ namespace LinqToDB.Internal.DataProvider
 		}
 
 		readonly ITable<TSource> _table;
+
+		IQueryable<TSource> IQueryableWrapper<TSource>.WrappedQuery => _table;
 
 		public IEnumerator<TSource> GetEnumerator()
 		{

--- a/Source/LinqToDB/Internal/Linq/IQueryableWrapper.cs
+++ b/Source/LinqToDB/Internal/Linq/IQueryableWrapper.cs
@@ -1,0 +1,18 @@
+﻿using System.Linq;
+
+namespace LinqToDB.Internal.Linq
+{
+	/// <summary>
+	/// Implemented by <see cref="IQueryable{T}"/> implementations, which wrap another query to add extra
+	/// query-building functionality (e.g. queries, returned by <c>LoadWith</c> or database-specific hint methods).
+	/// Provides access to wrapped query, so query consumers could detect linq2db query behind the wrapper.
+	/// </summary>
+	/// <typeparam name="TSource">Query element type.</typeparam>
+	interface IQueryableWrapper<out TSource>
+	{
+		/// <summary>
+		/// Gets wrapped query.
+		/// </summary>
+		IQueryable<TSource> WrappedQuery { get; }
+	}
+}

--- a/Source/LinqToDB/Internal/Linq/LinqInternalExtensions.cs
+++ b/Source/LinqToDB/Internal/Linq/LinqInternalExtensions.cs
@@ -142,12 +142,43 @@ namespace LinqToDB.Internal.Linq
 			return (IQueryable<T>)(LinqExtensions.ProcessSourceQueryable?.Invoke(source) ?? source);
 		}
 
+		/// <summary>
+		/// Returns query, wrapped by <paramref name="source"/>, if it is a query wrapper (e.g. query, returned by
+		/// <c>LoadWith</c> or by database-specific hint methods), otherwise returns <paramref name="source"/> as-is.
+		/// </summary>
+		internal static IQueryable<T> UnwrapQueryable<T>(this IQueryable<T> source)
+		{
+			while (source is IQueryableWrapper<T> wrapper)
+				source = wrapper.WrappedQuery;
+
+			return source;
+		}
+
+		/// <summary>
+		/// Returns query provider for <paramref name="source"/> query and throws, if it is not a linq2db query.
+		/// Use <see cref="AsLinqToDBQuery{T}"/> instead for callers that must fall back to non-linq2db behavior
+		/// instead of throwing.
+		/// </summary>
 		public static IQueryProviderAsync GetLinqToDBSource<T>(this IQueryable<T> source, [CallerMemberName] string? method = null)
 		{
-			if (source.ProcessIQueryable() is not IQueryProviderAsync query)
+			if (source.ProcessIQueryable().UnwrapQueryable() is not IQueryProviderAsync query)
 				return ThrowInvalidSource(method);
 
 			return query;
+		}
+
+		/// <summary>
+		/// Returns linq2db query behind <paramref name="source"/> or <see langword="null"/>, if <paramref name="source"/>
+		/// is not a linq2db query (including queries, wrapped by <see cref="IQueryableWrapper{T}"/> implementations).
+		/// <para>
+		/// Unlike <see cref="GetLinqToDBSource{T}"/> it doesn't throw for a non-linq2db query and doesn't apply
+		/// <see cref="ProcessIQueryable{T}"/>, as callers of this method have their own fallbacks for such queries
+		/// (e.g. <see cref="LinqExtensions.ExtensionsAdapter"/>).
+		/// </para>
+		/// </summary>
+		internal static ExpressionQuery<T>? AsLinqToDBQuery<T>(this IQueryable<T> source)
+		{
+			return source.UnwrapQueryable() as ExpressionQuery<T>;
 		}
 
 		[DoesNotReturn]

--- a/Source/LinqToDB/LinqExtensions/LinqExtensions.LoadWith.cs
+++ b/Source/LinqToDB/LinqExtensions/LinqExtensions.LoadWith.cs
@@ -62,10 +62,13 @@ namespace LinqToDB
 			return newTable;
 		}
 
-		abstract class LoadWithQueryableBase<TEntity>(IQueryable<TEntity> query) : IExpressionQuery
+		abstract class LoadWithQueryableBase<TEntity>(IQueryable<TEntity> query) : IExpressionQuery, IQueryableWrapper<TEntity>
 		{
 			[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 			public IQueryable<TEntity> Query { get; } = query;
+
+			[DebuggerBrowsable(DebuggerBrowsableState.Never)]
+			IQueryable<TEntity> IQueryableWrapper<TEntity>.WrappedQuery => Query;
 
 			[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 			Expression IExpressionQuery.Expression => Query.Expression;

--- a/Source/LinqToDB/LinqExtensions/LinqExtensions.cs
+++ b/Source/LinqToDB/LinqExtensions/LinqExtensions.cs
@@ -1720,9 +1720,6 @@ namespace LinqToDB
 		/// <remarks>Eager load queries currently return only SQL for main query.</remarks>
 		public static QuerySql ToSqlQuery<T>(this IQueryable<T> query, SqlGenerationOptions? options = null)
 		{
-			if (query is LoadWithQueryableBase<T> loadWith)
-				query = loadWith.Query;
-
 			var expressionQuery = (IExpressionQuery)query.GetLinqToDBSource();
 
 			// currently we have only non-linq APIs that could generate multiple commands like

--- a/Source/LinqToDB/TempTable.cs
+++ b/Source/LinqToDB/TempTable.cs
@@ -23,7 +23,7 @@ namespace LinqToDB
 	/// </summary>
 	/// <typeparam name="T">Table record mapping class.</typeparam>
 	[PublicAPI]
-	public class TempTable<T> : ITable<T>, ITableMutable<T>, IDisposable, IAsyncDisposable
+	public class TempTable<T> : ITable<T>, ITableMutable<T>, IQueryableWrapper<T>, IDisposable, IAsyncDisposable
 		where T : notnull
 	{
 		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -815,6 +815,9 @@ namespace LinqToDB
 
 		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 		IQueryProvider IQueryable.Provider    => _table.Provider;
+
+		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
+		IQueryable<T> IQueryableWrapper<T>.WrappedQuery => _table;
 
 		#endregion
 

--- a/Tests/Linq/Linq/AsyncTests.cs
+++ b/Tests/Linq/Linq/AsyncTests.cs
@@ -1,15 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 using LinqToDB;
 using LinqToDB.Async;
+using LinqToDB.Common;
 using LinqToDB.Data;
+using LinqToDB.DataProvider.SQLite;
 using LinqToDB.Internal.Async;
+using LinqToDB.Interceptors;
+using LinqToDB.Mapping;
 
 using NUnit.Framework;
+
+using Shouldly;
 
 using Tests.Model;
 using Tests.UserTests;
@@ -310,6 +318,88 @@ namespace Tests.Linq
 
 			foreach (var g in g1)
 				AreEqual(g1[g.Key], g2[g.Key]);
+		}
+
+		// Queries, returned by LoadWith/database-specific extensions or by temporary table creation, are wrappers
+		// over linq2db query. Materialization extensions below must recognize them, otherwise query is executed
+		// synchronously on a thread pool thread instead of using async ADO.NET API.
+		[Test]
+		public async Task LoadWithQueryMaterializedAsynchronously([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			var interceptor = new DataReaderApiInterceptor();
+
+			using var db = GetDataConnection(context, interceptor: interceptor);
+
+			var records = await db.Child.LoadWith(c => c.Parent).ToListAsync();
+
+			records.ShouldNotBeEmpty();
+			records.ShouldAllBe(c => c.Parent != null);
+
+			interceptor.AsyncCalls.ShouldBeGreaterThan(0);
+			interceptor.SyncCalls.ShouldBe(0);
+		}
+
+		[Test]
+		public async Task TempTableMaterializedAsynchronously([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			var interceptor = new DataReaderApiInterceptor();
+
+			using var db    = GetDataConnection(context, interceptor: interceptor);
+			using var table = db.CreateLocalTable(new[] { new AsyncMaterializationRecord { Id = 1 } });
+
+			interceptor.Reset();
+
+			var records = await table.ToListAsync();
+
+			records.ShouldHaveSingleItem();
+
+			interceptor.AsyncCalls.ShouldBeGreaterThan(0);
+			interceptor.SyncCalls.ShouldBe(0);
+		}
+
+		[Test]
+		public async Task DatabaseSpecificTableMaterializedAsynchronously([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			var interceptor = new DataReaderApiInterceptor();
+
+			using var db = GetDataConnection(context, interceptor: interceptor);
+
+			var records = await db.Child.AsSQLite().ToListAsync();
+
+			records.ShouldNotBeEmpty();
+
+			interceptor.AsyncCalls.ShouldBeGreaterThan(0);
+			interceptor.SyncCalls.ShouldBe(0);
+		}
+
+		[Table]
+		sealed class AsyncMaterializationRecord
+		{
+			[PrimaryKey] public int Id { get; set; }
+		}
+
+		sealed class DataReaderApiInterceptor : CommandInterceptor
+		{
+			public int SyncCalls  { get; private set; }
+			public int AsyncCalls { get; private set; }
+
+			public void Reset()
+			{
+				SyncCalls  = 0;
+				AsyncCalls = 0;
+			}
+
+			public override Option<DbDataReader> ExecuteReader(CommandEventData eventData, DbCommand command, CommandBehavior commandBehavior, Option<DbDataReader> result)
+			{
+				SyncCalls++;
+				return base.ExecuteReader(eventData, command, commandBehavior, result);
+			}
+
+			public override Task<Option<DbDataReader>> ExecuteReaderAsync(CommandEventData eventData, DbCommand command, CommandBehavior commandBehavior, Option<DbDataReader> result, CancellationToken cancellationToken)
+			{
+				AsyncCalls++;
+				return base.ExecuteReaderAsync(eventData, command, commandBehavior, result, cancellationToken);
+			}
 		}
 	}
 }

--- a/Tests/Linq/Linq/AsyncTests.cs
+++ b/Tests/Linq/Linq/AsyncTests.cs
@@ -10,6 +10,7 @@ using LinqToDB;
 using LinqToDB.Async;
 using LinqToDB.Common;
 using LinqToDB.Data;
+using LinqToDB.DataProvider.DuckDB;
 using LinqToDB.DataProvider.SQLite;
 using LinqToDB.Internal.Async;
 using LinqToDB.Interceptors;
@@ -353,6 +354,13 @@ namespace Tests.Linq
 
 			records.ShouldHaveSingleItem();
 
+			var asyncRecords = new List<AsyncMaterializationRecord>();
+
+			await foreach (var record in table.AsAsyncEnumerable())
+				asyncRecords.Add(record);
+
+			asyncRecords.ShouldHaveSingleItem();
+
 			interceptor.AsyncCalls.ShouldBeGreaterThan(0);
 			interceptor.SyncCalls.ShouldBe(0);
 		}
@@ -365,6 +373,23 @@ namespace Tests.Linq
 			using var db = GetDataConnection(context, interceptor: interceptor);
 
 			var records = await db.Child.AsSQLite().ToListAsync();
+
+			records.ShouldNotBeEmpty();
+
+			interceptor.AsyncCalls.ShouldBeGreaterThan(0);
+			interceptor.SyncCalls.ShouldBe(0);
+		}
+
+		// AsDuckDB over IQueryable (rather than ITable) is the only shape that produces
+		// DatabaseSpecificQueryable; SQLite has no such overload.
+		[Test]
+		public async Task DatabaseSpecificQueryableMaterializedAsynchronously([IncludeDataSources(TestProvName.AllDuckDB)] string context)
+		{
+			var interceptor = new DataReaderApiInterceptor();
+
+			using var db = GetDataConnection(context, interceptor: interceptor);
+
+			var records = await db.Child.Where(c => c.ChildID > 0).AsDuckDB().ToListAsync();
 
 			records.ShouldNotBeEmpty();
 

--- a/Tests/Linq/Linq/LoadWithTests.cs
+++ b/Tests/Linq/Linq/LoadWithTests.cs
@@ -34,6 +34,23 @@ namespace Tests.Linq
 			Assert.That(ch.Parent, Is.Not.Null);
 		}
 
+		// LoadWith returns a wrapper over linq2db query, so linq2db-only extensions must still see the
+		// query behind it instead of rejecting it as a non-linq2db IQueryable.
+		[Test]
+		public void LoadWithQueryIsLinqToDbSource([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var query = db.Child.LoadWith(c => c.Parent);
+
+			query.ToSqlQuery().Sql.ShouldNotBeNullOrWhiteSpace();
+
+			var child = query.ElementAtOrDefault(() => 0);
+
+			child.ShouldNotBeNull();
+			child.Parent.ShouldNotBeNull();
+		}
+
 		[Test]
 		public void LoadWithAsTable1([DataSources] string context)
 		{


### PR DESCRIPTION
Fixes #5805

## Problem

`LoadWith()` returns a wrapper over the linq2db query, and `AsyncExtensions` detected a linq2db query with a direct `source is ExpressionQuery<TSource>` check. A wrapper fails that check, so `ToListAsync()` fell through to `Task.Run(() => source.AsEnumerable()...)` — a synchronous read on a thread-pool thread. `FirstAsync()` and friends were unaffected because the generated overloads go through `source.Provider as IQueryProviderAsync`, which wrappers forward.

The same defect affects every query wrapper, not only `LoadWith`:

| Wrapper | Reachable via |
|---|---|
| `LoadWithQueryableBase<T>` | `LoadWith` / `ThenLoad` |
| `TempTable<T>` | `CreateTempTable` / `CreateLocalTable` |
| `DatabaseSpecificQueryable<T>` | `query.AsSqlServer()`, `AsOracle()`, ... |
| `DatabaseSpecificTable<T>` | `table.AsSQLite()`, `AsSqlServer()`, ... |

`PersistentTable<T>` also wraps a query, but it is a builder-internal association artifact that never reaches user materialization (its `DataContext` is `null!`), so it is left alone.

## Fix

Wrappers implement a new internal `IQueryableWrapper<T>` marker exposing the wrapped query. `LinqInternalExtensions.UnwrapQueryable` walks that chain, and both query lookups use it:

- `AsLinqToDBQuery` (new) — returns `ExpressionQuery<T>` or `null`, used by the 11 detection sites in `AsyncExtensions`: `ToListAsync`, `ToArrayAsync`, `ToDictionaryAsync` (x4), `ToLookupAsync` (x2), `ForEachAsync`, `ForEachUntilAsync`, `AsAsyncEnumerable`.
- `GetLinqToDBSource` — unchanged contract, one `.UnwrapQueryable()` inserted into the existing chain.

`AsLinqToDBQuery` deliberately does not apply `ProcessIQueryable`: the EF hook throws `LinqToDBForEFToolsException` for a plain non-EF `IQueryable`, which would turn today's graceful fallback into an exception.

### Second family, same root cause

`GetLinqToDBSource` rejected a `LoadWith` query outright, so `ElementAt` / `ElementAtOrDefault` (and their `Async` overloads), `Insert`, `Delete`, `Update`, `Merge`, `MultiInsert` and the `AnalyticFunctions` overloads threw `LinqToDB method 'X' called on non-LinqToDB IQueryable`. `ToSqlQuery` escaped only because it carried a hand-rolled `LoadWithQueryableBase` unwrap — removed here as redundant.

## Tests

SQLite-only, in the fixtures that own the behaviour:

- `AsyncTests.LoadWithQueryMaterializedAsynchronously`, `TempTableMaterializedAsynchronously`, `DatabaseSpecificTableMaterializedAsynchronously` — a `CommandInterceptor` counts `ExecuteReader` vs `ExecuteReaderAsync`, so the assertion is on the ADO.NET API actually used rather than on timing.
- `LoadWithTests.LoadWithQueryIsLinqToDbSource` — `ToSqlQuery` plus `ElementAtOrDefault`.

All verified red before the fix (`AsyncCalls == 0` for the async tests, `LinqToDBException` for `ElementAtOrDefault`).

Not covered: `DatabaseSpecificQueryable` (the `query.AsSqlServer()` shape) has no SQLite entry point, so only its `DatabaseSpecificTable` sibling is exercised by a test.

## Verification

- Full `Tests/Linq` suite on `SQLite.MS`: 10912 tests, 0 failed, 10634 passed, 278 skipped.
- Release build across `net462`, `netstandard2.0`, `net8.0`, `net9.0`, `net10.0` with analyzers: 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
