### PR TITLE
Oracle: add FOR UPDATE row-locking query hint API (issue #5706)

### DIFF
--- a/Source/LinqToDB/DataProvider/Oracle/OracleHints.cs
+++ b/Source/LinqToDB/DataProvider/Oracle/OracleHints.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Text;
 
 using JetBrains.Annotations;
 
@@ -9,6 +10,7 @@ using LinqToDB.Internal.DataProvider;
 using LinqToDB.Internal.DataProvider.Oracle;
 using LinqToDB.Internal.Linq;
 using LinqToDB.Internal.SqlProvider;
+using LinqToDB.Internal.SqlQuery;
 using LinqToDB.Mapping;
 using LinqToDB.SqlQuery;
 
@@ -157,6 +159,181 @@ namespace LinqToDB.DataProvider.Oracle
 				return string.Format(CultureInfo.InvariantCulture, "CONTAINERS(DEFAULT_PDB_HINT='{0}')", hint);
 			}
 		}
+
+		// https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/SELECT.html#GUID-CFA006CA-6FF1-4972-821E-6996142A51C6
+		//
+		public const string ForUpdate  = "FOR UPDATE";
+		public const string NoWait     = "NOWAIT";
+		public const string SkipLocked = "SKIP LOCKED";
+
+		/// <summary>Returns a <c>WAIT <paramref name="seconds"/></c> locking wait clause for use with <see cref="ForUpdateHint{TSource}(IOracleSpecificQueryable{TSource},string)"/>.</summary>
+		public static string Wait(int seconds) => string.Format(CultureInfo.InvariantCulture, "WAIT {0}", seconds);
+
+		#region SubQueryHint
+
+		sealed class ForUpdateHintExtensionBuilder : ISqlQueryExtensionBuilder
+		{
+			void ISqlQueryExtensionBuilder.Build(NullabilityContext nullability, ISqlBuilder sqlBuilder, StringBuilder stringBuilder, SqlQueryExtension sqlQueryExtension)
+			{
+				var hint = (string)((SqlValue)sqlQueryExtension.Arguments["hint"]).Value!;
+
+				stringBuilder.Append(ForUpdate);
+
+				var columnCount = (int)((SqlValue)sqlQueryExtension.Arguments["columns.Count"]).Value!;
+
+				if (columnCount > 0)
+				{
+					stringBuilder.Append(" OF ");
+
+					for (var i = 0; i < columnCount; i++)
+					{
+						if (i > 0)
+							stringBuilder.Append(", ");
+
+						stringBuilder.Append((string)((SqlValue)sqlQueryExtension.Arguments[string.Create(CultureInfo.InvariantCulture, $"columns.{i}")]).Value!);
+					}
+				}
+
+				if (!string.IsNullOrEmpty(hint))
+				{
+					stringBuilder.Append(' ');
+					stringBuilder.Append(hint);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Adds a <c>FOR UPDATE</c> sub-query hint to a generated query.
+		/// </summary>
+		/// <typeparam name="TSource">Table record mapping class.</typeparam>
+		/// <param name="source">Query source.</param>
+		/// <param name="hint">Optional locking wait clause: <see cref="NoWait"/>, <see cref="SkipLocked"/>, or <see cref="Wait(int)"/>.</param>
+		/// <param name="columns">Optional column names for the <c>OF</c> clause.</param>
+		/// <returns>Query source with sub-query hint.</returns>
+		[LinqTunnel, Pure, IsQueryable]
+		[Sql.QueryExtension(ProviderName.Oracle, Sql.QueryExtensionScope.SubQueryHint, typeof(ForUpdateHintExtensionBuilder))]
+		[Sql.QueryExtension(null,                Sql.QueryExtensionScope.None,         typeof(NoneExtensionBuilder))]
+		static IOracleSpecificQueryable<TSource> ForUpdateSubQueryHint<TSource>(
+			this IOracleSpecificQueryable<TSource> source,
+			[SqlQueryDependent] string             hint,
+			[SqlQueryDependent] params string[]    columns)
+			where TSource : notnull
+		{
+			var currentSource = source.ProcessIQueryable();
+
+			return new OracleSpecificQueryable<TSource>((IExpressionQuery<TSource>)currentSource.Provider.CreateQuery<TSource>(
+				Expression.Call(
+					null,
+					MethodHelper.GetMethodInfo(ForUpdateSubQueryHint, source, hint, columns),
+					currentSource.Expression,
+					Expression.Constant(hint),
+					Expression.NewArrayInit(typeof(string), columns.Select(Expression.Constant)))));
+		}
+
+		#endregion
+
+		#region ForUpdateHint
+
+		/// <summary>
+		/// Adds <c>FOR UPDATE</c> row-locking clause to the generated query.
+		/// <code>
+		/// // SELECT ... FOR UPDATE
+		/// var query = db.Table.AsOracle().ForUpdateHint();
+		/// </code>
+		/// </summary>
+		/// <typeparam name="TSource">Table record mapping class.</typeparam>
+		/// <param name="source">Query source.</param>
+		/// <returns>Query source with <c>FOR UPDATE</c> hint.</returns>
+		[ExpressionMethod(nameof(ForUpdateHintImpl))]
+		public static IOracleSpecificQueryable<TSource> ForUpdateHint<TSource>(this IOracleSpecificQueryable<TSource> source)
+			where TSource : notnull
+		{
+			return ForUpdateSubQueryHint(source, string.Empty);
+		}
+		static Expression<Func<IOracleSpecificQueryable<TSource>, IOracleSpecificQueryable<TSource>>> ForUpdateHintImpl<TSource>()
+			where TSource : notnull
+		{
+			return source => ForUpdateSubQueryHint(source, string.Empty);
+		}
+
+		/// <summary>
+		/// Adds <c>FOR UPDATE <paramref name="lockingClause"/></c> row-locking clause to the generated query.
+		/// <code>
+		/// // SELECT ... FOR UPDATE NOWAIT
+		/// var query = db.Table.AsOracle().ForUpdateHint(OracleHints.NoWait);
+		/// </code>
+		/// </summary>
+		/// <typeparam name="TSource">Table record mapping class.</typeparam>
+		/// <param name="source">Query source.</param>
+		/// <param name="lockingClause">Locking wait clause: <see cref="NoWait"/>, <see cref="SkipLocked"/>, or <see cref="Wait(int)"/>.</param>
+		/// <returns>Query source with <c>FOR UPDATE</c> hint.</returns>
+		[ExpressionMethod(nameof(ForUpdateHintWithClauseImpl))]
+		public static IOracleSpecificQueryable<TSource> ForUpdateHint<TSource>(
+			this IOracleSpecificQueryable<TSource> source,
+			[SqlQueryDependent] string             lockingClause)
+			where TSource : notnull
+		{
+			return ForUpdateSubQueryHint(source, lockingClause);
+		}
+		static Expression<Func<IOracleSpecificQueryable<TSource>, string, IOracleSpecificQueryable<TSource>>> ForUpdateHintWithClauseImpl<TSource>()
+			where TSource : notnull
+		{
+			return (source, lockingClause) => ForUpdateSubQueryHint(source, lockingClause);
+		}
+
+		/// <summary>
+		/// Adds <c>FOR UPDATE OF <paramref name="columns"/></c> row-locking clause to the generated query.
+		/// <code>
+		/// // SELECT ... FOR UPDATE OF col1, col2
+		/// var query = db.Table.AsOracle().ForUpdateHint("col1", "col2");
+		/// </code>
+		/// </summary>
+		/// <typeparam name="TSource">Table record mapping class.</typeparam>
+		/// <param name="source">Query source.</param>
+		/// <param name="columns">Column names for the <c>OF</c> clause.</param>
+		/// <returns>Query source with <c>FOR UPDATE OF</c> hint.</returns>
+		[ExpressionMethod(nameof(ForUpdateHintWithColumnsImpl))]
+		public static IOracleSpecificQueryable<TSource> ForUpdateHint<TSource>(
+			this IOracleSpecificQueryable<TSource> source,
+			[SqlQueryDependent] params string[]    columns)
+			where TSource : notnull
+		{
+			return ForUpdateSubQueryHint(source, string.Empty, columns);
+		}
+		static Expression<Func<IOracleSpecificQueryable<TSource>, string[], IOracleSpecificQueryable<TSource>>> ForUpdateHintWithColumnsImpl<TSource>()
+			where TSource : notnull
+		{
+			return (source, columns) => ForUpdateSubQueryHint(source, string.Empty, columns);
+		}
+
+		/// <summary>
+		/// Adds <c>FOR UPDATE OF <paramref name="columns"/> <paramref name="lockingClause"/></c> row-locking clause to the generated query.
+		/// <code>
+		/// // SELECT ... FOR UPDATE OF col1, col2 NOWAIT
+		/// var query = db.Table.AsOracle().ForUpdateHint(OracleHints.NoWait, "col1", "col2");
+		/// </code>
+		/// </summary>
+		/// <typeparam name="TSource">Table record mapping class.</typeparam>
+		/// <param name="source">Query source.</param>
+		/// <param name="lockingClause">Locking wait clause: <see cref="NoWait"/>, <see cref="SkipLocked"/>, or <see cref="Wait(int)"/>.</param>
+		/// <param name="columns">Column names for the <c>OF</c> clause.</param>
+		/// <returns>Query source with <c>FOR UPDATE OF</c> hint.</returns>
+		[ExpressionMethod(nameof(ForUpdateHintWithClauseAndColumnsImpl))]
+		public static IOracleSpecificQueryable<TSource> ForUpdateHint<TSource>(
+			this IOracleSpecificQueryable<TSource> source,
+			[SqlQueryDependent] string             lockingClause,
+			[SqlQueryDependent] params string[]    columns)
+			where TSource : notnull
+		{
+			return ForUpdateSubQueryHint(source, lockingClause, columns);
+		}
+		static Expression<Func<IOracleSpecificQueryable<TSource>, string, string[], IOracleSpecificQueryable<TSource>>> ForUpdateHintWithClauseAndColumnsImpl<TSource>()
+			where TSource : notnull
+		{
+			return (source, lockingClause, columns) => ForUpdateSubQueryHint(source, lockingClause, columns);
+		}
+
+		#endregion
 
 		#region OracleSpecific Hints
 

--- a/Source/LinqToDB/Internal/DataProvider/Oracle/OracleSqlBuilderBase.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Oracle/OracleSqlBuilderBase.cs
@@ -770,6 +770,29 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 			}
 		}
 
+		protected override void BuildSubQueryExtensions(SqlStatement statement)
+		{
+			if (statement.SelectQuery?.SqlQueryExtensions is not null)
+			{
+				var len = StringBuilder.Length;
+
+				AppendIndent();
+
+				var prefix = Environment.NewLine;
+
+				if (StringBuilder.Length > len)
+				{
+					var buffer = new char[StringBuilder.Length - len];
+
+					StringBuilder.CopyTo(len, buffer, 0, StringBuilder.Length - len);
+
+					prefix += new string(buffer);
+				}
+
+				BuildQueryExtensions(StringBuilder, statement.SelectQuery.SqlQueryExtensions, null, prefix, Environment.NewLine, Sql.QueryExtensionScope.SubQueryHint);
+			}
+		}
+
 		protected override void FinalizeBuildQuery(SqlStatement statement)
 		{
 			base.FinalizeBuildQuery(statement);

--- a/Source/LinqToDB/PublicAPI/PublicAPI.Unshipped.txt
+++ b/Source/LinqToDB/PublicAPI/PublicAPI.Unshipped.txt
@@ -1181,3 +1181,11 @@ virtual LinqToDB.Internal.SqlProvider.BasicSqlBuilder.GetParameterCastType(LinqT
 virtual LinqToDB.Internal.SqlQuery.Visitors.QueryElementVisitor.VisitInListValues(LinqToDB.Internal.SqlQuery.SqlPredicate.InList! predicate, System.Collections.Generic.List<LinqToDB.Internal.SqlQuery.ISqlExpression!>! values, LinqToDB.Internal.SqlQuery.Visitors.VisitMode mode) -> System.Collections.Generic.List<LinqToDB.Internal.SqlQuery.ISqlExpression!>?
 virtual LinqToDB.Internal.SqlQuery.Visitors.QueryElementVisitor.VisitSqlParameterCastExpression(LinqToDB.Internal.SqlQuery.SqlParameterCastExpression! element) -> LinqToDB.Internal.SqlQuery.IQueryElement!
 static LinqToDB.Internal.SqlQuery.QueryHelper.EnsureParameterCast(LinqToDB.Internal.SqlQuery.ISqlExpression! expression) -> LinqToDB.Internal.SqlQuery.ISqlExpression!
+const LinqToDB.DataProvider.Oracle.OracleHints.ForUpdate = "FOR UPDATE" -> string!
+const LinqToDB.DataProvider.Oracle.OracleHints.NoWait = "NOWAIT" -> string!
+const LinqToDB.DataProvider.Oracle.OracleHints.SkipLocked = "SKIP LOCKED" -> string!
+static LinqToDB.DataProvider.Oracle.OracleHints.Wait(int seconds) -> string!
+static LinqToDB.DataProvider.Oracle.OracleHints.ForUpdateHint<TSource>(this LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>! source) -> LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>!
+static LinqToDB.DataProvider.Oracle.OracleHints.ForUpdateHint<TSource>(this LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>! source, string! lockingClause) -> LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>!
+static LinqToDB.DataProvider.Oracle.OracleHints.ForUpdateHint<TSource>(this LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>! source, params string![]! columns) -> LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>!
+static LinqToDB.DataProvider.Oracle.OracleHints.ForUpdateHint<TSource>(this LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>! source, string! lockingClause, params string![]! columns) -> LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>!

--- a/Source/LinqToDB/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/Source/LinqToDB/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,11 @@
 #nullable enable
 override LinqToDB.DataProvider.DuckDB.DuckDBOptions.<Clone>$() -> LinqToDB.DataProvider.DuckDB.DuckDBOptions!
 *REMOVED*override LinqToDB.Internal.DataProvider.Ydb.Translation.YdbMemberTranslator.SqlTypesTranslation.ConvertDateOnly(LinqToDB.Linq.Translation.ITranslationContext! translationContext, System.Linq.Expressions.MemberExpression! memberExpression, LinqToDB.Linq.Translation.TranslationFlags translationFlags) -> System.Linq.Expressions.Expression?
+const LinqToDB.DataProvider.Oracle.OracleHints.ForUpdate = "FOR UPDATE" -> string!
+const LinqToDB.DataProvider.Oracle.OracleHints.NoWait = "NOWAIT" -> string!
+const LinqToDB.DataProvider.Oracle.OracleHints.SkipLocked = "SKIP LOCKED" -> string!
+static LinqToDB.DataProvider.Oracle.OracleHints.Wait(int seconds) -> string!
+static LinqToDB.DataProvider.Oracle.OracleHints.ForUpdateHint<TSource>(this LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>! source) -> LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>!
+static LinqToDB.DataProvider.Oracle.OracleHints.ForUpdateHint<TSource>(this LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>! source, string! lockingClause) -> LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>!
+static LinqToDB.DataProvider.Oracle.OracleHints.ForUpdateHint<TSource>(this LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>! source, params string![]! columns) -> LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>!
+static LinqToDB.DataProvider.Oracle.OracleHints.ForUpdateHint<TSource>(this LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>! source, string! lockingClause, params string![]! columns) -> LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>!

--- a/Source/LinqToDB/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/Source/LinqToDB/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,2 +1,10 @@
 #nullable enable
 override LinqToDB.DataProvider.DuckDB.DuckDBOptions.<Clone>$() -> LinqToDB.Internal.DataProvider.DataProviderOptions<LinqToDB.DataProvider.DuckDB.DuckDBOptions!>!
+const LinqToDB.DataProvider.Oracle.OracleHints.ForUpdate = "FOR UPDATE" -> string!
+const LinqToDB.DataProvider.Oracle.OracleHints.NoWait = "NOWAIT" -> string!
+const LinqToDB.DataProvider.Oracle.OracleHints.SkipLocked = "SKIP LOCKED" -> string!
+static LinqToDB.DataProvider.Oracle.OracleHints.Wait(int seconds) -> string!
+static LinqToDB.DataProvider.Oracle.OracleHints.ForUpdateHint<TSource>(this LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>! source) -> LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>!
+static LinqToDB.DataProvider.Oracle.OracleHints.ForUpdateHint<TSource>(this LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>! source, string! lockingClause) -> LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>!
+static LinqToDB.DataProvider.Oracle.OracleHints.ForUpdateHint<TSource>(this LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>! source, params string![]! columns) -> LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>!
+static LinqToDB.DataProvider.Oracle.OracleHints.ForUpdateHint<TSource>(this LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>! source, string! lockingClause, params string![]! columns) -> LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>!

--- a/Source/LinqToDB/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/Source/LinqToDB/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,11 @@
 #nullable enable
 override LinqToDB.DataProvider.DuckDB.DuckDBOptions.<Clone>$() -> LinqToDB.DataProvider.DuckDB.DuckDBOptions!
 *REMOVED*override LinqToDB.Internal.DataProvider.Ydb.Translation.YdbMemberTranslator.SqlTypesTranslation.ConvertDateOnly(LinqToDB.Linq.Translation.ITranslationContext! translationContext, System.Linq.Expressions.MemberExpression! memberExpression, LinqToDB.Linq.Translation.TranslationFlags translationFlags) -> System.Linq.Expressions.Expression?
+const LinqToDB.DataProvider.Oracle.OracleHints.ForUpdate = "FOR UPDATE" -> string!
+const LinqToDB.DataProvider.Oracle.OracleHints.NoWait = "NOWAIT" -> string!
+const LinqToDB.DataProvider.Oracle.OracleHints.SkipLocked = "SKIP LOCKED" -> string!
+static LinqToDB.DataProvider.Oracle.OracleHints.Wait(int seconds) -> string!
+static LinqToDB.DataProvider.Oracle.OracleHints.ForUpdateHint<TSource>(this LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>! source) -> LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>!
+static LinqToDB.DataProvider.Oracle.OracleHints.ForUpdateHint<TSource>(this LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>! source, string! lockingClause) -> LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>!
+static LinqToDB.DataProvider.Oracle.OracleHints.ForUpdateHint<TSource>(this LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>! source, params string![]! columns) -> LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>!
+static LinqToDB.DataProvider.Oracle.OracleHints.ForUpdateHint<TSource>(this LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>! source, string! lockingClause, params string![]! columns) -> LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>!

--- a/Source/LinqToDB/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/Source/LinqToDB/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,11 @@
 #nullable enable
 override LinqToDB.DataProvider.DuckDB.DuckDBOptions.<Clone>$() -> LinqToDB.DataProvider.DuckDB.DuckDBOptions!
 *REMOVED*override LinqToDB.Internal.DataProvider.Ydb.Translation.YdbMemberTranslator.SqlTypesTranslation.ConvertDateOnly(LinqToDB.Linq.Translation.ITranslationContext! translationContext, System.Linq.Expressions.MemberExpression! memberExpression, LinqToDB.Linq.Translation.TranslationFlags translationFlags) -> System.Linq.Expressions.Expression?
+const LinqToDB.DataProvider.Oracle.OracleHints.ForUpdate = "FOR UPDATE" -> string!
+const LinqToDB.DataProvider.Oracle.OracleHints.NoWait = "NOWAIT" -> string!
+const LinqToDB.DataProvider.Oracle.OracleHints.SkipLocked = "SKIP LOCKED" -> string!
+static LinqToDB.DataProvider.Oracle.OracleHints.Wait(int seconds) -> string!
+static LinqToDB.DataProvider.Oracle.OracleHints.ForUpdateHint<TSource>(this LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>! source) -> LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>!
+static LinqToDB.DataProvider.Oracle.OracleHints.ForUpdateHint<TSource>(this LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>! source, string! lockingClause) -> LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>!
+static LinqToDB.DataProvider.Oracle.OracleHints.ForUpdateHint<TSource>(this LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>! source, params string![]! columns) -> LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>!
+static LinqToDB.DataProvider.Oracle.OracleHints.ForUpdateHint<TSource>(this LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>! source, string! lockingClause, params string![]! columns) -> LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>!

--- a/Source/LinqToDB/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/Source/LinqToDB/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,10 @@
 #nullable enable
 override LinqToDB.DataProvider.DuckDB.DuckDBOptions.<Clone>$() -> LinqToDB.Internal.DataProvider.DataProviderOptions<LinqToDB.DataProvider.DuckDB.DuckDBOptions!>!
+const LinqToDB.DataProvider.Oracle.OracleHints.ForUpdate = "FOR UPDATE" -> string!
+const LinqToDB.DataProvider.Oracle.OracleHints.NoWait = "NOWAIT" -> string!
+const LinqToDB.DataProvider.Oracle.OracleHints.SkipLocked = "SKIP LOCKED" -> string!
+static LinqToDB.DataProvider.Oracle.OracleHints.Wait(int seconds) -> string!
+static LinqToDB.DataProvider.Oracle.OracleHints.ForUpdateHint<TSource>(this LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>! source) -> LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>!
+static LinqToDB.DataProvider.Oracle.OracleHints.ForUpdateHint<TSource>(this LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>! source, string! lockingClause) -> LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>!
+static LinqToDB.DataProvider.Oracle.OracleHints.ForUpdateHint<TSource>(this LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>! source, params string![]! columns) -> LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>!
+static LinqToDB.DataProvider.Oracle.OracleHints.ForUpdateHint<TSource>(this LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>! source, string! lockingClause, params string![]! columns) -> LinqToDB.DataProvider.Oracle.IOracleSpecificQueryable<TSource>!


### PR DESCRIPTION
Oracle had no API to emit `SELECT … FOR UPDATE [OF col, …] [NOWAIT | WAIT n | SKIP LOCKED]`. The generic `SubQueryHint("FOR UPDATE")` was silently dropped because `OracleSqlBuilderBase` never overrode `BuildSubQueryExtensions`.

## Changes

### `OracleHints.cs`
- Row-locking constants outside the optimizer-hint `Hint` class: `ForUpdate`, `NoWait`, `SkipLocked`, `Wait(int seconds)`
- Non-public `ForUpdateSubQueryHint` registered as `SubQueryHint` scope with `ForUpdateHintExtensionBuilder` (emits `FOR UPDATE [OF col, …] [clause]`)
- Four public `ForUpdateHint` convenience overloads via `[ExpressionMethod]` delegation

### `OracleSqlBuilderBase.cs`
- Override `BuildSubQueryExtensions` — mirrors the PostgreSQL implementation; emits `SubQueryHint`-scoped extensions on a new indented line after the query body

### `PublicAPI.Unshipped.txt` (all TFMs)
- New entries for constants, `Wait`, and `ForUpdateHint` overloads

## Usage

```csharp
db.GetTable<T>().AsOracle().Where(...)
    .ForUpdateHint();                              // FOR UPDATE
    .ForUpdateHint(OracleHints.NoWait);            // FOR UPDATE NOWAIT
    .ForUpdateHint(OracleHints.SkipLocked);        // FOR UPDATE SKIP LOCKED
    .ForUpdateHint(OracleHints.Wait(5));           // FOR UPDATE WAIT 5
    .ForUpdateHint("col1", "col2");                // FOR UPDATE OF col1, col2
    .ForUpdateHint(OracleHints.NoWait, "col1");    // FOR UPDATE OF col1 NOWAIT
```