### PR TITLE
Support interceptors on custom IDataContext, fix compiled query over ToList()

### DIFF
--- a/Source/LinqToDB/CompiledQuery.cs
+++ b/Source/LinqToDB/CompiledQuery.cs
@@ -119,11 +119,20 @@ namespace LinqToDB
 									typeof(IQueryable<>) :
 									typeof(IEnumerable<>);
 
-							var qtype  = type.GetGenericType(expr.Type);
-							var helper = ActivatorExt.CreateInstance<ITableHelper>(
-								typeof(TableHelper<>).MakeGenericType(qtype == null ? expr.Type : qtype.GetGenericArguments()[0]));
+							var qtype       = type.GetGenericType(expr.Type);
+							var elementType = qtype?.GetGenericArguments()[0];
 
-							return helper.CallTable(context.query, expr, context.ps, context.preambles, qtype != null ? MethodType.Queryable : MethodType.Element);
+							// The Queryable form substitutes a Table<T>, so it applies only when the call's static type
+							// can hold one. A client-side materializer such as ToList() is typed List<T> and cannot:
+							// leave the call in place so the inner queryable becomes the compiled table instead, which
+							// is what already happens for its async counterpart.
+							if (elementType == null || expr.Type.IsAssignableFrom(typeof(Table<>).MakeGenericType(elementType)))
+							{
+								var helper = ActivatorExt.CreateInstance<ITableHelper>(
+									typeof(TableHelper<>).MakeGenericType(elementType ?? expr.Type));
+
+								return helper.CallTable(context.query, expr, context.ps, context.preambles, elementType != null ? MethodType.Queryable : MethodType.Element);
+							}
 						}
 
 						if (string.Equals(expr.Method.Name, "GetTable", StringComparison.Ordinal) && expr.Method.DeclaringType == typeof(DataExtensions))

--- a/Source/LinqToDB/Internal/Interceptors/IInterceptable.cs
+++ b/Source/LinqToDB/Internal/Interceptors/IInterceptable.cs
@@ -2,11 +2,11 @@
 
 namespace LinqToDB.Internal.Interceptors
 {
-	interface IInterceptable
+	public interface IInterceptable
 	{
 	}
 
-	interface IInterceptable<T> : IInterceptable
+	public interface IInterceptable<T> : IInterceptable
 		where T : IInterceptor
 	{
 		T? Interceptor { get; set; }

--- a/Tests/Linq/Linq/CompileTests.cs
+++ b/Tests/Linq/Linq/CompileTests.cs
@@ -575,7 +575,6 @@ namespace Tests.Linq
 			}
 		}
 
-		[ActiveIssue]
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4365")]
 		public void IDataContext_CompiledQueryTest_AsList([DataSources(false)] string context)
 		{
@@ -590,7 +589,6 @@ namespace Tests.Linq
 			Assert.That(result2[0], Is.SameAs(result1[0]));
 		}
 
-		[ActiveIssue]
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4365")]
 		public void CustomContext_CompiledQueryCustomTest_AsList([DataSources(false)] string context)
 		{

--- a/Tests/Linq/Linq/CompileTests.cs
+++ b/Tests/Linq/Linq/CompileTests.cs
@@ -619,7 +619,6 @@ namespace Tests.Linq
 			Assert.That(result2[0], Is.SameAs(result1[0]));
 		}
 
-		[ActiveIssue]
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4365")]
 		public void CustomContext_CompiledQueryCustomTest([DataSources(false)] string context)
 		{

--- a/Tests/Linq/Linq/CompileTestsAsync.cs
+++ b/Tests/Linq/Linq/CompileTestsAsync.cs
@@ -752,7 +752,6 @@ namespace Tests.Linq
 			Assert.That(result2[0], Is.SameAs(result1[0]));
 		}
 
-		[ActiveIssue]
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/4365")]
 		public async Task CustomContext_CompiledQueryCustomTest([DataSources(false)] string context)
 		{

--- a/Tests/Model/TestDataCustomConnection.cs
+++ b/Tests/Model/TestDataCustomConnection.cs
@@ -7,15 +7,25 @@ using System.Threading.Tasks;
 using LinqToDB;
 using LinqToDB.Interceptors;
 using LinqToDB.Internal.Common;
+using LinqToDB.Internal.Infrastructure;
+using LinqToDB.Internal.Interceptors;
 using LinqToDB.Internal.Linq;
 using LinqToDB.Internal.SqlProvider;
 using LinqToDB.Mapping;
 
 namespace Tests.Model
 {
-	public class TestDataCustomConnection : ITestDataContext
+	public class TestDataCustomConnection : ITestDataContext, IInfrastructure<IServiceProvider>, IInterceptable<IEntityServiceInterceptor>
 	{
 		protected TestDataConnection Connection { get; }
+
+		IServiceProvider IInfrastructure<IServiceProvider>.Instance => ((IInfrastructure<IServiceProvider>)Connection).Instance;
+
+		IEntityServiceInterceptor? IInterceptable<IEntityServiceInterceptor>.Interceptor
+		{
+			get => ((IInterceptable<IEntityServiceInterceptor>)Connection).Interceptor;
+			set => ((IInterceptable<IEntityServiceInterceptor>)Connection).Interceptor = value;
+		}
 
 		public TestDataCustomConnection(DataOptions options)
 		{


### PR DESCRIPTION
Supersedes #5804 (carries @cal-tlabwest's commit — the fork is org-owned, so "allow edits by maintainers" cannot be enabled and the branch could not be extended in place).

Fixes #4365
Fixes #5803

## Interceptors on a custom `IDataContext`

Interceptor dispatch is driven entirely by `dataContext is IInterceptable<T>` type tests (~20 sites, e.g. `EntityConstructorBase.cs:855`, `QueryFlagsHelper.cs:16`). `IDataContext` exposes only the write side — `AddInterceptor` / `RemoveInterceptor` — so while `IInterceptable` is `internal`, a custom context can accept an interceptor and nothing will ever call it.

Both interfaces were `public` in `LinqToDB.Interceptors` through v5.4.1.9 and remained `public` in `Internal.Interceptors` after #4754; the visibility was dropped in #5027, a 374-file "remove public visibility from some internal apis" sweep whose criterion — "not used outside the assembly" — cannot see external implementers.

`TestDataCustomConnection` now implements `IInterceptable<IEntityServiceInterceptor>` and `IInfrastructure<IServiceProvider>`, making it an actually-complete custom context. The second one is undeclared on `IDataContext` but hard-cast by the query pipeline; declaring it is breaking, so it is filed separately as #5812 for 7.0.0.

## Compiled query ending in a client-side materializer

This turned out not to be custom-context-specific: `IDataContext_CompiledQueryTest_AsList` uses the plain `TestDataConnection` and had been `[ActiveIssue]` since #4540.

`Enumerable.ToList` satisfies `MethodCallExpression.IsQueryable`, so `CompiledQuery` treated `.ToList()` as the table boundary. `List<T>` is not `IQueryable`, so the `IEnumerable<>` branch matched, `qtype` came back non-null as `IEnumerable<Person>`, `MethodType.Queryable` was selected with `T = Person`, and the resulting `Query<Person>` was built over an expression still ending in `.ToList()` — which `BuildSequence` cannot translate.

The async counterpart works because `AsyncExtensions` is not in the `IsQueryable` list at all, so `ToListAsync` is left in place and only the *inner* queryable is compiled. The fix makes the sync path behave the same: use the queryable form only when the call's static type can hold the `Table<T>` that `CompiledTable<T>.Create` substitutes.

That predicate also means no previously-working path shifts — if the old code worked, the substituted `Table<T>` was assignable, so the guard is true and behaviour is identical.

## Verification

Local, SQLite.Classic / net10.0:

- both `CompileTests` fixtures — 148/148
- widened to every fixture that uses `CompiledQuery` — 1119/1119
- Release builds of `Source/LinqToDB` on `net10.0` (analyzers) and `netstandard2.0` (portable API surface) — both clean
- red→green confirmed: before the `CompiledQuery.cs` change both `_AsList` tests fail with the builder error; before the `TestDataCustomConnection` change both `CustomContext_` tests fail with `Expected: same as <Person>`

Each commit is independently green, so the branch is bisect-clean.

## Not fixed here

#3266 (async `Update` in a compiled query) was probed with its gate removed and is unaffected — `UpdateAsync` is typed `Task<int>`, which the `IEnumerable<>` match does not decompose, so it takes the same branch before and after. Its gate is left in place. Its current failure is `InvalidOperationException : Cannot convert async method call to sync.` from `ReplaceAsyncWithSync`, which looks for a sync `Update` counterpart on `Task<int>.DeclaringType` (null) and on `Queryable` (no `Update`) but never on `LinqExtensions`, where `Update` actually lives.
