### PR TITLE
Bootstrap the .claude corpus submodule at checkout time

### DIFF
--- a/.githooks/_refresh-corpus.sh
+++ b/.githooks/_refresh-corpus.sh
@@ -1,10 +1,16 @@
 #!/bin/sh
-# Fast-forward the .claude submodule (the agent-instruction corpus) to the tip of
-# github.com/linq2db/agents master.
+# Populate and fast-forward the .claude submodule (the agent-instruction corpus) to the
+# tip of github.com/linq2db/agents master.
 #
 # The .claude gitlink recorded in this repo is a bootstrap pointer, not a version pin:
 # corpus history lives in its own repo, so the working checkout should track that repo's
 # tip rather than whatever commit a linq2db branch happens to record.
+#
+# `git worktree add` runs `reset --hard --no-recurse-submodules` internally, so it leaves
+# the new worktree's `.claude/` empty - and because `.gitmodules` sets `ignore = all`, the
+# tree still reads clean. An agent starting there resolves its CLAUDE.md @-imports against
+# the empty directory before any session-level hook can run, so it loads zero project rules
+# with nothing signalling the absence. Hence: bootstrap here, at checkout time, not later.
 #
 # Never clobbers in-flight corpus work (skips when .claude has uncommitted tracked changes)
 # and never fails the git operation that triggered it - post-checkout's exit status becomes
@@ -12,8 +18,32 @@
 
 sm=".claude"
 
-# submodule not populated yet (fresh clone / fresh worktree) - nothing to refresh
-[ -e "$sm/.git" ] || exit 0
+# --- not populated yet (fresh clone / fresh worktree) - bootstrap it ---------
+if [ ! -e "$sm/.git" ]; then
+  case "$(git ls-tree HEAD -- "$sm" 2>/dev/null)" in
+    160000*) ;;
+    *) exit 0 ;;                       # no gitlink recorded here - nothing to bootstrap
+  esac
+
+  set -- --init
+  # Borrow the primary clone's corpus objects when we can: no download, and --dissociate
+  # copies them in so this checkout stays independent afterwards. git refuses a *shallow*
+  # reference outright, so only pass it when the primary's corpus isn't shallow.
+  common="$(git rev-parse --git-common-dir 2>/dev/null)"
+  if [ -n "$common" ]; then
+    ref="$(CDPATH= cd -- "$(dirname -- "$common")" 2>/dev/null && pwd)/$sm"
+    if [ -e "$ref/.git" ] &&
+       [ "$(git -C "$ref" rev-parse --is-shallow-repository 2>/dev/null)" = "false" ]; then
+      set -- "$@" --reference "$ref" --dissociate
+    fi
+  fi
+
+  if ! git submodule update "$@" -- "$sm" >/dev/null 2>&1; then
+    echo "[.githooks] $sm bootstrap skipped (offline or clone failed) - run" \
+         "'git submodule update --init -- $sm' by hand before working here." >&2
+    exit 0
+  fi
+fi
 
 # uncommitted tracked edits inside the corpus - leave them alone
 if [ -n "$(git -C "$sm" status --porcelain --untracked-files=no 2>/dev/null)" ]; then


### PR DESCRIPTION
`.githooks/_refresh-corpus.sh` opened with

```sh
# submodule not populated yet (fresh clone / fresh worktree) - nothing to refresh
[ -e "$sm/.git" ] || exit 0
```

which skipped exactly the case that needs handling. `git worktree add` **does** fire `post-checkout` with `$3 = 1`, so the hook was running — it just chose to do nothing, leaving `.claude/` empty. With `ignore = all` in `.gitmodules` the worktree still reads clean, so nothing signals the absence.

Consequence for Claude Code: the root `CLAUDE.md` trampoline resolves `@.claude/AGENTS.md`, `@.claude/CLAUDE.md` and `@.claude/docs/agent-rules.md` against the empty directory, and the session starts with zero project rules. The existing `SessionStart` bootstrap hook cannot fix that — it runs after the imports are already resolved and can only ask the agent to re-read them.

## Change

The early return becomes a bootstrap:

- guards on `git ls-tree HEAD -- .claude` actually recording a `160000` gitlink, so commits predating the submodule are untouched;
- borrows the primary clone's corpus objects via `--reference … --dissociate`, guarded by `rev-parse --is-shallow-repository` — git refuses a shallow reference outright rather than degrading;
- on failure prints a hint to stderr and still exits 0, since `post-checkout`'s exit status becomes the checkout's own;
- then falls through to the existing `--remote --merge` refresh, so a new worktree lands on the corpus tip rather than the recorded gitlink.

Also covers a fresh `git clone` without `--recurse-submodules`.

## Verification

`git worktree add --detach <tmp> HEAD` against the primary clone:

| | `.claude/` contents | `git submodule status` |
|---|---|---|
| before | empty | `-17f60dc44e… .claude` |
| after | `AGENTS.md`, `CLAUDE.md`, `docs`, `agents`, `skills`, `knowledge-base`, … | `+73868fb5cf… .claude (heads/master)` |

`sh -n` clean. The `--reference` branch is not exercised on this machine — the primary corpus clone is shallow, so the guard correctly falls back to cloning from origin.
