### PR TITLE
Raise Oracle bulk copy SQL length limit to 384KB, and make it configurable

### DIFF
--- a/Source/LinqToDB/Data/BulkCopyOptions.cs
+++ b/Source/LinqToDB/Data/BulkCopyOptions.cs
@@ -118,6 +118,11 @@ namespace LinqToDB.Data
 	/// <param name="MaxParametersForBatch">
 	/// If set, will set the maximum parameters per batch statement. Also see <see cref="UseParameters"/>.
 	/// </param>
+	/// <param name="MaxSqlLengthForBatch">
+	/// If set, overrides the provider-specific limit on the length of the generated statement per batch.
+	/// Used by <see cref="BulkCopyType.MultipleRows"/> mode to decide when to send the current batch and start a new one.
+	/// Provider defaults are conservative; raise this value if your database and driver accept longer statements.
+	/// </param>
 	/// <param name="MaxDegreeOfParallelism">
 	/// Implemented only by ClickHouse.Driver provider. Defines number of connections, used for parallel insert in <see cref="BulkCopyType.ProviderSpecific"/> mode.
 	/// </param>
@@ -154,7 +159,8 @@ namespace LinqToDB.Data
 		int?                        MaxParametersForBatch  = default,
 		int?                        MaxDegreeOfParallelism = default,
 		bool                        WithoutSession         = default,
-		ConflictAction              ConflictAction         = default
+		ConflictAction              ConflictAction         = default,
+		int?                        MaxSqlLengthForBatch   = default
 		// If you add another parameter here, don't forget to update
 		// BulkCopyOptions copy constructor and IConfigurationID.ConfigurationID.
 	)
@@ -209,6 +215,58 @@ namespace LinqToDB.Data
 			MaxParametersForBatch,
 			MaxDegreeOfParallelism,
 			WithoutSession,
+			default,
+			default
+		)
+		{ }
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("Retained for binary compatibility; planned for removal in version 7")]
+		public BulkCopyOptions
+		(
+			int? MaxBatchSize,
+			int? BulkCopyTimeout,
+			BulkCopyType BulkCopyType,
+			bool? CheckConstraints,
+			bool? KeepIdentity,
+			bool? TableLock,
+			bool? KeepNulls,
+			bool? FireTriggers,
+			bool? UseInternalTransaction,
+			string? ServerName,
+			string? DatabaseName,
+			string? SchemaName,
+			string? TableName,
+			TableOptions TableOptions,
+			int NotifyAfter,
+			Action<BulkCopyRowsCopied>? RowsCopiedCallback,
+			bool UseParameters,
+			int? MaxParametersForBatch,
+			int? MaxDegreeOfParallelism,
+			bool WithoutSession,
+			ConflictAction ConflictAction
+		) : this(
+			MaxBatchSize,
+			BulkCopyTimeout,
+			BulkCopyType,
+			CheckConstraints,
+			KeepIdentity,
+			TableLock,
+			KeepNulls,
+			FireTriggers,
+			UseInternalTransaction,
+			ServerName,
+			DatabaseName,
+			SchemaName,
+			TableName,
+			TableOptions,
+			NotifyAfter,
+			RowsCopiedCallback,
+			UseParameters,
+			MaxParametersForBatch,
+			MaxDegreeOfParallelism,
+			WithoutSession,
+			ConflictAction,
 			default
 		)
 		{ }
@@ -236,6 +294,7 @@ namespace LinqToDB.Data
 			MaxDegreeOfParallelism = original.MaxDegreeOfParallelism;
 			WithoutSession         = original.WithoutSession;
 			ConflictAction         = original.ConflictAction;
+			MaxSqlLengthForBatch   = original.MaxSqlLengthForBatch;
 		}
 
 		int? _configurationID;
@@ -268,6 +327,7 @@ namespace LinqToDB.Data
 						.Add(MaxDegreeOfParallelism)
 						.Add(WithoutSession)
 						.Add(ConflictAction)
+						.Add(MaxSqlLengthForBatch)
 						.CreateID();
 				}
 

--- a/Source/LinqToDB/DataOptionsExtensions.cs
+++ b/Source/LinqToDB/DataOptionsExtensions.cs
@@ -1730,6 +1730,17 @@ namespace LinqToDB
 		}
 
 		/// <summary>
+		/// If set, overrides the provider-specific limit on the length of the generated statement per batch.
+		/// Used by <see cref="BulkCopyType.MultipleRows"/> mode to decide when to send the current batch and start a new one.
+		/// Provider defaults are conservative; raise this value if your database and driver accept longer statements.
+		/// </summary>
+		[Pure]
+		public static BulkCopyOptions WithMaxSqlLengthForBatch(this BulkCopyOptions options, int? maxSqlLengthForBatch)
+		{
+			return options with { MaxSqlLengthForBatch = maxSqlLengthForBatch };
+		}
+
+		/// <summary>
 		/// Implemented only by ClickHouse.Driver provider. Defines number of connections, used for parallel insert in <see cref="BulkCopyType.ProviderSpecific"/> mode.
 		/// </summary>
 		[Pure]
@@ -1977,6 +1988,17 @@ namespace LinqToDB
 		public static DataOptions UseBulkCopyMaxParametersForBatch(this DataOptions options, int? maxParametersForBatch)
 		{
 			return options.WithOptions<BulkCopyOptions>(o => o with { MaxParametersForBatch = maxParametersForBatch });
+		}
+
+		/// <summary>
+		/// If set, overrides the provider-specific limit on the length of the generated statement per batch.
+		/// Used by <see cref="BulkCopyType.MultipleRows"/> mode to decide when to send the current batch and start a new one.
+		/// Provider defaults are conservative; raise this value if your database and driver accept longer statements.
+		/// </summary>
+		[Pure]
+		public static DataOptions UseBulkCopyMaxSqlLengthForBatch(this DataOptions options, int? maxSqlLengthForBatch)
+		{
+			return options.WithOptions<BulkCopyOptions>(o => o with { MaxSqlLengthForBatch = maxSqlLengthForBatch });
 		}
 
 		/// <summary>

--- a/Source/LinqToDB/Internal/DataProvider/BasicBulkCopy.cs
+++ b/Source/LinqToDB/Internal/DataProvider/BasicBulkCopy.cs
@@ -378,6 +378,8 @@ namespace LinqToDB.Internal.DataProvider
 					helper.Options.BulkCopyOptions.MaxParametersForBatch.GetValueOrDefault(maxParameters) / helper.Columns.Length)
 				: helper.BatchSize;
 
+			var adjustedMaxSqlLength = helper.Options.BulkCopyOptions.MaxSqlLengthForBatch.GetValueOrDefault(maxSqlLength);
+
 			prepFunction(helper);
 
 			foreach (var item in source)
@@ -386,7 +388,7 @@ namespace LinqToDB.Internal.DataProvider
 				helper.LastRowStringIndex    = helper.StringBuilder.Length;
 				addFunction(helper, item!, from);
 				var needRemove = helper.Parameters.Count > maxParameters ||
-				                 helper.StringBuilder.Length > maxSqlLength;
+				                 helper.StringBuilder.Length > adjustedMaxSqlLength;
 				var isSingle = helper.CurrentCount == 1;
 				if (helper.CurrentCount >= adjustedBatchSize || needRemove)
 				{
@@ -441,6 +443,8 @@ namespace LinqToDB.Internal.DataProvider
 				? Math.Min(helper.BatchSize, helper.Options.BulkCopyOptions.MaxParametersForBatch.GetValueOrDefault(maxParameters) / helper.Columns.Length)
 				: helper.BatchSize;
 
+			var adjustedMaxSqlLength = helper.Options.BulkCopyOptions.MaxSqlLengthForBatch.GetValueOrDefault(maxSqlLength);
+
 			prepFunction(helper);
 
 			foreach (var item in source)
@@ -450,7 +454,7 @@ namespace LinqToDB.Internal.DataProvider
 				addFunction(helper, item!, from);
 
 				var needRemove = helper.Parameters.Count     > maxParameters ||
-				                 helper.StringBuilder.Length > maxSqlLength;
+				                 helper.StringBuilder.Length > adjustedMaxSqlLength;
 				var isSingle = helper.CurrentCount == 1;
 				if (helper.CurrentCount >= adjustedBatchSize || needRemove)
 				{
@@ -522,6 +526,8 @@ namespace LinqToDB.Internal.DataProvider
 				? Math.Min(helper.BatchSize, helper.Options.BulkCopyOptions.MaxParametersForBatch.GetValueOrDefault(maxParameters) / helper.Columns.Length)
 				: helper.BatchSize;
 
+			var adjustedMaxSqlLength = helper.Options.BulkCopyOptions.MaxSqlLengthForBatch.GetValueOrDefault(maxSqlLength);
+
 			prepFunction(helper);
 
 			await foreach (var item in source.ConfigureAwait(false).WithCancellation(cancellationToken))
@@ -531,7 +537,7 @@ namespace LinqToDB.Internal.DataProvider
 				addFunction(helper, item!, from);
 
 				var needRemove = helper.Parameters.Count     > maxParameters ||
-				                 helper.StringBuilder.Length > maxSqlLength;
+				                 helper.StringBuilder.Length > adjustedMaxSqlLength;
 				var isSingle = helper.CurrentCount == 1;
 				if (helper.CurrentCount >= adjustedBatchSize || needRemove)
 				{

--- a/Source/LinqToDB/Internal/DataProvider/Oracle/OracleBulkCopy.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Oracle/OracleBulkCopy.cs
@@ -23,14 +23,26 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 		/// Settings based on https://www.jooq.org/doc/3.12/manual/sql-building/dsl-context/custom-settings/settings-inline-threshold/
 		/// We subtract 1 based on possibility of provider using parameter for command.
 		/// </remarks>
-		private const      int                _maxParameters = 32766;
-		/// <summary>
-		/// Setting is conservative, based on https://docs.oracle.com/cd/A58617_01/server.804/a58242/ch5.htm
-		/// Max is actually more arbitrary in later versions than Oracle 8.
-		/// </summary>
-		private const      int                _maxSqlLength  = 65535;
-		protected override int                 MaxParameters => _maxParameters;
-		protected override int                 MaxSqlLength  => _maxSqlLength;
+		protected override int                 MaxParameters => 32766;
+
+		/// <remarks>
+		/// Oracle publishes no fixed maximum statement length. "Logical Database Limits" only says the limit
+		/// "depends on many factors, including database configuration, disk space, and memory":
+		/// https://docs.oracle.com/en/database/oracle/oracle-database/19/refrn/logical-database-limits.html
+		/// The previous 65535 came from Oracle 8 documentation, which no longer applies to any supported version.
+		/// <para>
+		/// 384KB was chosen from measurement (2026-08, issue #5825): on Oracle 11 - the oldest supported version -
+		/// and on Oracle 23, both <c>INSERT ALL</c> and <c>INSERT ... SELECT FROM DUAL UNION ALL</c> statements of
+		/// inlined literals parsed and executed correctly up to 4MB (8MB of bytes for a multi-byte payload under
+		/// AL32UTF8). This value therefore keeps better than 10x headroom over what was verified, while staying in
+		/// line with the other providers here and bounding the cost of a hard parse: the default Oracle path inlines
+		/// literals, so every batch is a distinct statement that is parsed from scratch.
+		/// </para>
+		/// Users whose database and driver accept longer statements can raise it with
+		/// <see cref="BulkCopyOptions.MaxSqlLengthForBatch"/>.
+		/// </remarks>
+		protected override int                 MaxSqlLength  => 384 * 1024;
+
 		private readonly   OracleDataProvider  _provider;
 		private readonly   AlternativeBulkCopy _useAlternativeBulkCopy;
 
@@ -223,14 +235,14 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 			helper.StringBuilder.AppendLine("SELECT * FROM dual");
 		}
 
-		static BulkCopyRowsCopied OracleMultipleRowsCopy1(MultipleRowsHelper helper, IEnumerable source)
-			=> MultipleRowsCopyHelper(helper, source, null, OracleMultipleRowsCopy1Prep, OracleMultipleRowsCopy1Add, OracleMultipleRowsCopy1Finish, _maxParameters,_maxSqlLength);
+		BulkCopyRowsCopied OracleMultipleRowsCopy1(MultipleRowsHelper helper, IEnumerable source)
+			=> MultipleRowsCopyHelper(helper, source, null, OracleMultipleRowsCopy1Prep, OracleMultipleRowsCopy1Add, OracleMultipleRowsCopy1Finish, MaxParameters, MaxSqlLength);
 
-		static Task<BulkCopyRowsCopied> OracleMultipleRowsCopy1Async(MultipleRowsHelper helper, IEnumerable source, CancellationToken cancellationToken)
-			=> MultipleRowsCopyHelperAsync(helper, source, null, OracleMultipleRowsCopy1Prep, OracleMultipleRowsCopy1Add, OracleMultipleRowsCopy1Finish, cancellationToken, _maxParameters,_maxSqlLength);
+		Task<BulkCopyRowsCopied> OracleMultipleRowsCopy1Async(MultipleRowsHelper helper, IEnumerable source, CancellationToken cancellationToken)
+			=> MultipleRowsCopyHelperAsync(helper, source, null, OracleMultipleRowsCopy1Prep, OracleMultipleRowsCopy1Add, OracleMultipleRowsCopy1Finish, cancellationToken, MaxParameters, MaxSqlLength);
 
-		static Task<BulkCopyRowsCopied> OracleMultipleRowsCopy1Async<T>(MultipleRowsHelper helper, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
-			=> MultipleRowsCopyHelperAsync(helper, source, null, OracleMultipleRowsCopy1Prep, OracleMultipleRowsCopy1Add, OracleMultipleRowsCopy1Finish, cancellationToken, _maxParameters,_maxSqlLength);
+		Task<BulkCopyRowsCopied> OracleMultipleRowsCopy1Async<T>(MultipleRowsHelper helper, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
+			=> MultipleRowsCopyHelperAsync(helper, source, null, OracleMultipleRowsCopy1Prep, OracleMultipleRowsCopy1Add, OracleMultipleRowsCopy1Finish, cancellationToken, MaxParameters, MaxSqlLength);
 
 		static List<object> OracleMultipleRowsCopy2Prep(MultipleRowsHelper helper)
 		{
@@ -473,13 +485,13 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 			helper.StringBuilder.AppendLine();
 		}
 
-		static BulkCopyRowsCopied OracleMultipleRowsCopy3(MultipleRowsHelper helper, IEnumerable source)
-			=> MultipleRowsCopyHelper(helper, source, null, OracleMultipleRowsCopy3Prep, OracleMultipleRowsCopy3Add, OracleMultipleRowsCopy3Finish, _maxParameters, _maxSqlLength);
+		BulkCopyRowsCopied OracleMultipleRowsCopy3(MultipleRowsHelper helper, IEnumerable source)
+			=> MultipleRowsCopyHelper(helper, source, null, OracleMultipleRowsCopy3Prep, OracleMultipleRowsCopy3Add, OracleMultipleRowsCopy3Finish, MaxParameters, MaxSqlLength);
 
-		static Task<BulkCopyRowsCopied> OracleMultipleRowsCopy3Async(MultipleRowsHelper helper, IEnumerable source, CancellationToken cancellationToken)
-			=> MultipleRowsCopyHelperAsync(helper, source, null, OracleMultipleRowsCopy3Prep, OracleMultipleRowsCopy3Add, OracleMultipleRowsCopy3Finish, cancellationToken, _maxParameters, _maxSqlLength);
+		Task<BulkCopyRowsCopied> OracleMultipleRowsCopy3Async(MultipleRowsHelper helper, IEnumerable source, CancellationToken cancellationToken)
+			=> MultipleRowsCopyHelperAsync(helper, source, null, OracleMultipleRowsCopy3Prep, OracleMultipleRowsCopy3Add, OracleMultipleRowsCopy3Finish, cancellationToken, MaxParameters, MaxSqlLength);
 
-		static Task<BulkCopyRowsCopied> OracleMultipleRowsCopy3Async<T>(MultipleRowsHelper helper, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
-			=> MultipleRowsCopyHelperAsync(helper, source, null, OracleMultipleRowsCopy3Prep, OracleMultipleRowsCopy3Add, OracleMultipleRowsCopy3Finish, cancellationToken, _maxParameters, _maxSqlLength);
+		Task<BulkCopyRowsCopied> OracleMultipleRowsCopy3Async<T>(MultipleRowsHelper helper, IAsyncEnumerable<T> source, CancellationToken cancellationToken)
+			=> MultipleRowsCopyHelperAsync(helper, source, null, OracleMultipleRowsCopy3Prep, OracleMultipleRowsCopy3Add, OracleMultipleRowsCopy3Finish, cancellationToken, MaxParameters, MaxSqlLength);
 	}
 }

--- a/Source/LinqToDB/PublicAPI/PublicAPI.Unshipped.txt
+++ b/Source/LinqToDB/PublicAPI/PublicAPI.Unshipped.txt
@@ -236,3 +236,7 @@ LinqToDB.Internal.SqlQuery.SqlArgumentDomains
 LinqToDB.Internal.SqlQuery.SqlArgumentDomain.Element = 2 -> LinqToDB.Internal.SqlQuery.SqlArgumentDomain
 LinqToDB.Internal.SqlQuery.SqlArgumentDomain.None = 0 -> LinqToDB.Internal.SqlQuery.SqlArgumentDomain
 LinqToDB.Internal.SqlQuery.SqlArgumentDomain.SameKind = 1 -> LinqToDB.Internal.SqlQuery.SqlArgumentDomain
+LinqToDB.Data.BulkCopyOptions.MaxSqlLengthForBatch.get -> int?
+LinqToDB.Data.BulkCopyOptions.MaxSqlLengthForBatch.init -> void
+static LinqToDB.DataOptionsExtensions.UseBulkCopyMaxSqlLengthForBatch(this LinqToDB.DataOptions! options, int? maxSqlLengthForBatch) -> LinqToDB.DataOptions!
+static LinqToDB.DataOptionsExtensions.WithMaxSqlLengthForBatch(this LinqToDB.Data.BulkCopyOptions! options, int? maxSqlLengthForBatch) -> LinqToDB.Data.BulkCopyOptions!

--- a/Tests/Linq/DataProvider/OracleTests.cs
+++ b/Tests/Linq/DataProvider/OracleTests.cs
@@ -1176,6 +1176,47 @@ namespace Tests.DataProvider
 			}
 		}
 
+		[Table("BULK_SPLIT")]
+		sealed class BulkSplitTable
+		{
+			[PrimaryKey, Column("ID")]      public int     Id  { get; set; }
+			[Column("VAL", Length = 1000)]  public string? Val { get; set; }
+		}
+
+		/// <summary>
+		/// Covers the batch-splitting path in <see cref="LinqToDB.Internal.DataProvider.BasicBulkCopy"/>: the payload is
+		/// large enough to cross the generated-statement length limit many times over, in every Oracle bulk copy mode.
+		/// </summary>
+		[Test]
+		public void BulkCopyMultipleRowsCrossesSqlLengthLimit(
+			[IncludeDataSources(TestProvName.AllOracle)] string              context,
+			[Values]                                     AlternativeBulkCopy useAlternativeBulkCopy,
+			[Values]                                     bool                useParameters)
+		{
+			using var _  = new DisableBaseline("generated statement volume is the subject of the test");
+			using var db = GetDataContext(context, o => o.UseOracle(o => o with { AlternativeBulkCopy = useAlternativeBulkCopy }));
+
+			using var table = db.CreateLocalTable<BulkSplitTable>();
+
+			var rows = Enumerable.Range(1, 500)
+				.Select(i => new BulkSplitTable { Id = i, Val = new string((char)('a' + i % 26), 1000) })
+				.ToList();
+
+			db.BulkCopy(
+				new BulkCopyOptions
+				{
+					BulkCopyType  = BulkCopyType.MultipleRows,
+					MaxBatchSize  = 5000,
+					UseParameters = useParameters,
+				},
+				rows);
+
+			var loaded = table.OrderBy(r => r.Id).ToArray();
+
+			Assert.That(loaded.Select(r => r.Id),  Is.EqualTo(rows.Select(r => r.Id)));
+			Assert.That(loaded.Select(r => r.Val), Is.EqualTo(rows.Select(r => r.Val)));
+		}
+
 		[Test]
 		public void BulkCopyLinqTypesMultipleRows(
 			[IncludeDataSources(TestProvName.AllOracle)] string context,

--- a/Tests/Linq/Update/BulkCopyTests.cs
+++ b/Tests/Linq/Update/BulkCopyTests.cs
@@ -365,31 +365,50 @@ namespace Tests.xUpdate
 		[Test]
 		public void MaxSqlLengthForBatchSplitsStatements(
 			[IncludeDataSources(false, TestProvName.AllSQLite, TestProvName.AllPostgreSQL, TestProvName.AllFirebird)] string context,
-			[Values]                                                                                                 bool   useParameters)
+			[Values]                                                                                                 bool   useParameters,
+			[Values]                                                                                                 bool   viaDataOptions)
 		{
 			const int maxSqlLength = 4096;
 			const int rowCount     = 1000;
 			const int valueLength  = 200;
 
-			using var _         = new DisableBaseline("generated statement volume is the subject of the test");
-			var       counter   = new BulkCopyCommandCounter();
-			using var db        = GetDataConnection(context, interceptor: counter);
-			using var table     = db.CreateLocalTable<WideBulkCopyTable>();
+			using var _ = new DisableBaseline("generated statement volume is the subject of the test");
+			var       counter = new BulkCopyCommandCounter();
+
+			// the limit is reachable both per-call and connection-wide; cover both entry points
+			using var db = viaDataOptions
+				? GetDataConnection(context, o => o
+					.UseBulkCopyType(BulkCopyType.MultipleRows)
+					.UseBulkCopyMaxSqlLengthForBatch(maxSqlLength)
+					.UseBulkCopyMaxBatchSize(rowCount * 10)
+					.UseBulkCopyUseParameters(useParameters))
+				: GetDataConnection(context);
+
+			db.AddInterceptor(counter);
+
+			using var table = db.CreateLocalTable<WideBulkCopyTable>();
 
 			var rows = Enumerable.Range(1, rowCount)
 				.Select(i => new WideBulkCopyTable { Id = i, Value = new string((char)('a' + i % 26), valueLength) })
 				.ToList();
 
 			// MaxBatchSize is deliberately larger than rowCount so statement length is the only splitter
-			db.BulkCopy(
-				new BulkCopyOptions
-				{
-					BulkCopyType         = BulkCopyType.MultipleRows,
-					MaxBatchSize         = rowCount * 10,
-					MaxSqlLengthForBatch = maxSqlLength,
-					UseParameters        = useParameters,
-				},
-				rows);
+			if (viaDataOptions)
+			{
+				table.BulkCopy(rows);
+			}
+			else
+			{
+				db.BulkCopy(
+					new BulkCopyOptions
+					{
+						BulkCopyType         = BulkCopyType.MultipleRows,
+						MaxBatchSize         = rowCount * 10,
+						MaxSqlLengthForBatch = maxSqlLength,
+						UseParameters        = useParameters,
+					},
+					rows);
+			}
 
 			var loaded = table.OrderBy(r => r.Id).ToArray();
 

--- a/Tests/Linq/Update/BulkCopyTests.cs
+++ b/Tests/Linq/Update/BulkCopyTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -324,6 +325,86 @@ namespace Tests.xUpdate
 		public class SimpleBulkCopyTable
 		{
 			[PrimaryKey] public int Id { get; set; }
+		}
+
+		[Table]
+		public class WideBulkCopyTable
+		{
+			[PrimaryKey]           public int     Id    { get; set; }
+			[Column(Length = 200)] public string? Value { get; set; }
+		}
+
+		sealed class BulkCopyCommandCounter : CommandInterceptor
+		{
+			public int Count            { get; private set; }
+			public int MaxCommandLength { get; private set; }
+
+			public override DbCommand CommandInitialized(CommandEventData eventData, DbCommand command)
+			{
+				var sql = command.CommandText;
+
+				if (sql.Contains("INSERT", StringComparison.OrdinalIgnoreCase)
+					&& !sql.Contains("CREATE", StringComparison.OrdinalIgnoreCase)
+					&& !sql.Contains("DROP", StringComparison.OrdinalIgnoreCase))
+				{
+					Count++;
+					MaxCommandLength = Math.Max(MaxCommandLength, sql.Length);
+				}
+
+				return command;
+			}
+		}
+
+		// MaxSqlLengthForBatch is honored in shared BasicBulkCopy code, so it does not need the whole provider
+		// matrix. These three cover every distinct statement shape the splitter has to survive:
+		//   SQLite     - MultipleRowsCopy1, plain INSERT INTO ... VALUES (row), (row) (same path as SqlServer/MySql/ClickHouse)
+		//   PostgreSQL - MultipleRowsCopy1 plus a GetMultipleRowsSuffix that must be re-emitted on every batch
+		//   Firebird   - MultipleRowsCopy2 (SELECT ... UNION ALL) and the only provider with Cast*OnUnionAll,
+		//                where the first row of each batch renders differently from the rest
+		// Oracle has its own coverage in OracleTests.BulkCopyMultipleRowsCrossesSqlLengthLimit.
+		[Test]
+		public void MaxSqlLengthForBatchSplitsStatements(
+			[IncludeDataSources(false, TestProvName.AllSQLite, TestProvName.AllPostgreSQL, TestProvName.AllFirebird)] string context,
+			[Values]                                                                                                 bool   useParameters)
+		{
+			const int maxSqlLength = 4096;
+			const int rowCount     = 1000;
+			const int valueLength  = 200;
+
+			using var _         = new DisableBaseline("generated statement volume is the subject of the test");
+			var       counter   = new BulkCopyCommandCounter();
+			using var db        = GetDataConnection(context, interceptor: counter);
+			using var table     = db.CreateLocalTable<WideBulkCopyTable>();
+
+			var rows = Enumerable.Range(1, rowCount)
+				.Select(i => new WideBulkCopyTable { Id = i, Value = new string((char)('a' + i % 26), valueLength) })
+				.ToList();
+
+			// MaxBatchSize is deliberately larger than rowCount so statement length is the only splitter
+			db.BulkCopy(
+				new BulkCopyOptions
+				{
+					BulkCopyType         = BulkCopyType.MultipleRows,
+					MaxBatchSize         = rowCount * 10,
+					MaxSqlLengthForBatch = maxSqlLength,
+					UseParameters        = useParameters,
+				},
+				rows);
+
+			var loaded = table.OrderBy(r => r.Id).ToArray();
+
+			Assert.That(loaded.Select(r => r.Id),    Is.EqualTo(rows.Select(r => r.Id)));
+			Assert.That(loaded.Select(r => r.Value), Is.EqualTo(rows.Select(r => r.Value)));
+
+			using (Assert.EnterMultipleScope())
+			{
+				// the option must actually split: a single statement would mean it was ignored
+				Assert.That(counter.Count, Is.GreaterThan(1));
+				// a row is appended before the limit is checked, so one row may overshoot - but no more than that.
+				// Without the option this is what goes red: the provider default (1MB on SQLite) would let every
+				// row into a single statement, in both literal and parameterized mode.
+				Assert.That(counter.MaxCommandLength, Is.LessThan(maxSqlLength + 4 * valueLength));
+			}
 		}
 
 #if SUPPORTS_DATEONLY


### PR DESCRIPTION
Fixes #5825.

## What

Raises `OracleBulkCopy.MaxSqlLength` from `65535` to `384 * 1024`, and adds
`BulkCopyOptions.MaxSqlLengthForBatch` so the limit is no longer a hardcoded guess users cannot reach.

The old value came from Oracle 8 documentation (#2975). Oracle 11 is now the minimum supported
version, and Oracle's current *Logical Database Limits* no longer publishes a statement-length
number at all — it says the limit "depends on many factors, including database configuration, disk
space, and memory". So there is no newer figure to cite, which is the argument for making the
ceiling configurable rather than re-guessing it.

## Evidence for 384KB

Measured against **Oracle 11** (the oldest supported version, and the CI floor via
`Build/Azure/net*/oracle1112.json`) and **Oracle 23**. Both returned identical results across 96
probe points each, zero failures:

- Statements of inlined literals parsed and executed correctly up to **4 MB** — 8 MB of *bytes* for a
  multibyte payload under `AL32UTF8` — for both `INSERT ALL` and `INSERT ... SELECT FROM DUAL UNION ALL`.
  384 KB therefore keeps better than 10× headroom over what was verified.
- 4 MB was not chosen because it is the measured edge with no margin, and because
  `MultipleRowsHelper.Execute` does a full `StringBuilder.ToString()` per batch. 384 KB also lines up
  with the other providers here (DB2 / MySQL / PostgreSQL / SQL Server are all 327670).

**The 999-target-column ceiling documented for multitable insert in Oracle 9i/10g does not apply to
any supported version.** This was the main risk of raising the limit — today's 65535 cap masks it by
accident, so unmasking it would have surfaced ORA-24335 for users. Measured: **2000 target columns
succeed** on both Oracle 11 and 23, with literals *and* with bind variables. ORA-24335 never fired.
No column guard was added, because the limit it would guard against does not exist.

## Also in this PR

`OracleBulkCopy` was the only provider mirroring its limits into `private const` fields, because
`OracleMultipleRowsCopy1/3` were `static` and passed the consts positionally — which meant the
`MaxParameters` / `MaxSqlLength` **property overrides were dead code**. Those six methods are now
instance methods reading the properties, matching every other provider and making a future
version-dependent limit expressible (as Firebird already does for 2.5 vs 3.0+).

## Behaviour changes

`MaxSqlLengthForBatch` defaults to `null` and resolves via
`GetValueOrDefault(<provider limit>)`, so **every provider except Oracle is byte-for-byte unchanged**.
No other provider's `MaxSqlLength` is touched.

Two Oracle-side consequences worth calling out:

1. **`RowsCopiedCallback` fires once per batch** (`MultipleRowsHelper.Execute`, with no `NotifyAfter`
   gate on that path). With ~6× fewer batches it is invoked ~6× less often, so progress reporting and
   any callback-driven `Abort` become coarser. This only affects rows whose generated SQL exceeds
   ~65 characters; below that the `MaxBatchSize ?? 1000` row cap already bound first. Users who want
   the old cadence can set `MaxSqlLengthForBatch = 65535`.
2. **Pre-existing asymmetry left deliberately unfixed.** `MaxParametersForBatch` feeds only
   `adjustedBatchSize` in all three `MultipleRowsCopyHelper` overloads; the per-row `needRemove` check
   still compares against the raw provider `maxParameters`. That is arguably a bug, but fixing it
   would change behaviour for every provider, so it is untouched here — and the new
   `MaxSqlLengthForBatch` deliberately mirrors that existing shape rather than diverging from it.
   Worth a separate issue.

`BulkCopyOptions.ConfigurationID` now includes the new field, so the numeric ID of every instance
changes. It is computed in-process and used only for equality/hashing, never persisted, so there is
no semantic effect.

## API

New public surface, following the existing `MaxParametersForBatch` precedent exactly:

- `BulkCopyOptions.MaxSqlLengthForBatch`
- `DataOptionsExtensions.WithMaxSqlLengthForBatch`
- `DataOptionsExtensions.UseBulkCopyMaxSqlLengthForBatch`

So the limit is reachable connection-wide, per call, or globally:

```csharp
// connection-wide
var options = new DataOptions()
    .UseOracle(connectionString)
    .UseBulkCopyMaxSqlLengthForBatch(1_000_000);

// per call
db.BulkCopy(new BulkCopyOptions { MaxSqlLengthForBatch = 1_000_000 }, rows);

// global default
BulkCopyOptions.Default = BulkCopyOptions.Default with { MaxSqlLengthForBatch = 1_000_000 };
```

Note the pre-existing semantics that apply to every `BulkCopyOptions` property, not just this one:
`BulkCopy(options, source)` does `dataContext.Options.WithOptions(options)`, which *replaces* the
whole option set — so passing an explicit `BulkCopyOptions` discards a connection-level
`MaxSqlLengthForBatch` unless it is set on that object too.

Appending a parameter to the positional record required a new `[Obsolete]` compat constructor for the
previous 21-parameter signature, alongside the existing 20-parameter one — the same pattern used when
`ConflictAction` was added in #5395. `CompatibilitySuppressions.xml` was regenerated and came back
**byte-identical**: the baseline package's `Deconstruct` (20 outs) is already suppressed, and going
21 → 22 outs adds a member rather than removing another baseline one.

## Tests

The generated-statement-length split path had **no coverage at all** before this.

- `BulkCopyTests.MaxSqlLengthForBatchSplitsStatements` — SQLite, PostgreSQL and Firebird, with
  parameters on and off, and via both entry points (per-call `BulkCopyOptions` and connection-wide
  `UseBulkCopyMaxSqlLengthForBatch`). Deliberately not the full provider matrix: the option is honored in shared
  `BasicBulkCopy` code, and these three cover every distinct shape the splitter must survive —
  `MultipleRowsCopy1` (plain `VALUES`), `MultipleRowsCopy1` + a `GetMultipleRowsSuffix` that must be
  re-emitted per batch, and `MultipleRowsCopy2` (`SELECT ... UNION ALL`) on the only provider with
  `Cast*OnUnionAll`, where the first row of each batch renders differently from the rest. Asserts
  values round-trip (not just row count), that the option actually splits, and that no statement runs
  past the cap.
- `OracleTests.BulkCopyMultipleRowsCrossesSqlLengthLimit` — all three `AlternativeBulkCopy` modes ×
  parameters on/off.

Locally: 12/12 and 12/12 green (Oracle 11 + 23), plus the existing Oracle bulk-copy suite at 560 passed
/ 10 pre-existing skips / 0 failed under the new constant. All five TFMs build clean.
