### PR TITLE
Fix #5792: keep set-operation branch in nullability scope

### DIFF
--- a/Source/LinqToDB/Internal/SqlProvider/SqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/SqlProvider/SqlExpressionConvertVisitor.cs
@@ -184,7 +184,7 @@ namespace LinqToDB.Internal.SqlProvider
 				return selectQuery;
 
 			var saveNullabilityContext = NullabilityContext;
-			NullabilityContext = NullabilityContext.WithJoinSource(selectQuery);
+			NullabilityContext = NullabilityContext.WithQuery(selectQuery).WithJoinSource(selectQuery);
 
 			var newQuery = base.VisitSqlQuery(selectQuery);
 

--- a/Source/LinqToDB/Internal/SqlQuery/NullabilityContext.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/NullabilityContext.cs
@@ -156,7 +156,17 @@ namespace LinqToDB.Internal.SqlQuery
 							if (index >= set.SelectQuery.Select.Columns.Count)
 								return true;
 
-							if (set.SelectQuery.Select.Columns[index].CanBeNullable(this))
+							// the branch query is reachable only through SetOperators, which the source walk does not enter.
+							// Without registering it the branch's own tables resolve as unreachable, so a value that is nullable
+							// only through a join inside the branch is reported as not nullable to the enclosing query.
+							var setNullability = WithQuery(set.SelectQuery);
+
+							// carry the cycle guard over - WithQuery allocates a fresh context, which would otherwise start
+							// with an empty visited set and lose the protection against self-referencing column chains
+							if (!ReferenceEquals(setNullability, this))
+								setNullability._visitedColumns = _visitedColumns;
+
+							if (set.SelectQuery.Select.Columns[index].CanBeNullable(setNullability))
 								return true;
 						}
 					}

--- a/Source/LinqToDB/Internal/SqlQuery/NullabilityContext.cs
+++ b/Source/LinqToDB/Internal/SqlQuery/NullabilityContext.cs
@@ -153,6 +153,11 @@ namespace LinqToDB.Internal.SqlQuery
 
 						foreach (var set in column.Parent.SetOperators)
 						{
+							// EXCEPT / INTERSECT narrow the accumulated left side and contribute no values of their
+							// own, so a branch that is nullable only in itself cannot put a NULL into this column.
+							if (set.Operation is not (SetOperation.Union or SetOperation.UnionAll))
+								continue;
+
 							if (index >= set.SelectQuery.Select.Columns.Count)
 								return true;
 

--- a/Tests/Linq/Linq/QueryFilterTests.cs
+++ b/Tests/Linq/Linq/QueryFilterTests.cs
@@ -844,6 +844,43 @@ namespace Tests.Linq
 		}
 
 		[Test]
+		public void FilteredLeftJoinNullCheckSurvivesSetOperation([IncludeDataSources(false, TestProvName.AllSQLite)] string context)
+		{
+			// Regression: with a query filter on the joined entity, the `joined != null ? joined.X : fallback`
+			// conditional was discarded in every set-operation branch except the first, so a non-matching left
+			// join produced NULL instead of the fallback. Two ingredients keep the shape intact: the filter must
+			// not fold to a constant, and the projected column must be computed — with a plain column the join
+			// is flattened and the null check never has to survive on its own.
+
+			var builder = new FluentMappingBuilder(new MappingSchema());
+
+			builder.Entity<MasterClass>().HasQueryFilter<MyDataContext>((e, dc) => !dc.IsSoftDeleteFilterEnabled || !e.IsDeleted);
+
+			builder.Build();
+
+			var masters = new[] { new MasterClass { Id = 1, Value = "Master" } };
+			var details = new[]
+			{
+				new DetailClass { Id = 1, MasterId = 1   }, // resolves
+				new DetailClass { Id = 2, MasterId = 100 }  // does not
+			};
+
+			using var db = new MyDataContext(context, builder.MappingSchema);
+			using (db.CreateLocalTable(masters))
+			using (db.CreateLocalTable(details))
+			{
+				IQueryable<string> Values(int id) =>
+					from d in db.GetTable<DetailClass>().Where(d => d.Id == id)
+					from m in db.GetTable<MasterClass>()
+						.Select(x => new { x.Id, Value = x.Value + "!" })
+						.LeftJoin(x => x.Id == d.MasterId)
+					select m != null ? m.Value : "Unknown";
+
+				Values(1).Concat(Values(2)).ToList().ShouldBe(["Master!", "Unknown"]);
+			}
+		}
+
+		[Test]
 		public void NamedFilter_InterfaceTypedLambda_FastPath([IncludeDataSources(false, TestProvName.AllSQLite)] string context)
 		{
 			// Regression: a filter lambda typed against an interface (Func<ISoftDelete, ...>) applied to a concrete

--- a/Tests/Linq/Linq/QueryFilterTests.cs
+++ b/Tests/Linq/Linq/QueryFilterTests.cs
@@ -927,10 +927,10 @@ namespace Tests.Linq
 		public void SetOperationBranchNullabilityReachesEnclosingQuery([IncludeDataSources(false, TestProvName.AllSQLite)] string context)
 		{
 			// The enclosing query resolves a set-operation column by fanning out over SetOperators. Branch 1 is
-			// deliberately non-nullable so that fan-out is actually reached, and branch 2 is nullable only through
-			// a LEFT JOIN living inside the branch - which the source walk cannot see unless the branch query is
-			// registered in the nullability scope. Without that the null check folds away and the NULL surfaces
-			// as a default value.
+			// deliberately non-nullable so that the fan-out is the only thing that can report the column nullable,
+			// and branch 2 is nullable only through a LEFT JOIN living inside the branch - which the source walk
+			// cannot see unless the branch query is registered in the nullability scope. Without that the null
+			// check folds away and the NULL surfaces as a default value.
 
 			var builder = new FluentMappingBuilder(new MappingSchema());
 

--- a/Tests/Linq/Linq/QueryFilterTests.cs
+++ b/Tests/Linq/Linq/QueryFilterTests.cs
@@ -876,7 +876,7 @@ namespace Tests.Linq
 						.LeftJoin(x => x.Id == d.MasterId)
 					select m != null ? m.Value : "Unknown";
 
-				Values(1).Concat(Values(2)).ToList().ShouldBe(["Master!", "Unknown"]);
+				Values(1).Concat(Values(2)).ToList().ShouldBe(["Master!", "Unknown"], ignoreOrder: true);
 			}
 		}
 

--- a/Tests/Linq/Linq/QueryFilterTests.cs
+++ b/Tests/Linq/Linq/QueryFilterTests.cs
@@ -968,6 +968,51 @@ namespace Tests.Linq
 		}
 
 		[Test]
+		public void SetOperationNullabilityIgnoresNarrowingBranches([IncludeDataSources(false, TestProvName.AllSQLite)] string context)
+		{
+			// EXCEPT / INTERSECT narrow the accumulated left side and contribute no values of their own, so a
+			// branch that is nullable only through a join inside itself must not make the enclosing column
+			// nullable. The UNION ALL case shares the shape and must keep the check - that is the #5792 fix.
+
+			var builder = new FluentMappingBuilder(new MappingSchema());
+
+			builder.Entity<MasterClass>().HasQueryFilter<MyDataContext>((e, dc) => !dc.IsSoftDeleteFilterEnabled || !e.IsDeleted);
+
+			builder.Build();
+
+			var masters = new[] { new MasterClass { Id = 1, Value = "Master" } };
+			var details = new[]
+			{
+				new DetailClass { Id = 1, MasterId = 1   },
+				new DetailClass { Id = 2, MasterId = 100 }
+			};
+
+			using var db = new MyDataContext(context, builder.MappingSchema);
+			using (db.CreateLocalTable(masters))
+			using (db.CreateLocalTable(details))
+			{
+				var head = from d in db.GetTable<DetailClass>().Where(d => d.Id == 1)
+					select new { Key = (int?)d.Id };
+
+				// nullable only through the LEFT JOIN, which lives inside the branch
+				var branch = from d in db.GetTable<DetailClass>().Where(d => d.Id == 2)
+					from m in db.GetTable<MasterClass>()
+						.Select(x => new { x.Id, Value = x.Value + "!" })
+						.LeftJoin(x => x.Id == d.MasterId)
+					select new { Key = (int?)m.Id };
+
+				head.Concat(branch).Select(u => u.Key != null ? u.Key.Value : -1).ToList().ShouldBe([1, -1], ignoreOrder: true);
+				db.LastQuery!.ShouldContain("IS NOT NULL");
+
+				head.Except(branch).Select(u => u.Key != null ? u.Key.Value : -1).ToList().ShouldBe([1]);
+				db.LastQuery!.ShouldNotContain("IS NOT NULL");
+
+				head.Intersect(branch).Select(u => u.Key != null ? u.Key.Value : -1).ToList().ShouldBeEmpty();
+				db.LastQuery!.ShouldNotContain("IS NOT NULL");
+			}
+		}
+
+		[Test]
 		public void NamedFilter_InterfaceTypedLambda_FastPath([IncludeDataSources(false, TestProvName.AllSQLite)] string context)
 		{
 			// Regression: a filter lambda typed against an interface (Func<ISoftDelete, ...>) applied to a concrete

--- a/Tests/Linq/Linq/QueryFilterTests.cs
+++ b/Tests/Linq/Linq/QueryFilterTests.cs
@@ -862,7 +862,8 @@ namespace Tests.Linq
 			var details = new[]
 			{
 				new DetailClass { Id = 1, MasterId = 1   }, // resolves
-				new DetailClass { Id = 2, MasterId = 100 }  // does not
+				new DetailClass { Id = 2, MasterId = 100 }, // does not
+				new DetailClass { Id = 3, MasterId = 200 }  // does not either
 			};
 
 			using var db = new MyDataContext(context, builder.MappingSchema);
@@ -876,7 +877,49 @@ namespace Tests.Linq
 						.LeftJoin(x => x.Id == d.MasterId)
 					select m != null ? m.Value : "Unknown";
 
-				Values(1).Concat(Values(2)).ToList().ShouldBe(["Master!", "Unknown"], ignoreOrder: true);
+				Values(1).Concat(Values(2)).Concat(Values(3)).ToList().ShouldBe(["Master!", "Unknown", "Unknown"], ignoreOrder: true);
+			}
+		}
+
+		[Test]
+		public void FilteredLeftJoinFallbackChainSurvivesSetOperation([IncludeDataSources(false, TestProvName.AllSQLite)] string context)
+		{
+			// Companion to FilteredLeftJoinNullCheckSurvivesSetOperation: with a two-level fallback the whole chain
+			// collapsed to the first join's column in every branch after the first, so the second join stayed in the
+			// FROM clause but was never referenced in the projection.
+
+			var builder = new FluentMappingBuilder(new MappingSchema());
+
+			builder.Entity<MasterClass>().HasQueryFilter<MyDataContext>((e, dc) => !dc.IsSoftDeleteFilterEnabled || !e.IsDeleted);
+			builder.Entity<InfoClass>().HasQueryFilter<MyDataContext>((e, dc) => !dc.IsSoftDeleteFilterEnabled || !e.IsDeleted);
+
+			builder.Build();
+
+			var masters = new[] { new MasterClass { Id = 1, Value = "Master" } };
+			var infos   = new[] { new InfoClass   { Id = 1, Value = "Info", MasterId = 2 } };
+			var details = new[]
+			{
+				new DetailClass { Id = 1, MasterId = 1   }, // resolves through master
+				new DetailClass { Id = 2, MasterId = 2   }, // resolves through info only
+				new DetailClass { Id = 3, MasterId = 100 }  // resolves through neither
+			};
+
+			using var db = new MyDataContext(context, builder.MappingSchema);
+			using (db.CreateLocalTable(masters))
+			using (db.CreateLocalTable(infos))
+			using (db.CreateLocalTable(details))
+			{
+				IQueryable<string> Values(int id) =>
+					from d in db.GetTable<DetailClass>().Where(d => d.Id == id)
+					from m in db.GetTable<MasterClass>()
+						.Select(x => new { x.Id, Value = x.Value + "!" })
+						.LeftJoin(x => x.Id == d.MasterId)
+					from i in db.GetTable<InfoClass>()
+						.Select(x => new { x.Id, x.MasterId, Value = x.Value + "?" })
+						.LeftJoin(x => x.MasterId == d.MasterId)
+					select m != null ? m.Value : i != null ? i.Value : "Unknown";
+
+				Values(1).Concat(Values(2)).Concat(Values(3)).ToList().ShouldBe(["Master!", "Info?", "Unknown"], ignoreOrder: true);
 			}
 		}
 

--- a/Tests/Linq/Linq/QueryFilterTests.cs
+++ b/Tests/Linq/Linq/QueryFilterTests.cs
@@ -924,6 +924,50 @@ namespace Tests.Linq
 		}
 
 		[Test]
+		public void SetOperationBranchNullabilityReachesEnclosingQuery([IncludeDataSources(false, TestProvName.AllSQLite)] string context)
+		{
+			// The enclosing query resolves a set-operation column by fanning out over SetOperators. Branch 1 is
+			// deliberately non-nullable so that fan-out is actually reached, and branch 2 is nullable only through
+			// a LEFT JOIN living inside the branch - which the source walk cannot see unless the branch query is
+			// registered in the nullability scope. Without that the null check folds away and the NULL surfaces
+			// as a default value.
+
+			var builder = new FluentMappingBuilder(new MappingSchema());
+
+			builder.Entity<MasterClass>().HasQueryFilter<MyDataContext>((e, dc) => !dc.IsSoftDeleteFilterEnabled || !e.IsDeleted);
+
+			builder.Build();
+
+			var masters = new[] { new MasterClass { Id = 1, Value = "Master" } };
+			var details = new[]
+			{
+				new DetailClass { Id = 1, MasterId = 1   },
+				new DetailClass { Id = 2, MasterId = 100 }
+			};
+
+			using var db = new MyDataContext(context, builder.MappingSchema);
+			using (db.CreateLocalTable(masters))
+			using (db.CreateLocalTable(details))
+			{
+				// branch 1 is non-nullable, so CanBeNull cannot short-circuit before the set-operator fan-out
+				var branch1 = from d in db.GetTable<DetailClass>().Where(d => d.Id == 1)
+					select new { Key = (int?)d.Id };
+
+				// branch 2's key is nullable only through the LEFT JOIN, which lives inside SetOperators
+				var branch2 = from d in db.GetTable<DetailClass>().Where(d => d.Id == 2)
+					from m in db.GetTable<MasterClass>()
+						.Select(x => new { x.Id, Value = x.Value + "!" })
+						.LeftJoin(x => x.Id == d.MasterId)
+					select new { Key = (int?)m.Id };
+
+				var query = from u in branch1.Concat(branch2)
+					select u.Key != null ? u.Key.Value : -1;
+
+				query.ToList().ShouldBe([1, -1], ignoreOrder: true);
+			}
+		}
+
+		[Test]
 		public void NamedFilter_InterfaceTypedLambda_FastPath([IncludeDataSources(false, TestProvName.AllSQLite)] string context)
 		{
 			// Regression: a filter lambda typed against an interface (Func<ISoftDelete, ...>) applied to a concrete


### PR DESCRIPTION
Fixes #5792

## Problem

With a query filter on a left-joined entity, a `joined != null ? joined.X : fallback` conditional was dropped in every set-operation branch except the first, so a non-matching left join yielded `NULL` instead of the fallback. Regression in 6.4.0.

## Cause

`SqlExpressionConvertVisitor.VisitSqlQuery` descends into a query and optimizes its column expressions, but only set `JoinSource` — it never added the query to `NullabilityContext.Queries`.

Nullability was therefore resolved against an outer scope. `IsNullableSourceCalculator` walks `From`/`Joins`, which never enters `SetOperators`, so a source inside a set-operation branch came back `null` (unreachable). `CanBeNull` contributes nothing for `null`, and since the joined key is a non-nullable PK the join was the only source of nullability — so `IS NOT NULL` folded to `true` and `VisitSqlConditionExpression` reduced the `IIF` to its true-branch.

This is positional for a structural reason: the first branch *is* the outer query, so its tables are reachable from `From`/`Joins`; the second branch is reachable only through `SetOperators`.

`SqlExpressionOptimizerVisitor.VisitSqlQuery` already registers the query via `WithQuery`. The two visitors performed the same descent under different contracts; this restores the symmetry.

## Fix

```csharp
NullabilityContext = NullabilityContext.WithQuery(selectQuery).WithJoinSource(selectQuery);
```

## Verification

Local full runs, paired (same command, same binary path, DLL freshness asserted in-run):

| provider | without fix | with fix |
|---|---|---|
| SQLite.MS | 10927 total, 1 failed — exactly the new test | 10927 total, 0 failed |
| SQLite.Classic | — | 10938 total, 0 failed |
| SqlServer.2019.MS | 11749 total, 10 failed | 11749 total, same 10 |

Exactly one test changed state on SQLite.MS; no other test moved. The 10 SQL Server failures are pre-existing in the no-fix baseline — `CURRENT_TIMESTAMP`/`GETDATE` off by exactly 180 minutes, a container-vs-host timezone offset, unrelated to this change.

## Follow-up commits

- `eb31446b79` — the set-operation assertion is order-insensitive. `Concat` renders as UNION ALL with no ORDER BY, so branch order is not guaranteed. Each branch yields one row and the two values are distinct, so the test keeps its full discriminating power.
- `df41dd6001` — coverage for two facets of #5792 the first test did not pin: a three-operand `Concat`, so the null check is asserted in every branch after the first rather than only the second, and `FilteredLeftJoinFallbackChainSurvivesSetOperation` for the issue's second manifestation, where a two-level fallback collapsed to the first join's column and left the second join in `FROM` but unreferenced in the projection.
- `50798d58a5` — the same root cause at the consumer side. `NullabilityContext.CanBeNull` resolved a set-operation column by evaluating each branch's column with the current context, which does not contain the branch query. Since `IsNullableSourceCalculator` never enters `SetOperators`, the branch's own tables came back unreachable and a value nullable only through a join inside the branch was reported as not nullable to the enclosing query — the null check folded away and the NULL surfaced as a default value. Registering the branch via `WithQuery` fixes it. The visited-column cycle guard is carried over explicitly because `WithQuery` allocates a fresh context.

### Verification of the follow-ups

`QueryFilterTests` 42/42 on SQLite.MS. Full SQLite.MS run: 10929 total, 7 failed — all on the `SQLite.MS.LinqService` context and all flaky rather than caused by the change: a run with `50798d58a5` reverted failed a **disjoint** set of 3 (`Distinct6` ×3), and all 10 pass when re-run. Both tests added in `df41dd6001` are confirmed red at `8a80301ee5` and green after. The test added in `50798d58a5` is confirmed red at `8a80301ee5`, where the emitted SQL drops the null check entirely and the left join's NULL materialises as `0`.

`50798d58a5` touches core `NullabilityContext`, so its blast radius is wider than the original one-line scope fix — the CI matrix and the baselines diff it generates are the meaningful check.

## Notes

- The regression test is SQLite-only; the defect is provider-agnostic by trace (the fold happens in the shared convert/optimize pipeline, no provider-specific code on the path), not verified on other providers.
- SQL baselines are not evaluated locally here — CI is the check for generated-SQL shifts elsewhere.
