### PR TITLE
Stop configuring the unusable pomelo-nightly NuGet source

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -3,7 +3,10 @@
 	<packageSources>
 		<clear />
 		<add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-		<add key="pomelo-nightly" value="https://pkgs.dev.azure.com/pomelo-efcore/Pomelo.EntityFrameworkCore.MySql/_packaging/pomelo-efcore-public/nuget/v3/index.json" />
+		<!--Uncomment together with the pomelo-nightly mapping below when a Pomelo nightly is needed. A source
+		    listed here is enumerated by the NuGet vulnerability audit even when no package pattern maps to it,
+		    so leaving it enabled makes every build depend on that feed being reachable-->
+		<!--<add key="pomelo-nightly" value="https://pkgs.dev.azure.com/pomelo-efcore/Pomelo.EntityFrameworkCore.MySql/_packaging/pomelo-efcore-public/nuget/v3/index.json" />-->
 	</packageSources>
 	<packageSourceMapping>
 		<!--<packageSource key="pomelo-nightly">


### PR DESCRIPTION
Unblocks CI. Every build currently fails restore with `NU1900`, promoted to an error by `TreatWarningsAsErrors`:

```
Source\LinqToDB\LinqToDB.csproj(0,0): Error NU1900: Warning As Error: Error occurred while getting package
vulnerability data: Unable to load the service index for source
https://pkgs.dev.azure.com/pomelo-efcore/Pomelo.EntityFrameworkCore.MySql/_packaging/pomelo-efcore-public/nuget/v3/index.json.
```

## Why the source can be dropped

`pomelo-nightly` cannot supply anything today. Its `packageSourceMapping` entry is already commented out, and `nuget.org` claims the `*` pattern — so with package source mapping in effect, no package can restore from it. It is reached **only** by the NuGet vulnerability audit, which enumerates every configured source regardless of mapping. That makes every build depend on a feed the repo does not use.

Commenting the source out next to the mapping it belongs with keeps re-enabling a Pomelo nightly a matched pair.

## Not branch-specific

| Build | PR | Result |
|---|---|---|
| 23131 | [#5737](https://github.com/linq2db/linq2db/pull/5737) | succeeded, 12:54 |
| 23132 | [#5737](https://github.com/linq2db/linq2db/pull/5737) | failed, 13:47 |
| 23134 | [#5834](https://github.com/linq2db/linq2db/pull/5834) | failed |
| 23136 | [#5828](https://github.com/linq2db/linq2db/pull/5828) | failed |

The feed answers HTTP 200 outside CI, so it is reachable in general but not from the agents — which is the dependency worth removing rather than waiting out.

## Verification

Restored `Tests/EntityFrameworkCore/Tests.EntityFrameworkCore.EF10.csproj` — the project referencing `Pomelo.EntityFrameworkCore.MySql` — against the modified config: 18 projects restored, exit 0, no `NU1900`. All four Pomelo pins (`3.2.7`, `8.0.3`, `9.0.0` ×2) are released versions on nuget.org.
