### PR TITLE
CI: run the database-free build and checks on GitHub Actions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,5 +4,6 @@
 *.slnx     text      eol=crlf
 *.csproj   text      eol=crlf
 *.sh       text      eol=lf
+*.yml      text      eol=lf
 .githooks/** text    eol=lf
 "/Data/Setup Scripts/ase.sql" text eol=lf

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,7 @@
 /Source/**/*.cs  @igor-tkachev @sdanyliv @MaceWindu @viceroypenguin @jods4 @Shane32
 /Source/**/*.ttinclude  @igor-tkachev @sdanyliv @MaceWindu @viceroypenguin @jods4 @Shane32
+
+# CI definitions. A workflow file executes with repository credentials the moment it merges, so it
+# wants the same review bar as source. Neither path had an owner before.
+/Build/  @MaceWindu
+/.github/workflows/  @MaceWindu

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,23 +30,12 @@ concurrency:
   group: build-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-# Every actions/setup-dotnet step below carries `DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet`, which
-# installs the SDKs into a clean directory instead of alongside the image's preinstalled ones.
-#
-# That is not tidiness - the build does not compile without it. CodeGenerators is a source generator
-# built against Roslyn 5.6 (Microsoft.CodeAnalysis.CSharp 5.6.0, Directory.Packages.props:105), so
-# loading it needs an SDK whose compiler is at least 5.6, i.e. 10.0.4xx. global.json asks for 10.0.200
-# with rollForward: minor, and that policy prefers the highest patch of the 10.0.2xx band over rolling
-# forward - so on a runner image shipping 10.0.2xx, 10.0.3xx and 10.0.4xx side by side it picks a
-# 10.0.2xx whose compiler is 5.3, and every project fails with CS9057.
-#
-# Azure never hits this because UseDotNet@2 installs into an isolated tool directory, so the only SDKs
-# it can see are the ones it just installed. This reproduces that.
-#
-# It has to sit on each step rather than in a workflow-level `env:` block: the `runner` context is not
-# available there, and referencing it makes the whole workflow fail to compile with no job ever
-# starting. setup-dotnet exports DOTNET_ROOT and prepends PATH for later steps, so setting it on the
-# setup step alone is enough.
+# SDK selection is global.json's job, not this file's. It asks for rollForward: latestFeature, so a
+# runner image carrying 10.0.2xx, 10.0.3xx and 10.0.4xx side by side resolves to the newest - which is
+# what CodeGenerators needs, being built against Roslyn 5.6 and failing to load with CS9057 under the
+# 5.3 compiler a 10.0.2xx ships. setup-dotnet installs alongside the image's preinstalled SDKs rather
+# than isolating them the way Azure's UseDotNet@2 does, so that resolution is load-bearing here in a
+# way it never was on Azure.
 env:
   # Mirrors Build/Azure/pipelines/templates/build-vars.yml. Keep them in step.
   SOLUTION: linq2db.slnx
@@ -68,8 +57,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-        env:
-          DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
         with:
           dotnet-version: |
             8.x
@@ -130,8 +117,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-        env:
-          DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
         with:
           dotnet-version: |
             9.x
@@ -149,8 +134,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-        env:
-          DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
         with:
           dotnet-version: |
             8.x
@@ -172,8 +155,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-        env:
-          DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
         with:
           dotnet-version: 10.x
 
@@ -199,8 +180,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-        env:
-          DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
         with:
           dotnet-version: |
             8.x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,18 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # Install the SDKs into a clean directory instead of alongside the image's preinstalled ones.
+  #
+  # This is not tidiness - the build does not compile without it. CodeGenerators is a source generator
+  # built against Roslyn 5.6 (Microsoft.CodeAnalysis.CSharp 5.6.0, Directory.Packages.props:105), so
+  # loading it needs an SDK whose compiler is at least 5.6, i.e. 10.0.4xx. global.json asks for
+  # 10.0.200 with rollForward: minor, and that policy prefers the highest patch of the 10.0.2xx band
+  # over rolling forward - so on a runner image that ships 10.0.2xx, 10.0.3xx and 10.0.4xx side by
+  # side, it picks a 10.0.2xx whose compiler is 5.3 and every project fails with CS9057.
+  #
+  # Azure never hits this because UseDotNet@2 installs into an isolated tool directory, so the only
+  # SDKs it can see are the ones it just installed. Isolating here reproduces that.
+  DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
   # Mirrors Build/Azure/pipelines/templates/build-vars.yml. Keep them in step.
   SOLUTION: linq2db.slnx
   RELEASE_CONFIGURATION: Release
@@ -133,7 +145,10 @@ jobs:
             8.x
             10.x
 
-      - run: dotnet test Tests/Tests.Analyzers/Tests.Analyzers.csproj --configuration ${{ env.TEST_CONFIGURATION }}
+      # --project, not a positional path: global.json selects the Microsoft.Testing.Platform runner,
+      # whose CLI rejects a bare project argument with "Specifying a project for 'dotnet test' should
+      # be via '--project'". The AzDO DotNetCoreCLI@2 task hides this behind its `projects:` input.
+      - run: dotnet test --project Tests/Tests.Analyzers/Tests.Analyzers.csproj --configuration ${{ env.TEST_CONFIGURATION }}
 
   # Regression guard for #5488: provider detectors must not rely on Assembly.Location / File.Exists
   # heuristics that misbehave inside a single-file bundle. Publishes win-x64 self-contained, so Windows.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,19 +30,24 @@ concurrency:
   group: build-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Every actions/setup-dotnet step below carries `DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet`, which
+# installs the SDKs into a clean directory instead of alongside the image's preinstalled ones.
+#
+# That is not tidiness - the build does not compile without it. CodeGenerators is a source generator
+# built against Roslyn 5.6 (Microsoft.CodeAnalysis.CSharp 5.6.0, Directory.Packages.props:105), so
+# loading it needs an SDK whose compiler is at least 5.6, i.e. 10.0.4xx. global.json asks for 10.0.200
+# with rollForward: minor, and that policy prefers the highest patch of the 10.0.2xx band over rolling
+# forward - so on a runner image shipping 10.0.2xx, 10.0.3xx and 10.0.4xx side by side it picks a
+# 10.0.2xx whose compiler is 5.3, and every project fails with CS9057.
+#
+# Azure never hits this because UseDotNet@2 installs into an isolated tool directory, so the only SDKs
+# it can see are the ones it just installed. This reproduces that.
+#
+# It has to sit on each step rather than in a workflow-level `env:` block: the `runner` context is not
+# available there, and referencing it makes the whole workflow fail to compile with no job ever
+# starting. setup-dotnet exports DOTNET_ROOT and prepends PATH for later steps, so setting it on the
+# setup step alone is enough.
 env:
-  # Install the SDKs into a clean directory instead of alongside the image's preinstalled ones.
-  #
-  # This is not tidiness - the build does not compile without it. CodeGenerators is a source generator
-  # built against Roslyn 5.6 (Microsoft.CodeAnalysis.CSharp 5.6.0, Directory.Packages.props:105), so
-  # loading it needs an SDK whose compiler is at least 5.6, i.e. 10.0.4xx. global.json asks for
-  # 10.0.200 with rollForward: minor, and that policy prefers the highest patch of the 10.0.2xx band
-  # over rolling forward - so on a runner image that ships 10.0.2xx, 10.0.3xx and 10.0.4xx side by
-  # side, it picks a 10.0.2xx whose compiler is 5.3 and every project fails with CS9057.
-  #
-  # Azure never hits this because UseDotNet@2 installs into an isolated tool directory, so the only
-  # SDKs it can see are the ones it just installed. Isolating here reproduces that.
-  DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
   # Mirrors Build/Azure/pipelines/templates/build-vars.yml. Keep them in step.
   SOLUTION: linq2db.slnx
   RELEASE_CONFIGURATION: Release
@@ -63,6 +68,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        env:
+          DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
         with:
           dotnet-version: |
             8.x
@@ -123,6 +130,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        env:
+          DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
         with:
           dotnet-version: |
             9.x
@@ -140,6 +149,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        env:
+          DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
         with:
           dotnet-version: |
             8.x
@@ -161,6 +172,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        env:
+          DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
         with:
           dotnet-version: 10.x
 
@@ -186,6 +199,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        env:
+          DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
         with:
           dotnet-version: |
             8.x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,196 @@
+# Database-free CI, ported from the Azure Pipelines `build` definition
+# (Build/Azure/pipelines/build.yml -> templates/build-job.yml, plus templates/test-cli.yml).
+#
+# Nothing here needs a database, a container or a secret, so it runs on every PR automatically. The
+# provider test matrix is a separate, dispatched workflow.
+#
+# Two things are deliberate and easy to "fix" wrongly:
+#
+#   * `-c Azure` for anything under Tests/. Tests/Directory.Build.props defines the AZURE symbol from
+#     that configuration name, TestConfiguration.cs then appends ".Azure" to the config key, and that
+#     is what selects the CI connection strings and BaselinesPath. Building `-c Release` instead is
+#     silently wrong rather than broken.
+#   * Every job that touches net462 runs on Windows. That is the Release build of linq2db.slnx and the
+#     Examples solution (which has net462 projects of its own); the repo carries no
+#     Microsoft.NETFramework.ReferenceAssemblies reference, so a Linux build of those fails.
+#
+# Actions are pinned by SHA and limited to GitHub-owned ones, matching the repository's
+# `allowed_actions: selected` + `github_owned_allowed` policy.
+name: build
+
+on:
+  pull_request:
+  push:
+    branches: [master, release]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Mirrors Build/Azure/pipelines/templates/build-vars.yml. Keep them in step.
+  SOLUTION: linq2db.slnx
+  RELEASE_CONFIGURATION: Release
+  TEST_CONFIGURATION: Azure
+  # Per-test retry for the MTP runner, as build-vars.yml:24.
+  TEST_RETRY_ARGS: --retry-failed-tests 2 --retry-failed-tests-max-tests 5
+
+jobs:
+  # Release build + pack + the two pre-publish package gates. Windows because the solution targets
+  # net462. Nothing is published from here - publishing stays on Azure Pipelines - so the artifacts
+  # exist for inspection and for the LINQPad .lpx.
+  build:
+    name: Build and pack
+    runs-on: windows-2025
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: |
+            8.x
+            9.x
+            10.x
+
+      # Same shape as build-job.yml:49-55: a dev suffix everywhere except the release branch.
+      - name: Resolve version suffix
+        shell: pwsh
+        run: |
+          if ('${{ github.ref }}' -eq 'refs/heads/release') {
+            'VERSION_ARGS=-p:ApplyVersionSuffix=false' | Out-File -FilePath $env:GITHUB_ENV -Append
+          } else {
+            'VERSION_ARGS=-p:VersionSuffix=-dev.${{ github.run_number }}' | Out-File -FilePath $env:GITHUB_ENV -Append
+          }
+
+      # Analyzers stay off, matching build.yml's `with_analyzers: false` until dotnet/roslyn#80621
+      # ships. The API analyzers are a release-prep gate (/release-publicapi), not a per-PR one.
+      - name: Build solution
+        run: dotnet build ${{ env.SOLUTION }} --configuration ${{ env.RELEASE_CONFIGURATION }} -p:RunAnalyzersDuringBuild=false -p:RunApiAnalyzersDuringBuild=false ${{ env.VERSION_ARGS }}
+
+      - name: Pack solution
+        run: dotnet pack ${{ env.SOLUTION }} --configuration ${{ env.RELEASE_CONFIGURATION }} -p:RunAnalyzersDuringBuild=false -p:RunApiAnalyzersDuringBuild=false ${{ env.VERSION_ARGS }}
+
+      # Both scripts already carry -NoAzdoLogs and signal through their exit code, so they need no
+      # porting - only the switch. nuget-job.yml runs these before publishing; on a PR they are the
+      # only thing standing between a size or delivery-metadata regression and the release branch.
+      - name: Verify nupkg sizes
+        shell: pwsh
+        run: ./Build/Azure/scripts/verify-nuget-sizes.ps1 -PackagesDir .build/package/release -WarnMB 180 -FailMB 200 -NoAzdoLogs
+
+      - name: Verify analyzer delivery metadata
+        shell: pwsh
+        run: ./Build/Azure/scripts/verify-analyzer-delivery.ps1 -PackagesDir .build/package/release -NoAzdoLogs
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nugets
+          path: .build/package/release
+          if-no-files-found: error
+
+      # The .lpx is produced during the net472 build of LinqToDB.LINQPad (GenerateLpxArtifacts,
+      # default true). `error` rather than `warn`: a silently missing .lpx is how the LINQPad 5
+      # artifact goes stale without anyone noticing.
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: linq2db_linqpad_lpx
+          path: .build/lpx
+          if-no-files-found: error
+
+  # Windows because Examples has net462 projects (Examples/**/*.csproj: net462, net9.0, net10.0).
+  examples:
+    name: Examples build
+    runs-on: windows-2025
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: |
+            9.x
+            10.x
+
+      - run: dotnet build Examples/Examples.slnx --configuration Debug
+
+  # Roslyn analyzer/code-fix unit tests. DB-free and net8.0-only, so Linux is fine.
+  analyzer-tests:
+    name: Analyzer tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: |
+            8.x
+            10.x
+
+      - run: dotnet test Tests/Tests.Analyzers/Tests.Analyzers.csproj --configuration ${{ env.TEST_CONFIGURATION }}
+
+  # Regression guard for #5488: provider detectors must not rely on Assembly.Location / File.Exists
+  # heuristics that misbehave inside a single-file bundle. Publishes win-x64 self-contained, so Windows.
+  singlefile-smoke:
+    name: PublishSingleFile smoke test
+    runs-on: windows-2025
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: 10.x
+
+      - run: dotnet publish Tests/Tests.SingleFile/Tests.SingleFile.csproj -c Release -f net10.0 -r win-x64 --self-contained true -p:PublishSingleFile=true -o .build/publish/singlefile
+
+      - run: .build/publish/singlefile/linq2db.Tests.SingleFile.exe
+
+  # Port of templates/test-cli.yml. No database, so it belongs here rather than in the provider matrix.
+  cli-tests:
+    name: CLI tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            exe: linq2db.CLI.Tests
+          - os: windows-2025
+            exe: linq2db.CLI.Tests.exe
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: |
+            8.x
+            9.x
+            10.x
+
+      - run: dotnet build Tests/LinqToDB.CLI/Tests.LinqToDB.CLI.csproj --configuration ${{ env.TEST_CONFIGURATION }}
+
+      - name: Run CLI tests
+        shell: pwsh
+        run: |
+          foreach ($tfm in @('net8.0', 'net9.0', 'net10.0')) {
+            $exe = Join-Path ".build/bin/Tests.LinqToDB.CLI/${{ env.TEST_CONFIGURATION }}/$tfm" '${{ matrix.exe }}'
+            & $exe --filter "TestCategory != SkipCI" --settings .runsettings --report-trx --report-trx-filename "cli-$tfm.trx" --results-directory CliTestResults --hangdump --hangdump-timeout 5m $env:TEST_RETRY_ARGS.Split(' ')
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: cli-test-results-${{ matrix.os }}
+          path: CliTestResults/*.trx
+          if-no-files-found: error

--- a/global.json
+++ b/global.json
@@ -1,7 +1,8 @@
 {
 	"sdk": {
-		"version": "10.0.200",
-		"rollForward": "minor",
+		"//": "latestFeature, not minor: 'minor' prefers the highest patch of the requested feature band (10.0.2xx) over rolling forward, so on a machine that has 10.0.2xx and 10.0.4xx side by side it picks the 2xx - whose Roslyn is 5.3, while CodeGenerators is built against 5.6 and fails to load with CS9057. latestFeature takes the newest 10.0.x installed instead.",
+		"version": "10.0.100",
+		"rollForward": "latestFeature",
 		"allowPrerelease": false
 	},
 	"test": {


### PR DESCRIPTION
Second step of moving CI to GitHub Actions. Ports the database-free half of the Azure Pipelines `build` definition, which is everything that needs no database, no container and no secret — so it can run automatically on every PR.

The provider test matrix is **not** part of this change; it stays on Azure Pipelines and moves in a later step.

## Jobs

| Job | Runner | Ported from |
|---|---|---|
| `build` | windows-2025 | Release build + `dotnet pack`, then `verify-nuget-sizes.ps1` and `verify-analyzer-delivery.ps1`; uploads the `nugets` and `linq2db_linqpad_lpx` artifacts |
| `examples` | windows-2025 | `Build Examples (verify)` |
| `analyzer-tests` | ubuntu-24.04 | `Run Analyzer Tests` |
| `singlefile-smoke` | windows-2025 | `PublishSingleFile Smoke Test` (the #5488 regression guard) |
| `cli-tests` | ubuntu-24.04 + windows-2025 | `templates/test-cli.yml` |

## Two constraints that drive the layout

**Anything under `Tests/` builds `-c Azure`.** `Tests/Directory.Build.props:17-21` defines the `AZURE` symbol from that configuration name, and `TestConfiguration.cs:62-65` uses it to append `.Azure` to the config key — which is what selects the CI connection strings and `BaselinesPath` from `DataProviders.json`. Building `-c Release` instead is silently wrong rather than broken: the run picks up local connection strings and captures no baselines, with nothing red anywhere. The configuration name is kept verbatim for the same reason; renaming it is a much larger change than it looks.

**Every job that touches `net462` runs on Windows.** That is the Release build of `linq2db.slnx` and the `Examples` solution, which has `net462` projects of its own (`net462;net9.0;` and a bare `net462`). The repo carries no `Microsoft.NETFramework.ReferenceAssemblies` reference, so a Linux build of either fails.

## Reuse

`verify-nuget-sizes.ps1` and `verify-analyzer-delivery.ps1` are used **unmodified** — both already carry a `-NoAzdoLogs` switch and signal through their exit code, so only the switch was needed. Note these currently run in `nuget-job.yml`, which never runs on a `master`-targeting PR, so this is the first time a PR gets the nupkg size and analyzer-delivery gates at all.

Actions are GitHub-owned only and pinned by SHA, matching the repository's `allowed_actions: selected` + `github_owned_allowed` policy.

## Also here

- `.github/CODEOWNERS` gains `/Build/` and `/.github/workflows/` entries. Neither path had an owner, so CI definitions have been landing with no required-owner review — which matters more once workflow files exist, since a workflow executes with repository credentials the moment it merges.
- `.gitattributes` gains an explicit `*.yml eol=lf` rule beside the existing `*.sh` one. This is consistency, not a fix: all 25 tracked `.yml` files are already LF in the index under `text=auto`, so nothing is renormalized and no stored content changes.

`.github/` needs no `linq2db.slnx` edit — #5752 replaced the per-file listing with a `NoTargets` glue project that globs the directory.

## Not in this change

The Azure `build` definition still runs on every PR. Turning it off (`pr: none`) is deliberately sequenced **after** this workflow is proven green and after the required-check list in branch protection is updated — flipping it first would stall every PR if that check is currently required.

## Verification

`pull_request` runs execute from the merge commit, so this PR's own run is the verification. `if-no-files-found: error` on both artifact uploads is deliberate: a silently missing `.lpx` is how that artifact goes stale without anyone noticing.
