### PR TITLE
THROWAWAY probe: Linux containers and native DB servers on Windows agents

### DIFF
--- a/.github/workflows/probe-win-db.yml
+++ b/.github/workflows/probe-win-db.yml
@@ -117,7 +117,12 @@ jobs:
           export DEBIAN_FRONTEND=noninteractive
           apt-get update -qq
           apt-get install -y -qq docker.io iptables >/dev/null
+          # Before dockerd, not after. The previous run set this once the daemon was already up, so
+          # dockerd had built its chains under nftables and the legacy binary could not see them:
+          # "Unable to enable DNAT rule ... iptables: No chain/target/match by that name". Containers
+          # ran fine, only -p publishing broke - which is the one thing this probe needs.
           update-alternatives --set iptables /usr/sbin/iptables-legacy || true
+          update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy || true
           nohup dockerd >/tmp/dockerd.log 2>&1 &
           for i in $(seq 1 40); do docker info >/dev/null 2>&1 && break; sleep 2; done
           echo "--- docker info"
@@ -125,7 +130,7 @@ jobs:
           echo "--- hello-world"
           docker run --rm hello-world || { echo "--- dockerd.log"; tail -40 /tmp/dockerd.log; exit 11; }
           echo "--- postgres with a published port"
-          docker run -d -p 15432:5432 -e POSTGRES_PASSWORD=probe postgres:17-alpine
+          docker run -d -p 15432:5432 -e POSTGRES_PASSWORD=probe postgres:17-alpine || { echo "--- dockerd.log"; tail -40 /tmp/dockerd.log; exit 13; }
           for i in $(seq 1 40); do (echo > /dev/tcp/127.0.0.1/15432) >/dev/null 2>&1 && break; sleep 2; done
           ss -lntp | grep 15432 || { echo "port never opened inside wsl"; exit 12; }
           '@ -replace "`r`n", "`n"

--- a/.github/workflows/probe-win-db.yml
+++ b/.github/workflows/probe-win-db.yml
@@ -73,6 +73,42 @@ jobs:
           "=== Hyper-V / virtualisation"
           (Get-CimInstance Win32_ComputerSystem).HypervisorPresent
 
+      # 1b. WSL2. The first run found HypervisorPresent=True and WSL 2.7.12 on the image manifest, which
+      # is how Docker Desktop runs Linux containers on Windows in the first place: a lightweight VM with
+      # its ports forwarded to Windows localhost. If a distro boots and can run docker, then a Linux DB
+      # container *is* reachable from a netfx test process on the same agent - which is the whole
+      # premise behind the Windows-only providers (Informix IDS, netfx Oracle, Devart, SAP HANA netfx,
+      # Sybase native) having no CI coverage. Slow and allowed to fail: a partial answer still tells us
+      # which step is the wall.
+      - name: WSL2 - does a distro boot
+        id: wsl
+        continue-on-error: true
+        timeout-minutes: 15
+        shell: pwsh
+        run: |
+          wsl --version
+          "=== installed distros"
+          wsl -l -v
+          "=== install"
+          wsl --install -d Ubuntu-24.04 --no-launch
+          "install exit=$LASTEXITCODE"
+          wsl -l -v
+          "=== boot"
+          wsl -d Ubuntu-24.04 -- uname -a
+          "uname exit=$LASTEXITCODE"
+
+      - name: WSL2 - can it run a Linux container
+        id: wsldocker
+        continue-on-error: true
+        timeout-minutes: 20
+        shell: pwsh
+        run: |
+          wsl -d Ubuntu-24.04 -u root -- bash -lc "apt-get update -qq && apt-get install -y -qq docker.io >/dev/null 2>&1 && dockerd >/tmp/dockerd.log 2>&1 & sleep 15; docker run --rm hello-world"
+          "docker-in-wsl exit=$LASTEXITCODE"
+          "=== is a port published into WSL reachable from Windows"
+          wsl -d Ubuntu-24.04 -u root -- bash -lc "docker run -d -p 15432:5432 -e POSTGRES_PASSWORD=probe postgres:17-alpine >/dev/null 2>&1; sleep 25; ss -lntp | grep 15432"
+          Test-NetConnection -ComputerName localhost -Port 15432 -InformationLevel Detailed
+
       # 2. The native PostgreSQL server. This is the one that decides the question.
       - name: Native PostgreSQL service
         id: pg

--- a/.github/workflows/probe-win-db.yml
+++ b/.github/workflows/probe-win-db.yml
@@ -97,49 +97,117 @@ jobs:
           wsl -d Ubuntu-24.04 -- uname -a
           "uname exit=$LASTEXITCODE"
 
-      # The script goes in over stdin rather than as a `bash -lc "..."` argument: it avoids quoting
-      # through pwsh -> wsl -> bash, and it is why the previous attempt returned a meaningless 127.
-      # That run chained `apt-get install ... && dockerd ... &`, which backgrounds the *whole* chain -
-      # so `docker run` fired while apt was still working and reported command-not-found, saying
-      # nothing about whether docker works here.
+      # Diagnostics first, then three fixes in order, all in one job - each stage is seconds except
+      # the container starts, so one run either fixes this or names the exact layer that is absent.
       #
-      # WSL2 has no systemd unless it is switched on, so dockerd is started by hand and waited for.
-      # Ubuntu 24.04 defaults to nftables while dockerd wants iptables, hence the legacy alternative -
-      # a known wall rather than a guess, and if it is wrong /tmp/dockerd.log says so.
+      # Diagnosis being tested: since the 6.6.y series the WSL2 kernel ships netfilter pieces as
+      # *modules* in a separate VHD - NF_NAT and NFT_NAT are built in (=y) but NETFILTER_XT_NAT,
+      # NFT_COMPAT and IP_NF_NAT are =m. That matches the failure exactly: chain creation went through
+      # native nftables and succeeded (we saw a live DOCKER chain and docker0), and only the DNAT
+      # *target* failed, because that path needs nft_compat + xt_nat.
+      #
+      # It also explains why the previous run's "switch to iptables-legacy before dockerd" changed
+      # nothing: had legacy actually taken effect, dockerd would have failed at *startup* with
+      # "Table does not exist (do you need to insmod?)" rather than at -p time. The `|| true` hid it.
+      #
+      # Worth knowing: this whole approach is in production on these runners - Particular/setup-wsl-
+      # action and setup-ibmmq-action provision WSL2 + docker on windows-latest and publish ports from
+      # a Linux container to Windows-side .NET tests, with no iptables handling at all. So a failure
+      # here is environmental, not structural.
+      #
+      # The docker subnet is pinned to 10.x up front. WSL2 hands the VM a random /20 out of
+      # 172.16.0.0/12 each boot and docker's default 172.17.0.0/16 collides with it intermittently -
+      # our failing container sat at 172.17.0.2, so that variable is removed rather than left to chance.
       - name: WSL2 - can it run a Linux container
         id: wsldocker
         continue-on-error: true
-        timeout-minutes: 25
+        timeout-minutes: 30
         shell: pwsh
         run: |
           $sh = @'
-          set -x
           export DEBIAN_FRONTEND=noninteractive
+          # docker.io's postinst tries to start a service and this distro has no systemd - the likely
+          # cause of the Azure leg blowing a 25-minute step timeout inside apt. 101 means "do not start".
+          printf '#!/bin/sh\nexit 101\n' > /usr/sbin/policy-rc.d
+          chmod +x /usr/sbin/policy-rc.d
           apt-get update -qq
           apt-get install -y -qq docker.io iptables >/dev/null
-          # Before dockerd, not after. The previous run set this once the daemon was already up, so
-          # dockerd had built its chains under nftables and the legacy binary could not see them:
-          # "Unable to enable DNAT rule ... iptables: No chain/target/match by that name". Containers
-          # ran fine, only -p publishing broke - which is the one thing this probe needs.
-          update-alternatives --set iptables /usr/sbin/iptables-legacy || true
-          update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy || true
-          nohup dockerd >/tmp/dockerd.log 2>&1 &
-          for i in $(seq 1 40); do docker info >/dev/null 2>&1 && break; sleep 2; done
-          echo "--- docker info"
-          docker info --format 'server={{.ServerVersion}} driver={{.Driver}}' || { echo "--- dockerd.log"; tail -40 /tmp/dockerd.log; exit 10; }
-          echo "--- hello-world"
-          docker run --rm hello-world || { echo "--- dockerd.log"; tail -40 /tmp/dockerd.log; exit 11; }
-          echo "--- postgres with a published port"
-          docker run -d -p 15432:5432 -e POSTGRES_PASSWORD=probe postgres:17-alpine || { echo "--- dockerd.log"; tail -40 /tmp/dockerd.log; exit 13; }
-          for i in $(seq 1 40); do (echo > /dev/tcp/127.0.0.1/15432) >/dev/null 2>&1 && break; sleep 2; done
-          ss -lntp | grep 15432 || { echo "port never opened inside wsl"; exit 12; }
+          mkdir -p /etc/docker
+          printf '{ "bip": "10.11.0.1/24", "default-address-pools": [ { "base": "10.12.0.0/16", "size": 24 } ] }' > /etc/docker/daemon.json
+
+          echo "===== STAGE 0 diagnostics"
+          iptables --version
+          readlink -f /etc/alternatives/iptables
+          uname -r
+          ls /usr/lib/modules /lib/modules 2>/dev/null
+          if [ -f /proc/config.gz ]; then
+            zcat /proc/config.gz | grep -E 'CONFIG_(NF_NAT|IP_NF_NAT|IP_NF_IPTABLES|NETFILTER_XT_NAT|NFT_NAT|NFT_CHAIN_NAT|NFT_COMPAT|NF_TABLES_IPV4|BRIDGE)='
+          else
+            echo "no /proc/config.gz"
+          fi
+          find /usr/lib/modules /lib/modules \( -name 'xt_nat.ko*' -o -name 'nft_compat.ko*' -o -name 'iptable_nat.ko*' \) 2>/dev/null
+          for m in iptable_nat xt_nat nft_compat xt_MASQUERADE xt_conntrack xt_addrtype; do
+            modprobe -v $m; echo "modprobe $m rc=$?"
+          done
+          echo "--- direct DNAT probes, docker not involved"
+          iptables-nft    -t nat -A OUTPUT -p tcp --dport 19999 -j DNAT --to-destination 127.0.0.1:19998; echo "nft rc=$?"
+          iptables-legacy -t nat -A OUTPUT -p tcp --dport 19999 -j DNAT --to-destination 127.0.0.1:19998; echo "legacy rc=$?"
+          dmesg | tail -20
+
+          start_dockerd() {
+            pkill dockerd 2>/dev/null; sleep 3
+            nohup dockerd >/tmp/dockerd.log 2>&1 &
+            for i in $(seq 1 40); do docker info >/dev/null 2>&1 && return 0; sleep 2; done
+            echo "dockerd did not come up"; tail -30 /tmp/dockerd.log; return 1
+          }
+          try_publish() {
+            docker rm -f probe-pg >/dev/null 2>&1
+            docker run -d --name probe-pg -p 15432:5432 -e POSTGRES_PASSWORD=probe postgres:17-alpine
+            return $?
+          }
+
+          echo "===== STAGE 1 modprobe then publish"
+          PUBLISHED=0
+          start_dockerd && docker info --format 'server={{.ServerVersion}}' && try_publish && PUBLISHED=1
+          echo "stage1 published=$PUBLISHED"
+
+          if [ $PUBLISHED -eq 0 ]; then
+            echo "===== STAGE 2 docker 29 native nftables firewall backend"
+            printf '{ "bip": "10.11.0.1/24", "firewall-backend": "nftables", "default-address-pools": [ { "base": "10.12.0.0/16", "size": 24 } ] }' > /etc/docker/daemon.json
+            start_dockerd && try_publish && PUBLISHED=1
+            echo "stage2 published=$PUBLISHED"
+            [ $PUBLISHED -eq 0 ] && tail -30 /tmp/dockerd.log
+          fi
+
+          if [ $PUBLISHED -eq 0 ]; then
+            echo "===== STAGE 3 --network host, no NAT at all"
+            docker rm -f probe-pg >/dev/null 2>&1
+            docker run -d --name probe-pg --network host -e POSTGRES_PASSWORD=probe postgres:17-alpine
+            echo "stage3 run rc=$?"
+            HOSTMODE=1
+          fi
+
+          PORT=15432
+          [ -n "$HOSTMODE" ] && PORT=5432
+          for i in $(seq 1 40); do (echo > /dev/tcp/127.0.0.1/$PORT) >/dev/null 2>&1 && break; sleep 2; done
+          echo "--- listening inside wsl (expecting $PORT)"
+          ss -lntp | grep -E "$PORT" || echo "port $PORT never opened inside wsl"
+          echo "WSLPORT=$PORT"
+          hostname -I
           '@ -replace "`r`n", "`n"
-          $sh | wsl -d Ubuntu-24.04 -u root -- bash
+
+          $sh | wsl -d Ubuntu-24.04 -u root -- bash 2>&1 | Tee-Object -Variable out
           "docker-in-wsl exit=$LASTEXITCODE"
 
-          "=== is the published port reachable from Windows (localhostForwarding)"
-          $r = Test-NetConnection -ComputerName localhost -Port 15432 -WarningAction SilentlyContinue
-          "TcpTestSucceeded=$($r.TcpTestSucceeded)"
+          # Which port ended up in play depends on which stage succeeded, so read it back rather than
+          # assuming, and try both channels: the WSL VM's own IP (robust) and localhost (forwarded).
+          $port = if ($out -match 'WSLPORT=(\d+)') { $Matches[1] } else { '15432' }
+          $wslIp = (wsl -d Ubuntu-24.04 -- hostname -I).Trim().Split(' ')[0]
+          "=== reaching the container from Windows: port=$port wslIp=$wslIp"
+          foreach ($target in @($wslIp, 'localhost')) {
+            $r = Test-NetConnection -ComputerName $target -Port $port -WarningAction SilentlyContinue
+            "$target`:$port TcpTestSucceeded=$($r.TcpTestSucceeded)"
+          }
 
       # 2. The native PostgreSQL server. This is the one that decides the question.
       - name: Native PostgreSQL service

--- a/.github/workflows/probe-win-db.yml
+++ b/.github/workflows/probe-win-db.yml
@@ -1,0 +1,121 @@
+# THROWAWAY PROBE - not part of the CI. Delete with the branch.
+#
+# Question: can we run the EF.Core netfx tests against PostgreSQL and MySQL?
+#
+# The standing assumption is "no, because the Windows agent cannot run Linux docker images". netfx runs
+# only on Windows, and those servers run in Linux containers, so the two never meet. This probe checks
+# whether that framing is still the right one, by asking three things:
+#
+#   1. Can a Windows runner run a Linux container at all? (Expected no - the runner VMs are not enabled
+#      for nested virtualization. Worth measuring rather than citing.)
+#   2. Is the PostgreSQL server that ships *natively* on the image usable? images/windows/Windows2025-
+#      Readme.md lists PostgreSQL 17.11 as service postgresql-x64-17, Stopped and Disabled but present,
+#      with a known postgres/root credential. If it starts, no container is needed and the whole
+#      Linux-container question is beside the point.
+#   3. Is there a MySQL *server*, or only client tools? The image manifest lists "MySQL 8.0.46.0" under
+#      "Database tools" rather than under "Databases" with a ServiceName, which suggests client-only -
+#      but that is an inference from a heading, so ask the machine.
+#
+# The Azure half of this probe lives in Build/Azure/pipelines/build.yml on the same branch and asks the
+# identical questions. Both CIs run the same runner image (actions/runner-images), so the interesting
+# outcome is whether they answer differently at all.
+name: probe-win-db
+
+on:
+  push:
+    branches: [probe/win-linux-db]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: ${{ matrix.runner }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [windows-2025, windows-2022]
+
+    steps:
+      - name: Host and docker facts
+        shell: pwsh
+        run: |
+          "=== host"
+          (Get-CimInstance Win32_OperatingSystem).Caption
+          (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion').BuildLabEx
+          "=== docker"
+          docker version
+          docker info --format 'ostype={{.OSType}} isolation={{.Isolation}} osversion={{.OSVersion}}'
+
+      # 1. Linux containers. Both attempts are expected to fail; the value is in *how*, since the error
+      # distinguishes "daemon is in Windows mode" from "no nested virtualisation".
+      - name: Can this runner run a Linux container
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          "=== docker run --platform linux hello-world"
+          docker run --rm --platform linux hello-world
+          "exit=$LASTEXITCODE"
+
+      - name: Is a Linux daemon switch even available
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $cli = Join-Path $env:ProgramFiles 'Docker\Docker\DockerCli.exe'
+          if (Test-Path $cli) { "DockerCli.exe present (Docker Desktop) - a -SwitchDaemon is conceivable" }
+          else { "no DockerCli.exe - this is Moby/EE with no Linux mode to switch to" }
+          "=== WSL"
+          $wsl = Get-Command wsl -ErrorAction SilentlyContinue
+          if ($wsl) { wsl --status; "wsl exit=$LASTEXITCODE" } else { 'wsl not on PATH' }
+          "=== Hyper-V / virtualisation"
+          (Get-CimInstance Win32_ComputerSystem).HypervisorPresent
+
+      # 2. The native PostgreSQL server. This is the one that decides the question.
+      - name: Native PostgreSQL service
+        id: pg
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $svc = Get-Service -Name 'postgresql*' -ErrorAction SilentlyContinue
+          if (-not $svc) { throw 'no postgresql service on this image' }
+          $svc | Format-Table -AutoSize Name, Status, StartType
+          foreach ($s in $svc) {
+            Set-Service -Name $s.Name -StartupType Manual
+            Start-Service -Name $s.Name
+          }
+          Get-Service -Name 'postgresql*' | Format-Table -AutoSize Name, Status
+          $env:PGPASSWORD = 'root'
+          & "$env:PGBIN\psql.exe" -U postgres -h localhost -c 'select version()'
+          if ($LASTEXITCODE -ne 0) { throw "psql failed with $LASTEXITCODE" }
+          & "$env:PGBIN\psql.exe" -U postgres -h localhost -c 'create database testdata'
+          "create database exit=$LASTEXITCODE"
+
+      # 3. MySQL: server or client-only?
+      - name: Native MySQL
+        id: mysql
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          "=== services"
+          $svc = Get-Service -Name '*mysql*' -ErrorAction SilentlyContinue
+          if ($svc) { $svc | Format-Table -AutoSize Name, Status, StartType } else { 'no mysql service' }
+          "=== binaries on PATH"
+          foreach ($n in 'mysql', 'mysqld', 'mysqladmin') {
+            $c = Get-Command $n -ErrorAction SilentlyContinue
+            if ($c) { "$n -> $($c.Source)" } else { "$n not on PATH" }
+          }
+          "=== install roots"
+          Get-ChildItem 'C:\Program Files\MySQL', 'C:\tools\mysql' -ErrorAction SilentlyContinue |
+            Select-Object -ExpandProperty FullName
+
+      - name: Summary
+        if: always()
+        shell: pwsh
+        run: |
+          "| runner | linux container | native postgres | native mysql |",
+          "|---|---|---|---|",
+          "| ${{ matrix.runner }} | see step | ${{ steps.pg.outcome }} | ${{ steps.mysql.outcome }} |" |
+            Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8

--- a/.github/workflows/probe-win-db.yml
+++ b/.github/workflows/probe-win-db.yml
@@ -97,17 +97,44 @@ jobs:
           wsl -d Ubuntu-24.04 -- uname -a
           "uname exit=$LASTEXITCODE"
 
+      # The script goes in over stdin rather than as a `bash -lc "..."` argument: it avoids quoting
+      # through pwsh -> wsl -> bash, and it is why the previous attempt returned a meaningless 127.
+      # That run chained `apt-get install ... && dockerd ... &`, which backgrounds the *whole* chain -
+      # so `docker run` fired while apt was still working and reported command-not-found, saying
+      # nothing about whether docker works here.
+      #
+      # WSL2 has no systemd unless it is switched on, so dockerd is started by hand and waited for.
+      # Ubuntu 24.04 defaults to nftables while dockerd wants iptables, hence the legacy alternative -
+      # a known wall rather than a guess, and if it is wrong /tmp/dockerd.log says so.
       - name: WSL2 - can it run a Linux container
         id: wsldocker
         continue-on-error: true
-        timeout-minutes: 20
+        timeout-minutes: 25
         shell: pwsh
         run: |
-          wsl -d Ubuntu-24.04 -u root -- bash -lc "apt-get update -qq && apt-get install -y -qq docker.io >/dev/null 2>&1 && dockerd >/tmp/dockerd.log 2>&1 & sleep 15; docker run --rm hello-world"
+          $sh = @'
+          set -x
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update -qq
+          apt-get install -y -qq docker.io iptables >/dev/null
+          update-alternatives --set iptables /usr/sbin/iptables-legacy || true
+          nohup dockerd >/tmp/dockerd.log 2>&1 &
+          for i in $(seq 1 40); do docker info >/dev/null 2>&1 && break; sleep 2; done
+          echo "--- docker info"
+          docker info --format 'server={{.ServerVersion}} driver={{.Driver}}' || { echo "--- dockerd.log"; tail -40 /tmp/dockerd.log; exit 10; }
+          echo "--- hello-world"
+          docker run --rm hello-world || { echo "--- dockerd.log"; tail -40 /tmp/dockerd.log; exit 11; }
+          echo "--- postgres with a published port"
+          docker run -d -p 15432:5432 -e POSTGRES_PASSWORD=probe postgres:17-alpine
+          for i in $(seq 1 40); do (echo > /dev/tcp/127.0.0.1/15432) >/dev/null 2>&1 && break; sleep 2; done
+          ss -lntp | grep 15432 || { echo "port never opened inside wsl"; exit 12; }
+          '@ -replace "`r`n", "`n"
+          $sh | wsl -d Ubuntu-24.04 -u root -- bash
           "docker-in-wsl exit=$LASTEXITCODE"
-          "=== is a port published into WSL reachable from Windows"
-          wsl -d Ubuntu-24.04 -u root -- bash -lc "docker run -d -p 15432:5432 -e POSTGRES_PASSWORD=probe postgres:17-alpine >/dev/null 2>&1; sleep 25; ss -lntp | grep 15432"
-          Test-NetConnection -ComputerName localhost -Port 15432 -InformationLevel Detailed
+
+          "=== is the published port reachable from Windows (localhostForwarding)"
+          $r = Test-NetConnection -ComputerName localhost -Port 15432 -WarningAction SilentlyContinue
+          "TcpTestSucceeded=$($r.TcpTestSucceeded)"
 
       # 2. The native PostgreSQL server. This is the one that decides the question.
       - name: Native PostgreSQL service

--- a/Build/Azure/pipelines/build.yml
+++ b/Build/Azure/pipelines/build.yml
@@ -1,28 +1,118 @@
-# build solution only
-variables:
-  - template: templates/build-vars.yml
-
-# always trigger on PRs
+# THROWAWAY PROBE - this file normally holds the `build` pipeline. It is replaced on this branch only,
+# because the `build` definition is bound to this path and triggers on every PR, which makes it the
+# cheapest way to ask Azure a question. Restore from master before this branch goes anywhere near a
+# merge; the branch is meant to be deleted instead.
+#
+# Same three questions the GitHub half asks in .github/workflows/probe-win-db.yml:
+#
+#   1. Can a Windows agent run a Linux container?
+#   2. Does the PostgreSQL server that ships natively on the image start and accept connections?
+#   3. Is there a MySQL server, or only client tools?
+#
+# Both CIs run the same runner image (actions/runner-images), so if the answers differ, the difference
+# is in the host or the agent, not in what is installed - and that is the thing worth knowing before
+# concluding that migrating CI is what unblocks netfx EF.Core coverage for PostgreSQL and MySQL.
 trigger: none
 pr:
   branches:
     include:
-    - '*'
+    - probe/win-linux-db
 
 stages:
-
 - stage: ''
   displayName: ''
   jobs:
-##############
-#  BUILD JOB #
-##############
-  - template: templates/build-job.yml
-    parameters:
-      with_nugets: true
-      with_examples: true
-      with_tests: false
-      with_analyzer_tests: true
-      with_singlefile_smoke: true
-      with_analyzers: false # true disabled till https://github.com/dotnet/roslyn/pull/80621 shipped
-      with_release: false
+  - job: probe_win_db
+    strategy:
+      matrix:
+        windows_2025:
+          imageName: windows-2025
+        windows_2022:
+          imageName: windows-2022
+    pool:
+      vmImage: $(imageName)
+    displayName: 'Probe'
+    timeoutInMinutes: 30
+
+    steps:
+    - checkout: none
+
+    - task: PowerShell@2
+      displayName: Host and docker facts
+      inputs:
+        pwsh: true
+        targetType: inline
+        script: |
+          "=== host"
+          (Get-CimInstance Win32_OperatingSystem).Caption
+          (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion').BuildLabEx
+          "=== docker"
+          docker version
+          docker info --format 'ostype={{.OSType}} isolation={{.Isolation}} osversion={{.OSVersion}}'
+
+    - task: PowerShell@2
+      displayName: Can this agent run a Linux container
+      continueOnError: true
+      inputs:
+        pwsh: true
+        targetType: inline
+        script: |
+          "=== docker run --platform linux hello-world"
+          docker run --rm --platform linux hello-world
+          "exit=$LASTEXITCODE"
+
+    - task: PowerShell@2
+      displayName: Is a Linux daemon switch even available
+      continueOnError: true
+      inputs:
+        pwsh: true
+        targetType: inline
+        script: |
+          $cli = Join-Path $env:ProgramFiles 'Docker\Docker\DockerCli.exe'
+          if (Test-Path $cli) { "DockerCli.exe present (Docker Desktop) - a -SwitchDaemon is conceivable" }
+          else { "no DockerCli.exe - this is Moby/EE with no Linux mode to switch to" }
+          "=== WSL"
+          $wsl = Get-Command wsl -ErrorAction SilentlyContinue
+          if ($wsl) { wsl --status; "wsl exit=$LASTEXITCODE" } else { 'wsl not on PATH' }
+          "=== Hyper-V / virtualisation"
+          (Get-CimInstance Win32_ComputerSystem).HypervisorPresent
+
+    - task: PowerShell@2
+      displayName: Native PostgreSQL service
+      continueOnError: true
+      inputs:
+        pwsh: true
+        targetType: inline
+        script: |
+          $svc = Get-Service -Name 'postgresql*' -ErrorAction SilentlyContinue
+          if (-not $svc) { throw 'no postgresql service on this image' }
+          $svc | Format-Table -AutoSize Name, Status, StartType
+          foreach ($s in $svc) {
+            Set-Service -Name $s.Name -StartupType Manual
+            Start-Service -Name $s.Name
+          }
+          Get-Service -Name 'postgresql*' | Format-Table -AutoSize Name, Status
+          $env:PGPASSWORD = 'root'
+          & "$env:PGBIN\psql.exe" -U postgres -h localhost -c 'select version()'
+          if ($LASTEXITCODE -ne 0) { throw "psql failed with $LASTEXITCODE" }
+          & "$env:PGBIN\psql.exe" -U postgres -h localhost -c 'create database testdata'
+          "create database exit=$LASTEXITCODE"
+
+    - task: PowerShell@2
+      displayName: Native MySQL
+      continueOnError: true
+      inputs:
+        pwsh: true
+        targetType: inline
+        script: |
+          "=== services"
+          $svc = Get-Service -Name '*mysql*' -ErrorAction SilentlyContinue
+          if ($svc) { $svc | Format-Table -AutoSize Name, Status, StartType } else { 'no mysql service' }
+          "=== binaries on PATH"
+          foreach ($n in 'mysql', 'mysqld', 'mysqladmin') {
+            $c = Get-Command $n -ErrorAction SilentlyContinue
+            if ($c) { "$n -> $($c.Source)" } else { "$n not on PATH" }
+          }
+          "=== install roots"
+          Get-ChildItem 'C:\Program Files\MySQL', 'C:\tools\mysql' -ErrorAction SilentlyContinue |
+            Select-Object -ExpandProperty FullName

--- a/Build/Azure/pipelines/build.yml
+++ b/Build/Azure/pipelines/build.yml
@@ -15,8 +15,10 @@
 trigger: none
 pr:
   branches:
+    # A PR trigger's branch filter matches the PR's TARGET branch, not its source. Listing the probe
+    # branch here matched nothing and Azure reported the definition as "skipping" - keep master's '*'.
     include:
-    - probe/win-linux-db
+    - '*'
 
 stages:
 - stage: ''

--- a/Build/Azure/pipelines/build.yml
+++ b/Build/Azure/pipelines/build.yml
@@ -34,7 +34,8 @@ stages:
     pool:
       vmImage: $(imageName)
     displayName: 'Probe'
-    timeoutInMinutes: 30
+    # Above the 50-minute WSL step below, or the job kills it before the step can report.
+    timeoutInMinutes: 65
 
     steps:
     - checkout: none
@@ -105,28 +106,81 @@ stages:
     - task: PowerShell@2
       displayName: WSL2 - can it run a Linux container
       continueOnError: true
-      timeoutInMinutes: 25
+      timeoutInMinutes: 50
       inputs:
         pwsh: true
         targetType: inline
         script: |
           $sh = @'
-          set -x
           export DEBIAN_FRONTEND=noninteractive
+          # docker.io's postinst tries to start a service and this distro has no systemd - the likely
+          # cause of the Azure leg blowing a 25-minute step timeout inside apt. 101 means "do not start".
+          printf '#!/bin/sh\nexit 101\n' > /usr/sbin/policy-rc.d
+          chmod +x /usr/sbin/policy-rc.d
           apt-get update -qq
           apt-get install -y -qq docker.io iptables >/dev/null
-          update-alternatives --set iptables /usr/sbin/iptables-legacy || true
-          update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy || true
-          nohup dockerd >/tmp/dockerd.log 2>&1 &
-          for i in $(seq 1 40); do docker info >/dev/null 2>&1 && break; sleep 2; done
-          echo "--- docker info"
-          docker info --format 'server={{.ServerVersion}} driver={{.Driver}}' || { echo "--- dockerd.log"; tail -40 /tmp/dockerd.log; exit 10; }
-          echo "--- hello-world"
-          docker run --rm hello-world || { echo "--- dockerd.log"; tail -40 /tmp/dockerd.log; exit 11; }
-          echo "--- postgres with a published port"
-          docker run -d -p 15432:5432 -e POSTGRES_PASSWORD=probe postgres:17-alpine || { echo "--- dockerd.log"; tail -40 /tmp/dockerd.log; exit 13; }
-          for i in $(seq 1 40); do (echo > /dev/tcp/127.0.0.1/15432) >/dev/null 2>&1 && break; sleep 2; done
-          ss -lntp | grep 15432 || { echo "port never opened inside wsl"; exit 12; }
+          mkdir -p /etc/docker
+          printf '{ "bip": "10.11.0.1/24", "default-address-pools": [ { "base": "10.12.0.0/16", "size": 24 } ] }' > /etc/docker/daemon.json
+
+          echo "===== STAGE 0 diagnostics"
+          iptables --version
+          readlink -f /etc/alternatives/iptables
+          uname -r
+          ls /usr/lib/modules /lib/modules 2>/dev/null
+          if [ -f /proc/config.gz ]; then
+            zcat /proc/config.gz | grep -E 'CONFIG_(NF_NAT|IP_NF_NAT|IP_NF_IPTABLES|NETFILTER_XT_NAT|NFT_NAT|NFT_CHAIN_NAT|NFT_COMPAT|NF_TABLES_IPV4|BRIDGE)='
+          else
+            echo "no /proc/config.gz"
+          fi
+          find /usr/lib/modules /lib/modules \( -name 'xt_nat.ko*' -o -name 'nft_compat.ko*' -o -name 'iptable_nat.ko*' \) 2>/dev/null
+          for m in iptable_nat xt_nat nft_compat xt_MASQUERADE xt_conntrack xt_addrtype; do
+            modprobe -v $m; echo "modprobe $m rc=$?"
+          done
+          echo "--- direct DNAT probes, docker not involved"
+          iptables-nft    -t nat -A OUTPUT -p tcp --dport 19999 -j DNAT --to-destination 127.0.0.1:19998; echo "nft rc=$?"
+          iptables-legacy -t nat -A OUTPUT -p tcp --dport 19999 -j DNAT --to-destination 127.0.0.1:19998; echo "legacy rc=$?"
+          dmesg | tail -20
+
+          start_dockerd() {
+            pkill dockerd 2>/dev/null; sleep 3
+            nohup dockerd >/tmp/dockerd.log 2>&1 &
+            for i in $(seq 1 40); do docker info >/dev/null 2>&1 && return 0; sleep 2; done
+            echo "dockerd did not come up"; tail -30 /tmp/dockerd.log; return 1
+          }
+          try_publish() {
+            docker rm -f probe-pg >/dev/null 2>&1
+            docker run -d --name probe-pg -p 15432:5432 -e POSTGRES_PASSWORD=probe postgres:17-alpine
+            return $?
+          }
+
+          echo "===== STAGE 1 modprobe then publish"
+          PUBLISHED=0
+          start_dockerd && docker info --format 'server={{.ServerVersion}}' && try_publish && PUBLISHED=1
+          echo "stage1 published=$PUBLISHED"
+
+          if [ $PUBLISHED -eq 0 ]; then
+            echo "===== STAGE 2 docker 29 native nftables firewall backend"
+            printf '{ "bip": "10.11.0.1/24", "firewall-backend": "nftables", "default-address-pools": [ { "base": "10.12.0.0/16", "size": 24 } ] }' > /etc/docker/daemon.json
+            start_dockerd && try_publish && PUBLISHED=1
+            echo "stage2 published=$PUBLISHED"
+            [ $PUBLISHED -eq 0 ] && tail -30 /tmp/dockerd.log
+          fi
+
+          if [ $PUBLISHED -eq 0 ]; then
+            echo "===== STAGE 3 --network host, no NAT at all"
+            docker rm -f probe-pg >/dev/null 2>&1
+            docker run -d --name probe-pg --network host -e POSTGRES_PASSWORD=probe postgres:17-alpine
+            echo "stage3 run rc=$?"
+            HOSTMODE=1
+          fi
+
+          PORT=15432
+          [ -n "$HOSTMODE" ] && PORT=5432
+          for i in $(seq 1 40); do (echo > /dev/tcp/127.0.0.1/$PORT) >/dev/null 2>&1 && break; sleep 2; done
+          echo "--- listening inside wsl (expecting $PORT)"
+          ss -lntp | grep -E "$PORT" || echo "port $PORT never opened inside wsl"
+          echo "WSLPORT=$PORT"
+          hostname -I
           '@ -replace "`r`n", "`n"
           $sh | wsl -d Ubuntu-24.04 -u root -- bash
           "docker-in-wsl exit=$LASTEXITCODE"

--- a/Build/Azure/pipelines/build.yml
+++ b/Build/Azure/pipelines/build.yml
@@ -79,6 +79,62 @@ stages:
           "=== Hyper-V / virtualisation"
           (Get-CimInstance Win32_ComputerSystem).HypervisorPresent
 
+    # The WSL2 route, mirroring the GitHub half. On GitHub this already got as far as dockerd running
+    # inside WSL2 (server=29.1.3) and a real amd64 Linux container executing, with only -p publishing
+    # failing on an iptables-alternative ordering bug. Azure needs the same answer, because the Windows
+    # legs live here - a capability GitHub has and Azure lacks would be the one thing that genuinely
+    # makes the migration, rather than provider config, the unblocker for the netfx-only providers.
+    - task: PowerShell@2
+      displayName: WSL2 - does a distro boot
+      continueOnError: true
+      inputs:
+        pwsh: true
+        targetType: inline
+        script: |
+          wsl --version
+          "=== installed distros"
+          wsl -l -v
+          "=== install"
+          wsl --install -d Ubuntu-24.04 --no-launch
+          "install exit=$LASTEXITCODE"
+          wsl -l -v
+          "=== boot"
+          wsl -d Ubuntu-24.04 -- uname -a
+          "uname exit=$LASTEXITCODE"
+
+    - task: PowerShell@2
+      displayName: WSL2 - can it run a Linux container
+      continueOnError: true
+      timeoutInMinutes: 25
+      inputs:
+        pwsh: true
+        targetType: inline
+        script: |
+          $sh = @'
+          set -x
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update -qq
+          apt-get install -y -qq docker.io iptables >/dev/null
+          update-alternatives --set iptables /usr/sbin/iptables-legacy || true
+          update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy || true
+          nohup dockerd >/tmp/dockerd.log 2>&1 &
+          for i in $(seq 1 40); do docker info >/dev/null 2>&1 && break; sleep 2; done
+          echo "--- docker info"
+          docker info --format 'server={{.ServerVersion}} driver={{.Driver}}' || { echo "--- dockerd.log"; tail -40 /tmp/dockerd.log; exit 10; }
+          echo "--- hello-world"
+          docker run --rm hello-world || { echo "--- dockerd.log"; tail -40 /tmp/dockerd.log; exit 11; }
+          echo "--- postgres with a published port"
+          docker run -d -p 15432:5432 -e POSTGRES_PASSWORD=probe postgres:17-alpine || { echo "--- dockerd.log"; tail -40 /tmp/dockerd.log; exit 13; }
+          for i in $(seq 1 40); do (echo > /dev/tcp/127.0.0.1/15432) >/dev/null 2>&1 && break; sleep 2; done
+          ss -lntp | grep 15432 || { echo "port never opened inside wsl"; exit 12; }
+          '@ -replace "`r`n", "`n"
+          $sh | wsl -d Ubuntu-24.04 -u root -- bash
+          "docker-in-wsl exit=$LASTEXITCODE"
+
+          "=== is the published port reachable from Windows (localhostForwarding)"
+          $r = Test-NetConnection -ComputerName localhost -Port 15432 -WarningAction SilentlyContinue
+          "TcpTestSucceeded=$($r.TcpTestSucceeded)"
+
     - task: PowerShell@2
       displayName: Native PostgreSQL service
       continueOnError: true


### PR DESCRIPTION
**Do not merge. Delete the branch when the answers are recorded.**

Exists only to trigger the Azure `build` definition, which is bound to `Build/Azure/pipelines/build.yml` and runs on every PR — so that file is *replaced* on this branch with a probe. The GitHub half is `.github/workflows/probe-win-db.yml` and runs on push.

## The question

We don't run EF.Core netfx tests against PostgreSQL or MySQL. The standing reason is that netfx runs only on Windows, those servers run in Linux containers, and a Windows agent can't run Linux containers.

That may be the wrong framing. `images/windows/Windows2025-Readme.md` lists **PostgreSQL 17.11 as a real service** on the image — `postgresql-x64-17`, Stopped and Disabled, but present, with a documented `postgres`/`root` credential. A native server needs no container at all. MySQL 8.0.46 appears under *Database tools* rather than under *Databases* with a ServiceName, which suggests client-only — but that's an inference from a heading, not a fact.

## What both halves ask

1. Can the agent run a Linux container? (Expected no; the value is in *how* it fails — daemon in Windows mode versus no nested virtualisation.)
2. Does the native PostgreSQL service start and accept a connection?
3. Is there a MySQL server, or only client tools?

Both on `windows-2025` and `windows-2022`.

## Why both CIs

Azure and GitHub run the **same** `actions/runner-images` artifact. If the answers differ, the difference is the host or the agent rather than what's installed. That decides whether migrating CI is what unblocks this coverage — or whether it was available on Azure all along and the container framing was simply never revisited.

This PR also triggers the newly merged `build` workflow (#5836). That's incidental, and a first real-world exercise of it.
