### PR TITLE
CI: drop ClickHouse.Octonica from the ClickHouse test job

### DIFF
--- a/Build/Azure/net100/clickhouse.json
+++ b/Build/Azure/net100/clickhouse.json
@@ -2,8 +2,7 @@
 	"NET100.Azure": {
 		"Providers": [
 			"ClickHouse.Driver",
-			"ClickHouse.MySql",
-			"ClickHouse.Octonica"
+			"ClickHouse.MySql"
 		]
 	}
 }

--- a/Build/Azure/net80/clickhouse.json
+++ b/Build/Azure/net80/clickhouse.json
@@ -2,8 +2,7 @@
 	"NET80.Azure": {
 		"Providers": [
 			"ClickHouse.Driver",
-			"ClickHouse.MySql",
-			"ClickHouse.Octonica"
+			"ClickHouse.MySql"
 		]
 	}
 }

--- a/Build/Azure/net90/clickhouse.json
+++ b/Build/Azure/net90/clickhouse.json
@@ -2,8 +2,7 @@
 	"NET90.Azure": {
 		"Providers": [
 			"ClickHouse.Driver",
-			"ClickHouse.MySql",
-			"ClickHouse.Octonica"
+			"ClickHouse.MySql"
 		]
 	}
 }


### PR DESCRIPTION
`clickhouse/clickhouse-server:latest` (`Build/Azure/scripts/clickhouse.sh`) moved to **26.8.2.7** and broke `Octonica.ClickHouseClient` 4.1.4: the native-protocol session (`:9000`) dies mid-test and every following command on that connection fails with

```
Octonica.ClickHouseClient.Exceptions.ClickHouseException : The connection is closed.
ErrorCode: 3
   at Octonica.ClickHouseClient.ClickHouseCommand.OpenSession(...)
```

A different test fails on each run, and the two automatic task retries do not clear it.

| build | finished | CH server | ClickHouse leg |
|---|---|---|---|
| [23125](https://dev.azure.com/linq2db/linq2db/_build/results?buildId=23125) | 2026-08-30 | 26.7.5.10 | green |
| [23133](https://dev.azure.com/linq2db/linq2db/_build/results?buildId=23133) | 2026-09-01 | 26.8.2.7 | 3 failures, all `ClickHouse.Octonica` |
| [23144](https://dev.azure.com/linq2db/linq2db/_build/results?buildId=23144) | 2026-09-01 | 26.8.2.7 | 1 failure, `ClickHouse.Octonica` |
| [23146](https://dev.azure.com/linq2db/linq2db/_build/results?buildId=23146) | 2026-09-01 | 26.8.2.7 | 1 failure, `ClickHouse.Octonica` |

`ClickHouse.Driver` (HTTP `:8123`) and `ClickHouse.MySql` (`:9004`) run as parallel lanes against the same server and stay green, so this drops only the Octonica lane from `Build/Azure/net{80,90,100}/clickhouse.json`.

Hotfix to unblock CI; root cause still under investigation. 4.1.4 is the newest `Octonica.ClickHouseClient` release (repo last pushed 2026-07-14), and its [#109](https://github.com/Octonica/ClickHouseClient/issues/109) is a prior instance of the client lagging a ClickHouse native-protocol change.
