### PR TITLE
Fix chained TablesInScopeHint dropping all but the first hint

### DIFF
--- a/Source/LinqToDB/Internal/Linq/Builder/CteContext.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/CteContext.cs
@@ -67,7 +67,17 @@ namespace LinqToDB.Internal.Linq.Builder
 
 			_isRecursiveCall = true;
 
+			// A CTE body is its own scope: tables built here must not join an enclosing
+			// TablesInScopeHint, which would otherwise reach them whenever the body happens to be
+			// built before that scope closes.
+			//
+			var prevTablesInScope = Builder.TablesInScope;
+
+			Builder.TablesInScope = null;
+
 			var cteInnerQueryContext = Builder.BuildSequence(cteBuildInfo);
+
+			Builder.TablesInScope = prevTablesInScope;
 
 			CteInnerQueryContext = cteInnerQueryContext;
 			CteClause.Body       = cteInnerQueryContext.SelectQuery;

--- a/Source/LinqToDB/Internal/Linq/Builder/QueryExtensionBuilder.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/QueryExtensionBuilder.cs
@@ -70,124 +70,130 @@ namespace LinqToDB.Internal.Linq.Builder
 			if (attrs.Any(a => a.Scope == Sql.QueryExtensionScope.TablesInScopeHint))
 				builder.TablesInScope = new();
 
-			var sequence = builder.BuildSequence(new(buildInfo, methodCall.Object ?? methodCall.Arguments[0]));
-
-			for (var i = startIndex; i < list.Count; i++)
+			try
 			{
-				var data = list[i];
+				var sequence = builder.BuildSequence(new(buildInfo, methodCall.Object ?? methodCall.Arguments[0]));
 
-				if (data.SqlExpression == null)
+				for (var i = startIndex; i < list.Count; i++)
 				{
-					if (data.ParamsIndex >= 0)
+					var data = list[i];
+
+					if (data.SqlExpression == null)
 					{
-						var converted = data.Expression.Unwrap() switch
+						if (data.ParamsIndex >= 0)
 						{
-							LambdaExpression lex => builder.BuildSqlExpression(sequence, SequenceHelper.PrepareBody(lex, sequence)),
-							var ex => builder.BuildSqlExpression(sequence, ex),
-						};
-
-						if (converted is SqlPlaceholderExpression placeholder)
-							data.SqlExpression = placeholder.Sql;
-						else
-							return BuildSequenceResult.Error(methodCall);
-					}
-					else if (data.Expression is LambdaExpression le)
-					{
-						var converted = builder.ConvertToExtensionSql(sequence, le, null, null);
-
-						if (converted is SqlPlaceholderExpression placeholder)
-							data.SqlExpression = placeholder.Sql;
-						else
-							return BuildSequenceResult.Error(methodCall);
-					}
-					else
-					{
-						//TODO: These QueryExtensions needs tp be rewritten completely. Workaround over DateTime.
-
-						var isQueryDepended = data.Parameter.GetAttributes<SqlQueryDependentAttribute>().Length > 0;
-
-						var additionalFlags = isQueryDepended ? BuildFlags.None : BuildFlags.ForceParameter;
-
-						var converted = builder.BuildSqlExpression(sequence, data.Expression, BuildPurpose.Sql, buildFlags : additionalFlags);
-
-						if (converted is SqlPlaceholderExpression placeholder)
-							data.SqlExpression = placeholder.Sql;
-						else
-							return BuildSequenceResult.Error(methodCall);
-					}
-				}
-			}
-
-			List<SqlQueryExtension>? joinExtensions = null;
-
-			foreach (var attr in attrs)
-			{
-				switch (attr.Scope)
-				{
-					case Sql.QueryExtensionScope.TableHint    :
-					case Sql.QueryExtensionScope.IndexHint    :
-					case Sql.QueryExtensionScope.TableNameHint:
-					{
-						var table = SequenceHelper.GetTableContext(sequence) ?? throw new LinqToDBException($"Cannot get table context from {sequence.GetType()}");
-						attr.ExtendTable(table.SqlTable, list);
-						break;
-					}
-					case Sql.QueryExtensionScope.TablesInScopeHint:
-					{
-						foreach (var table in builder.TablesInScope!)
-							attr.ExtendTable(table.SqlTable, list);
-						break;
-					}
-					case Sql.QueryExtensionScope.JoinHint:
-					{
-						attr.ExtendJoin(joinExtensions ??= new(), list);
-						break;
-					}
-					case Sql.QueryExtensionScope.SubQueryHint:
-					{
-						if (sequence is SetOperationBuilder.SetOperationContext { SubQuery.SelectQuery : { HasSetOperators: true } q })
-							attr.ExtendSubQuery(q.SetOperators[^1].SelectQuery.SqlQueryExtensions ??= new(), list);
-						else
-						{
-							var queryToUpdate = sequence.SelectQuery;
-							if (sequence is AsSubqueryContext { SelectQuery.IsSimple: true } subquery)
+							var converted = data.Expression.Unwrap() switch
 							{
-								queryToUpdate = subquery.SubQuery.SelectQuery;
-							}
+								LambdaExpression lex => builder.BuildSqlExpression(sequence, SequenceHelper.PrepareBody(lex, sequence)),
+								var ex => builder.BuildSqlExpression(sequence, ex),
+							};
 
-							if (!queryToUpdate.IsSimple)
-							{
-								sequence      = new SubQueryContext(sequence);
-								queryToUpdate = sequence.SelectQuery;
-							}
-
-							attr.ExtendSubQuery(queryToUpdate.SqlQueryExtensions ??= new(), list);
+							if (converted is SqlPlaceholderExpression placeholder)
+								data.SqlExpression = placeholder.Sql;
+							else
+								return BuildSequenceResult.Error(methodCall);
 						}
+						else if (data.Expression is LambdaExpression le)
+						{
+							var converted = builder.ConvertToExtensionSql(sequence, le, null, null);
 
-						break;
-					}
-					case Sql.QueryExtensionScope.QueryHint:
-					{
-						attr.ExtendQuery(builder.SqlQueryExtensions ??= new(), list);
-						break;
-					}
-					case Sql.QueryExtensionScope.None:
-					{
-						break;
+							if (converted is SqlPlaceholderExpression placeholder)
+								data.SqlExpression = placeholder.Sql;
+							else
+								return BuildSequenceResult.Error(methodCall);
+						}
+						else
+						{
+							//TODO: These QueryExtensions needs tp be rewritten completely. Workaround over DateTime.
+
+							var isQueryDepended = data.Parameter.GetAttributes<SqlQueryDependentAttribute>().Length > 0;
+
+							var additionalFlags = isQueryDepended ? BuildFlags.None : BuildFlags.ForceParameter;
+
+							var converted = builder.BuildSqlExpression(sequence, data.Expression, BuildPurpose.Sql, buildFlags : additionalFlags);
+
+							if (converted is SqlPlaceholderExpression placeholder)
+								data.SqlExpression = placeholder.Sql;
+							else
+								return BuildSequenceResult.Error(methodCall);
+						}
 					}
 				}
+
+				List<SqlQueryExtension>? joinExtensions = null;
+
+				foreach (var attr in attrs)
+				{
+					switch (attr.Scope)
+					{
+						case Sql.QueryExtensionScope.TableHint    :
+						case Sql.QueryExtensionScope.IndexHint    :
+						case Sql.QueryExtensionScope.TableNameHint:
+						{
+							var table = SequenceHelper.GetTableContext(sequence) ?? throw new LinqToDBException($"Cannot get table context from {sequence.GetType()}");
+							attr.ExtendTable(table.SqlTable, list);
+							break;
+						}
+						case Sql.QueryExtensionScope.TablesInScopeHint:
+						{
+							foreach (var table in builder.TablesInScope!)
+								attr.ExtendTable(table.SqlTable, list);
+							break;
+						}
+						case Sql.QueryExtensionScope.JoinHint:
+						{
+							attr.ExtendJoin(joinExtensions ??= new(), list);
+							break;
+						}
+						case Sql.QueryExtensionScope.SubQueryHint:
+						{
+							if (sequence is SetOperationBuilder.SetOperationContext { SubQuery.SelectQuery : { HasSetOperators: true } q })
+								attr.ExtendSubQuery(q.SetOperators[^1].SelectQuery.SqlQueryExtensions ??= new(), list);
+							else
+							{
+								var queryToUpdate = sequence.SelectQuery;
+								if (sequence is AsSubqueryContext { SelectQuery.IsSimple: true } subquery)
+								{
+									queryToUpdate = subquery.SubQuery.SelectQuery;
+								}
+
+								if (!queryToUpdate.IsSimple)
+								{
+									sequence      = new SubQueryContext(sequence);
+									queryToUpdate = sequence.SelectQuery;
+								}
+
+								attr.ExtendSubQuery(queryToUpdate.SqlQueryExtensions ??= new(), list);
+							}
+
+							break;
+						}
+						case Sql.QueryExtensionScope.QueryHint:
+						{
+							attr.ExtendQuery(builder.SqlQueryExtensions ??= new(), list);
+							break;
+						}
+						case Sql.QueryExtensionScope.None:
+						{
+							break;
+						}
+					}
+				}
+
+				// Tables collected by a nested scope are still in scope for the enclosing one, so hand them
+				// over: without this a chained hint (q.TablesInScopeHint(a).TablesInScopeHint(b)) would see
+				// an empty scope and silently generate nothing. Only on the success path - a failed sub-tree
+				// has nothing to hand up.
+				//
+				if (prevTablesInScope != null && !ReferenceEquals(prevTablesInScope, builder.TablesInScope))
+					prevTablesInScope.AddRange(builder.TablesInScope!);
+
+				return BuildSequenceResult.FromContext(joinExtensions != null ? new JoinHintContext(sequence, joinExtensions) : sequence);
 			}
-
-			// Tables collected by a nested scope are still in scope for the enclosing one, so hand them
-			// over: without this a chained hint (q.TablesInScopeHint(a).TablesInScopeHint(b)) would see
-			// an empty scope and silently generate nothing.
-			//
-			if (prevTablesInScope != null && !ReferenceEquals(prevTablesInScope, builder.TablesInScope))
-				prevTablesInScope.AddRange(builder.TablesInScope!);
-
-			builder.TablesInScope = prevTablesInScope;
-
-			return BuildSequenceResult.FromContext(joinExtensions != null ? new JoinHintContext(sequence, joinExtensions) : sequence);
+			finally
+			{
+				builder.TablesInScope = prevTablesInScope;
+			}
 		}
 
 		public sealed class JoinHintContext : PassThroughContext

--- a/Source/LinqToDB/Internal/Linq/Builder/QueryExtensionBuilder.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/QueryExtensionBuilder.cs
@@ -182,8 +182,8 @@ namespace LinqToDB.Internal.Linq.Builder
 
 				// Tables collected by a nested scope are still in scope for the enclosing one, so hand them
 				// over: without this a chained hint (q.TablesInScopeHint(a).TablesInScopeHint(b)) would see
-				// an empty scope and silently generate nothing. Only on the success path - a failed sub-tree
-				// has nothing to hand up.
+				// an empty scope and silently generate nothing. Only on the success path: an Error return
+				// rejects this whole method call, so its scope contribution is discarded with it.
 				//
 				if (prevTablesInScope != null && !ReferenceEquals(prevTablesInScope, builder.TablesInScope))
 					prevTablesInScope.AddRange(builder.TablesInScope!);

--- a/Source/LinqToDB/Internal/Linq/Builder/QueryExtensionBuilder.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/QueryExtensionBuilder.cs
@@ -178,6 +178,13 @@ namespace LinqToDB.Internal.Linq.Builder
 				}
 			}
 
+			// Tables collected by a nested scope are still in scope for the enclosing one, so hand them
+			// over: without this a chained hint (q.TablesInScopeHint(a).TablesInScopeHint(b)) would see
+			// an empty scope and silently generate nothing.
+			//
+			if (prevTablesInScope != null && !ReferenceEquals(prevTablesInScope, builder.TablesInScope))
+				prevTablesInScope.AddRange(builder.TablesInScope!);
+
 			builder.TablesInScope = prevTablesInScope;
 
 			return BuildSequenceResult.FromContext(joinExtensions != null ? new JoinHintContext(sequence, joinExtensions) : sequence);

--- a/Tests/Linq/Extensions/OracleTests.cs
+++ b/Tests/Linq/Extensions/OracleTests.cs
@@ -457,8 +457,6 @@ namespace Tests.Extensions
 
 			_ = q.ToList();
 
-			// Tables of a nested scope stay in scope for the enclosing hint, so they get both hints.
-			//
 			Assert.That(LastQuery, Contains.Substring("SELECT /*+ NOCACHE(p) CLUSTER(p) NOCACHE(c_1) CLUSTER(c_1) FULL(c1) NOCACHE(c1) CLUSTER(c1) CLUSTER(c_2) CLUSTER(a_Parent) PARALLEL(p1) CLUSTER(p1) */"));
 		}
 

--- a/Tests/Linq/Extensions/OracleTests.cs
+++ b/Tests/Linq/Extensions/OracleTests.cs
@@ -457,7 +457,9 @@ namespace Tests.Extensions
 
 			_ = q.ToList();
 
-			Assert.That(LastQuery, Contains.Substring("SELECT /*+ NOCACHE(p) NOCACHE(c_1) FULL(c1) NOCACHE(c1) CLUSTER(c_2) CLUSTER(a_Parent) PARALLEL(p1) */"));
+			// Tables of a nested scope stay in scope for the enclosing hint, so they get both hints.
+			//
+			Assert.That(LastQuery, Contains.Substring("SELECT /*+ NOCACHE(p) CLUSTER(p) NOCACHE(c_1) CLUSTER(c_1) FULL(c1) NOCACHE(c1) CLUSTER(c1) CLUSTER(c_2) CLUSTER(a_Parent) PARALLEL(p1) CLUSTER(p1) */"));
 		}
 
 		[Test]

--- a/Tests/Linq/Extensions/SqlCeTests.cs
+++ b/Tests/Linq/Extensions/SqlCeTests.cs
@@ -87,8 +87,6 @@ namespace Tests.Extensions
 
 			var test = LastQuery?.Replace("\r", "");
 
-			// Tables of a nested scope stay in scope for the enclosing hint, so they get both hints.
-			//
 			Assert.That(test, Contains.Substring("[Person] [p] WITH (Index(PK_Person), UpdLock, PagLock)"));
 			Assert.That(test, Contains.Substring("[Child] [c_1] WITH (UpdLock, PagLock)"));
 			Assert.That(test, Contains.Substring("[Parent] [p1] WITH (HoldLock, PagLock)"));

--- a/Tests/Linq/Extensions/SqlCeTests.cs
+++ b/Tests/Linq/Extensions/SqlCeTests.cs
@@ -62,7 +62,10 @@ namespace Tests.Extensions
 				where c.ParentID == p.ID
 				select p
 			)
-			.TablesInScopeHint(SqlCeHints.Table.NoLock);
+			// UpdLock rather than NoLock: stacking would make it WITH (NoLock, PagLock), which SQL CE
+			// refuses — see ConflictingTablesInScopeHintTest.
+			//
+			.TablesInScopeHint(SqlCeHints.Table.UpdLock);
 
 			q =
 			(
@@ -84,11 +87,36 @@ namespace Tests.Extensions
 
 			var test = LastQuery?.Replace("\r", "");
 
-			Assert.That(test, Contains.Substring("[Person] [p] WITH (Index(PK_Person), NoLock)"));
-			Assert.That(test, Contains.Substring("[Child] [c_1] WITH (NoLock)"));
-			Assert.That(test, Contains.Substring("[Parent] [p1] WITH (HoldLock)"));
+			// Tables of a nested scope stay in scope for the enclosing hint, so they get both hints.
+			//
+			Assert.That(test, Contains.Substring("[Person] [p] WITH (Index(PK_Person), UpdLock, PagLock)"));
+			Assert.That(test, Contains.Substring("[Child] [c_1] WITH (UpdLock, PagLock)"));
+			Assert.That(test, Contains.Substring("[Parent] [p1] WITH (HoldLock, PagLock)"));
 			Assert.That(test, Contains.Substring("[Child] [c_2] WITH (PagLock)"));
 			Assert.That(test, Contains.Substring("[Parent] [a_Parent] WITH (PagLock)"));
+		}
+
+		// A nested scope no longer shields its tables from the enclosing hint, so a hint pair the engine
+		// refuses now reaches the server. SQL CE has no scope hint that combines with NoLock.
+		// https://github.com/linq2db/linq2db/issues/5714
+		[Test]
+		[ThrowsForProvider("System.Data.SqlServerCe.SqlCeException", ProviderName.SqlCe)]
+		public void ConflictingTablesInScopeHintTest([IncludeDataSources(false, ProviderName.SqlCe)] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var q =
+			(
+				from p in db.Person.TablesInScopeHint(SqlCeHints.Table.NoLock)
+				from c in db.Child
+				where c.ParentID == p.ID
+				select p
+			)
+			.TablesInScopeHint(SqlCeHints.Table.PagLock);
+
+			Assert.That(q.ToSqlQuery().Sql, Contains.Substring("[Person] [p] WITH (NoLock, PagLock)"));
+
+			_ = q.ToList();
 		}
 
 		[Test]

--- a/Tests/Linq/Extensions/SqlServerTests.cs
+++ b/Tests/Linq/Extensions/SqlServerTests.cs
@@ -681,6 +681,43 @@ namespace Tests.Extensions
 			Assert.That(LastQuery, Contains.Substring("OPTION (RECOMPILE, FAST 10)"));
 		}
 
+		// A CTE body is its own scope: an enclosing hint stops at the boundary. CteContext.InitQuery
+		// enforces that; without it, whether the outer hint reached the body depended on the query
+		// shape, since the boundary was only ever a matter of build order.
+		// https://github.com/linq2db/linq2db/issues/5714
+		[Test]
+		public void CteBodyTablesInScopeHintTest([IncludeDataSources(true, TestProvName.AllSqlServer)] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var cte =
+			(
+				from c in db.Child
+				where c.ParentID > 0
+				select c
+			)
+			.AsSqlServer()
+			.WithRowLockInScope()
+			.AsCte();
+
+			var q =
+			(
+				from p in db.Parent
+				from c in cte
+				where c.ParentID == p.ParentID
+				select p
+			)
+			.AsSqlServer()
+			.WithUpdLockInScope();
+
+			_ = q.FirstOrDefault();
+
+			var sql = LastQuery!;
+
+			sql.ShouldContain("[c_1] WITH (RowLock)", Case.Sensitive);
+			sql.ShouldContain("[p] WITH (UpdLock)",   Case.Sensitive);
+		}
+
 		[Test]
 		public void UnionTest([IncludeDataSources(true, TestProvName.AllSqlServer)] string context)
 		{

--- a/Tests/Linq/Extensions/SqlServerTests.cs
+++ b/Tests/Linq/Extensions/SqlServerTests.cs
@@ -507,8 +507,6 @@ namespace Tests.Extensions
 
 			var test = LastQuery?.Replace("\r", "");
 
-			// Tables of a nested scope stay in scope for the enclosing hint, so they get both hints.
-			//
 			Assert.That(test, Contains.Substring("[Parent] [p] WITH (NoLock, NoWait)"));
 			Assert.That(test, Contains.Substring("[Child] [c_1] WITH (NoLock, NoWait)"));
 			Assert.That(test, Contains.Substring("[Child] [c_2] WITH (NoWait)"));

--- a/Tests/Linq/Extensions/SqlServerTests.cs
+++ b/Tests/Linq/Extensions/SqlServerTests.cs
@@ -6,6 +6,8 @@ using LinqToDB.DataProvider.SqlServer;
 
 using NUnit.Framework;
 
+using Shouldly;
+
 namespace Tests.Extensions
 {
 	[TestFixture]
@@ -505,13 +507,40 @@ namespace Tests.Extensions
 
 			var test = LastQuery?.Replace("\r", "");
 
-			Assert.That(test, Contains.Substring("[Parent] [p] WITH (NoLock)"));
-			Assert.That(test, Contains.Substring("[Child] [c_1] WITH (NoLock)"));
+			// Tables of a nested scope stay in scope for the enclosing hint, so they get both hints.
+			//
+			Assert.That(test, Contains.Substring("[Parent] [p] WITH (NoLock, NoWait)"));
+			Assert.That(test, Contains.Substring("[Child] [c_1] WITH (NoLock, NoWait)"));
 			Assert.That(test, Contains.Substring("[Child] [c_2] WITH (NoWait)"));
 			Assert.That(test, Contains.Substring("[Parent] [a_Parent] WITH (NoWait)"));
-			Assert.That(test, Contains.Substring("[Child] [c1] WITH (Index(IX_ChildIndex), NoLock)"));
-			Assert.That(test, Contains.Substring("[Parent] [p1] WITH (HoldLock)"));
+			Assert.That(test, Contains.Substring("[Child] [c1] WITH (Index(IX_ChildIndex), NoLock, NoWait)"));
+			Assert.That(test, Contains.Substring("[Parent] [p1] WITH (HoldLock, NoWait)"));
 			Assert.That(test, Contains.Substring("[Child] [c_3]\n"));
+		}
+
+		// https://github.com/linq2db/linq2db/issues/5714
+		[Test]
+		public void ChainedTablesInScopeHintTest(
+			[IncludeDataSources(true, TestProvName.AllSqlServer)] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var q =
+			(
+				from p in db.Parent
+				join c in db.Child on p.ParentID equals c.ParentID
+				select p
+			)
+			.AsSqlServer()
+			.WithUpdLockInScope()
+			.WithRowLockInScope();
+
+			_ = q.FirstOrDefault();
+
+			var sql = LastQuery!;
+
+			sql.ShouldContain("[p] WITH (UpdLock, RowLock)",   Case.Sensitive);
+			sql.ShouldContain("[c_1] WITH (UpdLock, RowLock)", Case.Sensitive);
 		}
 
 		[Test]

--- a/Tests/Linq/Extensions/SqlServerTests.cs
+++ b/Tests/Linq/Extensions/SqlServerTests.cs
@@ -533,14 +533,15 @@ namespace Tests.Extensions
 			)
 			.AsSqlServer()
 			.WithUpdLockInScope()
-			.WithRowLockInScope();
+			.WithRowLockInScope()
+			.WithHoldLockInScope();
 
 			_ = q.FirstOrDefault();
 
 			var sql = LastQuery!;
 
-			sql.ShouldContain("[p] WITH (UpdLock, RowLock)",   Case.Sensitive);
-			sql.ShouldContain("[c_1] WITH (UpdLock, RowLock)", Case.Sensitive);
+			sql.ShouldContain("[p] WITH (UpdLock, RowLock, HoldLock)",   Case.Sensitive);
+			sql.ShouldContain("[c_1] WITH (UpdLock, RowLock, HoldLock)", Case.Sensitive);
 		}
 
 		[Test]


### PR DESCRIPTION
Fixes #5714

`.AsSqlServer().WithUpdLockInScope().WithRowLockInScope()` emitted only `WITH (UpdLock)`.

`QueryExtensionBuilder` swaps in a fresh `TablesInScope` list for the sub-tree and discards it on the way out, so the outer of two chained scope hints iterates an empty list and silently generates nothing. Present since the feature's first commit (`c6f2b7326b`, 2021-11-25). A nested scope now hands its collected tables back to the enclosing one; non-scope extensions (`TableHint`, `QueryHint`, …) are untouched. The restore is also unconditional now (`try`/`finally`) — the three early `Error` returns used to bypass it, leaking the temporary list into the callers of `TryBuildSequence` that swallow a failed result and keep building with the same builder.

### Behaviour change

Hints from an enclosing scope now **stack** onto tables claimed by a nested scope; previously a nested scope shielded them.

| | before | after |
|---|---|---|
| `q.TablesInScopeHint(a).TablesInScopeHint(b)` | `(a)` | `(a, b)` |
| nested `t.TablesInScopeHint(a)` under `.TablesInScopeHint(b)` | `(a)` | `(a, b)` |

Updated accordingly: `SqlServerTests.TablesInScopeHintTest`, `OracleTests.TableInScopeTest`, `SqlCeTests.TablesInScopeHintTest`. Both `CteTest`s stay green, and now for a structural reason. A CTE body was never a scope
boundary — whether an enclosing hint reached its tables depended on when `CteContext.InitQuery`
happened to build them, and chaining scope hints made that reachable. `InitQuery` now saves and
clears `TablesInScope` around the body build, so the boundary holds regardless of query shape.
This also closes a pre-existing leak: a CTE body with no scope hint of its own used to inherit
an enclosing one.

**Worth a release note:** stacking can now produce hint combinations the server rejects, which shielding used to prevent. SQL CE refuses `WITH (NoLock, PagLock)` (`Conflicting locking hints specified`) and has no scope hint that pairs with `NoLock`.

### Tests

- new `SqlServerTests.ChainedTablesInScopeHintTest` — the issue's query extended to three levels, red→green verified
- new `SqlCeTests.ConflictingTablesInScopeHintTest` — pins the cost of stacking
- new `SqlServerTests.CteBodyTablesInScopeHintTest` — pins that a CTE body ignores an enclosing scope hint

`Tests.Extensions` green on every provider that registers `QueryExtensionScope.TablesInScopeHint` — SQL Server, SQL CE, Oracle, MySQL, ClickHouse — plus the generic path on Access, PostgreSQL, SQLite and Firebird:

| run | providers |
|---|---|
| 957/957 | SqlServer.2019, SqlCe, Oracle.11.Managed, PostgreSQL.16, Firebird.5, SQLite.MS |
| 347/347 | MySqlConnector.8.0, ClickHouse.Client |
| 18/18 | Access.Ace.Odbc |

Not run locally: DB2, Informix, Sybase, SAP HANA, YDB — none of them registers a scope-hint builder, so they only exercise the unchanged generic path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
