### PR TITLE
Fix alignment in PostgreSQLFactory switch cases.

### DIFF
--- a/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLFactory.cs
+++ b/Source/LinqToDB/DataProvider/PostgreSQL/PostgreSQLFactory.cs
@@ -16,13 +16,13 @@ namespace LinqToDB.DataProvider.PostgreSQL
 			{
 				"9.2"                          => PostgreSQLVersion.v92,
 				"9.3" or "9.4"                 => PostgreSQLVersion.v93,
-				 "9.5" or "10"                 => PostgreSQLVersion.v95,
-				 "11"                          => PostgreSQLVersion.v11,
-				 "12"                          => PostgreSQLVersion.v12,
-				 "13" or "14"                  => PostgreSQLVersion.v13,
-				 "15" or "16" or "17"          => PostgreSQLVersion.v15,
-				 "18"                          => PostgreSQLVersion.v18,
-				 "19"                          => PostgreSQLVersion.v19,
+				"9.5" or "10"                  => PostgreSQLVersion.v95,
+				"11"                           => PostgreSQLVersion.v11,
+				"12"                           => PostgreSQLVersion.v12,
+				"13" or "14"                   => PostgreSQLVersion.v13,
+				"15" or "16" or "17"           => PostgreSQLVersion.v15,
+				"18"                           => PostgreSQLVersion.v18,
+				"19"                           => PostgreSQLVersion.v19,
 				_                              => PostgreSQLVersion.AutoDetect,
 			};
 


### PR DESCRIPTION
This pull request fixes the alignment of => operators in the PostgreSQLFactory.GetDataProvider switch expression for better readability and consistency with the project's code style.

No functional changes are introduced.