### PR TITLE
CI: build the generator before the solution, working around the CS2012 double-build race

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,36 +73,12 @@ jobs:
             'VERSION_ARGS=-p:VersionSuffix=-dev.${{ github.run_number }}' | Out-File -FilePath $env:GITHUB_ENV -Append
           }
 
-      # Build the Roslyn components on their own first, or a clean solution build intermittently
-      # loses this race:
-      #
-      #   CSC : error CS2012: Cannot open '.build\obj\CodeGenerators\Release\CodeGenerators.dll' for
-      #   writing -- ... because it is being used by another process.
-      #
-      # Each one gets built twice concurrently: once plain, and once as an inner build carrying an
-      # explicit TargetFramework global property, which is how a ProjectReference from
-      # multi-targeting LinqToDB resolves it. Being single-TFM, their obj path under ArtifactsPath
-      # has no target-framework segment - .build/obj/<name>/Release/<name>.dll - so both instances
-      # write the very same file and one of them loses. dotnet/roslyn#77538 shows the SDK printing
-      # both, one failed and one succeeded; .NET triage put the cause in how this repo declares the
-      # dependency, and it has been open since 2024.
-      #
-      # Building them up front means both instances find them current and skip compiling, so there
-      # is no second write left to race.
-      #
-      # This is the whole class, not one project: every Roslyn component here is single-TFM and
-      # reached from multi-TFM LinqToDB. CodeGenerators sets TargetFramework itself; the other two
-      # inherit it from Source/Analyzers.Common.props, which pins netstandard2.0 and clears the
-      # inherited TargetFrameworks list. A new Roslyn component belongs in this list - fixing only
-      # CodeGenerators just moved the failure onto LinqToDB.Analyzers.
-      #
-      # The properties have to match the solution build below, VERSION_ARGS in particular:
-      # VersionSuffix feeds the assembly version, and a mismatch would make the solution build
-      # recompile these, putting the race straight back.
-      #
-      # Azure hits this far less often: 2 vCPU against a GitHub runner's 4 leaves much less
-      # parallelism for the two instances to overlap in, which is why it surfaced only after the
-      # DB-free checks moved to GitHub in #5836.
+      # Avoids intermittent CS2012 on these projects (dotnet/roslyn#77538): single-TFM and reached
+      # from multi-TFM LinqToDB, so each builds twice concurrently - plain, and as a
+      # TargetFramework-pinned inner build - into one obj path. Pre-building makes both skip.
+      # The set is CodeGenerators plus everything pinned by Source/Analyzers.Common.props; add new
+      # Roslyn components here. Properties must match the solution build - a VERSION_ARGS mismatch
+      # recompiles these and the race is back.
       - name: Build Roslyn components
         shell: pwsh
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,8 @@ jobs:
       # Deliberately not -p:UseSharedCompilation=false: tried on this branch, and it only changed
       # which racer lost - the locking process went from VBCSCompiler to csc and the build still
       # failed, on linq2db.dll instead of CodeGenerators.dll. Nor -m:1, which would serialize every
-      # build to dodge a first-build-only race.
+      # build to dodge a first-build-only race. The real fix is to stop the double-build by changing
+      # how Source/LinqToDB references Source/CodeGenerators, which is not a CI concern.
       #
       # The retry is visible in the log as a warning rather than silent, and a real compile error
       # fails both attempts, so this cannot turn a broken build green.
@@ -116,11 +117,27 @@ jobs:
           }
           exit $LASTEXITCODE
 
-      # --no-build because the step above already produced everything for this configuration and both
-      # pass identical properties, so a recompile here is redundant - and a redundant compile is one
-      # more chance to hit the CS2012 lock described above.
+      # Retried on the same grounds as the build step: pack compiles the solution again, so it is
+      # exposed to the same race. Not --no-build - LinqToDB.CLI packs a .NET tool with per-RID
+      # publishes, and pack has to produce those RID outputs itself because a plain build never does.
+      # Tried it here and pack failed with MSB3030, unable to copy
+      # .build/bin/LinqToDB.CLI/Release/net9.0/osx-x64/dotnet-linq2db.runtimeconfig.json.
       - name: Pack solution
-        run: dotnet pack ${{ env.SOLUTION }} --no-build --configuration ${{ env.RELEASE_CONFIGURATION }} -p:RunAnalyzersDuringBuild=false -p:RunApiAnalyzersDuringBuild=false ${{ env.VERSION_ARGS }}
+        shell: pwsh
+        run: |
+          $packArgs = @(
+            '${{ env.SOLUTION }}'
+            '--configuration', '${{ env.RELEASE_CONFIGURATION }}'
+            '-p:RunAnalyzersDuringBuild=false'
+            '-p:RunApiAnalyzersDuringBuild=false'
+          ) + ('${{ env.VERSION_ARGS }}' -split ' ' | Where-Object { $_ })
+
+          dotnet pack @packArgs
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::warning title=Retrying pack::First pack failed; retrying over the warm .build tree (dotnet/roslyn#77538)."
+            dotnet pack @packArgs
+          }
+          exit $LASTEXITCODE
 
       # Both scripts already carry -NoAzdoLogs and signal through their exit code, so they need no
       # porting - only the switch. nuget-job.yml runs these before publishing; on a PR they are the

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,71 +73,38 @@ jobs:
             'VERSION_ARGS=-p:VersionSuffix=-dev.${{ github.run_number }}' | Out-File -FilePath $env:GITHUB_ENV -Append
           }
 
-      # Analyzers stay off, matching build.yml's `with_analyzers: false` until dotnet/roslyn#80621
-      # ships. The API analyzers are a release-prep gate (/release-publicapi), not a per-PR one.
-      #
-      # Retried once, because a *clean* build of this solution intermittently loses a CS2012 race:
+      # Build the generator on its own first, or a clean solution build intermittently loses this
+      # race:
       #
       #   CSC : error CS2012: Cannot open '.build\obj\CodeGenerators\Release\CodeGenerators.dll' for
       #   writing -- ... because it is being used by another process.
       #
-      # The project is built twice concurrently - once as an inner build carrying an explicit
-      # TargetFramework global property, once plain - and both write the same obj path, so one loses.
-      # dotnet/roslyn#77538 has the SDK printing both instances of the same project, one failed and
-      # one succeeded, and .NET triage places the cause in how this repo declares its generator
-      # dependency. It has been open since 2024.
+      # CodeGenerators gets built twice concurrently - once plain, and once as an inner build
+      # carrying an explicit TargetFramework global property, which is how the analyzer
+      # ProjectReference from multi-targeting LinqToDB resolves it. Being single-TFM, its obj path
+      # under ArtifactsPath has no target-framework segment, so both instances write the very same
+      # file and one of them loses. dotnet/roslyn#77538 shows the SDK printing both, one failed and
+      # one succeeded; .NET triage put the cause in how this repo declares the generator dependency,
+      # and it has been open since 2024.
       #
-      # A second build over the populated .build tree succeeds, which is what the issue reports and
-      # what we have been doing by hand on Azure ("as workaround we restart build"). This automates
-      # that. Azure hits it far less often: its agents have 2 vCPU against a GitHub runner's 4, so
-      # there is much less parallelism for the two instances to overlap in.
+      # Building it up front means both instances find it current and skip compiling, so there is no
+      # second write to race. It has to carry the same properties as the solution build below -
+      # VERSION_ARGS in particular, since VersionSuffix feeds the assembly version and a mismatch
+      # would make the solution build recompile it, putting the race straight back.
       #
-      # Deliberately not -p:UseSharedCompilation=false: tried on this branch, and it only changed
-      # which racer lost - the locking process went from VBCSCompiler to csc and the build still
-      # failed, on linq2db.dll instead of CodeGenerators.dll. Nor -m:1, which would serialize every
-      # build to dodge a first-build-only race. The real fix is to stop the double-build by changing
-      # how Source/LinqToDB references Source/CodeGenerators, which is not a CI concern.
-      #
-      # The retry is visible in the log as a warning rather than silent, and a real compile error
-      # fails both attempts, so this cannot turn a broken build green.
+      # Azure hits this far less often: 2 vCPU against a GitHub runner's 4 leaves much less
+      # parallelism for the two instances to overlap in, which is why it surfaced only after the
+      # DB-free checks moved to GitHub in #5836.
+      - name: Build code generators
+        run: dotnet build Source/CodeGenerators/CodeGenerators.csproj --configuration ${{ env.RELEASE_CONFIGURATION }} -p:RunAnalyzersDuringBuild=false -p:RunApiAnalyzersDuringBuild=false ${{ env.VERSION_ARGS }}
+
+      # Analyzers stay off, matching build.yml's `with_analyzers: false` until dotnet/roslyn#80621
+      # ships. The API analyzers are a release-prep gate (/release-publicapi), not a per-PR one.
       - name: Build solution
-        shell: pwsh
-        run: |
-          $buildArgs = @(
-            '${{ env.SOLUTION }}'
-            '--configuration', '${{ env.RELEASE_CONFIGURATION }}'
-            '-p:RunAnalyzersDuringBuild=false'
-            '-p:RunApiAnalyzersDuringBuild=false'
-          ) + ('${{ env.VERSION_ARGS }}' -split ' ' | Where-Object { $_ })
+        run: dotnet build ${{ env.SOLUTION }} --configuration ${{ env.RELEASE_CONFIGURATION }} -p:RunAnalyzersDuringBuild=false -p:RunApiAnalyzersDuringBuild=false ${{ env.VERSION_ARGS }}
 
-          dotnet build @buildArgs
-          if ($LASTEXITCODE -ne 0) {
-            Write-Host "::warning title=Retrying solution build::First build failed; retrying over the warm .build tree (dotnet/roslyn#77538)."
-            dotnet build @buildArgs
-          }
-          exit $LASTEXITCODE
-
-      # Retried on the same grounds as the build step: pack compiles the solution again, so it is
-      # exposed to the same race. Not --no-build - LinqToDB.CLI packs a .NET tool with per-RID
-      # publishes, and pack has to produce those RID outputs itself because a plain build never does.
-      # Tried it here and pack failed with MSB3030, unable to copy
-      # .build/bin/LinqToDB.CLI/Release/net9.0/osx-x64/dotnet-linq2db.runtimeconfig.json.
       - name: Pack solution
-        shell: pwsh
-        run: |
-          $packArgs = @(
-            '${{ env.SOLUTION }}'
-            '--configuration', '${{ env.RELEASE_CONFIGURATION }}'
-            '-p:RunAnalyzersDuringBuild=false'
-            '-p:RunApiAnalyzersDuringBuild=false'
-          ) + ('${{ env.VERSION_ARGS }}' -split ' ' | Where-Object { $_ })
-
-          dotnet pack @packArgs
-          if ($LASTEXITCODE -ne 0) {
-            Write-Host "::warning title=Retrying pack::First pack failed; retrying over the warm .build tree (dotnet/roslyn#77538)."
-            dotnet pack @packArgs
-          }
-          exit $LASTEXITCODE
+        run: dotnet pack ${{ env.SOLUTION }} --configuration ${{ env.RELEASE_CONFIGURATION }} -p:RunAnalyzersDuringBuild=false -p:RunApiAnalyzersDuringBuild=false ${{ env.VERSION_ARGS }}
 
       # Both scripts already carry -NoAzdoLogs and signal through their exit code, so they need no
       # porting - only the switch. nuget-job.yml runs these before publishing; on a PR they are the

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,30 +73,53 @@ jobs:
             'VERSION_ARGS=-p:VersionSuffix=-dev.${{ github.run_number }}' | Out-File -FilePath $env:GITHUB_ENV -Append
           }
 
-      # Build the generator on its own first, or a clean solution build intermittently loses this
-      # race:
+      # Build the Roslyn components on their own first, or a clean solution build intermittently
+      # loses this race:
       #
       #   CSC : error CS2012: Cannot open '.build\obj\CodeGenerators\Release\CodeGenerators.dll' for
       #   writing -- ... because it is being used by another process.
       #
-      # CodeGenerators gets built twice concurrently - once plain, and once as an inner build
-      # carrying an explicit TargetFramework global property, which is how the analyzer
-      # ProjectReference from multi-targeting LinqToDB resolves it. Being single-TFM, its obj path
-      # under ArtifactsPath has no target-framework segment, so both instances write the very same
-      # file and one of them loses. dotnet/roslyn#77538 shows the SDK printing both, one failed and
-      # one succeeded; .NET triage put the cause in how this repo declares the generator dependency,
-      # and it has been open since 2024.
+      # Each one gets built twice concurrently: once plain, and once as an inner build carrying an
+      # explicit TargetFramework global property, which is how a ProjectReference from
+      # multi-targeting LinqToDB resolves it. Being single-TFM, their obj path under ArtifactsPath
+      # has no target-framework segment - .build/obj/<name>/Release/<name>.dll - so both instances
+      # write the very same file and one of them loses. dotnet/roslyn#77538 shows the SDK printing
+      # both, one failed and one succeeded; .NET triage put the cause in how this repo declares the
+      # dependency, and it has been open since 2024.
       #
-      # Building it up front means both instances find it current and skip compiling, so there is no
-      # second write to race. It has to carry the same properties as the solution build below -
-      # VERSION_ARGS in particular, since VersionSuffix feeds the assembly version and a mismatch
-      # would make the solution build recompile it, putting the race straight back.
+      # Building them up front means both instances find them current and skip compiling, so there
+      # is no second write left to race.
+      #
+      # This is the whole class, not one project: every Roslyn component here is single-TFM and
+      # reached from multi-TFM LinqToDB. CodeGenerators sets TargetFramework itself; the other two
+      # inherit it from Source/Analyzers.Common.props, which pins netstandard2.0 and clears the
+      # inherited TargetFrameworks list. A new Roslyn component belongs in this list - fixing only
+      # CodeGenerators just moved the failure onto LinqToDB.Analyzers.
+      #
+      # The properties have to match the solution build below, VERSION_ARGS in particular:
+      # VersionSuffix feeds the assembly version, and a mismatch would make the solution build
+      # recompile these, putting the race straight back.
       #
       # Azure hits this far less often: 2 vCPU against a GitHub runner's 4 leaves much less
       # parallelism for the two instances to overlap in, which is why it surfaced only after the
       # DB-free checks moved to GitHub in #5836.
-      - name: Build code generators
-        run: dotnet build Source/CodeGenerators/CodeGenerators.csproj --configuration ${{ env.RELEASE_CONFIGURATION }} -p:RunAnalyzersDuringBuild=false -p:RunApiAnalyzersDuringBuild=false ${{ env.VERSION_ARGS }}
+      - name: Build Roslyn components
+        shell: pwsh
+        run: |
+          $common = @(
+            '--configuration', '${{ env.RELEASE_CONFIGURATION }}'
+            '-p:RunAnalyzersDuringBuild=false'
+            '-p:RunApiAnalyzersDuringBuild=false'
+          ) + ('${{ env.VERSION_ARGS }}' -split ' ' | Where-Object { $_ })
+
+          foreach ($project in @(
+            'Source/CodeGenerators/CodeGenerators.csproj'
+            'Source/LinqToDB.Analyzers/LinqToDB.Analyzers.csproj'
+            'Source/LinqToDB.Analyzers.CodeFixes/LinqToDB.Analyzers.CodeFixes.csproj'
+          )) {
+            dotnet build $project @common
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
 
       # Analyzers stay off, matching build.yml's `with_analyzers: false` until dotnet/roslyn#80621
       # ships. The API analyzers are a release-prep gate (/release-publicapi), not a per-PR one.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,25 +76,45 @@ jobs:
       # Analyzers stay off, matching build.yml's `with_analyzers: false` until dotnet/roslyn#80621
       # ships. The API analyzers are a release-prep gate (/release-publicapi), not a per-PR one.
       #
-      # UseSharedCompilation=false, or this step intermittently dies with:
+      # Retried once, because a *clean* build of this solution intermittently loses a CS2012 race:
       #
       #   CSC : error CS2012: Cannot open '.build\obj\CodeGenerators\Release\CodeGenerators.dll' for
-      #   writing -- ... because it is being used by another process.; file may be locked by
-      #   'VBCSCompiler' [Source\CodeGenerators\CodeGenerators.csproj]
+      #   writing -- ... because it is being used by another process.
       #
-      # LinqToDB.csproj consumes CodeGenerators with OutputItemType="Analyzer", and its five TFMs
-      # compile in parallel; each one loads CodeGenerators.dll into VBCSCompiler, which caches
-      # analyzer assemblies across invocations. The same solution build also compiles CodeGenerators
-      # itself, and ReferenceOutputAssembly="false" weakens the ordering guarantee, so that write can
-      # race a consumer compile already holding the file. Whether it does comes down to MSBuild node
-      # scheduling, which is why it fails on some runs and not others.
+      # The project is built twice concurrently - once as an inner build carrying an explicit
+      # TargetFramework global property, once plain - and both write the same obj path, so one loses.
+      # dotnet/roslyn#77538 has the SDK printing both instances of the same project, one failed and
+      # one succeeded, and .NET triage places the cause in how this repo declares its generator
+      # dependency. It has been open since 2024.
       #
-      # Without the compiler server, csc loads the analyzer per process and releases it on exit, so
-      # the persistent handle that causes this cannot exist. Upstream: dotnet/roslyn#77538, open and
-      # untriaged. The cost is losing compiler-server reuse for one solution build; a hosted runner's
-      # server is single-tenant and dies with the job, so nothing else wants it.
+      # A second build over the populated .build tree succeeds, which is what the issue reports and
+      # what we have been doing by hand on Azure ("as workaround we restart build"). This automates
+      # that. Azure hits it far less often: its agents have 2 vCPU against a GitHub runner's 4, so
+      # there is much less parallelism for the two instances to overlap in.
+      #
+      # Deliberately not -p:UseSharedCompilation=false: tried on this branch, and it only changed
+      # which racer lost - the locking process went from VBCSCompiler to csc and the build still
+      # failed, on linq2db.dll instead of CodeGenerators.dll. Nor -m:1, which would serialize every
+      # build to dodge a first-build-only race.
+      #
+      # The retry is visible in the log as a warning rather than silent, and a real compile error
+      # fails both attempts, so this cannot turn a broken build green.
       - name: Build solution
-        run: dotnet build ${{ env.SOLUTION }} --configuration ${{ env.RELEASE_CONFIGURATION }} -p:UseSharedCompilation=false -p:RunAnalyzersDuringBuild=false -p:RunApiAnalyzersDuringBuild=false ${{ env.VERSION_ARGS }}
+        shell: pwsh
+        run: |
+          $buildArgs = @(
+            '${{ env.SOLUTION }}'
+            '--configuration', '${{ env.RELEASE_CONFIGURATION }}'
+            '-p:RunAnalyzersDuringBuild=false'
+            '-p:RunApiAnalyzersDuringBuild=false'
+          ) + ('${{ env.VERSION_ARGS }}' -split ' ' | Where-Object { $_ })
+
+          dotnet build @buildArgs
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::warning title=Retrying solution build::First build failed; retrying over the warm .build tree (dotnet/roslyn#77538)."
+            dotnet build @buildArgs
+          }
+          exit $LASTEXITCODE
 
       # --no-build because the step above already produced everything for this configuration and both
       # pass identical properties, so a recompile here is redundant - and a redundant compile is one

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,11 +75,32 @@ jobs:
 
       # Analyzers stay off, matching build.yml's `with_analyzers: false` until dotnet/roslyn#80621
       # ships. The API analyzers are a release-prep gate (/release-publicapi), not a per-PR one.
+      #
+      # UseSharedCompilation=false, or this step intermittently dies with:
+      #
+      #   CSC : error CS2012: Cannot open '.build\obj\CodeGenerators\Release\CodeGenerators.dll' for
+      #   writing -- ... because it is being used by another process.; file may be locked by
+      #   'VBCSCompiler' [Source\CodeGenerators\CodeGenerators.csproj]
+      #
+      # LinqToDB.csproj consumes CodeGenerators with OutputItemType="Analyzer", and its five TFMs
+      # compile in parallel; each one loads CodeGenerators.dll into VBCSCompiler, which caches
+      # analyzer assemblies across invocations. The same solution build also compiles CodeGenerators
+      # itself, and ReferenceOutputAssembly="false" weakens the ordering guarantee, so that write can
+      # race a consumer compile already holding the file. Whether it does comes down to MSBuild node
+      # scheduling, which is why it fails on some runs and not others.
+      #
+      # Without the compiler server, csc loads the analyzer per process and releases it on exit, so
+      # the persistent handle that causes this cannot exist. Upstream: dotnet/roslyn#77538, open and
+      # untriaged. The cost is losing compiler-server reuse for one solution build; a hosted runner's
+      # server is single-tenant and dies with the job, so nothing else wants it.
       - name: Build solution
-        run: dotnet build ${{ env.SOLUTION }} --configuration ${{ env.RELEASE_CONFIGURATION }} -p:RunAnalyzersDuringBuild=false -p:RunApiAnalyzersDuringBuild=false ${{ env.VERSION_ARGS }}
+        run: dotnet build ${{ env.SOLUTION }} --configuration ${{ env.RELEASE_CONFIGURATION }} -p:UseSharedCompilation=false -p:RunAnalyzersDuringBuild=false -p:RunApiAnalyzersDuringBuild=false ${{ env.VERSION_ARGS }}
 
+      # --no-build because the step above already produced everything for this configuration and both
+      # pass identical properties, so a recompile here is redundant - and a redundant compile is one
+      # more chance to hit the CS2012 lock described above.
       - name: Pack solution
-        run: dotnet pack ${{ env.SOLUTION }} --configuration ${{ env.RELEASE_CONFIGURATION }} -p:RunAnalyzersDuringBuild=false -p:RunApiAnalyzersDuringBuild=false ${{ env.VERSION_ARGS }}
+        run: dotnet pack ${{ env.SOLUTION }} --no-build --configuration ${{ env.RELEASE_CONFIGURATION }} -p:RunAnalyzersDuringBuild=false -p:RunApiAnalyzersDuringBuild=false ${{ env.VERSION_ARGS }}
 
       # Both scripts already carry -NoAzdoLogs and signal through their exit code, so they need no
       # porting - only the switch. nuget-job.yml runs these before publishing; on a PR they are the


### PR DESCRIPTION
The GitHub `build` workflow's **Build and pack** job fails intermittently on a clean build:

```
CSC : error CS2012: Cannot open '.build\obj\CodeGenerators\Release\CodeGenerators.dll' for writing
-- The process cannot access the file ... because it is being used by another process.
```

This is **dotnet/roslyn#77538** — reported from this repo in 2024, still open.

## Cause

`CodeGenerators` is built **twice concurrently**: once plain, and once as an inner build carrying an explicit `TargetFramework` global property, which is how the analyzer `ProjectReference` from multi-targeting `LinqToDB` resolves it —

```xml
<ProjectReference Include="../CodeGenerators/CodeGenerators.csproj"
                  OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
```

Because the project is single-TFM, its obj path under `ArtifactsPath` carries **no target-framework segment** — `.build/obj/CodeGenerators/Release/CodeGenerators.dll` — so both instances write the identical file and one loses. (`LinqToDB` multi-targets, hence its `/net8.0/` segment; that asymmetry is visible in the error paths.)

The issue shows the SDK printing both instances:

```
CodeGenerators netstandard2.0 failed with 1 error(s) (6.8s)
  CSC : error CS2012: Cannot open '...\CodeGenerators.dll' for writing
CodeGenerators succeeded (5.2s) → .build\bin\CodeGenerators\Debug\CodeGenerators.dll
```

.NET triage put the cause in how this repo declares its generator dependency and moved it to Roslyn for guidance. Nothing has landed.

It is scheduling-dependent, so it fails on some runs and not others. Azure hits it far less often — 2 vCPU against a GitHub runner's 4 leaves much less parallelism for the two instances to overlap in — which is why it surfaced only once the DB-free checks moved to GitHub in #5836.

## Fix

Build `Source/CodeGenerators` on its own before the solution. Both instances then find it current and skip compiling, so no second write exists to race.

Deterministic where a retry would be probabilistic, and a few seconds against a possible second full solution build. It is really a targeted form of the workaround the issue already records — *"second build will succeed (if you don't remove .build)"* — since the reason a second build works is that the outputs are already there.

One constraint: the pre-build has to carry the **same properties** as the solution build, `VERSION_ARGS` in particular. `VersionSuffix` feeds the assembly version, and a mismatch would make the solution build recompile the generator, restoring the race.

Net change against master is a single added step.

## Rejected alternatives

All three were tried on this branch and are recorded in the step comment so they are not re-attempted:

- **`--no-build` on pack** — breaks it. `LinqToDB.CLI` packs a .NET tool with per-RID publishes that a plain build never produces, so pack failed with `MSB3030: Could not copy ... osx-x64\dotnet-linq2db.runtimeconfig.json`.
- **`-p:UseSharedCompilation=false`** — did not help. It only changed which racer lost: the locking process went from `VBCSCompiler` to `csc` and the build still failed, on `linq2db.dll` instead of `CodeGenerators.dll`.
- **Retrying the build once** — would work, since a second build succeeds, but it is probabilistic, hides the problem, and cannot be validated: on a run where the first build passes the retry never fires.

The underlying double-build is still worth fixing at the source, by changing how `Source/LinqToDB` references `Source/CodeGenerators`. That affects every consumer and analyzer delivery, so it belongs in its own change rather than in a CI workaround.

## Verification

The `build` workflow runs on `pull_request`, so the failing job runs here. Worth reading on the run: **Build code generators** succeeds, **Build solution** and **Pack solution** succeed, and **Verify nupkg sizes** / **Verify analyzer delivery metadata** still find packages under `.build/package/release`.

Because the failure is intermittent, one green run is not proof on its own — but unlike a retry, this change is falsifiable: if CS2012 appears again on `Build solution`, the up-to-date check is not holding and the reasoning above is wrong.
