### PR TITLE
CI: authenticate every baselines git read so the download throttle cannot kill a leg

### DIFF
--- a/Build/Azure/pipelines/templates/test-workflow-linux.yml
+++ b/Build/Azure/pipelines/templates/test-workflow-linux.yml
@@ -68,7 +68,14 @@ steps:
     # two root files instead of 343541, and --depth 1 --single-branch skips ~420 Mb of history for a
     # tree the leg only appends to. Master is cloned rather than the run branch, which may not
     # exist yet - see the push below. The commit step pairs this with git add --sparse.
-    script: 'git clone --depth 1 --single-branch --sparse --branch $(baselines_master) https://$(BASELINES_GH_PAT)@github.com/linq2db/linq2db.baselines.git baselines'
+    #
+    # http.proactiveAuth is what makes the token in the url count: git sends credentials only after a
+    # 401 challenge, and github never challenges an anonymous read of a public repository - so without
+    # it this clone is unauthenticated and github's unauthenticated-download throttle kills the leg
+    # (three legs on build 23238). The credential also has to be complete - user:token, not token
+    # alone, or git asks for the password it is missing. -c is written to the clone's config, so the
+    # fetch in the push retry below authenticates too.
+    script: 'git clone --depth 1 --single-branch --sparse -c http.proactiveAuth=basic --branch $(baselines_master) https://x-access-token:$(BASELINES_GH_PAT)@github.com/linq2db/linq2db.baselines.git baselines'
     workingDirectory: '$(System.DefaultWorkingDirectory)'
   displayName: Checkout test baselines
   condition: and(variables.title, ${{ parameters.with_baselines }}, succeeded())
@@ -100,6 +107,10 @@ steps:
     workingDirectory: '$(System.DefaultWorkingDirectory)/scripts'
   condition: and(variables.title, variables.script_global, succeeded())
   displayName: Setup tests
+  env:
+    # hana2.sh clones linq2db.ci, and an unauthenticated clone is subject to github's
+    # unauthenticated-download throttle. No other setup script reads this.
+    GITHUB_TOKEN: $(BASELINES_GH_PAT)
 
 # One block per TFM, run in list order.
 - ${{ each tfm in parameters.tfms }}:
@@ -197,7 +208,7 @@ steps:
       # first wins the ref; the rest are rejected and rebase onto it.
       $branch = "$(baselines_branch)"
       $orgName = "linq2db"
-      $repoUrl = "https://$(BASELINES_GH_PAT)@github.com/${orgName}/linq2db.baselines.git"
+      $repoUrl = "https://x-access-token:$(BASELINES_GH_PAT)@github.com/${orgName}/linq2db.baselines.git"
       $pushed = $false
       $attempts = 10
       while ($attempts -gt 0) {

--- a/Build/Azure/pipelines/templates/test-workflow-windows.yml
+++ b/Build/Azure/pipelines/templates/test-workflow-windows.yml
@@ -134,7 +134,14 @@ steps:
     # two root files instead of 343541, and --depth 1 --single-branch skips ~420 Mb of history for a
     # tree the leg only appends to. Master is cloned rather than the run branch, which may not
     # exist yet - see the push below. The commit step pairs this with git add --sparse.
-    script: 'git clone --depth 1 --single-branch --sparse --branch $(baselines_master) https://$(BASELINES_GH_PAT)@github.com/linq2db/linq2db.baselines.git baselines'
+    #
+    # http.proactiveAuth is what makes the token in the url count: git sends credentials only after a
+    # 401 challenge, and github never challenges an anonymous read of a public repository - so without
+    # it this clone is unauthenticated and github's unauthenticated-download throttle kills the leg
+    # (three legs on build 23238). The credential also has to be complete - user:token, not token
+    # alone, or git asks for the password it is missing. -c is written to the clone's config, so the
+    # fetch in the push retry below authenticates too.
+    script: 'git clone --depth 1 --single-branch --sparse -c http.proactiveAuth=basic --branch $(baselines_master) https://x-access-token:$(BASELINES_GH_PAT)@github.com/linq2db/linq2db.baselines.git baselines'
     workingDirectory: '$(System.DefaultWorkingDirectory)'
   displayName: Checkout test baselines
   condition: and(variables.title, ${{ parameters.with_baselines }}, succeeded())
@@ -293,7 +300,7 @@ steps:
       # first wins the ref; the rest are rejected and rebase onto it.
       $branch = "$(baselines_branch)"
       $orgName = "linq2db"
-      $repoUrl = "https://$(BASELINES_GH_PAT)@github.com/${orgName}/linq2db.baselines.git"
+      $repoUrl = "https://x-access-token:$(BASELINES_GH_PAT)@github.com/${orgName}/linq2db.baselines.git"
       $pushed = $false
       $attempts = 10
       while ($attempts -gt 0) {

--- a/Build/Azure/scripts/ensure-baselines-branch.ps1
+++ b/Build/Azure/scripts/ensure-baselines-branch.ps1
@@ -36,7 +36,12 @@ param(
 
 $orgName       = "linq2db"
 $baselinesRepo = "linq2db.baselines"
-$baselinesRepoUrl = "https://${Env:GITHUB_TOKEN}@github.com/${orgName}/${baselinesRepo}.git"
+# The reads below pass -c http.proactiveAuth=basic because git sends credentials only after a 401
+# challenge, and github never challenges an anonymous read of a public repository - so without it the
+# token here is inert and the read is subject to github's unauthenticated-download throttle. The
+# credential also has to be complete - user:token, not token alone, or git asks for the password it is
+# missing.
+$baselinesRepoUrl = "https://x-access-token:${Env:GITHUB_TOKEN}@github.com/${orgName}/${baselinesRepo}.git"
 
 # Resolve the branch name from the PR id
 if ($PrId) {
@@ -50,7 +55,7 @@ function Get-RemoteHash([string]$ref) {
     # @(...) keeps a single-line answer an array. Without it PowerShell hands back a bare string for
     # one match and a string[] for several, so a length test means "characters" in the first case and
     # "lines" in the second — and a legitimate multi-ref answer reads as "not found".
-    $out = @(git ls-remote --heads $baselinesRepoUrl $ref)
+    $out = @(git -c http.proactiveAuth=basic ls-remote --heads $baselinesRepoUrl $ref)
     if ($LASTEXITCODE -ne 0) {
         Write-Host "ls-remote for '${ref}' failed with code ${LASTEXITCODE}"
         exit 1
@@ -87,7 +92,7 @@ if (-not $branchHash) {
             Write-Host "Baselines branch already based on ${BaselinesMaster}, no rebase required"
         } else {
             Write-Host "Baselines head is ${branchHash} and the branch is '${status}', trying to rebase on current HEAD"
-            git clone $baselinesRepoUrl baselines
+            git clone -c http.proactiveAuth=basic $baselinesRepoUrl baselines
             if ($LASTEXITCODE -ne 0) {
                 Write-Host "Failed to clone baselines repository. Error code ${LASTEXITCODE}"
                 exit 1

--- a/Build/Azure/scripts/hana2.sh
+++ b/Build/Azure/scripts/hana2.sh
@@ -12,7 +12,16 @@ docker exec hana2 sudo chown 12000:79 /hana/password.json
 
 docker ps -a
 
-git clone https://github.com/linq2db/linq2db.ci.git ~/linq2db_ci
+# Authenticate the clone when the pipeline supplies a token: github throttles unauthenticated
+# downloads. proactiveAuth is required because git sends credentials only after a 401 challenge, which
+# github never issues for an anonymous read of a public repository, and the credential has to be
+# complete - user:token, not token alone, or git asks for the password it is missing. Falls back to an
+# anonymous clone so the script still runs outside the pipeline.
+if [ -n "$GITHUB_TOKEN" ]; then
+    git clone -c http.proactiveAuth=basic "https://x-access-token:${GITHUB_TOKEN}@github.com/linq2db/linq2db.ci.git" ~/linq2db_ci
+else
+    git clone https://github.com/linq2db/linq2db.ci.git ~/linq2db_ci
+fi
 
 retries=0
 until docker logs hana2 | grep -q 'Startup finished'; do


### PR DESCRIPTION
## Problem

Three Linux legs on [build 23238](https://dev.azure.com/linq2db/linq2db/_build/results?buildId=23238) ([#5841](https://github.com/linq2db/linq2db/pull/5841)) failed in `Checkout test baselines`:

```
fatal: remote error: GitHub is temporarily limiting some unauthenticated downloads
to protect the stability of the platform. Please retry later or authenticate.
##[error]Bash exited with code '128'.
```

The clone already carried `BASELINES_GH_PAT`, and the token was inert. Git sends HTTP credentials only **after a 401 challenge**, and GitHub never challenges an anonymous read of a *public* repository — so every baselines read has been counting against the anonymous quota, and the `PublishTestResults` failures on those legs are downstream of the dead checkout.

## Fix

Two things are needed together at every baselines read site:

- `-c http.proactiveAuth=basic` — send the credential unprompted (git 2.46+; both Azure agent pools report git 2.55)
- a **complete** credential — `x-access-token:<token>@`, not `<token>@`, or git asks for the password it is missing

| file | sites |
|---|---|
| `test-workflow-linux.yml` | baselines clone, `$repoUrl`, `GITHUB_TOKEN` mapped onto *Setup tests* |
| `test-workflow-windows.yml` | baselines clone, `$repoUrl` |
| `ensure-baselines-branch.ps1` | url, `ls-remote` (runs on every build), rebase-path clone |
| `hana2.sh` | `linq2db.ci` clone — carried no token at all |

`git clone -c` writes the setting into the clone's config, so the `git fetch origin` in the push-retry loop authenticates too. `hana2.sh` keeps an anonymous fallback when `GITHUB_TOKEN` is unset, so it still runs outside the pipeline; it is the only setup script that clones, which is why the token is mapped on the Linux *Setup tests* step only.

Pushes were never affected — `git-receive-pack` does issue a 401, so the credential was already being used there.

## Verification

Probed against the real repository:

| command | result |
|---|---|
| `git ls-remote https://<bogus-token>@github.com/linq2db/linq2db.baselines.git` | **succeeds** — credentials never sent |
| `git -c http.proactiveAuth=basic ls-remote https://x-access-token:<bogus-token>@…` | `remote: Invalid username or token` |

`git clone -c http.proactiveAuth=basic` was also confirmed to persist the setting into the new repository's config.

With `proactiveAuth` a read cannot silently fall back to anonymous, so a **successful** `Checkout test baselines` step is itself evidence the token is being sent and accepted — a wrong credential form fails loudly with `Invalid username or token` instead of quietly going anonymous.

Both templates parse as YAML, `bash -n` is clean on `hana2.sh`, and the PowerShell parser is clean on `ensure-baselines-branch.ps1`. A pipeline template cannot be exercised locally, so CI on this PR is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
