### PR TITLE
CI: re-enable ClickHouse.Octonica behind a server-side setting

### DIFF
--- a/Build/Azure/net100/clickhouse.json
+++ b/Build/Azure/net100/clickhouse.json
@@ -2,7 +2,8 @@
 	"NET100.Azure": {
 		"Providers": [
 			"ClickHouse.Driver",
-			"ClickHouse.MySql"
+			"ClickHouse.MySql",
+			"ClickHouse.Octonica"
 		]
 	}
 }

--- a/Build/Azure/net80/clickhouse.json
+++ b/Build/Azure/net80/clickhouse.json
@@ -2,7 +2,8 @@
 	"NET80.Azure": {
 		"Providers": [
 			"ClickHouse.Driver",
-			"ClickHouse.MySql"
+			"ClickHouse.MySql",
+			"ClickHouse.Octonica"
 		]
 	}
 }

--- a/Build/Azure/net90/clickhouse.json
+++ b/Build/Azure/net90/clickhouse.json
@@ -2,7 +2,8 @@
 	"NET90.Azure": {
 		"Providers": [
 			"ClickHouse.Driver",
-			"ClickHouse.MySql"
+			"ClickHouse.MySql",
+			"ClickHouse.Octonica"
 		]
 	}
 }

--- a/Build/Azure/scripts/clickhouse.sh
+++ b/Build/Azure/scripts/clickhouse.sh
@@ -5,7 +5,19 @@ docker run -d --name clickhouse --ulimit nofile=262144:262144 -p 8123:8123 -p 90
 docker ps -a
 
 echo Patching ClickHouse settings...
-docker exec clickhouse sed -i "0,/<\/default>/{s/<\/default>/<join_use_nulls>1<\/join_use_nulls><mutations_sync>1<\/mutations_sync><allow_experimental_object_type>1<\/allow_experimental_object_type><allow_experimental_geo_types>1<\/allow_experimental_geo_types><allow_experimental_json_type>1<\/allow_experimental_json_type><allow_experimental_correlated_subqueries>1<\/allow_experimental_correlated_subqueries><enable_analyzer>1<\/enable_analyzer><enable_materialized_cte>1<\/enable_materialized_cte><\/default>/}" /etc/clickhouse-server/users.xml
+# Two settings here work around Octonica.ClickHouseClient 4.1.4, which advertises protocol
+# revision 54483 and then fails on features that revision permits. The other two ClickHouse
+# providers are unaffected by either.
+#
+# enable_producing_buckets_out_of_order_in_aggregation - 54480. The server may send the buckets of
+#   a two-level aggregation out of order; the client throws on any non-zero count:
+#     "ClickHouseClient received N out-of-order bucket(s) in the server reply."
+# allow_special_serialization_kinds_in_output_formats - covers Sparse (54483) and Replicated
+#   (54482). With it on, the client throws:
+#     "Unexpected key (8) size when reading a column with 'replicated' serialization."
+#
+# Drop both once the client handles these, or once it stops advertising 54483.
+docker exec clickhouse sed -i "0,/<\/default>/{s/<\/default>/<join_use_nulls>1<\/join_use_nulls><mutations_sync>1<\/mutations_sync><allow_experimental_object_type>1<\/allow_experimental_object_type><allow_experimental_geo_types>1<\/allow_experimental_geo_types><allow_experimental_json_type>1<\/allow_experimental_json_type><allow_experimental_correlated_subqueries>1<\/allow_experimental_correlated_subqueries><enable_analyzer>1<\/enable_analyzer><enable_materialized_cte>1<\/enable_materialized_cte><enable_producing_buckets_out_of_order_in_aggregation>0<\/enable_producing_buckets_out_of_order_in_aggregation><allow_special_serialization_kinds_in_output_formats>0<\/allow_special_serialization_kinds_in_output_formats><\/default>/}" /etc/clickhouse-server/users.xml
 docker restart clickhouse
 
 retries=0


### PR DESCRIPTION
Reverts the disable from #5845 and re-enables `ClickHouse.Octonica` in all three TFM configs, with the two triggers switched off server-side.

## What the failures actually were

Not a ClickHouse 26.8 regression. `Octonica.ClickHouseClient` 4.1.4 declares `CurrentRevision = 54483` and then fails on features that revision permits the server to use. Two confirmed so far:

| Revision | Feature | Client behaviour |
|---|---|---|
| **54480** | out-of-order aggregation buckets | `ClickHouseClient received N out-of-order bucket(s) in the server reply. This feature is not supported on the client side.` |
| **54482** | replicated serialization | `Unexpected key (8) size when reading a column with 'replicated' serialization.` |

For the first, `src/Server/TCPHandler.cpp` gates the feature purely on the client's advertised revision:

```cpp
if (client_tcp_protocol_version < DBMS_MIN_REVISION_WITH_OUT_OF_ORDER_BUCKETS_IN_AGGREGATION)
    query_state->query_context->setSetting("enable_producing_buckets_out_of_order_in_aggregation", false);
```

At 54483 it stays on, and `ClickHouseTcpClient.Session.ReadTable` throws `FeatureNotImplemented`. This one reproduces on **26.5.1** as readily as on 26.8.2.7 — 26.8 only changed which of our queries take the two-level path, and `BooleanTests.Test`'s 24-column `GROUP BY` was the one that started to.

The second surfaced on `Issue1813Test11`'s three-`JOIN` query. That test **passes in isolation** on 26.8 (build 23280, 10/10 green with a narrowed filter) and only fails in the full suite, so it is a plan variation under concurrency rather than anything about the query. A probe walking 26.8's default flips reproduced it deterministically under `enable_analyzer = 0` or `enable_parallel_single_level_merge = 0`.

The visible symptom in both cases was misleading: the real exception surfaces from `reader.Read()`, the connection then dies, and teardown's `DROP TABLE` throws `The connection is closed.` — which replaces the original during `using`-scope unwinding. Every build report named only the second one. The real errors were recovered with a `DOTNET_STARTUP_HOOKS` first-chance listener attached to the test host.

## The change

Two settings in the container's default profile:

- `enable_producing_buckets_out_of_order_in_aggregation = 0`
- `allow_special_serialization_kinds_in_output_formats = 0` — covers Sparse (54483) and Replicated (54482) in one switch

`clickhouse.sh` already patches that profile for `join_use_nulls`, `enable_analyzer` and six others, so these sit with them. Server-side and scoped to the CI container, so the Driver and MySql lanes are unaffected either way.

## Verification

Build **23300**: full net10 suite, **26,753 tests, 0 failed**. That is the byte-identical test set (26,753 total / 569 skipped) which had **1 failure** on build 23261 before the second setting was added — so Octonica is genuinely running, and the only delta is the fixed test.

Drop both lines once the client handles these features, or once it stops advertising 54483.

## Follow-up

An upstream issue against [Octonica/ClickHouseClient](https://github.com/Octonica/ClickHouseClient) is being filed separately, now covering both defects — two instances make the case for lowering the advertised revision rather than implementing features one at a time. Related upstream: [#58](https://github.com/Octonica/ClickHouseClient/issues/58) (open since 2022) covers the connection dying and masking the original error.
