### PR TITLE
Fix the three build 23263 failures: docker daemon retry, merge-source order, CharTest isolation

### DIFF
--- a/Build/Azure/scripts/mssql-container.ps1
+++ b/Build/Azure/scripts/mssql-container.ps1
@@ -1,0 +1,202 @@
+<#
+mssql-container.ps1 - bring up the SQL Server container(s) a Windows test leg needs, and keep
+retrying until they answer or the budget runs out. Called by every sqlserver.*.cmd, which then
+runs its own version-specific `docker exec ... sqlcmd -Q "..."` setup statements.
+
+Replaces the hand-rolled `docker run` + `set max=100` / `sleep 1` / `docker exec ... SELECT 1`
+loop those scripts each carried. That loop could not distinguish the three ways the setup fails,
+and recovered from none of them:
+
+  - the agent's docker daemon is not reachable at all. On build 23263 the Win d_SqlServer2012 leg
+    got "failed to connect to the docker API ... check if the path is correct and if the daemon is
+    running" from every single call, so `docker run` never created anything and the wait loop then
+    spent 106s asking a container that did not exist for a row. Every other Windows docker leg in
+    that build was green, so it is a per-agent flake, not a broken image.
+  - the container was created but died during startup. firebird.sh already checks for this
+    (docker inspect .State.Running) and fails fast with the logs; the Windows scripts waited out
+    the full budget instead.
+  - the container was never created, or came up wedged. Nothing re-created it, so a single lost
+    `docker run` was terminal for the leg.
+
+So: probe the daemon first (and give a stopped docker service one push), then treat "container up
+and answering" as the thing being retried rather than assuming one `docker run` is enough.
+`docker rm -f` before each attempt is what makes a retry idempotent - without it a second attempt
+dies on "name is already in use" whenever the first one did create the container.
+
+All of a leg's containers are started before any of them is waited on, so the merged 2017+2019
+and 2022+2025 legs keep initialising both servers concurrently the way they do today.
+
+Invoked from a .cmd as:
+
+  pwsh -NoProfile -ExecutionPolicy Bypass -File "%~dp0mssql-container.ps1" -Container "mssql2012|1412|linq2db/linq2db:win-mssql-2012"
+  if %errorlevel% NEQ 0 exit /b 1
+
+Parameters:
+  -Container          one or more `name|hostPort|image|sqlcmdExtraArgs` specs. The last field is
+                      optional and is appended to every readiness probe (the 2025 image ships
+                      mssql-tools18, whose sqlcmd needs -C to accept the self-signed cert).
+                      Several specs may be passed as separate array elements or comma-separated
+                      inside one string - `pwsh -File` hands array syntax through as a literal
+                      string, so the comma form is what a .cmd can actually rely on.
+  -SaPassword         sa password. Must match the connection strings in DataProviders.json.
+  -MaxAttempts        create-and-wait attempts before giving up.
+  -DaemonTimeoutSec   how long to wait for the docker daemon before the first attempt.
+  -ReadyTimeoutSec    how long to wait for one container to accept a query, per attempt.
+
+The three budgets are picked, not measured: the step they replace had a fixed ~110s ceiling, and
+the worst case here is ~120s + 3 x 100s = ~7 min. That only elapses on a leg that was going to
+fail anyway, and a Windows test leg runs for tens of minutes, so trading the extra minutes for a
+recovered leg is worth it. A healthy container answers in a few seconds and pays none of it.
+#>
+
+param(
+    [Parameter(Mandatory = $true)][string[]] $Container,
+    [string] $SaPassword       = 'Password12!',
+    [int]    $MaxAttempts      = 3,
+    [int]    $DaemonTimeoutSec = 120,
+    [int]    $ReadyTimeoutSec  = 100
+)
+
+# Parse the specs up front so a typo fails before anything is created.
+$specs = foreach ($entry in ($Container -split ',')) {
+    $text = $entry.Trim()
+    if (-not $text) { continue }
+
+    $parts = $text -split '\|'
+    if ($parts.Count -lt 3) {
+        Write-Host "##vso[task.logissue type=error]mssql-container: '${text}' is not a name|hostPort|image[|sqlcmdExtraArgs] spec"
+        exit 1
+    }
+
+    [pscustomobject]@{
+        Name      = $parts[0]
+        Port      = $parts[1]
+        Image     = $parts[2]
+        ExtraArgs = @(if ($parts.Count -gt 3 -and $parts[3]) { $parts[3] -split '\s+' })
+        Ready     = $false
+    }
+}
+
+$specs = @($specs)
+if ($specs.Count -eq 0) {
+    Write-Host "##vso[task.logissue type=error]mssql-container: no container specs given"
+    exit 1
+}
+
+# True when the daemon answers. `docker version` is the probe rather than `docker info` because it
+# reports the *server* version, which only exists once the daemon is reachable - the client half
+# answers regardless.
+function Test-DockerDaemon {
+    $null = docker version --format '{{.Server.Version}}' 2>&1
+    return $LASTEXITCODE -eq 0
+}
+
+function Wait-DockerDaemon {
+    if (Test-DockerDaemon) {
+        return $true
+    }
+
+    Write-Host "Docker daemon is not responding, waiting up to ${DaemonTimeoutSec}s"
+
+    # The hosted image runs dockerd as a Windows service. If that service is not running, waiting
+    # cannot help on its own, so push it once - but keep polling either way, because a daemon that
+    # is merely slow to come up looks identical from here.
+    $service = Get-Service -Name docker -ErrorAction SilentlyContinue
+    if ($service -and $service.Status -ne 'Running') {
+        Write-Host "Docker service status is '$($service.Status)', trying to start it"
+        try {
+            Start-Service -Name docker -ErrorAction Stop
+            Write-Host "Docker service started"
+        }
+        catch {
+            Write-Host "Failed to start the docker service: $($_.Exception.Message)"
+        }
+    }
+
+    $deadline = (Get-Date).AddSeconds($DaemonTimeoutSec)
+    while ((Get-Date) -lt $deadline) {
+        Start-Sleep -Seconds 2
+        if (Test-DockerDaemon) {
+            Write-Host "Docker daemon is responding"
+            return $true
+        }
+    }
+
+    return $false
+}
+
+# False as soon as the container is known to be gone or stopped, so a crashed startup is not
+# waited out for the whole readiness budget.
+function Test-ContainerRunning([string]$name) {
+    $state = docker inspect -f '{{.State.Running}}' $name 2>&1
+    return $LASTEXITCODE -eq 0 -and "$state".Trim() -eq 'true'
+}
+
+function Test-SqlReady($spec) {
+    # Not $args - that is an automatic variable, and assigning to it inside a function shadows the
+    # caller's argument list.
+    $dockerArgs = @('exec', $spec.Name, 'sqlcmd', '-S', 'localhost', '-U', 'sa', '-P', $SaPassword, '-Q', 'SELECT 1') + $spec.ExtraArgs
+    $null = docker @dockerArgs 2>&1
+    return $LASTEXITCODE -eq 0
+}
+
+if (-not (Wait-DockerDaemon)) {
+    Write-Host "##vso[task.logissue type=error]mssql-container: the docker daemon did not become available within ${DaemonTimeoutSec}s"
+    exit 1
+}
+
+for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+    $pending = @($specs | Where-Object { -not $_.Ready })
+
+    Write-Host "=== Attempt ${attempt} of ${MaxAttempts}: starting $($pending.Name -join ', ') ==="
+
+    foreach ($spec in $pending) {
+        # Ignore the outcome: on the first attempt there is normally nothing to remove, and on a
+        # later one this is the whole point - it clears whatever the failed attempt left behind so
+        # `docker run` does not fail on a name collision.
+        docker rm -f $spec.Name 2>&1 | Out-Null
+
+        docker run -d `
+            -e "ACCEPT_EULA=Y" `
+            -e "MSSQL_SA_PASSWORD=$SaPassword" `
+            -p "$($spec.Port):1433" `
+            -h $spec.Name `
+            --name $spec.Name `
+            $spec.Image
+    }
+
+    docker ps -a
+
+    foreach ($spec in $pending) {
+        Write-Host "Waiting up to ${ReadyTimeoutSec}s for $($spec.Name) to accept connections"
+
+        $deadline = (Get-Date).AddSeconds($ReadyTimeoutSec)
+        while ((Get-Date) -lt $deadline) {
+            if (Test-SqlReady $spec) {
+                $spec.Ready = $true
+                Write-Host "$($spec.Name) is ready"
+                break
+            }
+
+            if (-not (Test-ContainerRunning $spec.Name)) {
+                Write-Host "$($spec.Name) is not running (crashed or exited during startup)"
+                break
+            }
+
+            Start-Sleep -Seconds 1
+        }
+
+        if (-not $spec.Ready) {
+            Write-Host "$($spec.Name) did not become ready"
+            docker logs $spec.Name
+        }
+    }
+
+    if (@($specs | Where-Object { -not $_.Ready }).Count -eq 0) {
+        exit 0
+    }
+}
+
+$failed = @($specs | Where-Object { -not $_.Ready }).Name -join ', '
+Write-Host "##vso[task.logissue type=error]mssql-container: ${failed} did not become ready after ${MaxAttempts} attempts"
+exit 1

--- a/Build/Azure/scripts/sqlserver.2005.cmd
+++ b/Build/Azure/scripts/sqlserver.2005.cmd
@@ -1,16 +1,5 @@
-docker run -d -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=Password12!" -p 1433:1433 -h mssql --name=mssql linq2db/linq2db:win-mssql-2005
-docker ps -a
-
-echo "Waiting for SQL Server to accept connections"
-set max=100
-:repeat
-set /a max=max-1
-if %max% EQU 0 goto fail
-echo pinging sql server
-sleep 1
-docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "SELECT 1"
-if %errorlevel% NEQ 0 goto repeat
-echo "SQL Server is operational"
+pwsh -NoProfile -ExecutionPolicy Bypass -File "%~dp0mssql-container.ps1" -Container "mssql|1433|linq2db/linq2db:win-mssql-2005"
+if %errorlevel% NEQ 0 exit /b 1
 
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "SELECT @@Version"
 
@@ -19,10 +8,3 @@ docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE T
 REM test-DB perf: SIMPLE recovery cuts transaction-log overhead (DELAYED_DURABILITY needs SQL 2014+, N/A here)
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestData SET RECOVERY SIMPLE;"
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestDataMS SET RECOVERY SIMPLE;"
-
-goto:eof
-
-:fail
-echo "Fail"
-docker logs mssql
-exit /b 1

--- a/Build/Azure/scripts/sqlserver.2008.cmd
+++ b/Build/Azure/scripts/sqlserver.2008.cmd
@@ -1,25 +1,9 @@
 rem SQL Server 2008 (host port 1408).
-docker run -d -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=Password12!" -p 1408:1433 -h mssql2008 --name=mssql2008 linq2db/linq2db:win-mssql-2008
-docker ps -a
-
-echo "Waiting for mssql2008 to accept connections"
-set max=100
-:repeat2008
-set /a max=max-1
-if %max% EQU 0 goto fail
-sleep 1
-docker exec mssql2008 sqlcmd -S localhost -U sa -P Password12! -Q "SELECT 1"
-if %errorlevel% NEQ 0 goto repeat2008
+pwsh -NoProfile -ExecutionPolicy Bypass -File "%~dp0mssql-container.ps1" -Container "mssql2008|1408|linq2db/linq2db:win-mssql-2008"
+if %errorlevel% NEQ 0 exit /b 1
 
 docker exec mssql2008 sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData;"
 docker exec mssql2008 sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS;"
 REM test-DB perf: SIMPLE recovery cuts transaction-log overhead (DELAYED_DURABILITY needs SQL 2014+, N/A here)
 docker exec mssql2008 sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestData SET RECOVERY SIMPLE;"
 docker exec mssql2008 sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestDataMS SET RECOVERY SIMPLE;"
-
-goto:eof
-
-:fail
-echo "Fail"
-docker logs mssql2008
-exit /b 1

--- a/Build/Azure/scripts/sqlserver.2012.cmd
+++ b/Build/Azure/scripts/sqlserver.2012.cmd
@@ -1,25 +1,9 @@
 rem SQL Server 2012 (host port 1412).
-docker run -d -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=Password12!" -p 1412:1433 -h mssql2012 --name=mssql2012 linq2db/linq2db:win-mssql-2012
-docker ps -a
-
-echo "Waiting for mssql2012 to accept connections"
-set max=100
-:repeat2012
-set /a max=max-1
-if %max% EQU 0 goto fail
-sleep 1
-docker exec mssql2012 sqlcmd -S localhost -U sa -P Password12! -Q "SELECT 1"
-if %errorlevel% NEQ 0 goto repeat2012
+pwsh -NoProfile -ExecutionPolicy Bypass -File "%~dp0mssql-container.ps1" -Container "mssql2012|1412|linq2db/linq2db:win-mssql-2012"
+if %errorlevel% NEQ 0 exit /b 1
 
 docker exec mssql2012 sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData;"
 docker exec mssql2012 sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS;"
 REM test-DB perf: SIMPLE recovery cuts transaction-log overhead (DELAYED_DURABILITY needs SQL 2014+, N/A here)
 docker exec mssql2012 sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestData SET RECOVERY SIMPLE;"
 docker exec mssql2012 sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestDataMS SET RECOVERY SIMPLE;"
-
-goto:eof
-
-:fail
-echo "Fail"
-docker logs mssql2012
-exit /b 1

--- a/Build/Azure/scripts/sqlserver.2014.cmd
+++ b/Build/Azure/scripts/sqlserver.2014.cmd
@@ -1,25 +1,9 @@
 rem SQL Server 2014 (host port 1414).
-docker run -d -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=Password12!" -p 1414:1433 -h mssql2014 --name=mssql2014 linq2db/linq2db:win-mssql-2014
-docker ps -a
-
-echo "Waiting for mssql2014 to accept connections"
-set max=100
-:repeat2014
-set /a max=max-1
-if %max% EQU 0 goto fail
-sleep 1
-docker exec mssql2014 sqlcmd -S localhost -U sa -P Password12! -Q "SELECT 1"
-if %errorlevel% NEQ 0 goto repeat2014
+pwsh -NoProfile -ExecutionPolicy Bypass -File "%~dp0mssql-container.ps1" -Container "mssql2014|1414|linq2db/linq2db:win-mssql-2014"
+if %errorlevel% NEQ 0 exit /b 1
 
 docker exec mssql2014 sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData;"
 docker exec mssql2014 sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS;"
 REM test-DB perf: SIMPLE recovery + delayed durability cut transaction-log-flush cost on the write-heavy suite
 docker exec mssql2014 sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestData SET RECOVERY SIMPLE; ALTER DATABASE TestData SET DELAYED_DURABILITY = FORCED;"
 docker exec mssql2014 sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestDataMS SET RECOVERY SIMPLE; ALTER DATABASE TestDataMS SET DELAYED_DURABILITY = FORCED;"
-
-goto:eof
-
-:fail
-echo "Fail"
-docker logs mssql2014
-exit /b 1

--- a/Build/Azure/scripts/sqlserver.2016.cmd
+++ b/Build/Azure/scripts/sqlserver.2016.cmd
@@ -1,25 +1,9 @@
 rem SQL Server 2016 (host port 1416).
-docker run -d -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=Password12!" -p 1416:1433 -h mssql2016 --name=mssql2016 linq2db/linq2db:win-mssql-2016
-docker ps -a
-
-echo "Waiting for mssql2016 to accept connections"
-set max=100
-:repeat2016
-set /a max=max-1
-if %max% EQU 0 goto fail
-sleep 1
-docker exec mssql2016 sqlcmd -S localhost -U sa -P Password12! -Q "SELECT 1"
-if %errorlevel% NEQ 0 goto repeat2016
+pwsh -NoProfile -ExecutionPolicy Bypass -File "%~dp0mssql-container.ps1" -Container "mssql2016|1416|linq2db/linq2db:win-mssql-2016"
+if %errorlevel% NEQ 0 exit /b 1
 
 docker exec mssql2016 sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData;"
 docker exec mssql2016 sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS;"
 REM test-DB perf: SIMPLE recovery + delayed durability cut transaction-log-flush cost on the write-heavy suite
 docker exec mssql2016 sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestData SET RECOVERY SIMPLE; ALTER DATABASE TestData SET DELAYED_DURABILITY = FORCED;"
 docker exec mssql2016 sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestDataMS SET RECOVERY SIMPLE; ALTER DATABASE TestDataMS SET DELAYED_DURABILITY = FORCED;"
-
-goto:eof
-
-:fail
-echo "Fail"
-docker logs mssql2016
-exit /b 1

--- a/Build/Azure/scripts/sqlserver.2017_2019.cmd
+++ b/Build/Azure/scripts/sqlserver.2017_2019.cmd
@@ -1,26 +1,7 @@
 rem SQL Server 2017 (host port 1417) and 2019 (host port 1419) run as concurrent lanes in one job.
 rem Each SQL Server listens on 1433 inside its container; the host port differentiates them.
-docker run -d -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=Password12!" -p 1417:1433 -h mssql2017 --name=mssql2017 linq2db/linq2db:win-mssql-2017
-docker run -d -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=Password12!" -p 1419:1433 -h mssql2019 --name=mssql2019 linq2db/linq2db:win-mssql-2019
-docker ps -a
-
-echo "Waiting for mssql2017 to accept connections"
-set max=100
-:repeat2017
-set /a max=max-1
-if %max% EQU 0 goto fail
-sleep 1
-docker exec mssql2017 sqlcmd -S localhost -U sa -P Password12! -Q "SELECT 1"
-if %errorlevel% NEQ 0 goto repeat2017
-
-echo "Waiting for mssql2019 to accept connections"
-set max=100
-:repeat2019
-set /a max=max-1
-if %max% EQU 0 goto fail
-sleep 1
-docker exec mssql2019 sqlcmd -S localhost -U sa -P Password12! -Q "SELECT 1"
-if %errorlevel% NEQ 0 goto repeat2019
+pwsh -NoProfile -ExecutionPolicy Bypass -File "%~dp0mssql-container.ps1" -Container "mssql2017|1417|linq2db/linq2db:win-mssql-2017,mssql2019|1419|linq2db/linq2db:win-mssql-2019"
+if %errorlevel% NEQ 0 exit /b 1
 
 docker exec mssql2017 sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData;"
 docker exec mssql2017 sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS;"
@@ -33,11 +14,3 @@ docker exec mssql2017 sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABAS
 docker exec mssql2017 sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestDataMS SET RECOVERY SIMPLE; ALTER DATABASE TestDataMS SET DELAYED_DURABILITY = FORCED;"
 docker exec mssql2019 sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestData SET RECOVERY SIMPLE; ALTER DATABASE TestData SET DELAYED_DURABILITY = FORCED;"
 docker exec mssql2019 sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestDataMS SET RECOVERY SIMPLE; ALTER DATABASE TestDataMS SET DELAYED_DURABILITY = FORCED;"
-
-goto:eof
-
-:fail
-echo "Fail"
-docker logs mssql2017
-docker logs mssql2019
-exit /b 1

--- a/Build/Azure/scripts/sqlserver.2022_2025.cmd
+++ b/Build/Azure/scripts/sqlserver.2022_2025.cmd
@@ -1,28 +1,9 @@
 rem SQL Server 2022 (host port 1422) and 2025 (host port 1425) run as concurrent lanes in one job.
 rem Each SQL Server listens on 1433 inside its container; the host port differentiates them.
-docker run -d -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=Password12!" -p 1422:1433 -h mssql2022 --name=mssql2022 linq2db/linq2db:win-mssql-2022
-docker run -d -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=Password12!" -p 1425:1433 -h mssql2025 --name=mssql2025 linq2db/linq2db:win-mssql-2025
-docker ps -a
-
-echo "Waiting for mssql2022 to accept connections"
-set max=100
-:repeat2022
-set /a max=max-1
-if %max% EQU 0 goto fail
-sleep 1
-docker exec mssql2022 sqlcmd -S localhost -U sa -P Password12! -Q "SELECT 1"
-if %errorlevel% NEQ 0 goto repeat2022
-
-echo "Waiting for mssql2025 to accept connections"
-set max=100
-:repeat2025
-set /a max=max-1
-if %max% EQU 0 goto fail
-sleep 1
-rem SQL Server 2025 image ships mssql-tools18 sqlcmd, which defaults to encrypted
-rem connections and rejects the self-signed cert without -C (trust server certificate).
-docker exec mssql2025 sqlcmd -S localhost -U sa -P Password12! -Q "SELECT 1" -C
-if %errorlevel% NEQ 0 goto repeat2025
+rem The 2025 image ships mssql-tools18 sqlcmd, which defaults to encrypted connections and rejects
+rem the self-signed cert without -C (trust server certificate) - hence the trailing spec field.
+pwsh -NoProfile -ExecutionPolicy Bypass -File "%~dp0mssql-container.ps1" -Container "mssql2022|1422|linq2db/linq2db:win-mssql-2022,mssql2025|1425|linq2db/linq2db:win-mssql-2025|-C"
+if %errorlevel% NEQ 0 exit /b 1
 
 docker exec mssql2022 sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestData;"
 docker exec mssql2022 sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE TestDataMS;"
@@ -33,11 +14,3 @@ docker exec mssql2022 sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABAS
 docker exec mssql2022 sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestDataMS SET RECOVERY SIMPLE; ALTER DATABASE TestDataMS SET DELAYED_DURABILITY = FORCED;"
 docker exec mssql2025 sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestData SET RECOVERY SIMPLE; ALTER DATABASE TestData SET DELAYED_DURABILITY = FORCED;" -C
 docker exec mssql2025 sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestDataMS SET RECOVERY SIMPLE; ALTER DATABASE TestDataMS SET DELAYED_DURABILITY = FORCED;" -C
-
-goto:eof
-
-:fail
-echo "Fail"
-docker logs mssql2022
-docker logs mssql2025
-exit /b 1

--- a/Build/Azure/scripts/sqlserver.extras.cmd
+++ b/Build/Azure/scripts/sqlserver.extras.cmd
@@ -1,16 +1,5 @@
-docker run -d -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=Password12!" -p 1433:1433 -h mssql --name=mssql linq2db/linq2db:win-mssql-2019
-docker ps -a
-
-echo "Waiting for SQL Server to accept connections"
-set max=100
-:repeat
-set /a max=max-1
-if %max% EQU 0 goto fail
-echo pinging sql server
-sleep 1
-docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "SELECT 1"
-if %errorlevel% NEQ 0 goto repeat
-echo "SQL Server is operational"
+pwsh -NoProfile -ExecutionPolicy Bypass -File "%~dp0mssql-container.ps1" -Container "mssql|1433|linq2db/linq2db:win-mssql-2019"
+if %errorlevel% NEQ 0 exit /b 1
 
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "SELECT @@Version"
 
@@ -27,10 +16,3 @@ docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE Te
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestDataMSSA SET RECOVERY SIMPLE; ALTER DATABASE TestDataMSSA SET DELAYED_DURABILITY = FORCED;"
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestDataContained SET RECOVERY SIMPLE; ALTER DATABASE TestDataContained SET DELAYED_DURABILITY = FORCED;"
 docker exec mssql sqlcmd -S localhost -U sa -P Password12! -Q "ALTER DATABASE TestDataMSContained SET RECOVERY SIMPLE; ALTER DATABASE TestDataMSContained SET DELAYED_DURABILITY = FORCED;"
-
-goto:eof
-
-:fail
-echo "Fail"
-docker logs mssql
-exit /b 1

--- a/Tests/Linq/Linq/TypesTests.cs
+++ b/Tests/Linq/Linq/TypesTests.cs
@@ -7,7 +7,6 @@ using System.Linq.Expressions;
 using System.Threading;
 
 using LinqToDB;
-using LinqToDB.Data;
 using LinqToDB.Internal.Extensions;
 using LinqToDB.Mapping;
 
@@ -631,43 +630,28 @@ namespace Tests.Linq
 		[Test]
 		public void CharTest11([DataSources] string context)
 		{
-			List<PersonCharTest> list;
-
-			using (var db = new DataConnection())
-				list = db.GetTable<PersonCharTest>().ToList();
-
-			using (var db = GetDataContext(context))
-				AreEqual(
-					from p in list                          where p.Gender == 'M' select p.PersonID,
-					from p in db.GetTable<PersonCharTest>() where p.Gender == 'M' select p.PersonID);
+			using var db = GetDataContext(context);
+			AreEqual(
+				from p in Person                        where p.Gender == Gender.Male select p.ID,
+				from p in db.GetTable<PersonCharTest>() where p.Gender == 'M'         select p.PersonID);
 		}
 
 		[Test]
 		public void CharTest12([DataSources] string context)
 		{
-			List<PersonCharTest> list;
-
-			using (var db = new DataConnection())
-				list = db.GetTable<PersonCharTest>().ToList();
-
-			using (var db = GetDataContext(context))
-				AreEqual(
-					from p in list                          where p.Gender == 77 select p.PersonID,
-					from p in db.GetTable<PersonCharTest>() where p.Gender == 77 select p.PersonID);
+			using var db = GetDataContext(context);
+			AreEqual(
+				from p in Person                        where p.Gender == Gender.Male select p.ID,
+				from p in db.GetTable<PersonCharTest>() where p.Gender == 77          select p.PersonID);
 		}
 
 		[Test]
 		public void CharTest2([DataSources] string context)
 		{
-			List<PersonCharTest> list;
-
-			using (var db = new DataConnection())
-				list = db.GetTable<PersonCharTest>().ToList();
-
-			using (var db = GetDataContext(context))
-				AreEqual(
-					from p in list                          where 'M' == p.Gender select p.PersonID,
-					from p in db.GetTable<PersonCharTest>() where 'M' == p.Gender select p.PersonID);
+			using var db = GetDataContext(context);
+			AreEqual(
+				from p in Person                        where p.Gender == Gender.Male select p.ID,
+				from p in db.GetTable<PersonCharTest>() where 'M' == p.Gender         select p.PersonID);
 		}
 
 		[Test]

--- a/Tests/Linq/Update/MergeTests.Operations.Combined.cs
+++ b/Tests/Linq/Update/MergeTests.Operations.Combined.cs
@@ -123,7 +123,7 @@ namespace Tests.xUpdate
 
 			var rows = table
 					.Merge()
-					.Using(GetSource1(db).ToList().Concat(new[] { new TestMapping1() { Id = 1, Field1 = 123 } }))
+					.Using(GetSource1(db).ToList().Concat(new[] { new TestMapping1() { Id = 1, Field1 = 123 } }).OrderBy(r => r.Id))
 					.OnTargetKey()
 					.UpdateWhenMatchedAnd((t, s) => t.Id == 3)
 					.DeleteWhenMatchedAnd((t, s) => s.Id == 1)

--- a/Tests/Linq/Update/MergeTests.Operations.Delete.cs
+++ b/Tests/Linq/Update/MergeTests.Operations.Delete.cs
@@ -369,7 +369,7 @@ namespace Tests.xUpdate
 
 			var rows = table
 					.Merge()
-					.Using(GetSource2(db).ToList().Select(_ => new
+					.Using(GetSource2(db).ToList().OrderBy(r => r.OtherId).Select(_ => new
 					{
 						update = _.OtherId,
 						Update = _.OtherField1,

--- a/Tests/Linq/Update/MergeTests.Operations.DeleteBySource.cs
+++ b/Tests/Linq/Update/MergeTests.Operations.DeleteBySource.cs
@@ -221,7 +221,7 @@ namespace Tests.xUpdate
 
 			var rows = table
 					.Merge()
-					.Using(GetSource2(db).ToList().Select(_ => new
+					.Using(GetSource2(db).ToList().OrderBy(r => r.OtherId).Select(_ => new
 					{
 						INSERT = _.OtherId,
 						insert = _.OtherField2

--- a/Tests/Linq/Update/MergeTests.Operations.Parameters.cs
+++ b/Tests/Linq/Update/MergeTests.Operations.Parameters.cs
@@ -588,7 +588,7 @@ namespace Tests.xUpdate
 
 			var rows = table
 					.Merge()
-					.Using(GetSource1(db).ToList().Select(_ => new { _.Id, Val = (TimeSpan?)param }))
+					.Using(GetSource1(db).ToList().OrderBy(_ => _.Id).Select(_ => new { _.Id, Val = (TimeSpan?)param }))
 					.On((t, s) => t.Id == s.Id && s.Val != null)
 					.UpdateWhenMatched((t, s) => new TestMapping1()
 					{

--- a/Tests/Linq/Update/MergeTests.Operations.UpdateBySource.cs
+++ b/Tests/Linq/Update/MergeTests.Operations.UpdateBySource.cs
@@ -287,7 +287,7 @@ namespace Tests.xUpdate
 
 			var rows = table
 					.Merge()
-					.Using(GetSource2(db).ToList().Select(_ => new
+					.Using(GetSource2(db).ToList().OrderBy(s => s.OtherId).Select(_ => new
 					{
 						Key = _.OtherId,
 						Field01 = _.OtherField1,

--- a/Tests/Linq/Update/MergeTests.Operations.UpdateWithDelete.cs
+++ b/Tests/Linq/Update/MergeTests.Operations.UpdateWithDelete.cs
@@ -476,7 +476,7 @@ namespace Tests.xUpdate
 
 			var rows = table
 					.Merge()
-					.Using(GetSource2(db).ToList().Select(_ => new
+					.Using(GetSource2(db).ToList().OrderBy(_ => _.OtherId).Select(_ => new
 					{
 						Key = _.OtherId,
 						Field01 = _.OtherField1,
@@ -582,7 +582,7 @@ namespace Tests.xUpdate
 
 			var rows = table
 					.Merge()
-					.Using(GetSource2(db).ToList().Select(_ => new
+					.Using(GetSource2(db).ToList().OrderBy(_ => _.OtherId).Select(_ => new
 					{
 						@in = _.OtherId,
 						join = _.OtherField1,


### PR DESCRIPTION
All three job failures in [build 23263](https://dev.azure.com/linq2db/linq2db/_build/results?buildId=23263) (on [#5737](https://github.com/linq2db/linq2db/pull/5737)) are pre-existing infrastructure/test defects, not regressions in that PR. Evidence came from the previous attempt's timeline, since the failed jobs were restarted.

#5737 needs no code change — only a master merge and a CI re-run once this lands.

## 1. `Win d_SqlServer2012` — the agent's docker daemon was down

Every call in `sqlserver.2012.cmd` answered *"failed to connect to the docker API … check if the path is correct and if the daemon is running"*, so `docker run` created nothing and the `max=100` / `sleep 1` wait loop then spent 106 s asking a container that did not exist for a row. Every other Windows docker leg in that build was green, so it was a per-agent flake.

All 8 `sqlserver.*.cmd` carried the same hand-rolled loop, which could not tell apart the three ways the setup fails and recovered from none of them:

- the daemon is unreachable;
- the container died during startup (`firebird.sh` already detects this and fails fast with the logs);
- the container was never created, or came up wedged.

New `Build/Azure/scripts/mssql-container.ps1` probes the daemon first (and gives a stopped `docker` service one push), then retries create-and-wait up to 3 times, with `docker rm -f` ahead of each attempt so a retry cannot collide on the container name, and a `State.Running` check so a crashed startup is not waited out for the full budget. All of a leg's containers still start before any of them is waited on, so the merged 2017+2019 and 2022+2025 legs keep initialising both servers concurrently.

Worst-case step budget is ~7 min (120 s daemon wait + 3 × 100 s readiness) against ~110 s today; those three numbers are documented in the script header. No pipeline file changes — `script_win_global` still points at the same `.cmd`, and the scripts artifact is assembled by a wholesale `xcopy`, so the new `.ps1` ships automatically.

## 2. `Lin k_Firebird` — unordered materialized merge source

`MergeTests.DeleteReservedAndCaseNamesFromList("Firebird.4.LinqService")` failed in TearDown with *"Baselines for remote context doesn't match direct access baselines"*.

The merge source is `GetSource2(db).ToList()` — unordered. `TestMerge2` is read with no `ORDER BY` and that row order flows straight into the generated `MERGE … USING (SELECT … UNION ALL …)`. `PrepareData` deletes and re-inserts before every case, so the direct and the remote run of one provider can materialize different orders, and `BaselinesWriter` compares the second capture against the first byte-for-byte.

`7c3adc075` ("fix unstable tests/baselines") already added `.OrderBy` after `.ToList()` to **seven** sibling merge tests. **Six** sites were missed; this adds the same call to all of them, so every materialized merge source in the suite is now ordered.

## 3. `Lin s_SQLite` — `CharTest` compared two different databases

`CharTest11("SQLite.Classic.MPU")` failed with `Expected: property Count equal to 4 / But was: 3`.

The three `CharTest` methods built their expected list from `new DataConnection()` — the default configuration, which `DataProviders.json` pins to `SQLite.MS` on every leg — and compared it against the context under test. The captured trace shows the two sides hitting different databases:

| side | traced context | rows |
|---|---|---|
| expected | `-- SQLite.MS SQLite`, `SELECT … FROM [Person]` | 5 (4 male) |
| actual | `-- SQLite.Classic.MPU …`, `WHERE [Gender] = 'M'` | 3 |

Those are separate files (`TestData.MS.sqlite` and `TestData.MiniProfiler.Unmapped.sqlite`) and the pristine seed is 4 rows / 3 male, so the default database was carrying a transient extra row written by a concurrent lane. It only bites on the SQLite leg — the one leg where the default provider is itself under test and therefore being mutated.

These now use `TestBase.Person`, the cached reference list every other reference-data comparison in the suite already goes through, which removes the cross-database read and the per-test round trip with it.

## Verification

**Item 1** — the `win-mssql-*` images can't run off a Windows agent, so the helper was exercised against a local SQL Server image on all four paths: unreachable daemon (bogus `DOCKER_HOST`), a container that never answers (3 attempts, `rm -f` + re-create each time, logs dumped, exit 1), the happy path, and a re-run over an already-existing container with two comma-separated specs — the last driven through a real `cmd /c` so the `cmd → pwsh -File` hand-off is proven rather than assumed.

**Item 2** — deterministic red→green on Firebird.4:

| step | state | result |
|---|---|---|
| red | ordering removed, plus a probe reversing the source for the remote case only | 1 of 4 failed, `.sql.other` emitted |
| — | diff `.sql` vs `.sql.other` | 248 lines each, differing **only** in the `UNION ALL` operand order |
| green | `.OrderBy` restored, probe still active | 4/4, no `.other` |
| clean | probe removed, whole `MergeTests` fixture | 357/357 |

The `.other` diff is what settles the mechanism: trace misrouting would have shown missing or extra statements, not a pure reordering of one clause.

Of the 165 regenerated Firebird.4 baselines, **164 are byte-identical** to the committed ones and 0 are new. The one change is `UpdateWithConditionDeleteWithConditionUpdate`, where the `Concat`-appended synthetic `Id = 1` row moves from last to first — same rows, same columns.

**Item 3** — 27/27 passed on `SQLite.Classic`, `SQLite.MS` and `SQLite.Classic.MPU`; the discovered set confirms `CharTest11("SQLite.Classic.MPU")`, the exact CI failure, was included.

**Not verified locally:** 4 of the 7 merge sites need Firebird 5 (`NOT MATCHED BY SOURCE`) or Oracle, so they're covered only by CI here. They are mechanically identical one-line edits to the three that were exercised — and the riskiest of the seven *is* in the covered set, since `TestParametersInSourceEnumerableFirebird` asserts on generated SQL via `LastQuery` and still passes.

A Release build of `Tests/Linq` reported no diagnostics in any file this PR touches.
