### PR TITLE
CI: capture and push baselines from the GitHub Linux legs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,12 @@ on:
       ref:
         description: 'Ref to test. Defaults to the branch this workflow was dispatched on.'
         required: false
+      baselines_branch:
+        description: 'Baselines branch to push to, e.g. baselines/pr_5848. Empty = do not capture baselines.'
+        required: false
+      pr:
+        description: 'Source PR number, for the courtesy comment on the baselines PR.'
+        required: false
 
 permissions:
   contents: read
@@ -37,6 +43,7 @@ env:
   TEST_SOLUTION_FILTER: linq2db.Testing.slnf
   TEST_CONFIGURATION: Azure
   TEST_RETRY_ARGS: --retry-failed-tests 2 --retry-failed-tests-max-tests 5
+  BASELINES_MASTER: master
 
 jobs:
   # Reads the same test-matrix.yml Azure compiles, which is the point of expressing entry selection as
@@ -238,6 +245,19 @@ jobs:
       - name: Make scripts executable
         run: chmod +x scripts/*.sh
 
+      # Cloned to <leg root>/baselines because AzureConnectionStrings sets
+      # BaselinesPath: ./../../../baselines, resolved from the test assembly. Sparse and shallow: the
+      # leg only ever appends whole files, and the full tree is 343541 files. Master, not the run
+      # branch - the push is what creates that.
+      - name: Checkout test baselines
+        if: inputs.baselines_branch != ''
+        env:
+          TOKEN: ${{ secrets.BASELINES_GH_PAT }}
+        run: >
+          git clone --depth 1 --single-branch --sparse -c http.proactiveAuth=basic
+          --branch "$BASELINES_MASTER"
+          "https://x-access-token:$TOKEN@github.com/linq2db/linq2db.baselines.git" baselines
+
       - name: Free disk space
         run: scripts/free-disk-space.sh
 
@@ -329,5 +349,25 @@ jobs:
           TITLE: ${{ matrix.title }}
         run: |
           ./scripts/report-trx.ps1 -ResultsDirectory TestResults -Title "Lin $Env:TITLE"
+          exit $LASTEXITCODE
+
+      # Default success() gating, matching Azure: a failed leg pushes nothing, because the report
+      # step above has already failed the job by then. The first leg to get here creates the branch
+      # and opens the PR; the rest rebase onto it.
+      - name: Commit test baselines
+        if: inputs.baselines_branch != ''
+        shell: pwsh
+        working-directory: baselines
+        env:
+          GITHUB_TOKEN: ${{ secrets.BASELINES_GH_PAT }}
+          EMAIL: actions@linq2db.com
+          GIT_AUTHOR_NAME: GitHub Actions Bot
+          GIT_COMMITTER_NAME: GitHub Actions Bot
+          TITLE: ${{ matrix.title }}
+          BRANCH: ${{ inputs.baselines_branch }}
+          PR_ID: ${{ inputs.pr }}
+        run: |
+          ../scripts/push-baselines.ps1 -Platform Linux -Title "$Env:TITLE" -Branch "$Env:BRANCH" `
+            -BaselinesMaster "$Env:BASELINES_MASTER" -PrId "$Env:PR_ID" -GitHubAnnotations
           exit $LASTEXITCODE
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -253,10 +253,16 @@ jobs:
         if: inputs.baselines_branch != ''
         env:
           TOKEN: ${{ secrets.BASELINES_GH_PAT }}
-        run: >
-          git clone --depth 1 --single-branch --sparse -c http.proactiveAuth=basic
-          --branch "$BASELINES_MASTER"
-          "https://x-access-token:$TOKEN@github.com/linq2db/linq2db.baselines.git" baselines
+        run: |
+          # Named, because an empty token clones as x-access-token:@... and git then fails on the
+          # password it is missing rather than on the thing that is actually wrong.
+          if [ -z "$TOKEN" ]; then
+            echo "::error::BASELINES_GH_PAT is not set, but baselines_branch was supplied - nothing could be pushed"
+            exit 1
+          fi
+          git clone --depth 1 --single-branch --sparse -c http.proactiveAuth=basic \
+            --branch "$BASELINES_MASTER" \
+            "https://x-access-token:$TOKEN@github.com/linq2db/linq2db.baselines.git" baselines
 
       - name: Free disk space
         run: scripts/free-disk-space.sh


### PR DESCRIPTION
Second increment of the GitHub Actions test side, on top of #5866: the Linux legs now capture and push baselines, the way the Azure legs do.

This has to land **before** the Azure→GitHub dispatch. Dispatching real work to legs that discard their baselines would silently lose them, so the order matters.

## What changed

Two steps, mirroring `test-workflow-linux.yml`:

- **`Checkout test baselines`** — sparse, shallow clone of `linq2db.baselines` at `<leg root>/baselines`. That location is not arbitrary: `AzureConnectionStrings` sets `BaselinesPath: ./../../../baselines`, resolved relative to the test assembly, so `<tfm>/main/x64/../../../baselines` puts it exactly there. Nothing in `DataProviders.json` needed changing.
- **`Commit test baselines`** — the shared `Build/CI/push-baselines.ps1` with `-GitHubAnnotations`, on the same `success()` gating Azure uses (a failed leg pushes nothing, because the report step has already failed the job).

Both are gated on a new **`baselines_branch`** input. Empty means capture nothing, so a hand-run dispatch behaves exactly as it did before this PR. The branch name comes from the caller because Azure's `ensure-baselines-branch.ps1` owns creating it — the dispatch job will forward it.

Also new: a `pr` input, which `push-baselines.ps1` uses for the courtesy comment on the source PR.

The clone carries `-c http.proactiveAuth=basic` and the `x-access-token:` credential form from #5859. Both are load-bearing and neither had ever been exercised outside Azure: git sends credentials only after a 401, GitHub never challenges an anonymous read of a public repo, and an incomplete credential makes git prompt for the password it lacks.

Author identity is `GitHub Actions Bot <actions@linq2db.com>` rather than Azure's `linq2db bot`, so a baselines commit records which CI produced it.

## Verification

Dispatched end to end against `[sqlite.all]` with `baselines_branch=baselines/gha-probe` (run 33892423049, green). `pr` was left empty on purpose so no courtesy comment landed on an unrelated PR.

| Check | Result |
|---|---|
| `Checkout test baselines` executed, not skipped | `success` |
| Clone landed where the tests look for it | commit produced, so `BaselinesPath` resolved |
| Branch created by the first pusher | `baselines/gha-probe` |
| PR opened by the first pusher | `linq2db.baselines#2100` |
| Commit message | `[Linux / SQLite (all providers)] baselines` |
| Author | `GitHub Actions Bot <actions@linq2db.com>` |

The probe branch and PR have been cleaned up.

Two things that verification was specifically for, since neither is visible by reading: `BASELINES_GH_PAT` on the GitHub side is a **different token** from the one Azure holds, and the clone location was the real risk — had it been off by a directory, the tests would have written baselines elsewhere and the push would have been a silent no-op on a green run.

## Note on dispatching workflow changes

Now that `tests.yml` is on master, `gh workflow run --ref <branch>` runs **that branch's** version of the workflow. Confirmed by dispatching with the `pr` input, which exists only on this branch — master's definition would have rejected it as unexpected, and it returned 204. So changes to this workflow no longer need the temporary `push` trigger that #5866 used.
