### PR TITLE
CI: let Azure dispatch the GitHub Actions test workflow

### DIFF
--- a/Build/Azure/pipelines/templates/test-jobs.yml
+++ b/Build/Azure/pipelines/templates/test-jobs.yml
@@ -19,6 +19,13 @@ parameters:
 - name: full_run
   type: boolean
   default: false
+  # Default true, so merging the dispatch job changes nothing: Azure keeps running the whole matrix
+  # and GitHub is not asked to. Flip it to false in the same change that moves legs to GitHub, or
+  # both CIs run everything. Settable per-run from the Azure UI, which is how the dispatch gets
+  # exercised before that.
+- name: all_in_azure
+  type: boolean
+  default: true
   # Linux legs allowed to run at once, out of the ten slots the project has. 0 leaves the job
   # uncapped, which is the default because a cap measured worse than none.
   #
@@ -75,6 +82,50 @@ jobs:
       EMAIL: azp@linq2db.com
       GIT_AUTHOR_NAME: Azure Pipelines Bot
       GIT_COMMITTER_NAME: Azure Pipelines Bot
+
+##############################################################################################
+#  Hands the same surface to the GitHub Actions `tests` workflow. Fire-and-verify, not        #
+#  fire-and-forget: the job ends as soon as the run is confirmed created, so no Azure slot is  #
+#  held while GitHub tests.                                                                    #
+##############################################################################################
+- ${{ if eq(parameters.all_in_azure, false) }}:
+  - job: dispatch_github
+    pool:
+      vmImage: 'ubuntu-24.04'
+    displayName: 'Dispatch GitHub tests'
+    dependsOn: create_baselines_branch
+    # Fork PRs are deliberately excluded, and stay Azure-only: workflow_dispatch needs a branch or
+    # tag in this repo, and a fork PR has only refs/pull/<n>/head, which the endpoint rejects with
+    # 422 "No ref found". Pushing the head to a scratch branch would work but writes back to the repo
+    # from CI. The carve-out also keeps the Azure path exercised on real work rather than letting it
+    # rot into an untested fallback.
+    condition: and(eq(${{ parameters.enabled }}, 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
+    variables:
+      source_pr_id: $[coalesce(variables['system.pullRequest.pullRequestNumber'], '')]
+      baselines_branch: $[ dependencies.create_baselines_branch.outputs['baselines_init.baselines_branch'] ]
+
+    steps:
+    - checkout: none
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: $(artifact_test_scripts)
+        targetPath: '$(System.DefaultWorkingDirectory)/scripts'
+      displayName: Extract test scripts
+    - task: PowerShell@2
+      inputs:
+        pwsh: true
+        filePath: '$(System.DefaultWorkingDirectory)/scripts/dispatch-github-tests.ps1'
+        arguments: >
+          -Ref "$(System.PullRequest.SourceBranch)"
+          -Surface "${{ parameters.db_filter }}"
+          -BaselinesBranch "$(baselines_branch)"
+          -PrId "$(source_pr_id)"
+          -FullRun $${{ parameters.full_run }}
+        workingDirectory: '$(System.DefaultWorkingDirectory)'
+      displayName: Dispatch GitHub tests
+      name: gh_dispatch
+      env:
+        GITHUB_TOKEN: $(GITHUB_DISPATCH_PAT)
 
 ###################
 #  Tests: Windows #

--- a/Build/Azure/pipelines/templates/test-jobs.yml
+++ b/Build/Azure/pipelines/templates/test-jobs.yml
@@ -100,9 +100,20 @@ jobs:
     # from CI. The carve-out also keeps the Azure path exercised on real work rather than letting it
     # rot into an untested fallback.
     condition: and(eq(${{ parameters.enabled }}, 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
+    # List form, because the group has to be scoped here rather than pipeline-wide: a top-level
+    # `- group:` would hand the dispatch PAT to every job in every test definition, including the
+    # provider legs that run third-party database images.
     variables:
-      source_pr_id: $[coalesce(variables['system.pullRequest.pullRequestNumber'], '')]
-      baselines_branch: $[ dependencies.create_baselines_branch.outputs['baselines_init.baselines_branch'] ]
+    - group: github-dispatch
+    - name: source_pr_id
+      value: $[coalesce(variables['system.pullRequest.pullRequestNumber'], '')]
+    - name: baselines_branch
+      value: $[ dependencies.create_baselines_branch.outputs['baselines_init.baselines_branch'] ]
+      # The PR's head branch on a PR build; Build.SourceBranch otherwise. Never Build.SourceBranch on
+      # a PR build - that is refs/pull/<n>/merge, which workflow_dispatch rejects. The fallback is
+      # what makes a manual run work, which is the only way to set all_in_azure from the UI.
+    - name: dispatch_ref
+      value: $[coalesce(variables['System.PullRequest.SourceBranch'], variables['Build.SourceBranch'])]
 
     steps:
     - checkout: none
@@ -116,7 +127,7 @@ jobs:
         pwsh: true
         filePath: '$(System.DefaultWorkingDirectory)/scripts/dispatch-github-tests.ps1'
         arguments: >
-          -Ref "$(System.PullRequest.SourceBranch)"
+          -Ref "$(dispatch_ref)"
           -Surface "${{ parameters.db_filter }}"
           -BaselinesBranch "$(baselines_branch)"
           -PrId "$(source_pr_id)"

--- a/Build/Azure/pipelines/templates/test-matrix.yml
+++ b/Build/Azure/pipelines/templates/test-matrix.yml
@@ -4,6 +4,7 @@ parameters:
   full_run: false # when false, only netfx and latest netX tests executed (linq2db only, efcore tests executed for all TFMs always)
   linux_max_parallel: 0 # linux legs allowed to run at once, 0 for uncapped. See test-jobs.yml.
   db_filter: '[all]'
+  all_in_azure: true # when true, no GitHub Actions dispatch. See test-jobs.yml.
 
 # db_filter specify test db selection filter for pipeline. Current list of supported values:
 # - '[all]' - any target supported
@@ -94,6 +95,7 @@ jobs:
       # Required by test-jobs.yml, which does the per-entry filter test. Forgetting it is a compile
       # error there by design - see the note on its parameters block.
       db_filter: ${{ parameters.db_filter }}
+      all_in_azure: ${{ parameters.all_in_azure }}
       test_matrix:
 # Two things decide the order legs run in, and which one you see depends on whether the job caps its
 # parallelism. Both were measured on build 23050, the first run to carry a cap.

--- a/Build/Azure/pipelines/testing.yml
+++ b/Build/Azure/pipelines/testing.yml
@@ -1,5 +1,16 @@
+parameters:
+# Settable from the Azure "Run pipeline" dialog. Default true keeps every leg on Azure and dispatches
+# nothing, so this pipeline behaves exactly as before; set it false for a run to hand the same surface
+# to GitHub Actions as well.
+- name: all_in_azure
+  type: boolean
+  default: true
+  displayName: 'Run everything on Azure (no GitHub Actions dispatch)'
+
 variables:
   - template: templates/build-vars.yml
+  # Carries GITHUB_DISPATCH_PAT for the dispatch job.
+  - group: github-dispatch
 
 trigger: none
 pr:
@@ -35,6 +46,7 @@ stages:
         enabled: succeeded()
         with_baselines: true
         full_run: false
+        all_in_azure: ${{ parameters.all_in_azure }}
         # db_filter parameter. [] wrap used to avoid potential naming conflicts
         ${{ if eq(variables['Build.DefinitionName'], 'test-access') }}:
           db_filter: '[access.all]'

--- a/Build/Azure/pipelines/testing.yml
+++ b/Build/Azure/pipelines/testing.yml
@@ -9,8 +9,6 @@ parameters:
 
 variables:
   - template: templates/build-vars.yml
-  # Carries GITHUB_DISPATCH_PAT for the dispatch job.
-  - group: github-dispatch
 
 trigger: none
 pr:

--- a/Build/CI/dispatch-github-tests.ps1
+++ b/Build/CI/dispatch-github-tests.ps1
@@ -16,7 +16,9 @@ Exit codes: 0 = run created, 1 = dispatch rejected or no run appeared, 2 = bad a
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory)][string] $Ref,
+    # AllowEmptyString, or parameter binding rejects an empty $(dispatch_ref) with "Cannot bind
+    # argument to parameter 'Ref'" before the validation below can say what is actually wrong.
+    [Parameter(Mandatory)][AllowEmptyString()][string] $Ref,
     [Parameter(Mandatory)][string] $Surface,
     [string] $BaselinesBranch = '',
     [string] $PrId            = '',
@@ -33,8 +35,19 @@ if (-not $Env:GITHUB_TOKEN) {
     exit 2
 }
 
-# Branch name without refs/heads/, which is what Azure's SourceBranch carries.
-$branch = $Ref -replace '^refs/heads/', ''
+# Validated here rather than left to the API, which answers every bad ref with the same 422 and no
+# indication of which of these it was.
+if ([string]::IsNullOrWhiteSpace($Ref)) {
+    Write-Host "##vso[task.logissue type=error]-Ref is empty - on a non-PR run it should fall back to Build.SourceBranch"
+    exit 2
+}
+if ($Ref -like 'refs/pull/*') {
+    Write-Host "##vso[task.logissue type=error]-Ref is '$Ref'. workflow_dispatch takes a branch or tag; a pull ref is rejected. Fork PRs must be skipped by the caller, and a PR build must pass System.PullRequest.SourceBranch, not Build.SourceBranch (which is refs/pull/<n>/merge)."
+    exit 2
+}
+
+# Azure's SourceBranch carries the refs/ prefix; the API wants the short name.
+$branch = $Ref -replace '^refs/(heads|tags)/', ''
 
 $headers = @{
     Authorization          = "Bearer $Env:GITHUB_TOKEN"

--- a/Build/CI/dispatch-github-tests.ps1
+++ b/Build/CI/dispatch-github-tests.ps1
@@ -1,0 +1,83 @@
+<#
+dispatch-github-tests.ps1 - trigger the GitHub Actions `tests` workflow from Azure Pipelines.
+
+Verifies the run appeared rather than trusting the POST: the dispatch endpoint answers 204 with no
+body, so a wrong ref, a revoked token or a workflow rename all look identical to success from the
+caller's side. Exits non-zero when no run shows up, so the Azure job fails loudly instead of leaving
+the impression that GitHub is testing something.
+
+`ref` must be a branch or tag in the target repo. A fork PR has only refs/pull/<n>/head, which the
+endpoint rejects with 422 "No ref found" - callers must skip fork PRs rather than pass that.
+
+Auth: $Env:GITHUB_TOKEN, a PAT with Actions: Read and write (fine-grained) on the target repo.
+
+Exit codes: 0 = run created, 1 = dispatch rejected or no run appeared, 2 = bad arguments.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string] $Ref,
+    [Parameter(Mandatory)][string] $Surface,
+    [string] $BaselinesBranch = '',
+    [string] $PrId            = '',
+    [bool]   $FullRun         = $false,
+    [string] $Repo            = 'linq2db/linq2db',
+    [string] $Workflow        = 'tests.yml',
+    [int]    $VerifyTimeoutSeconds = 90
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $Env:GITHUB_TOKEN) {
+    Write-Host "##vso[task.logissue type=error]GITHUB_TOKEN is not set - it carries the dispatch PAT"
+    exit 2
+}
+
+# Branch name without refs/heads/, which is what Azure's SourceBranch carries.
+$branch = $Ref -replace '^refs/heads/', ''
+
+$headers = @{
+    Authorization          = "Bearer $Env:GITHUB_TOKEN"
+    Accept                 = 'application/vnd.github+json'
+    'X-GitHub-Api-Version' = '2022-11-28'
+}
+$api = "https://api.github.com/repos/$Repo/actions/workflows/$Workflow"
+
+# Every input is a string on the wire, including the boolean.
+$inputs = @{ surface = $Surface; full_run = $FullRun.ToString().ToLowerInvariant() }
+if ($BaselinesBranch) { $inputs.baselines_branch = $BaselinesBranch }
+if ($PrId)            { $inputs.pr               = $PrId }
+
+$since = (Get-Date).ToUniversalTime().AddSeconds(-30)
+Write-Host "Dispatching $Workflow on ${branch}: surface=$Surface full_run=$FullRun baselines_branch='$BaselinesBranch' pr='$PrId'"
+
+try {
+    Invoke-RestMethod -Method Post -Uri "$api/dispatches" -Headers $headers `
+        -ContentType 'application/json' `
+        -Body (@{ ref = $branch; inputs = $inputs } | ConvertTo-Json -Compress) | Out-Null
+}
+catch {
+    Write-Host "##vso[task.logissue type=error]dispatch rejected: $($_.Exception.Message)"
+    if ($_.ErrorDetails.Message) { Write-Host $_.ErrorDetails.Message }
+    exit 1
+}
+
+# The run takes a moment to register, and the endpoint gives us no id to look it up by.
+$deadline = (Get-Date).AddSeconds($VerifyTimeoutSeconds)
+while ((Get-Date) -lt $deadline) {
+    Start-Sleep -Seconds 5
+    try {
+        $runs = Invoke-RestMethod -Uri "$api/runs?event=workflow_dispatch&branch=$branch&per_page=10" -Headers $headers
+    } catch { continue }
+
+    $run = $runs.workflow_runs | Where-Object { [datetime]::Parse($_.created_at).ToUniversalTime() -ge $since } |
+        Sort-Object { [datetime]::Parse($_.created_at) } -Descending | Select-Object -First 1
+    if ($run) {
+        Write-Host "GitHub run: $($run.html_url)"
+        Write-Host "##vso[task.setvariable variable=github_run_id;isOutput=true]$($run.id)"
+        exit 0
+    }
+}
+
+Write-Host "##vso[task.logissue type=error]dispatch accepted but no run appeared within ${VerifyTimeoutSeconds}s - check the workflow's triggers and the token's Actions permission"
+exit 1


### PR DESCRIPTION
Third increment of the GitHub Actions test side: Azure can now hand a surface to the GitHub `tests` workflow. **Off by default — merging this changes no run.**

> **Merge after #5868.** The dispatch passes a `baselines_branch` input that only exists on `tests.yml` once #5868 lands; before that the endpoint rejects the call with `422 Unexpected inputs`. That is a runtime ordering constraint, not a code dependency — this PR touches no workflow file, so the diff is independent.

## The switch

A pipeline parameter `all_in_azure`, settable from Azure's *Run pipeline* dialog:

| Value | Behaviour |
|---|---|
| `true` (default) | Every leg on Azure, no dispatch. Exactly today's behaviour. |
| `false` | Same surface also handed to GitHub Actions. |

Flipping the **default** belongs in the change that moves legs to GitHub — until then both CIs would run everything. Keeping it opt-in means the handshake can be exercised on a real PR without doubling anyone's runs, and the parameter is the one the migration wants long-term rather than a throwaway.

## Fire-and-verify, not fire-and-forget

`Build/CI/dispatch-github-tests.ps1` polls for the created run and **fails the job if none appears**. The dispatch endpoint answers `204` with no body, so a wrong ref, a revoked token and a renamed workflow are all indistinguishable from success at the call site. A silent no-op that reads as *"GitHub is testing this"* is precisely the failure class this migration keeps producing — Azure build 23192 went green having run zero tests, and build 23199 ran all 29 legs for a single-provider request. The job ends as soon as the run is confirmed, so no Azure slot is held while GitHub tests.

## Fork PRs stay on Azure

`workflow_dispatch` requires `ref` to be a **branch or tag in the target repo**. A fork PR has only `refs/pull/<n>/head`, which the endpoint rejects:

```
$ gh api .../actions/workflows/tests.yml/dispatches -f ref=refs/pull/5866/head ...
422  No ref found for: refs/pull/5866/head

$ git ls-remote https://github.com/linq2db/linq2db refs/pull/5866/head
b6e0f7987...  refs/pull/5866/head
```

The ref exists — so this is the endpoint refusing pull refs as a *kind*, not a missing ref. Pushing the head to a scratch branch would work, but writes back to the repo from CI. The carve-out also has a real upside: it keeps the Azure path exercised on live work instead of letting it rot into an untested fallback.

## Two structural notes

- The job is included by a **compile-time `${{ if }}`** in the sequence-item form `testing.yml` already uses, not a runtime condition on the boolean. A bare mapping key inside the `jobs` sequence is not a shape this repo proves, and Azure template errors surface as pipeline-init failures with an *empty timeline* — expensive to diagnose for no gain.
- `GITHUB_DISPATCH_PAT` comes from a new **`github-dispatch` variable group**, the first in this repo. The alternative was pasting the token into 18 definitions and rotating it in all of them; `BASELINES_GH_PAT` is currently duplicated that way.

## Known divergence, worth recording

Azure tests the PR **merge commit**; a dispatched GitHub run tests the **branch head**, because `workflow_dispatch` takes a branch. For most PRs these agree, but a PR that is stale against master will be tested against different code on the two CIs. Not addressed here — flagging it because it is invisible until it bites.

## Verification

Not exercised end to end yet: it needs #5868 merged and `GITHUB_DISPATCH_PAT` in place. What has been verified — all four pipeline files parse, the job list shape is `[job, ${{ if }}, job, job]` matching the proven pattern, the script parses, and the fork-PR rejection above was measured against the live API.
