### PR TITLE
CI: start the GitHub test legs from the PR comment, not from Azure

### DIFF
--- a/.github/workflows/tests-comment.yml
+++ b/.github/workflows/tests-comment.yml
@@ -1,0 +1,122 @@
+# Starts the GitHub test legs from the same `/azp run test-<db>` comment Azure listens for, so one
+# comment starts both CIs at once.
+#
+# It calls tests.yml rather than dispatching it, which is what makes fork PRs work: workflow_dispatch
+# needs a branch in this repo and a fork PR has only refs/pull/<n>/head, but a called workflow takes
+# the ref as an input and actions/checkout fetches refs/pull/<n>/merge happily.
+#
+# issue_comment always runs the default branch's copy of this file, whatever the PR contains - so a PR
+# cannot alter its own trigger, and changes here only take effect once merged.
+name: tests (comment)
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write   # the refusal comment and the acknowledgement reaction
+
+jobs:
+  authorize:
+    # Cheap gate first: PR comments that look like a trigger. The membership check is a step, not
+    # part of this, so a refusal can be reported rather than silently skipped.
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/azp run')
+    runs-on: ubuntu-24.04
+    outputs:
+      go: ${{ steps.resolve.outputs.go }}
+      surface: ${{ steps.resolve.outputs.surface }}
+      ref: ${{ steps.resolve.outputs.ref }}
+      baselines_branch: ${{ steps.resolve.outputs.baselines_branch }}
+    steps:
+      # MEMBER is "member of the organization that owns the repository", which is the requirement:
+      # a fork PR's author is CONTRIBUTOR and cannot trigger even on their own PR, and an outside
+      # COLLABORATOR cannot either. OWNER is accepted because it is strictly more privileged.
+      #
+      # author_association is used rather than the members API on purpose: GITHUB_TOKEN is not an org
+      # member, so /orgs/{org}/members only reveals *public* members to it and every private member
+      # would be refused. Fixing that needs a PAT, which this trigger exists to avoid.
+      - name: Check org membership
+        id: gate
+        env:
+          ASSOC: ${{ github.event.comment.author_association }}
+        run: |
+          case "$ASSOC" in
+            MEMBER|OWNER) echo "ok=true"  >> "$GITHUB_OUTPUT" ;;
+            *)            echo "ok=false" >> "$GITHUB_OUTPUT" ;;
+          esac
+          echo "association=$ASSOC" >> "$GITHUB_OUTPUT"
+
+      # Refusals are announced. A silent skip would be indistinguishable from the workflow being
+      # broken, and this gate's values are not something we have observed across every real caller yet.
+      - name: Explain the refusal
+        if: steps.gate.outputs.ok != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ASSOC: ${{ steps.gate.outputs.association }}
+          NUMBER: ${{ github.event.issue.number }}
+          WHO: ${{ github.event.comment.user.login }}
+        run: |
+          gh pr comment "$NUMBER" --repo "$GITHUB_REPOSITORY" --body \
+            "@$WHO the GitHub test legs can only be started by a linq2db organization member (your association here is \`$ASSOC\`). Azure Pipelines will still pick up this comment."
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: steps.gate.outputs.ok == 'true'
+        with:
+          sparse-checkout: Build/Azure/pipelines/templates/test-matrix.yml
+          sparse-checkout-cone-mode: false
+
+      - name: Resolve surface
+        id: resolve
+        if: steps.gate.outputs.ok == 'true'
+        env:
+          BODY: ${{ github.event.comment.body }}
+          NUMBER: ${{ github.event.issue.number }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if ! python3 -c 'import yaml' 2>/dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y python3-yaml
+          fi
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import os, re, sys, yaml
+          body = os.environ['BODY']
+          # `/azp run <definition>`, the same spelling Azure accepts. A bare `/azp run` means every
+          # pipeline on the Azure side; here it maps to test-all's surface.
+          m = re.match(r'^/azp\s+run\s*(\S+)?', body.strip())
+          name = (m.group(1) if m and m.group(1) else 'test-all').strip()
+
+          doc = yaml.safe_load(open('Build/Azure/pipelines/templates/test-matrix.yml', encoding='utf-8'))
+          surfaces = doc['parameters']['surfaces']
+          surface = surfaces.get(name)
+          if not surface:
+              print(f"::notice::'{name}' has no GitHub surface - leaving it to Azure", file=sys.stderr)
+              print('go=false')
+              raise SystemExit(0)
+
+          n = os.environ['NUMBER']
+          print('go=true')
+          print('surface=' + surface)
+          print(f'ref=refs/pull/{n}/merge')
+          # Same branch Azure's ensure-baselines-branch.ps1 derives, so both CIs append to one branch.
+          print(f'baselines_branch=baselines/pr_{n}')
+          PY
+
+      - name: Acknowledge
+        if: steps.resolve.outputs.go == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content=rocket --silent
+
+  tests:
+    needs: authorize
+    if: needs.authorize.outputs.go == 'true'
+    uses: ./.github/workflows/tests.yml
+    with:
+      surface: ${{ needs.authorize.outputs.surface }}
+      ref: ${{ needs.authorize.outputs.ref }}
+      baselines_branch: ${{ needs.authorize.outputs.baselines_branch }}
+      pr: ${{ github.event.issue.number }}
+    secrets: inherit

--- a/.github/workflows/tests-comment.yml
+++ b/.github/workflows/tests-comment.yml
@@ -15,7 +15,9 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write   # the refusal comment and the acknowledgement reaction
+  pull-requests: write   # the refusal comment - POST /issues/{n}/comments takes either of these two
+  issues: write          # the acknowledgement reaction - POST /issues/comments/{id}/reactions takes
+                         # only this one, so pull-requests alone would 403
 
 jobs:
   authorize:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,9 @@
-# Provider tests on GitHub Actions - first increment: the Linux legs, baselines off, no Azure dispatch.
+# Provider tests on GitHub Actions - the Linux legs.
 #
-# Deliberately scoped. Baselines need BASELINES_GH_PAT as a repository secret and the dispatch needs a
-# PAT on the Azure side; neither exists yet, and neither is needed to prove the part that is actually
-# uncertain - that a provider leg can download the build artifacts, resolve its config, start its
-# database, run the suite and report. Those two are additive on top.
-#
-# Triggered by hand for now (`gh workflow run tests.yml -f surface='[sqlite.all]'`). The Azure pipeline
-# will dispatch it later, which is why the inputs already carry the values that handshake needs.
+# Run it by hand (`gh workflow run tests.yml -f surface='[sqlite.all]'`), from Azure's dispatch job, or
+# through tests-comment.yml when someone comments `/azp run test-<db>` on a PR. The comment path is the
+# one that reaches fork PRs: it calls this workflow rather than dispatching it, so `ref` can be
+# refs/pull/<n>/merge, which workflow_dispatch refuses.
 name: tests
 
 on:
@@ -28,6 +25,26 @@ on:
         required: false
       pr:
         description: 'Source PR number, for the courtesy comment on the baselines PR.'
+        required: false
+
+  # Same inputs, because workflow_call cannot reuse the workflow_dispatch block and Actions has no
+  # anchors. Keep the two in step.
+  workflow_call:
+    inputs:
+      surface:
+        type: string
+        required: true
+      full_run:
+        type: boolean
+        default: false
+      ref:
+        type: string
+        required: false
+      baselines_branch:
+        type: string
+        required: false
+      pr:
+        type: string
         required: false
 
 permissions:

--- a/Build/Azure/pipelines/templates/test-jobs.yml
+++ b/Build/Azure/pipelines/templates/test-jobs.yml
@@ -19,13 +19,12 @@ parameters:
 - name: full_run
   type: boolean
   default: false
-  # Default true, so merging the dispatch job changes nothing: Azure keeps running the whole matrix
-  # and GitHub is not asked to. Flip it to false in the same change that moves legs to GitHub, or
-  # both CIs run everything. Settable per-run from the Azure UI, which is how the dispatch gets
-  # exercised before that.
-- name: all_in_azure
+  # Off by default: Azure keeps running the whole matrix and GitHub is not asked to, so this changes
+  # no run until legs actually move. Named for what it enables - the earlier all_in_azure spelling
+  # inverted the UI checkbox, and build 23357 ran a full matrix proving nothing because of it.
+- name: dispatch_github
   type: boolean
-  default: true
+  default: false
   # Linux legs allowed to run at once, out of the ten slots the project has. 0 leaves the job
   # uncapped, which is the default because a cap measured worse than none.
   #
@@ -88,7 +87,7 @@ jobs:
 #  fire-and-forget: the job ends as soon as the run is confirmed created, so no Azure slot is  #
 #  held while GitHub tests.                                                                    #
 ##############################################################################################
-- ${{ if eq(parameters.all_in_azure, false) }}:
+- ${{ if eq(parameters.dispatch_github, true) }}:
   - job: dispatch_github
     pool:
       vmImage: 'ubuntu-24.04'
@@ -111,7 +110,7 @@ jobs:
       value: $[ dependencies.create_baselines_branch.outputs['baselines_init.baselines_branch'] ]
       # The PR's head branch on a PR build; Build.SourceBranch otherwise. Never Build.SourceBranch on
       # a PR build - that is refs/pull/<n>/merge, which workflow_dispatch rejects. The fallback is
-      # what makes a manual run work, which is the only way to set all_in_azure from the UI.
+      # what makes a manual run work, which is the only way to set dispatch_github from the UI.
     - name: dispatch_ref
       value: $[coalesce(variables['System.PullRequest.SourceBranch'], variables['Build.SourceBranch'])]
 

--- a/Build/Azure/pipelines/templates/test-matrix.yml
+++ b/Build/Azure/pipelines/templates/test-matrix.yml
@@ -3,8 +3,34 @@ parameters:
   with_baselines: false
   full_run: false # when false, only netfx and latest netX tests executed (linq2db only, efcore tests executed for all TFMs always)
   linux_max_parallel: 0 # linux legs allowed to run at once, 0 for uncapped. See test-jobs.yml.
-  db_filter: '[all]'
-  all_in_azure: true # when true, no GitHub Actions dispatch. See test-jobs.yml.
+  db_filter: '[all]' # fallback for a definition absent from `surfaces` below, e.g. default.yml
+  dispatch_github: false # when true, also hand the surface to GitHub Actions. See test-jobs.yml.
+
+  # Which surface each Azure pipeline definition tests, keyed by definition name. Data rather than
+  # the if-chain this replaced in testing.yml, for the reason #5848 moved entry selection here: an
+  # Azure template expression is readable only by Azure, and the GitHub side needs the same mapping
+  # to turn `/azp run test-db2` into a surface. A definition not listed here falls back to db_filter.
+  #
+  # Not derivable by convention - four of these do not follow strip-`test-`-and-append-`.all`.
+  surfaces:
+    test-access:          '[access.all]'
+    test-clickhouse:      '[clickhouse.all]'
+    test-db2:             '[db2.all]'
+    test-duckdb:          '[duckdb.all]'
+    test-firebird:        '[firebird.all]'
+    test-informix:        '[informix.all]'
+    test-mysql:           '[mysql.all]'
+    test-oracle:          '[oracle.all]'
+    test-postgresql:      '[postgresql.all]'
+    test-saphana:         '[saphana.all]'
+    test-sqlce:           '[sqlce.all]'
+    test-sqlite:          '[sqlite.all]'
+    test-sqlserver:       '[sqlserver.all]'
+    test-sqlserver-2019:  '[sqlserver.2019]'
+    test-sqlserver-2022:  '[sqlserver.2022]'
+    test-sybase:          '[sybase.ase.all]'
+    test-ydb:             '[ydb.all]'
+    test-all:             '[all]'
 
 # db_filter specify test db selection filter for pipeline. Current list of supported values:
 # - '[all]' - any target supported
@@ -94,8 +120,8 @@ jobs:
       linux_max_parallel: ${{ parameters.linux_max_parallel }}
       # Required by test-jobs.yml, which does the per-entry filter test. Forgetting it is a compile
       # error there by design - see the note on its parameters block.
-      db_filter: ${{ parameters.db_filter }}
-      all_in_azure: ${{ parameters.all_in_azure }}
+      db_filter: ${{ coalesce(parameters.surfaces[variables['Build.DefinitionName']], parameters.db_filter) }}
+      dispatch_github: ${{ parameters.dispatch_github }}
       test_matrix:
 # Two things decide the order legs run in, and which one you see depends on whether the job caps its
 # parallelism. Both were measured on build 23050, the first run to carry a cap.

--- a/Build/Azure/pipelines/testing.yml
+++ b/Build/Azure/pipelines/testing.yml
@@ -1,11 +1,12 @@
 parameters:
-# Settable from the Azure "Run pipeline" dialog. Default true keeps every leg on Azure and dispatches
-# nothing, so this pipeline behaves exactly as before; set it false for a run to hand the same surface
-# to GitHub Actions as well.
-- name: all_in_azure
+# Settable from the Azure "Run pipeline" dialog. Off by default, so this pipeline behaves exactly as
+# before; tick it for a run to hand the same surface to GitHub Actions as well. Phrased as the thing
+# it enables - the earlier all_in_azure spelling meant the box had to be *unticked* to turn the
+# feature on, which is how build 23357 ran a full matrix proving nothing.
+- name: dispatch_github
   type: boolean
-  default: true
-  displayName: 'Run everything on Azure (no GitHub Actions dispatch)'
+  default: false
+  displayName: 'Also run the tests on GitHub Actions'
 
 variables:
   - template: templates/build-vars.yml
@@ -44,39 +45,8 @@ stages:
         enabled: succeeded()
         with_baselines: true
         full_run: false
-        all_in_azure: ${{ parameters.all_in_azure }}
-        # db_filter parameter. [] wrap used to avoid potential naming conflicts
-        ${{ if eq(variables['Build.DefinitionName'], 'test-access') }}:
-          db_filter: '[access.all]'
-        ${{ if eq(variables['Build.DefinitionName'], 'test-db2') }}:
-          db_filter: '[db2.all]'
-        ${{ if eq(variables['Build.DefinitionName'], 'test-firebird') }}:
-          db_filter: '[firebird.all]'
-        ${{ if eq(variables['Build.DefinitionName'], 'test-informix') }}:
-          db_filter: '[informix.all]'
-        ${{ if eq(variables['Build.DefinitionName'], 'test-mysql') }}:
-          db_filter: '[mysql.all]'
-        ${{ if eq(variables['Build.DefinitionName'], 'test-oracle') }}:
-          db_filter: '[oracle.all]'
-        ${{ if eq(variables['Build.DefinitionName'], 'test-postgresql') }}:
-          db_filter: '[postgresql.all]'
-        ${{ if eq(variables['Build.DefinitionName'], 'test-saphana') }}:
-          db_filter: '[saphana.all]'
-        ${{ if eq(variables['Build.DefinitionName'], 'test-sqlce') }}:
-          db_filter: '[sqlce.all]'
-        ${{ if eq(variables['Build.DefinitionName'], 'test-sqlite') }}:
-          db_filter: '[sqlite.all]'
-        ${{ if eq(variables['Build.DefinitionName'], 'test-sqlserver') }}:
-          db_filter: '[sqlserver.all]'
-        ${{ if eq(variables['Build.DefinitionName'], 'test-sqlserver-2019') }}:
-          db_filter: '[sqlserver.2019]'
-        ${{ if eq(variables['Build.DefinitionName'], 'test-sqlserver-2022') }}:
-          db_filter: '[sqlserver.2022]'
-        ${{ if eq(variables['Build.DefinitionName'], 'test-sybase') }}:
-          db_filter: '[sybase.ase.all]'
-        ${{ if eq(variables['Build.DefinitionName'], 'test-clickhouse') }}:
-          db_filter: '[clickhouse.all]'
-        ${{ if eq(variables['Build.DefinitionName'], 'test-duckdb') }}:
-          db_filter: '[duckdb.all]'
-        ${{ if eq(variables['Build.DefinitionName'], 'test-ydb') }}:
-          db_filter: '[ydb.all]'
+        dispatch_github: ${{ parameters.dispatch_github }}
+        # db_filter is resolved inside test-matrix.yml from its surfaces map, keyed by definition
+        # name. It used to be a 34-line if-chain here, which only Azure could read - the GitHub side
+        # needs the same mapping, and #5848 already moved entry selection into that file for exactly
+        # this reason.


### PR DESCRIPTION
Moves the GitHub trigger off Azure, so one `/azp run` comment starts both CIs **simultaneously** instead of GitHub waiting on Azure's queue.

## The problem this fixes

The dispatch job from #5869 sits behind three sequential Azure agent acquisitions:

```
dispatch_github  ->  create_baselines_branch  ->  build_job
```

So GitHub cannot start until Azure has finished a full build and then acquired two more agents. When Azure is saturated — the condition this whole migration exists to fix — GitHub idles with twenty free slots. Build **23357** was queued `notStarted` for exactly this reason while the question was being discussed.

The dependency is almost entirely artificial: the GitHub workflow builds its own artifacts and needs nothing from `build_job`. The only real Azure input is the baselines branch *name*, a string derived from the PR number.

## What changed

`tests-comment.yml` reads the same `/azp run test-<db>` comment Azure listens for and starts the legs itself. No Azure involvement, so both CIs start at once. Two things fall out of that:

- **No PAT.** The built-in `GITHUB_TOKEN` is enough, so `GITHUB_DISPATCH_PAT` becomes unnecessary for this path.
- **Fork PRs work.** It *calls* `tests.yml` rather than dispatching it, so the ref is an input and can be `refs/pull/<n>/merge` — which `workflow_dispatch` rejects outright (`422 No ref found`, measured on #5869). The fork carve-out that PR documented is no longer forced.

`tests.yml` gains a `workflow_call` trigger mirroring its `workflow_dispatch` inputs. Actions has no anchors, so the two blocks are duplicated and must be kept in step; there's a check for that below.

## Authorization

Only **linq2db organization members**. `author_association` of `MEMBER` means exactly "member of the organization that owns the repository", so:

| Commenter | Association | Can trigger |
|---|---|---|
| org member | `MEMBER` | yes |
| org owner | `OWNER` | yes |
| outside collaborator | `COLLABORATOR` | no |
| fork PR author, on their own PR | `CONTRIBUTOR` | no |
| anyone else | `NONE` | no |

The members API is deliberately **not** used: `GITHUB_TOKEN` is not an org member, so `/orgs/{org}/members` reveals only *public* members to it and every private member would be refused — and fixing that needs the PAT this change exists to retire.

A refusal **posts a comment naming the association** rather than skipping silently, so a false negative is visible immediately rather than looking like a broken workflow.

**Security note worth reviewing explicitly:** on a fork PR this runs fork code with `secrets: inherit`, i.e. with `BASELINES_GH_PAT` present. That is the same exposure Azure has today, and the org-member gate is the control — a member is expected to read the diff before commenting. This is the standard `/ok-to-test` pattern, but it is a deliberate trade-off rather than an oversight.

## Surface selection becomes data

The 34-line `${{ if eq(variables['Build.DefinitionName'], …) }}` chain in `testing.yml` — readable only by Azure — becomes a `surfaces` map in `test-matrix.yml` that both CIs read. `testing.yml` no longer computes `db_filter` at all. Same move #5848 made for entry selection, one level up.

Not derivable by convention: `test-all`, `test-sybase` (`[sybase.ase.all]`) and the two `test-sqlserver-<year>` definitions all break strip-`test-`-and-append-`.all`.

## Switch inverted

`all_in_azure` meant the UI checkbox had to be **unticked** to turn the feature on — and build 23357 duly ran with `all_in_azure: "True"`, dispatching nothing. It is now `dispatch_github`, default `false`, labelled *"Also run the tests on GitHub Actions"*.

## Verification

Ran the shipped resolver — extracted from the workflow, not a copy — against the real `test-matrix.yml`:

| comment | surface |
|---|---|
| `/azp run test-sqlite` | `[sqlite.all]` |
| `/azp run test-sqlserver-2019` | `[sqlserver.2019]` |
| `/azp run test-sybase` | `[sybase.ase.all]` |
| `/azp run` | `[all]` |
| `/azp run test-cli` | declined — no GitHub surface, left to Azure |
| `/azp run test-nonsense` | declined |

Also checked mechanically: every surface value maps to at least one matrix entry, every matrix filter token is requestable by some definition, `workflow_call` and `workflow_dispatch` input sets are identical, and all four pipeline files plus both workflows parse.

**Not yet exercised end to end** — that needs this merged, since `issue_comment` always runs the default branch's copy of the workflow. First real test is a `/azp run test-sqlite` comment after merge.

## Follow-up

The Azure `dispatch_github` job is left in place. It becomes redundant once this path proves out, but removing it beforehand would leave no fallback.
