### PR TITLE
CI: count a retried-then-passed test as passed in report-trx

### DIFF
--- a/Build/CI/report-trx.ps1
+++ b/Build/CI/report-trx.ps1
@@ -70,13 +70,22 @@ foreach ($group in $trx | Group-Object Name) {
 
         foreach ($r in @($doc.TestRun.Results.UnitTestResult)) {
             $outcome[$r.testName] = $r.outcome
-            if ($r.outcome -eq 'Failed') { $message[$r.testName] = ($r.Output.ErrorInfo.Message -join ' ').Trim() }
+            $message[$r.testName] = ($r.Output.ErrorInfo.Message -join ' ').Trim()
         }
     }
 
-    $stillFailed = @($outcome.Keys | Where-Object { $outcome[$_] -eq 'Failed' })
-    $total   = [int] $baseCounters.total
-    $skipped = $total - [int] $baseCounters.executed
+    # Anything that is not Passed and not NotExecuted counts as a failure - Error, Timeout, Aborted,
+    # Inconclusive and the rest. Classifying by outcome rather than deriving passed as a remainder,
+    # which would have folded every one of those into the passed column and exited 0.
+    $stillFailed = @($outcome.Keys | Where-Object { $outcome[$_] -notin @('Passed', 'NotExecuted') })
+    $skipped     = @($outcome.Keys | Where-Object { $outcome[$_] -eq 'NotExecuted' }).Count
+    $total       = $outcome.Count
+
+    # The counters summarise the same rows, so a disagreement means one of the two is being read
+    # wrongly - say so rather than quietly reporting a different number from Azure's.
+    if ($null -ne $baseCounters -and [int] $baseCounters.total -ne $total) {
+        Write-Host "::warning::report-trx: $($group.Name) lists $total results but its counters say $([int] $baseCounters.total)"
+    }
 
     $rows += [pscustomobject]@{
         File     = $group.Name
@@ -88,7 +97,7 @@ foreach ($group in $trx | Group-Object Name) {
     }
 
     foreach ($name in $stillFailed) {
-        $failures += [pscustomobject]@{ Test = $name; Message = $message[$name] }
+        $failures += [pscustomobject]@{ Test = $name; Message = "[$($outcome[$name])] $($message[$name])".Trim() }
     }
 }
 

--- a/Build/CI/report-trx.ps1
+++ b/Build/CI/report-trx.ps1
@@ -45,24 +45,50 @@ if ($trx.Count -eq 0) {
 $rows = @()
 $failures = @()
 
-foreach ($file in $trx) {
-    [xml] $doc = Get-Content -LiteralPath $file.FullName -Raw
+# --retry-failed-tests writes each attempt as its own .trx under Retries/<id>/<attempt>/, holding only
+# the tests it re-ran, next to the full run at the top of the results directory. Summing them all
+# counts a test that failed and then passed as a failure, so every retry leg went red while its own
+# test steps exited 0 - the three Oracle legs on GitHub run 33946658182.
+#
+# So group by file name, which is suite+TFM, and replay the attempts in order: a test's outcome is the
+# one from the last attempt that contains it. Attempt order is the numeric directory under Retries/,
+# with the top-level file first.
+$attemptOrder = {
+    param($file)
+    if ($file.FullName -match '[/\\]Retries[/\\][^/\\]+[/\\](\d+)[/\\]') { [int] $Matches[1] } else { 0 }
+}
 
-    # MTP writes the VSTest schema, so counters are on ResultSummary/Counters.
-    $counters = $doc.TestRun.ResultSummary.Counters
-    $rows += [pscustomobject]@{
-        File    = $file.Name
-        Total   = [int] $counters.total
-        Passed  = [int] $counters.passed
-        Failed  = [int] $counters.failed
-        Skipped = ([int] $counters.total - [int] $counters.executed)
+foreach ($group in $trx | Group-Object Name) {
+    $outcome = [ordered]@{}   # test name -> last outcome seen
+    $message = @{}            # test name -> failure message from that attempt
+    $baseCounters = $null
+
+    foreach ($file in $group.Group | Sort-Object @{ Expression = $attemptOrder }) {
+        [xml] $doc = Get-Content -LiteralPath $file.FullName -Raw
+        # MTP writes the VSTest schema, so counters are on ResultSummary/Counters.
+        if ($null -eq $baseCounters) { $baseCounters = $doc.TestRun.ResultSummary.Counters }
+
+        foreach ($r in @($doc.TestRun.Results.UnitTestResult)) {
+            $outcome[$r.testName] = $r.outcome
+            if ($r.outcome -eq 'Failed') { $message[$r.testName] = ($r.Output.ErrorInfo.Message -join ' ').Trim() }
+        }
     }
 
-    foreach ($r in @($doc.TestRun.Results.UnitTestResult | Where-Object { $_.outcome -eq 'Failed' })) {
-        $failures += [pscustomobject]@{
-            Test    = $r.testName
-            Message = ($r.Output.ErrorInfo.Message -join ' ').Trim()
-        }
+    $stillFailed = @($outcome.Keys | Where-Object { $outcome[$_] -eq 'Failed' })
+    $total   = [int] $baseCounters.total
+    $skipped = $total - [int] $baseCounters.executed
+
+    $rows += [pscustomobject]@{
+        File     = $group.Name
+        Attempts = $group.Count
+        Total    = $total
+        Passed   = $total - $skipped - $stillFailed.Count
+        Failed   = $stillFailed.Count
+        Skipped  = $skipped
+    }
+
+    foreach ($name in $stillFailed) {
+        $failures += [pscustomobject]@{ Test = $name; Message = $message[$name] }
     }
 }
 
@@ -76,12 +102,12 @@ $totals = [pscustomobject]@{
 $md = [System.Collections.Generic.List[string]]::new()
 $md.Add("### $Title")
 $md.Add('')
-$md.Add('| Result file | Total | Passed | Failed | Skipped |')
-$md.Add('|---|---:|---:|---:|---:|')
+$md.Add('| Result file | Attempts | Total | Passed | Failed | Skipped |')
+$md.Add('|---|---:|---:|---:|---:|---:|')
 foreach ($r in $rows) {
-    $md.Add("| $($r.File) | $($r.Total) | $($r.Passed) | $($r.Failed) | $($r.Skipped) |")
+    $md.Add("| $($r.File) | $($r.Attempts) | $($r.Total) | $($r.Passed) | $($r.Failed) | $($r.Skipped) |")
 }
-$md.Add("| **total** | **$($totals.Total)** | **$($totals.Passed)** | **$($totals.Failed)** | **$($totals.Skipped)** |")
+$md.Add("| **total** | | **$($totals.Total)** | **$($totals.Passed)** | **$($totals.Failed)** | **$($totals.Skipped)** |")
 
 if ($failures.Count -gt 0) {
     $md.Add('')


### PR DESCRIPTION
Found by the first `test-all` on GitHub ([run 33946658182](https://github.com/linq2db/linq2db/actions/runs/33946658182)): **all three Oracle legs went red while their own test steps exited 0**. They are exactly the Linux legs with `retry: true`.

## Cause

`--retry-failed-tests` writes each attempt as its own `.trx` under `Retries/<id>/<attempt>/`, containing only the tests it re-ran, alongside the full run:

```
TestResults/net10.0-main-x64.trx
TestResults/Retries/zt1cQ/1/net10.0-main-x64.trx
TestResults/Retries/zt1cQ/2/net10.0-main-x64.trx
```

`report-trx.ps1` recursed and summed them, so a test that failed and then passed was counted once as a failure *and* once as a pass. `t_Oracle1112` reported this:

| Result file | Total | Passed | Failed | Skipped |
|---|---:|---:|---:|---:|
| net10.0-main-x64.trx | 2 | 2 | 0 | 0 |
| net10.0-main-x64.trx | 20334 | 19988 | 2 | 344 |
| **total** | **20357** | **20011** | **2** | **344** |

Two rows, same filename: the 2-test row *is* the retry, showing both tests passing. MTP exited 0; the report said 2 failed and failed the leg.

## Fix

Group attempts by file name — which is suite plus TFM — and replay them in order, so a test's outcome is the one from the **last attempt that contains it**. The table gains an `Attempts` column, so a leg that needed retries says so rather than hiding it.

## Verification

Against a fixture reproducing the real layout above:

| retry outcome | exit | totals reported |
|---|---|---|
| passes | **0** — matches MTP | 5 total, 4 passed, 0 failed, 1 skipped |
| fails | **1** | 5 total, 2 passed, 2 failed, 1 skipped |

The escaping probe from #5848 still passes, and the missing-`.trx` guard is untouched — a leg whose test app never ran still fails.

## Scope

This affects every `retry: true` entry: the three Oracle legs today, and `r_Access_MDB` / `v_Access_ACE_Odbc` / `x_Access_ACE_OleDb` once the Windows legs move to GitHub. It is GitHub-only; Azure uses `PublishTestResults@2`, which handles the retry layout itself.

Separately, that same run had one **genuine** failure on ClickHouse — `ProvidersWithoutCreateDatabaseArePreMarkedReady`, an `Assume.That(unsignalled, Is.Not.Empty)` reporting *"no lane key without a CreateDatabase case is enabled for this run"*. That is unrelated to this fix and is being compared against Azure's leg on the same PR before deciding whether it is environment-specific.
