### PR TITLE
CI: put the GitHub test run on the PR as a commit status

### DIFF
--- a/.github/workflows/tests-comment.yml
+++ b/.github/workflows/tests-comment.yml
@@ -18,6 +18,7 @@ permissions:
   pull-requests: write   # the refusal comment - POST /issues/{n}/comments takes either of these two
   issues: write          # the acknowledgement reaction - POST /issues/comments/{id}/reactions takes
                          # only this one, so pull-requests alone would 403
+  statuses: write        # the commit status that puts this run on the PR - see the report job
 
 jobs:
   authorize:
@@ -30,6 +31,8 @@ jobs:
       surface: ${{ steps.resolve.outputs.surface }}
       ref: ${{ steps.resolve.outputs.ref }}
       baselines_branch: ${{ steps.resolve.outputs.baselines_branch }}
+      head_sha: ${{ steps.status.outputs.head_sha }}
+      context: ${{ steps.status.outputs.context }}
     steps:
       # MEMBER is "member of the organization that owns the repository", which is the requirement:
       # a fork PR's author is CONTRIBUTOR and cannot trigger even on their own PR, and an outside
@@ -112,6 +115,29 @@ jobs:
           gh api "repos/$GITHUB_REPOSITORY/issues/comments/${{ github.event.comment.id }}/reactions" \
             -f content=rocket --silent
 
+      # An issue_comment run is associated with the default branch's commit, not the PR's, so GitHub
+      # has nothing to attach a check to and the run is invisible on the PR - findable only in the
+      # Actions tab. A commit status on the PR's head puts it in the checks list where a reviewer
+      # actually looks. The context carries the surface, so two surfaces on one PR do not overwrite
+      # each other's status.
+      - name: Report pending on the PR
+        id: status
+        if: steps.resolve.outputs.go == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUMBER: ${{ github.event.issue.number }}
+          SURFACE: ${{ steps.resolve.outputs.surface }}
+        run: |
+          head_sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$NUMBER" --jq .head.sha)
+          context="tests $SURFACE"
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "context=$context"   >> "$GITHUB_OUTPUT"
+          gh api "repos/$GITHUB_REPOSITORY/statuses/$head_sha" --silent \
+            -f state=pending \
+            -f context="$context" \
+            -f description='Running on GitHub Actions' \
+            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+
   tests:
     needs: authorize
     if: needs.authorize.outputs.go == 'true'
@@ -122,3 +148,30 @@ jobs:
       baselines_branch: ${{ needs.authorize.outputs.baselines_branch }}
       pr: ${{ github.event.issue.number }}
     secrets: inherit
+
+  # Closes the pending status. always(), or a failed or cancelled run leaves the PR showing "pending"
+  # for good - worse than no status at all, because it reads as still running.
+  report:
+    needs: [authorize, tests]
+    if: always() && needs.authorize.outputs.go == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      statuses: write
+    steps:
+      - env:
+          GH_TOKEN: ${{ github.token }}
+          RESULT: ${{ needs.tests.result }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          CONTEXT: ${{ needs.authorize.outputs.context }}
+        run: |
+          # success/failure are the only states a checks list renders usefully; cancelled and skipped
+          # both mean "no result", which is a failure of the thing the reviewer wanted.
+          case "$RESULT" in
+            success) state=success; desc='All legs passed' ;;
+            *)       state=failure; desc="Run $RESULT" ;;
+          esac
+          gh api "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" --silent \
+            -f state="$state" \
+            -f context="$CONTEXT" \
+            -f description="$desc" \
+            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"

--- a/.github/workflows/tests-comment.yml
+++ b/.github/workflows/tests-comment.yml
@@ -164,6 +164,20 @@ jobs:
           HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
           CONTEXT: ${{ needs.authorize.outputs.context }}
         run: |
+          run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+
+          # Two comments for the same surface produce two runs writing one context, so a slower older
+          # run can finish last and overwrite a newer run's status - reporting a stale result against
+          # a link that is not the newest run. The combined-status endpoint gives one entry per
+          # context, so if it no longer points at this run, a newer one owns the context and this one
+          # stays quiet.
+          current=$(gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/status" \
+            --jq ".statuses[] | select(.context == \"$CONTEXT\") | .target_url" 2>/dev/null || true)
+          if [ -n "$current" ] && [ "$current" != "$run_url" ]; then
+            echo "::notice::a newer run owns '$CONTEXT' ($current) - leaving its status alone"
+            exit 0
+          fi
+
           # success/failure are the only states a checks list renders usefully; cancelled and skipped
           # both mean "no result", which is a failure of the thing the reviewer wanted.
           case "$RESULT" in
@@ -174,4 +188,4 @@ jobs:
             -f state="$state" \
             -f context="$CONTEXT" \
             -f description="$desc" \
-            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            -f target_url="$run_url"


### PR DESCRIPTION
The GitHub test run was **invisible on the PR**. Reported from #5704: the `test-all` comment started both CIs, GitHub ran 15 legs green-except-four, and the PR's checks list showed only the `build` workflow's jobs. The tests were findable solely in the Actions tab.

## Cause

An `issue_comment` run is associated with the **default branch's** commit, not the PR's — the PR ref is only checked out *inside* the jobs. So GitHub has no commit of the PR's to attach a check run to, and nothing appears.

## Fix

`authorize` posts a **pending commit status** against the PR's head sha; a new `report` job closes it as success or failure. Statuses attach to a commit, and a PR renders its head commit's statuses in the checks list, which is where a reviewer looks.

- **Context carries the surface** — `tests [sqlite.all]` — so two surfaces on one PR don't overwrite each other's status.
- **`target_url`** points at the run, so the status is one click from the logs.
- **`report` is `always()`.** A failed or cancelled run would otherwise leave the PR showing *pending* permanently, which reads as "still running" and is worse than no status at all. `cancelled` and `skipped` both report as failure: they mean the reviewer didn't get the answer they asked for.

Needs `statuses: write`, which is what `POST /repos/{owner}/{repo}/statuses/{sha}` documents as `"Commit statuses"` write — checked against GitHub's REST metadata rather than assumed, as with the `issues: write` grant in #5871.

## Note

This applies to future triggers only; the existing run on #5704 won't gain a status retroactively.

Also worth knowing for reviewers: a commit status is not a *check run*, so it can't carry annotations or a summary — those stay on the workflow run itself, linked from the status. Creating a real check run is possible with `checks: write`, and would render the per-leg detail inline on the PR; it's a bigger change and worth doing separately if the status proves too coarse.
