### PR TITLE
CI: pre-build LinqToDB too, the other project CS2012 hits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,10 +79,11 @@ jobs:
       # Properties must match the solution build - a VERSION_ARGS mismatch recompiles them and the
       # race is back.
       #
-      # The Roslyn components are the clearest case: single-TFM, so the plain build and the
-      # TargetFramework-pinned inner build a multi-TFM consumer asks for share one obj path with no
-      # target-framework segment. That set is CodeGenerators plus everything pinned by
-      # Source/Analyzers.Common.props; a new Roslyn component belongs here.
+      # The Roslyn components are the clearest case. Being single-TFM, their obj path carries no
+      # target-framework segment, so two builds write the same file: the plain one, and the
+      # TargetFramework-pinned inner build that a multi-TFM consumer negotiates. That set is
+      # CodeGenerators plus everything pinned by Source/Analyzers.Common.props; a new Roslyn
+      # component belongs here.
       #
       # LinqToDB is here for a different reason and was added after the first three did not stop it:
       # it is the most-referenced project in the repo, so many consumers request the same

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,13 +73,23 @@ jobs:
             'VERSION_ARGS=-p:VersionSuffix=-dev.${{ github.run_number }}' | Out-File -FilePath $env:GITHUB_ENV -Append
           }
 
-      # Avoids intermittent CS2012 on these projects (dotnet/roslyn#77538): single-TFM and reached
-      # from multi-TFM LinqToDB, so each builds twice concurrently - plain, and as a
-      # TargetFramework-pinned inner build - into one obj path. Pre-building makes both skip.
-      # The set is CodeGenerators plus everything pinned by Source/Analyzers.Common.props; add new
-      # Roslyn components here. Properties must match the solution build - a VERSION_ARGS mismatch
-      # recompiles these and the race is back.
-      - name: Build Roslyn components
+      # Avoids intermittent CS2012 (dotnet/roslyn#77538), where one project is compiled twice
+      # concurrently into the same obj path and the second write loses. Pre-building serialises the
+      # projects it happens to, so the solution build finds them current and skips compiling them.
+      # Properties must match the solution build - a VERSION_ARGS mismatch recompiles them and the
+      # race is back.
+      #
+      # The Roslyn components are the clearest case: single-TFM, so the plain build and the
+      # TargetFramework-pinned inner build a multi-TFM consumer asks for share one obj path with no
+      # target-framework segment. That set is CodeGenerators plus everything pinned by
+      # Source/Analyzers.Common.props; a new Roslyn component belongs here.
+      #
+      # LinqToDB is here for a different reason and was added after the first three did not stop it:
+      # it is the most-referenced project in the repo, so many consumers request the same
+      # TargetFramework=net8.0 instance at once, and two nodes can start it before either registers.
+      # Observed as CS2012 on .build/obj/LinqToDB/Release/net8.0/linq2db.dll, on a PR touching only
+      # Azure YAML.
+      - name: Build hot-spot projects
         shell: pwsh
         run: |
           $common = @(
@@ -92,6 +102,7 @@ jobs:
             'Source/CodeGenerators/CodeGenerators.csproj'
             'Source/LinqToDB.Analyzers/LinqToDB.Analyzers.csproj'
             'Source/LinqToDB.Analyzers.CodeFixes/LinqToDB.Analyzers.CodeFixes.csproj'
+            'Source/LinqToDB/LinqToDB.csproj'
           )) {
             dotnet build $project @common
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }


### PR DESCRIPTION
The pre-build added in #5858 covered the Roslyn components and **did not stop the race**. #5872's build failed with:

```
CSC : error CS2012: Cannot open '.build\obj\LinqToDB\Release\net8.0\linq2db.dll' for writing
-- ... because it is being used by another process.
```

on a PR that changes only Azure YAML and deletes a pwsh script — nothing compiled. So this is the same intermittent CS2012 (dotnet/roslyn#77538), reaching a project the existing fix doesn't cover.

## Why LinqToDB races, and why it's a different mechanism

The Roslyn components collide for a specific reason: they are **single-TFM**, so their obj path has no target-framework segment, and the plain build and the `TargetFramework`-pinned inner build a multi-TFM consumer negotiates both write `.build/obj/<name>/Release/<name>.dll`.

`LinqToDB` is multi-TFM and its path *does* carry the TFM — `.../Release/net8.0/linq2db.dll` — so the two colliding writes are **the same instance**, not two differently-parameterised ones. It is the most-referenced project in the repo, so many consumers request `TargetFramework=net8.0` concurrently and two MSBuild nodes can start it before either registers its result.

That is why extending the existing list is the fix rather than re-deriving one: the *remedy* is the same (make it current before the parallel phase), even though the *cause* differs.

## Cost

None in duplicate work — the solution build compiles `LinqToDB` anyway. Pre-building only moves it ahead of the parallel phase, trading a little parallelism for determinism on the project most likely to be contended.

The step is renamed from **Build Roslyn components** to **Build hot-spot projects**, since the list no longer describes only Roslyn components, and the comment now separates the two mechanisms so the next person adding to the list knows which case they have.

## Honest limitation

This is still a workaround for an upstream bug that has been open since 2024, and it is reactive: it covers the two projects observed to lose the race. A project that starts racing later needs adding. The root fix is in how these projects are referenced — for the Roslyn components, `SkipGetTargetFrameworkProperties` or equivalent on the `ProjectReference` — which touches every consumer and analyzer delivery and belongs in its own change.
