### PR TITLE
CI: base a test leg's baselines clone on the run branch, not master

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -266,23 +266,17 @@ jobs:
         run: chmod +x scripts/*.sh
 
       # Cloned to <leg root>/baselines because AzureConnectionStrings sets
-      # BaselinesPath: ./../../../baselines, resolved from the test assembly. Sparse and shallow: the
-      # leg only ever appends whole files, and the full tree is 343541 files. Master, not the run
-      # branch - the push is what creates that.
+      # BaselinesPath: ./../../../baselines, resolved from the test assembly. The script picks the
+      # base - the run branch when it exists, master otherwise - and says why it matters.
       - name: Checkout test baselines
         if: inputs.baselines_branch != ''
+        shell: pwsh
         env:
-          TOKEN: ${{ secrets.BASELINES_GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.BASELINES_GH_PAT }}
+          BRANCH: ${{ inputs.baselines_branch }}
         run: |
-          # Named, because an empty token clones as x-access-token:@... and git then fails on the
-          # password it is missing rather than on the thing that is actually wrong.
-          if [ -z "$TOKEN" ]; then
-            echo "::error::BASELINES_GH_PAT is not set, but baselines_branch was supplied - nothing could be pushed"
-            exit 1
-          fi
-          git clone --depth 1 --single-branch --sparse -c http.proactiveAuth=basic \
-            --branch "$BASELINES_MASTER" \
-            "https://x-access-token:$TOKEN@github.com/linq2db/linq2db.baselines.git" baselines
+          ./scripts/checkout-baselines.ps1 -Branch "$Env:BRANCH" -BaselinesMaster "$Env:BASELINES_MASTER"
+          exit $LASTEXITCODE
 
       - name: Free disk space
         run: scripts/free-disk-space.sh

--- a/Build/Azure/pipelines/templates/test-workflow-linux.yml
+++ b/Build/Azure/pipelines/templates/test-workflow-linux.yml
@@ -61,24 +61,16 @@ steps:
   condition: and(variables.title, succeeded())
   displayName: Extract test scripts
 
-- task: CmdLine@2
+- task: PowerShell@2
   inputs:
-    # The leg needs the index, not the tree: BaselinesWriter creates its own directories and always
-    # writes whole files, so nothing here is ever read back from the repository. --sparse lays out the
-    # two root files instead of 343541, and --depth 1 --single-branch skips ~420 Mb of history for a
-    # tree the leg only appends to. Master is cloned rather than the run branch, which may not
-    # exist yet - see the push below. The commit step pairs this with git add --sparse.
-    #
-    # http.proactiveAuth is what makes the token in the url count: git sends credentials only after a
-    # 401 challenge, and github never challenges an anonymous read of a public repository - so without
-    # it this clone is unauthenticated and github's unauthenticated-download throttle kills the leg
-    # (three legs on build 23238). The credential also has to be complete - user:token, not token
-    # alone, or git asks for the password it is missing. -c is written to the clone's config, so the
-    # fetch in the push retry below authenticates too.
-    script: 'git clone --depth 1 --single-branch --sparse -c http.proactiveAuth=basic --branch $(baselines_master) https://x-access-token:$(BASELINES_GH_PAT)@github.com/linq2db/linq2db.baselines.git baselines'
+    pwsh: true
+    filePath: '$(System.DefaultWorkingDirectory)/scripts/checkout-baselines.ps1'
+    arguments: -Branch "$(baselines_branch)" -BaselinesMaster "$(baselines_master)"
     workingDirectory: '$(System.DefaultWorkingDirectory)'
   displayName: Checkout test baselines
   condition: and(variables.title, ${{ parameters.with_baselines }}, succeeded())
+  env:
+    GITHUB_TOKEN: $(BASELINES_GH_PAT)
 
 - task: DownloadPipelineArtifact@2
   inputs:

--- a/Build/Azure/pipelines/templates/test-workflow-windows.yml
+++ b/Build/Azure/pipelines/templates/test-workflow-windows.yml
@@ -127,24 +127,16 @@ steps:
   condition: and(variables.title, succeeded())
   displayName: Extract test scripts
 
-- task: CmdLine@2
+- task: PowerShell@2
   inputs:
-    # The leg needs the index, not the tree: BaselinesWriter creates its own directories and always
-    # writes whole files, so nothing here is ever read back from the repository. --sparse lays out the
-    # two root files instead of 343541, and --depth 1 --single-branch skips ~420 Mb of history for a
-    # tree the leg only appends to. Master is cloned rather than the run branch, which may not
-    # exist yet - see the push below. The commit step pairs this with git add --sparse.
-    #
-    # http.proactiveAuth is what makes the token in the url count: git sends credentials only after a
-    # 401 challenge, and github never challenges an anonymous read of a public repository - so without
-    # it this clone is unauthenticated and github's unauthenticated-download throttle kills the leg
-    # (three legs on build 23238). The credential also has to be complete - user:token, not token
-    # alone, or git asks for the password it is missing. -c is written to the clone's config, so the
-    # fetch in the push retry below authenticates too.
-    script: 'git clone --depth 1 --single-branch --sparse -c http.proactiveAuth=basic --branch $(baselines_master) https://x-access-token:$(BASELINES_GH_PAT)@github.com/linq2db/linq2db.baselines.git baselines'
+    pwsh: true
+    filePath: '$(System.DefaultWorkingDirectory)/scripts/checkout-baselines.ps1'
+    arguments: -Branch "$(baselines_branch)" -BaselinesMaster "$(baselines_master)"
     workingDirectory: '$(System.DefaultWorkingDirectory)'
   displayName: Checkout test baselines
   condition: and(variables.title, ${{ parameters.with_baselines }}, succeeded())
+  env:
+    GITHUB_TOKEN: $(BASELINES_GH_PAT)
 
 - task: DownloadPipelineArtifact@2
   inputs:

--- a/Build/Azure/scripts/ensure-baselines-branch.ps1
+++ b/Build/Azure/scripts/ensure-baselines-branch.ps1
@@ -13,8 +13,8 @@ been deleting the empty branch and which cost a fresh agent acquisition - 78 min
 build 23009 - for 0.3 min of work.
 
 What is left here is the one case the legs cannot handle: a branch left by an earlier
-run of the same PR that has fallen behind baselines master. The legs clone master and
-would rebase their commit onto that stale base, so it is rebased onto master here,
+run of the same PR that has fallen behind baselines master. Every leg then bases its
+clone on that stale branch (checkout-baselines.ps1), so it is rebased onto master here,
 once, before any leg starts.
 
 Reads the auth token from the GITHUB_TOKEN environment variable (= BASELINES_GH_PAT).

--- a/Build/CI/checkout-baselines.ps1
+++ b/Build/CI/checkout-baselines.ps1
@@ -1,0 +1,72 @@
+<#
+checkout-baselines.ps1 - clone the baselines repository into a test leg's working directory.
+
+Run it from the directory the clone should land in; every leg's configuration expects ./baselines
+(AzureConnectionStrings sets BaselinesPath relative to the test assembly).
+
+The clone is shallow, single-branch and sparse. The leg needs the index, not the tree:
+BaselinesWriter creates its own directories and always writes whole files, so nothing here is ever
+read back from the repository. --sparse lays out the two root files instead of 343541, and
+--depth 1 --single-branch skips ~420 Mb of history for a tree the leg only appends to. The commit
+step pairs this with git add --sparse.
+
+The base is the run branch when it exists and baselines master when it does not, and which one it is
+decides what the leg's commit can contain: git stages a delta against whatever was checked out. On
+master, a baseline this PR changed in an earlier run and has since changed back is an empty delta -
+it enters no commit, so the earlier run's version stays on the run branch and the baselines PR goes
+on showing SQL the branch no longer emits. Against the run branch the same file is a staged revert.
+Master stays the base when the branch does not exist, because the first leg's push is what creates
+it, and a branch that does not exist has nothing to revert.
+
+http.proactiveAuth is what makes the token in the url count: git sends credentials only after a 401
+challenge, and github never challenges an anonymous read of a public repository - so without it the
+clone is unauthenticated and github's unauthenticated-download throttle kills the leg (three legs on
+build 23238). The credential also has to be complete - user:token, not token alone, or git asks for
+the password it is missing. -c is written to the clone's config, so push-baselines.ps1's fetch
+authenticates from it too.
+
+Auth comes from GITHUB_TOKEN (= BASELINES_GH_PAT).
+
+Exit codes: 0 = cloned. 1 = a real failure to check the branch out.
+#>
+
+[CmdletBinding()]
+param(
+    # The per-run baselines branch, e.g. baselines/pr_5848. Cloned when it already exists.
+    [Parameter(Mandatory)][string] $Branch,
+    # The baselines repo's default branch, i.e. the fallback base and the baselines PR's target.
+    [Parameter(Mandatory)][string] $BaselinesMaster,
+    # Directory the clone lands in, relative to the working directory.
+    [string] $Path = 'baselines',
+    [string] $Org = 'linq2db',
+    [string] $BaselinesRepo = 'linq2db.baselines'
+)
+
+$ErrorActionPreference = 'Continue'
+
+# Named, because an empty token clones as x-access-token:@... and git then fails on the password it
+# is missing rather than on the thing that is actually wrong.
+if (-not $Env:GITHUB_TOKEN) {
+    Write-Host 'GITHUB_TOKEN is not set - it carries the baselines PAT, so nothing could be cloned or pushed'
+    exit 1
+}
+
+$repoUrl = "https://x-access-token:${Env:GITHUB_TOKEN}@github.com/${Org}/${BaselinesRepo}.git"
+
+# @(...) keeps a single-line answer an array. Without it PowerShell hands back a bare string for one
+# match and a string[] for several, so a length test means "characters" in the first case and "lines"
+# in the second - and a legitimate multi-ref answer reads as "not found".
+$refs = @(git -c http.proactiveAuth=basic ls-remote --heads $repoUrl $Branch)
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "ls-remote for '${Branch}' failed with code ${LASTEXITCODE}"
+    exit 1
+}
+
+$base = if ($refs | Where-Object { $_ -match '^[0-9a-f]{40}\s' }) { $Branch } else { $BaselinesMaster }
+Write-Host "Cloning baselines from '${base}'"
+
+$output = git clone --depth 1 --single-branch --sparse -c http.proactiveAuth=basic --branch $base $repoUrl $Path 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Failed to clone baselines from '${base}'. Error code ${LASTEXITCODE}, output: ${output}"
+    exit 1
+}

--- a/Build/CI/push-baselines.ps1
+++ b/Build/CI/push-baselines.ps1
@@ -7,9 +7,10 @@ which were 124 lines each and differed on exactly one: the commit message's plat
 now -Platform. The GitHub Actions legs need the same logic, and a third copy of a 124-line script whose
 every branch encodes a reproduced CI failure was not worth having.
 
-Run it with the baselines clone as the working directory. The clone is made shallow and sparse
-(--depth 1 --single-branch --sparse) off baselines master, not off the run branch - which may not exist
-yet, because this script is what creates it.
+Run it with the baselines clone as the working directory. checkout-baselines.ps1 makes that clone
+shallow and sparse (--depth 1 --single-branch --sparse), off the run branch when it already exists and
+off baselines master when it does not - which is the case this script's push resolves, by creating the
+branch.
 
 Auth comes from GITHUB_TOKEN (= BASELINES_GH_PAT), used both for the push URL and by gh. Git identity
 comes from EMAIL / GIT_AUTHOR_NAME / GIT_COMMITTER_NAME, as the callers already set.
@@ -69,8 +70,8 @@ if ($LASTEXITCODE -ne 0) {
     exit 1
 }
 
-# The leg cloned baselines master, so this push is what creates the run branch, and only a leg
-# that actually has baselines to push ever creates it. A run that changes none leaves nothing
+# When the run branch did not exist the leg cloned master, so this push is what creates it, and only
+# a leg that actually has baselines to push ever creates it. A run that changes none leaves nothing
 # behind, which is what retired create_baselines_pr - a job that cost a fresh agent acquisition
 # at the very end of the run (78 min on build 23009) for 0.3 min of work. Whichever leg commits
 # first wins the ref; the rest are rejected and rebase onto it.
@@ -94,11 +95,12 @@ while ($attempts -gt 0) {
         exit 1
     }
     # -X theirs, which during a rebase means the commit being replayed - this leg's freshly captured
-    # baseline - and not the branch it is going onto. Without it the second run of a PR whose SQL
-    # moved fails every baseline-carrying leg: the leg clones baselines master, so its commit rewrites
-    # the same files the previous run already changed on the branch, and the replay conflicts.
-    # Reproduced on a scratch repository with this exact sequence; the fresh capture is always the one
-    # that should win, so resolving that way is the answer rather than a papered-over conflict.
+    # baseline - and not the branch it is going onto. Without it a leg whose clone is based on master
+    # fails whenever its commit rewrites a file the branch already carries, which is every leg on the
+    # second run of a PR whose SQL moved: the replay conflicts. Reproduced on a scratch repository
+    # with this exact sequence; the fresh capture is always the one that should win, so resolving that
+    # way is the answer rather than a papered-over conflict. A leg based on the run branch pushes a
+    # fast-forward instead and only reaches this loop when a concurrent leg got there first.
     # --onto FETCH_HEAD HEAD~1 keeps that to this leg's own commit. A bare FETCH_HEAD replays
     # everything back to the merge base, and the clone is --depth 1: when baselines master advanced
     # after create_baselines_branch rebased the branch, the shallow root is unreachable from the


### PR DESCRIPTION
A test leg clones baselines **master**, so the commit `push-baselines.ps1` creates is a delta against master. A baseline this PR changed in an earlier run and has since changed back is an *empty* delta there: it enters no commit, the earlier run's version stays on `baselines/pr_N`, and the baselines PR keeps showing SQL the branch no longer emits. No later run clears it — each one produces the same empty delta — so the entry survives until the release-time baselines reset.

Introduced in [#5819](https://github.com/linq2db/linq2db/pull/5819), which switched the leg from checking out the run branch to cloning master so that the branch would no longer have to exist up front (retiring `create_baselines_pr`). Before that the leg checked out the run branch and the revert was staged.

```diff
- git clone ... --branch $(baselines_branch) origin/$(baselines_branch)   # pre-#5819: delta vs the branch
+ git clone --depth 1 --single-branch --sparse ... --branch master        # today: delta vs master
```

## Observed on #5725

`GroupByTests.Max11/Max12` for `ClickHouse.Driver` / `ClickHouse.MySql` still carry the CASE-folded `MAX` written by the run that preceded the fold's removal, three ClickHouse legs later:

```sql
maxOrNull(CASE WHEN t1.ChildID > 20 THEN 1 ELSE 0 END)   -- on baselines/pr_5725
maxOrNull(t1.ChildID > 20)                               -- what the branch actually emits, = master
```

Those legs ran the full suite — build 23338's ClickHouse leg reports `total: 26975, failed: 0` and the main step filters on nothing but `TestCategory != SkipCI`. `AggregationTests.MinMaxOverBooleanExpression`, added by the same PR and exercising the same non-grouped `Max(bool)`, *was* corrected on the first run after the fix: a file master does not have is never an empty delta.

## Fix

`Build/CI/checkout-baselines.ps1` clones the run branch when it exists and master when it does not — the case `push-baselines.ps1`'s push resolves by creating the branch, and a branch that does not exist carries nothing to revert, so the fallback loses nothing. Every #5819 property of the clone is kept: `--depth 1 --single-branch --sparse -c http.proactiveAuth=basic`.

The three inline copies of the clone — both Azure templates and the GitHub Actions leg — call it instead, which also puts the reasoning in one place rather than three. `Build/CI` is `xcopy`'d wholesale into the test-scripts artifact, so no packaging change is needed, and every leg already extracts that artifact before this step.

`ensure-baselines-branch.ps1` matters more now, not less: it rebases a run branch that has fallen behind master *before* any leg starts, so a branch-based clone is never stale. Its header and two comments in `push-baselines.ps1` that asserted the master base are corrected.

## Verification

Against the real repositories, writing master's content for the `Max11` baseline into a leg-shaped clone and staging it the way `push-baselines.ps1` does:

| clone base | staged |
|---|---|
| `baselines/pr_5725` (branch exists) | `M …/Tests.Linq.GroupByTests.Max11(ClickHouse.Driver).sql` |
| `master` (branch absent — today's behaviour) | *nothing* |

The second row reproduces the bug; the first is the fix. The fallback path is exercised by the same probe, so both branches of the base selection are covered. CI is the real gate — a `test-all` run on this PR exercises the changed step on every leg.

## Not covered

The GitHub Actions path (`tests-comment.yml`) resolves the branch name but has no `ensure-baselines-branch` equivalent, so a GH leg can base its clone on a branch that is behind master. That introduces nothing — only files the leg writes are staged, and the branch was already behind — but it is a gap worth closing when that migration lands.
