### PR TITLE
Migrate EF Core 10 MySQL testing to Microting.EntityFrameworkCore.MySql

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -224,7 +224,9 @@
 		<PackageVersion Include="Pomelo.EntityFrameworkCore.MySql"                      Version="3.2.7"                        Condition="'$(TargetFramework)'=='net462'"  />
 		<PackageVersion Include="Pomelo.EntityFrameworkCore.MySql"                      Version="8.0.3"                        Condition="'$(TargetFramework)'=='net8.0'"  />
 		<PackageVersion Include="Pomelo.EntityFrameworkCore.MySql"                      Version="9.0.0"                        Condition="'$(TargetFramework)'=='net9.0'"  />
-		<PackageVersion Include="Pomelo.EntityFrameworkCore.MySql"                      Version="9.0.0"                        Condition="'$(TargetFramework)'=='net10.0'" />
+		<!--Pomelo's newest line is EF Core 9; Microting is a maintained fork of it that ships an EF Core 10 line.
+		    Its versions track EF Core patch numbers 1:1, so keep this in step with $(Net10Latest)-->
+		<PackageVersion Include="Microting.EntityFrameworkCore.MySql"                   Version="10.0.10"                      Condition="'$(TargetFramework)'=='net10.0'" />
 		<PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime"        Version="3.1.18"                       Condition="'$(TargetFramework)'=='net462'"  />
 		<PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime"        Version="8.0.11"                       Condition="'$(TargetFramework)'=='net8.0'"  />
 		<PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime"        Version="9.0.4"                        Condition="'$(TargetFramework)'=='net9.0'"  />

--- a/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFToolsImplDefault.cs
+++ b/Source/LinqToDB.EntityFrameworkCore/LinqToDBForEFToolsImplDefault.cs
@@ -243,6 +243,8 @@ namespace LinqToDB.EntityFrameworkCore
 			{
 				"Microsoft.EntityFrameworkCore.SqlServer"                                                   => new LinqToDBProviderInfo { ProviderName = ProviderName.SqlServer      },
 				"Pomelo.EntityFrameworkCore.MySql" or "Devart.Data.MySql.EFCore"                            => new LinqToDBProviderInfo { ProviderName = ProviderName.MySql          },
+				// Microting is a fork of Pomelo; it renames the assembly, which is what EF reports here
+				"Microting.EntityFrameworkCore.MySql"                                                       => new LinqToDBProviderInfo { ProviderName = ProviderName.MySql          },
 				"MySql.Data.EntityFrameworkCore"                                                            => new LinqToDBProviderInfo { ProviderName = ProviderName.MySql          },
 				"Npgsql.EntityFrameworkCore.PostgreSQL" or "Devart.Data.PostgreSql.EFCore"                  => new LinqToDBProviderInfo { ProviderName = ProviderName.PostgreSQL     },
 				"Microsoft.EntityFrameworkCore.Sqlite" or "Devart.Data.SQLite.EFCore"                       => new LinqToDBProviderInfo { ProviderName = ProviderName.SQLite         },

--- a/Source/LinqToDB.EntityFrameworkCore/README.md
+++ b/Source/LinqToDB.EntityFrameworkCore/README.md
@@ -204,7 +204,7 @@ There are many reasons. Some of them:
 Below is a list of providers, that should work right now:
 
 * SQL Server
-* MySQL (including Devart and Pomelo providers)
+* MySQL (including Devart, Pomelo and Microting providers)
 * PostgreSQL (Both npgsql and Devart providers)
 * SQLite (including Devart provider)
 * Firebird

--- a/Tests/Base/TestConfiguration.cs
+++ b/Tests/Base/TestConfiguration.cs
@@ -264,9 +264,7 @@ namespace Tests
 			TestProvName.AllSqlServer2016PlusMS,
 			// latest tested ef.core doesn't support older versions, leading to too many failing tests to disable
 			TestProvName.AllPostgreSQL13Plus,
-#if !NET10_0 // provider need update for v10
 			TestProvName.AllMySqlConnector,
-#endif
 
 #if NETFRAMEWORK
 			// test providers with .net framework provider only

--- a/Tests/EntityFrameworkCore/ContextTestBase.cs
+++ b/Tests/EntityFrameworkCore/ContextTestBase.cs
@@ -30,13 +30,11 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 					=> optionsBuilder
 					.UseNpgsql(connectionString, o => o.UseNodaTime())
 					.UseLinqToDB(builder => builder.AddCustomOptions(o => o.UseMappingSchema(NodaTimeSupport))),
-#if !NET10_0
 				_ when provider.IsAnyOf(TestProvName.AllMySql) => optionsBuilder
 #if !NETFRAMEWORK
 					.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString)),
 #else
 					.UseMySql(connectionString),
-#endif
 #endif
 				_ when provider.IsAnyOf(TestProvName.AllSQLite) => optionsBuilder.UseSqlite(connectionString),
 				_ when provider.IsAnyOf(TestProvName.AllSqlServer) => optionsBuilder.UseSqlServer(connectionString),

--- a/Tests/EntityFrameworkCore/Models/ForMapping/MySql/ForMappingContext.cs
+++ b/Tests/EntityFrameworkCore/Models/ForMapping/MySql/ForMappingContext.cs
@@ -2,7 +2,7 @@
 
 using Microsoft.EntityFrameworkCore;
 
-namespace LinqToDB.EntityFrameworkCore.Tests.Pomelo.Models.ForMapping
+namespace LinqToDB.EntityFrameworkCore.Tests.MySql.Models.ForMapping
 {
 	public class ForMappingContext : ForMappingContextBase
 	{
@@ -17,10 +17,8 @@ namespace LinqToDB.EntityFrameworkCore.Tests.Pomelo.Models.ForMapping
 			modelBuilder.Entity<WithIdentity>(b =>
 			{
 				b.HasKey(e => e.Id);
-#if !NET10_0
 				b.Property(e => e.Id)
 					.UseMySqlIdentityColumn();
-#endif
 			});
 
 			modelBuilder.Entity<NoIdentity>(b =>

--- a/Tests/EntityFrameworkCore/Models/IssueModel/MySql/IssueContext.cs
+++ b/Tests/EntityFrameworkCore/Models/IssueModel/MySql/IssueContext.cs
@@ -2,7 +2,7 @@
 
 using Microsoft.EntityFrameworkCore;
 
-namespace LinqToDB.EntityFrameworkCore.Tests.Pomelo.Models.IssueModel
+namespace LinqToDB.EntityFrameworkCore.Tests.MySql.Models.IssueModel
 {
 	public class IssueContext(DbContextOptions options) : IssueContextBase(options)
 	{

--- a/Tests/EntityFrameworkCore/Models/ManyToMany/MySql/ManyToManyContext.cs
+++ b/Tests/EntityFrameworkCore/Models/ManyToMany/MySql/ManyToManyContext.cs
@@ -3,7 +3,7 @@ using LinqToDB.EntityFrameworkCore.Tests.Models.ManyToMany;
 
 using Microsoft.EntityFrameworkCore;
 
-namespace LinqToDB.EntityFrameworkCore.Tests.Pomelo.Models.ManyToMany
+namespace LinqToDB.EntityFrameworkCore.Tests.MySql.Models.ManyToMany
 {
 	public class ManyToManyContext(DbContextOptions options) : ManyToManyContextBase(options);
 }

--- a/Tests/EntityFrameworkCore/Models/Northwind/MySql/CategoriesMap.cs
+++ b/Tests/EntityFrameworkCore/Models/Northwind/MySql/CategoriesMap.cs
@@ -3,7 +3,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace LinqToDB.EntityFrameworkCore.Tests.Pomelo.Models.Northwind.Mapping
+namespace LinqToDB.EntityFrameworkCore.Tests.MySql.Models.Northwind.Mapping
 {
 	public class CategoriesMap : IEntityTypeConfiguration<Category>
 	{

--- a/Tests/EntityFrameworkCore/Models/Northwind/MySql/CustomerCustomerDemoMap.cs
+++ b/Tests/EntityFrameworkCore/Models/Northwind/MySql/CustomerCustomerDemoMap.cs
@@ -3,7 +3,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace LinqToDB.EntityFrameworkCore.Tests.Pomelo.Models.Northwind.Mapping
+namespace LinqToDB.EntityFrameworkCore.Tests.MySql.Models.Northwind.Mapping
 {
 	public class CustomerCustomerDemoMap : IEntityTypeConfiguration<CustomerCustomerDemo>
 	{

--- a/Tests/EntityFrameworkCore/Models/Northwind/MySql/CustomerDemographicsMap.cs
+++ b/Tests/EntityFrameworkCore/Models/Northwind/MySql/CustomerDemographicsMap.cs
@@ -3,7 +3,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace LinqToDB.EntityFrameworkCore.Tests.Pomelo.Models.Northwind.Mapping
+namespace LinqToDB.EntityFrameworkCore.Tests.MySql.Models.Northwind.Mapping
 {
 	public class CustomerDemographicsMap : IEntityTypeConfiguration<CustomerDemographics>
 	{

--- a/Tests/EntityFrameworkCore/Models/Northwind/MySql/CustomersMap.cs
+++ b/Tests/EntityFrameworkCore/Models/Northwind/MySql/CustomersMap.cs
@@ -3,7 +3,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace LinqToDB.EntityFrameworkCore.Tests.Pomelo.Models.Northwind.Mapping
+namespace LinqToDB.EntityFrameworkCore.Tests.MySql.Models.Northwind.Mapping
 {
 	public class CustomersMap : IEntityTypeConfiguration<Customer>
 	{

--- a/Tests/EntityFrameworkCore/Models/Northwind/MySql/EmployeeTerritoriesMap.cs
+++ b/Tests/EntityFrameworkCore/Models/Northwind/MySql/EmployeeTerritoriesMap.cs
@@ -3,7 +3,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace LinqToDB.EntityFrameworkCore.Tests.Pomelo.Models.Northwind.Mapping
+namespace LinqToDB.EntityFrameworkCore.Tests.MySql.Models.Northwind.Mapping
 {
 	public class EmployeeTerritoriesMap : IEntityTypeConfiguration<EmployeeTerritory>
 	{

--- a/Tests/EntityFrameworkCore/Models/Northwind/MySql/EmployeesMap.cs
+++ b/Tests/EntityFrameworkCore/Models/Northwind/MySql/EmployeesMap.cs
@@ -3,7 +3,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace LinqToDB.EntityFrameworkCore.Tests.Pomelo.Models.Northwind.Mapping
+namespace LinqToDB.EntityFrameworkCore.Tests.MySql.Models.Northwind.Mapping
 {
 	public class EmployeesMap : IEntityTypeConfiguration<Employee>
 	{

--- a/Tests/EntityFrameworkCore/Models/Northwind/MySql/NorthwindContext.cs
+++ b/Tests/EntityFrameworkCore/Models/Northwind/MySql/NorthwindContext.cs
@@ -1,9 +1,9 @@
 ﻿using LinqToDB.EntityFrameworkCore.Tests.Models.Northwind;
-using LinqToDB.EntityFrameworkCore.Tests.Pomelo.Models.Northwind.Mapping;
+using LinqToDB.EntityFrameworkCore.Tests.MySql.Models.Northwind.Mapping;
 
 using Microsoft.EntityFrameworkCore;
 
-namespace LinqToDB.EntityFrameworkCore.Tests.Pomelo.Models.Northwind
+namespace LinqToDB.EntityFrameworkCore.Tests.MySql.Models.Northwind
 {
 	public class NorthwindContext : NorthwindContextBase
 	{

--- a/Tests/EntityFrameworkCore/Models/Northwind/MySql/OrderDetailsMap.cs
+++ b/Tests/EntityFrameworkCore/Models/Northwind/MySql/OrderDetailsMap.cs
@@ -3,7 +3,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace LinqToDB.EntityFrameworkCore.Tests.Pomelo.Models.Northwind.Mapping
+namespace LinqToDB.EntityFrameworkCore.Tests.MySql.Models.Northwind.Mapping
 {
 	public class OrderDetailsMap : IEntityTypeConfiguration<OrderDetail>
 	{

--- a/Tests/EntityFrameworkCore/Models/Northwind/MySql/OrderMap.cs
+++ b/Tests/EntityFrameworkCore/Models/Northwind/MySql/OrderMap.cs
@@ -3,7 +3,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace LinqToDB.EntityFrameworkCore.Tests.Pomelo.Models.Northwind.Mapping
+namespace LinqToDB.EntityFrameworkCore.Tests.MySql.Models.Northwind.Mapping
 {
 	public class OrderMap : IEntityTypeConfiguration<Order>
 	{

--- a/Tests/EntityFrameworkCore/Models/Northwind/MySql/ProductsMap.cs
+++ b/Tests/EntityFrameworkCore/Models/Northwind/MySql/ProductsMap.cs
@@ -3,7 +3,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace LinqToDB.EntityFrameworkCore.Tests.Pomelo.Models.Northwind.Mapping
+namespace LinqToDB.EntityFrameworkCore.Tests.MySql.Models.Northwind.Mapping
 {
 	public class ProductsMap : IEntityTypeConfiguration<Product>
 	{

--- a/Tests/EntityFrameworkCore/Models/Northwind/MySql/RegionMap.cs
+++ b/Tests/EntityFrameworkCore/Models/Northwind/MySql/RegionMap.cs
@@ -3,7 +3,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace LinqToDB.EntityFrameworkCore.Tests.Pomelo.Models.Northwind.Mapping
+namespace LinqToDB.EntityFrameworkCore.Tests.MySql.Models.Northwind.Mapping
 {
 	public class RegionMap : IEntityTypeConfiguration<Region>
 	{

--- a/Tests/EntityFrameworkCore/Models/Northwind/MySql/ShippersMap.cs
+++ b/Tests/EntityFrameworkCore/Models/Northwind/MySql/ShippersMap.cs
@@ -3,7 +3,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace LinqToDB.EntityFrameworkCore.Tests.Pomelo.Models.Northwind.Mapping
+namespace LinqToDB.EntityFrameworkCore.Tests.MySql.Models.Northwind.Mapping
 {
 	public class ShippersMap : IEntityTypeConfiguration<Shipper>
 	{

--- a/Tests/EntityFrameworkCore/Models/Northwind/MySql/SuppliersMap.cs
+++ b/Tests/EntityFrameworkCore/Models/Northwind/MySql/SuppliersMap.cs
@@ -3,7 +3,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace LinqToDB.EntityFrameworkCore.Tests.Pomelo.Models.Northwind.Mapping
+namespace LinqToDB.EntityFrameworkCore.Tests.MySql.Models.Northwind.Mapping
 {
 	public class SuppliersMap : IEntityTypeConfiguration<Supplier>
 	{

--- a/Tests/EntityFrameworkCore/Models/Northwind/MySql/TerritoriesMap.cs
+++ b/Tests/EntityFrameworkCore/Models/Northwind/MySql/TerritoriesMap.cs
@@ -3,7 +3,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace LinqToDB.EntityFrameworkCore.Tests.Pomelo.Models.Northwind.Mapping
+namespace LinqToDB.EntityFrameworkCore.Tests.MySql.Models.Northwind.Mapping
 {
 	public class TerritoriesMap : IEntityTypeConfiguration<Territory>
     {

--- a/Tests/EntityFrameworkCore/NorthwindContextTestBase.cs
+++ b/Tests/EntityFrameworkCore/NorthwindContextTestBase.cs
@@ -22,7 +22,7 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 			return provider switch
 			{
 				_ when provider.IsAnyOf(TestProvName.AllPostgreSQL) => new PostgreSQL.Models.Northwind.NorthwindContext(options),
-				_ when provider.IsAnyOf(TestProvName.AllMySql) => new Pomelo.Models.Northwind.NorthwindContext(options),
+				_ when provider.IsAnyOf(TestProvName.AllMySql) => new MySql.Models.Northwind.NorthwindContext(options),
 				_ when provider.IsAnyOf(TestProvName.AllSQLite) => new SQLite.Models.Northwind.NorthwindContext(options),
 				_ when provider.IsAnyOf(TestProvName.AllSqlServer) => new SqlServer.Models.Northwind.NorthwindContext(options),
 				_ => throw new InvalidOperationException($"{nameof(CreateProviderContext)} is not implemented for provider {provider}")

--- a/Tests/EntityFrameworkCore/TestBase.cs
+++ b/Tests/EntityFrameworkCore/TestBase.cs
@@ -21,12 +21,10 @@ using NUnit.Framework;
 
 using Tests;
 
-#if !NET10_0
 #if NETFRAMEWORK
 using MySqlConnectionStringBuilder = MySql.Data.MySqlClient.MySqlConnectionStringBuilder;
 #else
 using MySqlConnectionStringBuilder = MySqlConnector.MySqlConnectionStringBuilder;
-#endif
 #endif
 
 namespace LinqToDB.EntityFrameworkCore.Tests
@@ -205,7 +203,6 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 						connectionString = cnb.ConnectionString;
 						break;
 					}
-#if !NET10_0
 					case var _ when provider.IsAnyOf(TestProvName.AllMySql):
 					{
 						var cnb = new MySqlConnectionStringBuilder(connectionString);
@@ -214,7 +211,6 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 						connectionString = cnb.ConnectionString;
 						break;
 					}
-#endif
 					case var _ when provider.IsAnyOf(TestProvName.AllSQLite):
 					{
 						// EF tests use their own per-TFM DB file. The SQLite base connection string may be

--- a/Tests/EntityFrameworkCore/Tests.EntityFrameworkCore.EF10.csproj
+++ b/Tests/EntityFrameworkCore/Tests.EntityFrameworkCore.EF10.csproj
@@ -9,7 +9,9 @@
 	
 	<ItemGroup>
 		<ProjectReference Include="..\..\Source\LinqToDB.EntityFrameworkCore\LinqToDB.EntityFrameworkCore.EF10.csproj" />
+		<!--Pomelo has no EF Core 10 release; the Microting fork of it does-->
 		<PackageReference Remove="Pomelo.EntityFrameworkCore.MySql" />
+		<PackageReference Include="Microting.EntityFrameworkCore.MySql" />
 	</ItemGroup>
 
 </Project>

--- a/Tests/EntityFrameworkCore/Tests/CustomContextIssueTests.cs
+++ b/Tests/EntityFrameworkCore/Tests/CustomContextIssueTests.cs
@@ -56,13 +56,11 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 					// UseNodaTime called due to bug in Npgsql v8, where UseNodaTime ignored, when UseNpgsql already called without it
 					_ when provider.IsAnyOf(TestProvName.AllPostgreSQL)
 						=> optionsBuilder.UseNpgsql(connectionString, o => o.UseNodaTime()).UseLinqToDB(builder => builder.AddCustomOptions(o => o.UseMappingSchema(NodaTimeSupport))),
-#if !NET10_0
 					_ when provider.IsAnyOf(TestProvName.AllMySql) => optionsBuilder
 #if !NETFRAMEWORK
 						.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString)),
 #else
 						.UseMySql(connectionString),
-#endif
 #endif
 					_ when provider.IsAnyOf(TestProvName.AllSQLite) => optionsBuilder.UseSqlite(connectionString),
 					_ when provider.IsAnyOf(TestProvName.AllSqlServer) => optionsBuilder.UseSqlServer(connectionString),

--- a/Tests/EntityFrameworkCore/Tests/ForMappingTests.cs
+++ b/Tests/EntityFrameworkCore/Tests/ForMappingTests.cs
@@ -25,7 +25,7 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 			return provider switch
 			{
 				_ when provider.IsAnyOf(TestProvName.AllPostgreSQL) => new PostgreSQL.Models.ForMapping.ForMappingContext(options),
-				_ when provider.IsAnyOf(TestProvName.AllMySql) => new Pomelo.Models.ForMapping.ForMappingContext(options),
+				_ when provider.IsAnyOf(TestProvName.AllMySql) => new MySql.Models.ForMapping.ForMappingContext(options),
 				_ when provider.IsAnyOf(TestProvName.AllSQLite) => new SQLite.Models.ForMapping.ForMappingContext(options),
 				_ when provider.IsAnyOf(TestProvName.AllSqlServer) => new SqlServer.Models.ForMapping.ForMappingContext(options),
 				_ => throw new InvalidOperationException($"{nameof(CreateProviderContext)} is not implemented for provider {provider}")

--- a/Tests/EntityFrameworkCore/Tests/IssueTests.cs
+++ b/Tests/EntityFrameworkCore/Tests/IssueTests.cs
@@ -30,7 +30,7 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 			return provider switch
 			{
 				_ when provider.IsAnyOf(TestProvName.AllPostgreSQL) => new PostgreSQL.Models.IssueModel.IssueContext(options),
-				_ when provider.IsAnyOf(TestProvName.AllMySql) => new Pomelo.Models.IssueModel.IssueContext(options),
+				_ when provider.IsAnyOf(TestProvName.AllMySql) => new MySql.Models.IssueModel.IssueContext(options),
 				_ when provider.IsAnyOf(TestProvName.AllSQLite) => new SQLite.Models.IssueModel.IssueContext(options),
 				_ when provider.IsAnyOf(TestProvName.AllSqlServer) => new SqlServer.Models.IssueModel.IssueContext(options),
 				_ => throw new InvalidOperationException($"{nameof(CreateProviderContext)} is not implemented for provider {provider}")

--- a/Tests/EntityFrameworkCore/Tests/ManyToManyTests.cs
+++ b/Tests/EntityFrameworkCore/Tests/ManyToManyTests.cs
@@ -21,7 +21,7 @@ namespace LinqToDB.EntityFrameworkCore.Tests
 			return provider switch
 			{
 				_ when provider.IsAnyOf(TestProvName.AllPostgreSQL) => new PostgreSQL.Models.ManyToMany.ManyToManyContext(options),
-				_ when provider.IsAnyOf(TestProvName.AllMySql)       => new Pomelo.Models.ManyToMany.ManyToManyContext(options),
+				_ when provider.IsAnyOf(TestProvName.AllMySql)       => new MySql.Models.ManyToMany.ManyToManyContext(options),
 				_ when provider.IsAnyOf(TestProvName.AllSQLite)      => new SQLite.Models.ManyToMany.ManyToManyContext(options),
 				_ when provider.IsAnyOf(TestProvName.AllSqlServer)   => new SqlServer.Models.ManyToMany.ManyToManyContext(options),
 				_ => throw new InvalidOperationException($"{nameof(CreateProviderContext)} is not implemented for provider {provider}")

--- a/Tests/EntityFrameworkCore/Tests/MySqlTests.cs
+++ b/Tests/EntityFrameworkCore/Tests/MySqlTests.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 
 namespace LinqToDB.EntityFrameworkCore.Tests
 {
-	public class PomeloMySqlTests : NorthwindContextTestBase
+	public class MySqlTests : NorthwindContextTestBase
 	{
 		[Test]
 		public void SimpleProviderTest([EFDataSources] string provider)

--- a/Tests/EntityFrameworkCore/Tests/Providers.md
+++ b/Tests/EntityFrameworkCore/Tests/Providers.md
@@ -5,7 +5,7 @@ List of existing Entity Framework providers: https://learn.microsoft.com/en-us/e
 | Tests Folder | Provider Nuget | Database |
 |-|-|-|
 | `Npgsql` | [Npgsql.EntityFrameworkCore.PostgreSQL](https://www.nuget.org/packages/Npgsql.EntityFrameworkCore.PostgreSQL) | PostgreSQL |
-| `Pomelo` | [Pomelo.EntityFrameworkCore.MySql](https://www.nuget.org/packages/Pomelo.EntityFrameworkCore.MySql) | MySQL and MariaDB |
+| `MySql` | [Pomelo.EntityFrameworkCore.MySql](https://www.nuget.org/packages/Pomelo.EntityFrameworkCore.MySql) (net462/net8.0/net9.0), [Microting.EntityFrameworkCore.MySql](https://www.nuget.org/packages/Microting.EntityFrameworkCore.MySql) (net10.0, Pomelo has no EF Core 10 release) | MySQL and MariaDB |
 | `SQLite` | [Microsoft.EntityFrameworkCore.Sqlite](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Sqlite) | SQLite |
 | `SQLServer` | [Microsoft.EntityFrameworkCore.SqlServer](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.SqlServer) | SQL Server incl. Azure SQL |
 

--- a/nuget.config
+++ b/nuget.config
@@ -3,15 +3,8 @@
 	<packageSources>
 		<clear />
 		<add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-		<!--Uncomment together with the pomelo-nightly mapping below when a Pomelo nightly is needed. A source
-		    listed here is enumerated by the NuGet vulnerability audit even when no package pattern maps to it,
-		    so leaving it enabled makes every build depend on that feed being reachable-->
-		<!--<add key="pomelo-nightly" value="https://pkgs.dev.azure.com/pomelo-efcore/Pomelo.EntityFrameworkCore.MySql/_packaging/pomelo-efcore-public/nuget/v3/index.json" />-->
 	</packageSources>
 	<packageSourceMapping>
-		<!--<packageSource key="pomelo-nightly">
-			<package pattern="Pomelo.EntityFrameworkCore.MySql" />
-		</packageSource>-->
 		<packageSource key="nuget.org">
 			<package pattern="*" />
 		</packageSource>


### PR DESCRIPTION
## Problem

[Pomelo.EntityFrameworkCore.MySql](https://www.nuget.org/packages/Pomelo.EntityFrameworkCore.MySql) never shipped an EF Core 10 release — its newest line is 9.0.x. When .NET 10 support landed ([#5151](https://github.com/linq2db/linq2db/pull/5151)) the workaround was to drop MySQL from the EF10 leg entirely: the package reference is stripped in `Tests.EntityFrameworkCore.EF10.csproj`, `TestConfiguration.EFProviders` excludes `AllMySqlConnector` under `#if !NET10_0`, and four call sites are `#if`-ed out.

The result is that linq2db's EF Core 10 integration has **zero MySQL coverage**, while net462 / net8.0 / net9.0 all have it.

## Fix

[Microting.EntityFrameworkCore.MySql](https://www.nuget.org/packages/Microting.EntityFrameworkCore.MySql) is a maintained fork of Pomelo ([microting/Pomelo.EntityFrameworkCore.MySql](https://github.com/microting/Pomelo.EntityFrameworkCore.MySql), MIT) that does publish an EF Core 10 line. Checked against the package itself:

- the public surface is byte-identical to Pomelo's — `Microsoft.EntityFrameworkCore.MySqlDbContextOptionsBuilderExtensions.UseMySql`, `Microsoft.EntityFrameworkCore.ServerVersion`, `MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn`, `MySqlOptionsExtension` — so no test source changes shape, only its `#if` gates;
- the **assembly and internal namespaces are renamed** to `Microting.EntityFrameworkCore.MySql.*`, so `DatabaseFacade.ProviderName` reports `"Microting.EntityFrameworkCore.MySql"`, which linq2db did not recognise;
- `MySqlMethodCallTranslatorProvider` keeps its type name, so the [#1801](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1801) workaround in `EFCoreMetadataReader` applies unchanged.

Changes:

- **`Directory.Packages.props`** — the `net10.0` row becomes `Microting.EntityFrameworkCore.MySql` `10.0.10`. `net462` / `net8.0` / `net9.0` stay on Pomelo.
- **`nuget.config`** — the `pomelo-nightly` feed is dropped. It was already commented out, and with the fork coming from nuget.org there is no reason to carry a Pomelo pre-release feed.
- **`LinqToDBForEFToolsImplDefault.GetLinqToDBProviderInfo(DatabaseFacade)`** — recognises the fork's renamed assembly. Not strictly required for the tests (the `MySqlOptionsExtension` arm resolves first), but it makes the fork work for real consumers.
- **Five `#if !NET10_0` gates removed** — `TestConfiguration.cs`, `TestBase.cs` (×2), `ContextTestBase.cs`, `CustomContextIssueTests.cs`, `ForMappingContext.cs`. This re-enables `MySqlConnector.5.7`, `MySqlConnector.8.0` and `MariaDB.11` on the EF10 leg. **No pipeline change needed** — `Build/Azure/net100/{mysql,mysql57,mariadb11}.json` already enable those providers and the workflows already run the net10.0 EF assembly on them.
- **Rename `Pomelo` → `MySql`** in the EF test tree (model folders, namespaces, `PomeloMySqlTests` → `MySqlTests`), since the package now differs per TFM.

### Why `10.0.10` and not the newest `10.0.11`

Microting's dependencies track EF Core patch numbers exactly, and 10.0.10's are an exact match for this repo's current pins, so the restore graph moves no package at all:

| Microting | needs `Microsoft.EntityFrameworkCore.Relational` | needs `MySqlConnector` | repo pins |
|-|-|-|-|
| **10.0.10** | `[10.0.10, 10.0.999]` | `2.6.1` | `$(Net10Latest)` = **10.0.10**, `MySqlConnector` = **2.6.1** |
| 10.0.11 | `[10.0.11, 10.0.999]` | `2.6.2` | both above the current pins |

Confirmed from the EF10 test project's restore graph: EF Core Relational / SqlServer / Sqlite / InMemory all resolve to 10.0.10 and `MySqlConnector` to 2.6.1, with no `NU1605` / `NU1608`. Moving to 10.0.11 belongs to a `Directory.Packages.props` bump of `$(Net10Latest)` + `MySqlConnector`, not here.

## Verification

Local, against `MySqlConnector.5.7`, `MySqlConnector.8.0` and `MariaDB.11`, full EF test suite:

| Run | Total | Passed | Skipped | Failed |
|-|-|-|-|-|
| EF9 + Pomelo (control) | 522 | **462** | 58 | 2 |
| EF10 + Microting | 534 | **462** | 70 | 2 |

Identical pass count and identical failures. The 12-test delta is entirely the EF10-only named-query-filter set (`TestNamedQueryFilter_AppliesAll`, `TestIgnoreQueryFilters_All_StillWorks` / `_ByKey` / `_Empty_IsNoOp` × 3 providers), all skipped by the pre-existing `[ActiveIssue]` on [#4669](https://github.com/linq2db/linq2db/issues/4669). A diff of the two skip lists shows nothing skipped under EF9 that is not also skipped under EF10.

The 2 failures — `TestNativeBulkCopy[Async]NoIdentity("MySqlConnector.8.0")`, `MySqlException 3948 "Loading local data is disabled"` — reproduce identically under EF9/Pomelo. They are the local container's `local_infile` server setting, not this change; the same tests already run on CI's mysql leg for EF8/EF9.

Builds: all four EF test projects green in `Debug` (net462 / net8.0 / net9.0 / net10.0, 0 warnings) and in `Release` (the only errors are the pre-existing local-toolchain `MA0206` / `EF1001` sites in files this branch does not touch).
