### PR TITLE
Measure a DateTimeOffset difference on instants, not local readings

### DIFF
--- a/Source/LinqToDB/Internal/DataProvider/Oracle/OracleSqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Oracle/OracleSqlExpressionConvertVisitor.cs
@@ -44,6 +44,11 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 		/// bare <c>timestamp</c> - six digits - so the sub-microsecond tick cannot survive the subtraction whatever
 		/// the column holds. Declaring the floor makes the member fall back to .NET, which answers it from the two
 		/// dates, rather than depending on what the driver happens to round-trip.
+		/// <para>
+		/// A zone-carrying operand is subtracted uncast and so could reach further, but this is one value for the
+		/// provider and cannot be told per operand. It stays at the floor the cast imposes, which only ever declines
+		/// a member that might have been answerable - never claims one that is not.
+		/// </para>
 		/// </remarks>
 		public override SqlIntervalUnit IntervalResolution => SqlIntervalUnit.Microsecond;
 
@@ -51,9 +56,9 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 		/// Elapsed ticks summed field by field out of the interval two timestamps subtract to.
 		/// </summary>
 		/// <remarks>
-		/// Both operands are cast to <c>timestamp</c> first: subtracting Oracle <c>date</c> values yields a number
-		/// of days instead, and a date carries no fraction of a second to lose. Field by field rather than through
-		/// the day count, because that count is a floating number of days and cannot carry a tick over a long
+		/// Both operands go through <see cref="AsTimestamp"/> first: subtracting Oracle <c>date</c> values yields a
+		/// number of days instead, and a date carries no fraction of a second to lose. Field by field rather than
+		/// through the day count, because that count is a floating number of days and cannot carry a tick over a long
 		/// range - the same reason the existing <c>DateDiff</c> lowering decomposes its millisecond form.
 		/// <para>
 		/// Fields of a negative interval are all negative, so the sum needs no sign handling.
@@ -93,8 +98,26 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 			return Factory.Function(resultType, "Extract", Factory.Expression(resultType, $"{part} From {{0}}", value));
 		}
 
+		/// <summary>
+		/// The operand in a form two of which subtract to an interval, leaving a zone-carrying one alone.
+		/// </summary>
+		/// <remarks>
+		/// <c>CAST(x AS timestamp)</c> over a <c>timestamp with time zone</c> keeps the local reading and drops the
+		/// zone, so two marks denoting the same moment in different zones would subtract to a non-zero interval - a
+		/// plausible number rather than a refusal, and every member taken from it inherits the error. Oracle
+		/// normalises two zoned operands to UTC before subtracting them, which is what CLR subtraction does
+		/// (<see cref="DateTimeOffset"/> compares <see cref="DateTimeOffset.UtcDateTime"/>), so the cast is simply
+		/// left off there.
+		/// <para>
+		/// It stays for everything else, which is what it was for: subtracting two Oracle <c>date</c> values yields a
+		/// number of days rather than an interval.
+		/// </para>
+		/// </remarks>
 		ISqlExpression AsTimestamp(ISqlExpression value)
 		{
+			if (QueryHelper.GetDbDataType(value, MappingSchema).SystemType.ToUnderlying() == typeof(DateTimeOffset))
+				return value;
+
 			return Factory.Cast(value, Factory.GetDbDataType(typeof(DateTime)).WithDataType(DataType.DateTime2));
 		}
 

--- a/Source/LinqToDB/Internal/DataProvider/Oracle/OracleSqlExpressionConvertVisitor.cs
+++ b/Source/LinqToDB/Internal/DataProvider/Oracle/OracleSqlExpressionConvertVisitor.cs
@@ -40,14 +40,14 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 		/// microsecond is identically zero rather than merely imprecise, and is declined instead.
 		/// </summary>
 		/// <remarks>
-		/// <see cref="AsTimestamp"/> casts to <see cref="DataType.DateTime2"/> with no precision, which renders as a
-		/// bare <c>timestamp</c> - six digits - so the sub-microsecond tick cannot survive the subtraction whatever
-		/// the column holds. Declaring the floor makes the member fall back to .NET, which answers it from the two
-		/// dates, rather than depending on what the driver happens to round-trip.
+		/// <see cref="AsTimestamp"/> casts a <c>date</c> operand to <see cref="DataType.DateTime2"/> with no
+		/// precision, which renders as a bare <c>timestamp</c> - six digits. Declaring the floor makes the member
+		/// fall back to .NET, which answers it from the two dates, rather than depending on what the driver happens
+		/// to round-trip.
 		/// <para>
-		/// A zone-carrying operand is subtracted uncast and so could reach further, but this is one value for the
-		/// provider and cannot be told per operand. It stays at the floor the cast imposes, which only ever declines
-		/// a member that might have been answerable - never claims one that is not.
+		/// An operand left uncast is subtracted at its own precision and so could reach further, but this is one
+		/// value for the provider and cannot be told per operand. It stays at the floor the cast imposes, which only
+		/// ever declines a member that might have been answerable - never claims one that is not.
 		/// </para>
 		/// </remarks>
 		public override SqlIntervalUnit IntervalResolution => SqlIntervalUnit.Microsecond;
@@ -99,7 +99,7 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 		}
 
 		/// <summary>
-		/// The operand in a form two of which subtract to an interval, leaving a zone-carrying one alone.
+		/// The operand in a form two of which subtract to an interval, widening only an Oracle <c>date</c>.
 		/// </summary>
 		/// <remarks>
 		/// <c>CAST(x AS timestamp)</c> over a <c>timestamp with time zone</c> keeps the local reading and drops the
@@ -109,13 +109,13 @@ namespace LinqToDB.Internal.DataProvider.Oracle
 		/// (<see cref="DateTimeOffset"/> compares <see cref="DateTimeOffset.UtcDateTime"/>), so the cast is simply
 		/// left off there.
 		/// <para>
-		/// It stays for everything else, which is what it was for: subtracting two Oracle <c>date</c> values yields a
-		/// number of days rather than an interval.
+		/// It is applied only to a <c>date</c> operand, which is what it was for: subtracting two Oracle <c>date</c>
+		/// values yields a number of days rather than an interval. Every other type already subtracts to one.
 		/// </para>
 		/// </remarks>
 		ISqlExpression AsTimestamp(ISqlExpression value)
 		{
-			if (QueryHelper.GetDbDataType(value, MappingSchema).SystemType.ToUnderlying() == typeof(DateTimeOffset))
+			if (QueryHelper.GetDbDataType(value, MappingSchema).DataType is not (DataType.Date or DataType.DateTime))
 				return value;
 
 			return Factory.Cast(value, Factory.GetDbDataType(typeof(DateTime)).WithDataType(DataType.DateTime2));

--- a/Source/LinqToDB/Internal/DataProvider/SQLite/SQLiteDataProvider.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SQLite/SQLiteDataProvider.cs
@@ -293,6 +293,20 @@ namespace LinqToDB.Internal.DataProvider.SQLite
 					dataType = dataType.WithDataType(DataType.VarChar);
 			}
 
+			// System.Data.SQLite knows nothing about DateTimeOffset and falls back to the value's own ToString(),
+			// which is neither invariant nor a SQLite time string: "1/1/2026 12:00:00 PM +00:00" on this machine and
+			// something else on the next one. Every date function returns null over it, ordering compares it as the
+			// text it is, and it does not even match the literal the mapping schema writes for the same value - so a
+			// stored offset is unusable server-side although it round-trips through the reader. Written in that
+			// literal's own shape instead, which SQLite parses and which carries the offset.
+			//
+			// Microsoft.Data.Sqlite already writes an equivalent ISO form of its own, so it is left alone.
+			if (value is DateTimeOffset dto && string.Equals(Name, ProviderName.SQLiteClassic, StringComparison.Ordinal))
+			{
+				value    = dto.ToString(SQLiteMappingSchema.DATETIMEOFFSET_FORMAT_RAW, DateTimeFormatInfo.InvariantInfo);
+				dataType = dataType.WithDataType(DataType.VarChar);
+			}
+
 #if SUPPORTS_DATEONLY
 			if (!Adapter.SupportsDateOnly && value is DateOnly d)
 			{

--- a/Source/LinqToDB/Internal/DataProvider/SQLite/SQLiteMappingSchema.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SQLite/SQLiteMappingSchema.cs
@@ -12,14 +12,19 @@ namespace LinqToDB.Internal.DataProvider.SQLite
 	public sealed class SQLiteMappingSchema : LockedMappingSchema
 	{
 		internal const string DATE_FORMAT_RAW                   = "yyyy-MM-dd";
+		/// <summary>
+		/// Shared with the parameter path, which writes the same text for a value that is inlined as a literal here -
+		/// the two have to agree, because a comparison against such a column is a comparison of the stored text.
+		/// </summary>
+		internal const string DATETIMEOFFSET_FORMAT_RAW         = "yyyy-MM-dd HH:mm:ss.fffzzz";
 #if SUPPORTS_COMPOSITE_FORMAT
 		private static readonly CompositeFormat DATE_FORMAT           = CompositeFormat.Parse("'{0:yyyy-MM-dd}'");
 		private static readonly CompositeFormat DATETIME_FORMAT       = CompositeFormat.Parse("'{0:yyyy-MM-dd HH:mm:ss.fff}'");
-		private static readonly CompositeFormat DATETIMEOFFSET_FORMAT = CompositeFormat.Parse("'{0:yyyy-MM-dd HH:mm:ss.fffzzz}'");
+		private static readonly CompositeFormat DATETIMEOFFSET_FORMAT = CompositeFormat.Parse("'{0:" + DATETIMEOFFSET_FORMAT_RAW + "}'");
 #else
 		private  const string DATE_FORMAT           = "'{0:yyyy-MM-dd}'";
 		private  const string DATETIME_FORMAT       = "'{0:yyyy-MM-dd HH:mm:ss.fff}'";
-		private  const string DATETIMEOFFSET_FORMAT = "'{0:yyyy-MM-dd HH:mm:ss.fffzzz}'";
+		private  const string DATETIMEOFFSET_FORMAT = "'{0:" + DATETIMEOFFSET_FORMAT_RAW + "}'";
 #endif
 
 		SQLiteMappingSchema() : base(ProviderName.SQLite)

--- a/Tests/Linq/DataProvider/SQLiteTests.cs
+++ b/Tests/Linq/DataProvider/SQLiteTests.cs
@@ -796,7 +796,6 @@ namespace Tests.DataProvider
 			db.InsertOrReplace(record);
 		}
 
-		[ActiveIssue(Configuration = TestProvName.AllSQLiteClassic)]
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/3766")]
 		public void Issue3766Test2([IncludeDataSources(true, TestProvName.AllSQLite)] string context, [Values] bool inline)
 		{

--- a/Tests/Linq/Linq/IntervalTranslationTests.Difference.cs
+++ b/Tests/Linq/Linq/IntervalTranslationTests.Difference.cs
@@ -24,7 +24,6 @@ namespace Tests.Linq
 		/// rows are chosen so that reading the offset and ignoring it give different answers in both directions -
 		/// one is zero only if offsets are honoured, the other is non-zero only if they are.
 		/// </remarks>
-		[ActiveIssue(5797, Configurations = [TestProvName.AllSQLiteClassic, TestProvName.AllOracle], Details = "The storage keeps the instant - the round-trip guard inside the test passes - but the difference is measured on the local reading: SQLite's julianday ignores the offset suffix, and every Oracle version loses the zone in the CAST(x AS timestamp) that the elapsed lowering uses. A wrong number rather than a refusal, so it is recorded rather than skipped.")]
 		[Test]
 		[ThrowsForProvider(typeof(LinqToDBException), UnsupportedDifferenceProviders, ErrorMessage = ErrorHelper.Error_Interval_Difference)]
 		public void ZonedDifferenceMeasuresInstantsNotLocalTime(
@@ -85,7 +84,6 @@ namespace Tests.Linq
 		/// <c>timestamptz</c> can hold, so the expectation needs no per-provider tolerance.
 		/// </para>
 		/// </remarks>
-		[ActiveIssue(5797, Configurations = [TestProvName.AllSQLiteClassic, TestProvName.AllOracle], Details = "The storage keeps the instant - the round-trip guard inside the test passes - but the difference is measured on the local reading: SQLite's julianday ignores the offset suffix, and every Oracle version loses the zone in the CAST(x AS timestamp) that the elapsed lowering uses. A wrong number rather than a refusal, so it is recorded rather than skipped.")]
 		[Test]
 		[ThrowsForProvider(typeof(LinqToDBException), UnsupportedDifferenceProviders, ErrorMessage = ErrorHelper.Error_Interval_Difference)]
 		public void ZonedDifferenceMembersMatchClr(
@@ -153,9 +151,15 @@ namespace Tests.Linq
 		/// the member falls to the shared decomposition, which is exact here because this provider sums the
 		/// interval's own fields into a tick count rather than dividing an epoch.
 		/// </para>
+		/// <para>
+		/// The two refusals are the same one at different depths, and neither has anything to do with the zone:
+		/// SQLite measures to the millisecond, so a microsecond component is always zero there, and Oracle measures
+		/// to the microsecond, so a nanosecond one is. Both are refused by name, and one refused member sinks the
+		/// whole projection - which is why the two providers appear here rather than among the answers.
+		/// </para>
 		/// </remarks>
-		[ActiveIssue(5797, Configurations = [TestProvName.AllOracle], Details = "Every Oracle version measures the difference on the local reading although the storage kept the instant - the zone is lost in the CAST(x AS timestamp) that the elapsed lowering uses.")]
 		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllSQLite, ErrorMessage = ErrorHelper.Error_Interval_ComponentBelowResolution)]
+		[ThrowsForProvider(typeof(LinqToDBException), TestProvName.AllOracle, ErrorMessage = ErrorHelper.Error_Interval_ComponentBelowResolution)]
 		[Test]
 		[ThrowsForProvider(typeof(LinqToDBException), UnsupportedDifferenceProviders, ErrorMessage = ErrorHelper.Error_Interval_Difference)]
 		public void ZonedDifferenceSubMillisecondMembersMatchClr(


### PR DESCRIPTION
Fixes #5797
Fixes #3766

A `DateTimeOffset` difference was measured on the stored local reading rather than the instant, on Oracle (every version) and SQLite Classic. Two marks denoting the same moment in different zones subtracted to a non-zero interval - a plausible number rather than a refusal, so every total and component taken from it inherited the error.

Two independent causes.

**Oracle** - `AsTimestamp` wrapped both operands of the elapsed-ticks lowering in `CAST(x AS timestamp)`. Over a `timestamp with time zone` that keeps the local reading and drops the zone. Oracle normalises two zoned operands to UTC before subtracting, which is what CLR subtraction does (`DateTimeOffset` compares `UtcDateTime`), so a zoned operand needs no cast at all. The cast is what it always was for - subtracting two Oracle `date` values yields a number of days rather than an interval - so it now applies to a `date` operand and nothing else, the same rule PostgreSQL already uses.

**SQLite Classic** - not an interval bug at all. `System.Data.SQLite` knows nothing about `DateTimeOffset` and fell back to the value's own `ToString()`, storing `1/1/2026 12:00:00 PM +00:00` - `CurrentCulture`-dependent, so different text on a different machine. Every date function returned NULL over it, ordering compared it as the text it was, and it did not match the literal the mapping schema writes for the same value. The parameter path now writes that literal's own shape, sharing the format constant so the two cannot drift apart again.

### Behaviour change

This changes the format SQLite Classic **stores** for `DateTimeOffset`. Values written by earlier versions still read back (both shapes parse), but they no longer compare equal to newly-written parameters. The old format was `CurrentCulture`-dependent and so was never portable between machines.

### Also fixes #3766

The SQLite Classic parameter fix resolves #3766 as well, and the two turn out to be the same defect seen from different ends. That issue reported a `DateTimeOffset` primary key behaving unpredictably - an `InsertOrReplace` or `Update` matching no rows, or failing a UNIQUE constraint. The cause was never the primary key: with `InlineParameters` the `WHERE` clause carried the mapping schema's ISO literal while the row had been stored in `System.Data.SQLite`'s culture-formatted shape, so the two never compared equal. Once both sides write the same text, the symptom goes.

`Issue3766Test2`'s SQLite Classic gate is removed accordingly. Attribution was verified rather than assumed: with the parameter fix disabled 2 of its 4 SQLite Classic cases fail; with it enabled all 16 cases pass across both drivers, both contexts and both `inline` values. `Issue3766Test1` was already passing and stays green.

### Tests

Removes the #5797 gates on three `ZonedDifference*` tests, and declares Oracle's sub-millisecond refusal by name (`Error_Interval_ComponentBelowResolution`) rather than gating it - that refusal is about Oracle's microsecond resolution and never concerned the zone.

### Verification

- `IntervalTranslationTests` fixture: 618/618 on Oracle 11, Oracle 23, SQLite Classic, SQLite MS and their LinqService variants - so the retired gate's "every Oracle version" claim was checked, not inferred.
- `ZonedDifference*` across 12 provider configurations - SQL Server 2019 (both drivers), PostgreSQL 16, MySqlConnector 8.0, Oracle 11/23, SQLite Classic/MS, ClickHouse (Client + MySql), DuckDB, YDB - all green, confirming the defect was confined to the two gated providers.
- Full suite on SQLite Classic: 11163 tests, 0 failed.
- SQLite Classic's literal and parameter paths were compared directly: both now store byte-identical text, for a whole-second value and for a fractional one.
- Release builds clean on `net10.0`, `netstandard2.0` and `net462`.

No public API surface changes; the shared format constant is `internal`.

Baselines were not captured locally, so the Oracle change's effect on emitted SQL - a dropped `CAST` - still needs review from CI's generated baselines. The cast is dropped for every operand that is not a `date`, so the delta is wider than a zone-only change would have been.
