### PR TITLE
Fix NullReferenceException disposing an un-advanced async enumerator, and three ForEachUntilAsync defects

### DIFF
--- a/Source/LinqToDB/Internal/Async/AsyncEnumeratorAsyncWrapper.cs
+++ b/Source/LinqToDB/Internal/Async/AsyncEnumeratorAsyncWrapper.cs
@@ -9,19 +9,41 @@ namespace LinqToDB.Internal.Async
 		private IAsyncEnumerator<T>? _enumerator;
 		private readonly Func<Task<Tuple<IAsyncEnumerator<T>, IAsyncDisposable?>>> _init;
 		private IAsyncDisposable? _disposable;
+		private bool _disposed;
 
 		public AsyncEnumeratorAsyncWrapper(Func<Task<Tuple<IAsyncEnumerator<T>, IAsyncDisposable?>>> init)
 		{
 			_init = init;
 		}
 
-		T IAsyncEnumerator<T>.Current => _enumerator!.Current;
+		T IAsyncEnumerator<T>.Current
+		{
+			get
+			{
+				if (_enumerator == null)
+					throw new InvalidOperationException("Enumeration not started.");
+
+				return _enumerator.Current;
+			}
+		}
 
 		async ValueTask IAsyncDisposable.DisposeAsync()
 		{
-			await _enumerator!.DisposeAsync().ConfigureAwait(false);
-			if (_disposable != null)
-				await _disposable.DisposeAsync().ConfigureAwait(false);
+			if (_disposed)
+				return;
+
+			_disposed = true;
+
+			try
+			{
+				if (_enumerator != null)
+					await _enumerator.DisposeAsync().ConfigureAwait(false);
+			}
+			finally
+			{
+				if (_disposable != null)
+					await _disposable.DisposeAsync().ConfigureAwait(false);
+			}
 		}
 
 		async ValueTask<bool> IAsyncEnumerator<T>.MoveNextAsync()

--- a/Source/LinqToDB/Internal/Async/AsyncEnumeratorAsyncWrapper.cs
+++ b/Source/LinqToDB/Internal/Async/AsyncEnumeratorAsyncWrapper.cs
@@ -48,6 +48,11 @@ namespace LinqToDB.Internal.Async
 
 		async ValueTask<bool> IAsyncEnumerator<T>.MoveNextAsync()
 		{
+			// without this the disposed instance re-runs _init, and the enumerator and load
+			// transaction it opens are unreachable from DisposeAsync, which returns at the flag
+			if (_disposed)
+				return false;
+
 			if (_enumerator == null)
 			{
 				var tuple   = await _init().ConfigureAwait(false);

--- a/Source/LinqToDB/Internal/Async/AsyncEnumeratorAsyncWrapper.cs
+++ b/Source/LinqToDB/Internal/Async/AsyncEnumeratorAsyncWrapper.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
+using LinqToDB.Internal.Common;
+
 namespace LinqToDB.Internal.Async
 {
 	internal sealed class AsyncEnumeratorAsyncWrapper<T> : IAsyncEnumerator<T>
@@ -21,7 +23,7 @@ namespace LinqToDB.Internal.Async
 			get
 			{
 				if (_enumerator == null)
-					throw new InvalidOperationException("Enumeration not started.");
+					throw new InvalidOperationException(ErrorHelper.Error_EnumerationNotStarted);
 
 				return _enumerator.Current;
 			}

--- a/Source/LinqToDB/Internal/Common/ErrorHelper.cs
+++ b/Source/LinqToDB/Internal/Common/ErrorHelper.cs
@@ -26,6 +26,7 @@
 		public const string Error_OrderByRequiredForIndexing       = "For retrieving index of row, specify OrderBy part.";
 		public const string Error_DistinctByRequiresOrderBy        = "DistinctBy requires at least one ordering key.";
 		public const string Error_LinqToDBQueryExpected            = "Linq To DB query expected";
+		public const string Error_EnumerationNotStarted            = "Enumeration not started.";
 
 		public const string Error_WindowFunctionsInSearchCondition                = "Window functions cannot be used in search condition.";
 		public const string Error_WindowFunction_PercentRank                      = "PERCENT_RANK is not supported by current provider.";

--- a/Source/LinqToDB/Internal/Linq/Builder/GroupByBuilder.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/GroupByBuilder.cs
@@ -754,7 +754,7 @@ namespace LinqToDB.Internal.Linq.Builder
 						get
 						{
 							if (_grouped == null)
-								throw new InvalidOperationException("Enumeration not started.");
+								throw new InvalidOperationException(ErrorHelper.Error_EnumerationNotStarted);
 
 							if (_current == null)
 								throw new InvalidOperationException("Enumeration returned no result.");

--- a/Source/LinqToDB/Internal/Linq/ExpressionQuery.cs
+++ b/Source/LinqToDB/Internal/Linq/ExpressionQuery.cs
@@ -186,13 +186,22 @@ namespace LinqToDB.Internal.Linq
 			if (!dependsOnParameters)
 				Expression = expressions.MainExpression;
 
-			var enumerable = (IAsyncEnumerable<T>)query.GetResultEnumerable(DataContext, expressions, Parameters, Preambles);
-			var enumerator = enumerable.GetAsyncEnumerator(cancellationToken);
+			var transaction = await StartLoadTransactionAsync(query, cancellationToken).ConfigureAwait(false);
+			await using var _ = (transaction ?? EmptyIAsyncDisposable.Instance).ConfigureAwait(false);
 
-			while (await enumerator.MoveNextAsync().ConfigureAwait(false))
+			Preambles = await query.InitPreamblesAsync(DataContext, expressions, Parameters, cancellationToken)
+				.ConfigureAwait(false);
+
+			var enumerable = (IAsyncEnumerable<T>)query.GetResultEnumerable(DataContext, expressions, Parameters, Preambles);
+
+			var enumerator = enumerable.GetAsyncEnumerator(cancellationToken);
+			await using (enumerator.ConfigureAwait(false))
 			{
-				if (func(enumerator.Current))
-					break;
+				while (await enumerator.MoveNextAsync().ConfigureAwait(false))
+				{
+					if (!func(enumerator.Current))
+						break;
+				}
 			}
 		}
 

--- a/Source/LinqToDB/Internal/Linq/ExpressionQuery.cs
+++ b/Source/LinqToDB/Internal/Linq/ExpressionQuery.cs
@@ -152,32 +152,17 @@ namespace LinqToDB.Internal.Linq
 				.GetResultEnumerable(DataContext, expressions, Parameters, Preambles);
 		}
 
-		public async Task GetForEachAsync(Action<T> action, CancellationToken cancellationToken)
+		public Task GetForEachAsync(Action<T> action, CancellationToken cancellationToken)
 		{
-			var expression  = Expression;
-			var expressions = GetOwnExpressions(expression);
-			var query       = GetQuery(ref expressions, true, out var dependsOnParameters);
-
-			if (!dependsOnParameters)
-				Expression = expressions.MainExpression;
-
-			var transaction = await StartLoadTransactionAsync(query, cancellationToken).ConfigureAwait(false);
-			await using var _ = (transaction ?? EmptyIAsyncDisposable.Instance).ConfigureAwait(false);
-
-			Preambles = await query.InitPreamblesAsync(DataContext, expressions, Parameters, cancellationToken)
-				.ConfigureAwait(false);
-
-			var enumerable = (IAsyncEnumerable<T>)query.GetResultEnumerable(DataContext, expressions, Parameters, Preambles);
-
-			var enumerator = enumerable.GetAsyncEnumerator(cancellationToken);
-			await using (enumerator.ConfigureAwait(false))
-			{
-				while (await enumerator.MoveNextAsync().ConfigureAwait(false))
-					action(enumerator.Current);
-			}
+			return GetForEachCoreAsync(x => { action(x); return true; }, cancellationToken);
 		}
 
-		public async Task GetForEachUntilAsync(Func<T,bool> func, CancellationToken cancellationToken)
+		public Task GetForEachUntilAsync(Func<T,bool> func, CancellationToken cancellationToken)
+		{
+			return GetForEachCoreAsync(func, cancellationToken);
+		}
+
+		async Task GetForEachCoreAsync(Func<T,bool> func, CancellationToken cancellationToken)
 		{
 			var expression  = Expression;
 			var expressions = GetOwnExpressions(expression);

--- a/Source/LinqToDB/Internal/Linq/LimitResultEnumerable.cs
+++ b/Source/LinqToDB/Internal/Linq/LimitResultEnumerable.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using LinqToDB;
+using LinqToDB.Internal.Common;
 
 namespace LinqToDB.Internal.Linq
 {
@@ -70,7 +71,7 @@ namespace LinqToDB.Internal.Linq
 				get
 				{
 					if (_enumerator == null)
-						throw new InvalidOperationException("Enumeration not started.");
+						throw new InvalidOperationException(ErrorHelper.Error_EnumerationNotStarted);
 
 					return _enumerator.Current;
 				}

--- a/Tests/Linq/Linq/AsyncTests.cs
+++ b/Tests/Linq/Linq/AsyncTests.cs
@@ -337,6 +337,28 @@ namespace Tests.Linq
 			act.ShouldThrow<InvalidOperationException>();
 		}
 
+		// MaskingChild maps to a table that does not exist, so the eager-load preamble fails inside the
+		// enumerator's initializer while its inner enumerator is still null. A query without preambles
+		// runs nothing there that can fail, so it cannot reach this path.
+		[Test]
+		public async Task DisposeAsyncDoesNotMaskInitFailureTest([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			Func<Task> act = async () =>
+			{
+				await using var enumerator = db.GetTable<MaskingParent>()
+					.LoadWith(p => p.Children)
+					.AsAsyncEnumerable()
+					.GetAsyncEnumerator();
+
+				await enumerator.MoveNextAsync();
+			};
+
+			var ex = await act.ShouldThrowAsync<Exception>();
+			ex.ShouldNotBeOfType<NullReferenceException>();
+		}
+
 		// ForEachUntilAsync stops when the callback returns false, per its own documentation and per
 		// the non-linq2db source path asserted here as the control.
 		[Test]
@@ -514,6 +536,21 @@ namespace Tests.Linq
 		sealed class AsyncMaterializationRecord
 		{
 			[PrimaryKey] public int Id { get; set; }
+		}
+
+		[Table("Parent")]
+		sealed class MaskingParent
+		{
+			[PrimaryKey] public int ParentID { get; set; }
+
+			[Association(ThisKey = "ParentID", OtherKey = "ParentID")]
+			public List<MaskingChild> Children { get; set; } = null!;
+		}
+
+		[Table("NoSuchTable5891")]
+		sealed class MaskingChild
+		{
+			[PrimaryKey] public int ParentID { get; set; }
 		}
 
 		sealed class DataReaderApiInterceptor : CommandInterceptor

--- a/Tests/Linq/Linq/AsyncTests.cs
+++ b/Tests/Linq/Linq/AsyncTests.cs
@@ -296,8 +296,7 @@ namespace Tests.Linq
 
 			var enumerator = db.Parent.AsAsyncEnumerable().GetAsyncEnumerator();
 
-			Func<Task> dispose = async () => await enumerator.DisposeAsync();
-			await dispose.ShouldNotThrowAsync();
+			await enumerator.DisposeAsync();
 		}
 
 		[Test]
@@ -307,8 +306,7 @@ namespace Tests.Linq
 
 			await using var enumerator = db.Parent.AsAsyncEnumerable().GetAsyncEnumerator();
 
-			Func<Task> dispose = async () => await enumerator.DisposeAsync();
-			await dispose.ShouldNotThrowAsync();
+			await enumerator.DisposeAsync();
 		}
 
 		[Test]
@@ -324,9 +322,8 @@ namespace Tests.Linq
 
 			count.ShouldBe(Parent.Count());
 
-			Func<Task> dispose = async () => await enumerator.DisposeAsync();
-			await dispose.ShouldNotThrowAsync();
-			await dispose.ShouldNotThrowAsync();
+			await enumerator.DisposeAsync();
+			await enumerator.DisposeAsync();
 		}
 
 		[Test]

--- a/Tests/Linq/Linq/AsyncTests.cs
+++ b/Tests/Linq/Linq/AsyncTests.cs
@@ -340,6 +340,65 @@ namespace Tests.Linq
 			act.ShouldThrow<InvalidOperationException>();
 		}
 
+		// ForEachUntilAsync stops when the callback returns false, per its own documentation and per
+		// the non-linq2db source path asserted here as the control.
+		[Test]
+		public async Task ForEachUntilAsyncStopsOnFalseTest([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var expected = new List<int>();
+			await Parent.OrderBy(p => p.ParentID).AsQueryable().ForEachUntilAsync(p =>
+			{
+				expected.Add(p.ParentID);
+				return expected.Count < 2;
+			});
+
+			var all = new List<int>();
+			await db.Parent.OrderBy(p => p.ParentID).ForEachUntilAsync(p =>
+			{
+				all.Add(p.ParentID);
+				return true;
+			});
+
+			var stopped = new List<int>();
+			await db.Parent.OrderBy(p => p.ParentID).ForEachUntilAsync(p =>
+			{
+				stopped.Add(p.ParentID);
+				return stopped.Count < 2;
+			});
+
+			// an implementation that always stopped on the first row would satisfy `stopped` by
+			// accident, so pin that the two arms can differ at all
+			expected.Count.ShouldBe(2);
+			all.Count.ShouldBeGreaterThan(expected.Count);
+
+			stopped.ShouldBe(expected);
+		}
+
+		[Test]
+		public async Task ForEachUntilAsyncEagerLoadTest([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			// each arm must build its own query: sharing one lets the second arm read the preamble
+			// results the first one cached, hiding whether it initializes them itself
+			var expected = await db.Parent.LoadWith(p => p.Children).OrderBy(p => p.ParentID).ToListAsync();
+
+			var actual = new List<Parent>();
+			await db.Parent.LoadWith(p => p.Children).OrderBy(p => p.ParentID).ForEachUntilAsync(p =>
+			{
+				actual.Add(p);
+				return true;
+			});
+
+			// without eager-loaded children the child-count comparison below could not fail
+			expected.Sum(p => p.Children.Count).ShouldBeGreaterThan(0);
+
+			actual.Select(p => p.ParentID).ShouldBe(expected.Select(p => p.ParentID));
+			actual.Select(p => p.Children.Count).ShouldBe(expected.Select(p => p.Children.Count));
+		}
+
 		[Test]
 		public async Task ToLookupAsyncTest([DataSources] string context)
 		{

--- a/Tests/Linq/Linq/AsyncTests.cs
+++ b/Tests/Linq/Linq/AsyncTests.cs
@@ -286,6 +286,60 @@ namespace Tests.Linq
 			});
 		}
 
+		// The enumerator for a linq2db query creates its underlying enumerator lazily, on the first
+		// MoveNextAsync, so disposing before that must be a no-op.
+		// https://github.com/linq2db/linq2db/discussions/5891
+		[Test]
+		public async Task DisposeAsyncWithoutMoveNextTest([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var enumerator = db.Parent.AsAsyncEnumerable().GetAsyncEnumerator();
+
+			Func<Task> dispose = async () => await enumerator.DisposeAsync();
+			await dispose.ShouldNotThrowAsync();
+		}
+
+		[Test]
+		public async Task DisposeAsyncTwiceWithoutMoveNextTest([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			await using var enumerator = db.Parent.AsAsyncEnumerable().GetAsyncEnumerator();
+
+			Func<Task> dispose = async () => await enumerator.DisposeAsync();
+			await dispose.ShouldNotThrowAsync();
+		}
+
+		[Test]
+		public async Task DisposeAsyncTwiceAfterEnumerationTest([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var enumerator = db.Parent.AsAsyncEnumerable().GetAsyncEnumerator();
+
+			var count = 0;
+			while (await enumerator.MoveNextAsync())
+				count++;
+
+			count.ShouldBe(Parent.Count());
+
+			Func<Task> dispose = async () => await enumerator.DisposeAsync();
+			await dispose.ShouldNotThrowAsync();
+			await dispose.ShouldNotThrowAsync();
+		}
+
+		[Test]
+		public async Task CurrentBeforeMoveNextTest([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			await using var enumerator = db.Parent.AsAsyncEnumerable().GetAsyncEnumerator();
+
+			Action act = () => { _ = enumerator.Current; };
+			act.ShouldThrow<InvalidOperationException>();
+		}
+
 		[Test]
 		public async Task ToLookupAsyncTest([DataSources] string context)
 		{


### PR DESCRIPTION
Fixes the `NullReferenceException` reported in [discussion #5891](https://github.com/linq2db/linq2db/discussions/5891), plus three defects in `ExpressionQuery.GetForEachUntilAsync` found while verifying it.

## `AsyncEnumeratorAsyncWrapper.DisposeAsync`

`AsyncEnumeratorAsyncWrapper` creates its underlying enumerator lazily on the first `MoveNextAsync`, but `DisposeAsync` dereferenced it unconditionally:

```csharp
await _enumerator!.DisposeAsync().ConfigureAwait(false);
```

`ExpressionQuery<T>` is itself an `IAsyncEnumerable<T>`, so `AsAsyncEnumerable()` returns the query and `GetAsyncEnumerator()` hands back this wrapper. Disposing it without enumerating threw — the reported symptom.

The more damaging case is **exception masking**. The wrapper's `_init` opens the implicit load transaction and executes eager-load preamble queries, so if either fails (a cancelled token, or any SQL error in a `LoadWith` preamble) `_enumerator` stays null, and the `DisposeAsync` in the `try/finally` the compiler emits for `await foreach` / `await using` **replaces** the real exception with a `NullReferenceException`.

The fix aligns the wrapper with the two sibling lazily-initialized enumerators — `LimitResultEnumerable.LimitAsyncEnumerator` and `GroupByBuilder.GroupingAsyncEnumerator`, both of which already do this:

- null-guard the dispose;
- `Current` before enumeration starts throws `InvalidOperationException("Enumeration not started.")` instead of an NRE, matching both siblings;
- `DisposeAsync` is idempotent via a `_disposed` flag, as `IAsyncDisposable` requires — the reporter's own repro double-disposes. A flag rather than nulling `_enumerator`, which would let `MoveNextAsync` silently re-run the query;
- the implicit load transaction is disposed in a `finally`, so a throwing enumerator dispose can no longer leak it.

## `ExpressionQuery.GetForEachUntilAsync`

Three separate defects, no test coverage since it was added in `4727fe0c1` (2017).

**The predicate was inverted.** It broke when the callback returned `true`, while its own XML doc (*"Returning `false` from function will stop numeration"*) and the non-linq2db fallback path in `AsyncExtensions.ForEachUntilAsync` both stop on `false`. The intent is settled by the one in-repo caller: `LinqExtensions.SelectAsync` passes `r => { read = true; item = r; return false; }`, meaning *take one row and stop* — and was instead enumerating the whole result set, harmless only because that query returns a single row.

**Eager loading was broken.** Unlike its twin `GetForEachAsync`, it never started the implicit load transaction and never called `InitPreamblesAsync`, so it passed a stale or null `Preambles` into `GetResultEnumerable` and threw a `NullReferenceException` in the row mapper for any eager-loading query.

**The enumerator was never disposed**, leaving the reader and its command open until the context was disposed.

The method body is now identical to `GetForEachAsync` apart from the predicate break.

> [!NOTE]
> The predicate fix is a **behaviour change** for anyone who wrote `ForEachUntilAsync` against a linq2db query and matched the implementation rather than the documentation. The doc, the fallback path for non-linq2db sources, and the in-repo caller all agree against the old implementation, so the two paths previously disagreed with each other for the same callback.

## Tests

Six tests in `Tests/Linq/Linq/AsyncTests.cs`, all `[DataSources]` (every provider, plus each one's `.LinqService` variant).

Each defect was proven red independently before the fix:

| Test | Failure on master |
|---|---|
| `DisposeAsyncWithoutMoveNextTest` | `NullReferenceException` at `AsyncEnumeratorAsyncWrapper.cs:22` |
| `DisposeAsyncTwiceWithoutMoveNextTest` | same — the reporter's exact `await using` + explicit-dispose shape |
| `CurrentBeforeMoveNextTest` | `NullReferenceException` at `:22`, which *replaced* the test's own assertion failure — the masking mechanism itself |
| `ForEachUntilAsyncStopsOnFalseTest` | `all.Count` was 1 where > 2 was due; the in-memory fallback control arm passed at 2 |
| `ForEachUntilAsyncEagerLoadTest` | `[1]` where `[1..7]` was due (inverted predicate); with only the predicate fixed, it then failed with `NullReferenceException` in `QueryRunner.BasicResultEnumerable.GetAsyncEnumerable` from `GetForEachUntilAsync` — the preamble defect, isolated |
| `DisposeAsyncTwiceAfterEnumerationTest` | passed on master — it guards the `_disposed` flag on the already-initialized path |

`ForEachUntilAsyncStopsOnFalseTest` carries a discriminating guard (`all.Count > expected.Count`) so an implementation that always stopped on the first row cannot satisfy it by accident, and it cross-checks the linq2db path against the non-linq2db fallback so the two are pinned to agree.

## Verification

- New tests green on **SQLite.Classic, SQLite.MS, DuckDB, YDB, Informix.DB2, ClickHouse.Octonica, ClickHouse.Driver, ClickHouse.MySql** — each with its `.LinqService` variant, 0 skipped. Five engines, six ADO.NET drivers.
- Regression: `AsyncTests` + `EagerLoadingTests` + `SelectScalarTests` 266/266; `DataConnectionTests` + `SelectScalarTests` (the other `SelectAsync` call sites, the one existing caller whose behaviour changes) 94 passed / 3 pre-existing skips / 0 failed.
- Baselines: **0 changed**, 0 removed — no generated SQL moved. The new eager-load baseline shows both arms emitting the identical preamble + main SQL pair.
- Release builds of `Source/LinqToDB` at `net10.0` (analyzers) and `netstandard2.0` (portable TFM): 0 warnings, 0 errors.
- No public API surface change — `AsyncEnumeratorAsyncWrapper` is `internal` and `GetForEachUntilAsync`'s signature is untouched, so no `PublicAPI.Unshipped.txt` or `CompatibilitySuppressions.xml` changes.

The remaining providers are covered by `test-all` on this PR.

## Follow-up commits

Five commits from an agentic review pass. All five are structural or test-side; none changes emitted SQL or the behaviour the sections above describe.

| Commit | Change |
|---|---|
| `cc93a933e` | `GetForEachAsync` and `GetForEachUntilAsync` were left as verbatim copies apart from the predicate break — the same duplication that let the "until" variant miss the load transaction, the preamble init and the enumerator disposal in the first place. Both now call a private `GetForEachCoreAsync`. `GetForEachAsync` pays one extra delegate invocation per row for it. |
| `211f3faee` | Await the disposes directly instead of wrapping them in `ShouldNotThrowAsync`, which was used nowhere else in `Tests/`. An unexpected throw fails the test either way, and the direct form surfaces the original exception rather than a Shouldly wrapper around it. |
| `531ae3b51` | `DisposeAsyncDoesNotMaskInitFailureTest` — exception masking is described above as the more damaging case, but no test constructed it. |
| `14f0c4725` | `MoveNextAsync` ran the initializer whenever the inner enumerator was null, so advancing a *disposed* instance opened an enumerator and, for a query with preambles, an implicit load transaction that `DisposeAsync` could no longer reach. `if (_disposed) return false;` closes it. |
| `11ddce57a` | `"Enumeration not started."` had three inline copies across the lazily-initialized enumerators; moved to `ErrorHelper.Error_EnumerationNotStarted`. |

`14f0c4725` also disproves the rationale given above for preferring a `_disposed` flag over nulling `_enumerator`. Nulling was rejected because it "would let `MoveNextAsync` silently re-run the query" — but the flag alone did not prevent that either, since it only guarded `DisposeAsync`. Measured on SQLite with a `LoadWith` query before the fix: `MoveNextAsync` after `DisposeAsync` returned a row, and the implicit load transaction was still open after two further `DisposeAsync` calls.

The masking test was proven red before it shipped. With `DisposeAsync` reverted to the unguarded `await _enumerator!.DisposeAsync()` it fails with `NullReferenceException` raised at the `await using` scope exit, on both `SQLite.Classic` and `SQLite.Classic.LinqService`. Restored: 807/807 green across `AsyncTests`, `EagerLoadingTests`, `GroupByTests`, `TakeSkipTests` and `SelectScalarTests` on SQLite. Release builds of `Source/LinqToDB` at `net10.0` and `netstandard2.0` are clean.

Two claims in the sections above are now stale:

- **Seven tests, not six** — `DisposeAsyncDoesNotMaskInitFailureTest` was added.
- **Baselines: 204 added and 1 modified, not 0 changed.** The modification is `Issue1174Tests.TestConcurrentSelect` on ClickHouse.Octonica gaining a second byte-identical `SELECT ... LIMIT 1`. That test fires two concurrent `FirstAsync()` calls on separate connections, so how many statements reach the capture sink is timing-dependent, and its blob hash round-trips against #5880's baselines commit six hours earlier (`933072b` to `484f2be` there, `484f2be` to `933072b` here). Pre-existing capture race, unrelated to this PR.
