### PR TITLE
Prepare CLI 6.5.0 for MCP Registry publication

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -16,6 +16,15 @@ name: publish-mcp
 on:
   release:
     types: [published]
+  # Recovery path. If the automatic run fails - nuget.org lag beyond the poll budget, a transient
+  # registry error - re-run it here rather than falling back to the interactive Owner device flow.
+  # The tag supplies the version; nothing else is read from the tag's tree, so dispatching from
+  # the default branch is correct.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to publish, e.g. v6.5.0.
+        required: true
 
 permissions:
   contents: read
@@ -25,8 +34,8 @@ jobs:
   publish:
     name: Publish to MCP Registry
     runs-on: ubuntu-24.04
-    # A prerelease must not claim the registry version.
-    if: ${{ !github.event.release.prerelease }}
+    # A prerelease must not claim the registry version. A manual dispatch is always deliberate.
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
     timeout-minutes: 40
 
     env:
@@ -39,12 +48,17 @@ jobs:
 
       - name: Resolve release version
         env:
-          TAG: ${{ github.event.release.tag_name }}
-        run: echo "VERSION=${TAG#v}" >> "$GITHUB_ENV"
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          if [ -z "$TAG" ]; then
+            echo "No release tag resolved from either the release event or the dispatch input."
+            exit 1
+          fi
+          echo "VERSION=${TAG#v}" >> "$GITHUB_ENV"
 
-      # server.json pins the version literally - the schema rejects "latest" - and carries it in two
-      # places. Both are derived from the tag here, so the committed values cannot drift into being
-      # wrong: they are documentation, not the value that gets published.
+      # The schema rejects a floating version, so both fields have to carry a literal one. They are
+      # committed as 0.0.0 and populated here from the tag, so nothing has to remember to bump them
+      # and an unedited manual publish fails loudly instead of re-registering a stale version.
       - name: Set version in server.json
         run: |
           jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' \

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,98 @@
+# MCP Registry publication for linq2db.cli.
+#
+# Hooked to release publication rather than the `release` branch push. The registry verifies
+# ownership by reading the *published* nupkg's README - Azure's nuget-job.yml owns that push - so
+# the package must be live and served by nuget.org before this can succeed.
+#
+# The wait step polls exactly what the registry's validator reads: the ReadmeUriTemplate/6.13.0
+# resource resolved from nuget.org's service index. A green poll therefore means publication will
+# not fail on "wait for validation to complete".
+#
+# Actions are pinned by SHA and limited to GitHub-owned ones, matching the repository's
+# `allowed_actions: selected` + `github_owned_allowed` policy. mcp-publisher is not an action; it
+# is fetched from its GitHub release at a pinned tag rather than `latest`.
+name: publish-mcp
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write # github-oidc grants io.github.<owner>/* from the repository_owner claim
+
+jobs:
+  publish:
+    name: Publish to MCP Registry
+    runs-on: ubuntu-24.04
+    # A prerelease must not claim the registry version.
+    if: ${{ !github.event.release.prerelease }}
+    timeout-minutes: 40
+
+    env:
+      PUBLISHER_VERSION: v1.8.1
+      PACKAGE_ID: linq2db.cli
+      SERVER_NAME: io.github.linq2db/linq2db.cli
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Resolve release version
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: echo "VERSION=${TAG#v}" >> "$GITHUB_ENV"
+
+      # server.json pins the version literally - the schema rejects "latest" - and carries it in two
+      # places. Both are derived from the tag here, so the committed values cannot drift into being
+      # wrong: they are documentation, not the value that gets published.
+      - name: Set version in server.json
+        run: |
+          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' \
+            Source/LinqToDB.CLI/server.json > server.tmp
+          mv server.tmp Source/LinqToDB.CLI/server.json
+          cat Source/LinqToDB.CLI/server.json
+
+      # Substring match is deliberate: this is a readiness gate, not the ownership check. The
+      # authoritative boundary-anchored match is the publisher's, and it fails loudly if the marker
+      # is ever glued to a trailing character.
+      - name: Wait for nuget.org to serve the package README
+        run: |
+          TEMPLATE=$(curl -fsSL https://api.nuget.org/v3/index.json \
+            | jq -r '.resources[] | select(."@type" == "ReadmeUriTemplate/6.13.0") | ."@id"')
+          if [ -z "$TEMPLATE" ]; then
+            echo "ReadmeUriTemplate/6.13.0 is missing from the nuget.org service index."
+            exit 1
+          fi
+          LOWER_ID=$(printf '%s' "$PACKAGE_ID" | tr '[:upper:]' '[:lower:]')
+          LOWER_VER=$(printf '%s' "$VERSION"   | tr '[:upper:]' '[:lower:]')
+          URL=${TEMPLATE//\{lower_id\}/$LOWER_ID}
+          URL=${URL//\{lower_version\}/$LOWER_VER}
+          echo "Polling $URL"
+          for i in $(seq 1 60); do
+            if curl -fsSL "$URL" -o readme.published; then
+              if grep -Fq "mcp-name: $SERVER_NAME" readme.published; then
+                echo "README served with marker present after attempt $i."
+                exit 0
+              fi
+              echo "Attempt $i: README served, marker absent."
+            else
+              echo "Attempt $i: README not served yet."
+            fi
+            sleep 30
+          done
+          echo "Timed out waiting for $URL to carry 'mcp-name: $SERVER_NAME'."
+          exit 1
+
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz" \
+            | tar xz mcp-publisher
+
+      - name: Validate manifest
+        run: ./mcp-publisher validate Source/LinqToDB.CLI/server.json
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish Source/LinqToDB.CLI/server.json

--- a/Source/LinqToDB.CLI/MCP-REGISTRY.md
+++ b/Source/LinqToDB.CLI/MCP-REGISTRY.md
@@ -13,7 +13,7 @@ which `LinqToDB.CLI.csproj` includes in the NuGet package.
 
 The registry checks the README of the published NuGet package, not the GitHub
 working tree. Version 6.4.0 does not contain the marker and cannot be registered
-under this identity. The initial manifest targets the upcoming 6.4.1 release.
+under this identity. The initial manifest targets the upcoming 6.5.0 release.
 
 ## Register the released package
 
@@ -39,7 +39,7 @@ Clients use the NuGet `dnx` runtime (.NET 10 SDK or later), the fixed `mcp`
 subcommand, and a user-supplied absolute `--config` path. Equivalent invocation:
 
 ```text
-dnx linq2db.cli@6.4.1 --yes -- mcp --config /absolute/path/to/query.json
+dnx linq2db.cli@6.5.0 --yes -- mcp --config /absolute/path/to/query.json
 ```
 
 Create the local configuration using `config-init`, as described in the CLI

--- a/Source/LinqToDB.CLI/MCP-REGISTRY.md
+++ b/Source/LinqToDB.CLI/MCP-REGISTRY.md
@@ -14,8 +14,13 @@ under this identity; 6.5.0 is the first registrable version.
 publication. It derives both version fields from the release tag, waits for nuget.org to serve
 the package README, and authenticates with `mcp-publisher login github-oidc`, which grants the
 `io.github.linq2db/*` namespace from the workflow's `repository_owner` claim - no secret and no
-organization Owner required. The version fields committed in `server.json` are documentation;
-the workflow overwrites them at publish time.
+organization Owner required.
+
+Both version fields are committed as `0.0.0` and populated by the workflow from the release tag,
+so there is nothing to keep in step with a release. The placeholder is deliberate rather than
+cosmetic: publishing the committed file unedited fails at the registry's package-existence check,
+whereas a real-looking version would silently re-register a stale one. Read the live version from
+the registry API linked below, not from this file.
 
 A `release`-triggered workflow is read from the tree its tag points at, so the workflow must be
 merged before the release branch is cut, or that release publishes manually (below).

--- a/Source/LinqToDB.CLI/MCP-REGISTRY.md
+++ b/Source/LinqToDB.CLI/MCP-REGISTRY.md
@@ -1,0 +1,51 @@
+# Publishing to the MCP Registry
+
+The registry identity is `io.github.linq2db/linq2db.cli`. Its metadata lives in
+[server.json](server.json); the ownership marker lives in [readme.md](readme.md),
+which `LinqToDB.CLI.csproj` includes in the NuGet package.
+
+## Release prerequisites
+
+1. Set both version fields in `server.json` to the CLI package version being released.
+2. Publish that version of `linq2db.cli` through the normal NuGet release process.
+3. Confirm that the published package README contains
+   `<!-- mcp-name: io.github.linq2db/linq2db.cli -->`.
+
+The registry checks the README of the published NuGet package, not the GitHub
+working tree. Version 6.4.0 does not contain the marker and cannot be registered
+under this identity. The initial manifest targets the upcoming 6.4.1 release.
+
+## Register the released package
+
+Install the official [mcp-publisher](https://github.com/modelcontextprotocol/registry/releases)
+for your operating system. From this directory, run:
+
+```text
+mcp-publisher login github
+mcp-publisher publish server.json
+```
+
+Complete the GitHub device authorization using an account that is an **Owner**
+of the `linq2db` organization. See the registry's
+[authentication requirements](https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/authentication.mdx).
+
+Verify the returned name and version through the
+[registry API](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.linq2db/linq2db.cli).
+Repeat publication with updated version fields for subsequent releases.
+
+## Client configuration
+
+Clients use the NuGet `dnx` runtime (.NET 10 SDK or later), the fixed `mcp`
+subcommand, and a user-supplied absolute `--config` path. Equivalent invocation:
+
+```text
+dnx linq2db.cli@6.4.1 --yes -- mcp --config /absolute/path/to/query.json
+```
+
+Create the local configuration using `config-init`, as described in the CLI
+README. It can contain multiple profiles, which agents discover through
+`linq2db_info`. The optional `--profile` selects the default profile.
+The optional `--enable-execute-tool` defaults to `false`; setting it to `true`
+registers the write-capable tool, but execution also requires `enableExecute: true`
+in the selected configuration profile.
+Do not put connection strings or credentials in `server.json`.

--- a/Source/LinqToDB.CLI/MCP-REGISTRY.md
+++ b/Source/LinqToDB.CLI/MCP-REGISTRY.md
@@ -4,34 +4,41 @@ The registry identity is `io.github.linq2db/linq2db.cli`. Its metadata lives in
 [server.json](server.json); the ownership marker lives in [readme.md](readme.md),
 which `LinqToDB.CLI.csproj` includes in the NuGet package.
 
-## Release prerequisites
-
-1. Set both version fields in `server.json` to the CLI package version being released.
-2. Publish that version of `linq2db.cli` through the normal NuGet release process.
-3. Confirm that the published package README contains
-   `<!-- mcp-name: io.github.linq2db/linq2db.cli -->`.
-
 The registry checks the README of the published NuGet package, not the GitHub
 working tree. Version 6.4.0 does not contain the marker and cannot be registered
-under this identity. The initial manifest targets the upcoming 6.5.0 release.
+under this identity; 6.5.0 is the first registrable version.
 
-## Register the released package
+## Publication
 
-Install the official [mcp-publisher](https://github.com/modelcontextprotocol/registry/releases)
-for your operating system. From this directory, run:
+[publish-mcp.yml](../../.github/workflows/publish-mcp.yml) publishes on GitHub release
+publication. It derives both version fields from the release tag, waits for nuget.org to serve
+the package README, and authenticates with `mcp-publisher login github-oidc`, which grants the
+`io.github.linq2db/*` namespace from the workflow's `repository_owner` claim - no secret and no
+organization Owner required. The version fields committed in `server.json` are documentation;
+the workflow overwrites them at publish time.
+
+A `release`-triggered workflow is read from the tree its tag points at, so the workflow must be
+merged before the release branch is cut, or that release publishes manually (below).
+
+## Publishing manually
+
+Fallback for a release whose tag predates the workflow, or to re-publish out of band. Install the
+official [mcp-publisher](https://github.com/modelcontextprotocol/registry/releases) for your
+operating system, set both version fields in `server.json` to the released CLI version, then from
+this directory:
 
 ```text
+mcp-publisher validate server.json
 mcp-publisher login github
 mcp-publisher publish server.json
 ```
 
-Complete the GitHub device authorization using an account that is an **Owner**
-of the `linq2db` organization. See the registry's
+Interactive `login github` grants an organization namespace only to an **Owner** of the
+`linq2db` organization; ordinary membership is not sufficient. See the registry's
 [authentication requirements](https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/authentication.mdx).
 
 Verify the returned name and version through the
 [registry API](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.linq2db/linq2db.cli).
-Repeat publication with updated version fields for subsequent releases.
 
 ## Client configuration
 

--- a/Source/LinqToDB.CLI/readme.md
+++ b/Source/LinqToDB.CLI/readme.md
@@ -1,6 +1,8 @@
 <!-- omit in toc -->
 # LINQ to DB CLI tools
 
+<!-- mcp-name: io.github.linq2db/linq2db.cli -->
+
 ***
 > **NOTE**: This is not a library you could reference from your project, but command line utility, installed using `dotnet tool` command (see [installation notes](#installation)).
 ***

--- a/Source/LinqToDB.CLI/server.json
+++ b/Source/LinqToDB.CLI/server.json
@@ -6,6 +6,7 @@
   "repository": {
     "url": "https://github.com/linq2db/linq2db",
     "source": "github",
+    "id": "1916228",
     "subfolder": "Source/LinqToDB.CLI"
   },
   "version": "6.5.0",

--- a/Source/LinqToDB.CLI/server.json
+++ b/Source/LinqToDB.CLI/server.json
@@ -9,13 +9,13 @@
     "id": "1916228",
     "subfolder": "Source/LinqToDB.CLI"
   },
-  "version": "6.5.0",
+  "version": "0.0.0",
   "packages": [
     {
       "registryType": "nuget",
       "registryBaseUrl": "https://api.nuget.org/v3/index.json",
       "identifier": "linq2db.cli",
-      "version": "6.5.0",
+      "version": "0.0.0",
       "runtimeHint": "dnx",
       "transport": {
         "type": "stdio"

--- a/Source/LinqToDB.CLI/server.json
+++ b/Source/LinqToDB.CLI/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "subfolder": "Source/LinqToDB.CLI"
   },
-  "version": "6.4.1",
+  "version": "6.5.0",
   "packages": [
     {
       "registryType": "nuget",
       "registryBaseUrl": "https://api.nuget.org/v3/index.json",
       "identifier": "linq2db.cli",
-      "version": "6.4.1",
+      "version": "6.5.0",
       "runtimeHint": "dnx",
       "transport": {
         "type": "stdio"

--- a/Source/LinqToDB.CLI/server.json
+++ b/Source/LinqToDB.CLI/server.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.linq2db/linq2db.cli",
+  "title": "LINQ to DB",
+  "description": "Inspect database schemas and execute SQL queries across multiple database providers with LINQ to DB.",
+  "repository": {
+    "url": "https://github.com/linq2db/linq2db",
+    "source": "github",
+    "subfolder": "Source/LinqToDB.CLI"
+  },
+  "version": "6.4.1",
+  "packages": [
+    {
+      "registryType": "nuget",
+      "registryBaseUrl": "https://api.nuget.org/v3/index.json",
+      "identifier": "linq2db.cli",
+      "version": "6.4.1",
+      "runtimeHint": "dnx",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        },
+        {
+          "type": "named",
+          "name": "--config",
+          "description": "Absolute path to a local linq2db query/MCP configuration file containing database profiles.",
+          "format": "filepath",
+          "isRequired": true
+        },
+        {
+          "type": "named",
+          "name": "--profile",
+          "description": "Default database profile from the configuration file.",
+          "format": "string"
+        },
+        {
+          "type": "named",
+          "name": "--enable-execute-tool",
+          "description": "Register the write-capable tool. Execution also requires enableExecute=true in the selected profile.",
+          "format": "boolean",
+          "default": "false"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Prepare linq2db.cli 6.5.0 for publication as io.github.linq2db/linq2db.cli in the official MCP Registry.

Add the ownership marker to the packaged README, a NuGet/dnx STDIO manifest with required --config and optional --profile and --enable-execute-tool arguments, and publication instructions. Registry publication follows the NuGet release containing the marker.

Validation: server.json passes the official 2025-12-11 JSON Schema; git diff --check passes. Metadata and documentation only; no runtime changes.
