### PR TITLE
CI: run the docker-free Windows test legs on GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,5 @@
-# Provider tests on GitHub Actions - the Linux legs.
+# Provider tests on GitHub Actions - the Linux legs, and the Windows legs that need no docker
+# container (the win-mssql ones stay on Azure).
 #
 # Normally started by tests-comment.yml, when someone comments `/azp run test-<db>` on a PR. That path
 # calls this workflow rather than dispatching it, so `ref` can be refs/pull/<n>/merge - which
@@ -74,7 +75,10 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       linux: ${{ steps.select.outputs.linux }}
+      windows: ${{ steps.select.outputs.windows }}
       any: ${{ steps.select.outputs.any }}
+      windows_any: ${{ steps.select.outputs.windows_any }}
+      windows_x86: ${{ steps.select.outputs.windows_x86 }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -112,41 +116,104 @@ jobs:
               raise SystemExit(1)
           doc = yaml.safe_load(open('Build/Azure/pipelines/templates/test-matrix.yml', encoding='utf-8'))
           entries = doc['jobs'][0]['parameters']['test_matrix']
-          legs = []
-          # Counted before the gh_linux filter, to tell "this surface selects nothing at all" - the
-          # silent-empty-matrix that took build 23192 green with zero tests - apart from "every leg
-          # for this surface stays on Azure", which is a normal outcome for e.g. [oracle.all].
+          linux, windows = [], []
+          # Counted before the gh_linux / gh_windows filters, to tell "this surface selects nothing at
+          # all" - the silent-empty-matrix that took build 23192 green with zero tests - apart from
+          # "every leg for this surface stays on Azure", which is a normal outcome for e.g.
+          # [oracle.all] and for every win-mssql surface.
           matched = 0
           for e in entries:
               if surface not in e['filters']:
                   continue
-              if e.get('enable_os_ubuntu') is not True:
-                  continue
-              matched += 1
-              # The other half of the split in test-jobs.yml: Azure skips entries marked gh_linux, so
-              # only those run here. An entry without it stays on Azure - today the three Oracle legs,
-              # which Azure passes and this environment fails.
-              if e.get('gh_linux') != 'true':
-                  continue
-              legs.append({
-                  'name':          e['name'],
-                  'title':         e['title'],
-                  'config':        e['config_linux'],
-                  'script_global': e.get('script_linux_global', ''),
-                  'script_local':  e.get('script_linux_local', ''),
-                  'retry':         bool(e.get('retry', False)),
-                  'net80':         e.get('enable_fw_net80') is True,
-                  'net90':         e.get('enable_fw_net90') is True,
-                  'net100':        e.get('enable_fw_net100') is True,
-              })
-          legs.sort(key=lambda l: l['name'])          # the a_..y_ duration ordering from #5819
-          print('linux=' + json.dumps({'include': legs}))
-          print('any=' + ('true' if legs else 'false'))
+
+              # w_DB2InformixDuckDB sets enable_os_windows inside an Azure template conditional, so a
+              # stock parser sees a key whose whole name is that conditional and e.get(...) is None -
+              # the entry drops out silently. That is the right answer for it today (its windows leg is
+              # release-run only, and release runs stay on Azure), but the next entry to grow one of
+              # these must not be dropped without a word.
+              #
+              # The prefix is assembled rather than written out because GitHub evaluates its own
+              # expression syntax ANYWHERE in this file - script bodies and comments included - and a
+              # literal one here fails the whole workflow at dispatch with "Unrecognized named-value".
+              azure_expr = '$' + '{{'
+              if e.get('gh_windows') == 'true' and any(str(k).startswith(azure_expr) for k in e):
+                  print(f"::error::{e['name']} is marked gh_windows but carries an Azure template "
+                        "conditional key - a stock YAML parser cannot see the selectors inside it, so "
+                        "the leg would be silently dropped here", file=sys.stderr)
+                  raise SystemExit(1)
+
+              if e.get('enable_os_ubuntu') is True:
+                  matched += 1
+                  # The other half of the split in test-jobs.yml: Azure skips entries marked gh_linux,
+                  # so only those run here. An entry without it stays on Azure - today the three Oracle
+                  # legs, which Azure passes and this environment fails.
+                  if e.get('gh_linux') == 'true':
+                      linux.append({
+                          'name':          e['name'],
+                          'title':         e['title'],
+                          'config':        e['config_linux'],
+                          'script_global': e.get('script_linux_global', ''),
+                          'script_local':  e.get('script_linux_local', ''),
+                          'retry':         bool(e.get('retry', False)),
+                          'net80':         e.get('enable_fw_net80') is True,
+                          'net90':         e.get('enable_fw_net90') is True,
+                          'net100':        e.get('enable_fw_net100') is True,
+                      })
+
+              if e.get('enable_os_windows') is True:
+                  matched += 1
+                  if e.get('gh_windows') == 'true':
+                      # test-jobs.yml's rule, restated: windows runs a non-netfx TFM only for a leg
+                      # linux cannot cover, unless win_tfms_always opts out. netfx is windows-only, so
+                      # it always follows the entry's own switch.
+                      own_tfms = e.get('enable_os_ubuntu') is not True or e.get('win_tfms_always') is True
+                      tfms = {
+                          'netfx':  e.get('enable_fw_netfx') is True,
+                          'net80':  own_tfms and e.get('enable_fw_net80') is True,
+                          'net90':  own_tfms and e.get('enable_fw_net90') is True,
+                          'net100': own_tfms and e.get('enable_fw_net100') is True,
+                      }
+                      # What win_tfms_always exists to prevent. Without this the leg runs no suite at
+                      # all and fails one step later on a missing .trx, which reads as a test problem.
+                      if not any(tfms.values()):
+                          print(f"::error::{e['name']} selects a windows leg with no TFM enabled - see "
+                                "win_tfms_always in test-matrix.yml", file=sys.stderr)
+                          raise SystemExit(1)
+                      x86 = e.get('x86') is True
+                      windows.append({
+                          'name':            e['name'],
+                          'title':           e['title'],
+                          'config':          e['config_win'],
+                          'arch':            'x86' if x86 else 'x64',
+                          # Names the binaries artifact half: test_net80<suffix>_binaries. Data rather
+                          # than an expression in the step, so the artifact naming stays in one place.
+                          'artifact_suffix': '_x86' if x86 else '',
+                          'script_global':   e.get('script_win_global', ''),
+                          'psscript_global': e.get('psscript_win_global', ''),
+                          'script_local':    e.get('script_win_local', ''),
+                          'psscript_local':  e.get('psscript_win_local', ''),
+                          'pre_test':        e.get('pre_test_win_local', ''),
+                          'post_test':       e.get('post_test_win_local', ''),
+                          'retry':           bool(e.get('retry', False)),
+                          'efcore_only':     e.get('win_efcore_only') is True,
+                          **tfms,
+                      })
+
+          # the a_..y_ duration ordering from #5819
+          linux.sort(key=lambda l: l['name'])
+          windows.sort(key=lambda l: l['name'])
+          print('linux=' + json.dumps({'include': linux}))
+          print('windows=' + json.dumps({'include': windows}))
+          print('any=' + ('true' if linux else 'false'))
+          print('windows_any=' + ('true' if windows else 'false'))
+          print('windows_x86=' + ('true' if any(l['arch'] == 'x86' for l in windows) else 'false'))
           print('matched=' + str(matched))
-          for l in legs:
-              print(f"::notice::selected {l['name']} ({l['title']})", file=__import__('sys').stderr)
-          if matched and not legs:
-              print(f"::notice::every leg for this surface runs on Azure - nothing to do here", file=__import__('sys').stderr)
+          for l in linux:
+              print(f"::notice::selected Lin {l['name']} ({l['title']})", file=sys.stderr)
+          for l in windows:
+              print(f"::notice::selected Win {l['name']} ({l['title']}, {l['arch']})", file=sys.stderr)
+          if matched and not linux and not windows:
+              print("::notice::every leg for this surface runs on Azure - nothing to do here", file=sys.stderr)
           PY
         env:
           SURFACE: ${{ inputs.surface }}
@@ -154,19 +221,22 @@ jobs:
       # A surface that matches no entry at all is the failure that looks like success - build 23192 on
       # the Azure side went green having run nothing. A surface whose legs all stay on Azure is a
       # normal outcome, so it is reported and skipped rather than failed.
-      - if: steps.select.outputs.any != 'true' && steps.select.outputs.matched == '0'
+      - if: steps.select.outputs.any != 'true' && steps.select.outputs.windows_any != 'true' && steps.select.outputs.matched == '0'
         run: |
-          echo "::error::no Linux leg matches surface '${{ inputs.surface }}' - nothing would run"
+          echo "::error::no leg matches surface '${{ inputs.surface }}' - nothing would run"
           exit 1
 
   # Windows because Tests.csproj targets net462 and restore covers every TFM, so a Linux host cannot
-  # restore it without the reference assemblies the repo does not reference. Only the x64 net8/9/10
-  # output is staged, which is all a Linux leg consumes.
+  # restore it without the reference assemblies the repo does not reference. x64 net8/9/10 is staged
+  # unconditionally - it is all a Linux leg consumes - and netfx only when a windows leg was selected,
+  # so a linux-only surface does not pay for two publishes nothing will download.
   build:
     name: Build test artifacts
-    # Gated on prepare only to avoid burning a 15-minute Windows build on a surface that selects
-    # nothing - a typo in a hand-dispatched run. prepare costs a minute or two of critical path.
+    # Gated on prepare to avoid burning a 15-minute Windows build on a surface that selects nothing -
+    # a typo in a hand-dispatched run, or a surface whose every leg stays on Azure. prepare costs a
+    # minute or two of critical path.
     needs: prepare
+    if: needs.prepare.outputs.any == 'true' || needs.prepare.outputs.windows_any == 'true'
     runs-on: windows-2025
     timeout-minutes: 90
     steps:
@@ -211,10 +281,36 @@ jobs:
             Copy-Item -Recurse -Force "Build/$cfg/$($t.flag)" "testing/configs/$($t.flag)"
           }
 
+          # Unconditional, unlike the netfx binaries below: these are three-line JSON files, and one
+          # shape for test_configs beats a second artifact variant to reason about.
+          Copy-Item -Recurse -Force "Build/$cfg/netfx" "testing/configs/netfx"
+
           New-Item -ItemType Directory -Force -Path testing/scripts | Out-Null
           Copy-Item -Recurse -Force "Build/$cfg/scripts/*" testing/scripts
           Copy-Item -Recurse -Force 'Build/CI/*' testing/scripts
           Copy-Item 'Data/Create Scripts/Northwind.sql' testing/scripts/northwind.sql
+
+      # netfx runs on windows only, so this is skipped entirely for a linux-only surface.
+      - name: Publish and stage netfx
+        if: needs.prepare.outputs.windows_any == 'true'
+        shell: pwsh
+        run: |
+          $cfg = '${{ env.TEST_CONFIGURATION }}'
+
+          dotnet publish Tests/Linq/Tests.csproj -f net462 -c $cfg -o ".build/publish/Tests/$cfg/net462_x64"
+          if ($LASTEXITCODE) { throw 'publish Tests net462 failed' }
+
+          # -a x64: net462 is AnyCPU and runs as x64; without an explicit RID the SQLitePCLRaw net4x
+          # native target ships only the x86 e_sqlite3, which the x64 EF test process cannot load.
+          dotnet publish Tests/EntityFrameworkCore/Tests.EntityFrameworkCore.EF3.csproj -f net462 -c $cfg -a x64 -o ".build/publish/EFTests/$cfg/net462_x64"
+          if ($LASTEXITCODE) { throw 'publish EF3 net462 failed' }
+
+          foreach ($kind in @(@{ n = 'main'; src = "Tests/$cfg/net462_x64" }, @{ n = 'efcore'; src = "EFTests/$cfg/net462_x64" })) {
+            $dest = "testing/net462/$($kind.n)/x64"
+            New-Item -ItemType Directory -Force -Path $dest | Out-Null
+            Copy-Item -Recurse -Force ".build/publish/$($kind.src)/*" $dest
+            Copy-Item DataProviders.json, .runsettings $dest
+          }
 
       # include-hidden-files on every upload below: .runsettings is a dotfile, which upload-artifact
       # drops by default and without warning, and MTP does not auto-discover it - so each leg fails
@@ -230,6 +326,14 @@ jobs:
         with:
           name: test_configs
           path: testing/configs
+          if-no-files-found: error
+          include-hidden-files: true
+
+      - if: needs.prepare.outputs.windows_any == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test_netfx_binaries
+          path: testing/net462
           if-no-files-found: error
           include-hidden-files: true
 
@@ -254,9 +358,100 @@ jobs:
           if-no-files-found: error
           include-hidden-files: true
 
+  # Its own job, mirroring Azure's build_x86_job, because -a x86 rebuilds the whole graph for the
+  # win-x86 RID and reuses nothing from the x64 build - ~6.8 min there against ~2.1 for the x64
+  # publishes. Only the three Access legs are x86, so the job is skipped for every other surface.
+  #
+  # Unlike Azure this uploads one artifact per TFM rather than one for all four. download-artifact has
+  # no itemPattern, so a single artifact would make every leg take all four TFMs at once, losing the
+  # download-run-delete disk discipline the per-TFM steps below rely on.
+  build_x86:
+    name: Build test artifacts (win-x86)
+    needs: prepare
+    if: needs.prepare.outputs.windows_x86 == 'true'
+    runs-on: windows-2025
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: |
+            8.x
+            9.x
+            10.x
+
+      - name: Publish and stage (win-x86)
+        shell: pwsh
+        run: |
+          $cfg = '${{ env.TEST_CONFIGURATION }}'
+          $tfms = @(
+            @{ dir = 'net462';  ef = 'EF3';  stubs = $false },
+            @{ dir = 'net8.0';  ef = 'EF8';  stubs = $true  },
+            @{ dir = 'net9.0';  ef = 'EF9';  stubs = $true  },
+            @{ dir = 'net10.0'; ef = 'EF10'; stubs = $true  }
+          )
+          foreach ($t in $tfms) {
+            # Built as an array and splatted once, rather than conditionally splatting a second one:
+            # an `if` expression returning a single-element array unrolls to a bare string, and
+            # splatting a string into a native command passes it one character at a time. That is not
+            # theoretical - it produced `- p : X 8 6 S T U B S = T r u e` and MSBUILD error MSB1001.
+            # X86STUBS is netcore-only in Azure's script; net462 publishes without it.
+            $pub = @('publish', 'Tests/Linq/Tests.csproj', '-f', $t.dir, '-c', $cfg, '-a', 'x86')
+            if ($t.stubs) { $pub += '-p:X86STUBS=True' }
+            $pub += @('-o', ".build/publish/Tests/$cfg/$($t.dir)_x86")
+            dotnet @pub
+            if ($LASTEXITCODE) { throw "publish Tests $($t.dir) x86 failed" }
+            dotnet publish "Tests/EntityFrameworkCore/Tests.EntityFrameworkCore.$($t.ef).csproj" -f $t.dir -c $cfg -a x86 -o ".build/publish/EFTests/$cfg/$($t.dir)_x86"
+            if ($LASTEXITCODE) { throw "publish EF $($t.dir) x86 failed" }
+
+            # Same layout as the x64 artifacts, so a leg finds main/x86 and efcore/x86 where it expects.
+            foreach ($kind in @(@{ n = 'main'; src = "Tests/$cfg/$($t.dir)_x86" }, @{ n = 'efcore'; src = "EFTests/$cfg/$($t.dir)_x86" })) {
+              $dest = "testing/$($t.dir)/$($kind.n)/x86"
+              New-Item -ItemType Directory -Force -Path $dest | Out-Null
+              Copy-Item -Recurse -Force ".build/publish/$($kind.src)/*" $dest
+              Copy-Item DataProviders.json, .runsettings $dest
+            }
+          }
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test_netfx_x86_binaries
+          path: testing/net462
+          if-no-files-found: error
+          include-hidden-files: true
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test_net80_x86_binaries
+          path: testing/net8.0
+          if-no-files-found: error
+          include-hidden-files: true
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test_net90_x86_binaries
+          path: testing/net9.0
+          if-no-files-found: error
+          include-hidden-files: true
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test_net100_x86_binaries
+          path: testing/net10.0
+          if-no-files-found: error
+          include-hidden-files: true
+
   linux-tests:
     name: Lin ${{ matrix.name }}
     needs: [prepare, build]
+    # An empty matrix is not "no jobs" - it fails the RUN, with no failed job to point at and no
+    # annotation on any check run, so `gh run view` shows every job green under a red run. Surfaces
+    # whose linux legs all stay on Azure ([oracle.all], and every windows-only surface) hit it, so the
+    # job is skipped explicitly rather than instantiated with nothing in it.
+    if: needs.prepare.outputs.any == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 180
     strategy:
@@ -402,6 +597,232 @@ jobs:
           PR_ID: ${{ inputs.pr }}
         run: |
           ../scripts/push-baselines.ps1 -Platform Linux -Title "$Env:TITLE" -Branch "$Env:BRANCH" `
+            -BaselinesMaster "$Env:BASELINES_MASTER" -PrId "$Env:PR_ID" -GitHubAnnotations
+          exit $LASTEXITCODE
+
+  # The windows legs that need no docker container. Same shape as linux-tests, with three differences
+  # forced by the platform: netfx is in the TFM list, the suites are apphost .exe rather than
+  # `dotnet <dll>`, and a leg may be x86 - which changes both the SDK installed and the artifact half
+  # it downloads.
+  windows-tests:
+    name: Win ${{ matrix.name }}
+    # build_x86 is skipped for a surface with no x86 leg, and a skipped dependency skips the dependent
+    # by default - so the gate is spelled out rather than left to `needs`. !cancelled() rather than
+    # always(), so a cancelled run does not start legs. windows_any for the same reason linux-tests
+    # tests `any`: an empty matrix fails the run rather than producing no jobs.
+    needs: [prepare, build, build_x86]
+    if: >
+      !cancelled()
+      && needs.prepare.outputs.windows_any == 'true'
+      && needs.build.result == 'success'
+      && (needs.build_x86.result == 'success' || needs.build_x86.result == 'skipped')
+    runs-on: windows-2025
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.windows) }}
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: test_scripts
+          path: scripts
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: test_configs
+          path: configs
+
+      # Cloned to <leg root>/baselines because AzureConnectionStrings sets
+      # BaselinesPath: ./../../../baselines, resolved from the test assembly.
+      - name: Checkout test baselines
+        if: inputs.baselines_branch != ''
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.BASELINES_GH_PAT }}
+          BRANCH: ${{ inputs.baselines_branch }}
+        run: |
+          ./scripts/checkout-baselines.ps1 -Branch "$Env:BRANCH" -BaselinesMaster "$Env:BASELINES_MASTER"
+          exit $LASTEXITCODE
+
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: |
+            8.x
+            9.x
+            10.x
+
+      # An x86 leg runs x86 apphosts, which need an x86 runtime the image does not carry - Azure does
+      # the same thing with UseDotNet@2 under PROCESSOR_ARCHITECTURE=x86. Installed after the x64 one
+      # so the x86 install owns DOTNET_ROOT and PATH on the legs that need it.
+      - if: matrix.arch == 'x86'
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          architecture: x86
+          dotnet-version: |
+            8.x
+            9.x
+            10.x
+
+      - name: Execute global setup script
+        if: matrix.script_global != ''
+        working-directory: scripts
+        shell: pwsh
+        env:
+          SCRIPT: ${{ matrix.script_global }}
+        run: |
+          & cmd.exe /c ".\$Env:SCRIPT"
+          exit $LASTEXITCODE
+
+      # $LASTEXITCODE is reset first because both current global scripts end their success path in
+      # `return`, not `exit`, which leaves it holding whatever a previous native command set - and a
+      # called script's `exit` terminates only that script, so without the explicit exit below a failed
+      # install would be a green step.
+      - name: Execute global PowerShell setup script
+        if: matrix.psscript_global != ''
+        working-directory: scripts
+        shell: pwsh
+        env:
+          SCRIPT: ${{ matrix.psscript_global }}
+        run: |
+          $global:LASTEXITCODE = 0
+          & "./$Env:SCRIPT"
+          exit $LASTEXITCODE
+
+      # One download/run/delete cycle per TFM, in Azure's order. Matrix values go through env, not
+      # `run:` interpolation, which would turn test-matrix.yml data into code.
+
+      - name: Extract NETFX test binaries
+        if: matrix.netfx
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: test_netfx${{ matrix.artifact_suffix }}_binaries
+          path: net462
+
+      - name: Tests (NETFX)
+        if: matrix.netfx
+        shell: pwsh
+        env:
+          CONFIG: ${{ matrix.config }}
+          ARCH: ${{ matrix.arch }}
+          SETUP_CMD: ${{ matrix.script_local }}
+          SETUP_PS1: ${{ matrix.psscript_local }}
+          PRE_TEST: ${{ matrix.pre_test }}
+          POST_TEST: ${{ matrix.post_test }}
+          RETRY: ${{ matrix.retry }}
+          # netfx carries the main suite on every run (pr_main: true), except on an entry that leaves
+          # it to the linux legs - which makes that entry's netfx main suite release-run only. Mirrors
+          # win_efcore_only in test-workflow-windows.yml.
+          RUN_MAIN: ${{ inputs.full_run || !matrix.efcore_only }}
+        run: |
+          ./scripts/run-provider-tests.ps1 -Tfm net462 -Flag netfx -Arch "$Env:ARCH" -Config "$Env:CONFIG" `
+            -SetupCmd "$Env:SETUP_CMD" -SetupPs1 "$Env:SETUP_PS1" -PreTest "$Env:PRE_TEST" -PostTest "$Env:POST_TEST" `
+            -Retry "$Env:RETRY" -Main "$Env:RUN_MAIN"
+          exit $LASTEXITCODE
+
+      - name: Extract .NET 8 test binaries
+        if: matrix.net80
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: test_net80${{ matrix.artifact_suffix }}_binaries
+          path: net8.0
+
+      - name: Tests (.NET 8)
+        if: matrix.net80
+        shell: pwsh
+        env:
+          CONFIG: ${{ matrix.config }}
+          ARCH: ${{ matrix.arch }}
+          SETUP_CMD: ${{ matrix.script_local }}
+          SETUP_PS1: ${{ matrix.psscript_local }}
+          PRE_TEST: ${{ matrix.pre_test }}
+          POST_TEST: ${{ matrix.post_test }}
+          RETRY: ${{ matrix.retry }}
+          # net8/net9 run the main suite on release runs only; the EF.Core suite always runs.
+          RUN_MAIN: ${{ inputs.full_run }}
+        run: |
+          ./scripts/run-provider-tests.ps1 -Tfm net8.0 -Flag net80 -Arch "$Env:ARCH" -Config "$Env:CONFIG" `
+            -SetupCmd "$Env:SETUP_CMD" -SetupPs1 "$Env:SETUP_PS1" -PreTest "$Env:PRE_TEST" -PostTest "$Env:POST_TEST" `
+            -Retry "$Env:RETRY" -Main "$Env:RUN_MAIN"
+          exit $LASTEXITCODE
+
+      - name: Extract .NET 9 test binaries
+        if: matrix.net90
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: test_net90${{ matrix.artifact_suffix }}_binaries
+          path: net9.0
+
+      - name: Tests (.NET 9)
+        if: matrix.net90
+        shell: pwsh
+        env:
+          CONFIG: ${{ matrix.config }}
+          ARCH: ${{ matrix.arch }}
+          SETUP_CMD: ${{ matrix.script_local }}
+          SETUP_PS1: ${{ matrix.psscript_local }}
+          PRE_TEST: ${{ matrix.pre_test }}
+          POST_TEST: ${{ matrix.post_test }}
+          RETRY: ${{ matrix.retry }}
+          RUN_MAIN: ${{ inputs.full_run }}
+        run: |
+          ./scripts/run-provider-tests.ps1 -Tfm net9.0 -Flag net90 -Arch "$Env:ARCH" -Config "$Env:CONFIG" `
+            -SetupCmd "$Env:SETUP_CMD" -SetupPs1 "$Env:SETUP_PS1" -PreTest "$Env:PRE_TEST" -PostTest "$Env:POST_TEST" `
+            -Retry "$Env:RETRY" -Main "$Env:RUN_MAIN"
+          exit $LASTEXITCODE
+
+      - name: Extract .NET 10 test binaries
+        if: matrix.net100
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: test_net100${{ matrix.artifact_suffix }}_binaries
+          path: net10.0
+
+      - name: Tests (.NET 10)
+        if: matrix.net100
+        shell: pwsh
+        env:
+          CONFIG: ${{ matrix.config }}
+          ARCH: ${{ matrix.arch }}
+          SETUP_CMD: ${{ matrix.script_local }}
+          SETUP_PS1: ${{ matrix.psscript_local }}
+          PRE_TEST: ${{ matrix.pre_test }}
+          POST_TEST: ${{ matrix.post_test }}
+          RETRY: ${{ matrix.retry }}
+          # The newest TFM carries the main suite on every run - pr_main: true - unless the entry
+          # leaves it to the linux legs.
+          RUN_MAIN: ${{ inputs.full_run || !matrix.efcore_only }}
+        run: |
+          ./scripts/run-provider-tests.ps1 -Tfm net10.0 -Flag net100 -Arch "$Env:ARCH" -Config "$Env:CONFIG" `
+            -SetupCmd "$Env:SETUP_CMD" -SetupPs1 "$Env:SETUP_PS1" -PreTest "$Env:PRE_TEST" -PostTest "$Env:POST_TEST" `
+            -Retry "$Env:RETRY" -Main "$Env:RUN_MAIN"
+          exit $LASTEXITCODE
+
+      # Stands in for PublishTestResults@2, including its failTaskOnMissingResultsFile: a leg whose
+      # test app never ran writes no .trx, and without this it would finish green having tested
+      # nothing.
+      - name: Report test results
+        if: always()
+        shell: pwsh
+        env:
+          TITLE: ${{ matrix.title }}
+        run: |
+          ./scripts/report-trx.ps1 -ResultsDirectory TestResults -Title "Win $Env:TITLE"
+          exit $LASTEXITCODE
+
+      - name: Commit test baselines
+        if: inputs.baselines_branch != ''
+        shell: pwsh
+        working-directory: baselines
+        env:
+          GITHUB_TOKEN: ${{ secrets.BASELINES_GH_PAT }}
+          EMAIL: actions@linq2db.com
+          GIT_AUTHOR_NAME: GitHub Actions Bot
+          GIT_COMMITTER_NAME: GitHub Actions Bot
+          TITLE: ${{ matrix.title }}
+          BRANCH: ${{ inputs.baselines_branch }}
+          PR_ID: ${{ inputs.pr }}
+        run: |
+          ../scripts/push-baselines.ps1 -Platform Windows -Title "$Env:TITLE" -Branch "$Env:BRANCH" `
             -BaselinesMaster "$Env:BASELINES_MASTER" -PrId "$Env:PR_ID" -GitHubAnnotations
           exit $LASTEXITCODE
 

--- a/Build/Azure/pipelines/templates/test-jobs.yml
+++ b/Build/Azure/pipelines/templates/test-jobs.yml
@@ -45,6 +45,17 @@ parameters:
 - name: offload_linux_to_github
   type: boolean
   default: false
+  # Same split for the windows legs. Only the entries marked gh_windows move - the win-mssql ones stay
+  # here either way, so build_x86_job and the whole windows workflow below remain live even when this
+  # is on.
+  #
+  # No caller passes it yet, deliberately: tests-comment.yml runs the DEFAULT branch's tests.yml, so
+  # between turning this on and merging the windows job there is a window where Azure has been told to
+  # skip a leg that GitHub cannot yet run - the leg would run nowhere and nothing would say so. The
+  # flip in testing.yml is its own one-line PR, after the windows job is on master.
+- name: offload_windows_to_github
+  type: boolean
+  default: false
 
 jobs:
 ##############################################################################################
@@ -107,7 +118,10 @@ jobs:
   strategy:
     matrix:
       ${{ each test_config in parameters.test_matrix }}:
-        ${{ if and(contains(test_config.filters, parameters.db_filter), eq(test_config.enable_os_windows, 'true')) }}:
+        # An entry marked gh_windows runs its windows leg on GitHub Actions instead, so Azure skips it -
+        # but only when the caller asks for the split, exactly as the linux job below does. default.yml
+        # does not ask, which is what keeps the release run covering every leg on one CI.
+        ${{ if and(contains(test_config.filters, parameters.db_filter), eq(test_config.enable_os_windows, 'true'), not(and(eq(parameters.offload_windows_to_github, true), eq(test_config.gh_windows, 'true')))) }}:
           ${{ test_config.name }}:
             title: ${{ test_config.title }}
             config: ${{ test_config.config_win }}

--- a/Build/Azure/pipelines/templates/test-matrix.yml
+++ b/Build/Azure/pipelines/templates/test-matrix.yml
@@ -5,6 +5,7 @@ parameters:
   linux_max_parallel: 0 # linux legs allowed to run at once, 0 for uncapped. See test-jobs.yml.
   db_filter: '[all]' # fallback for a definition absent from `surfaces` below, e.g. default.yml
   offload_linux_to_github: false # when true, linux legs marked gh_linux run on GitHub Actions instead
+  offload_windows_to_github: false # when true, windows legs marked gh_windows run on GitHub Actions instead
 
   # Which surface each Azure pipeline definition tests, keyed by definition name. Data rather than
   # the if-chain this replaced in testing.yml, for the reason #5848 moved entry selection here: an
@@ -110,6 +111,14 @@ parameters:
 # - win_efcore_only (true/false string, optional) : windows-only, run just the EF.Core suite on non-release
 #   runs and leave the main suite to the linux legs. Since netfx runs only on windows, that also makes the
 #   entry's netfx main suite release-run only. Release runs (full_run) run the main suite for every TFM.
+# - gh_linux   (true/false string, optional) : the entry's linux leg runs on GitHub Actions instead of
+#   Azure. It takes effect only when the caller passes offload_linux_to_github - test-jobs.yml then skips
+#   the entry and .github/workflows/tests.yml selects exactly the entries carrying the flag. Without the
+#   caller's opt-in the entry runs on Azure as before, which is what keeps the release run (default.yml)
+#   whole on one CI rather than silently shrinking it when a leg moves.
+# - gh_windows (true/false string, optional) : the same split for the windows leg, driven by
+#   offload_windows_to_github. Set only on legs that need no docker container - a windows container image
+#   is multiple GB per leg, so the win-mssql entries stay on Azure (see D-2 in the migration plan).
 
 jobs:
   - template: test-jobs.yml
@@ -122,6 +131,7 @@ jobs:
       # error there by design - see the note on its parameters block.
       db_filter: ${{ coalesce(parameters.surfaces[variables['Build.DefinitionName']], parameters.db_filter) }}
       offload_linux_to_github: ${{ parameters.offload_linux_to_github }}
+      offload_windows_to_github: ${{ parameters.offload_windows_to_github }}
       test_matrix:
 # Two things decide the order legs run in, and which one you see depends on whether the job caps its
 # parallelism. Both were measured on build 23050, the first run to carry a cap.
@@ -252,6 +262,7 @@ jobs:
           filters: '[all][sqlserver.all]'
 
         - name: g_SqlCE
+          gh_windows: 'true'
           title: SQL CE
           config_win: sqlce
           psscript_win_global: sqlce.ps1
@@ -410,6 +421,7 @@ jobs:
           filters: '[all][oracle.all]'
 
         - name: r_Access_MDB
+          gh_windows: 'true'
           title: Access MDB (Jet/ODBC)
           config_win: access.mdb
           enable_os_windows: true
@@ -423,6 +435,7 @@ jobs:
 
         - name: s_SQLite
           gh_linux: 'true'
+          gh_windows: 'true'
           title: SQLite (all providers)
           config_win: sqlite
           config_linux: sqlite
@@ -484,6 +497,7 @@ jobs:
 # also takes away the ODBC anchor that used to keep the shared ACE engine warm for both, and without an OLE DB
 # anchor of its own that half alone takes 1866s.
         - name: v_Access_ACE_Odbc
+          gh_windows: 'true'
           title: Access ACE (ODBC) x86
           config_win: access.ace.odbc
           psscript_win_global: access.ace.ps1
@@ -521,6 +535,7 @@ jobs:
           filters: '[all][db2.all][informix.all][duckdb.all]'
 
         - name: x_Access_ACE_OleDb
+          gh_windows: 'true'
           title: Access ACE (OLEDB) x86
           config_win: access.ace.oledb
           psscript_win_global: access.ace.ps1

--- a/Build/CI/run-provider-tests.ps1
+++ b/Build/CI/run-provider-tests.ps1
@@ -1,0 +1,180 @@
+<#
+run-provider-tests.ps1 - run one TFM's test suites for one Windows provider leg, then free the
+binaries:
+  config -> local setup -> pre-test -> main suite (optional) -> EF.Core suite -> post-test -> remove
+
+Windows counterpart of run-provider-tests.sh, and the same reason for existing: it is the body of
+test-workflow-windows.yml's per-TFM loop, which GitHub cannot express, because a matrix leg's steps
+are fixed at parse time and artifact downloads must be actions. The workflow downloads per TFM and
+calls this per downloaded TFM. Exiting non-zero reproduces Azure's succeeded() guards, skipping the
+EF.Core suite and later TFMs while leaving the .trx already written.
+
+Run from the leg root - the directory holding scripts/, configs/ and the downloaded <tfm>/.
+
+Usage:
+    ./scripts/run-provider-tests.ps1 -Tfm net10.0 -Flag net100 -Arch x64 -Config sqlce `
+                                     -Main true -Retry false
+#>
+
+[CmdletBinding()]
+param(
+    # Directory the binaries were extracted into, and the TFM's moniker: net462, net8.0, net9.0, net10.0.
+    [Parameter(Mandatory)][string] $Tfm,
+    # Matrix flag for the same TFM - netfx, net80, net90, net100. Names the config subdirectory.
+    [Parameter(Mandatory)][string] $Flag,
+    # Config file name without extension, from the entry's config_win.
+    [Parameter(Mandatory)][string] $Config,
+    [ValidateSet('x64', 'x86')][string] $Arch = 'x64',
+    # test-matrix.yml's script_win_local / psscript_win_local, run from the main test app's directory.
+    [string] $SetupCmd = '',
+    [string] $SetupPs1 = '',
+    # pre_test_win_local / post_test_win_local, run from scripts/ as Azure does.
+    [string] $PreTest  = '',
+    [string] $PostTest = '',
+    # Strings rather than switches, so a matrix value forwards straight through and a typo is a hard
+    # failure here rather than a silently skipped main suite - the same quiet no-op an empty test
+    # matrix produces.
+    [ValidateSet('true', 'false')][string] $Main  = 'false',
+    [ValidateSet('true', 'false')][string] $Retry = 'false'
+)
+
+# Continue, like push-baselines.ps1 and like the .sh which runs without `set -e`: every exit code below
+# is inspected explicitly. Stop would also route a native command's non-zero exit through the error
+# stream on PowerShell 7.4+ ($PSNativeCommandUseErrorActionPreference defaults on), turning a failing
+# test suite into a terminating error that skips the retry loop and loses the suite's own exit code.
+$ErrorActionPreference = 'Continue'
+
+$runMain  = $Main  -eq 'true'
+$doRetry  = $Retry -eq 'true'
+
+$root    = (Get-Location).Path
+$tfmDir  = Join-Path $root $Tfm
+$results = Join-Path $root 'TestResults'
+
+if (-not (Test-Path -LiteralPath $tfmDir)) {
+    Write-Host "::error::run-provider-tests: '$Tfm' does not exist - the binaries artifact was not downloaded"
+    exit 2
+}
+
+New-Item -ItemType Directory -Force -Path $results | Out-Null
+
+# Every native call below pipes to Out-Host, and that is load-bearing rather than cosmetic: a native
+# command's stdout joins its enclosing function's OUTPUT stream, so `$rc = Invoke-Suite ...` would be
+# an array of log lines with the exit code as its last element. Every comparison against it is then
+# nonsense - `$rc -ne 0` filters the array and is truthy no matter what the suite did. Measured on
+# GitHub run 34291985676: after a PASSING main suite the script exited without running EF.Core at all,
+# and the leg reported green. Out-Host writes straight to the host, so the log is unchanged and the
+# function returns only the int.
+#
+# Runs a script from scripts/ and returns its exit code. cmd files go through cmd.exe: PowerShell
+# will not surface a .cmd's exit code in $LASTEXITCODE reliably when invoked any other way.
+function Invoke-LegScript([string] $name, [string] $workingDirectory) {
+    $path = Join-Path (Join-Path $root 'scripts') $name
+    # Checked separately from the run so an absent script reads as a staging bug rather than a
+    # provider one - the two get debugged in different places.
+    if (-not (Test-Path -LiteralPath $path)) {
+        Write-Host "::error::run-provider-tests: scripts/$name is not in the test-scripts artifact"
+        return 2
+    }
+
+    Push-Location $workingDirectory
+    try {
+        # Reset first: a .ps1 that ends in `return` rather than `exit` - which both of the current
+        # global setup scripts do on their success path - leaves $LASTEXITCODE holding whatever the
+        # previous native command set, so an unreset read invents a failure.
+        $global:LASTEXITCODE = 0
+        if ([System.IO.Path]::GetExtension($name) -eq '.ps1') { & $path | Out-Host }
+        else { & cmd.exe /c $path | Out-Host }
+        return $LASTEXITCODE
+    }
+    finally { Pop-Location }
+}
+
+# Only the main suite retries as a whole, matching retryCountOnTaskFailure: 2 on the Azure step -
+# GitHub Actions has no step-level retry, so the loop lives here. It covers the crash case that MTP's
+# in-process retry cannot: a host that dies takes its results with it.
+function Invoke-Suite([string] $kind, [string] $exeName) {
+    $appDir = Join-Path (Join-Path $tfmDir $kind) $Arch
+    $exe    = Join-Path $appDir $exeName
+
+    if (-not (Test-Path -LiteralPath $exe)) {
+        Write-Host "::error::run-provider-tests: $exe is missing - the $Arch binaries artifact is not what this leg needs"
+        return 2
+    }
+
+    $testArgs = @(
+        '--filter', 'TestCategory != SkipCI'
+        '--settings', (Join-Path $appDir '.runsettings')
+        '--report-trx', '--report-trx-filename', "$Tfm-$kind-$Arch.trx"
+        '--results-directory', $results
+        '--hangdump', '--hangdump-timeout', '5m'
+    )
+    # MTP's own failed-test retry, applied to the flaky legs (Access) only.
+    if ($doRetry) { $testArgs += @('--retry-failed-tests', '2', '--retry-failed-tests-max-tests', '5') }
+
+    $attempts = if ($doRetry -and $kind -eq 'main') { 3 } else { 1 }
+
+    for ($i = 1; ; $i++) {
+        Write-Host "::group::$kind suite, $Tfm ($Arch, attempt $i/$attempts)"
+        & $exe @testArgs | Out-Host
+        $rc = $LASTEXITCODE
+        Write-Host '::endgroup::'
+        if ($rc -eq 0 -or $i -ge $attempts) { return $rc }
+        Write-Host "::warning::$kind suite failed for $Tfm (attempt $i/$attempts), retrying"
+    }
+}
+
+try {
+    # The config lands in the TFM root rather than beside the test app: TestConfiguration walks up from
+    # the assembly location to find UserDataProviders.json.
+    #
+    # Checked, because a silent failure here leaves the suite to fall back to DataProviders.json
+    # defaults and run a different provider set to a green finish.
+    $source = Join-Path (Join-Path (Join-Path $root 'configs') $Flag) "$Config.json"
+    try {
+        Copy-Item -LiteralPath $source -Destination (Join-Path $tfmDir 'UserDataProviders.json') -Force -ErrorAction Stop
+    }
+    catch {
+        Write-Host "::error::run-provider-tests: could not stage configs/$Flag/$Config.json - the leg would test the wrong providers"
+        exit 2
+    }
+    Write-Host ">>> config: configs/$Flag/$Config.json -> $Tfm/UserDataProviders.json"
+
+    $appDir = Join-Path (Join-Path $tfmDir 'main') $Arch
+
+    foreach ($setup in @(@{ n = $SetupCmd; d = $appDir }, @{ n = $SetupPs1; d = $appDir },
+                         @{ n = $PreTest;  d = (Join-Path $root 'scripts') })) {
+        if (-not $setup.n) { continue }
+        Write-Host "::group::Setup $Tfm ($($setup.n))"
+        $rc = Invoke-LegScript $setup.n $setup.d
+        Write-Host '::endgroup::'
+        if ($rc -ne 0) {
+            Write-Host "::error::run-provider-tests: setup script '$($setup.n)' failed for $Tfm"
+            exit $rc
+        }
+    }
+
+    # The main suite is skipped on non-release runs for every TFM but netfx and the newest, and for a
+    # win_efcore_only entry it is skipped outright - both decided by the caller. The EF.Core suite
+    # always runs, on every enabled TFM.
+    if ($runMain) {
+        $rc = Invoke-Suite 'main' 'linq2db.Tests.exe'
+        if ($rc -ne 0) { exit $rc }
+    }
+
+    $status = Invoke-Suite 'efcore' 'linq2db.EntityFrameworkCore.Tests.exe'
+    if ($status -ne 0) { exit $status }
+
+    # Azure's post-test step is gated on succeeded(), so a failed suite skips it - hence the exit
+    # above rather than running it on the way out.
+    if ($PostTest) {
+        $status = Invoke-LegScript $PostTest (Join-Path $root 'scripts')
+    }
+
+    exit $status
+}
+finally {
+    # Azure removes the TFM directory whether or not the suites passed, so the next TFM's download has
+    # the disk. Errors ignored, matching its `rmdir /S /Q`.
+    Remove-Item -LiteralPath $tfmDir -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -88,7 +88,7 @@
 		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces"              Version="4.8.0"                        />
 		<PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers"             Version="5.6.0"                        />
 		<PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers"             Version="5.6.0"                        />
-		<PackageVersion Include="Microsoft.SourceLink.GitHub"                           Version="10.0.301"                     />
+		<PackageVersion Include="Microsoft.SourceLink.GitHub"                           Version="10.0.303"                     />
 	</ItemGroup>
 
 	<ItemGroup Label="Polyfills">


### PR DESCRIPTION
Phase 4a of the Azure → GitHub Actions test migration: the five Windows legs that need no docker container move to GitHub. The eight win-mssql legs stay on Azure.

| Leg | Setup | Arch |
|---|---|---|
| `g_SqlCE` | `sqlce.ps1` (MSI download) | x64 |
| `s_SQLite` | none | x64 |
| `r_Access_MDB` | none | x86 |
| `v_Access_ACE_Odbc` | `access.ace.ps1` | x86 |
| `x_Access_ACE_OleDb` | `access.ace.ps1` | x86 |

#5880 measured GitHub at 1.4–1.6x faster per leg and left Azure's critical path entirely Windows — build 23500's 13 Windows legs took 1h2m–1h12m each against a 67-min pole for GitHub's whole 12-leg Linux set. Thirteen legs over ten Azure slots is two waves; eight is one.

## This PR changes no existing run

`offload_windows_to_github` defaults to false and **nothing passes it yet**. Azure keeps running all thirteen Windows legs; the new GitHub job is reachable only by `workflow_dispatch`.

That is deliberate. `tests-comment.yml` runs the *default branch's* `tests.yml`, so between turning the flag on and merging the Windows job there is a window where those five legs run on neither CI, with nothing red to say so. The flip in `testing.yml` is a one-line follow-up PR once this is on master — the same order #5866 used for the Linux legs.

`default.yml` will never pass it: the release run keeps every leg on one CI. `build_x86_job` therefore stays on the Azure side.

## What is here

- `test-matrix.yml` — `gh_windows` on the five entries; `offload_windows_to_github` declared and forwarded; `gh_linux` and `gh_windows` documented in the property list (`gh_linux` only had an inline note in `test-jobs.yml`).
- `test-jobs.yml` — the same `not(and(…))` matrix skip the Linux job already carries.
- `Build/CI/run-provider-tests.ps1` — Windows counterpart of `run-provider-tests.sh`. Three differences the port could not copy: netfx is a TFM, the suites are apphost `.exe` rather than `dotnet <dll>`, and a leg may be x86.
- `tests.yml` — `prepare` emits a second matrix; `build` stages netfx x64 when a Windows leg is selected; new `build_x86` job; new `windows-tests` matrix job.

Two selection guards, both shown *firing* against mutated copies of the matrix rather than by reading: a `gh_windows` entry carrying an Azure template conditional key (whose selectors a stock YAML parser cannot see), and a selected Windows leg with no TFM enabled. Both would otherwise be a green run that tested nothing.

Artifacts are per TFM rather than Azure's single win-x86 one — `download-artifact` has no `itemPattern`, so one artifact would force every leg to take all four TFMs at once and lose the download-run-delete disk discipline.

## Unrelated CI blocker, fixed here

`Microsoft.SourceLink.GitHub` 10.0.301 -> 10.0.303, one line in `Directory.Packages.props`.

NuGet's vulnerability index picked up GHSA-23fw-v26w-5fgq after master's last build, so every restore in the repo now fails `NU1902` on the transitive `Microsoft.Build.Tasks.Git` 10.0.301 (flagged range 10.0.300-10.0.301). With audit warnings treated as errors that is a hard restore failure on every branch, not only this one - all six DB-free legs here died before compiling anything. 10.0.303 is the version the advisory names as patched for that band; verified against the restored graph, `Build.Tasks.Git`, `SourceLink.Common` and `SourceLink.GitHub` all resolve to it.
## Verification

Hand-dispatched against this branch:

| Surface | Result |
|---|---|
| `[access.all]` | 3 legs green. `r_Access_MDB` 28748 tests / 0 failures across 6 `.trx` |
| `[sqlce.all]` | green, 16115 tests / 0 failures across 6 `.trx` |
| `[sqlite.all]` | green. Windows leg is **netfx EF.Core only** (147 tests), main left to the Linux leg per `win_efcore_only` |
| `[oracle.all]` | green with every job skipped — control for the empty-matrix fix below |

Three defects were found and fixed during bring-up, each with both arms measured:

1. **GitHub evaluates `${{ … }}` anywhere in a workflow file**, including inside a Python heredoc comment. A comment quoting Azure's own `${{ if … }}` failed the whole workflow at dispatch with `Unrecognized named-value: 'if'`. The prefix is now assembled in Python.
2. **An empty matrix fails the run**, rather than producing no jobs — with no failed job to point at and no annotation on any check run, so every job reads green under a red run. Every matrix job is now gated on its own leg list being non-empty. `[oracle.all]` above is the red→green control.
3. **A native command's stdout joins its enclosing function's output stream**, so the suite's exit code came back as the last element of an array of log lines. Measured: the EF.Core suite never ran on any TFM that ran the main suite (4 of 6 expected `.trx`), and a main suite exiting 3 produced exit 0. Every native call now pipes to `Out-Host`. Against stub test apps carrying the real assembly names, pre-fix `main 3 → exit 0, efcore x0`; post-fix `main 3 → exit 3`, `main 0 → efcore x1`.

The x86 runtime step was verified with a control arm on a throwaway branch: without `setup-dotnet … architecture: x86`, `DOTNET_ROOT` stays `C:\Program Files\dotnet` and every x86 leg dies loading the x64 `hostfxr.dll` (`HRESULT: 0x800700C1`). With it, `DOTNET_ROOT: C:\Program Files\dotnet\x86` and 14484 net10 x86 tests pass.

One flake seen and not reproduced: `DataConnectionCommitTransactionAsync("Access.Jet.OleDb")` failed once with `Query must have at least one destination field`, then passed on `gh run rerun --failed` at the same commit. Across runs it alternates between Inconclusive-and-skipped and this failure. That re-run also confirms artifacts survive a partial re-run.
