### PR TITLE
CI: move the docker-free Windows legs off Azure

### DIFF
--- a/Build/Azure/pipelines/templates/test-jobs.yml
+++ b/Build/Azure/pipelines/templates/test-jobs.yml
@@ -49,10 +49,10 @@ parameters:
   # here either way, so build_x86_job and the whole windows workflow below remain live even when this
   # is on.
   #
-  # No caller passes it yet, deliberately: tests-comment.yml runs the DEFAULT branch's tests.yml, so
-  # between turning this on and merging the windows job there is a window where Azure has been told to
-  # skip a leg that GitHub cannot yet run - the leg would run nowhere and nothing would say so. The
-  # flip in testing.yml is its own one-line PR, after the windows job is on master.
+  # It was landed off and flipped on in a second PR, because tests-comment.yml runs the DEFAULT
+  # branch's tests.yml: turning it on before the windows job reached master would have left those legs
+  # running on neither CI, with nothing red to say so. Any future leg moves the same way - add
+  # gh_windows first, flip nothing, and let the workflow reach master before it is relied on.
 - name: offload_windows_to_github
   type: boolean
   default: false

--- a/Build/Azure/pipelines/testing.yml
+++ b/Build/Azure/pipelines/testing.yml
@@ -35,9 +35,10 @@ stages:
         enabled: succeeded()
         with_baselines: true
         full_run: false
-        # PR runs split the linux legs; default.yml deliberately does not, so the release run keeps
-        # every leg on one CI.
+        # PR runs split the linux legs and the docker-free windows ones; default.yml deliberately does
+        # not, so the release run keeps every leg on one CI.
         offload_linux_to_github: true
+        offload_windows_to_github: true
         # db_filter is resolved inside test-matrix.yml from its surfaces map, keyed by definition
         # name. It used to be a 34-line if-chain here, which only Azure could read - the GitHub side
         # needs the same mapping, and #5848 already moved entry selection into that file for exactly


### PR DESCRIPTION
The second half of #5898. That PR added the GitHub `windows-tests` job and the `offload_windows_to_github` parameter but passed it nowhere; this turns it on for PR runs.

Effect on a PR run: Azure's `Win` job drops from **13 legs to 8** — only the win-mssql ones — and `g_SqlCE`, `s_SQLite`, `r_Access_MDB`, `v_Access_ACE_Odbc` and `x_Access_ACE_OleDb` run on GitHub Actions instead. Thirteen legs over ten Azure slots is two waves; eight is one, which is where the remaining wall-clock win identified in #5880 lives.

`default.yml` still does not pass the flag, so the release run keeps every leg on Azure.

## Why this is a separate PR

`tests-comment.yml` runs the **default branch's** `tests.yml`. Flipping the parameter in #5898 itself would have opened a window where Azure was told to skip five legs that GitHub could not yet run — they would have run on neither CI, with nothing red to say so. Now that the Windows job is on master, the flip is safe.

The parameter's comment in `test-jobs.yml` said "no caller passes it yet", which this change falsifies; it is rewritten to record the ordering instead, since any future leg move wants the same two steps.

## Verification

The five legs were already proven on GitHub by hand-dispatch against #5898's branch, before that PR merged:

| Surface | Result |
|---|---|
| `[access.all]` | 3 legs green; `r_Access_MDB` 28748 tests / 0 failures over six `.trx` |
| `[sqlce.all]` | green, 16115 tests / 0 failures over six `.trx` |
| `[sqlite.all]` | green; Windows leg runs netfx EF.Core only, main left to the Linux leg |

What this PR adds is the Azure side of the split, which needs a run to confirm: an Azure `test-*` on this branch must show **no** Windows leg for a moved surface, while the same comment starts the GitHub leg. That is also the first exercise of the comment trigger with Windows legs present on master.
