### PR TITLE
Refuse an untranslatable aggregate inside a projection

### DIFF
--- a/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuildVisitor.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuildVisitor.cs
@@ -2775,9 +2775,10 @@ namespace LinqToDB.Internal.Linq.Builder
 			IBuildContext? ctx;
 			bool           isSequence;
 			string?        errorMessage;
+			Expression?    errorExpression;
 			using (Builder.IsolateOrderBy())
 			{
-				ctx = GetSubQuery(node, onContext, out isSequence, out errorMessage);
+				ctx = GetSubQuery(node, onContext, out isSequence, out errorMessage, out errorExpression);
 			}
 
 			_disableSubqueries.Pop();
@@ -2805,6 +2806,9 @@ namespace LinqToDB.Internal.Linq.Builder
 							return true;
 						}
 
+						if (IsUnbuildableAggregateExecute(node, errorExpression, errorMessage, out subqueryExpression))
+							return true;
+
 						return false;
 					}
 
@@ -2815,6 +2819,9 @@ namespace LinqToDB.Internal.Linq.Builder
 							subqueryExpression = new SqlErrorExpression(node, errorMessage, node.Type);
 							return true;
 						}
+
+						if (IsUnbuildableAggregateExecute(node, errorExpression, errorMessage, out subqueryExpression))
+							return true;
 					}
 				}
 
@@ -2846,6 +2853,29 @@ namespace LinqToDB.Internal.Linq.Builder
 				_translationCache[cacheKey] = subqueryExpression;
 
 			return true;
+		}
+
+		/// <summary>
+		/// <see cref="LinqExtensions.AggregateExecute{TSource,TResult}"/> re-dispatches to
+		/// <see cref="IQueryProvider.Execute{TResult}"/>, so the client-evaluation fallback cannot run it — leaving it
+		/// in the materialization lambda ends in <c>There is no method 'AggregateExecute'</c> from
+		/// <c>EnumerableRewriter</c> instead of the translation error. Surface that error here.
+		/// </summary>
+		static bool IsUnbuildableAggregateExecute(Expression node, Expression? errorExpression, string? errorMessage, [NotNullWhen(true)] out Expression? subqueryExpression)
+		{
+			if (node is MethodCallExpression mc && mc.IsSameGenericMethod(Methods.LinqToDB.AggregateExecute))
+			{
+				// Same shape as ExpressionBuilder.BuildSequence, so the message matches the one the aggregate
+				// produces outside a projection.
+				subqueryExpression = errorExpression is SqlErrorExpression error
+					? error.WithType(node.Type)
+					: new SqlErrorExpression(errorExpression ?? node, errorMessage, node.Type);
+
+				return true;
+			}
+
+			subqueryExpression = null;
+			return false;
 		}
 
 		public override Expression VisitSqlPlaceholderExpression(SqlPlaceholderExpression node)
@@ -5245,8 +5275,10 @@ namespace LinqToDB.Internal.Linq.Builder
 
 		int _gettingSubquery;
 
-		public IBuildContext? GetSubQuery(Expression expr, IBuildContext onContext, out bool isSequence, out string? errorMessage)
+		public IBuildContext? GetSubQuery(Expression expr, IBuildContext onContext, out bool isSequence, out string? errorMessage, out Expression? errorExpression)
 		{
+			errorExpression = null;
+
 			var info = new BuildInfo(onContext, expr, new SelectQuery())
 			{
 				CreateSubQuery       = true,
@@ -5295,7 +5327,9 @@ namespace LinqToDB.Internal.Linq.Builder
 
 			snapshot?.Accept();
 
-			errorMessage = buildResult.AdditionalDetails;
+			errorMessage    = buildResult.AdditionalDetails;
+			errorExpression = buildResult.ErrorExpression;
+
 			return buildResult.BuildContext;
 		}
 

--- a/Tests/Linq/Linq/AggregationTests.cs
+++ b/Tests/Linq/Linq/AggregationTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using LinqToDB;
+using LinqToDB.Internal.Common;
 using LinqToDB.Mapping;
 
 using NUnit.Framework;
@@ -293,6 +294,128 @@ namespace Tests.Linq
 				.ToList();
 
 			actual.ShouldBe(expected);
+		}
+
+		/// <summary>
+		/// An aggregate whose selector cannot be translated refuses the same way inside a projection as it does on
+		/// its own, and refuses while the query is still being built.
+		/// </summary>
+		/// <remarks>
+		/// The projection form used to leave the internal <c>AggregateExecute</c> marker in the materialization
+		/// lambda: the query ran without its aggregate and then failed on the client with
+		/// <c>There is no method 'AggregateExecute'</c>. https://github.com/linq2db/linq2db/issues/5787
+		/// <para>
+		/// <see cref="DateTime.ToBinary"/> is a selector no provider translates, so the refusal is
+		/// provider-independent and SQLite alone covers it.
+		/// </para>
+		/// </remarks>
+		[Test]
+		public void UntranslatableAggregateInProjectionRefusesLikeTheBareForm([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataConnection(context);
+
+			var bare = Assert.Throws<LinqToDBException>(() => db.Types.Min(t => t.DateTimeValue.ToBinary()));
+
+			var projected = Assert.Throws<LinqToDBException>(() => db.Types
+				.Select(_ => new { Min = db.Types.Min(t => t.DateTimeValue.ToBinary()) })
+				.First());
+
+			projected!.Message.ShouldBe(bare!.Message);
+
+			// Both refusals happen while building the query, so nothing was ever sent.
+			db.LastQuery.ShouldBeNull();
+		}
+
+		[Test]
+		public void UntranslatableAggregateInProjectionRefusesForEveryAggregate([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataConnection(context);
+
+			Assert.Throws<LinqToDBException>(() => db.Types
+				.Select(_ => new { Value = db.Types.Max(t => t.DateTimeValue.ToBinary()) })
+				.First());
+
+			Assert.Throws<LinqToDBException>(() => db.Types
+				.Select(_ => new { Value = db.Types.Sum(t => t.DateTimeValue.ToBinary()) })
+				.First());
+
+			Assert.Throws<LinqToDBException>(() => db.Types
+				.Select(_ => new { Value = db.Types.Average(t => t.DateTimeValue.ToBinary()) })
+				.First());
+
+			Assert.Throws<LinqToDBException>(() => db.Types
+				.Select(_ => new { Value = db.Types.AggregateExecute(e => e.Min(t => t.DateTimeValue.ToBinary())) })
+				.First());
+		}
+
+		/// <summary>
+		/// The other positions an aggregate can take. The <c>OrderBy</c> case is the one that used to fail silently:
+		/// the untranslatable aggregate was dropped from the ordering and the query ran.
+		/// </summary>
+		[Test]
+		public void UntranslatableAggregateRefusesInPredicateOrderByAndGrouping([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataConnection(context);
+
+			Assert.Throws<LinqToDBException>(() => db.Types
+				.Where(_ => db.Types.Min(t => t.DateTimeValue.ToBinary()) > 0)
+				.ToArray());
+
+			Assert.Throws<LinqToDBException>(() => db.Types
+				.OrderBy(_ => db.Types.Min(t => t.DateTimeValue.ToBinary()))
+				.ToArray());
+
+			Assert.Throws<LinqToDBException>(() => db.Types
+				.GroupBy(t => t.ID)
+				.Select(g => new { Min = g.Min(t => t.DateTimeValue.ToBinary()) })
+				.ToArray());
+		}
+
+#if NET8_0_OR_GREATER
+		/// <summary>
+		/// The aggregate's own body translates; its <b>source</b> is what refuses, and it refuses with a detail
+		/// message rather than an error expression. That detail must survive into the projection form too.
+		/// </summary>
+		[Test]
+		public void UnbuildableAggregateSourceKeepsItsDetailMessage([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using var db = GetDataConnection(context);
+
+			var bare = Assert.Throws<LinqToDBException>(() => db.Types
+				.DistinctBy(t => t.SmallIntValue)
+				.Min(t => t.ID));
+
+			var projected = Assert.Throws<LinqToDBException>(() => db.Types
+				.Select(_ => new { Min = db.Types.DistinctBy(t => t.SmallIntValue).Min(t => t.ID) })
+				.First());
+
+			bare!.Message.ShouldContain(ErrorHelper.Error_DistinctByRequiresOrderBy);
+			projected!.Message.ShouldBe(bare.Message);
+		}
+#endif
+
+		/// <summary>
+		/// The unchanged path: an aggregate the provider can translate still builds and runs inside the same
+		/// projection shape the refusals above use.
+		/// </summary>
+		[Test]
+		public void TranslatableAggregateInProjectionStillRuns([IncludeDataSources(TestProvName.AllSQLite)] string context)
+		{
+			using var db    = GetDataConnection(context);
+			using var items = db.CreateLocalTable(Item.Data);
+
+			var row = items
+				.Select(_ => new
+				{
+					Min = items.Min(i => i.Id),
+					Max = items.Max(i => i.Id),
+					Sum = items.Sum(i => i.Id),
+				})
+				.First();
+
+			row.Min.ShouldBe(Item.Data.Min(i => i.Id));
+			row.Max.ShouldBe(Item.Data.Max(i => i.Id));
+			row.Sum.ShouldBe(Item.Data.Sum(i => i.Id));
 		}
 
 		/// <summary>

--- a/Tests/Linq/Linq/IntervalTranslationTests.Queries.cs
+++ b/Tests/Linq/Linq/IntervalTranslationTests.Queries.cs
@@ -368,7 +368,7 @@ namespace Tests.Linq
 		/// <c>Min</c> and <c>Max</c> put the lowered arithmetic inside an aggregate, which is where a provider that
 		/// renders the difference as a multi-part expression is most likely to object.
 		/// </remarks>
-		[ActiveIssue(5787, Configurations = [NoTickTotalProviders, UnsupportedDifferenceProviders], Details = "Every provider that cannot translate the aggregate's body lands on that core defect, so none of them reaches the refusal it would otherwise report: verified on Access, on Informix and on SQL Server 2014-minus, all three giving the same 'no method AggregateExecute' failure in this shape. Asked outside a projection the same aggregates do refuse by name - LinqToDBException, 'could not be converted to SQL' - which is what this would assert once the fallback is fixed.")]
+		[ThrowsCannotBeConverted(NoTickTotalProviders + "," + UnsupportedDifferenceProviders)]
 		[Test]
 		public void AggregatesOverADifference([DataSources(false)] string context)
 		{


### PR DESCRIPTION
Fixes #5787

## Problem

An aggregate whose selector cannot be translated refuses honestly on its own and fails with an internal `InvalidOperationException` when the same aggregate sits inside a projection — after running a query that carries no aggregate at all:

```csharp
t.Min(r => r.StartedOn.ToBinary());
// LinqToDBException: The LINQ expression 'x.StartedOn.ToBinary()' could not be converted to SQL.

t.Select(_ => new { M = t.Min(r => r.StartedOn.ToBinary()) }).First();
// InvalidOperationException: There is no method 'AggregateExecute' on type 'LinqToDB.LinqExtensions'
//   that matches the specified arguments
```

## Cause

`GetSubQuery` forwarded only `BuildSequenceResult.AdditionalDetails` and discarded `ErrorExpression`. A failed `AggregateExecute` build therefore reached `HandleSubquery` as `ctx == null, errorMessage == null` — indistinguishable from "not a sequence" — and, with no context to ask `IsSingleElement` of, fell through to client evaluation. The marker's source became a `SqlEagerLoadExpression` and the marker itself survived into the materialization lambda, where `EnumerableRewriter` cannot find `Enumerable.AggregateExecute`.

That contradicts an invariant `ExpressionTreeOptimizationContext` already asserts twice: `AggregateExecute` is `IsServerSideOnly` and not `CanBeEvaluatedOnClient`.

## Fix

`GetSubQuery` now hands `ErrorExpression` back, and `HandleSubquery` surfaces it when the failed node is the `AggregateExecute` marker — on both the `BuildPurpose.Expression` and the `Sql`/`Root` legs. The `SqlErrorExpression` is built exactly the way `ExpressionBuilder.BuildSequence` builds it, including `additionalDetails`, so the projection form's message is identical to the bare form's.

The guard is keyed on the marker method rather than on `IsServerSideOnly`, which would have changed behaviour for any failed subquery containing a server-side-only member anywhere.

## Also fixed

`OrderBy(_ => t.Min(<untranslatable>))` used to drop the aggregate from the ordering **silently** and run the query. It now refuses.

## Tests

Five tests in `AggregationTests`, reusing that fixture's existing `db.Types` / `Item.Data` models:

| Test | Arm |
|---|---|
| `UntranslatableAggregateInProjectionRefusesLikeTheBareForm` | red→green; also asserts `LastQuery` stays `null` — nothing reaches the server |
| `UntranslatableAggregateInProjectionRefusesForEveryAggregate` | red→green; `Max`/`Sum`/`Average`/direct `AggregateExecute` |
| `UntranslatableAggregateRefusesInPredicateOrderByAndGrouping` | red→green on the `OrderBy` shape (red arm: no exception at all); characterization for `Where`/`GroupBy`, which already refused |
| `UnbuildableAggregateSourceKeepsItsDetailMessage` | red→green; pins that the source's `additionalDetails` survives |
| `TranslatableAggregateInProjectionStillRuns` | control on the unchanged path |

`IntervalTranslationTests.AggregatesOverADifference` loses its `[ActiveIssue(5787)]` gate and now asserts the refusal via `[ThrowsCannotBeConverted]` for the provider families that genuinely cannot translate the aggregate.

## Verification

| Check | Result |
|---|---|
| `Tests/Linq` full run, `SQLite.Classic` | 11295 total, 0 failed, 338 skipped |
| `AggregationTests` + `IntervalTranslationTests` | 178 / 0 |
| Red arm (fix reverted) | 4 of 27 fail, each for the defect's own reason |
| `AggregatesOverADifference` on `Access.Ace.Odbc` / `Informix.DB2` | 1/1 each |
| `Source/LinqToDB` Release net10.0 + netstandard2.0 | 0 warnings, 0 errors |
| `Tests/Linq` Debug, all four TFMs | 0 warnings, 0 errors |
| `Tests/Linq` Release net10.0 analyzers | 14 pre-existing errors, none in a file this branch touches |

Not covered locally: `TestProvName.AllSqlServer2014Minus` (no container on the dev machine) and the baselines diff — both fall to CI. No public API change.
