### PR TITLE
Stop executing the 101-join StackOverflow test

### DIFF
--- a/Tests/Linq/Linq/JoinTests.cs
+++ b/Tests/Linq/Linq/JoinTests.cs
@@ -1033,14 +1033,11 @@ namespace Tests.Linq
 			Assert.That(arr, Is.Not.Empty);
 		}
 
-		// MySQL: 61 joined tables limit
-		// SQLite: 64 joined tables limit
-		// ASE: The "default data cache (id: 0)" is configured with 410 buffers.  The current query plan requires 2448 buffers.  Please reconfigure the data cache and try the command again.
-		// Access: Query is too complex (lol)
-		// DB2: Processing was cancelled due to an interrupt.
-		// SQLCE: slow (~2-3 min)
+		// Query is not executed: Parent has no unique key, so JoinsOptimizer cannot collapse the self-join
+		// chain, and no server optimizes 101 joins within the default 30s command timeout. What this test
+		// guards is the query build, which needs no server - see StackOverflowExecute for the executed one.
 		[Test]
-		public void StackOverflow([DataSources(TestProvName.AllAccess, ProviderName.SqlCe, TestProvName.AllDB2, TestProvName.AllMySql, TestProvName.AllSQLite, TestProvName.AllSybase)] string context)
+		public void StackOverflow([DataSources] string context)
 		{
 			using var db = GetDataContext(context);
 			var q =
@@ -1056,8 +1053,31 @@ namespace Tests.Linq
 					select new { p, c.c };
 			}
 
+			var sql = q.ToSqlQuery().Sql;
+			sql.ShouldNotBeNullOrEmpty();
+
+			BaselinesManager.LogQuery(sql);
+		}
+
+		[Test]
+		public void StackOverflowExecute([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+			var q =
+					from c in db.Child
+					join p in db.Parent on c.ParentID equals p.ParentID
+					select new { p, c };
+
+			for (var i = 0; i < 10; i++)
+			{
+				q =
+					from c in q
+					join p in db.Parent on c.p.ParentID equals p.ParentID
+					select new { p, c.c };
+			}
+
 			var list = q.ToList();
-			Assert.That(list, Is.Not.Empty);
+			list.ShouldNotBeEmpty();
 		}
 
 		[Test]


### PR DESCRIPTION
## Problem

`JoinTests.StackOverflow` builds a 101-way self-join chain and executes it. SQL Server 2017 needs more than SqlClient's default 30s command timeout to optimize that query, so the test races the timeout: on build 23568 it failed on two of three attempts, always on the `SqlServer.2017` contexts.

## Why the query cannot be made cheaper

`JoinsOptimizer` implements self-join removal by unique key, and correctly declines here. `Parent.ParentID` carries `[PrimaryKey(Configuration = ProviderName.Ydb)]` — a key on YDB only — and the physical table's PK is the synthetic `_ID` identity column. `ParentID` is not unique, so collapsing `Parent JOIN Parent ON ParentID = ParentID` would change cardinality.

## Change

The test was added in 97cf44015 (2012) alongside a `QueryVisitor` rewrite: what it guards is `StackOverflowException` while *building* a deeply nested query. Remote contexts build SQL client-side too, so executing the result adds nothing to that guard.

- `StackOverflow` keeps depth 100 and asserts on the generated SQL, logging it to baselines.
- `StackOverflowExecute` is new — same shape at depth 10, still executed end-to-end.
- Both take a bare `[DataSources]`. The removed exclusion list (Access, SqlCe, DB2, MySQL, SQLite, Sybase) recorded *server-side* limits — table-count caps, "query is too complex", ASE buffer cache — which no longer apply once the deep query is not executed.

## Verification

Ran across 15 provider configurations locally, direct and `.LinqService`: SQL Server 2017/2017.MS/2022, SQLite x2, MySQL x2, DB2, Sybase.Managed, SqlCe, Access Ace OleDb/Odbc, PostgreSQL.16, DuckDB — all green.

Access **Jet** cannot be verified on this machine: the Jet 4.0 OLE DB provider is not registered and there is no Jet ODBC DSN, so `CreateDatabase` fails before any test body runs. Left to CI.

Baselines will move: the recorded text loses the execution header, and the newly-included providers gain files.
