### PR TITLE
Fold nulls in one traversal for single-predicate search conditions

### DIFF
--- a/Source/LinqToDB/Internal/SqlProvider/SqlExpressionOptimizerVisitor.cs
+++ b/Source/LinqToDB/Internal/SqlProvider/SqlExpressionOptimizerVisitor.cs
@@ -341,8 +341,13 @@ namespace LinqToDB.Internal.SqlProvider
 			var saveAllowToOptimize = _allowOptimizeList;
 			_allowOptimizeList = element.Predicates;
 
+			// Null folding is deferred to a second traversal only so OptimizeSimilarFlat sees unfolded
+			// siblings; with a single predicate it is a no-op, so fold in the first traversal instead.
+			var singlePredicate = element.Predicates.Count <= 1;
+
 			var saveDoNotOptimizeNulls = _doNotOptimizeNulls;
-			_doNotOptimizeNulls = true;
+			if (!singlePredicate)
+				_doNotOptimizeNulls = true;
 
 			var newElement = base.VisitSqlSearchCondition(element);
 
@@ -355,7 +360,7 @@ namespace LinqToDB.Internal.SqlProvider
 			if (!ReferenceEquals(newElement, element))
 				return Visit(newElement);
 
-			if (!_doNotOptimizeNulls && !_nullabilityContext.IsEmpty)
+			if (!singlePredicate && !_doNotOptimizeNulls && !_nullabilityContext.IsEmpty)
 			{
 				// run again to optimize possible new IS [NOT] NULL predicates with nullability context updated with previous optimizations
 				newElement = base.VisitSqlSearchCondition(element);

--- a/Tests/Tests.Benchmarks/Benchmarks/QueryGeneration/DeepJoinChainBenchmark.cs
+++ b/Tests/Tests.Benchmarks/Benchmarks/QueryGeneration/DeepJoinChainBenchmark.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Data;
+using System.Linq;
+
+using LinqToDB.Benchmarks.TestProvider;
+using LinqToDB.Data;
+using LinqToDB.DataProvider.SqlServer;
+using LinqToDB.Mapping;
+
+namespace LinqToDB.Benchmarks.QueryGeneration
+{
+	// Query-generation cost of the Tests.Linq JoinTests.StackOverflow shape: a self-join chain built by
+	// re-joining Parent onto the previous Parent N times. Parent deliberately has no unique key, so
+	// JoinsOptimizer cannot collapse the chain and every level survives into the generated SQL.
+	//
+	// No [Benchmark] attributes on purpose: one operation at depth 100 costs seconds, so BDN's
+	// auto-iteration would dominate the default *.QueryGeneration.* run. Use the manual runner.
+	public class DeepJoinChainBenchmark
+	{
+		[Table("Parent")]
+		public sealed class Parent
+		{
+			[Column] public int  ParentID { get; set; }
+			[Column] public int? Value1   { get; set; }
+		}
+
+		[Table("Child")]
+		public sealed class Child
+		{
+			[PrimaryKey] public int ParentID { get; set; }
+			[PrimaryKey] public int ChildID  { get; set; }
+		}
+
+		DataConnection _db = null!;
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+		public void Setup()
+		{
+			_db = new DataConnection(new DataOptions()
+				.UseConnection(
+					SqlServerTools.GetDataProvider(SqlServerVersion.v2017, SqlServerProvider.MicrosoftDataSqlClient),
+					new MockDbConnection(Array.Empty<QueryResult>(), ConnectionState.Open))
+				// the point of the benchmark is building the query, so it must not be served from the cache
+				.UseDisableQueryCache(true));
+		}
+#pragma warning restore CA2000 // Dispose objects before losing scope
+
+		public void Cleanup()
+		{
+			_db.Dispose();
+		}
+
+		public string Build(int depth)
+		{
+			var q =
+					from c in _db.GetTable<Child>()
+					join p in _db.GetTable<Parent>() on c.ParentID equals p.ParentID
+					select new { p, c };
+
+			for (var i = 0; i < depth; i++)
+			{
+				q =
+					from c in q
+					join p in _db.GetTable<Parent>() on c.p.ParentID equals p.ParentID
+					select new { p, c.c };
+			}
+
+			return q.ToSqlQuery().Sql;
+		}
+
+		// Manual runner, mirroring WeakJoinScanBenchmark.RunManually: BDN's child-process toolchain cannot
+		// restore its auto-generated project in this repo layout (NU1101), and one operation here costs
+		// seconds. Sweeping the depth is the point - the shape of the curve says whether the cost is linear
+		// in the number of joins or worse.
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0030", Justification = "Benchmark output requires Console")]
+		public static void RunManually(int warmups = 1, int iterations = 3, int onlyDepth = 0)
+		{
+			if (warmups    < 0) warmups    = 0;
+			if (iterations < 1) iterations = 1;
+
+			var b = new DeepJoinChainBenchmark();
+			b.Setup();
+
+			var depths = onlyDepth > 0 ? new[] { onlyDepth } : new[] { 10, 25, 50, 100 };
+
+			Console.WriteLine();
+			Console.WriteLine("=== DeepJoinChainBenchmark manual run | warmups: " + warmups + " | iterations: " + iterations + " ===");
+			Console.WriteLine();
+			Console.WriteLine("| Depth | Joins | Mean (ms) | Median (ms) | Min (ms) | ms/join | SQL len |");
+			Console.WriteLine("|---:|---:|---:|---:|---:|---:|---:|");
+
+			foreach (var depth in depths)
+			{
+				for (var i = 0; i < warmups; i++)
+					b.Build(depth);
+
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+				GC.Collect();
+
+				var samples = new double[iterations];
+				var sw      = new System.Diagnostics.Stopwatch();
+				var sqlLen  = 0;
+
+				for (var i = 0; i < iterations; i++)
+				{
+					sw.Restart();
+					var sql = b.Build(depth);
+					sw.Stop();
+					samples[i] = sw.Elapsed.TotalMilliseconds;
+					sqlLen     = sql.Length;
+				}
+
+				var mean  = samples.Average();
+				var joins = depth + 1;
+
+				Array.Sort(samples);
+				var mid    = samples.Length / 2;
+				var median = samples.Length % 2 == 0
+					? (samples[mid - 1] + samples[mid]) / 2.0
+					: samples[mid];
+
+				Console.WriteLine($"| {depth,5} | {joins,5} | {mean,9:F1} | {median,11:F1} | {samples[0],8:F1} | {mean / joins,7:F2} | {sqlLen,7} |");
+			}
+
+			Console.WriteLine();
+
+			b.Cleanup();
+		}
+	}
+}

--- a/Tests/Tests.Benchmarks/Program.cs
+++ b/Tests/Tests.Benchmarks/Program.cs
@@ -49,6 +49,16 @@ namespace LinqToDB.Benchmarks
 				return;
 			}
 
+			// Usage: manual-deepjoin [iterations] [warmups] [onlyDepth]
+			if (args.Length > 0 && args[0] == "manual-deepjoin")
+			{
+				var iters   = args.Length > 1 && int.TryParse(args[1], out var dn) ? dn : 3;
+				var warmups = args.Length > 2 && int.TryParse(args[2], out var dw) ? dw : 1;
+				var depth   = args.Length > 3 && int.TryParse(args[3], out var dd) ? dd : 0;
+				DeepJoinChainBenchmark.RunManually(warmups, iters, depth);
+				return;
+			}
+
 			//if (args.Length == 0)
 			//{
 			//	//	var b1 = new FetchGraphBenchmark();


### PR DESCRIPTION
## Problem

`SqlExpressionOptimizerVisitor.VisitSqlSearchCondition` suppresses null folding for its first traversal (`_doNotOptimizeNulls = true`) and then runs a **second** full traversal of the same condition to perform the folding. `_doNotOptimizeNulls` has exactly one consumer — the non-nullable `IS [NOT] NULL` fold in `VisitIsNullPredicate` — so the second traversal is where that folding happens.

The deferral has a real purpose: it lets `OptimizeSimilarFlat` merge sibling predicates while the `IS [NOT] NULL`s are still unfolded. That is why it was introduced in bb2ded1bf (#5341, "Fix unwanted join condition nullability weakening").

But `OptimizeSimilarFlat` returns immediately when the condition holds a single predicate — there are no siblings to merge. For those conditions the second traversal duplicates the first and buys nothing. Single-predicate conditions are not a corner case: every join `ON` clause is one.

## Change

Compute `singlePredicate` from `Predicates.Count <= 1` before the traversal; when it holds, don't suppress folding and don't run the second traversal. Exactly one folding traversal happens either way. Conditions with siblings keep today's behaviour unchanged, and a nested condition that has siblings suppresses the flag itself on entry, so nesting is unaffected.

## Measurements

101-join self-join chain, query cache disabled, SQL Server 2017 provider, no database. Both arms measured with the same counter in the same worktree.

| arm | `OptimizeExpExprPredicate` calls | per predicate | guard tests | full suite (SQLite.MS) |
|---|---:|---:|---|---|
| master | 1313 | 13.00 | pass | 0 failed |
| **this PR** | **707** | **7.00** | **pass** | **11270 tests, 0 failed** |
| deliberately wrong form | 707 | 7.00 | **fail** | 3 failed |

101 distinct predicate nodes in all arms.

## Verification

The "deliberately wrong form" row is the control: skip the second traversal *while still suppressing the fold*, so the fold is lost. Running the full suite against it surfaced three existing tests that depend on this folding:

- `GuidTests.GuidToStringNoRedundantCaseWrap` (direct and `.LinqService`) — asserts no nested `LOWER(LOWER(…))` wrap
- `UserTests.Issue5049Tests.Issue5049Test` — `LoadWith` over an association aggregate

All three pass on master, fail under the wrong form, and pass with this change. No new test is added: these existing ones are stronger guards than anything hand-written for the purpose, and a hand-written attempt was discarded for being insensitive to the change.

## Caveats

- Local verification is SQLite-only. SQL text movement on other providers will show up in the baselines diff on CI; none is expected.
- The −46% is one query shape, dominated by single-predicate join conditions. It is not a general throughput claim.

## Benchmark

`DeepJoinChainBenchmark` is the instrument behind the numbers, added so a future regression can be re-measured. It deliberately carries no `[Benchmark]` attributes — a single depth-100 build costs seconds and would dominate the default `*.QueryGeneration.*` run. Drive it with `manual-deepjoin [iterations] [warmups] [onlyDepth]`.
