### PR TITLE
Bump versions for 6.6.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,11 +1,11 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<!-- Update to next after release -->
-		<Version>6.5.0</Version>
-		<EF3Version>3.34.0</EF3Version>
-		<EF8Version>8.8.0</EF8Version>
-		<EF9Version>9.7.0</EF9Version>
-		<EF10Version>10.6.0</EF10Version>
+		<Version>6.6.0</Version>
+		<EF3Version>3.35.0</EF3Version>
+		<EF8Version>8.9.0</EF8Version>
+		<EF9Version>9.8.0</EF9Version>
+		<EF10Version>10.7.0</EF10Version>
 
 		<!-- Baselines update on next major release -->
 		<BaselineVersion>6.0.0</BaselineVersion>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -264,7 +264,7 @@
 	</ItemGroup>
 
 	<ItemGroup Label="Examples">
-		<PackageVersion Include="linq2db.t4models"                                      Version="6.4.0"                        />
+		<PackageVersion Include="linq2db.t4models"                                      Version="6.5.0"                        />
 		<PackageVersion Include="Microsoft.Extensions.ObjectPool"                       Version="$(Net10Latest)"               />
 		<PackageVersion Include="OpenTelemetry"                                         Version="$(OpenTelemetryVersion)"      />
 		<PackageVersion Include="OpenTelemetry.Exporter.Console"                        Version="$(OpenTelemetryVersion)"      />


### PR DESCRIPTION
Bootstraps the 6.6.0 development cycle, following the 6.5.0 release.

## Changes

`Directory.Build.props` — product version and each EF variant minor +1:

| Property | From | To |
|---|---|---|
| `Version` | 6.5.0 | 6.6.0 |
| `EF3Version` | 3.34.0 | 3.35.0 |
| `EF8Version` | 8.8.0 | 8.9.0 |
| `EF9Version` | 9.7.0 | 9.8.0 |
| `EF10Version` | 10.6.0 | 10.7.0 |

`Directory.Packages.props` — `linq2db.t4models` re-pinned `6.4.0` → **`6.5.0`**, the version just published, so this cycle's T4 tests consume the released nuget. It is deliberately *not* pinned to 6.6.0: that would recreate the chicken-and-egg the re-pin exists to break.

`linq2db.t4models 6.5.0` is already live on nuget.org, so restore will not fail.

## Context

6.5.0 shipped on 2026-09-11 — release [v6.5.0](https://github.com/linq2db/linq2db/releases/tag/v6.5.0), 40 packages published, milestone closed with 118 items.

No other changes: this is a single-purpose version bump.
