### PR TITLE
Fix flaky ParameterReuse_ImpureExpression_CostDoesNotGrowPerBuild

### DIFF
--- a/Tests/Linq/Linq/ParameterTests.Reuse.cs
+++ b/Tests/Linq/Linq/ParameterTests.Reuse.cs
@@ -63,7 +63,7 @@ namespace Tests.Linq
 			sql.Parameters[0].Value.ShouldNotBe(sql.Parameters[1].Value);
 		}
 
-		[Test]
+		[Test, QueryCacheTest]
 		public void ParameterReuse_ImpureExpression_CostDoesNotGrowPerBuild([IncludeDataSources(TestProvName.AllSQLite, TestProvName.AllSqlServer)] string context)
 		{
 			using var db = GetDataContext(context);


### PR DESCRIPTION
Test-only fix for a flaky test. No product code changes.

## Symptom

`ParameterReuse_ImpureExpression_CostDoesNotGrowPerBuild` fails intermittently with:

```
Shouldly.ShouldAssertException : 5
    should be
2
    but was not
```

Most recently on build 23575, on the **NETFX** SQL Server 2005 and 2008 legs. Every net8/9/10 leg was green. The build it failed on (#5908) touches only `Tests/Linq/Linq/JoinTests.cs`, so it did not introduce this.

## Cause

The test builds one query four times and asserts that the last two builds cost the same number of parameter-accessor evaluations:

```csharp
perBuild[^1].ShouldBe(perBuild[^2]);
```

A cache miss costs 5 evaluations, a cache hit 2, so the expected profile is `[5,2,2,2]`. The assertion therefore holds only while the query-cache entry survives the loop — but the test asserted that against the process-wide `QueryCache.Default` without opting out of either pressure that can evict the entry:

| Pressure | Where |
|---|---|
| netfx legs cap the cache at 100 entries while a full run produces ~1700 distinct queries, so trimming is continuous | `Tests/Linq/TestsInitialization.cs` (`#if NETFRAMEWORK` → `capByDefault = true`) |
| tests run in parallel, so a concurrent test can add entries during the loop | `Tests/Base/Parallelization/ResourceLaneDispatcher.cs` |

An entry evicted between build 3 and build 4 turns the last build back into a cache miss, giving `[5,2,2,5]` — hence `5 should be 2`. That the two failing legs are both netfx is the 100-entry cap showing itself.

`TestsInitialization` already names this failure mode: a small cap "trims freshly-added, low-hit entries mid-test, which breaks the exact-miss-count cache tests".

## Fix

Add `[QueryCacheTest]`, the attribute that exists for exactly this. It fixes both pressures at once — `ParallelScope.None` routes the test to the globally exclusive lane, and it lifts `MaxEntriesOverride` for the test's duration so the netfx cap cannot trim the entry.

`ParameterTests.cs` already marks 17 cache-dependent tests this way; `ParameterTests.Reuse.cs` had none.

The assertion keeps its full power: the profile becomes a deterministic `[5,2,2,2]`, while the original bug's `1, 5, 9, 13` growth still fails it.

This is the only test in `ParameterTests.Reuse.cs` that builds repeatedly — the rest assert `Parameters.Count` on a single build and are cache-independent.
