### PR TITLE
Make SQL baselines agree between the release and PR pipelines

### DIFF
--- a/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLSchemaProvider.cs
+++ b/Source/LinqToDB/Internal/DataProvider/PostgreSQL/PostgreSQLSchemaProvider.cs
@@ -859,6 +859,7 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 								LEFT JOIN (SELECT SPECIFIC_SCHEMA, SPECIFIC_NAME, COUNT(*) as cnt FROM INFORMATION_SCHEMA.parameters WHERE parameter_mode IN('OUT', 'INOUT') GROUP BY SPECIFIC_SCHEMA, SPECIFIC_NAME) as outp
 									ON r.SPECIFIC_SCHEMA = outp.SPECIFIC_SCHEMA AND r.SPECIFIC_NAME = outp.SPECIFIC_NAME
 								WHERE {GenerateSchemaFilter(dataConnection, "n.nspname")}
+								ORDER BY r.SPECIFIC_SCHEMA, r.ROUTINE_NAME, r.SPECIFIC_NAME
 						"""
 					)
 					.ToList(),
@@ -910,6 +911,7 @@ namespace LinqToDB.Internal.DataProvider.PostgreSQL
 								LEFT JOIN (SELECT SPECIFIC_SCHEMA, SPECIFIC_NAME, COUNT(*)as cnt FROM INFORMATION_SCHEMA.parameters WHERE parameter_mode IN('OUT', 'INOUT') GROUP BY SPECIFIC_SCHEMA, SPECIFIC_NAME) as outp
 									ON r.SPECIFIC_SCHEMA = outp.SPECIFIC_SCHEMA AND r.SPECIFIC_NAME = outp.SPECIFIC_NAME
 								WHERE {GenerateSchemaFilter(dataConnection, "n.nspname")}
+								ORDER BY r.SPECIFIC_SCHEMA, r.ROUTINE_NAME, r.SPECIFIC_NAME
 						"""
 					)
 					.ToList(),

--- a/Source/LinqToDB/Internal/DataProvider/SqlServer/SqlServerSqlBuilder.cs
+++ b/Source/LinqToDB/Internal/DataProvider/SqlServer/SqlServerSqlBuilder.cs
@@ -430,6 +430,8 @@ namespace LinqToDB.Internal.DataProvider.SqlServer
 
 					if (type == provider.Adapter.VectorDbType && provider.Adapter.SqlVectorType is not null)
 						return $"VECTOR({param.Size.ToString(NumberFormatInfo.InvariantInfo)})";
+					if (type == provider.Adapter.JsonDbType && provider.Adapter.SqlJsonType is not null)
+						return "Json";
 					return type.ToString();
 				}
 			}

--- a/Tests/Base/BaselinesManager.cs
+++ b/Tests/Base/BaselinesManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using System.Threading;
 
 using NUnit.Framework;
 
@@ -6,20 +7,28 @@ namespace Tests
 {
 	public static class BaselinesManager
 	{
+		// The trace sink calls LogQuery on whatever thread ran the query, so two concurrent queries in
+		// one test race over the shared builder: unguarded, both can see null and each create one, and
+		// ctx.Set's last-writer-wins then drops a whole capture rather than tearing a single line.
+		static readonly Lock _sync = new();
+
 		public static void LogQuery(string message)
 		{
 			var ctx = CustomTestContext.Get();
 
 			if (!ctx.Get<bool>(CustomTestContext.BASELINE_DISABLED))
 			{
-				var baseline = ctx.Get<StringBuilder>(CustomTestContext.BASELINE);
-				if (baseline == null)
+				lock (_sync)
 				{
-					baseline = new StringBuilder();
-					ctx.Set(CustomTestContext.BASELINE, baseline);
-				}
+					var baseline = ctx.Get<StringBuilder>(CustomTestContext.BASELINE);
+					if (baseline == null)
+					{
+						baseline = new StringBuilder();
+						ctx.Set(CustomTestContext.BASELINE, baseline);
+					}
 
-				baseline.AppendLine(message);
+					baseline.AppendLine(message);
+				}
 			}
 		}
 

--- a/Tests/Linq/DataProvider/DB2Tests.cs
+++ b/Tests/Linq/DataProvider/DB2Tests.cs
@@ -991,10 +991,9 @@ namespace Tests.DataProvider
 		{
 			using var db = GetDataConnection(context);
 			// DB2 SYSCAT.COLUMNS.TABSCHEMA column is padded with spaces to max(schema.length) length despite it being of varchar type
-			var schemas = db.Query<string>("SELECT SCHEMANAME FROM SYSCAT.SCHEMATA").AsEnumerable().Select(_ => _.TrimEnd(' ')).ToArray();
-
-			if (schemas.Select(_ => _.Length).Distinct().Count() < 2)
-				Assert.Inconclusive("Test requires at least two schemas with different name length");
+			// Fixed rather than read from SYSCAT.SCHEMATA: the list reaches the captured SQL, so a live one makes the
+			// baseline depend on what ran before (SESSION appears for good once any test creates a global temporary table).
+			var schemas = new[] { "SYSCAT", "SYSSTAT" };
 
 			var schema = db.DataProvider.GetSchemaProvider().GetSchema(db, new GetSchemaOptions() { IncludedSchemas = schemas });
 
@@ -1011,6 +1010,7 @@ namespace Tests.DataProvider
 				usedSchemas.Add(table.SchemaName!);
 			}
 
+			Assert.That(usedSchemas, Is.EquivalentTo(schemas));
 			Assert.That(usedSchemas.Select(_ => _.Length).Distinct().Count(), Is.GreaterThan(1));
 		}
 

--- a/Tests/Linq/DataProvider/Types/SqlServerTypeTests.cs
+++ b/Tests/Linq/DataProvider/Types/SqlServerTypeTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 
 using LinqToDB;
+using LinqToDB.Data;
 
 using Microsoft.Data.SqlTypes;
 
@@ -56,6 +57,24 @@ namespace Tests.DataProvider
 				await TestType<SqlJson, SqlJson?>(context, new(typeof(SqlJson)), new("{ }"), SqlJson.Null, filterByValue: false, filterByNullableValue: false, isExpectedValue: v => v.Value == expectedEmpty, isExpectedNullableValue: v => v?.IsNull == true);
 				await TestType<SqlJson, SqlJson?>(context, new(typeof(SqlJson)), new(json1), new(json2), filterByValue: false, filterByNullableValue: false, isExpectedValue: v => v.Value == expected1, isExpectedNullableValue: v => v?.Value == expected2);
 			}
+		}
+
+		[Test(Description = "Parameter type name must not vary with the target framework")]
+		public void TestJSONParameterTypeName([IncludeDataSources(TestProvName.AllSqlServer2025Plus)] string context)
+		{
+			// System.Data.SqlDbType gained Json (35) only in .NET 9, so the enum has no name for it on
+			// net462/net8 and would otherwise render as the bare number - a release-only netfx leg then
+			// captures different SQL from every other leg.
+			using var db = GetDataConnection(context);
+
+			const string json = /*lang=json,strict*/ "{ \"prop1\": 123 }";
+			db.Execute<string>("SELECT CAST(@p AS NVARCHAR(MAX))", new DataParameter("p", json, DataType.Json));
+
+			// without SqlJson the provider maps DataType.Json to NVarChar, which must keep its own name
+			var expected = context.IsAnyOf(TestProvName.AllSqlServerMS) ? "Json" : "NVarChar";
+
+			// the declaration is in the captured trace, not in LastQuery, which holds the command text alone
+			Assert.That(GetCurrentBaselines(), Does.Contain($"DECLARE @p {expected}"));
 		}
 
 		[Test(Description = "https://github.com/linq2db/linq2db/issues/5240")]

--- a/Tests/Linq/Infrastructure/BaselinesManagerTests.cs
+++ b/Tests/Linq/Infrastructure/BaselinesManagerTests.cs
@@ -46,7 +46,8 @@ namespace Tests.Infrastructure
 			var baseline = CustomTestContext.Get().Get<StringBuilder>(CustomTestContext.BASELINE);
 
 			baseline.ShouldNotBeNull();
-			baseline.ToString().Split('\n', StringSplitOptions.RemoveEmptyEntries).Length
+			// char[] overload rather than the char one: Split(char, StringSplitOptions) is not on net462
+			baseline.ToString().Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries).Length
 				.ShouldBe(writers * linesPerWriter);
 		}
 	}

--- a/Tests/Linq/Infrastructure/BaselinesManagerTests.cs
+++ b/Tests/Linq/Infrastructure/BaselinesManagerTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using Shouldly;
+
+namespace Tests.Infrastructure
+{
+	/// <summary>
+	/// Capture accounting behind <see cref="BaselinesManager.LogQuery"/>. The trace sink calls it on whatever
+	/// thread ran the query, so a test issuing concurrent queries appends from several threads at once — and the
+	/// first appends of a test also race to <em>create</em> the shared builder, where a last-writer-wins store
+	/// used to drop one thread's builder whole.
+	/// </summary>
+	/// <remarks>
+	/// This fixture deliberately takes no data-source parameter: <c>BaselinesWriter.Write</c> returns before
+	/// touching the disk when the test has none, so hammering the buffer here writes no baseline file.
+	/// </remarks>
+	[TestFixture]
+	public class BaselinesManagerTests : TestBase
+	{
+		[Test]
+		public void LogQueryKeepsEveryConcurrentAppend()
+		{
+			const int writers        = 8;
+			const int linesPerWriter = 500;
+
+			using var start = new ManualResetEventSlim(false);
+
+			var writerTasks = Enumerable.Range(0, writers).Select(_ => Task.Run(() =>
+			{
+				// released together, so the contended window includes the builder's lazy creation
+				start.Wait();
+
+				for (var i = 0; i < linesPerWriter; i++)
+					BaselinesManager.LogQuery("SELECT 1");
+			})).ToArray();
+
+			start.Set();
+			Task.WaitAll(writerTasks);
+
+			var baseline = CustomTestContext.Get().Get<StringBuilder>(CustomTestContext.BASELINE);
+
+			baseline.ShouldNotBeNull();
+			baseline.ToString().Split('\n', StringSplitOptions.RemoveEmptyEntries).Length
+				.ShouldBe(writers * linesPerWriter);
+		}
+	}
+}


### PR DESCRIPTION
The first ordinary PR after every release carries a baselines diff it did not
cause — after 6.5.0 that was linq2db.baselines#2118, 21 files unrelated to #5912.
An unrelated later PR reproduced 20 of the same 21 byte-for-byte, so it is
systematic rather than flaky.

A baseline's path carries the provider and nothing else — no TFM, no OS, no CI
host — and `push-baselines.ps1` resolves the cross-leg race with
`git rebase -X theirs`, so the last leg to push wins. A release run
(`full_run: true`) runs strictly more legs than a PR run, and `/release-publish`
resets baselines master to the anchor, so the whole corpus is release-pipeline
output. Three mechanisms then make the two pipelines disagree.

**netfx renders a JSON parameter as `35`.** `GetProviderTypeName` fell through to
`SqlDbType.ToString()`, and the adapter supplies `(SqlDbType)35` because the BCL
enum has no such member before .NET 9. The release run also runs a netfx-only
Windows leg for SQL Server 2022+2025, so its value won the race.

**Captured SQL encoded live database state.** `Issue2763Test` passed the live
`SYSCAT.SCHEMATA` result as `IncludedSchemas`, which DB2 interpolates verbatim
into seven catalog queries; `SESSION` appears permanently once any test creates a
catalogued global temporary table. PostgreSQL's `GetProcedures` had no `ORDER BY`
in either version branch, so table-function probe order was server-determined.

**Baseline capture lost an append.** `LogQuery` lazily created the shared
`StringBuilder` with no lock while the trace sink called it from the query's
thread, so two concurrent queries could each create one and lose a whole capture.

### Verification

| | proof |
|---|---|
| JSON type name | red→green on **net8.0**: 28 `DECLARE @x 35` → 28 `Json` |
| PostgreSQL ordering | characterization: two runs identical, order = the `ORDER BY` key |
| DB2 schema list | red→green: two passes now byte-identical, `SESSION` gone from the capture while still present in the database |
| capture lock | red 3/3 without it (`ArgumentException` from `StringBuilder.AppendWithExpansion`), green 1/1 |

`Source/LinqToDB` also builds clean in Release on `netstandard2.0` and `net462`,
which is load-bearing here because the first change exists for exactly those TFMs.

### What to expect from CI

The baselines PR will be large and that is intended: `GetProcedures`' query text
is itself captured, so all **332** PostgreSQL baseline files change. Nothing
outside the 13 PostgreSQL directories and the one DB2 file should move.

`SqlServer.2025.MS/TestJSONType` will **not** change on this run — the PR
pipeline's Linux net10 leg already emits `Json`, so that fix is only visible on a
`full_run`. Its absence from the diff is the expected outcome.

### Not in scope

The `IN (...)` schema filter is still emitted unsorted from `DB2LUWSchemaProvider`
and `SchemaProviderBase.BuildSchemaFilter` (PostgreSQL already sorts), and the
trace builder has the same unguarded lazy-create this PR fixes for baselines.
Both are separable and get their own issue.

Filed as #5918.

The PostgreSQL reordering's actual trigger on CI was **not** identified — no
in-tree statement mutates `pg_proc` for those functions, and the flip was confined
to PG 17/18 although 13–19 share one job. The `ORDER BY` is justified as
determinism by construction, not as a diagnosed fix.
