### PR TITLE
Keep projection members when a set-operation branch is cast to object

### DIFF
--- a/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuildVisitor.cs
+++ b/Source/LinqToDB/Internal/Linq/Builder/ExpressionBuildVisitor.cs
@@ -2427,6 +2427,14 @@ namespace LinqToDB.Internal.Linq.Builder
 						{
 							var placeholder = placeholders[0];
 
+							// The column has to be the operand itself. A constructed object that happens to hold one
+							// column is not interchangeable with it: reading it as the column drops every other member,
+							// and every column a member evaluated client-side reads contributes no placeholder here.
+							if (node.Method == null && operandExpr is not SqlPlaceholderExpression)
+							{
+								return base.VisitUnary(node);
+							}
+
 							if (node.Type                         == typeof(object)
 							    || node.Type.UnwrapNullableType() == node.Operand.Type.UnwrapNullableType()
 							    || node.Type.UnwrapNullableType() == placeholder.Sql.SystemType?.UnwrapNullableType()
@@ -2439,11 +2447,6 @@ namespace LinqToDB.Internal.Linq.Builder
 								}
 
 								return Visit(CreatePlaceholder(placeholder.Sql, node));
-							}
-
-							if (node.Method == null && operandExpr is not SqlPlaceholderExpression)
-							{
-								return base.VisitUnary(node);
 							}
 
 							if (TryCastTo(placeholder, node.Type, node.Type, out var casted))

--- a/Tests/Linq/UserTests/Issue5916Tests.cs
+++ b/Tests/Linq/UserTests/Issue5916Tests.cs
@@ -1,0 +1,191 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using LinqToDB;
+
+using NUnit.Framework;
+
+using Shouldly;
+
+namespace Tests.UserTests
+{
+	[TestFixture]
+	public class Issue5916Tests : TestBase
+	{
+		// AssertQuery's default comparer walks the members of `object`, finds none, and folds the empty set
+		// into an always-true equality - leaving only the row count, which is already right when members are
+		// dropped. Every object-typed query below is asserted with structural equality instead.
+		static IEqualityComparer<object> Structural => EqualityComparer<object>.Default;
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5916 - an (object)-cast set-operation branch must keep members evaluated client-side")]
+		public void ConcatObjectCastKeepsClientSideMember([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var query =
+				(from p in db.Person where p.ID > 2 select (object)new { id = "p_" + p.ID.ToString("X"), name = p.FirstName })
+				.Concat(
+				 from p in db.Person where p.ID <= 2 select (object)new { id = "q_" + p.ID.ToString("X"), name = p.FirstName });
+
+			var result = AssertQuery(query, Structural);
+
+			// the whole defect in one line: the projection loses `id`, and the row is materialized as the
+			// single surviving column's value
+			result.ShouldAllBe(x => x.GetType() != typeof(string));
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5916 - the (object)-cast form must read the same columns as the uncast form")]
+		public void ConcatObjectCastSelectsSameColumnsAsUncast([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var uncast =
+				(from p in db.Person where p.ID > 2 select new { id = "p_" + p.ID.ToString("X"), name = p.FirstName })
+				.Concat(
+				 from p in db.Person where p.ID <= 2 select new { id = "q_" + p.ID.ToString("X"), name = p.FirstName });
+
+			var cast =
+				(from p in db.Person where p.ID > 2 select (object)new { id = "p_" + p.ID.ToString("X"), name = p.FirstName })
+				.Concat(
+				 from p in db.Person where p.ID <= 2 select (object)new { id = "q_" + p.ID.ToString("X"), name = p.FirstName });
+
+			// compared against the uncast form rather than a literal, so the expectation cannot be tuned to
+			// whatever the run happens to produce
+			cast.GetSelectQuery()!.Select.Columns.Count.ShouldBe(uncast.GetSelectQuery()!.Select.Columns.Count);
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5916 - differently shaped (object)-cast branches keep their own members")]
+		public void ConcatObjectCastDifferentShapes([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var query =
+				(from p in db.Person where p.ID > 2 select (object)new { id = "p_" + p.ID.ToString("X"), name = p.FirstName })
+				.Concat(
+				 from p in db.Person where p.ID <= 2 select (object)new { key = "c_" + p.ID.ToString("X"), first = p.FirstName, last = p.LastName });
+
+			var result = AssertQuery(query, Structural);
+
+			result.ShouldAllBe(x => x.GetType() != typeof(string));
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5916 - UnionAll behaves as Concat does")]
+		public void UnionAllObjectCastKeepsClientSideMember([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var query =
+				(from p in db.Person where p.ID > 2 select (object)new { id = "p_" + p.ID.ToString("X"), name = p.FirstName })
+				.UnionAll(
+				 from p in db.Person where p.ID <= 2 select (object)new { id = "q_" + p.ID.ToString("X"), name = p.FirstName });
+
+			var result = AssertQuery(query, Structural);
+
+			result.ShouldAllBe(x => x.GetType() != typeof(string));
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5916 - the dropped member is not specific to a formatted key column: one computed from a translated expression (Length) is dropped too")]
+		public void ConcatObjectCastStringLengthClientSideMember([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var query =
+				(from p in db.Person where p.ID > 2 select (object)new { id = p.FirstName.Length.ToString("X"), name = p.FirstName })
+				.Concat(
+				 from p in db.Person where p.ID <= 2 select (object)new { id = p.LastName.Length.ToString("X"), name = p.FirstName });
+
+			var result = AssertQuery(query, Structural);
+
+			result.ShouldAllBe(x => x.GetType() != typeof(string));
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5916 - `as object` is rewritten into the same conversion and reaches the same site")]
+		public void ConcatObjectCastThroughAs([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var query =
+				(from p in db.Person where p.ID > 2 select new { id = "p_" + p.ID.ToString("X"), name = p.FirstName } as object)
+				.Concat(
+				 from p in db.Person where p.ID <= 2 select new { id = "q_" + p.ID.ToString("X"), name = p.FirstName } as object);
+
+			var result = AssertQuery(query, Structural);
+
+			result.ShouldAllBe(x => x.GetType() != typeof(string));
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5916 - the collapse is order-independent: a client-side member on the second operand is dropped too (the issue's case 6, recorded there as passing)")]
+		public void ConcatObjectCastClientSideMemberOnSecondOperand([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var query =
+				(from p in db.Person where p.ID > 2 select (object)new { key = "c_" + p.ID.ToString("X"), first = p.FirstName, last = p.LastName })
+				.Concat(
+				 from p in db.Person where p.ID <= 2 select (object)new { id = "p_" + p.ID.ToString("X"), name = p.FirstName });
+
+			var result = AssertQuery(query, Structural);
+
+			result.ShouldAllBe(x => x.GetType() != typeof(string));
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5916 - control: every member translates, so nothing is at risk")]
+		public void ConcatObjectCastTranslatableMembers([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var query =
+				(from p in db.Person where p.ID > 2 select (object)new { id = p.ID, name = p.FirstName })
+				.Concat(
+				 from p in db.Person where p.ID <= 2 select (object)new { id = p.ID, name = p.LastName });
+
+			var result = AssertQuery(query, Structural);
+
+			result.ShouldAllBe(x => x.GetType() != typeof(string));
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5916 - control: a third member leaves more than one column standing")]
+		public void ConcatObjectCastThreeMembers([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var query =
+				(from p in db.Person where p.ID > 2 select (object)new { id = "p_" + p.ID.ToString("X"), name = p.FirstName, last = p.LastName })
+				.Concat(
+				 from p in db.Person where p.ID <= 2 select (object)new { id = "q_" + p.ID.ToString("X"), name = p.FirstName, last = p.LastName });
+
+			var result = AssertQuery(query, Structural);
+
+			result.ShouldAllBe(x => x.GetType() != typeof(string));
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5916 - control: the same projection outside a set operation")]
+		public void SelectObjectCastClientSideMember([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var query = from p in db.Person select (object)new { id = "p_" + p.ID.ToString("X"), name = p.FirstName };
+
+			var result = AssertQuery(query, Structural);
+
+			result.ShouldAllBe(x => x.GetType() != typeof(string));
+		}
+
+		[Test(Description = "https://github.com/linq2db/linq2db/issues/5916 - control: a bare column cast to object stays a single column")]
+		public void ConcatObjectCastScalarMember([DataSources] string context)
+		{
+			using var db = GetDataContext(context);
+
+			var query =
+				(from p in db.Person where p.ID > 2 select (object)p.FirstName)
+				.Concat(
+				 from p in db.Person where p.ID <= 2 select (object)p.LastName);
+
+			// the operand here IS the placeholder, so the conversion still collapses to that one column -
+			// this is the shape the collapse exists for and the one the fix must leave alone
+			AssertQuery(query, Structural).ShouldAllBe(x => x.GetType() == typeof(string));
+
+			query.GetSelectQuery()!.Select.Columns.Count.ShouldBe(1);
+		}
+	}
+}


### PR DESCRIPTION
Fixes #5916.

### The defect

A set operation whose operands are cast to `object` — the only common element type C# offers for two different anonymous shapes — silently dropped every projected member that would be evaluated client-side. No exception, no diagnostic: the query built, executed, returned the right number of rows, and each row was missing data. Where the drop left a single column, the row materialized as that column's scalar value, so a caller got a bare `string` where the query declared an object.

Correct in 6.0.0, threw in 6.4.0, silently wrong in 6.5.0.

### Cause

`ExpressionBuildVisitor.VisitUnary`'s `Convert` arm replaced `Convert(<constructor>, object)` with whichever single "straight" placeholder the constructor held. `CollectPlaceholdersStraight` recurses only into `SqlGenericConstructorExpression` assignments and parameters, `MemberInitExpression` bindings and `NewExpression` arguments, so a member holding a client-side expression tree — `"p_" + p.Id.ToString("N")` is a binary/method-call tree — contributes **zero** placeholders even though it reads real columns. That left exactly one, and the conversion treated it as the whole object.

It surfaces only in a set operation because a conversion under `BuildPurpose.Expression` is handed to the ordinary client-side visitor unless `BuildFlags.ForSetProjection` is set, and `MergeProjectionHelper.BuildProjectionExpression` always sets it. A terminal `Select` of the same projection was unaffected.

### Fix

The pre-existing `node.Method == null && operandExpr is not SqlPlaceholderExpression` bail-out is hoisted above the type-matching condition. The guard is **moved, not rewritten** — the neighbouring arm of the same `if` already applied it; only the arm requiring `object`, an identity conversion, or an enum pair was missing it. A conversion to any other base type already exited through that guard and is untouched.

### Reach

The behavioural delta is confined to the type-matching arm with a non-placeholder operand. Outside set projections it is narrower than it looks: `JoinBuilder`/`OrderByBuilder` call `.Unwrap()` on key bodies first, which strips every `Convert`, and `GroupByBuilder`, `DistinctByBuilder`, `DistinctBuilder`, `ContainsBuilder`, `HasUniqueKey`, `DefaultIfEmptyBuilder` and the eager-load union sites all consume through the *deep* `CollectPlaceholders`, which sees through a kept conversion. `CollectPlaceholdersStraight` has exactly one call site in the repo — the line this change guards.

### Verification

- New fixture `Tests/Linq/UserTests/Issue5916Tests.cs`: **14 failures against the unfixed base, 23/23 passing with the fix** (SQLite.MS + SQLite.MS.LinqService). Four controls stayed green in *both* arms, so the reds are attributable.
- The impact map's named neighbours — `Issue5683Tests` (incl. its `Select.Columns.Count == 3` assertions), `Issue1225Tests`, `ConcatUnionTests`, `SetOperatorComplexTests`, `CteTests`, `MicrosoftODataTests`, `GroupByTests`, `ContainsTests`, `TphInheritanceTests`, `InterfaceTests` — **917/917**.
- **Baseline-neutral.** Of 3881 pre-existing SQLite.MS baselines, 3877 unchanged and 4 moved; those 4 were re-run with the fix stashed and produced identical hashes, so the movement is pre-existing drift, not this change.
- `dotnet build Source/LinqToDB/LinqToDB.csproj -c Release -f netstandard2.0` → succeeded, zero warnings.

The post-fix SQL matches the uncast form exactly — four columns, no `__projection__set_id__` anchor, since the differing constants already discriminate the branches.

**Not verified locally:** the full `Tests/Linq` suite never completed on the dev box (killed for host memory three times, best run 6982 tests at 0 failures). `Tests.UserTests` and the tail namespaces rest on the 917-test neighbour run above — the full matrix is CI's.

### Note for #5916

The issue's case 6 ("operand order swapped") is recorded as correct on 6.5.0. It is not — the collapse is order-independent and it fails in either order. A regression test pins it.
